### PR TITLE
feat(quant-tier): availability guard + capability-aware Auto default + durable per-model picks

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -2031,6 +2031,30 @@ fn mlx_convert_output_tiers(converted_dir: &FsPath) -> Vec<&'static str> {
         .collect()
 }
 
+/// Per-tier install state for a convert-at-install model's FULL possible tier set (q4/q8/bf16), so the
+/// Studio picker can show EVERY tier with the un-converted ones DISABLED — the same "show all, disable
+/// unavailable" rule the download-matrix `variants[]` array gives. Unlike [`mlx_convert_output_tiers`]
+/// (installed tiers only, which can only ever GROW the picker), this lists all three whether or not they
+/// are on disk. `installState` is `"installed"` when the tier holds loadable weights, else `"missing"`;
+/// `cacheState` mirrors it (`"complete"`/`"missing"`). NOTE the completeness here is as coarse as
+/// [`tier_subdir_has_weights`] — it can't yet flag a torn tier (backbone present, text-encoder/VAE gone)
+/// as `incomplete` the way the diffusers `variants[]` path does via `model_index.json`; a torn convert
+/// output would read `installed`. Tightening that needs the worker's family-specific completeness
+/// (anima/boogu/sana) mirrored here — tracked separately.
+fn mlx_convert_output_tier_states(converted_dir: &FsPath) -> Vec<Value> {
+    ["q4", "q8", "bf16"]
+        .into_iter()
+        .map(|tier| {
+            let installed = tier_subdir_has_weights(&converted_dir.join(tier));
+            json!({
+                "tier": tier,
+                "installState": if installed { "installed" } else { "missing" },
+                "cacheState": if installed { "complete" } else { "missing" },
+            })
+        })
+        .collect()
+}
+
 /// Whether a converted tier subdir holds loadable weights: a non-hidden `.safetensors` / `.index.json`
 /// under a known backbone dir (`diffusion_models/` for Anima's Cosmos DiT, `transformer/` for other
 /// DiTs, `unet/` for SDXL) or flat in the tier dir. A hidden `._*` AppleDouble sidecar is not a weight
@@ -2100,6 +2124,14 @@ fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
             let tiers = mlx_convert_output_tiers(converted);
             if !tiers.is_empty() {
                 object.insert("mlxTiers".to_owned(), json!(tiers));
+                // The FULL possible tier set with per-tier state, so the Studio shows un-converted tiers
+                // disabled rather than omitting them (the web reads `mlxTierStates` in preference to the
+                // installed-only `mlxTiers`). Emitted only when the model is actually converted (>=1 tier
+                // present), matching `mlxTiers` — an unconverted model still renders no picker.
+                object.insert(
+                    "mlxTierStates".to_owned(),
+                    Value::Array(mlx_convert_output_tier_states(converted)),
+                );
             }
         }
         object.insert(
@@ -3724,6 +3756,41 @@ mod mlx_tier_probe_tests {
         let flat = tempfile::tempdir().unwrap();
         std::fs::write(flat.path().join("model_index.json"), b"{}").unwrap();
         assert!(mlx_convert_output_tiers(flat.path()).is_empty());
+    }
+
+    #[test]
+    fn convert_output_tier_states_lists_the_full_set_marking_un_converted_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Only q4 + q8 are converted; bf16 is absent — but ALL THREE must appear so the picker can show
+        // bf16 disabled (the "show all, disable unavailable" rule for convert-at-install models).
+        write_weight(
+            &root.join("q4"),
+            "diffusion_models",
+            "anima-base-v1.0.safetensors",
+        );
+        write_weight(
+            &root.join("q8"),
+            "diffusion_models",
+            "anima-base-v1.0.safetensors",
+        );
+        let states = mlx_convert_output_tier_states(root);
+        assert_eq!(states.len(), 3);
+        let by_tier: std::collections::BTreeMap<_, _> = states
+            .iter()
+            .map(|state| {
+                (
+                    state["tier"].as_str().unwrap(),
+                    (
+                        state["installState"].as_str().unwrap(),
+                        state["cacheState"].as_str().unwrap(),
+                    ),
+                )
+            })
+            .collect();
+        assert_eq!(by_tier["q4"], ("installed", "complete"));
+        assert_eq!(by_tier["q8"], ("installed", "complete"));
+        assert_eq!(by_tier["bf16"], ("missing", "missing"));
     }
 
     // Full catalog path: a converted convert-at-install model (Anima) emits `mlxTiers` from

--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -9,6 +9,7 @@
 
 use super::*;
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 const PREFERENCES_FILENAME: &str = "ui-preferences.json";
@@ -22,15 +23,33 @@ pub(crate) struct UiPreferences {
     /// Last-used accent palette id (see `ACCENT_IDS`); absent until first set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     accent: Option<String>,
-    /// App-wide default generation quality (`bf16`|`q8`|`q4`); the baseline quant tier
-    /// new generations use when no per-(screen,model) sticky pick exists (sc-10728).
-    /// Absent in the stored file until first set — but the GET response always resolves
-    /// an absent/invalid value to the q8 default, so the web always has a value to seed.
-    /// Made durable through this API (not just origin-keyed `localStorage`) for the same
-    /// reason as theme/accent: the desktop shell's `127.0.0.1:<port>` origin changes every
-    /// launch, wiping `localStorage`.
+    /// App-wide default generation quality (`auto`|`bf16`|`q8`|`q4`); the baseline the
+    /// per-model default tier derives from when no per-(screen,model) sticky pick exists
+    /// (sc-10728). `auto` (epic 10721 R3) is the default: each model defaults to the
+    /// highest-fidelity tier that fits this machine's memory. Absent in the stored file
+    /// until first set — but the GET response always resolves an absent/invalid value to
+    /// `auto`, so the web always has a value to seed. Made durable through this API (not
+    /// just origin-keyed `localStorage`) for the same reason as theme/accent: the desktop
+    /// shell's `127.0.0.1:<port>` origin changes every launch, wiping `localStorage`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     default_generation_quality: Option<String>,
+    /// One-time migration marker (epic 10721 R3). The quality setting predates the `auto`
+    /// option, so every stored `q8` is the OLD forced default that rode along in unrelated
+    /// PUTs, not a choice AGAINST Auto (which didn't exist). On GET we flip a stored `q8`
+    /// to `auto` exactly once and set this true; a DELIBERATE quality PUT also sets it — so
+    /// a q8 the user picks AFTER the upgrade sticks and is never re-migrated.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    migrated_quality_auto: bool,
+    /// Per-(screen, modelId) last-picked quant tier — the DURABLE form of the studio tier sticky
+    /// (epic 10721 R1). The desktop shell's per-launch `127.0.0.1:<port>` origin wipes localStorage, so
+    /// a tier a user picks for a model in a studio would be lost on relaunch and they'd have to re-pick
+    /// every session. Persisting it here (re-seeded into localStorage on launch) makes "your per-model
+    /// picks are remembered" actually hold across restarts. Shape: `{ [screen]: { [modelId]: tier } }`;
+    /// the frontend owns the tier vocabulary, so values are stored verbatim. A PUT carrying this field
+    /// replaces the whole map — the web sends the full merged map it holds in its localStorage cache, so
+    /// no server-side deep-merge is needed (and a PUT without the field leaves it untouched).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    per_model_tier: Option<BTreeMap<String, BTreeMap<String, String>>>,
 }
 
 /// User-selectable accent palettes. Keep in sync with web/src/accents.js.
