### PR TITLE
feat(audio): Music mode — ACE-Step + extend/edit source band [sc-13410]

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -915,12 +915,52 @@ pub(crate) struct AudioJobRequest {
     /// range is the real gate the generator's `validate` applies (sc-13409).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) guidance: Option<f32>,
-    /// Solver step count for diffusion-audio models (Sound FX / MOSS-SoundEffect). Rides the
-    /// top-level [`gen_core::GenerationRequest::steps`]. `None` ⇒ the model's default (MOSS: 100).
-    /// Bounded to a blanket sane ceiling here; the model's advertised step ceiling is the real gate
-    /// the generator's `validate` applies (sc-13409).
+    /// Solver step count for diffusion-audio models (Sound FX / MOSS-SoundEffect + Music / ACE-Step).
+    /// Rides the top-level [`gen_core::GenerationRequest::steps`]. `None` ⇒ the model's default (MOSS:
+    /// 100; ACE-Step turbo: 8). Bounded to a blanket sane ceiling here; the model's advertised step
+    /// ceiling is the real gate the generator's `validate` applies (sc-13409 / sc-13410).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) steps: Option<u32>,
+    /// Negative prompt — the traits to steer away from (music models that advertise it). Rides the
+    /// top-level [`gen_core::GenerationRequest::negative_prompt`]. `None` ⇒ unconditional. The
+    /// guidance-distilled ACE-Step turbo advertises no negative-prompt support, so the studio never
+    /// sends one to it; a value posted to such a model is a typed Unsupported at the gen-core floor
+    /// (the "honor advertised knobs, let the model gate" contract). sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) negative_prompt: Option<String>,
+    /// Musical tempo in beats per minute (music models — ACE-Step). Rides the worker-side
+    /// [`gen_core::AudioParams::bpm`]. `None` ⇒ the model derives its own tempo. sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) bpm: Option<f32>,
+    /// Musical key (e.g. `"C minor"`; music models). Free-form — rides
+    /// [`gen_core::AudioParams::musical_key`]; each model documents what it accepts. sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) musical_key: Option<String>,
+    /// Lyrics to sing / condition on (music models). Free-form, distinct from `prompt` — rides
+    /// [`gen_core::AudioParams::lyrics`]; empty ⇒ instrumental. sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) lyrics: Option<String>,
+    /// Extend/edit SOURCE track (a library `type: "audio"` asset id) for prompted source-audio editing
+    /// (music models that advertise `audio.editModes`). The worker resolves the asset's WAV and builds a
+    /// [`gen_core::Conditioning::AudioEdit`] from it. `None` ⇒ plain text-to-music. sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source_audio_asset_id: Option<String>,
+    /// The edit operation for the source track — `"inpaint"` / `"repaint"` / `"extend"` / `"cover"`,
+    /// gated against the model's advertised [`gen_core::Capabilities::audio_edit_modes`] by the
+    /// generator's `validate`. Only consulted when `source_audio_asset_id` is set. sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) edit_mode: Option<String>,
+    /// Edit-region start (seconds) for a bounded inpaint/repaint window. For `extend` the worker
+    /// defaults it to the source clip's own length. `None` ⇒ the provider default. sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) edit_region_start_secs: Option<f32>,
+    /// Edit-region end (seconds): the inpaint/repaint window end, OR — for `extend` — the appended
+    /// clip's new TOTAL length. `None` ⇒ to the clip end (region modes). sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) edit_region_end_secs: Option<f32>,
+    /// Edit strength (0..=1) for the source-audio edit. `None` ⇒ the model default. sc-13410.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) edit_strength: Option<f32>,
     #[serde(default)]
     pub(crate) seed: Option<i64>,
     #[serde(default = "default_requested_gpu")]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2814,7 +2814,10 @@ fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
     }
     // Reuse the shared negative-prompt + `advanced`-size guard. Music models (ACE-Step) can carry a
     // negative prompt when they advertise support; the size guard bounds it exactly like image/video.
