### PR TITLE
fix(build): resolve the Windows link against one CRT (LNK4098)

### DIFF
--- a/apps/rust-api/build.rs
+++ b/apps/rust-api/build.rs
@@ -11,6 +11,36 @@ fn main() {
     if dist.is_dir() {
         emit_rerun_for_tree(dist);
     }
+    pin_dynamic_crt();
+}
+
+// Resolve the whole link against ONE C runtime on Windows (LNK4098).
+//
+// `backend-candle` pulls candle-kernels, whose build.rs compiles the MoE/GGUF
+// kernels with nvcc into `libmoe.a`. nvcc's MSVC host default is the STATIC CRT,
+// so those objects carry `/DEFAULTLIB:LIBCMT` + `/DEFAULTLIB:libcpmt` while rustc
+// and every other native dep here (sqlite3, onig, ring) ask for the DYNAMIC
+// `msvcrt`. The linker warns and silently resolves the conflict for us — today it
+// pulls `std::_Xlength_error` out of the STATIC libcpmt, i.e. the binary really
+// does end up with a sliver of a second CRT in it.
+//
+// Excluding the static pair alone breaks the link (that one C++ symbol goes
+// unresolved), so `msvcprt` — the dynamic-CRT sibling of libcpmt — has to be named
+// explicitly. Net effect: one CRT, chosen deliberately rather than by link order.
+// Adds no new runtime DLL dependency (msvcprt satisfies it statically; the import
+// table is unchanged).
+//
+// The real fix belongs upstream in candle-kernels' build.rs (`-Xcompiler /MD` on
+// the MSVC branch); this keeps our link honest until that lands.
+fn pin_dynamic_crt() {
+    let msvc = std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+    let candle = std::env::var_os("CARGO_FEATURE_BACKEND_CANDLE").is_some();
+    if !(msvc && candle) {
+        return;
+    }
+    println!("cargo:rustc-link-arg=/NODEFAULTLIB:libcmt");
+    println!("cargo:rustc-link-arg=/NODEFAULTLIB:libcpmt");
+    println!("cargo:rustc-link-arg=/DEFAULTLIB:msvcprt");
 }
 
 fn emit_rerun_for_tree(dir: &Path) {


### PR DESCRIPTION
Silences — and actually fixes — the linker warning on candle-enabled Windows builds:

```
LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library
```

## Cause

`backend-candle` pulls `candle-kernels`, whose `build.rs` compiles the MoE/GGUF kernels with **nvcc** into `libmoe.a`. nvcc's MSVC host default is the **static** CRT, so those objects carry `/DEFAULTLIB:LIBCMT` + `/DEFAULTLIB:libcpmt`, while rustc and every other native dep ask for the dynamic `msvcrt`:

```
libmoe.a       ->  15x LIBCMT, 15x libcpmt,  0x MSVCRT   <- offender
sqlite3.lib    ->   0x LIBCMT,               1x MSVCRT
onig.lib       ->   0x LIBCMT,              48x MSVCRT
ring_core.lib  ->   0x LIBCMT,              15x MSVCRT
```

## Not purely cosmetic

The linker was resolving the conflict silently by pulling `std::_Xlength_error` out of the **static** `libcpmt`, so the shipped binary really did carry a sliver of a second CRT. Excluding the static pair without a replacement proves it — the link fails:

```
libmoe.a(moe_wmma_gguf.o) : error LNK2019: unresolved external symbol
  "void __cdecl std::_Xlength_error(char const *)"
```

## Fix

Three link args from `apps/rust-api/build.rs`:

```
/NODEFAULTLIB:libcmt  /NODEFAULTLIB:libcpmt  /DEFAULTLIB:msvcprt
```

`msvcprt` is not optional — it is `libcpmt`'s dynamic-CRT sibling and supplies that one C++ symbol. The import table is unchanged (no new `MSVCP140.dll` dependency), so packaging is unaffected.

## Scope

`apps/rust-api` is the only artifact that can link candle: `apps/rust-worker` has no `backend-candle` passthrough, and `apps/desktop` does not depend on `sceneworks-worker`. Gated on `target_env = "msvc"` + the `backend-candle` feature, so macOS/Linux and non-candle builds are untouched.

Kept in the package build script rather than `.cargo/config.toml` deliberately: `rustflags` there would invalidate the whole workspace build cache and force a full candle rebuild locally and on the self-hosted Windows runners.

## Verification

Release relink of `sceneworks-rust-api` with `backend-candle` on the Blackwell box now emits **zero** linker diagnostics (previously 1 warning). Confirmed the build script emits the args, and that the resulting binary imports a single CRT (`VCRUNTIME140.dll`). `cargo fmt --check` clean.

## Related

Chasing this warning surfaced an unrelated and more serious problem in the same `libmoe.a` — its multi-arch fatbin has regressed to a single sm_80 cubin with no PTX, breaking quantized models on Blackwell. That is filed separately as **sc-13510** (regression of sc-7544) and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)