@@ -42,9 +61,14 @@ const ACCENT_IDS: [&str; 7] = [
 /// web/src/quantTier.js `GENERATION_QUALITY_TIERS`.
 const GENERATION_QUALITY_IDS: [&str; 3] = ["bf16", "q8", "q4"];
 
-/// The app-wide default generation quality when unset or invalid. Matches the worker's
-/// generation default (sc-10726) and the web `DEFAULT_GENERATION_QUALITY`.
-const DEFAULT_GENERATION_QUALITY: &str = "q8";
+/// The capability-aware "Auto" mode (epic 10721 R3). Keep in sync with
+/// web/src/generationQuality.js `AUTO_GENERATION_QUALITY`.
+const AUTO_GENERATION_QUALITY: &str = "auto";
+
+/// The app-wide default generation quality when unset or invalid: `auto` (epic 10721 R3),
+/// so an untouched install gets the capability-aware default, not a flat q8. Keep in sync
+/// with the web `AUTO_GENERATION_QUALITY` default in `normalizeGenerationQuality`.
+const DEFAULT_GENERATION_QUALITY: &str = AUTO_GENERATION_QUALITY;
 
 fn preferences_path(state: &AppState) -> PathBuf {
     state.settings.config_dir.join(PREFERENCES_FILENAME)
@@ -91,9 +115,25 @@ fn normalize_accent(input: Option<&str>) -> Option<String> {
 /// clobbers a previously-set value.
 fn normalize_generation_quality(input: Option<&str>) -> String {
     match input.map(str::trim) {
-        Some(value) if GENERATION_QUALITY_IDS.contains(&value) => value.to_owned(),
+        Some(value)
+            if value == AUTO_GENERATION_QUALITY || GENERATION_QUALITY_IDS.contains(&value) =>
+        {
+            value.to_owned()
+        }
         _ => DEFAULT_GENERATION_QUALITY.to_owned(),
     }
+}
+
+/// Apply the one-time `q8` → `auto` migration to `prefs` in place (epic 10721 R3). Returns `true` when
+/// it changed something, so the caller persists. Idempotent: guarded by `migrated_quality_auto`, so a
+/// deliberate q8 pick (which sets that marker via PUT) is never re-migrated.
+fn migrate_quality_to_auto(prefs: &mut UiPreferences) -> bool {
+    if !prefs.migrated_quality_auto && prefs.default_generation_quality.as_deref() == Some("q8") {
+        prefs.default_generation_quality = Some(AUTO_GENERATION_QUALITY.to_owned());
+        prefs.migrated_quality_auto = true;
+        return true;
+    }
+    false
 }
 
 /// Current UI preferences (empty object on first run).
@@ -104,8 +144,13 @@ pub(crate) async fn get_ui_preferences(
     let path = preferences_path(&state);
     let prefs = tokio::task::spawn_blocking(move || {
         let mut prefs = load_preferences(&path);
-        // Always hand the web a concrete quality tier to seed (q8 when unset/invalid), so the
-        // durable value survives a desktop relaunch even before the user changes it.
+        // One-time migration (epic 10721 R3): flip a stored `q8` (the old forced default, predating the
+        // `auto` option) to `auto` and persist — see `migrate_quality_to_auto`. Only writes on a change.
+        if migrate_quality_to_auto(&mut prefs) {
+            let _ = save_preferences(&path, &prefs);
+        }
+        // Always hand the web a concrete value to seed (`auto` when unset/invalid), so the durable
+        // value survives a desktop relaunch even before the user changes it.
         prefs.default_generation_quality = Some(normalize_generation_quality(
             prefs.default_generation_quality.as_deref(),
         ));
@@ -133,12 +178,20 @@ pub(crate) async fn set_ui_preferences(
         if let Some(accent) = normalize_accent(payload.accent.as_deref()) {
             prefs.accent = Some(accent);
         }
-        // Only touch the quality when the payload actually carries it, so a theme- or
-        // accent-only PUT can't reset it. A present-but-invalid value coerces to q8.
+        // Only touch the quality when the payload actually carries it, so a theme- or accent-only PUT
+        // can't reset it. A present-but-invalid value coerces to `auto`. A deliberate quality PUT also
+        // sets the migration marker, so a q8 the user picks AFTER the upgrade is never auto-migrated
+        // (a theme-only PUT deliberately does NOT set it, so an existing q8 still migrates on GET).
         if payload.default_generation_quality.is_some() {
             prefs.default_generation_quality = Some(normalize_generation_quality(
                 payload.default_generation_quality.as_deref(),
             ));
+            prefs.migrated_quality_auto = true;
+        }
+        // The per-model tier map is replaced wholesale ONLY when the payload carries it (the web sends
+        // the full merged map from its cache), so a theme/quality-only PUT never clobbers a stored map.
+        if let Some(per_model_tier) = payload.per_model_tier {
+            prefs.per_model_tier = Some(per_model_tier);
         }
         save_preferences(&path, &prefs)?;
         Ok(prefs)
@@ -151,7 +204,10 @@ pub(crate) async fn set_ui_preferences(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_accent, normalize_generation_quality, normalize_theme};
+    use super::{
+        migrate_quality_to_auto, normalize_accent, normalize_generation_quality, normalize_theme,
+        UiPreferences,
+    };
 
     #[test]
     fn normalize_theme_accepts_only_known_themes() {
@@ -174,13 +230,46 @@ mod tests {
     }
 
     #[test]
-    fn normalize_generation_quality_accepts_only_known_tiers_and_defaults_to_q8() {
+    fn normalize_generation_quality_accepts_auto_and_tiers_and_defaults_to_auto() {
+        assert_eq!(normalize_generation_quality(Some(" auto ")), "auto");
         assert_eq!(normalize_generation_quality(Some(" bf16 ")), "bf16");
         assert_eq!(normalize_generation_quality(Some("q8")), "q8");
         assert_eq!(normalize_generation_quality(Some("q4")), "q4");
-        // Unknown/candle-only tiers and absent values fall back to the q8 default.
-        assert_eq!(normalize_generation_quality(Some("int8-convrot")), "q8");
-        assert_eq!(normalize_generation_quality(Some("")), "q8");
-        assert_eq!(normalize_generation_quality(None), "q8");
+        // Unknown/candle-only tiers and absent values fall back to the Auto default (epic 10721 R3).
+        assert_eq!(normalize_generation_quality(Some("int8-convrot")), "auto");
+        assert_eq!(normalize_generation_quality(Some("")), "auto");
+        assert_eq!(normalize_generation_quality(None), "auto");
+    }
+
+    #[test]
+    fn migrate_quality_to_auto_flips_a_stored_q8_exactly_once() {
+        // A stored q8 (the old forced default) migrates to auto and sets the marker.
+        let mut prefs = UiPreferences {
+            default_generation_quality: Some("q8".to_owned()),
+            ..Default::default()
+        };
+        assert!(migrate_quality_to_auto(&mut prefs));
+        assert_eq!(prefs.default_generation_quality.as_deref(), Some("auto"));
+        assert!(prefs.migrated_quality_auto);
+        // Idempotent: a second pass does nothing.
+        assert!(!migrate_quality_to_auto(&mut prefs));
+
+        // A DELIBERATE q8 (marker already set, e.g. picked via PUT after the upgrade) is left alone.
+        let mut deliberate = UiPreferences {
+            default_generation_quality: Some("q8".to_owned()),
+            migrated_quality_auto: true,
+            ..Default::default()
+        };
+        assert!(!migrate_quality_to_auto(&mut deliberate));
+        assert_eq!(deliberate.default_generation_quality.as_deref(), Some("q8"));
+
+        // Non-q8 values (a deliberate bf16, or an unset install) never migrate.
+        let mut bf16 = UiPreferences {
+            default_generation_quality: Some("bf16".to_owned()),
+            ..Default::default()
+        };
+        assert!(!migrate_quality_to_auto(&mut bf16));
+        let mut unset = UiPreferences::default();
+        assert!(!migrate_quality_to_auto(&mut unset));
     }
 }

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -287,20 +287,20 @@ async fn ui_preferences_put_open_when_no_token_configured() {
 
 #[tokio::test]
 async fn ui_preferences_default_generation_quality_round_trips_and_merges() {
-    // sc-10728: the app-wide default generation quality persists like theme/accent so it
-    // survives a desktop relaunch — the shell's per-launch 127.0.0.1:<port> origin wipes
-    // origin-keyed localStorage, so the durable copy must live server-side. GET resolves an
-    // unset value to the q8 default; PUT accepts bf16|q8|q4 and MERGES, so a theme-only
-    // write can't reset a previously-chosen quality, and an invalid value coerces to q8.
+    // sc-10728 / epic 10721 R3: the app-wide default generation quality persists like theme/accent so
+    // it survives a desktop relaunch — the shell's per-launch 127.0.0.1:<port> origin wipes origin-keyed
+    // localStorage, so the durable copy must live server-side. GET resolves an unset value to the `auto`
+    // default; PUT accepts auto|bf16|q8|q4 and MERGES, so a theme-only write can't reset a previously-
+    // chosen quality, and an invalid value coerces to `auto`.
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir); // no token configured ⇒ PUT is open
     assert!(settings.access_token.is_empty());
     let app = create_app(settings).expect("app creates");
 
-    // Fresh install: GET resolves the absent value to the q8 default so the web can seed it.
+    // Fresh install: GET resolves the absent value to the `auto` default so the web can seed it.
     let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(prefs["defaultGenerationQuality"], "q8");
+    assert_eq!(prefs["defaultGenerationQuality"], "auto");
 
     // PUT a valid tier: persisted and echoed back.
     let (status, saved) = request(
@@ -332,7 +332,7 @@ async fn ui_preferences_default_generation_quality_round_trips_and_merges() {
     assert_eq!(prefs["defaultGenerationQuality"], "q4");
     assert_eq!(prefs["theme"], "dark");
 
-    // A present-but-invalid tier coerces to the q8 default (defensive; the UI never sends one).
+    // A present-but-invalid tier coerces to the `auto` default (defensive; the UI never sends one).
     let (status, saved) = request(
         app,
         "PUT",
@@ -341,7 +341,102 @@ async fn ui_preferences_default_generation_quality_round_trips_and_merges() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(saved["defaultGenerationQuality"], "q8");
+    assert_eq!(saved["defaultGenerationQuality"], "auto");
+}
+
+/// epic 10721 R3: an existing install with a stored `q8` (the old forced default, from before the
+/// `auto` option existed) is one-time migrated to `auto` on GET — but a q8 the user picks DELIBERATELY
+/// after the upgrade (which sets the migration marker via PUT) is left alone.
+#[tokio::test]
+async fn ui_preferences_migrates_a_legacy_q8_to_auto_once() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let prefs_path = settings.config_dir.join("ui-preferences.json");
+    std::fs::create_dir_all(&settings.config_dir).expect("config dir creates");
+    // Simulate a pre-Auto install: a stored q8 with no migration marker (rode along in a theme PUT).
+    std::fs::write(
+        &prefs_path,
+        r#"{"theme":"dark","defaultGenerationQuality":"q8"}"#,
+    )
+    .expect("seed legacy prefs");
+    let app = create_app(settings).expect("app creates");
+
+    // GET migrates the legacy q8 to auto and persists it.
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["defaultGenerationQuality"], "auto");
+    let on_disk = std::fs::read_to_string(&prefs_path).expect("prefs persisted");
+    assert!(
+        on_disk.contains("\"auto\""),
+        "migration is written to disk: {on_disk}"
+    );
+
+    // A DELIBERATE q8 pick after the upgrade sets the marker and sticks across a fresh GET.
+    let (status, _) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "defaultGenerationQuality": "q8" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, prefs) = request(app, "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        prefs["defaultGenerationQuality"], "q8",
+        "a deliberate post-upgrade q8 is not re-migrated"
+    );
+}
+
+/// epic 10721 R1: the per-(screen, model) tier sticky persists server-side so a user's studio pick
+/// survives a desktop relaunch (localStorage alone is wiped by the shell's per-launch origin). A PUT
+/// carrying the map replaces it wholesale (the web sends the full merged map); a PUT without it merges.
+#[tokio::test]
+async fn ui_preferences_per_model_tier_round_trips_and_merges() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let app = create_app(settings).expect("app creates");
+
+    // PUT a per-model tier map: persisted and echoed back.
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "perModelTier": { "image": { "sana_sprint_1600m": "bf16" } } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["perModelTier"]["image"]["sana_sprint_1600m"], "bf16");
+
+    // Survives a "relaunch": a fresh GET reads it back from disk.
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["perModelTier"]["image"]["sana_sprint_1600m"], "bf16");
+
+    // A theme-only PUT MERGES — it must not clobber the stored per-model map.
+    let (status, _) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "light" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (_, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(prefs["perModelTier"]["image"]["sana_sprint_1600m"], "bf16");
+    assert_eq!(prefs["theme"], "light");
+
+    // A new full map replaces (the web sends the merged map after adding another model's pick).
+    let (status, saved) = request(
+        app,
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "perModelTier": { "image": { "sana_sprint_1600m": "q8", "flux_dev": "q4" } } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["perModelTier"]["image"]["sana_sprint_1600m"], "q8");
+    assert_eq!(saved["perModelTier"]["image"]["flux_dev"], "q4");
 }
 
 #[test]

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -43,6 +43,7 @@ import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import { generationModelsForType } from "./modelEligibility.js";
 import { isAccentId } from "./accents.js";
 import { writeDefaultGenerationQuality } from "./generationQuality.js";
+import { seedLastTiersFromServer } from "./lastTierStore.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -1067,6 +1068,12 @@ export function App() {
         // normalizes, so an absent/legacy value lands on q8. No PUT: this is a read-only seed.
         if (prefs?.defaultGenerationQuality) {
           writeDefaultGenerationQuality(prefs.defaultGenerationQuality);
+        }
+        // Re-prime the per-(screen,model) tier sticky cache from the durable server copy (epic 10721
+        // R1), so a tier a user picked for a model in a previous session is returned by readLastTier
+        // even after the desktop origin — and its localStorage — changed on relaunch.
+        if (prefs?.perModelTier) {
+          seedLastTiersFromServer(prefs.perModelTier);
         }
       })
       .catch(() => {});

--- a/apps/web/src/components/editor/GenerationRail.jsx
+++ b/apps/web/src/components/editor/GenerationRail.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Icon } from "../Icons.jsx";
 import { LoraPickerSection } from "../../screens/generationStudio.jsx";
-import { tierLabel } from "../../quantTier.js";
 import { MOTIONS } from "./editorUtils.js";
 import { StudioUpdateBadge, StudioUpdateNotice, updateOptionLabel } from "../StudioUpdateNotice.jsx";
 
@@ -302,15 +301,16 @@ export function GenerationRail({ gen, header, contextActions = [], onGenerate, g
                 <div className="ve-field">
                   <span className="ve-field-label">Generation tier</span>
                   <div className="ve-chip-row">
-                    {gen.availableTiers.map((tier) => (
+                    {gen.tierPickerItems.map((item) => (
                       <button
-                        className={`ve-chip${gen.quantTier === tier ? " active" : ""}`}
-                        key={tier}
-                        onClick={() => gen.setQuantTier(tier)}
-                        title={tierLabel(tier)}
+                        className={`ve-chip${gen.quantTier === item.tier ? " active" : ""}`}
+                        key={item.tier}
+                        disabled={item.disabled}
+                        onClick={() => gen.selectTier(item.tier)}
+                        title={item.label}
                         type="button"
                       >
-                        {tier.toUpperCase()}
+                        {item.tier.toUpperCase()}
                       </button>
                     ))}
                   </div>

--- a/apps/web/src/components/editor/useEditorGeneration.js
+++ b/apps/web/src/components/editor/useEditorGeneration.js
@@ -7,7 +7,12 @@ import {
   schedulerDefaultFromModel,
   schedulerShiftDefaultFromModel,
 } from "../../samplerOptions.js";
-import { installedTiers, tierQuantize } from "../../quantTier.js";
+import {
+  allPossibleTiers,
+  installedTiers,
+  tierPickerOptions,
+  tierQuantize,
+} from "../../quantTier.js";
 import { serializeLora, buildStudioPresetPayload } from "../../presetUtils.js";
 import { WAN_A14B_LIGHTNING_MODEL_IDS } from "../../constants.js";
 import { useGenerationStudio } from "../../screens/generationStudio.jsx";
@@ -108,14 +113,23 @@ export function useEditorGeneration({ context }) {
   const durationOptions = selectedModel?.limits?.durations ?? DURATION_FALLBACK;
   const samplerOptions = useMemo(() => samplerOptionsFromModel(selectedModel, null), [selectedModel]);
   const schedulerOptions = useMemo(() => schedulerOptionsFromModel(selectedModel, null), [selectedModel]);
-  const availableTiers = useMemo(
-    () => installedTiers(selectedModel, { convRotEligible: false, nvfp4Eligible: false, defaultQuality: EDITOR_DEFAULT_TIER }),
-    [selectedModel],
-  );
+  const tierPickerOpts = { convRotEligible: false, nvfp4Eligible: false, defaultQuality: EDITOR_DEFAULT_TIER };
+  const availableTiers = useMemo(() => installedTiers(selectedModel, tierPickerOpts), [selectedModel]);
+  // Full display set + option list with un-downloaded tiers disabled — same show-all/disable-unavailable
+  // rule as the studios. `availableTiers` stays the SELECTABLE set; the picker shows when there is more
+  // than one POSSIBLE tier and at least one is installed.
+  const possibleTiers = useMemo(() => allPossibleTiers(selectedModel, tierPickerOpts), [selectedModel]);
+  const tierPickerItems = useMemo(() => tierPickerOptions(selectedModel, tierPickerOpts), [selectedModel]);
+  // Only an installed tier can be selected; disabled chips are shown for discoverability, never picked.
+  const selectTier = (tier) => {
+    if (availableTiers.includes(tier)) {
+      setQuantTier(tier);
+    }
+  };
 
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
-  const showTierPicker = availableTiers.length > 1;
+  const showTierPicker = possibleTiers.length > 1 && availableTiers.length > 0;
   const showLightning = WAN_A14B_LIGHTNING_MODEL_IDS.has(model);
   const lightningActive = showLightning && lightning;
 
@@ -327,6 +341,8 @@ export function useEditorGeneration({ context }) {
     quantTier,
     setQuantTier,
     availableTiers,
+    tierPickerItems,
+    selectTier,
     showTierPicker,
     lightning,
     setLightning,

--- a/apps/web/src/generationQuality.js
+++ b/apps/web/src/generationQuality.js
@@ -23,10 +23,21 @@ import { DEFAULT_GENERATION_QUALITY, GENERATION_QUALITY_TIERS } from "./quantTie
 // import without also reaching into quantTier.js.
 export { DEFAULT_GENERATION_QUALITY, GENERATION_QUALITY_TIERS } from "./quantTier.js";
 
+// The capability-aware "Auto" mode (epic 10721 R3) — the DEFAULT. In Auto, each model's default tier is
+// the highest-fidelity tier that fits this machine's memory (`suggestTier`), so a small model defaults to
+// bf16 and a heavy one on a small Mac defaults to what fits — instead of a flat tier for everything. A
+// user can still pin an explicit bf16/q8/q4 globally, or override per-model in a studio (that pick is
+// saved). NOT a quant tier, so it is deliberately absent from `GENERATION_QUALITY_TIERS`.
+export const AUTO_GENERATION_QUALITY = "auto";
+
+// The Settings dropdown vocabulary, in display order: Auto first (the default), then the explicit tiers.
+export const GENERATION_QUALITY_OPTIONS = [AUTO_GENERATION_QUALITY, ...GENERATION_QUALITY_TIERS];
+
 const STORAGE_KEY = "sceneworks-default-generation-quality";
 
-// Legible Settings labels, keyed by tier. Unknown keys fall back to the raw key.
+// Legible Settings labels, keyed by value. Unknown keys fall back to the raw key.
 const LABELS = {
+  [AUTO_GENERATION_QUALITY]: "Auto (best that fits this Mac)",
   bf16: "High fidelity (bf16)",
   q8: "Balanced (Q8)",
   q4: "Fast (Q4)",
@@ -36,9 +47,13 @@ export function generationQualityLabel(value) {
   return LABELS[value] ?? value;
 }
 
-// The valid quality tier for `value`, or the q8 default when it isn't one of bf16|q8|q4.
+// The valid setting for `value` — "auto" or an explicit bf16|q8|q4 — else the "auto" default when it
+// isn't one of them. Auto is the app-wide default (epic 10721 R3): an unset/invalid preference means
+// "let the app pick the best tier that fits", not a flat q8.
 export function normalizeGenerationQuality(value) {
-  return GENERATION_QUALITY_TIERS.includes(value) ? value : DEFAULT_GENERATION_QUALITY;
+  return value === AUTO_GENERATION_QUALITY || GENERATION_QUALITY_TIERS.includes(value)
+    ? value
+    : AUTO_GENERATION_QUALITY;
 }
 
 // The global default generation quality from the instant-paint cache, or q8 when unset / invalid /

--- a/apps/web/src/generationQuality.test.js
+++ b/apps/web/src/generationQuality.test.js
@@ -17,9 +17,11 @@ describe("generationQuality store (sc-10728)", () => {
     window.localStorage.clear();
   });
 
-  it("defaults to q8 when nothing is stored", () => {
+  it("defaults to Auto when nothing is stored (epic 10721 R3)", () => {
+    // DEFAULT_GENERATION_QUALITY stays q8 — it is the no-signal FALLBACK tier used when Auto has no
+    // capability reading — but the SETTING's default is now Auto (capability-aware).
     expect(DEFAULT_GENERATION_QUALITY).toBe("q8");
-    expect(readDefaultGenerationQuality()).toBe("q8");
+    expect(readDefaultGenerationQuality()).toBe("auto");
   });
 
   it("reads back a valid stored value", () => {
@@ -29,11 +31,11 @@ describe("generationQuality store (sc-10728)", () => {
     expect(readDefaultGenerationQuality()).toBe("q4");
   });
 
-  it("normalizes an unknown/garbage stored value back to q8", () => {
+  it("normalizes an unknown/garbage stored value back to Auto", () => {
     window.localStorage.setItem(STORAGE_KEY, "int8-convrot");
-    expect(readDefaultGenerationQuality()).toBe("q8");
+    expect(readDefaultGenerationQuality()).toBe("auto");
     window.localStorage.setItem(STORAGE_KEY, "totally-bogus");
-    expect(readDefaultGenerationQuality()).toBe("q8");
+    expect(readDefaultGenerationQuality()).toBe("auto");
   });
 
   it("persists a write and survives a simulated restart (round-trip)", () => {
@@ -44,18 +46,20 @@ describe("generationQuality store (sc-10728)", () => {
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("bf16");
   });
 
-  it("write normalizes an invalid value to q8 before persisting", () => {
-    expect(writeDefaultGenerationQuality("nonsense")).toBe("q8");
-    expect(readDefaultGenerationQuality()).toBe("q8");
+  it("write normalizes an invalid value to Auto before persisting", () => {
+    expect(writeDefaultGenerationQuality("nonsense")).toBe("auto");
+    expect(readDefaultGenerationQuality()).toBe("auto");
   });
 
-  it("normalizeGenerationQuality validates against bf16|q8|q4", () => {
+  it("normalizeGenerationQuality validates against auto|bf16|q8|q4", () => {
+    expect(normalizeGenerationQuality("auto")).toBe("auto");
     expect(normalizeGenerationQuality("bf16")).toBe("bf16");
     expect(normalizeGenerationQuality("q8")).toBe("q8");
     expect(normalizeGenerationQuality("q4")).toBe("q4");
-    expect(normalizeGenerationQuality("int8-convrot")).toBe("q8");
-    expect(normalizeGenerationQuality(null)).toBe("q8");
-    expect(normalizeGenerationQuality(undefined)).toBe("q8");
+    // Unknown / non-quality values fall back to Auto (the new default), not a flat q8.
+    expect(normalizeGenerationQuality("int8-convrot")).toBe("auto");
+    expect(normalizeGenerationQuality(null)).toBe("auto");
+    expect(normalizeGenerationQuality(undefined)).toBe("auto");
   });
 
   it("labels each tier legibly and falls back to the raw key", () => {

--- a/apps/web/src/hooks/useUnifiedMemoryGb.js
+++ b/apps/web/src/hooks/useUnifiedMemoryGb.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { apiFetch } from "../api.js";
+import { serverToken } from "../credentials.js";
+import { isDesktop, tauriInvoke } from "../runtime.js";
+
+// The host's unified memory (GPU VRAM off Mac) in GB, or `null` until the probe resolves / when the
+// signal is unavailable. Desktop reads the Tauri GPU probe (`get_gpu_info`); a remote LAN browser reads
+// the auth-protected REST host-capabilities signal derived from the registered GPU worker (epic 4484
+// story 9). Extracted verbatim from ModelManagerScreen's probe so the Models download suggestion and
+// the studios' capability-aware default tier (`suggestTier`) budget against the SAME memory reading.
+//
+// `null` is a valid, safe value everywhere it flows: `tierFits`/`suggestTier` treat an unknown memory as
+// "fits" (never withhold a tier on missing data), so the capability default leans to the highest tier
+// until the reading lands — and the worker's own capability downtier (sc-10733) still clamps a
+// non-explicit pick to what actually fits, so a brief high default never OOMs a constrained host.
+export function useUnifiedMemoryGb() {
+  const [unifiedMemoryGb, setUnifiedMemoryGb] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    if (isDesktop) {
+      // Desktop: read unified memory straight from the Tauri GPU probe.
+      tauriInvoke("get_gpu_info")
+        .then((info) => {
+          if (!cancelled && info && typeof info.unifiedMemoryMb === "number") {
+            setUnifiedMemoryGb(info.unifiedMemoryMb / 1024);
+          }
+        })
+        .catch(() => {});
+    } else {
+      // Remote LAN browser: the Tauri probe is unavailable, so read the host's memory from the
+      // auth-protected REST signal (unified memory on macOS / GPU VRAM on Windows).
+      apiFetch("/api/v1/host-capabilities", serverToken())
+        .then((caps) => {
+          if (cancelled || !caps) {
+            return;
+          }
+          const gb = caps.unifiedMemoryGb ?? caps.gpuMemoryGb;
+          if (typeof gb === "number") {
+            setUnifiedMemoryGb(gb);
+          }
+        })
+        .catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return unifiedMemoryGb;
+}

--- a/apps/web/src/lastTierStore.js
+++ b/apps/web/src/lastTierStore.js
@@ -21,7 +21,31 @@
 // `defaultTierSelection`, which honors it whenever the sticky tier is still installed and otherwise
 // falls through to the base default — so a stale/uninstalled sticky is safely ignored (clamped).
 
+import { apiFetch } from "./api.js";
+
 const STORAGE_KEY = "sceneworks-last-tier";
+
+// Persist the full `{ [screen]: { [modelId]: tier } }` map to the durable server copy (epic 10721 R1).
+// localStorage alone does NOT survive a desktop relaunch — the shell's `127.0.0.1:<port>` origin changes
+// every launch, wiping origin-keyed storage — so a pick would be forgotten each session without this.
+// Best-effort + fire-and-forget: the localStorage write already succeeded, so a failed PUT only means the
+// pick isn't durable this once. Public route, empty token — mirrors the global default-quality PUT.
+function persistToServer(map) {
+  apiFetch("/api/v1/ui-preferences", "", {
+    method: "PUT",
+    body: JSON.stringify({ perModelTier: map }),
+  }).catch(() => {});
+}
+
+// Seed the localStorage instant-paint cache from the durable server copy on launch (App.jsx, after
+// GET /api/v1/ui-preferences). Without this, `readLastTier` would miss a pick made in a previous session
+// once the desktop origin — and its localStorage — changed. Overwrites the cache with the server map,
+// which is authoritative across launches (the cache is only ever a within-session mirror of it).
+export function seedLastTiersFromServer(map) {
+  if (map && typeof map === "object") {
+    writeAll(map);
+  }
+}
 
 function readAll() {
   try {
@@ -67,4 +91,6 @@ export function writeLastTier(screen, modelId, tier) {
   }
   map[screen] = { ...perScreen, [modelId]: tier };
   writeAll(map);
+  // Mirror the pick to the durable server copy so it survives a desktop relaunch (localStorage doesn't).
+  persistToServer(map);
 }

--- a/apps/web/src/lastTierStore.test.js
+++ b/apps/web/src/lastTierStore.test.js
@@ -1,5 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readLastTier, writeLastTier } from "./lastTierStore.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The store mirrors every pick to the durable server copy (epic 10721 R1) so it survives a desktop
+// relaunch. Mock the API so the tests can assert the write-through without a live server.
+vi.mock("./api.js", () => ({ apiFetch: vi.fn(() => Promise.resolve({})) }));
+
+import { apiFetch } from "./api.js";
+import { readLastTier, seedLastTiersFromServer, writeLastTier } from "./lastTierStore.js";
 import { defaultTierSelection } from "./quantTier.js";
 
 // A download-matrix model whose `installed` tiers are present; unlisted declared tiers are missing.
@@ -19,6 +25,7 @@ const STORAGE_KEY = "sceneworks-last-tier";
 
 beforeEach(() => {
   window.localStorage.clear();
+  apiFetch.mockClear();
 });
 
 afterEach(() => {
@@ -131,5 +138,42 @@ describe("lastTierStore — precedence with defaultTierSelection", () => {
     expect(defaultTierSelection(convertModel, readLastTier("image", convertModel.id))).toBe("q8");
     writeLastTier("image", convertModel.id, "q4");
     expect(defaultTierSelection(convertModel, readLastTier("image", convertModel.id))).toBe("q4");
+  });
+});
+
+describe("lastTierStore — durable server persistence (epic 10721 R1)", () => {
+  it("mirrors each pick to the durable ui-preferences copy as the full merged map", () => {
+    writeLastTier("image", "sana_sprint_1600m", "bf16");
+    writeLastTier("image", "flux_dev", "q4");
+    writeLastTier("video", "wan_ti2v_5b", "q8");
+
+    // Every write PUTs the FULL map (so the server can replace wholesale — no deep-merge needed).
+    expect(apiFetch).toHaveBeenCalledTimes(3);
+    const [path, token, opts] = apiFetch.mock.calls.at(-1);
+    expect(path).toBe("/api/v1/ui-preferences");
+    expect(token).toBe(""); // public route
+    expect(opts.method).toBe("PUT");
+    expect(JSON.parse(opts.body)).toEqual({
+      perModelTier: {
+        image: { sana_sprint_1600m: "bf16", flux_dev: "q4" },
+        video: { wan_ti2v_5b: "q8" },
+      },
+    });
+  });
+
+  it("does not re-PUT when the pick is unchanged", () => {
+    writeLastTier("image", "model_x", "q8");
+    apiFetch.mockClear();
+    writeLastTier("image", "model_x", "q8"); // same value — no-op
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("seedLastTiersFromServer primes the cache so a prior-session pick is read back after relaunch", () => {
+    // Simulate a fresh launch: localStorage empty, server returns a stored map.
+    expect(readLastTier("image", "sana_sprint_1600m")).toBe(null);
+    seedLastTiersFromServer({ image: { sana_sprint_1600m: "bf16" } });
+    expect(readLastTier("image", "sana_sprint_1600m")).toBe("bf16");
+    // Seeding is a read-only cache prime — it must not echo a redundant PUT back to the server.
+    expect(apiFetch).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/quantTier.js
+++ b/apps/web/src/quantTier.js
@@ -179,14 +179,117 @@ export function installedTiers(model, options = {}) {
       .map((variant) => variant.variant)
       .sort(sortByTierOrder);
   }
-  // Convert-at-install models (sc-10730): tiers are convert OUTPUTS on disk, surfaced by the catalog as
-  // `mlxTiers` — a plain array of installed tier keys, DECOUPLED from the download variant-matrix so the
-  // Models download panel (`hasVariantMatrix`) is untouched. Anima (and other convert-at-install models)
-  // get a Studio generation-time tier picker this way.
+  // Convert-at-install models (sc-10730): tiers are convert OUTPUTS on disk, DECOUPLED from the download
+  // variant-matrix so the Models download panel (`hasVariantMatrix`) is untouched. Preferred shape is the
+  // richer per-tier `mlxTierStates` (each `{ tier, installState, cacheState }`) — the SELECTABLE set is
+  // the tiers whose install is `"installed"` (complete), exactly like the variant matrix above, so a torn
+  // convert output is never offered. Falls back to the legacy installed-only `mlxTiers` list (a plain
+  // array of already-installed keys) when the richer field is absent.
+  if (Array.isArray(model?.mlxTierStates) && model.mlxTierStates.length > 0) {
+    return model.mlxTierStates
+      .filter(
+        (state) =>
+          state &&
+          isSelectableTier(state.tier) &&
+          hostEligible(state.tier) &&
+          state.installState === "installed",
+      )
+      .map((state) => state.tier)
+      .sort(sortByTierOrder);
+  }
   if (Array.isArray(model?.mlxTiers) && model.mlxTiers.length > 0) {
     return model.mlxTiers.filter((tier) => isSelectableTier(tier) && hostEligible(tier)).sort(sortByTierOrder);
   }
   return [];
+}
+
+// Per-tier install state keyed by tier, drawn from whichever catalog shape the model carries. Returns a
+// lookup `tier => { installState, cacheState }` (both may be undefined for a tier the catalog omits).
+// Download-matrix models carry it on `variants[]`; convert-at-install models on the richer
+// `mlxTierStates[]` (each `{ tier, installState, cacheState }`) added so their picker can show the FULL
+// possible set with per-tier availability, not just the installed ones (the legacy `mlxTiers` list has
+// no completeness metadata). Only used to explain WHY a tier is disabled — never to decide selectability
+// (that stays `installedTiers`, the single source of "safe to send").
+function tierStateLookup(model) {
+  const map = new Map();
+  if (model?.hasVariantMatrix && Array.isArray(model.variants)) {
+    for (const variant of model.variants) {
+      if (variant?.variant) {
+        map.set(variant.variant, {
+          installState: variant.installState,
+          cacheState: variant.cacheState,
+        });
+      }
+    }
+  } else if (Array.isArray(model?.mlxTierStates)) {
+    for (const state of model.mlxTierStates) {
+      if (state?.tier) {
+        map.set(state.tier, { installState: state.installState, cacheState: state.cacheState });
+      }
+    }
+  }
+  return (tier) => map.get(tier);
+}
+
+// The FULL set of quant tiers to DISPLAY in a studio picker — every tier the model CAN have, installed
+// or not, in display order. UNLIKE `installedTiers` (only the on-disk-and-complete, selectable tiers),
+// this is the superset the dropdown renders so a user SEES a tier they haven't downloaded (rendered
+// disabled) instead of it silently not existing. The user's bottom line — never generate off a tier
+// that isn't in the cache — is enforced by `installedTiers` (selectability), NOT by this set; this only
+// governs what is shown.
+//
+// Source of the "possible" set:
+//  - Download variant-matrix models (sc-8508): every declared `variants[].variant` — the catalog lists
+//    each tier whether or not it is installed — filtered to selectable + host-eligible.
+//  - Convert-at-install models (sc-10730) that emit the richer per-tier `mlxTierStates` array: every
+//    tier key in it. Falls back to the legacy installed-only `mlxTiers` list when the richer field is
+//    absent, so an older API (or a model not yet upgraded) keeps today's installed-only display rather
+//    than regressing to an empty picker.
+// Returns [] when the model exposes no tier information at all.
+export function allPossibleTiers(model, options = {}) {
+  const { convRotEligible = true, nvfp4Eligible = true } = options;
+  const hostEligible = (tier) =>
+    (convRotEligible || !isConvRotTier(tier)) && (nvfp4Eligible || !isNvfp4Tier(tier));
+  if (model?.hasVariantMatrix && Array.isArray(model.variants)) {
+    return model.variants
+      .filter(
+        (variant) => variant && isSelectableTier(variant.variant) && hostEligible(variant.variant),
+      )
+      .map((variant) => variant.variant)
+      .sort(sortByTierOrder);
+  }
+  if (Array.isArray(model?.mlxTierStates) && model.mlxTierStates.length > 0) {
+    return model.mlxTierStates
+      .filter((state) => state && isSelectableTier(state.tier) && hostEligible(state.tier))
+      .map((state) => state.tier)
+      .sort(sortByTierOrder);
+  }
+  if (Array.isArray(model?.mlxTiers) && model.mlxTiers.length > 0) {
+    return model.mlxTiers.filter((tier) => isSelectableTier(tier) && hostEligible(tier)).sort(sortByTierOrder);
+  }
+  return [];
+}
+
+// The studio tier-picker option list: every POSSIBLE tier as `{ tier, label, disabled }`, in display
+// order, with `disabled: true` for any tier that is NOT installed-and-complete. The three studio
+// surfaces (Image / Video / Editor) render this directly, so the "show all, disable the un-downloaded"
+// rule and its labelling live in ONE place. A disabled option's label carries an explanatory suffix so
+// the user understands why it can't be picked (and, for a torn install, that a re-download is needed).
+// Selectability is `installedTiers` verbatim — the ONLY set that is safe to send to the worker.
+export function tierPickerOptions(model, options = {}) {
+  const installed = new Set(installedTiers(model, options));
+  const stateFor = tierStateLookup(model);
+  return allPossibleTiers(model, options).map((tier) => {
+    if (installed.has(tier)) {
+      return { tier, label: tierLabel(tier), disabled: false };
+    }
+    // A tier present-but-torn reports cacheState "incomplete" (never "installed"); a cleanly-absent one
+    // reports "missing"/undefined. Distinguish so a torn tier reads as "re-download", not "not
+    // downloaded" — the torn case is exactly the crash this whole change exists to prevent.
+    const suffix =
+      stateFor(tier)?.cacheState === "incomplete" ? "download incomplete" : "not downloaded";
+    return { tier, label: `${tierLabel(tier)} — ${suffix}`, disabled: true };
+  });
 }
 
 // Quality rank of a generation quant tier: higher = more faithful (bf16 > q8 > q4). Derived from
@@ -289,16 +392,24 @@ export function defaultTierSelection(model, lastUsed, options = {}) {
   // catalog (no `default` emitted), kept so a manifest that does declare one still wins — subject to the
   // floor below (a declared q4 on a q8-floored model still starts at q8).
   const declared = defaultInstalledTier(model, tiers);
-  // Rung 3: the global default-generation-quality setting is the app-wide base default. The caller
-  // passes it as `options.defaultQuality`; an absent/invalid value falls back to Q8 (the historical
-  // base + worker default) so legacy call sites are unchanged. The base leads a clean-tier fallback so
-  // it is always clamped to what's installed — a base tier that isn't on disk resolves to the nearest
-  // installed clean tier (never the washed q4 unless that's all that's left), never null.
-  let base =
-    declared ??
-    (GENERATION_QUALITY_TIERS.includes(options.defaultQuality)
-      ? options.defaultQuality
-      : DEFAULT_GENERATION_QUALITY);
+  // Rung 3: the global default-generation-quality setting (`options.defaultQuality`), the app-wide base:
+  //   - an explicit tier (bf16/q8/q4) is used verbatim — the user pinned a global quality in Settings;
+  //   - "auto" (the DEFAULT, epic 10721 R3) — or an absent/invalid value — uses the capability-aware
+  //     suggestion `options.autoTier`: the highest-fidelity tier that FITS this machine's memory, which
+  //     the caller computes via `suggestTier(model, unifiedMemoryGb)`. This is what lets a tiny model
+  //     (SANA-Sprint) default to bf16 and a heavy model on a small Mac default to what actually fits,
+  //     instead of a flat q8 for everything (epic 10721 R1/R4/R5 — "lean higher on Apple Silicon").
+  //   - when Auto has no signal (no memory reading yet, or a model with no matrix), `autoTier` is
+  //     null/unknown and this falls back to `DEFAULT_GENERATION_QUALITY` (q8), the historical base — so
+  //     legacy callers that pass neither field stay byte-identical.
+  // The clean-tier fallback below then clamps whatever base we pick to what's actually installed.
+  const explicitQuality = GENERATION_QUALITY_TIERS.includes(options.defaultQuality)
+    ? options.defaultQuality
+    : null;
+  const autoBase = GENERATION_QUALITY_TIERS.includes(options.autoTier)
+    ? options.autoTier
+    : DEFAULT_GENERATION_QUALITY;
+  let base = declared ?? explicitQuality ?? autoBase;
   // Clamp the default UP to the model's quality floor (raises only — a base at/above the floor is
   // untouched; the below fallback still caps it at what's installed).
   if (floor && isTierBelow(base, floor)) {

--- a/apps/web/src/quantTier.test.js
+++ b/apps/web/src/quantTier.test.js
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_GENERATION_QUALITY,
   GENERATION_QUALITY_TIERS,
+  allPossibleTiers,
   defaultTierSelection,
   installedTiers,
   isBelowFloor,
+  tierPickerOptions,
   isConvRotTier,
   isNvfp4Tier,
   isSelectableTier,
@@ -543,5 +545,127 @@ describe("defaultTierSelection — full precedence ladder (sc-10732)", () => {
     // installed tier (rung 4 / `tiers[0]`), proving the bottom of the ladder.
     const model = matrixModel({ tiers: ["bf16"], installed: ["bf16"], defaultTier: "none" });
     expect(defaultTierSelection(model, null)).toBe("bf16");
+  });
+});
+
+// A variant-matrix model where SOME tiers are installed, some torn (present-but-incomplete), some
+// cleanly absent — the exact mix the picker must render "all shown, only installed selectable".
+function mixedMatrixModel() {
+  return {
+    id: "z_image_turbo",
+    hasVariantMatrix: true,
+    variants: [
+      { variant: "q4", installState: "installed", cacheState: "complete" },
+      { variant: "q8", installState: "missing", cacheState: "incomplete" }, // torn: DiT present, tokenizer gone
+      { variant: "bf16", installState: "missing", cacheState: "missing" }, // never downloaded
+    ],
+  };
+}
+
+describe("allPossibleTiers — the full display set (all tiers, installed or not)", () => {
+  it("returns EVERY declared variant tier, installed or not, in display order", () => {
+    // Only q4 is installed, yet all three must be listed so the un-downloaded ones can render disabled.
+    expect(allPossibleTiers(mixedMatrixModel())).toEqual(["q4", "q8", "bf16"]);
+  });
+
+  it("differs from installedTiers, which stays the selectable (safe-to-send) subset", () => {
+    const model = mixedMatrixModel();
+    expect(installedTiers(model)).toEqual(["q4"]);
+    expect(allPossibleTiers(model)).toEqual(["q4", "q8", "bf16"]);
+  });
+
+  it("uses the richer mlxTierStates set for convert-at-install models when present", () => {
+    const model = {
+      id: "sana_sprint_1600m",
+      hasVariantMatrix: false,
+      mlxTierStates: [
+        { tier: "q4", installState: "installed", cacheState: "complete" },
+        { tier: "q8", installState: "installed", cacheState: "complete" },
+        { tier: "bf16", installState: "missing", cacheState: "missing" },
+      ],
+    };
+    expect(allPossibleTiers(model)).toEqual(["q4", "q8", "bf16"]);
+    expect(installedTiers(model)).toEqual(["q4", "q8"]);
+  });
+
+  it("falls back to the legacy installed-only mlxTiers list when no richer field exists", () => {
+    // No mlxTierStates: an un-upgraded catalog keeps today's installed-only display, no regression.
+    expect(allPossibleTiers({ id: "anima_base", hasVariantMatrix: false, mlxTiers: ["q4", "q8"] })).toEqual([
+      "q4",
+      "q8",
+    ]);
+  });
+
+  it("returns [] when the model exposes no tier information", () => {
+    expect(allPossibleTiers({ id: "boogu", hasVariantMatrix: false })).toEqual([]);
+    expect(allPossibleTiers(undefined)).toEqual([]);
+  });
+});
+
+describe("tierPickerOptions — show all, disable the un-downloaded", () => {
+  it("marks installed tiers selectable and un-installed tiers disabled", () => {
+    const options = tierPickerOptions(mixedMatrixModel());
+    expect(options.map((o) => o.tier)).toEqual(["q4", "q8", "bf16"]);
+    expect(options.map((o) => o.disabled)).toEqual([false, true, true]);
+  });
+
+  it("labels a torn (incomplete) tier distinctly from a never-downloaded one", () => {
+    const byTier = Object.fromEntries(tierPickerOptions(mixedMatrixModel()).map((o) => [o.tier, o.label]));
+    expect(byTier.q4).toBe("Q4 (smallest)"); // installed → plain label, no suffix
+    expect(byTier.q8).toBe("Q8 (balanced) — download incomplete"); // torn → re-download hint
+    expect(byTier.bf16).toBe("Full precision (bf16) — not downloaded"); // cleanly absent
+  });
+
+  it("never marks an installed tier disabled (the selectable set is installedTiers verbatim)", () => {
+    const model = matrixModel({ tiers: ["q4", "q8", "bf16"], installed: ["q4", "bf16"] });
+    const disabledInstalled = tierPickerOptions(model).filter(
+      (o) => o.disabled && installedTiers(model).includes(o.tier),
+    );
+    expect(disabledInstalled).toEqual([]);
+  });
+});
+
+describe("defaultTierSelection — capability-aware Auto base (epic 10721 R1/R3/R4)", () => {
+  // `defaultTier: "none"` mirrors the real catalog, which never emits `variant.default` — so the dead
+  // rung-2 `declared` never masks the Auto base under test.
+  it("uses options.autoTier as the base when the global quality is Auto (or unset)", () => {
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    // Auto suggested bf16 (small model / roomy Mac) → default bf16.
+    expect(defaultTierSelection(model, null, { defaultQuality: "auto", autoTier: "bf16" })).toBe("bf16");
+    // Auto suggested q4 (heavy model / small Mac) → default q4, even though bf16 IS installed — Auto
+    // respects what fits, it doesn't just grab the highest installed.
+    expect(defaultTierSelection(model, null, { defaultQuality: "auto", autoTier: "q4" })).toBe("q4");
+    // An absent defaultQuality behaves like Auto (the new default).
+    expect(defaultTierSelection(model, null, { autoTier: "q8" })).toBe("q8");
+  });
+
+  it("an explicit global tier setting overrides Auto", () => {
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "q4", autoTier: "bf16" })).toBe("q4");
+  });
+
+  it("a saved sticky overrides Auto; an uninstalled sticky reverts to Auto (not q8)", () => {
+    const model = matrixModel({ tiers: ["q4", "q8", "bf16"], installed: ["q4", "bf16"], defaultTier: "none" });
+    // Saved bf16, still installed → honored over Auto's q4 suggestion.
+    expect(defaultTierSelection(model, "bf16", { defaultQuality: "auto", autoTier: "q4" })).toBe("bf16");
+    // Saved q8 no longer installed (user deleted it) → revert to Auto's q4 suggestion, NOT a flat q8.
+    expect(defaultTierSelection(model, "q8", { defaultQuality: "auto", autoTier: "q4" })).toBe("q4");
+  });
+
+  it("falls back to q8 only when Auto has no signal (autoTier null — no memory / no matrix)", () => {
+    const model = matrixModel({ installed: ["q4", "q8", "bf16"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "auto", autoTier: null })).toBe("q8");
+  });
+
+  it("clamps the Auto suggestion to what's installed", () => {
+    // Auto suggested bf16 but it isn't downloaded → nearest installed clean tier (q8), never null.
+    const model = matrixModel({ tiers: ["q4", "q8", "bf16"], installed: ["q4", "q8"], defaultTier: "none" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "auto", autoTier: "bf16" })).toBe("q8");
+  });
+
+  it("clamps the Auto suggestion UP to the model quality floor", () => {
+    // Auto suggested q4, but the model's floor is q8 → raised to q8 (floor wins over the suggestion).
+    const model = flooredConvertModel({ mlxTiers: ["q4", "q8", "bf16"], floor: "q8" });
+    expect(defaultTierSelection(model, null, { defaultQuality: "auto", autoTier: "q4" })).toBe("q8");
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -138,13 +138,16 @@ import {
 import { ControlPanel } from "../components/ControlPanel.jsx";
 import { pidToggleVisible } from "../pidEligibility.js";
 import {
+  allPossibleTiers,
   defaultTierSelection,
   installedTiers,
   isBelowFloor,
   modelQualityFloor,
-  shouldShowTierPicker,
   tierLabel,
+  tierPickerOptions,
 } from "../quantTier.js";
+import { suggestTier } from "../tierSuggestion.js";
+import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
 import { readLastTier, writeLastTier } from "../lastTierStore.js";
 import { readDefaultGenerationQuality } from "../generationQuality.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
@@ -932,17 +935,39 @@ export function ImageStudio() {
   // Whether the model ships a packed default + a hosted full-precision bf16 build, exposing the
   // Studio "Full precision (bf16)" toggle (sc-6568) — Boogu Base/Turbo/Edit.
   const precisionToggle = Boolean(selectedModel?.ui?.precisionToggle);
-  // Installed quant tiers of the active model + whether the tier picker should show (sc-8515).
-  // The picker renders only when MORE THAN ONE tier is installed; a single installed tier keeps
-  // the studio unchanged (no toggle). Boogu's `precisionToggle` is orthogonal — those models are
-  // single-download (no variant matrix), so they never hit this path.
+  // Quant-tier picker state (sc-8515, generalized). `availableTiers` is the SELECTABLE set — tiers that
+  // are installed AND complete on disk, and the ONLY tiers we ever send to the worker (the user's bottom
+  // line: never generate off a tier that isn't in the cache). `possibleTiers` is the FULL display set —
+  // every tier the model can have, installed or not — so an un-downloaded tier renders disabled rather
+  // than silently missing. The picker shows whenever there is MORE THAN ONE possible tier (so a user with
+  // one installed tier still sees the others, greyed), provided at least one is actually installed to
+  // select. Boogu's `precisionToggle` is orthogonal — those models have no tier matrix, so `possibleTiers`
+  // is empty and this stays hidden for them.
   const availableTiers = useMemo(
     () => installedTiers(selectedModel, tierOptions),
     [selectedModel, tierOptions],
   );
-  const showTierPicker = useMemo(
-    () => shouldShowTierPicker(selectedModel, tierOptions),
+  // Capability-aware "Auto" default (epic 10721): the highest-fidelity tier that fits this machine's
+  // memory. Fed to `defaultTierSelection` as the base when the global quality setting is Auto (the
+  // default), so a small model (SANA-Sprint) defaults to bf16 and a heavy one on a small Mac to what
+  // fits — instead of a flat q8. `null` memory (probe pending / unavailable) leans to the highest tier;
+  // the worker's capability downtier (sc-10733) still clamps a non-explicit pick to what actually fits.
+  const unifiedMemoryGb = useUnifiedMemoryGb();
+  const autoTier = useMemo(
+    () => suggestTier(selectedModel, unifiedMemoryGb),
+    [selectedModel, unifiedMemoryGb],
+  );
+  const possibleTiers = useMemo(
+    () => allPossibleTiers(selectedModel, tierOptions),
     [selectedModel, tierOptions],
+  );
+  const tierPickerItems = useMemo(
+    () => tierPickerOptions(selectedModel, tierOptions),
+    [selectedModel, tierOptions],
+  );
+  const showTierPicker = useMemo(
+    () => possibleTiers.length > 1 && availableTiers.length > 0,
+    [possibleTiers, availableTiers],
   );
   // Per-model quality floor (sc-10731): the model's minimum-fidelity tier (`minQualityTier`) and whether
   // the CURRENT pick sits below it. The DEFAULT is already clamped up to the floor (defaultTierSelection),
@@ -1325,10 +1350,12 @@ export function ImageStudio() {
         // the per-(screen,model) sticky. Read fresh here (like readLastTier) so a change made in Settings
         // is picked up the next time this effect derives a default — no stale in-memory copy.
         defaultQuality: readDefaultGenerationQuality(),
+        // When that setting is Auto (the default), the base is this capability-aware suggestion.
+        autoTier,
       }) ?? "",
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [model, availableTiersKey]);
+  }, [model, availableTiersKey, autoTier]);
   // Switch the active quant tier (sc-8515): persist it as this (screen, model)'s last EXPLICIT tier
   // (sc-10727 — sticky) and surface a brief "loading <tier>" note (reload-always — the worker evicts
   // + reloads a heavy tier on the next generation; there is no co-residence). The note self-clears.
@@ -1336,7 +1363,11 @@ export function ImageStudio() {
   useEffect(() => () => clearTimeout(tierSwitchTimer.current), []);
   const handleTierChange = useCallback(
     (nextTier) => {
-      if (nextTier === quantTier) {
+      // Only an installed-and-complete tier can be selected — the disabled options in the dropdown are
+      // shown for discoverability, never as a pickable target. This is the belt behind the native
+      // `<option disabled>` (which already blocks selection) so no code path can strand the state on a
+      // tier that isn't in the cache.
+      if (nextTier === quantTier || !availableTiers.includes(nextTier)) {
         return;
       }
       setQuantTier(nextTier);
@@ -1345,7 +1376,7 @@ export function ImageStudio() {
       clearTimeout(tierSwitchTimer.current);
       tierSwitchTimer.current = setTimeout(() => setTierSwitching(""), 1500);
     },
-    [model, quantTier],
+    [model, quantTier, availableTiers],
   );
   const {
     availablePresets,
@@ -2045,12 +2076,19 @@ export function ImageStudio() {
       precisionToggle,
       bf16Precision,
       showTierPicker,
-      quantTier,
+      // Never send a tier that isn't installed-and-complete. The seed effect keeps `quantTier` clamped to
+      // an installed tier, but gate the OUTGOING value on the selectable set as a hard belt so no state —
+      // a race, a stale sticky, a torn tier newly reported missing — can leak an uninstalled tier into the
+      // payload (the worker would then default/crash against a tier the user never downloaded). Mirrors the
+      // guard VideoStudio/Editor already apply. Empty string ⇒ `tierQuantize("")` is null ⇒ no mlxQuantize.
+      quantTier: availableTiers.includes(quantTier) ? quantTier : "",
       // sc-10733: the tier is a DELIBERATE pick (not the pure global/base default) when it equals this
       // (screen, model)'s persisted sticky — a prior explicit pick, which `handleTierChange` writes and
       // the seed effect reads back into `quantTier`. The worker honors an explicit pick (never silently
-      // downtiers it); only a non-explicit default is capability-clamped.
-      tierExplicit: quantTier !== "" && readLastTier(TIER_SCREEN, model) === quantTier,
+      // downtiers it); only a non-explicit default is capability-clamped. Gate on the same installed-set
+      // membership so an uninstalled sticky is never flagged explicit.
+      tierExplicit:
+        availableTiers.includes(quantTier) && readLastTier(TIER_SCREEN, model) === quantTier,
       showPidToggle,
       usePid,
       pidTarget,
@@ -3302,15 +3340,15 @@ export function ImageStudio() {
                 </label>
               ) : null}
               {showTierPicker ? (
-                <label className="quant-tier-picker" title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation.">
+                <label className="quant-tier-picker" title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation. Tiers you haven't downloaded are shown but disabled — install them from the Models page to enable.">
                   Quant tier
                   <select
                     onChange={(event) => handleTierChange(event.target.value)}
                     value={quantTier}
                   >
-                    {availableTiers.map((tier) => (
-                      <option key={tier} value={tier}>
-                        {tierLabel(tier)}
+                    {tierPickerItems.map((item) => (
+                      <option key={item.tier} value={item.tier} disabled={item.disabled}>
+                        {item.label}
                       </option>
                     ))}
                   </select>

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1000,19 +1000,42 @@ describe("ImageStudio model picker capability gating", () => {
   const generateButton = () =>
     [...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate");
 
-  it("shows the quant-tier picker with only installed tiers when >1 is installed (sc-8515)", async () => {
+  it("shows ALL possible tiers, disabling the un-installed ones (sc-8515, availability guard)", async () => {
     await render(baseContext({ imageModels: [matrixModel(["q4", "bf16"])], macCapabilities: MAC_CAPS }));
     await openAdvanced(container);
     await act(async () => {});
     const picker = tierPicker(container);
     expect(picker).toBeTruthy();
     const options = [...picker.options].map((o) => o.value);
-    // q8 is declared but not installed → excluded; smallest→largest order.
-    expect(options).toEqual(["q4", "bf16"]);
+    // Every declared tier appears (smallest→largest) so the un-downloaded q8 is DISCOVERABLE…
+    expect(options).toEqual(["q4", "q8", "bf16"]);
+    // …but only the installed tiers are selectable; q8 (declared, not installed) is disabled so it can
+    // never be picked or sent.
+    const disabledByTier = Object.fromEntries([...picker.options].map((o) => [o.value, o.disabled]));
+    expect(disabledByTier).toEqual({ q4: false, q8: true, bf16: false });
   });
 
-  it("hides the picker when only one tier is installed (sc-8515)", async () => {
+  it("shows the picker with a single installed tier, disabling the un-downloaded rest (sc-8515)", async () => {
     await render(baseContext({ imageModels: [matrixModel(["q4"])], macCapabilities: MAC_CAPS }));
+    await openAdvanced(container);
+    await act(async () => {});
+    const picker = tierPicker(container);
+    // Even with one tier installed the picker now shows, so the other tiers are discoverable (greyed)…
+    expect(picker).toBeTruthy();
+    expect(picker.value).toBe("q4");
+    // …and only the installed q4 is selectable; q8/bf16 are disabled and unsendable.
+    const disabledByTier = Object.fromEntries([...picker.options].map((o) => [o.value, o.disabled]));
+    expect(disabledByTier).toEqual({ q4: false, q8: true, bf16: true });
+  });
+
+  it("hides the picker when only ONE tier is possible at all — nothing to choose (sc-8515)", async () => {
+    const singleTier = {
+      ...Z_IMAGE,
+      id: "z_image_turbo",
+      hasVariantMatrix: true,
+      variants: [{ variant: "q4", default: true, installState: "installed" }],
+    };
+    await render(baseContext({ imageModels: [singleTier], macCapabilities: MAC_CAPS }));
     await openAdvanced(container);
     await act(async () => {});
     expect(tierPicker(container)).toBeFalsy();
@@ -1063,7 +1086,7 @@ describe("ImageStudio model picker capability gating", () => {
     expect(pid().disabled).toBe(true);
   });
 
-  it("still sends the resolved tier's mlxQuantize when only one tier is installed — picker hidden (sc-12090)", async () => {
+  it("still sends the resolved tier's mlxQuantize when only one tier is installed (sc-12090)", async () => {
     const createImageJob = vi.fn(async () => ({ id: "job-1" }));
     await render(
       baseContext({
@@ -1074,12 +1097,14 @@ describe("ImageStudio model picker capability gating", () => {
     );
     await openAdvanced(container);
     await act(async () => {});
-    // The picker stays hidden with a single installed tier…
-    expect(tierPicker(container)).toBeFalsy();
+    // The picker now shows (with q8/bf16 disabled) and q4 — the only installed tier — is selected…
+    const picker = tierPicker(container);
+    expect(picker).toBeTruthy();
+    expect(picker.value).toBe("q4");
     await click(generateButton());
-    // …but the resolved tier (q4) now rides the payload regardless, so the worker budgets/loads THAT
-    // tier instead of defaulting to q8 against a tier the user never downloaded (#1516). It is NOT a
-    // deliberate pick (no sticky), so the explicit marker is absent — the worker may capability-downtier.
+    // …and the resolved tier (q4) rides the payload, so the worker budgets/loads THAT tier instead of
+    // defaulting to q8 against a tier the user never downloaded (#1516). It is NOT a deliberate pick (no
+    // sticky), so the explicit marker is absent — the worker may capability-downtier.
     expect(createImageJob.mock.calls[0][0].advanced.mlxQuantize).toBe(4);
     expect(createImageJob.mock.calls[0][0].advanced).not.toHaveProperty("mlxQuantizeExplicit");
   });

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -9,6 +9,7 @@ import {
 import { apiFetch } from "../api.js";
 import { isDesktop, tauriInvoke as invoke } from "../runtime.js";
 import {
+  GENERATION_QUALITY_OPTIONS,
   generationQualityLabel,
   readDefaultGenerationQuality,
   writeDefaultGenerationQuality,
@@ -295,9 +296,10 @@ export function SettingsScreen() {
         <h3>Generation quality</h3>
         <p className="settings-muted">
           The default quality tier new generations use for a model you haven’t picked a
-          tier for yet. Higher fidelity looks best but uses more memory and is slower;
-          smaller tiers are faster and lighter. You can still override this per model in
-          the studio, and your per-model picks are remembered.
+          tier for yet. <strong>Auto</strong> picks the highest-fidelity tier that fits this
+          machine’s memory for each model — so a small model runs at full precision and a
+          heavy one steps down to what fits. You can still pin a fixed tier here, or override
+          per model in the studio; your per-model picks are remembered.
         </p>
         <div className="settings-actions">
           <label htmlFor="default-generation-quality">Default quality</label>
@@ -307,9 +309,11 @@ export function SettingsScreen() {
             onChange={(event) => changeDefaultQuality(event.target.value)}
             aria-label="Default generation quality"
           >
-            <option value="bf16">High fidelity (bf16)</option>
-            <option value="q8">Balanced (Q8)</option>
-            <option value="q4">Fast (Q4)</option>
+            {GENERATION_QUALITY_OPTIONS.map((value) => (
+              <option key={value} value={value}>
+                {generationQualityLabel(value)}
+              </option>
+            ))}
           </select>
         </div>
       </section>

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -427,12 +427,15 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
   const qualitySelect = () =>
     container.querySelector('[aria-label="Default generation quality"]');
 
-  it("renders the control defaulting to Balanced (Q8) when nothing is stored", async () => {
+  it("renders the control defaulting to Auto when nothing is stored (epic 10721 R3)", async () => {
     await render();
     expect(container.textContent).toContain("Generation quality");
     const select = qualitySelect();
     expect(select).toBeTruthy();
-    expect(select.value).toBe("q8");
+    expect(select.value).toBe("auto");
+    // Auto is offered as the first option, alongside the explicit tiers.
+    const optionValues = [...select.options].map((option) => option.value);
+    expect(optionValues).toEqual(["auto", "bf16", "q8", "q4"]);
   });
 
   it("writes a change to the localStorage instant-paint cache and confirms it in the status line (cache path)", async () => {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -71,11 +71,12 @@ import {
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { qualityChoices } from "../jobTypes.js";
 import {
+  allPossibleTiers,
   defaultTierSelection,
   installedTiers,
   quantizeTier,
-  shouldShowTierPicker,
   tierLabel,
+  tierPickerOptions,
   tierQuantize,
 } from "../quantTier.js";
 import {
@@ -415,9 +416,21 @@ export function VideoStudio() {
     () => (mlxTierLane ? installedTiers(selectedModel, tierOptions) : []),
     [mlxTierLane, selectedModel, tierOptions],
   );
-  const showTierPicker = useMemo(
-    () => mlxTierLane && shouldShowTierPicker(selectedModel, tierOptions),
+  // The full display set (all possible tiers, installed or not) + the picker option list with
+  // un-downloaded tiers disabled — same show-all/disable-unavailable rule as Image Studio. `availableTiers`
+  // stays the SELECTABLE/send set; the picker shows whenever there is more than one POSSIBLE tier and at
+  // least one is installed to select.
+  const possibleTiers = useMemo(
+    () => (mlxTierLane ? allPossibleTiers(selectedModel, tierOptions) : []),
     [mlxTierLane, selectedModel, tierOptions],
+  );
+  const tierPickerItems = useMemo(
+    () => (mlxTierLane ? tierPickerOptions(selectedModel, tierOptions) : []),
+    [mlxTierLane, selectedModel, tierOptions],
+  );
+  const showTierPicker = useMemo(
+    () => mlxTierLane && possibleTiers.length > 1 && availableTiers.length > 0,
+    [mlxTierLane, possibleTiers, availableTiers],
   );
   const showTorchQuantization = !mlxTierLane && supportsQuantization;
   const selectedMlxQuantize =
@@ -459,7 +472,9 @@ export function VideoStudio() {
   const tierSwitchTimer = useRef(null);
   useEffect(() => () => clearTimeout(tierSwitchTimer.current), []);
   const handleTierChange = (nextTier) => {
-    if (nextTier === quantTier) {
+    // Only an installed-and-complete tier can be selected; the disabled options are shown for
+    // discoverability, never as a pickable target (belt behind the native `<option disabled>`).
+    if (nextTier === quantTier || !availableTiers.includes(nextTier)) {
       return;
     }
     setQuantTier(nextTier);
@@ -1804,9 +1819,9 @@ export function VideoStudio() {
                 >
                   Quant tier
                   <select onChange={(event) => handleTierChange(event.target.value)} value={quantTier}>
-                    {availableTiers.map((tier) => (
-                      <option key={tier} value={tier}>
-                        {tierLabel(tier)}
+                    {tierPickerItems.map((item) => (
+                      <option key={item.tier} value={item.tier} disabled={item.disabled}>
+                        {item.label}
                       </option>
                     ))}
                   </select>

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -923,7 +923,7 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
       .find((label) => label.textContent.trim().startsWith("Quantization"))
       ?.querySelector("select") ?? null;
 
-  it("shows installed tiers on MLX, stays q4-first, and hides with one installed tier", async () => {
+  it("shows ALL possible MLX tiers (disabling un-installed), stays q4-first (sc-12165)", async () => {
     await render(
       baseContext({
         videoModels: [tieredVideoModel(["q4", "q8"])],
@@ -932,9 +932,15 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
     );
     await openAdvanced();
 
-    expect([...tierPicker().options].map((option) => option.value)).toEqual(["q4", "q8"]);
+    // All bits-based tiers appear (NVFP4 filtered on MLX); bf16 is declared-but-not-installed → disabled.
+    expect([...tierPicker().options].map((option) => option.value)).toEqual(["q4", "q8", "bf16"]);
+    const disabledByTier = Object.fromEntries(
+      [...tierPicker().options].map((option) => [option.value, option.disabled]),
+    );
+    expect(disabledByTier).toEqual({ q4: false, q8: false, bf16: true });
     expect(tierPicker().value).toBe("q4");
 
+    // Even with a single installed tier the picker now shows (others disabled), and q4 still rides the payload.
     await unmountRoot(root, container);
     ({ container, root } = mountRoot());
     const context = baseContext({
@@ -944,12 +950,17 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
     await render(context);
     await openAdvanced();
 
-    expect(tierPicker()).toBeNull();
+    expect(tierPicker()).toBeTruthy();
+    expect(tierPicker().value).toBe("q4");
+    const soloInstalled = Object.fromEntries(
+      [...tierPicker().options].map((option) => [option.value, option.disabled]),
+    );
+    expect(soloInstalled).toEqual({ q4: false, q8: true, bf16: true });
     await click(buttonWithText(container, "Render clip"));
     expect(context.createVideoJob.mock.calls[0][0].advanced.mlxQuantize).toBe(4);
   });
 
-  it("keeps the candle-only NVFP4 tier out of the MLX video picker", async () => {
+  it("keeps the candle-only NVFP4 tier out of the MLX video picker (sc-11042)", async () => {
     const context = baseContext({
       videoModels: [tieredVideoModel(["q4", "nvfp4"])],
       macCapabilities: MAC_CAPS,
@@ -957,7 +968,11 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
     await render(context);
     await openAdvanced();
 
-    expect(tierPicker()).toBeNull();
+    // The picker shows the bits-based tiers, but NVFP4 is filtered out even though it's installed.
+    expect(tierPicker()).toBeTruthy();
+    const optionValues = [...tierPicker().options].map((option) => option.value);
+    expect(optionValues).toEqual(["q4", "q8", "bf16"]);
+    expect(optionValues).not.toContain("nvfp4");
     await click(buttonWithText(container, "Render clip"));
     expect(context.createVideoJob.mock.calls[0][0].advanced).toMatchObject({ mlxQuantize: 4 });
     expect(context.createVideoJob.mock.calls[0][0].advanced).not.toHaveProperty("quantTier");

--- a/apps/web/src/tierSuggestion.test.js
+++ b/apps/web/src/tierSuggestion.test.js
@@ -238,3 +238,25 @@ describe("suggestTier", () => {
     expect(suggestTier({ hasVariantMatrix: false, variants: [] }, 32)).toBe(null);
   });
 });
+
+describe("suggestTier — real SANA-Sprint footprints (epic 10721 Auto default)", () => {
+  // Actual on-disk tier sizes for SceneWorks/Sana_Sprint_1.6B_1024px_mlx (from the live catalog).
+  const sanaSprint = () =>
+    matrixModel([
+      { variant: "q4", diskGb: 5.19 },
+      { variant: "q8", diskGb: 6.54 },
+      { variant: "bf16", diskGb: 9.05 },
+    ]);
+
+  it("suggests bf16 for a small model on a roomy Mac (Michael's 128 GB case)", () => {
+    // bf16 peak ≈ 9.05 + 14 transient = ~23 GB, well under 128 × 0.9 = 115 GB → full precision.
+    expect(suggestTier(sanaSprint(), 128)).toBe("bf16");
+  });
+
+  it("still leans as high as fits on a mid Mac, and steps down on a tiny one", () => {
+    // 64 GB: bf16 ~23 GB < 57.6 budget → bf16.
+    expect(suggestTier(sanaSprint(), 64)).toBe("bf16");
+    // 16 GB: every tier's peak (~19–23 GB) exceeds the 14.4 GB budget → smallest declared (q4).
+    expect(suggestTier(sanaSprint(), 16)).toBe("q4");
+  });
+});

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1219,20 +1219,118 @@ fn dir_has_visible_entry(dir: &Path) -> bool {
     })
 }
 
+/// Whether `dir` holds at least one non-hidden file whose name ends with `suffix` (e.g. `.safetensors`
+/// / `.index.json`). The building block for the per-family completeness checks of turnkeys that ship
+/// no `model_index.json` (Anima / Boogu / SANA), where [`tier_components_present`] is a no-op. Hidden
+/// AppleDouble `._*` sidecars never count (SceneWorks#1333).
+fn dir_has_visible_file_ending(dir: &Path, suffix: &str) -> bool {
+    std::fs::read_dir(dir).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            !sceneworks_core::lora_family::is_hidden_file(&entry.path())
+                && entry.file_name().to_string_lossy().ends_with(suffix)
+        })
+    })
+}
+
+/// Whether an Anima tier `dir` is COMPLETE and loadable (issue #850 class, generalized). Anima ships no
+/// `model_index.json`, so the shared [`tier_components_present`] guard is a no-op for it and a torn tier
+/// (DiT present, text-encoder/VAE absent) reached the loader, which then died with a raw
+/// "No such file or directory" (mlx-gen-anima `load_text_phase` / `load_vae`). A tier is complete when
+/// all three concrete inputs are present: the DiT (any visible `.safetensors` in `diffusion_models/`),
+/// the dense text encoder, and the VAE. Tokenizers are vendored into the binary, so there is no
+/// tokenizer file to check here.
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
+fn anima_tier_complete(dir: &Path) -> bool {
+    dir_has_visible_file_ending(&dir.join("diffusion_models"), ".safetensors")
+        && dir.join("text_encoders/qwen_3_06b_base.safetensors").is_file()
+        && dir.join("vae/qwen_image_vae.safetensors").is_file()
+}
+
+/// Whether a Boogu tier `dir` is COMPLETE and loadable. Boogu ships no `model_index.json`, so the shared
+/// guard is a no-op; the loader crashes FIRST on a missing `mllm/tokenizer.json`, then on an absent
+/// `mllm`/`transformer`/`vae` weight. A tier is complete when the transformer (packed single-file OR
+/// sharded index) plus its `config.json`, the Qwen3-VL `mllm/` (weights + `tokenizer.json`), and the VAE
+/// weights are all present.
+fn boogu_tier_complete(dir: &Path) -> bool {
+    let transformer = dir.join("transformer");
+    let transformer_weights = transformer
+        .join("diffusion_pytorch_model.safetensors")
+        .is_file()
+        || transformer
+            .join("diffusion_pytorch_model.safetensors.index.json")
+            .is_file();
+    transformer_weights
+        && transformer.join("config.json").is_file()
+        && dir.join("mllm/tokenizer.json").is_file()
+        && dir_has_visible_file_ending(&dir.join("mllm"), ".safetensors")
+        && dir_has_visible_file_ending(&dir.join("vae"), ".safetensors")
+}
+
+/// Whether a SANA tier `dir` is COMPLETE and loadable. The `SceneWorks/Sana_*_mlx` turnkeys ship no
+/// `model_index.json`, so the standard-tier guard is a no-op for SANA specifically (flux/qwen/etc. DO
+/// ship one and stay protected by [`tier_components_present`]); the SANA loader dies with a raw OS error
+/// on an absent Gemma text encoder or its tokenizer (mlx-gen-sana `SanaTextEncoder::from_snapshot`). A
+/// tier is complete when the Linear-DiT transformer, the DC-AE VAE, and the Gemma-2 text encoder + its
+/// tokenizer (both bundled inside `text_encoder/`) are all present.
+fn sana_tier_complete(dir: &Path) -> bool {
+    dir_has_visible_file_ending(&dir.join("transformer"), ".safetensors")
+        && dir_has_visible_file_ending(&dir.join("vae"), ".safetensors")
+        && dir.join("text_encoder/gemma-2-2b-it.safetensors").is_file()
+        && dir.join("text_encoder/tokenizer.json").is_file()
+}
+
+/// Whether the tier dir `resolve_weights_dir` resolved for `request` is COMPLETE — every component its
+/// loader reads is on disk. Used ONLY by [`mlx_weights_gap`] to turn a torn-tier load (which otherwise
+/// dies mid-generation with a raw "No such file or directory") into an actionable PRE-FLIGHT message.
+/// After the sc-12279-generalized resolvers, `resolve_weights_dir` already falls back to a complete
+/// sibling tier whenever one exists, so this only ever returns `false` when NO complete tier is
+/// installed for the model.
+///
+/// Dispatches to the SAME family completeness predicate the resolvers use. An unrecognized family falls
+/// back to [`tier_components_present`] (the `model_index.json` guard), which is `true` for a layout
+/// without one — so a dispatch miss degrades to "no extra message" (today's raw error at load), NEVER a
+/// false "incomplete" that would block a loadable tier.
+#[cfg(target_os = "macos")]
+fn resolved_tier_is_complete(request: &ImageRequest, dir: &Path) -> bool {
+    if is_anima_model(&request.model) {
+        return anima_tier_complete(dir);
+    }
+    if matches!(
+        request.model.as_str(),
+        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit"
+    ) {
+        return boogu_tier_complete(dir);
+    }
+    if matches!(request.model.as_str(), "sana_1600m" | "sana_sprint_1600m") {
+        return tier_components_present(dir) && sana_tier_complete(dir);
+    }
+    tier_components_present(dir)
+}
+
 /// Walk `chain` (a tier-name preference order) and return the first tier that is safe to load: one
-/// whose declared component tree is COMPLETE if any qualifies, else the first that merely clears
+/// that is COMPLETE (`complete` returns true) if any qualifies, else the first that merely clears
 /// `present`'s backbone probe. `None` when no tier is installed at all.
 ///
 /// The shared tail of every tier resolver (sc-12279). `present` alone accepts a tier on its backbone,
 /// so a torn tier — the transformer landed, `tokenizer/` did not — short-circuited the chain and the
 /// loader died on `tokenizer: No such file or directory` even when a complete sibling tier was
 /// installed (issue #850's symptom). Running the chain twice, rather than folding completeness into
-/// `present`, is deliberate: if [`tier_components_present`] ever misjudges a tier shape we haven't
-/// seen, pass 2 lands exactly where the pre-sc-12279 code did, so this can never strand a model that
-/// loads today. Duplicates in `chain` (the preferred tier is usually also a fallback) are harmless.
-fn pick_loadable_tier(chain: &[&str], present: &dyn Fn(&str) -> Option<PathBuf>) -> Option<PathBuf> {
+/// `present`, is deliberate: if `complete` ever misjudges a tier shape we haven't seen, pass 2 lands
+/// exactly where the pre-sc-12279 code did, so this can never strand a model that loads today.
+/// Duplicates in `chain` (the preferred tier is usually also a fallback) are harmless.
+///
+/// `complete` is family-specific: the diffusers-turnkey families pass [`tier_components_present`]
+/// (reads the tier's own `model_index.json`); families with a bespoke on-disk layout and no
+/// `model_index.json` (Anima's `diffusion_models/ + text_encoders/ + vae/`, Boogu's packed subfolders,
+/// InstantID's `unet/`) pass their own predicate so the completeness half is not a silent no-op for
+/// them (the pre-generalization gap that let those families still short-circuit onto a torn tier).
+fn pick_loadable_tier(
+    chain: &[&str],
+    present: &dyn Fn(&str) -> Option<PathBuf>,
+    complete: &dyn Fn(&Path) -> bool,
+) -> Option<PathBuf> {
     let first = |probe: &dyn Fn(&str) -> Option<PathBuf>| chain.iter().find_map(|name| probe(name));
-    if let Some(dir) = first(&|name: &str| present(name).filter(|dir| tier_components_present(dir))) {
+    if let Some(dir) = first(&|name: &str| present(name).filter(|dir| complete(dir))) {
         return Some(dir);
     }
     // No complete tier: load the torn one anyway (pre-sc-12279 behavior) but say so — the loader
@@ -1240,8 +1338,8 @@ fn pick_loadable_tier(chain: &[&str], present: &dyn Fn(&str) -> Option<PathBuf>)
     let torn = first(present)?;
     tracing::warn!(
         tier = %torn.display(),
-        "Tier is missing components its model_index.json declares, and no complete tier is \
-         installed. Loading it anyway; re-download the tier if load fails."
+        "Tier is missing components it should ship, and no complete tier is installed. Loading it \
+         anyway; re-download the tier if load fails."
     );
     Some(torn)
 }
@@ -1343,11 +1441,16 @@ fn standard_tier_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: b
         min_quality_floor(request),
         nvfp4_requested(request) && nvfp4_host,
     );
-    // sc-12279: prefer a tier whose `model_index.json` component tree is fully on disk, so a torn
-    // tier falls through to a complete sibling instead of reaching the loader. Flat unified tiers
-    // (SenseNova-U1 MoT) ship no `model_index.json`, so `tier_components_present` passes them through
-    // and they resolve on the backbone probe exactly as before.
-    pick_loadable_tier(&[preferred, "q8", "bf16", "q4"], &present)
+    // sc-12279: prefer a tier whose component tree is fully on disk, so a torn tier falls through to a
+    // complete sibling instead of reaching the loader. Diffusers-shaped turnkeys (flux/qwen/sd3.5/…)
+    // ship a per-tier `model_index.json` that `tier_components_present` reads. SANA is the exception:
+    // its `SceneWorks/Sana_*_mlx` turnkeys ship NO `model_index.json`, so that guard is a no-op for it —
+    // fold in the concrete `sana_tier_complete` check (transformer + VAE + Gemma TE + tokenizer) so a
+    // torn SANA tier is demoted too. Flat unified tiers (SenseNova-U1 MoT) ship no `model_index.json`
+    // either but are not SANA, so they resolve on the backbone probe exactly as before.
+    let is_sana = matches!(request.model.as_str(), "sana_1600m" | "sana_sprint_1600m");
+    let complete = |dir: &Path| tier_components_present(dir) && (!is_sana || sana_tier_complete(dir));
+    pick_loadable_tier(&[preferred, "q8", "bf16", "q4"], &present, &complete)
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -1424,10 +1527,10 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // lane is candle/Blackwell-only. Passing `false` keeps this resolver byte-identical to its pre-sc-11042
     // behavior; wire it here if an Anima NVFP4 tier is ever converted.
     let preferred = preferred_tier(bits, min_quality_floor(request), false);
-    present(preferred)
-        .or_else(|| present("q8"))
-        .or_else(|| present("bf16"))
-        .or_else(|| present("q4"))
+    // sc-12279 generalized: Anima ships no `model_index.json`, so route the chain through the concrete
+    // `anima_tier_complete` predicate — a torn tier (DiT present, text-encoder/VAE absent) now falls
+    // through to a complete sibling instead of reaching the loader and dying on the missing file.
+    pick_loadable_tier(&[preferred, "q8", "bf16", "q4"], &present, &anima_tier_complete)
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -1502,7 +1605,8 @@ fn ideogram_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     let preferred = preferred_tier(bits, min_quality_floor(request), false);
     // sc-12279: the Ideogram turnkey ships a per-tier `model_index.json`, so the shared chain prefers
     // a tier whose declared component tree is fully on disk over a torn one.
-    pick_loadable_tier(&[preferred, "q8", "q4"], &present).unwrap_or_else(|| root.to_path_buf())
+    pick_loadable_tier(&[preferred, "q8", "q4"], &present, &tier_components_present)
+        .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// The Boogu subfolder for a `mlxQuantize` request — `None` keeps the Q8 default. The FETCH-side helper
@@ -1577,10 +1681,13 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // `nvfp4: false` (sc-11042): Boogu's `<variant>-bf16` MLX layout hosts no NVFP4 tier. Byte-identical
     // to its pre-sc-11042 behavior; wire it here if one is ever converted.
     let preferred = preferred_tier(bits, min_quality_floor(request), false);
-    present(&variant_folder(preferred))
-        .or_else(|| present(variant))
-        .or_else(|| present(&q4))
-        .or_else(|| present(&bf16))
+    // sc-12279 generalized: Boogu ships no `model_index.json`, so route the folder chain through the
+    // concrete `boogu_tier_complete` predicate — a torn tier (transformer present, `mllm/tokenizer.json`
+    // or VAE absent) now falls through to a complete sibling instead of crashing the loader on the
+    // missing tokenizer. Chain is folder names (`<variant>`, `<variant>-q4`, `<variant>-bf16`).
+    let chain = [variant_folder(preferred), variant.to_owned(), q4, bf16];
+    let chain_refs: Vec<&str> = chain.iter().map(String::as_str).collect();
+    pick_loadable_tier(&chain_refs, &present, &boogu_tier_complete)
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -1646,7 +1753,7 @@ fn krea_model_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: bool
     // whose `model_index.json` component tree is fully on disk, so Raw with a torn `q8/` and a
     // complete `bf16/` training-base tier now generates off bf16 instead of dying on the absent
     // `q8/tokenizer/` (issue #850's symptom).
-    pick_loadable_tier(&[preferred, "q8", "q4", "bf16"], &present)
+    pick_loadable_tier(&[preferred, "q8", "q4", "bf16"], &present, &tier_components_present)
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -7554,6 +7661,171 @@ mod standard_tier_tests {
         assert!(
             tier_components_present(&root.join("bf16")),
             "a tier with no model_index.json has no component tree to check"
+        );
+    }
+
+    // ---- sc-12279 generalized to the no-`model_index.json` families (SANA / Boogu / Anima) ----
+    // These turnkeys ship no `model_index.json`, so the shared `tier_components_present` guard is a
+    // no-op for them and a torn tier used to short-circuit the chain and crash the loader on the first
+    // missing component. Each resolver now routes through a concrete per-family completeness predicate.
+
+    /// Seed a SANA MLX tier (`SceneWorks/Sana_*_mlx` layout): transformer + (when `complete`) the DC-AE
+    /// VAE and the Gemma-2 text encoder with its bundled tokenizer. No `model_index.json` (as shipped).
+    fn seed_sana_tier(root: &Path, tier: &str, complete: bool) {
+        let dir = root.join(tier);
+        std::fs::create_dir_all(dir.join("transformer")).unwrap();
+        std::fs::write(dir.join("transformer/diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        if complete {
+            std::fs::create_dir_all(dir.join("vae")).unwrap();
+            std::fs::write(dir.join("vae/diffusion_pytorch_model.safetensors"), b"x").unwrap();
+            std::fs::create_dir_all(dir.join("text_encoder")).unwrap();
+            std::fs::write(dir.join("text_encoder/gemma-2-2b-it.safetensors"), b"x").unwrap();
+            std::fs::write(dir.join("text_encoder/tokenizer.json"), b"{}").unwrap();
+        }
+    }
+
+    /// A torn SANA tier (transformer only, TE/VAE absent) must fall through to a complete sibling rather
+    /// than reaching the loader, which would die on the missing Gemma text encoder. SANA ships no
+    /// `model_index.json`, so this is caught by the concrete `sana_tier_complete` check, not the no-op
+    /// `tier_components_present` guard.
+    #[test]
+    fn sana_torn_tier_falls_through_to_a_complete_sibling() {
+        let request = |bits: serde_json::Value| {
+            ImageRequest::from_payload(
+                json!({ "model": "sana_1600m", "advanced": { "mlxQuantize": bits } })
+                    .as_object()
+                    .unwrap(),
+            )
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_sana_tier(root, "q8", false); // torn: transformer only
+        seed_sana_tier(root, "bf16", true); // complete
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!(null))),
+            root.join("bf16"),
+            "the torn q8 default must skip to the complete bf16 tier, not crash on the missing Gemma TE"
+        );
+        assert_eq!(
+            standard_tier_subdir(root, &request(json!(8))),
+            root.join("bf16"),
+            "an explicit q8 pick is redirected too — a working render beats an os-error-2 we can avoid"
+        );
+    }
+
+    /// Regression contract: with NO complete SANA tier, the torn one still resolves (pass 2), unchanged
+    /// from before — the user gets the same loader error they would have, never a silent no-op.
+    #[test]
+    fn sana_torn_tier_is_returned_when_it_is_all_there_is() {
+        let request = ImageRequest::from_payload(
+            json!({ "model": "sana_1600m", "advanced": {} }).as_object().unwrap(),
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        seed_sana_tier(tmp.path(), "q8", false);
+        assert_eq!(
+            standard_tier_subdir(tmp.path(), &request),
+            tmp.path().join("q8"),
+            "no complete tier: the torn tier still resolves, not the repo root"
+        );
+    }
+
+    /// Non-SANA standard turnkeys (flux/qwen/…) are unaffected: they DO ship `model_index.json`, so
+    /// their completeness stays `tier_components_present` — the added SANA branch never touches them.
+    #[test]
+    fn non_sana_standard_turnkey_ignores_the_sana_completeness_branch() {
+        let request = ImageRequest::from_payload(
+            json!({ "model": "flux_dev", "advanced": {} }).as_object().unwrap(),
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // A flux tier with only a transformer and no text_encoder dir would FAIL sana_tier_complete, but
+        // flux is not SANA — it resolves on its backbone/model_index exactly as before.
+        seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
+        assert_eq!(standard_tier_subdir(root, &request), root.join("q8"));
+    }
+
+    /// Seed a Boogu tier folder (`<variant>` / `<variant>-q4` / `<variant>-bf16`): packed transformer +
+    /// its config, and (when `complete`) the Qwen3-VL `mllm/` with tokenizer and the VAE. No index.
+    fn seed_boogu_tier(root: &Path, folder: &str, complete: bool) {
+        let dir = root.join(folder);
+        std::fs::create_dir_all(dir.join("transformer")).unwrap();
+        std::fs::write(dir.join("transformer/diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        std::fs::write(dir.join("transformer/config.json"), b"{}").unwrap();
+        if complete {
+            std::fs::create_dir_all(dir.join("mllm")).unwrap();
+            std::fs::write(dir.join("mllm/model.safetensors"), b"x").unwrap();
+            std::fs::write(dir.join("mllm/tokenizer.json"), b"{}").unwrap();
+            std::fs::create_dir_all(dir.join("vae")).unwrap();
+            std::fs::write(dir.join("vae/diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        }
+    }
+
+    /// A torn Boogu tier (transformer present, `mllm/tokenizer.json` + VAE absent) must fall through to a
+    /// complete sibling rather than crash the loader on the first-read `mllm/tokenizer.json`.
+    #[test]
+    fn boogu_torn_tier_falls_through_to_a_complete_sibling() {
+        let request = ImageRequest::from_payload(
+            json!({ "model": "boogu_image", "advanced": {} }).as_object().unwrap(),
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // `base` is the Q8 default folder (torn); `base-bf16` is complete.
+        seed_boogu_tier(root, "base", false);
+        seed_boogu_tier(root, "base-bf16", true);
+        assert_eq!(
+            boogu_model_subdir(root, &request),
+            root.join("base-bf16"),
+            "the torn Q8 `base/` must skip to the complete `base-bf16`, not crash on `mllm/tokenizer.json`"
+        );
+    }
+
+    /// `resolved_tier_is_complete` (the pre-flight completeness dispatcher behind the friendly
+    /// `mlx_weights_gap` message) reports a torn SANA tier as incomplete and a whole one as complete.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resolved_tier_is_complete_flags_a_torn_sana_tier() {
+        let request = ImageRequest::from_payload(
+            json!({ "model": "sana_1600m", "advanced": {} }).as_object().unwrap(),
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_sana_tier(root, "q8", false);
+        seed_sana_tier(root, "bf16", true);
+        assert!(!resolved_tier_is_complete(&request, &root.join("q8")));
+        assert!(resolved_tier_is_complete(&request, &root.join("bf16")));
+    }
+
+    /// Seed an Anima tier (`bf16/ q8/ q4/`, `split_files` shape): the DiT + (when `complete`) the dense
+    /// text encoder and the VAE. Tokenizers are vendored into the binary, so none is on disk. No index.
+    #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+    fn seed_anima_tier(root: &Path, tier: &str, complete: bool) {
+        let dir = root.join(tier);
+        std::fs::create_dir_all(dir.join("diffusion_models")).unwrap();
+        std::fs::write(dir.join("diffusion_models/anima-base-v1.0.safetensors"), b"x").unwrap();
+        if complete {
+            std::fs::create_dir_all(dir.join("text_encoders")).unwrap();
+            std::fs::write(dir.join("text_encoders/qwen_3_06b_base.safetensors"), b"x").unwrap();
+            std::fs::create_dir_all(dir.join("vae")).unwrap();
+            std::fs::write(dir.join("vae/qwen_image_vae.safetensors"), b"x").unwrap();
+        }
+    }
+
+    /// A torn Anima tier (DiT present, text-encoder/VAE absent) must fall through to a complete sibling
+    /// rather than reaching the loader, which would die on the missing `text_encoders/…` (mlx-gen-anima).
+    #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+    #[test]
+    fn anima_torn_tier_falls_through_to_a_complete_sibling() {
+        let request = ImageRequest::from_payload(
+            json!({ "model": "anima_base", "advanced": {} }).as_object().unwrap(),
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_anima_tier(root, "q8", false); // torn: DiT only
+        seed_anima_tier(root, "bf16", true); // complete
+        assert_eq!(
+            anima_tier_subdir(root, &request),
+            root.join("bf16"),
+            "the torn q8 default must skip to the complete bf16 tier, not crash on the missing text encoder"
         );
     }
 

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -208,10 +208,12 @@ fn instantid_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
             .any(|entry| entry.file_name().to_string_lossy().ends_with(".safetensors"));
         has_backbone.then(|| root.join(name))
     };
-    present(preferred)
-        .or_else(|| present("bf16"))
-        .or_else(|| present("q4"))
-        .or_else(|| present("q8"))
+    // sc-12279 generalized: the `SceneWorks/realvisxl-mlx` base ships a per-tier `model_index.json`, so
+    // route the chain through the shared completeness guard — a torn tier (e.g. `unet/` present but
+    // `tokenizer/` missing) now falls through to a complete sibling instead of crashing the SDXL loader
+    // on the absent tokenizer. `instantid.rs` is `include!`d into the `image_jobs` module, so
+    // `pick_loadable_tier` / `tier_components_present` (base.rs) are directly in scope.
+    pick_loadable_tier(&[preferred, "bf16", "q4", "q8"], &present, &tier_components_present)
         .unwrap_or_else(|| root.to_path_buf())
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/stream.rs
+++ b/crates/sceneworks-worker/src/image_jobs/stream.rs
@@ -268,7 +268,23 @@ where
 pub(crate) fn mlx_weights_gap(request: &ImageRequest, settings: &Settings) -> Option<String> {
     let model = mlx_model(&request.model)?;
     match resolve_weights_dir(request, settings) {
-        Ok(Some(_)) => return None,
+        Ok(Some(dir)) => {
+            // The resolvers fall back to a COMPLETE sibling tier whenever one exists (sc-12279
+            // generalized), so reaching here with an incomplete `dir` means NO complete tier is
+            // installed for this model — the load would die mid-generation on the first missing file.
+            // Turn that into an actionable pre-flight message naming the tier, directing the user to
+            // Model Manager or to pick an installed tier, instead of a raw "No such file or directory".
+            if !resolved_tier_is_complete(request, &dir) {
+                let tier = dir.file_name().and_then(|s| s.to_str()).unwrap_or("selected");
+                return Some(format!(
+                    "{}: the '{tier}' quant tier isn't fully installed on this machine (some weight \
+                     files are missing). Re-download or repair it in Model Manager, or pick a tier \
+                     you have already installed from the studio's Quant tier menu, then retry.",
+                    request.model,
+                ));
+            }
+            return None;
+        }
         Err(error) => return Some(error.to_string()),
         Ok(None) => {}
     }


### PR DESCRIPTION
Never select, send, resolve, or crash on a quant tier the user hasn't fully installed; default each model to the best tier that fits the machine; remember per-model picks across relaunch.

## Availability guard — never send/resolve/crash on an uninstalled tier ([sc-13511](https://app.shortcut.com/trefry/epic/13511) / [sc-13512](https://app.shortcut.com/trefry/story/13512))
The original recurring bug (issue #850): the loader defaulted to `q8`, the user didn't have it, and instead of falling back it died on the absent `q8/tokenizer/`. sc-12279 only patched one resolver family.

- **Frontend** (`quantTier.js`, Image/Video/Editor studios): `allPossibleTiers` + `tierPickerOptions` — pickers now show **all** tiers with un-downloaded ones **disabled** ("not downloaded" / "download incomplete"); the picker shows whenever >1 tier is *possible*; selection **and** the outgoing payload are hard-gated to the installed set. **The studio can never send a tier that isn't in cache.**
- **Worker** (`image_jobs/base.rs`, `instantid.rs`, `stream.rs`): generalized `pick_loadable_tier` to take a per-family completeness predicate, and wired the previously-**unguarded** families — **Anima / Boogu / SANA** (which ship no `model_index.json`, so the shared guard was a no-op) and **InstantID**. A torn tier now falls back to a complete sibling instead of crashing. `mlx_weights_gap` returns a **friendly, actionable** message ("pick an installed tier / re-download") when no complete tier exists.

## Capability-aware **Auto** default (epic [10721](https://app.shortcut.com/trefry/epic/10721) S8 / [sc-13514](https://app.shortcut.com/trefry/story/13514))
Revives the deferred Auto. `defaultTierSelection` derives from `suggestTier(model, unifiedMemoryGb)` when the global quality is **Auto** (the new default). rust-api normalizes `auto` and **one-time-migrates a legacy `q8`→`auto`** (marker-guarded so a deliberate post-upgrade q8 sticks). Settings gains an "Auto (best that fits this Mac)" option. Image-only — dense video keeps q4 ([sc-10750](https://app.shortcut.com/trefry/story/10750) owned exception).
- **Proven:** real SANA-Sprint footprints → **bf16 on a 128 GB Mac**, → q4 on a 16 GB Mac.

## Durable per-model picks (epic 10721 R1 / [sc-13515](https://app.shortcut.com/trefry/story/13515))
The per-(screen,model) tier sticky was localStorage-only, which the desktop shell's per-launch origin **wipes on relaunch**. It's now mirrored to the durable `ui-preferences` server copy (`perModelTier` map) and re-seeded on launch — picks survive relaunch; revert-to-Auto when the saved tier is deleted.

## `mlxTierStates` for convert-at-install (epic 10721 R6 / [sc-13516](https://app.shortcut.com/trefry/story/13516))
Convert-at-install models (Anima) now emit the full q4/q8/bf16 set with per-tier state, so their picker shows un-converted tiers disabled too.

## Deferred (filed)
[sc-13513](https://app.shortcut.com/trefry/story/13513) — tighten catalog per-tier completeness for no-`model_index` turnkeys so a *torn* tier reads `incomplete` (pre-existing coarse-glob edge case; mitigated by the download guard + the worker belt in this PR).

## Verification
- Web **2177/2177**; worker + rust-api `clippy --all-targets`, `cargo fmt --all --check`, and unit/integration tests green.
- New tests: quantTier availability + Auto-base + all-3-studio picker tests; worker torn-tier tests (SANA/Anima/Boogu); rust-api `q8→auto` migration + `perModelTier` round-trip + `mlxTierStates`; lastTierStore durable-persistence.
- Merged `origin/main` and re-verified on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)