-    validate_prompt_extras(payload.negative_prompt.as_deref().unwrap_or(""), &payload.advanced)?;
+    validate_prompt_extras(
+        payload.negative_prompt.as_deref().unwrap_or(""),
+        &payload.advanced,
+    )?;
     if let Some(target) = payload.target_duration_secs {
         if !target.is_finite() || !(0.0..=300.0).contains(&target) {
             return Err(ApiError::bad_request(
@@ -2853,7 +2856,7 @@ fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
     // advertised `audio.editModes` is the real gate the generator's `validate` applies — this only
     // rejects a garbage token up front). Region seconds must be finite and well-ordered; strength is a
     // 0..=1 weight.
-    validate_audio_edit_fields(&payload)?;
+    validate_audio_edit_fields(payload)?;
     // Diffusion-audio sampling knobs (Sound FX / MOSS-SoundEffect, sc-13409). Bounded to a blanket
     // sane range here — the same "API blanket vs. model's real cap" split the duration uses: the
     // generator's `validate` owns the per-model guidance range (MOSS: 1.0..=20.0) and step ceiling
@@ -2899,7 +2902,11 @@ fn validate_audio_edit_fields(payload: &AudioJobRequest) -> Result<(), ApiError>
             "an audio edit needs both sourceAudioAssetId and editMode (or neither)",
         ));
     }
-    if let Some(mode) = payload.edit_mode.as_deref().filter(|m| !m.trim().is_empty()) {
+    if let Some(mode) = payload
+        .edit_mode
+        .as_deref()
+        .filter(|m| !m.trim().is_empty())
+    {
         if !AUDIO_EDIT_MODES.contains(&mode) {
             return Err(ApiError::bad_request(format!(
                 "editMode must be one of {AUDIO_EDIT_MODES:?}"
@@ -2918,7 +2925,8 @@ fn validate_audio_edit_fields(payload: &AudioJobRequest) -> Result<(), ApiError>
             }
         }
     }
-    if let (Some(start), Some(end)) = (payload.edit_region_start_secs, payload.edit_region_end_secs) {
+    if let (Some(start), Some(end)) = (payload.edit_region_start_secs, payload.edit_region_end_secs)
+    {
         if end <= start {
             return Err(ApiError::bad_request(
                 "editRegionEndSecs must be greater than editRegionStartSecs",

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2907,7 +2907,11 @@ fn validate_audio_edit_fields(payload: &AudioJobRequest) -> Result<(), ApiError>
         .as_deref()
         .filter(|m| !m.trim().is_empty())
     {
-        if !AUDIO_EDIT_MODES.contains(&mode) {
+        // Match the worker's case handling (`edit_mode.map(|m| m.to_lowercase())` at deserialize,
+        // then `parse_audio_edit_mode`): the token is case-insensitive, so lowercase before the
+        // membership check. Otherwise a mixed-case value like "Extend" is 400'd here even though the
+        // worker would accept it — the two validation seams must agree.
+        if !AUDIO_EDIT_MODES.contains(&mode.to_lowercase().as_str()) {
             return Err(ApiError::bad_request(format!(
                 "editMode must be one of {AUDIO_EDIT_MODES:?}"
             )));

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2812,8 +2812,9 @@ fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
             "prompt must be between 1 and 4000 characters",
         ));
     }
-    // Reuse the shared `advanced`-size guard (audio carries no negative prompt, so pass an empty one).
-    validate_prompt_extras("", &payload.advanced)?;
+    // Reuse the shared negative-prompt + `advanced`-size guard. Music models (ACE-Step) can carry a
+    // negative prompt when they advertise support; the size guard bounds it exactly like image/video.
+    validate_prompt_extras(payload.negative_prompt.as_deref().unwrap_or(""), &payload.advanced)?;
     if let Some(target) = payload.target_duration_secs {
         if !target.is_finite() || !(0.0..=300.0).contains(&target) {
             return Err(ApiError::bad_request(
@@ -2821,6 +2822,38 @@ fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
             ));
         }
     }
+    // Music describe-the-music sub-block (ACE-Step, sc-13410). BPM must be a real positive tempo; the
+    // model's own `validate` re-checks it (finite & > 0), so this is a blanket sanity bound. key/lyrics
+    // are free-form — bound their length so a runaway payload can't slip past the prompt-size floor.
+    if let Some(bpm) = payload.bpm {
+        if !bpm.is_finite() || !(0.0..=1000.0).contains(&bpm) || bpm <= 0.0 {
+            return Err(ApiError::bad_request("bpm must be between 0 and 1000"));
+        }
+    }
+    if payload
+        .musical_key
+        .as_deref()
+        .is_some_and(|key| key.chars().count() > 64)
+    {
+        return Err(ApiError::bad_request(
+            "musicalKey must be at most 64 characters",
+        ));
+    }
+    if payload
+        .lyrics
+        .as_deref()
+        .is_some_and(|lyrics| lyrics.chars().count() > MAX_PROMPT_CHARS)
+    {
+        return Err(ApiError::bad_request(format!(
+            "lyrics must be at most {MAX_PROMPT_CHARS} characters"
+        )));
+    }
+    // Extend/edit source band (Conditioning::AudioEdit, sc-13410). Source id + edit mode are a pair: one
+    // without the other is a malformed edit request. The mode must be a known token (the model's
+    // advertised `audio.editModes` is the real gate the generator's `validate` applies — this only
+    // rejects a garbage token up front). Region seconds must be finite and well-ordered; strength is a
+    // 0..=1 weight.
+    validate_audio_edit_fields(&payload)?;
     // Diffusion-audio sampling knobs (Sound FX / MOSS-SoundEffect, sc-13409). Bounded to a blanket
     // sane range here — the same "API blanket vs. model's real cap" split the duration uses: the
     // generator's `validate` owns the per-model guidance range (MOSS: 1.0..=20.0) and step ceiling
@@ -2835,6 +2868,68 @@ fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
     if let Some(steps) = payload.steps {
         if !(1..=10_000).contains(&steps) {
             return Err(ApiError::bad_request("steps must be between 1 and 10000"));
+        }
+    }
+    Ok(())
+}
+
+/// The edit operations the audio route accepts up front (the union across audio models — each model's
+/// advertised `audio.editModes` is the real gate the generator's `validate` applies). Matches the
+/// [`gen_core::AudioEditMode`] variant set.
+const AUDIO_EDIT_MODES: &[&str] = &["inpaint", "repaint", "extend", "cover"];
+
+/// Sanity-bound the extend/edit source-band fields on an [`AudioJobRequest`] (Conditioning::AudioEdit,
+/// sc-13410). This is the API blanket floor: the source id + edit mode must be a well-formed pair, the
+/// mode a known token, the region seconds finite/ordered, and the strength a 0..=1 weight. The
+/// per-model gates (mode ∈ advertised `audio.editModes`, region inside the clip, 48 kHz source) belong
+/// to the worker/provider, which knows the model surface and the loaded clip.
+fn validate_audio_edit_fields(payload: &AudioJobRequest) -> Result<(), ApiError> {
+    let has_source = payload
+        .source_audio_asset_id
+        .as_deref()
+        .is_some_and(|id| !id.trim().is_empty());
+    let has_mode = payload
+        .edit_mode
+        .as_deref()
+        .is_some_and(|mode| !mode.trim().is_empty());
+    // A source without a mode (or vice versa) is a malformed edit request — one names WHAT to edit, the
+    // other HOW. Reject the half-specified pair rather than silently dropping the edit.
+    if has_source != has_mode {
+        return Err(ApiError::bad_request(
+            "an audio edit needs both sourceAudioAssetId and editMode (or neither)",
+        ));
+    }
+    if let Some(mode) = payload.edit_mode.as_deref().filter(|m| !m.trim().is_empty()) {
+        if !AUDIO_EDIT_MODES.contains(&mode) {
+            return Err(ApiError::bad_request(format!(
+                "editMode must be one of {AUDIO_EDIT_MODES:?}"
+            )));
+        }
+    }
+    for (field, value) in [
+        ("editRegionStartSecs", payload.edit_region_start_secs),
+        ("editRegionEndSecs", payload.edit_region_end_secs),
+    ] {
+        if let Some(secs) = value {
+            if !secs.is_finite() || !(0.0..=3600.0).contains(&secs) {
+                return Err(ApiError::bad_request(format!(
+                    "{field} must be between 0 and 3600"
+                )));
+            }
+        }
+    }
+    if let (Some(start), Some(end)) = (payload.edit_region_start_secs, payload.edit_region_end_secs) {
+        if end <= start {
+            return Err(ApiError::bad_request(
+                "editRegionEndSecs must be greater than editRegionStartSecs",
+            ));
+        }
+    }
+    if let Some(strength) = payload.edit_strength {
+        if !strength.is_finite() || !(0.0..=1.0).contains(&strength) {
+            return Err(ApiError::bad_request(
+                "editStrength must be between 0 and 1",
+            ));
         }
     }
     Ok(())

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -648,6 +648,62 @@ async fn create_audio_job_rejects_nonsense_music_fields() {
         .is_some_and(|d| d.contains("editRegionEndSecs")));
 }
 
+/// The editMode token is case-insensitive at the API, matching the worker's own case handling
+/// (`edit_mode.map(|m| m.to_lowercase())` at deserialize, then `parse_audio_edit_mode`). A mixed-case
+/// KNOWN token (`"Extend"`) is accepted and forwarded verbatim (the worker lowercases it), while a
+/// mixed-case UNKNOWN token (`"Morph"`) is still rejected — lowercasing widens casing, not the mode
+/// set (sc-13410, worker-parity fix).
+#[tokio::test]
+async fn create_audio_job_accepts_case_insensitive_edit_mode() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Music Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // A mixed-case KNOWN token is accepted (parity with the worker) and forwarded verbatim.
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "acestep_v15_turbo",
+            "prompt": "gentle lofi piano loop",
+            "sourceAudioAssetId": "audio-src-1",
+            "editMode": "Extend",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job}");
+    assert_eq!(job["payload"]["editMode"], "Extend");
+
+    // A mixed-case UNKNOWN token is still rejected — casing widened, the mode set did not.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "acestep_v15_turbo",
+            "prompt": "loop",
+            "sourceAudioAssetId": "audio-src-1",
+            "editMode": "Morph",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|d| d.contains("editMode")));
+}
+
 /// The audio route is a door for `type: audio` models only: an image/video model posted here is
 /// rejected up front rather than failing deep in the worker's audio lane (sc-13404).
 #[tokio::test]

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -286,6 +286,24 @@ fn write_audio_manifest(config_dir: &std::path::Path) {
               "ui": { "label": "MOSS SoundEffect v2" }
             },
             {
+              "id": "acestep_v15_turbo",
+              "name": "ACE-Step v1.5 XL Turbo (Music)",
+              "family": "acestep",
+              "type": "audio",
+              "audio": {
+                "languages": ["en", "zh"],
+                "sampleRates": [48000],
+                "maxDurationSecs": 600,
+                "editModes": ["inpaint", "repaint", "extend"],
+                "conditioning": ["AudioEdit"]
+              },
+              "downloads": [
+                { "provider": "huggingface", "repo": "ACE-Step/acestep-v15-xl-turbo-diffusers", "files": ["model_index.json"] }
+              ],
+              "paths": { "model": "${HF_CACHE}/ACE-Step/acestep-v15-xl-turbo-diffusers" },
+              "ui": { "label": "ACE-Step v1.5 XL Turbo" }
+            },
+            {
               "id": "not-audio-img",
               "name": "Not Audio",
               "family": "z_image",
@@ -453,6 +471,181 @@ async fn create_audio_job_rejects_nonsense_sampling_knobs() {
     assert!(body["detail"]
         .as_str()
         .is_some_and(|detail| detail.contains("steps")));
+}
+
+/// The Music path (ACE-Step, sc-13410): a well-formed music `POST /api/v1/audio/jobs` carries the
+/// describe-the-music sub-block (bpm / musicalKey / lyrics) + steps AND the extend/edit source band
+/// (sourceAudioAssetId / editMode / editRegion* / editStrength) through to the worker payload verbatim,
+/// alongside the resolved ACE-Step `type: audio` manifest entry — so the worker maps them onto
+/// AudioParams + a Conditioning::AudioEdit.
+#[tokio::test]
+async fn create_audio_job_maps_music_and_edit_fields() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Music Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "acestep_v15_turbo",
+            "prompt": "gentle lofi piano loop",
+            "language": "en",
+            "targetDurationSecs": 8.0,
+            "steps": 8,
+            "bpm": 92.0,
+            "musicalKey": "C minor",
+            "lyrics": "[verse] la la la",
+            "sourceAudioAssetId": "audio-src-1",
+            "editMode": "extend",
+            "editRegionEndSecs": 20.0,
+            "editStrength": 0.5,
+            "seed": 5,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job}");
+    assert_eq!(job["type"], "audio_generate");
+    let payload = &job["payload"];
+    assert_eq!(payload["model"], "acestep_v15_turbo");
+    // Describe-the-music sub-block (rides AudioParams music fields).
+    assert_eq!(payload["bpm"], 92.0);
+    assert_eq!(payload["musicalKey"], "C minor");
+    assert_eq!(payload["lyrics"], "[verse] la la la");
+    assert_eq!(payload["steps"], 8);
+    // Extend/edit source band (rides a Conditioning::AudioEdit).
+    assert_eq!(payload["sourceAudioAssetId"], "audio-src-1");
+    assert_eq!(payload["editMode"], "extend");
+    assert_eq!(payload["editRegionEndSecs"], 20.0);
+    assert_eq!(payload["editStrength"], 0.5);
+    let entry = &payload["modelManifestEntry"];
+    assert_eq!(entry["id"], "acestep_v15_turbo");
+    assert_eq!(entry["type"], "audio");
+    assert_eq!(
+        entry["downloads"][0]["repo"],
+        "ACE-Step/acestep-v15-xl-turbo-diffusers"
+    );
+}
+
+/// A half-specified edit (a source track without an edit mode, or vice versa) is malformed — one names
+/// WHAT to edit, the other HOW — so the validator rejects it up front rather than silently dropping the
+/// edit (sc-13410).
+#[tokio::test]
+async fn create_audio_job_rejects_half_specified_edit() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Music Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "acestep_v15_turbo",
+            "prompt": "gentle lofi piano loop",
+            // A source with no editMode → rejected as a malformed pair.
+            "sourceAudioAssetId": "audio-src-1",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("editMode")));
+}
+
+/// The Music validator sanity-bounds the describe-the-music + edit fields up front (sc-13410): a
+/// non-positive BPM, an unknown edit mode, and a mis-ordered region are all 400s before the job is
+/// enqueued (the per-model gate — mode ∈ advertised editModes, region inside the clip — is the
+/// generator's own `validate`).
+#[tokio::test]
+async fn create_audio_job_rejects_nonsense_music_fields() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Music Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    // A non-positive BPM is rejected.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "acestep_v15_turbo",
+            "prompt": "loop",
+            "bpm": 0.0,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"].as_str().is_some_and(|d| d.contains("bpm")));
+
+    // An unknown edit mode token is rejected up front.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "acestep_v15_turbo",
+            "prompt": "loop",
+            "sourceAudioAssetId": "audio-src-1",
+            "editMode": "morph",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|d| d.contains("editMode")));
+
+    // A region whose end is at/below its start is rejected.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "acestep_v15_turbo",
+            "prompt": "loop",
+            "sourceAudioAssetId": "audio-src-1",
+            "editMode": "inpaint",
+            "editRegionStartSecs": 5.0,
+            "editRegionEndSecs": 2.0,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|d| d.contains("editRegionEndSecs")));
 }
 
 /// The audio route is a door for `type: audio` models only: an image/video model posted here is

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -13,6 +13,7 @@ import {
 } from "../modelEligibility.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { jobAudioResultAssets } from "../jobResultAssets.js";
+import { AssetPickerField } from "../components/AssetPicker.jsx";
 
 // SceneWorks Audio Studio — the navigable shell (epic 13400, C0 / sc-13407). This screen mirrors
 // the canonical studio shell (VideoStudio.jsx): page-frame > WorkPanel + .mode-tabs + AdvancedSection
@@ -25,15 +26,21 @@ import { jobAudioResultAssets } from "../jobResultAssets.js";
 // mode (Speech = ships a voice bank, Music = advertises edit ops, Voice Clone = reference/embedding
 // conditioning, Sound FX = residual text→audio generator).
 //
-// SCOPE (C1 sc-13408 + C2 sc-13409): Speech (TTS) and Sound FX are both fully wired — the Generate CTA
-// submits the prompt + capability-driven knobs through createAudioJob → rememberLocalGenerationJob(
-// 'audio', job), surfacing the run in the audioLocalJobs stack below via the shared audio-player card
-// (A5, sc-13405). Speech carries voice/language/length/seed; Sound FX (MOSS-SoundEffect v2) carries the
-// prompt + length/language + the diffusion sampling knobs guidance(CFG)/steps/seed — MOSS advertises no
-// voice surface, so none is sent (the shared gen-core floor would reject an explicit voice). The
-// remaining modes (C3 Music, C4 Voice Clone) keep the C0 scaffold: their fields render capability-driven,
-// but submit stays inert until their stories land (the Generate CTA is disabled off a wired tab rather
-// than being a silent no-op).
+// SCOPE (C1 sc-13408 + C2 sc-13409 + C3 sc-13410): Speech (TTS), Sound FX and Music are fully wired —
+// the Generate CTA submits the prompt + capability-driven knobs through createAudioJob →
+// rememberLocalGenerationJob('audio', job), surfacing the run in the audioLocalJobs stack below via the
+// shared audio-player card (A5, sc-13405). Speech carries voice/language/length/seed; Sound FX
+// (MOSS-SoundEffect v2) carries the prompt + length/language + the diffusion sampling knobs
+// guidance(CFG)/steps/seed. Music (ACE-Step v1.5 XL Turbo) carries the describe-the-music prompt +
+// length/language + BPM/key/lyrics (the gen-core AudioParams music sub-block) + steps/seed, and — ONLY
+// when the selected model advertises audio.editModes — an extend/inpaint/repaint SOURCE band that picks a
+// library audio track + edit mode and rides through as a Conditioning::AudioEdit (mirroring the Video
+// Studio source-band pattern). guidance(CFG)/negative are capability-gated: the pinned ACE-Step turbo is
+// guidance-distilled (advertises neither), so they stay hidden for it — surfacing them would be a typed
+// Unsupported at the gen-core floor; a future non-distilled music model that advertises them shows them.
+// The remaining mode (C4 Voice Clone) keeps the C0 scaffold: its fields render capability-driven, but
+// submit stays inert until its story lands (the Generate CTA is disabled off a wired tab rather than
+// being a silent no-op).
 
 // Tab labels per the epic, keyed by the AUDIO_MODES ids so the ordering follows that array.
 const MODE_LABELS = {
@@ -54,10 +61,11 @@ const MODE_PLACEHOLDER = {
 // Modes that emit a fixed-length waveform, so a length control (clamped to the model's
 // audio.maxDurationSecs) applies. Voice Clone follows its reference clip's length.
 const DURATION_MODES = new Set(["speech", "sfx", "music"]);
-// Modes whose Generate CTA is fully wired to createAudioJob (Speech C1 sc-13408, Sound FX C2 sc-13409).
-// The remaining modes keep the C0 scaffold — their CTA stays disabled rather than a silent no-op — until
-// their own stories land, so this set is the single guard both `canGenerate` and `submit` read.
-const WIRED_MODES = new Set(["speech", "sfx"]);
+// Modes whose Generate CTA is fully wired to createAudioJob (Speech C1 sc-13408, Sound FX C2 sc-13409,
+// Music C3 sc-13410). The remaining mode (Voice Clone) keeps the C0 scaffold — its CTA stays disabled
+// rather than a silent no-op — until its own story lands, so this set is the single guard both
+// `canGenerate` and `submit` read.
+const WIRED_MODES = new Set(["speech", "sfx", "music"]);
 // Modes that expose the diffusion sampling knobs (CFG guidance + solver steps) in the advanced panel.
 // Sound FX runs the MOSS-SoundEffect flow-matching pipeline, which reads guidance/steps off the
 // top-level request; Speech (Kokoro) is not a diffusion model and ignores them, so it hides them. This
@@ -141,10 +149,26 @@ export function AudioStudio() {
     saved.targetDurationSecs ?? DEFAULT_TARGET_DURATION_SECS,
   );
   const [seed, setSeed] = useState(saved.seed ?? "");
-  // Sound FX (MOSS-SoundEffect) diffusion sampling knobs — the CFG guidance scale and the solver step
-  // count. Empty ⇒ the model's own default (MOSS: CFG 4.0 / 100 steps), matching the advanced hint.
+  // Sound FX (MOSS-SoundEffect) + Music (ACE-Step) diffusion sampling knobs — the CFG guidance scale and
+  // the solver step count. Empty ⇒ the model's own default (MOSS: CFG 4.0 / 100 steps; ACE-Step turbo:
+  // 8 steps, guidance baked in), matching the advanced hint.
   const [guidance, setGuidance] = useState(saved.guidance ?? "");
   const [steps, setSteps] = useState(saved.steps ?? "");
+  // Music (ACE-Step) describe-the-music sub-block — the gen-core AudioParams music fields. BPM + key are
+  // optional metadata; lyrics is free-form (empty ⇒ instrumental). Cleared ⇒ omitted so the model derives
+  // its own. Negative is capability-gated (hidden for the guidance-distilled turbo).
+  const [bpm, setBpm] = useState(saved.bpm ?? "");
+  const [musicalKey, setMusicalKey] = useState(saved.musicalKey ?? "");
+  const [lyrics, setLyrics] = useState(saved.lyrics ?? "");
+  const [negativePrompt, setNegativePrompt] = useState(saved.negativePrompt ?? "");
+  // Music extend/edit SOURCE band (Conditioning::AudioEdit) — a USER selection, so it persists like the
+  // Video Studio source band. `sourceAudioAssetId` names a library audio track; `editMode` (inpaint /
+  // repaint / extend) comes from the model's advertised audio.editModes. Region seconds bound an
+  // inpaint/repaint window; extend reuses the Length field as the new total. Strength is optional.
+  const [sourceAudioAssetId, setSourceAudioAssetId] = useState(saved.sourceAudioAssetId ?? "");
+  const [editRegionStartSecs, setEditRegionStartSecs] = useState(saved.editRegionStartSecs ?? "");
+  const [editRegionEndSecs, setEditRegionEndSecs] = useState(saved.editRegionEndSecs ?? "");
+  const [editStrength, setEditStrength] = useState(saved.editStrength ?? "");
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   // Guards a Speech run in flight so a second submit (double-click / ⌘↵) can't double-enqueue
   // (mirrors VideoStudio's `submitting`). Cleared in submit's finally.
@@ -185,16 +209,36 @@ export function AudioStudio() {
   const showVoice = mode === "speech" && voices.length > 0;
   const showLanguage = DURATION_MODES.has(mode) && languages.length > 0;
   const showDuration = DURATION_MODES.has(mode) && maxDurationSecs != null;
+  // Music describe-the-music sub-block fields — surfaced on the Music tab. BPM/key/lyrics ride the
+  // gen-core AudioParams music sub-block ACE-Step reads; they are optional, so they render whenever the
+  // Music tab is active (a music model that ignored one would simply not consume it).
+  const showMusicFields = mode === "music";
+  // The extend/edit SOURCE band is revealed ONLY when the selected model advertises audio.editModes —
+  // exactly the capability that makes a model a Music model (modelEligibility.audioHasEditModes). ACE-Step
+  // advertises inpaint/repaint/extend; a model without editModes never shows it. Mirrors VideoStudio's
+  // `studio-source-band`, which reveals its source-clip picker only on the edit sub-modes.
   const showEditModes = mode === "music" && editModes.length > 0;
   const showConditioning = mode === "voiceclone" && conditioning.length > 0;
-  // The CFG guidance + steps advanced knobs surface only on the diffusion-audio (Sound FX) modes the
-  // selected model actually runs through a sampler — the model's `supports_guidance` surface. See
-  // SAMPLING_KNOB_MODES for why this is mode-gated today.
-  const showSamplingKnobs = SAMPLING_KNOB_MODES.has(mode);
+  // Steps: both the Sound FX (MOSS) and Music (ACE-Step) diffusion samplers read the top-level
+  // `steps`, so the solver-step count surfaces on both. Guidance(CFG): only when the model advertises
+  // guidance support — MOSS does (SAMPLING_KNOB_MODES), the guidance-distilled ACE-Step turbo does NOT
+  // (audio.supportsGuidance falsy), so it stays hidden rather than being sent and rejected as a typed
+  // Unsupported at the gen-core floor. Negative prompt is capability-gated the same way. See
+  // SAMPLING_KNOB_MODES for why SFX is mode-gated while Music reads the manifest capability flags.
+  const musicSupportsGuidance = mode === "music" && Boolean(audio.supportsGuidance);
+  const musicSupportsNegative = mode === "music" && Boolean(audio.supportsNegativePrompt);
+  const showSteps = SAMPLING_KNOB_MODES.has(mode) || mode === "music";
+  const showGuidance = SAMPLING_KNOB_MODES.has(mode) || musicSupportsGuidance;
+  const showNegative = musicSupportsNegative;
 
   // The voice picker's <optgroup> structure — derived from the selected model's voice bank, grouped
   // by accent + gender (sc-13408). Rebuilt only when the bank changes.
   const voiceGroups = useMemo(() => groupVoicesByGenderAccent(voices), [voices]);
+
+  // Library audio tracks the Music extend/edit source band can pick from — the audio twin of
+  // VideoStudio's `videoAssets` (type-scoped so the picker only offers real audio; the picker itself
+  // runs with categories hidden since its `all/image/video` tabs carry no audio bucket).
+  const audioAssets = useMemo(() => assets.filter((asset) => asset?.type === "audio"), [assets]);
 
   // Generate is guarded (never a silent no-op): a run needs a wired mode, a non-empty prompt, an
   // installed model, and no run already in flight. The empty-prompt guard is the DoD's "disable on
@@ -258,6 +302,14 @@ export function AudioStudio() {
       seed,
       guidance,
       steps,
+      bpm,
+      musicalKey,
+      lyrics,
+      negativePrompt,
+      sourceAudioAssetId,
+      editRegionStartSecs,
+      editRegionEndSecs,
+      editStrength,
       advancedOpen,
     },
     audioModels.length > 0,
@@ -320,6 +372,41 @@ export function AudioStudio() {
         // `voice` is sent — MOSS advertises no voice surface and the floor rejects one.
         payload.guidance = guidance === "" ? undefined : Number(guidance);
         payload.steps = steps === "" ? undefined : Number(steps);
+      } else if (mode === "music") {
+        // Music (ACE-Step) — the describe-the-music sub-block. BPM/key/lyrics ride the gen-core
+        // AudioParams music fields; steps rides the top-level request (the turbo's 8-step sampler).
+        // Cleared ⇒ omitted so the model derives its own. guidance/negative are sent ONLY when the model
+        // advertises support (the guidance-distilled turbo advertises neither, so they are never sent —
+        // the shared floor would reject them as typed Unsupported).
+        payload.bpm = bpm === "" ? undefined : Number(bpm);
+        payload.musicalKey = musicalKey.trim() || undefined;
+        payload.lyrics = lyrics.trim() || undefined;
+        payload.steps = steps === "" ? undefined : Number(steps);
+        if (musicSupportsGuidance) {
+          payload.guidance = guidance === "" ? undefined : Number(guidance);
+        }
+        if (musicSupportsNegative) {
+          payload.negativePrompt = negativePrompt.trim() || undefined;
+        }
+        // Extend/edit SOURCE band → Conditioning::AudioEdit. Only when the user has both picked a source
+        // track AND chosen an edit mode the model advertises; otherwise this is plain text-to-music.
+        if (showEditModes && sourceAudioAssetId && editMode) {
+          payload.sourceAudioAssetId = sourceAudioAssetId;
+          payload.editMode = editMode;
+          if (editMode === "extend") {
+            // Extend: the appended tail's new TOTAL length is the Length field; the worker defaults the
+            // region start to the source clip's own length (where generation begins).
+            payload.editRegionEndSecs = clampedDuration;
+          } else {
+            // Inpaint / repaint: a bounded interior window (seconds). Cleared bounds are omitted so the
+            // worker/provider apply their own defaults (end unset ⇒ to the clip end).
+            payload.editRegionStartSecs =
+              editRegionStartSecs === "" ? undefined : Number(editRegionStartSecs);
+            payload.editRegionEndSecs =
+              editRegionEndSecs === "" ? undefined : Number(editRegionEndSecs);
+          }
+          payload.editStrength = editStrength === "" ? undefined : Number(editStrength);
+        }
       }
       const job = await createAudioJob?.(payload);
       if (job) {
@@ -472,25 +559,110 @@ export function AudioStudio() {
                     />
                   </label>
                 ) : null}
+
+                {/* Music: optional tempo (BPM) + musical key. Both ride the gen-core AudioParams music
+                    sub-block ACE-Step reads; cleared ⇒ omitted so the model derives its own. */}
+                {showMusicFields ? (
+                  <label className="settings-field settings-field-bpm">
+                    BPM
+                    <input
+                      min="1"
+                      onChange={(event) => setBpm(event.target.value)}
+                      placeholder="Optional"
+                      step="1"
+                      type="number"
+                      value={bpm}
+                    />
+                  </label>
+                ) : null}
+
+                {showMusicFields ? (
+                  <label className="settings-field settings-field-key">
+                    Key
+                    <input
+                      onChange={(event) => setMusicalKey(event.target.value)}
+                      placeholder="e.g. C minor"
+                      type="text"
+                      value={musicalKey}
+                    />
+                  </label>
+                ) : null}
               </div>
 
-              {/* Music editing ops the model advertises (audio.editModes) — capability-driven scaffold
-                  the C3 story builds on. */}
+              {/* Music: optional lyrics (free-form; empty ⇒ instrumental). Rides the AudioParams
+                  `lyrics` field, distinct from the describe-the-music prompt. */}
+              {showMusicFields ? (
+                <label className="settings-field settings-field-lyrics">
+                  Lyrics
+                  <textarea
+                    aria-label="Lyrics"
+                    onChange={(event) => setLyrics(event.target.value)}
+                    placeholder="Optional — [verse] / [chorus] tags supported; leave empty for instrumental"
+                    value={lyrics}
+                  />
+                </label>
+              ) : null}
+
+              {/* Music extend/edit SOURCE band (sc-13410) — revealed ONLY when the selected model
+                  advertises audio.editModes (Conditioning::AudioEdit). Mirrors VideoStudio's
+                  `studio-source-band`: pick a library audio track + an edit mode the model advertises,
+                  then (for a bounded inpaint/repaint) a region window. Extend reuses the Length field as
+                  the new total length. Empty source ⇒ plain text-to-music (the band is optional). */}
               {showEditModes ? (
-                <div className="settings-bar-styles">
-                  <span className="settings-bar-label">Edit</span>
-                  <div className="preset-chips">
-                    {editModes.map((value) => (
-                      <button
-                        className={editMode === value ? "preset-chip active" : "preset-chip"}
-                        key={value}
-                        onClick={() => setEditMode(value)}
-                        type="button"
-                      >
-                        {value}
-                      </button>
-                    ))}
+                <div className="studio-source-band">
+                  <AssetPickerField
+                    assets={audioAssets}
+                    buttonLabel="Select audio"
+                    changeLabel="Change"
+                    emptyLabel="No source track selected"
+                    label="Source track (extend / edit)"
+                    onChange={setSourceAudioAssetId}
+                    showCategories={false}
+                    value={sourceAudioAssetId}
+                  />
+                  <div className="settings-bar-styles">
+                    <span className="settings-bar-label">Edit</span>
+                    <div className="preset-chips">
+                      {editModes.map((value) => (
+                        <button
+                          className={editMode === value ? "preset-chip active" : "preset-chip"}
+                          key={value}
+                          onClick={() => setEditMode(value)}
+                          type="button"
+                        >
+                          {value}
+                        </button>
+                      ))}
+                    </div>
                   </div>
+                  {/* Inpaint / repaint bound a region (seconds) inside the source clip. Extend needs no
+                      region here — its new total length is the Length field, and the worker begins the
+                      appended tail at the source clip's own length. */}
+                  {sourceAudioAssetId && (editMode === "inpaint" || editMode === "repaint") ? (
+                    <div className="settings-bar-row">
+                      <label className="settings-field settings-field-region-start">
+                        Region start (s)
+                        <input
+                          min="0"
+                          onChange={(event) => setEditRegionStartSecs(event.target.value)}
+                          step="0.1"
+                          type="number"
+                          value={editRegionStartSecs}
+                        />
+                      </label>
+                      <label className="settings-field settings-field-region-end">
+                        Region end (s)
+                        <input
+                          min="0"
+                          onChange={(event) => setEditRegionEndSecs(event.target.value)}
+                          placeholder="To clip end"
+                          step="0.1"
+                          type="number"
+                          value={editRegionEndSecs}
+                        />
+                      </label>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </div>
@@ -519,11 +691,13 @@ export function AudioStudio() {
                     value={seed}
                   />
                 </label>
-                {/* Sound FX diffusion sampling knobs (MOSS-SoundEffect). Guidance is the CFG scale and
-                    Steps is the solver step count — both ride the top-level request the flow-matching
-                    pipeline reads. Cleared ⇒ the model's own default; the gen-core floor range-checks
-                    any value sent, so no hardcoded ceiling is baked into the input. */}
-                {showSamplingKnobs ? (
+                {/* Diffusion sampling knobs. Steps (the solver step count) rides the top-level request
+                    both the Sound FX (MOSS) and Music (ACE-Step) samplers read. Guidance (the CFG scale)
+                    surfaces only when the model advertises guidance support — MOSS does; the
+                    guidance-distilled ACE-Step turbo does NOT, so it stays hidden rather than sent (the
+                    gen-core floor would reject it). Cleared ⇒ the model's own default; the floor
+                    range-checks any value sent, so no hardcoded ceiling is baked into the input. */}
+                {showGuidance ? (
                   <label>
                     Guidance (CFG)
                     <input
@@ -536,7 +710,7 @@ export function AudioStudio() {
                     />
                   </label>
                 ) : null}
-                {showSamplingKnobs ? (
+                {showSteps ? (
                   <label>
                     Steps
                     <input
@@ -546,6 +720,21 @@ export function AudioStudio() {
                       step="1"
                       type="number"
                       value={steps}
+                    />
+                  </label>
+                ) : null}
+                {/* Negative prompt — the traits to steer away from. Capability-gated: surfaced only when
+                    the model advertises negative-prompt support (audio.supportsNegativePrompt). The
+                    guidance-distilled ACE-Step turbo advertises none, so it stays hidden; a music model
+                    that supports it renders this and rides it through as GenerationRequest.negative_prompt. */}
+                {showNegative ? (
+                  <label>
+                    Negative prompt
+                    <textarea
+                      aria-label="Negative prompt"
+                      onChange={(event) => setNegativePrompt(event.target.value)}
+                      placeholder="Traits to avoid"
+                      value={negativePrompt}
                     />
                   </label>
                 ) : null}

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -663,6 +663,23 @@ export function AudioStudio() {
                       </label>
                     </div>
                   ) : null}
+                  {/* Edit strength (0..=1) — an optional weight on the whole AudioEdit, part of the
+                      Conditioning::AudioEdit contract. Cleared ⇒ the model default; a model that ignores
+                      it (the ACE-Step turbo) simply falls back to its own behaviour. */}
+                  {sourceAudioAssetId ? (
+                    <label className="settings-field settings-field-edit-strength">
+                      Edit strength
+                      <input
+                        max="1"
+                        min="0"
+                        onChange={(event) => setEditStrength(event.target.value)}
+                        placeholder="Model default"
+                        step="0.05"
+                        type="number"
+                        value={editStrength}
+                      />
+                    </label>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -438,15 +438,15 @@ describe("AudioStudio Speech generation (sc-13408)", () => {
     expect(results.textContent).not.toContain("No audio yet");
   });
 
-  it("does not submit on a still-scaffold tab (Music / Voice Clone stay inert)", async () => {
+  it("does not submit on a still-scaffold tab (Voice Clone stays inert)", async () => {
     const createAudioJob = vi.fn(async () => ({ id: "nope" }));
     await render(
       baseContext({ createAudioJob, rememberLocalGenerationJob: vi.fn() }),
     );
-    // Music is served only by ACE-Step in the base fixture; switch to it, type a script. (Speech and
-    // Sound FX are wired — C1/C2 — so Music/Voice Clone are the remaining scaffold tabs.)
-    await click(modeTab(container, "Music"));
-    await setTextarea(container.querySelector(".prompt-input"), "some music");
+    // Voice Clone is served only by OpenVoice in the base fixture; switch to it, type a script. (Speech,
+    // Sound FX and Music are wired — C1/C2/C3 — so Voice Clone is the remaining scaffold tab.)
+    await click(modeTab(container, "Voice Clone"));
+    await setTextarea(container.querySelector(".prompt-input"), "reference this voice");
     // The CTA is disabled off a wired tab, and a direct form submit is a no-op there.
     expect(generateButton(container).disabled).toBe(true);
     await act(async () => {
@@ -611,6 +611,270 @@ describe("AudioStudio Sound FX generation (sc-13409)", () => {
     await submitForm();
     // MOSS advertises maxDurationSecs 30 — the submit clamps to it, never a hardcoded ceiling.
     expect(createAudioJob.mock.calls[0][0].targetDurationSecs).toBe(30);
+  });
+});
+
+// A music model that (unlike the guidance-distilled ACE-Step turbo) DOES advertise CFG guidance +
+// negative-prompt support — proves the advanced music knobs are capability-gated off the manifest
+// flags, not hardcoded to the mode.
+const MUSIC_WITH_GUIDANCE = {
+  id: "music_guided",
+  name: "Guided Music",
+  type: "audio",
+  audio: {
+    languages: ["en"],
+    sampleRates: [48000],
+    maxDurationSecs: 120,
+    editModes: ["inpaint", "repaint", "extend"],
+    conditioning: ["AudioEdit"],
+    supportsGuidance: true,
+    supportsNegativePrompt: true,
+  },
+  ui: { label: "Guided Music" },
+};
+
+describe("AudioStudio Music generation (sc-13410)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <AudioStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const generateButton = (root) => buttonWithText(root, "Generate");
+  const advancedFieldByLabel = (root, label) =>
+    [...root.querySelectorAll(".advanced-panel label")].find((el) =>
+      el.textContent.trim().startsWith(label),
+    );
+  const setTextarea = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const setNumber = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const setText = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const submitForm = async () => {
+    await act(async () => {
+      container
+        .querySelector("form")
+        .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+    });
+  };
+
+  it("switching to Music snaps to ACE-Step and reveals the describe-the-music fields + source band", async () => {
+    await render(baseContext({ createAudioJob: vi.fn() }));
+    await click(modeTab(container, "Music"));
+    expect(modelSelect(container).value).toBe("acestep_v15_turbo");
+
+    // The optional describe-the-music sub-block (BPM / key / lyrics) is present.
+    expect(container.querySelector(".settings-field-bpm input")).toBeTruthy();
+    expect(container.querySelector(".settings-field-key input")).toBeTruthy();
+    expect(container.querySelector(".settings-field-lyrics textarea")).toBeTruthy();
+
+    // The extend/edit source band is revealed (ACE-Step advertises editModes) with the three
+    // advertised edit ops — capability-driven, never a hardcoded taxonomy.
+    const band = container.querySelector(".studio-source-band");
+    expect(band).toBeTruthy();
+    expect(band.textContent).toContain("Source track");
+    const editChips = [...band.querySelectorAll(".preset-chip")].map((b) => b.textContent.trim());
+    expect(editChips).toEqual(["inpaint", "repaint", "extend"]);
+  });
+
+  it("hides the music fields + source band on Speech / Sound FX (no editModes advertised)", async () => {
+    await render(baseContext({ createAudioJob: vi.fn() }));
+    // Speech (Kokoro): no music sub-block, no source band.
+    expect(container.querySelector(".settings-field-bpm input")).toBeNull();
+    expect(container.querySelector(".studio-source-band")).toBeNull();
+    // Sound FX (MOSS): still no editModes, so no source band.
+    await click(modeTab(container, "Sound FX"));
+    expect(container.querySelector(".settings-field-bpm input")).toBeNull();
+    expect(container.querySelector(".studio-source-band")).toBeNull();
+  });
+
+  it("submitting Music maps the describe-the-music payload and omits guidance/negative for the distilled turbo", async () => {
+    const job = { id: "music-job-1", type: "audio_generate", status: "queued" };
+    const createAudioJob = vi.fn(async () => job);
+    const rememberLocalGenerationJob = vi.fn();
+    await render(baseContext({ createAudioJob, rememberLocalGenerationJob }));
+
+    await click(modeTab(container, "Music"));
+    await setTextarea(container.querySelector(".prompt-input"), "gentle lofi piano loop");
+    // Non-default values so the assertions discriminate (a hardcoded payload would not follow them).
+    await setNumber(container.querySelector(".settings-field-bpm input"), "92");
+    await setText(container.querySelector(".settings-field-key input"), "C minor");
+    await setTextarea(container.querySelector(".settings-field-lyrics textarea"), "[verse] la la la");
+    await setNumber(fieldByLabelStart(container, "Length").querySelector("input"), "8");
+    await click(container.querySelector(".advanced-section-toggle"));
+    await setNumber(advancedFieldByLabel(container, "Seed").querySelector("input"), "77");
+    await setNumber(advancedFieldByLabel(container, "Steps").querySelector("input"), "8");
+
+    await submitForm();
+
+    expect(createAudioJob).toHaveBeenCalledTimes(1);
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.model).toBe("acestep_v15_turbo");
+    expect(payload.prompt).toBe("gentle lofi piano loop");
+    expect(payload.bpm).toBe(92);
+    expect(payload.musicalKey).toBe("C minor");
+    expect(payload.lyrics).toBe("[verse] la la la");
+    expect(payload.targetDurationSecs).toBe(8);
+    expect(payload.steps).toBe(8);
+    expect(payload.seed).toBe(77);
+    // The guidance-distilled ACE-Step turbo advertises neither guidance nor negative-prompt support,
+    // so the studio never sends them (the gen-core floor would reject them as typed Unsupported).
+    expect(payload.guidance).toBeUndefined();
+    expect(payload.negativePrompt).toBeUndefined();
+    // Music carries no voice, and no source band was picked → plain text-to-music.
+    expect(payload.voice).toBeUndefined();
+    expect(payload.sourceAudioAssetId).toBeUndefined();
+    expect(payload.editMode).toBeUndefined();
+    expect(rememberLocalGenerationJob).toHaveBeenCalledWith("audio", job);
+  });
+
+  it("hides guidance + negative-prompt for ACE-Step but shows steps (capability-gated)", async () => {
+    await render(baseContext({ createAudioJob: vi.fn() }));
+    await click(modeTab(container, "Music"));
+    await click(container.querySelector(".advanced-section-toggle"));
+    // ACE-Step reads the top-level `steps`, so the solver-step count surfaces...
+    expect(advancedFieldByLabel(container, "Steps")).toBeTruthy();
+    // ...but the distilled turbo advertises no guidance / negative-prompt support, so neither shows.
+    expect(advancedFieldByLabel(container, "Guidance")).toBeFalsy();
+    expect(advancedFieldByLabel(container, "Negative prompt")).toBeFalsy();
+  });
+
+  it("shows AND sends guidance + negative for a music model that advertises them (not hardcoded)", async () => {
+    const createAudioJob = vi.fn(async () => ({ id: "guided-1" }));
+    await render(
+      baseContext({
+        audioModels: [MUSIC_WITH_GUIDANCE],
+        models: [MUSIC_WITH_GUIDANCE],
+        createAudioJob,
+        rememberLocalGenerationJob: vi.fn(),
+      }),
+    );
+    await click(modeTab(container, "Music"));
+    await setTextarea(container.querySelector(".prompt-input"), "orchestral swell");
+    await click(container.querySelector(".advanced-section-toggle"));
+    // This model advertises both — so the knobs are present (capability-gated off the manifest flags).
+    expect(advancedFieldByLabel(container, "Guidance")).toBeTruthy();
+    expect(advancedFieldByLabel(container, "Negative prompt")).toBeTruthy();
+    await setNumber(advancedFieldByLabel(container, "Guidance").querySelector("input"), "4.5");
+    await setTextarea(
+      advancedFieldByLabel(container, "Negative prompt").querySelector("textarea"),
+      "harsh distortion",
+    );
+    await submitForm();
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.model).toBe("music_guided");
+    expect(payload.guidance).toBe(4.5);
+    expect(payload.negativePrompt).toBe("harsh distortion");
+  });
+
+  it("rides an extend edit through as an AudioEdit: source + editMode=extend + editRegionEndSecs=length", async () => {
+    // A source track is a persisted user selection, so it restores from the studio snapshot at mount
+    // (like the Video Studio source band). Seed it directly, then pick the edit op.
+    window.localStorage.setItem(
+      "sceneworks-studio-audio-project_1",
+      JSON.stringify({ sourceAudioAssetId: "audio-src-1" }),
+    );
+    const sourceAsset = { id: "audio-src-1", type: "audio", displayName: "Base loop" };
+    const createAudioJob = vi.fn(async () => ({ id: "extend-1" }));
+    await render(
+      baseContext({
+        assets: [sourceAsset],
+        createAudioJob,
+        rememberLocalGenerationJob: vi.fn(),
+      }),
+    );
+    await click(modeTab(container, "Music"));
+    await setTextarea(container.querySelector(".prompt-input"), "extend the outro");
+    await setNumber(fieldByLabelStart(container, "Length").querySelector("input"), "20");
+    // Pick the "extend" edit op from the advertised chips.
+    const band = container.querySelector(".studio-source-band");
+    const extendChip = [...band.querySelectorAll(".preset-chip")].find(
+      (b) => b.textContent.trim() === "extend",
+    );
+    await click(extendChip);
+    await submitForm();
+
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.sourceAudioAssetId).toBe("audio-src-1");
+    expect(payload.editMode).toBe("extend");
+    // Extend reuses the Length field as the new TOTAL length (editRegionEndSecs); the worker begins the
+    // appended tail at the source clip's own length. No interior region start/end is sent for extend.
+    expect(payload.editRegionEndSecs).toBe(20);
+    expect(payload.editRegionStartSecs).toBeUndefined();
+  });
+
+  it("rides an inpaint edit through with a bounded region + strength", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-audio-project_1",
+      JSON.stringify({ sourceAudioAssetId: "audio-src-1" }),
+    );
+    const sourceAsset = { id: "audio-src-1", type: "audio", displayName: "Base loop" };
+    const createAudioJob = vi.fn(async () => ({ id: "inpaint-1" }));
+    await render(
+      baseContext({
+        assets: [sourceAsset],
+        createAudioJob,
+        rememberLocalGenerationJob: vi.fn(),
+      }),
+    );
+    await click(modeTab(container, "Music"));
+    await setTextarea(container.querySelector(".prompt-input"), "repaint the bridge");
+    // editMode defaults to the first advertised op ("inpaint") — which reveals the region window.
+    await setNumber(container.querySelector(".settings-field-region-start input"), "2");
+    await setNumber(container.querySelector(".settings-field-region-end input"), "5");
+    await setNumber(container.querySelector(".settings-field-edit-strength input"), "0.7");
+    await submitForm();
+
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.sourceAudioAssetId).toBe("audio-src-1");
+    expect(payload.editMode).toBe("inpaint");
+    expect(payload.editRegionStartSecs).toBe(2);
+    expect(payload.editRegionEndSecs).toBe(5);
+    expect(payload.editStrength).toBe(0.7);
   });
 });
 

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -320,10 +320,8 @@ pub(crate) async fn run_audio_generate_job(
     // while it runs so a long synthesis (a cold pipeline build, a 30 s clip, or a slow host) is never
     // flagged stale and marked `interrupted` mid-flight. Mirrors the video path's interval keepalive
     // for the no-progress cold-load phase.
-    let track = run_audio_synthesis(
-        api, settings, job, backend, &request, model_dir, audio_edit,
-    )
-    .await?;
+    let track =
+        run_audio_synthesis(api, settings, job, backend, &request, model_dir, audio_edit).await?;
 
     check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
     update_job(
@@ -545,8 +543,12 @@ fn build_audio_edit(
         )
     })?;
     let mode = parse_audio_edit_mode(mode)?;
-    let source_path =
-        crate::video_jobs::resolve_clip_media_path(settings, &request.project_id, source_id, project_path)?;
+    let source_path = crate::video_jobs::resolve_clip_media_path(
+        settings,
+        &request.project_id,
+        source_id,
+        project_path,
+    )?;
     let track = read_wav_pcm16(&source_path)?;
     // The clip's running length in seconds (interleaved: total samples / (rate · channels)).
     let src_secs = track.samples.len() as f32
@@ -686,6 +688,27 @@ fn audio_asset_fact(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(AUDIO_ADAPTER_FALLBACK);
+    // Build the `rawAdapterSettings` sub-object separately (not inline in the outer `json!`): the audio
+    // knob set has grown wide enough (TTS + SFX + the sc-13410 music/edit fields) that a single nested
+    // `json!` literal blows past the macro recursion limit. A separate expansion keeps each within it.
+    let raw_adapter_settings = json!({
+        "model": request.model,
+        "voice": request.voice,
+        "language": request.language,
+        "targetDurationSecs": request.target_duration_secs,
+        "guidance": request.guidance,
+        "steps": request.steps,
+        "negativePrompt": request.negative_prompt,
+        "bpm": request.bpm,
+        "musicalKey": request.musical_key,
+        "lyrics": request.lyrics,
+        "sourceAudioAssetId": request.source_audio_asset_id,
+        "editMode": request.edit_mode,
+        "editRegionStartSecs": request.edit_region_start_secs,
+        "editRegionEndSecs": request.edit_region_end_secs,
+        "editStrength": request.edit_strength,
+        "sampleRate": sample_rate,
+    });
     json!({
         "type": "audio",
         "assetId": plan.asset_id,
@@ -723,24 +746,7 @@ fn audio_asset_fact(
         "editRegionEndSecs": request.edit_region_end_secs,
         "editStrength": request.edit_strength,
         "seed": request.seed,
-        "rawAdapterSettings": {
-            "model": request.model,
-            "voice": request.voice,
-            "language": request.language,
-            "targetDurationSecs": request.target_duration_secs,
-            "guidance": request.guidance,
-            "steps": request.steps,
-            "negativePrompt": request.negative_prompt,
-            "bpm": request.bpm,
-            "musicalKey": request.musical_key,
-            "lyrics": request.lyrics,
-            "sourceAudioAssetId": request.source_audio_asset_id,
-            "editMode": request.edit_mode,
-            "editRegionStartSecs": request.edit_region_start_secs,
-            "editRegionEndSecs": request.edit_region_end_secs,
-            "editStrength": request.edit_strength,
-            "sampleRate": sample_rate,
-        },
+        "rawAdapterSettings": raw_adapter_settings,
     })
 }
 
@@ -933,6 +939,179 @@ mod tests {
         assert_eq!(result["expectedCount"], 1);
         assert_eq!(result["assetWrites"].as_array().map(Vec::len), Some(1));
         assert_eq!(result["assetWrites"][0]["type"], "audio");
+    }
+
+    #[test]
+    fn from_payload_reads_the_music_and_edit_fields() {
+        // The Music path (ACE-Step, sc-13410) carries the describe-the-music sub-block (bpm / key /
+        // lyrics), a negative prompt, and the extend/edit source band (source id + mode + region +
+        // strength). All ride verbatim onto the AudioRequest.
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "acestep_v15_turbo",
+            "prompt": "gentle lofi piano loop",
+            "language": "en",
+            "targetDurationSecs": 8.0,
+            "steps": 8,
+            "bpm": 92.0,
+            "musicalKey": "C minor",
+            "lyrics": "  [verse] la la la  ",
+            "negativePrompt": "harsh distortion",
+            "sourceAudioAssetId": "audio-src-1",
+            "editMode": "Extend",
+            "editRegionStartSecs": 3.0,
+            "editRegionEndSecs": 20.0,
+            "editStrength": 0.5,
+            "seed": 5,
+        })));
+        assert_eq!(request.model, "acestep_v15_turbo");
+        assert_eq!(request.bpm, Some(92.0));
+        assert_eq!(request.musical_key.as_deref(), Some("C minor"));
+        // Lyrics are read verbatim (interior whitespace / tags preserved), only trimmed of nothing —
+        // they may legitimately be multi-line; a purely-blank value would be None (instrumental).
+        assert_eq!(request.lyrics.as_deref(), Some("  [verse] la la la  "));
+        assert_eq!(request.negative_prompt.as_deref(), Some("harsh distortion"));
+        assert_eq!(
+            request.source_audio_asset_id.as_deref(),
+            Some("audio-src-1")
+        );
+        // The edit mode is lowercased at the parse seam so a mixed-case token still routes.
+        assert_eq!(request.edit_mode.as_deref(), Some("extend"));
+        assert_eq!(request.edit_region_start_secs, Some(3.0));
+        assert_eq!(request.edit_region_end_secs, Some(20.0));
+        assert_eq!(request.edit_strength, Some(0.5));
+        assert_eq!(request.steps, Some(8));
+        assert_eq!(request.seed, Some(5));
+        // A blank lyrics value is dropped to None (instrumental), not carried as an empty string.
+        let instrumental = AudioRequest::from_payload(&payload(json!({ "lyrics": "   " })));
+        assert_eq!(instrumental.lyrics, None);
+    }
+
+    #[test]
+    fn parse_audio_edit_mode_maps_the_tokens_and_rejects_garbage() {
+        assert_eq!(
+            parse_audio_edit_mode("inpaint").unwrap(),
+            AudioEditMode::Inpaint
+        );
+        assert_eq!(
+            parse_audio_edit_mode("repaint").unwrap(),
+            AudioEditMode::Repaint
+        );
+        assert_eq!(
+            parse_audio_edit_mode("extend").unwrap(),
+            AudioEditMode::Extend
+        );
+        assert_eq!(
+            parse_audio_edit_mode("cover").unwrap(),
+            AudioEditMode::Cover
+        );
+        assert!(parse_audio_edit_mode("bogus").is_err());
+    }
+
+    #[test]
+    fn audio_edit_region_policy_matches_the_mode_contract() {
+        // Extend: begins the appended tail at the source clip's own length when no start is given, and
+        // reads `end` as the new total length (gen_core AudioEditMode::Extend contract).
+        let region = audio_edit_region(AudioEditMode::Extend, 10.0, None, Some(20.0))
+            .expect("extend yields a region");
+        assert_eq!(region.start_secs, 10.0);
+        assert_eq!(region.end_secs, Some(20.0));
+        // An explicit start overrides the source-length default.
+        let region = audio_edit_region(AudioEditMode::Extend, 10.0, Some(8.0), Some(20.0))
+            .expect("extend region");
+        assert_eq!(region.start_secs, 8.0);
+
+        // Inpaint / Repaint: carry the request's bounded window; a MISSING start ⇒ None (so the
+        // generator's own "region required" check fires rather than the worker inventing a window).
+        let region = audio_edit_region(AudioEditMode::Inpaint, 10.0, Some(2.0), Some(5.0))
+            .expect("inpaint region");
+        assert_eq!(region.start_secs, 2.0);
+        assert_eq!(region.end_secs, Some(5.0));
+        assert!(audio_edit_region(AudioEditMode::Repaint, 10.0, None, None).is_none());
+
+        // Cover: whole-clip, no region.
+        assert!(audio_edit_region(AudioEditMode::Cover, 10.0, Some(1.0), Some(2.0)).is_none());
+    }
+
+    #[test]
+    fn build_audio_edit_is_none_without_a_source() {
+        // No source id ⇒ plain text-to-music (no Conditioning), regardless of the other edit fields.
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "acestep_v15_turbo",
+            "editMode": "extend",
+        })));
+        let settings = crate::test_env::offline_settings();
+        assert!(
+            build_audio_edit(&settings, &request, Path::new("/tmp/project"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn read_wav_pcm16_roundtrips_a_written_wav() {
+        // A clip written by the shared `write_wav_pcm16` (48 kHz stereo, the ACE-Step output shape) must
+        // decode back through `read_wav_pcm16` into a gen_core::AudioTrack with the same rate / channels
+        // / sample count — the source-track reader the extend/edit path resolves through.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("source.wav");
+        let track = AudioTrack {
+            samples: vec![0.0, 0.25, -0.5, 0.75, -0.1, 0.4], // 3 interleaved stereo frames
+            sample_rate: 48_000,
+            channels: 2,
+        };
+        write_wav_pcm16(&track, &path).expect("write wav");
+        let decoded = read_wav_pcm16(&path).expect("read wav");
+        assert_eq!(decoded.sample_rate, 48_000);
+        assert_eq!(decoded.channels, 2);
+        assert_eq!(decoded.samples.len(), 6);
+        assert!(decoded.stems.is_empty());
+        // Values land in the normalized [-1, 1) range (peak-normalized on write), and are finite.
+        assert!(decoded
+            .samples
+            .iter()
+            .all(|s| s.is_finite() && (-1.0..=1.0).contains(s)));
+
+        // A non-RIFF blob is a clear error, not a silent mis-decode.
+        let junk = dir.path().join("junk.wav");
+        std::fs::write(&junk, b"not a wav file at all").expect("write junk");
+        assert!(read_wav_pcm16(&junk).is_err());
+    }
+
+    #[test]
+    fn music_asset_fact_records_the_music_and_edit_fields_for_replay() {
+        // A Music run records the describe-the-music sub-block + the extend/edit source band in both the
+        // top-level replay record and rawAdapterSettings, so a re-generate round-trips exactly (sc-13410).
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "acestep_v15_turbo",
+            "prompt": "gentle lofi piano loop",
+            "targetDurationSecs": 8.0,
+            "steps": 8,
+            "bpm": 92.0,
+            "musicalKey": "C minor",
+            "lyrics": "[verse] la la la",
+            "sourceAudioAssetId": "audio-src-1",
+            "editMode": "extend",
+            "editRegionEndSecs": 20.0,
+            "editStrength": 0.5,
+            "seed": 5,
+        })));
+        let plan = AudioPlan::new(&request, Path::new("/tmp/project"));
+        let fact = audio_asset_fact(&plan, &request, 48_000, 2, 8.0);
+        assert_eq!(fact["sampleRate"], 48_000);
+        assert_eq!(fact["channels"], 2);
+        assert_eq!(fact["bpm"], 92.0);
+        assert_eq!(fact["musicalKey"], "C minor");
+        assert_eq!(fact["lyrics"], "[verse] la la la");
+        assert_eq!(fact["sourceAudioAssetId"], "audio-src-1");
+        assert_eq!(fact["editMode"], "extend");
+        assert_eq!(fact["editRegionEndSecs"], 20.0);
+        assert_eq!(fact["editStrength"], 0.5);
+        // ...and mirrored into rawAdapterSettings so the exact request is reconstructable.
+        assert_eq!(fact["rawAdapterSettings"]["bpm"], 92.0);
+        assert_eq!(fact["rawAdapterSettings"]["editMode"], "extend");
+        assert_eq!(fact["rawAdapterSettings"]["editStrength"], 0.5);
+        // A music run carries no voice; a distilled-turbo run carries no guidance/negative.
+        assert!(fact["voice"].is_null(), "music carries no voice");
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -18,7 +18,8 @@
 use super::*;
 
 use gen_core::{
-    AudioParams, CancelFlag, GenerationOutput, GenerationRequest, LoadSpec, Progress, WeightsSource,
+    AudioEditMode, AudioParams, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
+    LoadSpec, Progress, TimeRegion, WeightsSource,
 };
 
 use crate::video_jobs::{write_wav_pcm16, AudioTrack};
@@ -45,6 +46,28 @@ struct AudioRequest {
     /// Solver step count for diffusion-audio models. Rides the top-level `GenerationRequest::steps`.
     /// `None` ⇒ the model's sampler default.
     steps: Option<u32>,
+    /// Negative prompt for music models that advertise it. Rides the top-level
+    /// `GenerationRequest::negative_prompt` (sc-13410). `None` ⇒ unconditional. The guidance-distilled
+    /// ACE-Step turbo advertises no support, so the studio never sends one to it.
+    negative_prompt: Option<String>,
+    /// Musical tempo (BPM) — rides `AudioParams::bpm` (music models). `None` ⇒ the model's own tempo.
+    bpm: Option<f32>,
+    /// Musical key (e.g. `"C minor"`) — rides `AudioParams::musical_key`. `None` ⇒ the model's own.
+    musical_key: Option<String>,
+    /// Lyrics — rides `AudioParams::lyrics` (empty ⇒ instrumental).
+    lyrics: Option<String>,
+    /// Extend/edit source track asset id — resolved to a WAV and built into a
+    /// `Conditioning::AudioEdit` (sc-13410). `None` ⇒ plain text-to-music.
+    source_audio_asset_id: Option<String>,
+    /// Edit operation for the source track (`inpaint` / `repaint` / `extend` / `cover`).
+    edit_mode: Option<String>,
+    /// Edit-region start (seconds) — inpaint/repaint window start; for `extend` the worker defaults it
+    /// to the source clip's own length.
+    edit_region_start_secs: Option<f32>,
+    /// Edit-region end (seconds) — inpaint/repaint window end, OR (for `extend`) the new total length.
+    edit_region_end_secs: Option<f32>,
+    /// Edit strength (0..=1). `None` ⇒ the model default.
+    edit_strength: Option<f32>,
     seed: Option<i64>,
     model_manifest_entry: Value,
 }
@@ -81,6 +104,34 @@ impl AudioRequest {
                 .get("steps")
                 .and_then(Value::as_u64)
                 .map(|value| value as u32),
+            negative_prompt: string("negativePrompt"),
+            bpm: payload
+                .get("bpm")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
+            musical_key: string("musicalKey"),
+            // Lyrics are free-form and may legitimately be multi-line/whitespace-led ([verse] tags),
+            // so read them verbatim (unlike the trimmed `string()` helper) — only an entirely-absent
+            // key ⇒ None (instrumental).
+            lyrics: payload
+                .get("lyrics")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_owned),
+            source_audio_asset_id: string("sourceAudioAssetId"),
+            edit_mode: string("editMode").map(|mode| mode.to_lowercase()),
+            edit_region_start_secs: payload
+                .get("editRegionStartSecs")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
+            edit_region_end_secs: payload
+                .get("editRegionEndSecs")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
+            edit_strength: payload
+                .get("editStrength")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
             seed: payload.get("seed").and_then(Value::as_i64),
             model_manifest_entry: payload
                 .get("modelManifestEntry")
@@ -244,6 +295,11 @@ pub(crate) async fn run_audio_generate_job(
 
     check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
     let model_dir = resolve_audio_model_dir(settings, &request)?;
+    // Extend/edit SOURCE band (sc-13410): resolve + decode the source track and build the
+    // `Conditioning::AudioEdit` here (in async, where the project path + store are in scope), then move
+    // it into the blocking synthesis. `None` ⇒ plain text-to-music. The per-model gates (edit mode ∈
+    // advertised, region inside the clip, 48 kHz source) run in the generator's `validate` at synthesis.
+    let audio_edit = build_audio_edit(settings, &request, &project_path)?;
 
     update_job(
         api,
@@ -264,7 +320,10 @@ pub(crate) async fn run_audio_generate_job(
     // while it runs so a long synthesis (a cold pipeline build, a 30 s clip, or a slow host) is never
     // flagged stale and marked `interrupted` mid-flight. Mirrors the video path's interval keepalive
     // for the no-progress cold-load phase.
-    let track = run_audio_synthesis(api, settings, job, backend, &request, model_dir).await?;
+    let track = run_audio_synthesis(
+        api, settings, job, backend, &request, model_dir, audio_edit,
+    )
+    .await?;
 
     check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
     update_job(
@@ -334,6 +393,7 @@ const AUDIO_KEEPALIVE_SECS: u64 = 15;
 /// Load the audio generator and run one synthesis on a blocking thread, emitting periodic keepalive
 /// heartbeats + progress updates while it runs. Returns the engine [`AudioTrack`] (`gen_core`'s) for
 /// the caller to write + register.
+#[allow(clippy::too_many_arguments)]
 async fn run_audio_synthesis(
     api: &ApiClient,
     settings: &Settings,
@@ -341,6 +401,7 @@ async fn run_audio_synthesis(
     backend: &str,
     request: &AudioRequest,
     model_dir: PathBuf,
+    audio_edit: Option<Conditioning>,
 ) -> WorkerResult<gen_core::AudioTrack> {
     let model_id = request.model.clone();
     let prompt = request.prompt.clone();
@@ -354,6 +415,14 @@ async fn run_audio_synthesis(
     // Speech jobs — which never carry them — are unaffected.
     let guidance = request.guidance;
     let steps = request.steps;
+    // Music describe-the-music sub-block (ACE-Step, sc-13410). BPM/key/lyrics ride the AudioParams
+    // music fields; negative_prompt rides the top-level request. A model that doesn't consume one
+    // ignores it; a model that advertises no negative-prompt support rejects a supplied one at the
+    // gen-core floor (the studio only sends one to a model that advertises support).
+    let negative_prompt = request.negative_prompt.clone();
+    let bpm = request.bpm;
+    let musical_key = request.musical_key.clone();
+    let lyrics = request.lyrics.clone();
     let seed = request.seed.map(|seed| seed as u64);
     let handle = tokio::task::spawn_blocking(move || -> WorkerResult<gen_core::AudioTrack> {
         let spec = LoadSpec::new(WeightsSource::Dir(model_dir));
@@ -361,6 +430,7 @@ async fn run_audio_synthesis(
             .map_err(|error| crate::classify_engine_error("audio model load failed", error))?;
         let req = GenerationRequest {
             prompt,
+            negative_prompt,
             seed,
             steps,
             guidance,
@@ -368,8 +438,14 @@ async fn run_audio_synthesis(
                 voice,
                 language,
                 target_duration,
+                bpm,
+                musical_key,
+                lyrics,
                 ..Default::default()
             }),
+            // Extend/edit source-audio conditioning (Conditioning::AudioEdit), when a source band was
+            // supplied; empty for plain text-to-music.
+            conditioning: audio_edit.into_iter().collect(),
             cancel: CancelFlag::new(),
             ..Default::default()
         };
@@ -423,6 +499,168 @@ async fn run_audio_synthesis(
     }
 }
 
+/// Parse an edit-mode token (`inpaint` / `repaint` / `extend` / `cover`) into the gen-core
+/// [`AudioEditMode`]. The API already rejects an unknown token up front; this is the worker-side
+/// mirror so a raw-enqueued job still fails cleanly rather than mis-routing.
+fn parse_audio_edit_mode(mode: &str) -> WorkerResult<AudioEditMode> {
+    match mode {
+        "inpaint" => Ok(AudioEditMode::Inpaint),
+        "repaint" => Ok(AudioEditMode::Repaint),
+        "extend" => Ok(AudioEditMode::Extend),
+        "cover" => Ok(AudioEditMode::Cover),
+        other => Err(WorkerError::InvalidPayload(format!(
+            "unknown audio edit mode {other:?} (expected inpaint / repaint / extend / cover)"
+        ))),
+    }
+}
+
+/// Build the prompted source-audio-edit conditioning (sc-13410) from the request's source band, or
+/// `None` for plain text-to-music. Resolves the source track asset to its WAV (guarded through
+/// `resolve_clip_media_path`, the same project-scoped resolver the video source-clip path uses),
+/// decodes it into a [`gen_core::AudioTrack`], and assembles the [`Conditioning::AudioEdit`] the
+/// ACE-Step generator consumes: the source clip + the edit mode + a time region.
+///
+/// Region policy mirrors the [`AudioEditMode`] contract: `Extend` begins the appended tail at the
+/// source clip's own length (unless the request overrides `start`) and reads `end` as the new total
+/// length; `Inpaint`/`Repaint` carry the request's bounded window (`None` ⇒ the generator's own
+/// default region check fires); `Cover` is whole-clip (no region). The per-model gates (mode ∈
+/// advertised `audio_edit_modes`, region inside the clip duration, 48 kHz source) run in the
+/// generator's `validate` at synthesis, so a bad region surfaces as a clear engine error there.
+fn build_audio_edit(
+    settings: &Settings,
+    request: &AudioRequest,
+    project_path: &Path,
+) -> WorkerResult<Option<Conditioning>> {
+    let Some(source_id) = request
+        .source_audio_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let mode = request.edit_mode.as_deref().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "an audio edit source was supplied without an editMode.".to_owned(),
+        )
+    })?;
+    let mode = parse_audio_edit_mode(mode)?;
+    let source_path =
+        crate::video_jobs::resolve_clip_media_path(settings, &request.project_id, source_id, project_path)?;
+    let track = read_wav_pcm16(&source_path)?;
+    // The clip's running length in seconds (interleaved: total samples / (rate · channels)).
+    let src_secs = track.samples.len() as f32
+        / (track.sample_rate.max(1) as f32 * track.channels.max(1) as f32);
+    let region = audio_edit_region(
+        mode,
+        src_secs,
+        request.edit_region_start_secs,
+        request.edit_region_end_secs,
+    );
+    Ok(Some(Conditioning::AudioEdit {
+        audio: track,
+        mode,
+        region,
+        strength: request.edit_strength,
+    }))
+}
+
+/// The edit-region policy (sc-13410), factored out of [`build_audio_edit`] so it is unit-testable
+/// without a project store or a real clip. `Extend` begins the appended tail at the source clip's own
+/// length when the request omits a start, and reads the request `end` as the new total length;
+/// `Inpaint`/`Repaint` carry the request's bounded window (a missing start ⇒ `None`, so the
+/// generator's own "region required" check fires); `Cover` is whole-clip.
+fn audio_edit_region(
+    mode: AudioEditMode,
+    src_secs: f32,
+    start: Option<f32>,
+    end: Option<f32>,
+) -> Option<TimeRegion> {
+    match mode {
+        AudioEditMode::Extend => Some(TimeRegion {
+            start_secs: start.unwrap_or(src_secs),
+            end_secs: end,
+        }),
+        AudioEditMode::Inpaint | AudioEditMode::Repaint => start.map(|start_secs| TimeRegion {
+            start_secs,
+            end_secs: end,
+        }),
+        AudioEditMode::Cover => None,
+    }
+}
+
+/// Decode a canonical PCM-16 WAV (the format both `write_wav_pcm16` writers emit) into a
+/// [`gen_core::AudioTrack`] — the source-track reader for the extend/edit path (sc-13410). Iterates
+/// the RIFF chunk list so a file carrying extra chunks (LIST/fact) still reads, requires PCM
+/// (`audio_format == 1`) 16-bit samples, and converts interleaved `i16` to `f32` in `[-1, 1)`.
+/// Non-PCM / non-16-bit inputs are a clear `Unsupported` rather than a silent mis-decode.
+fn read_wav_pcm16(path: &Path) -> WorkerResult<gen_core::AudioTrack> {
+    let bytes = std::fs::read(path)?;
+    if bytes.len() < 12 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+        return Err(WorkerError::InvalidPayload(format!(
+            "source audio {} is not a RIFF/WAVE file",
+            path.display()
+        )));
+    }
+    let le16 = |b: &[u8], o: usize| u16::from_le_bytes([b[o], b[o + 1]]);
+    let le32 = |b: &[u8], o: usize| u32::from_le_bytes([b[o], b[o + 1], b[o + 2], b[o + 3]]);
+    let mut pos = 12usize;
+    let mut fmt: Option<(u16, u16, u32, u16)> = None; // (audio_format, channels, sample_rate, bits)
+    let mut data: Option<(usize, usize)> = None; // (start, end)
+    while pos + 8 <= bytes.len() {
+        let id = &bytes[pos..pos + 4];
+        let size = le32(&bytes, pos + 4) as usize;
+        let body = pos + 8;
+        let end = body.saturating_add(size).min(bytes.len());
+        if id == b"fmt " && size >= 16 && body + 16 <= bytes.len() {
+            fmt = Some((
+                le16(&bytes, body),
+                le16(&bytes, body + 2),
+                le32(&bytes, body + 4),
+                le16(&bytes, body + 14),
+            ));
+        } else if id == b"data" {
+            data = Some((body, end));
+        }
+        // RIFF chunks are word-aligned: an odd body is followed by a pad byte.
+        pos = body + size + (size & 1);
+    }
+    let (audio_format, channels, sample_rate, bits) = fmt.ok_or_else(|| {
+        WorkerError::InvalidPayload(format!("source audio {} has no fmt chunk", path.display()))
+    })?;
+    if audio_format != 1 || bits != 16 {
+        return Err(WorkerError::InvalidPayload(format!(
+            "source audio {} must be PCM 16-bit (got format {audio_format}, {bits}-bit)",
+            path.display()
+        )));
+    }
+    if channels == 0 || sample_rate == 0 {
+        return Err(WorkerError::InvalidPayload(format!(
+            "source audio {} declares {channels} channels @ {sample_rate} Hz",
+            path.display()
+        )));
+    }
+    let (start, end) = data.ok_or_else(|| {
+        WorkerError::InvalidPayload(format!("source audio {} has no data chunk", path.display()))
+    })?;
+    let samples: Vec<f32> = bytes[start..end]
+        .chunks_exact(2)
+        .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32_768.0)
+        .collect();
+    if samples.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "source audio {} decoded to zero samples",
+            path.display()
+        )));
+    }
+    Ok(gen_core::AudioTrack {
+        samples,
+        sample_rate,
+        channels,
+        stems: Vec::new(),
+    })
+}
+
 /// The `type: "audio"` asset fact the API persists into a sidecar (via
 /// `project_store::build_audio_sidecar_parts`) — the audio twin of `video_asset_fact`. Carries the
 /// MEASURED clip facts (duration / sampleRate / channels off the produced track) plus the REQUESTED
@@ -467,11 +705,23 @@ fn audio_asset_fact(
         // REQUESTED knobs (the replay record). `null` for an omitted voice/language/duration — the
         // studio falls back to the model's own defaults, exactly as the video recipe does. `guidance`
         // / `steps` are the Sound FX (diffusion) sampling knobs; `null` for a TTS run that carries none.
+        // The music sub-block (bpm / musicalKey / lyrics / negativePrompt) and the extend/edit source
+        // band (sourceAudioAssetId / editMode / editRegion* / editStrength) round-trip for replay too —
+        // `null` on a run that carries none (sc-13410).
         "voice": request.voice,
         "language": request.language,
         "targetDurationSecs": request.target_duration_secs,
         "guidance": request.guidance,
         "steps": request.steps,
+        "negativePrompt": request.negative_prompt,
+        "bpm": request.bpm,
+        "musicalKey": request.musical_key,
+        "lyrics": request.lyrics,
+        "sourceAudioAssetId": request.source_audio_asset_id,
+        "editMode": request.edit_mode,
+        "editRegionStartSecs": request.edit_region_start_secs,
+        "editRegionEndSecs": request.edit_region_end_secs,
+        "editStrength": request.edit_strength,
         "seed": request.seed,
         "rawAdapterSettings": {
             "model": request.model,
@@ -480,6 +730,15 @@ fn audio_asset_fact(
             "targetDurationSecs": request.target_duration_secs,
             "guidance": request.guidance,
             "steps": request.steps,
+            "negativePrompt": request.negative_prompt,
+            "bpm": request.bpm,
+            "musicalKey": request.musical_key,
+            "lyrics": request.lyrics,
+            "sourceAudioAssetId": request.source_audio_asset_id,
+            "editMode": request.edit_mode,
+            "editRegionStartSecs": request.edit_region_start_secs,
+            "editRegionEndSecs": request.edit_region_end_secs,
+            "editStrength": request.edit_strength,
             "sampleRate": sample_rate,
         },
     })

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -8791,7 +8791,7 @@ fn build_video_clip_conditioning(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn resolve_clip_media_path(
+pub(crate) fn resolve_clip_media_path(
     settings: &Settings,
     project_id: &str,
     asset_id: &str,


### PR DESCRIPTION
## Summary

Finishes **C3 Music mode** for the SceneWorks Audio Studio (epic 13400), completing the WIP on top of the C1 Speech / C2 SFX wiring. Music runs the **ACE-Step v1.5 XL Turbo** text-to-music model: a describe-the-music prompt plus BPM / key / lyrics, and — only when the model advertises `audio.editModes` — an extend/inpaint/repaint **source band** that rides through as a `Conditioning::AudioEdit`. 48 kHz stereo output.

Story: [sc-13410](https://app.shortcut.com/trefry/story/13410)

## Music fields (capability-driven)
- Describe-the-music prompt; **Length** (capped to the model's `audio.maxDurationSecs`), optional **BPM**, optional **Key**, optional **Lyrics** (empty ⇒ instrumental).
- Advanced: **Steps** + **Seed** always; **Guidance (CFG)** and **Negative prompt** only when the model advertises `audio.supportsGuidance` / `audio.supportsNegativePrompt`. The pinned ACE-Step turbo is guidance-distilled and advertises neither, so they stay hidden (sending one would be a typed `Unsupported` at the gen-core floor). A model that advertises them shows and sends them (proven by a discriminating test).

## Source band (extend / edit — capability-gated)
- Revealed **only** when the selected model advertises `audio.editModes` (mirrors VideoStudio's `studio-source-band`). Picks a library `type:"audio"` asset + an edit op (inpaint / repaint / extend), an interior region for inpaint/repaint, and an optional Edit strength.
- Extend reuses the **Length** field as the new total length; the worker begins the appended tail at the source clip's own length.

## Backend
- **DTO + validation** (`dto.rs`, `lib.rs`): new Option fields (bpm/musicalKey/lyrics/negativePrompt + sourceAudioAssetId/editMode/editRegion*/editStrength) with serde default+skip-if-none and blanket sanity bounds in `validate_audio_job` / `validate_audio_edit_fields` (bpm>0, known edit token, well-ordered region, source+mode pairing, strength 0..=1). Per-model gates stay in the generator's `validate`.
- **Worker** (`audio_jobs.rs`): `AudioRequest::from_payload` reads the new fields; BPM/key/lyrics ride `AudioParams`, negative rides the top-level request; `build_audio_edit` resolves the source asset's WAV (via the shared `resolve_clip_media_path`), decodes it (`read_wav_pcm16`), and assembles a `Conditioning::AudioEdit` with the per-mode region policy (`audio_edit_region`). Music/edit fields recorded in the asset fact for replay. Speech/SFX paths unaffected.
- **WIP bug fixed**: the enlarged `audio_asset_fact` `json!` literal blew past the default macro recursion limit — the nested `rawAdapterSettings` is now built as a separate `json!` local (byte-identical output).
- `video_jobs.rs`: keeps the WIP's 2-line change making `resolve_clip_media_path` `pub(crate)` — the audio source band reuses it (intentional shared-helper refactor).

## Tests
- **Web (vitest)**: Music payload maps discriminating non-defaults (bpm/key/lyrics/steps); guidance/negative hidden for ACE-Step, shown+sent for a model that advertises them; source band hidden on Speech/SFX (no editModes), shown for ACE-Step; extend rides through with `editRegionEndSecs=length`; inpaint rides through with a bounded region + strength; Speech/SFX untouched. **Full suite: 2157 passed.**
- **Rust worker**: from_payload reads music+edit fields; `audio_edit_region` matches the `AudioEditMode` contract; `parse_audio_edit_mode`; `write_wav_pcm16` → `read_wav_pcm16` roundtrip; `build_audio_edit` None without a source; asset fact records the fields for replay.
- **Rust API**: music+edit fields map to the worker payload; half-specified edit rejected; nonsense music fields (bpm≤0 / unknown editMode / mis-ordered region) → 400.
- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, `cargo build`, and `npm run web:build` all green.

## Real-inference evidence (release build, API level, minimal settings)
Ran the actual `POST /api/v1/audio/jobs` → worker-claim → ACE-Step synthesis path against the real 10 GB ACE-Step snapshot:

- **(a) Base music** — prompt "gentle lofi piano loop", 3 s, 8 steps, seed 4242 → real `type:audio` asset. WAV facts: **bytes=576044, sampleRate=48000, channels=2 (stereo), 144000 frames, duration=3.000 s, non-zero samples**.
- **(b) Extend/edit** — the base clip as the real source track, `editMode=extend`, `editRegionEndSecs=6.0`, `editStrength=0.5` → real edited asset built from a `Conditioning::AudioEdit`. WAV facts: **bytes=1152044, sampleRate=48000, channels=2, 288000 frames, duration=6.000 s** (correctly extended 3 s → 6 s), non-zero samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)