### PR TITLE
feat(audio): Voice Clone mode — Kokoro→OpenVoice V2 conversion chain [sc-13411]

### DIFF
--- a/apps/rust-api/src/defaults.rs
+++ b/apps/rust-api/src/defaults.rs
@@ -133,6 +133,13 @@ pub(crate) fn default_audio_model() -> String {
     "kokoro_82m".to_owned()
 }
 
+/// The default base TTS model for a Voice Clone job (sc-13411 C4): the "content" generator whose speech
+/// OpenVoice V2 re-timbres toward the reference. Kokoro-82M is the recommended, always-installed Speech
+/// model — the base clip's voice is itself a knob (`voice`), but the base generator is Kokoro.
+pub(crate) fn default_audio_base_model() -> String {
+    "kokoro_82m".to_owned()
+}
+
 // No `default_video_duration` either, and for a sharper reason than fps: the blanket 6.0 that used
 // to live here is past the `hardMaxDuration` of 7 of the 10 shipped video models, so once sc-12297
 // began enforcing that cap, this default made the API reject its own duration-less requests

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -961,6 +961,23 @@ pub(crate) struct AudioJobRequest {
     /// Edit strength (0..=1) for the source-audio edit. `None` ⇒ the model default. sc-13410.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) edit_strength: Option<f32>,
+    /// Voice Clone (sc-13411 C4): the reference-voice library `type: "audio"` asset id whose timbre is
+    /// transferred onto the base TTS clip. Its presence routes the job onto the two-call
+    /// Kokoro→OpenVoice chain (the worker's `run_voice_clone_synthesis`); `None` ⇒ an ordinary
+    /// Speech/SFX/Music generation. The route additionally resolves + injects the base TTS model's
+    /// manifest entry (`baseModelManifestEntry`) when this is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reference_audio_asset_id: Option<String>,
+    /// Voice Clone base TTS model id — the "content" generator (Kokoro) whose speech OpenVoice re-timbres.
+    /// Defaults to `kokoro_82m`. Only consulted on a voice-clone request; the route asserts it is a
+    /// `type: "audio"` model and injects its manifest entry as `baseModelManifestEntry`.
+    #[serde(default = "default_audio_base_model")]
+    pub(crate) base_model: String,
+    /// Voice Clone match strength — overrides OpenVoice V2's posterior-sampling temperature τ (rides the
+    /// worker-side `AudioTransformRequest::strength`). `None` ⇒ the converter's own default (0.3).
+    /// Bounded to a blanket sane 0..=1 range here; the converter re-checks it (finite, >= 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) match_strength: Option<f32>,
     #[serde(default)]
     pub(crate) seed: Option<i64>,
     #[serde(default = "default_requested_gpu")]

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -694,6 +694,28 @@ pub(crate) async fn create_audio_job(
         )));
     }
     job_payload.insert("modelManifestEntry".to_owned(), model_manifest_entry);
+    // Voice Clone (sc-13411 C4): the two-call chain runs a SECOND model — the base TTS (Kokoro) whose
+    // speech the selected converter (OpenVoice V2) re-timbres. Resolve + inject its manifest entry too so
+    // the worker resolves BOTH snapshots without re-parsing the jsonc, exactly as the primary model entry
+    // is injected. Only when the request actually carries a reference voice (the voice-clone discriminator).
+    if payload
+        .reference_audio_asset_id
+        .as_deref()
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        let base_model_id = payload.base_model.clone();
+        let base_entry = resolve_model_manifest_entry(&state, &base_model_id).await?;
+        let base_type = base_entry
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if base_type != "audio" {
+            return Err(ApiError::bad_request(format!(
+                "Base voice model {base_model_id} is not an audio model (type: \"audio\" required)"
+            )));
+        }
+        job_payload.insert("baseModelManifestEntry".to_owned(), base_entry);
+    }
     let job = create_generation_job(
         state,
         JobType::AudioGenerate,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2873,6 +2873,19 @@ fn validate_audio_job(payload: &AudioJobRequest) -> Result<(), ApiError> {
             return Err(ApiError::bad_request("steps must be between 1 and 10000"));
         }
     }
+    // Voice Clone (sc-13411 C4). The match strength overrides OpenVoice V2's posterior-sampling
+    // temperature τ — bounded to a blanket sane 0..=1 range here (the UI-facing knob range); the
+    // converter re-checks it (finite, >= 0). `baseModel`, when supplied, must be a well-formed model id
+    // (the route additionally asserts it is a `type: "audio"` model). `referenceAudioAssetId` is a plain
+    // library asset id resolved (project-scoped) by the worker; no membership check belongs here.
+    if let Some(strength) = payload.match_strength {
+        if !strength.is_finite() || !(0.0..=1.0).contains(&strength) {
+            return Err(ApiError::bad_request(
+                "matchStrength must be between 0 and 1",
+            ));
+        }
+    }
+    validate_model_id(&payload.base_model)?;
     Ok(())
 }
 

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -304,6 +304,21 @@ fn write_audio_manifest(config_dir: &std::path::Path) {
               "ui": { "label": "ACE-Step v1.5 XL Turbo" }
             },
             {
+              "id": "openvoice_v2",
+              "name": "OpenVoice V2 (Voice Conversion)",
+              "family": "openvoice",
+              "type": "audio",
+              "audio": {
+                "sampleRates": [22050],
+                "conditioning": ["ReferenceAudio"]
+              },
+              "downloads": [
+                { "provider": "huggingface", "repo": "myshell-ai/OpenVoiceV2", "files": ["converter/config.json", "converter/checkpoint.pth"] }
+              ],
+              "paths": { "model": "${HF_CACHE}/myshell-ai/OpenVoiceV2" },
+              "ui": { "label": "OpenVoice V2" }
+            },
+            {
               "id": "not-audio-img",
               "name": "Not Audio",
               "family": "z_image",
@@ -436,6 +451,120 @@ async fn create_audio_job_maps_sfx_sampling_knobs() {
         entry["downloads"][0]["repo"],
         "OpenMOSS-Team/MOSS-SoundEffect-v2.0"
     );
+}
+
+/// The Voice Clone path (OpenVoice V2 conversion chain, sc-13411 C4): a `POST /api/v1/audio/jobs` that
+/// names a converter model + `referenceAudioAssetId` carries the reference + match strength through to
+/// the worker payload AND injects a SECOND manifest entry — the base TTS model (`baseModelManifestEntry`)
+/// — so the worker resolves both snapshots. The converter's own entry rides as `modelManifestEntry`.
+#[tokio::test]
+async fn create_audio_job_injects_base_model_entry_for_voice_clone() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Voice Clone Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "openvoice_v2",
+            "prompt": "Clone this into my reference voice.",
+            "referenceAudioAssetId": "ref-voice-1",
+            "matchStrength": 0.5,
+            "seed": 3,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job}");
+    assert_eq!(job["type"], "audio_generate");
+    let payload = &job["payload"];
+    assert_eq!(payload["model"], "openvoice_v2");
+    assert_eq!(payload["referenceAudioAssetId"], "ref-voice-1");
+    assert_eq!(payload["matchStrength"], 0.5);
+    // The selected converter's entry rides as modelManifestEntry (weights resolution).
+    assert_eq!(payload["modelManifestEntry"]["id"], "openvoice_v2");
+    assert_eq!(
+        payload["modelManifestEntry"]["downloads"][0]["repo"],
+        "myshell-ai/OpenVoiceV2"
+    );
+    // ...and the base TTS (Kokoro) entry is injected so the worker resolves the base generator too.
+    let base = &payload["baseModelManifestEntry"];
+    assert_eq!(base["id"], "kokoro_82m");
+    assert_eq!(base["type"], "audio");
+    assert_eq!(base["downloads"][0]["repo"], "hexgrad/Kokoro-82M");
+}
+
+/// A non-voice-clone audio job (no reference) carries NO `baseModelManifestEntry` — the base-model
+/// resolution is scoped to the voice-clone path so ordinary Speech/SFX/Music jobs are untouched.
+#[tokio::test]
+async fn create_audio_job_omits_base_model_entry_without_a_reference() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Plain Audio Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "kokoro_82m",
+            "prompt": "Just plain speech.",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job}");
+    assert!(job["payload"].get("baseModelManifestEntry").is_none());
+}
+
+/// The Voice Clone match-strength floor (sc-13411 C4): the API blanket-bounds `matchStrength` to
+/// 0..=1 (the converter re-checks it), so an out-of-range value is a 400 rather than reaching the worker.
+#[tokio::test]
+async fn create_audio_job_rejects_out_of_range_match_strength() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Bad Strength Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let (status, _body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "openvoice_v2",
+            "prompt": "over-driven strength",
+            "referenceAudioAssetId": "ref-voice-1",
+            "matchStrength": 1.5,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
 /// The audio validator rejects out-of-blanket sampling knobs up front (sc-13409) — the API blanket

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -38,9 +38,17 @@ import { AssetPickerField } from "../components/AssetPicker.jsx";
 // Studio source-band pattern). guidance(CFG)/negative are capability-gated: the pinned ACE-Step turbo is
 // guidance-distilled (advertises neither), so they stay hidden for it — surfacing them would be a typed
 // Unsupported at the gen-core floor; a future non-distilled music model that advertises them shows them.
-// The remaining mode (C4 Voice Clone) keeps the C0 scaffold: its fields render capability-driven, but
-// submit stays inert until its story lands (the Generate CTA is disabled off a wired tab rather than
-// being a silent no-op).
+//
+// SCOPE (C4 sc-13411): Voice Clone is fully wired too. Its generate model is a CONVERTER — a model
+// advertising ReferenceAudio conditioning (OpenVoice V2); a bare speaker embedder (Chatterbox-VE,
+// VoiceEmbedding only) is filtered out of the tab/picker (isVoiceCloneConverter). The mode surfaces a
+// reference-voice band (pick a library audio track whose voice is cloned) + a match-strength control
+// (OpenVoice's tone-color sampling temperature τ), and its prompt is the SCRIPT the base voice speaks.
+// Generate submits referenceAudioAssetId + matchStrength through createAudioJob; the worker orchestrates
+// the two backend calls — base TTS (Kokoro) speaks the script, then OpenVoice V2 transfers the reference's
+// tone color — and registers the single converted clip. A named-voice registry (register-a-voice via a
+// stored Chatterbox-VE embedding) is deferred: the embedding's consumer is the future native clone-TTS
+// (E1), not this reference-clip pipeline.
 
 // Tab labels per the epic, keyed by the AUDIO_MODES ids so the ordering follows that array.
 const MODE_LABELS = {
@@ -62,10 +70,18 @@ const MODE_PLACEHOLDER = {
 // audio.maxDurationSecs) applies. Voice Clone follows its reference clip's length.
 const DURATION_MODES = new Set(["speech", "sfx", "music"]);
 // Modes whose Generate CTA is fully wired to createAudioJob (Speech C1 sc-13408, Sound FX C2 sc-13409,
-// Music C3 sc-13410). The remaining mode (Voice Clone) keeps the C0 scaffold — its CTA stays disabled
-// rather than a silent no-op — until its own story lands, so this set is the single guard both
-// `canGenerate` and `submit` read.
-const WIRED_MODES = new Set(["speech", "sfx", "music"]);
+// Music C3 sc-13410, Voice Clone C4 sc-13411). This set is the single guard both `canGenerate` and
+// `submit` read.
+const WIRED_MODES = new Set(["speech", "sfx", "music", "voiceclone"]);
+// Voice Clone runs the OpenVoice V2 conversion chain, so its generate model must be a CONVERTER — a model
+// whose conditioning includes ReferenceAudio (OpenVoice V2). A bare speaker EMBEDDER (Chatterbox-VE,
+// VoiceEmbedding only) also "serves" the voiceclone mode conceptually, but it cannot run the conversion —
+// its embedding feeds register-a-voice / the future native clone-TTS (E1), not this pipeline — so it is
+// filtered out of the generate picker.
+function isVoiceCloneConverter(item) {
+  const conditioning = Array.isArray(item?.audio?.conditioning) ? item.audio.conditioning : [];
+  return conditioning.some((kind) => String(kind).toLowerCase() === "referenceaudio");
+}
 // Modes that expose the diffusion sampling knobs (CFG guidance + solver steps) in the advanced panel.
 // Sound FX runs the MOSS-SoundEffect flow-matching pipeline, which reads guidance/steps off the
 // top-level request; Speech (Kokoro) is not a diffusion model and ignores them, so it hides them. This
@@ -169,6 +185,11 @@ export function AudioStudio() {
   const [editRegionStartSecs, setEditRegionStartSecs] = useState(saved.editRegionStartSecs ?? "");
   const [editRegionEndSecs, setEditRegionEndSecs] = useState(saved.editRegionEndSecs ?? "");
   const [editStrength, setEditStrength] = useState(saved.editStrength ?? "");
+  // Voice Clone (C4 sc-13411) — a USER selection, so it persists like the Music source band.
+  // `referenceAudioAssetId` names the library audio track whose voice is cloned; `matchStrength` is the
+  // OpenVoice conversion strength (τ), empty ⇒ the converter default (0.3).
+  const [referenceAudioAssetId, setReferenceAudioAssetId] = useState(saved.referenceAudioAssetId ?? "");
+  const [matchStrength, setMatchStrength] = useState(saved.matchStrength ?? "");
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   // Guards a Speech run in flight so a second submit (double-click / ⌘↵) can't double-enqueue
   // (mirrors VideoStudio's `submitting`). Cleared in submit's finally.
@@ -178,7 +199,12 @@ export function AudioStudio() {
   // audio capability block matches (audioModelServesMode). The tabs, the picker and the snap effect
   // all derive from this so the user is never trapped on a mode whose model can't serve the others.
   const modelServesMode = (item, value) => audioModelServesMode(item, value);
-  const modelsForMode = (value) => audioModels.filter((item) => modelServesMode(item, value));
+  const modelsForMode = (value) => {
+    const serving = audioModels.filter((item) => modelServesMode(item, value));
+    // Voice Clone's generate model must be a CONVERTER (OpenVoice V2), not a bare speaker embedder —
+    // filter Chatterbox-VE out of the tab/picker so the CTA never routes a conversion to an embedder.
+    return value === "voiceclone" ? serving.filter(isVoiceCloneConverter) : serving;
+  };
   const selectedModel = audioModels.find((item) => item.id === model) ?? audioModels[0] ?? null;
 
   // Model-availability gate: `ready` follows the picker (audioModels is live-catalog-then-fallback in
@@ -218,7 +244,12 @@ export function AudioStudio() {
   // advertises inpaint/repaint/extend; a model without editModes never shows it. Mirrors VideoStudio's
   // `studio-source-band`, which reveals its source-clip picker only on the edit sub-modes.
   const showEditModes = mode === "music" && editModes.length > 0;
-  const showConditioning = mode === "voiceclone" && conditioning.length > 0;
+  // Voice Clone: the reference-voice band (pick a library audio track) + the match-strength control are
+  // revealed whenever the selected converter advertises ReferenceAudio conditioning — the capability that
+  // makes it a voice-conversion model (isVoiceCloneConverter). Chatterbox-VE (VoiceEmbedding only) never
+  // reaches this tab (modelsForMode filters it out).
+  const showVoiceClone =
+    mode === "voiceclone" && conditioning.some((kind) => String(kind).toLowerCase() === "referenceaudio");
   // Steps: both the Sound FX (MOSS) and Music (ACE-Step) diffusion samplers read the top-level
   // `steps`, so the solver-step count surfaces on both. Guidance(CFG): only when the model advertises
   // guidance support — MOSS does (SAMPLING_KNOB_MODES), the guidance-distilled ACE-Step turbo does NOT
@@ -244,8 +275,16 @@ export function AudioStudio() {
   // installed model, and no run already in flight. The empty-prompt guard is the DoD's "disable on
   // empty prompt"; the WIRED_MODES gate keeps the still-scaffold tabs (Music / Voice Clone) inert.
   const promptReady = prompt.trim().length > 0;
+  // Voice Clone additionally needs a reference-voice clip selected — the conversion has no target
+  // without it. The other wired modes carry no such extra requirement.
+  const referenceReady = mode !== "voiceclone" || referenceAudioAssetId.length > 0;
   const canGenerate =
-    WIRED_MODES.has(mode) && modelReady && Boolean(model) && promptReady && !submitting;
+    WIRED_MODES.has(mode) &&
+    modelReady &&
+    Boolean(model) &&
+    promptReady &&
+    referenceReady &&
+    !submitting;
 
   // Snap the model to one that serves the active mode (mirrors VideoStudio). A no-op when the current
   // model already serves the mode, or when nothing serves it (a reduced catalog).
@@ -310,6 +349,8 @@ export function AudioStudio() {
       editRegionStartSecs,
       editRegionEndSecs,
       editStrength,
+      referenceAudioAssetId,
+      matchStrength,
       advancedOpen,
     },
     audioModels.length > 0,
@@ -407,6 +448,14 @@ export function AudioStudio() {
           }
           payload.editStrength = editStrength === "" ? undefined : Number(editStrength);
         }
+      } else if (mode === "voiceclone") {
+        // Voice Clone (OpenVoice V2 conversion chain, sc-13411 C4). The prompt is the SCRIPT the base TTS
+        // (Kokoro) speaks; `referenceAudioAssetId` names the library audio track whose voice is cloned;
+        // `matchStrength` overrides the converter's τ. `canGenerate` guarantees a reference is selected.
+        // No `voice` is sent — the base clip uses Kokoro's default voice, which OpenVoice re-timbres toward
+        // the reference. `baseModel` defaults to kokoro_82m server-side.
+        payload.referenceAudioAssetId = referenceAudioAssetId;
+        payload.matchStrength = matchStrength === "" ? undefined : Number(matchStrength);
       }
       const job = await createAudioJob?.(payload);
       if (job) {
@@ -684,13 +733,42 @@ export function AudioStudio() {
               ) : null}
             </div>
 
-            {/* Voice Clone conditioning scaffold — surfaced from audio.conditioning. Reference upload +
-                cloned-speech wiring is a later mode story (C4); this shows the model's capability. */}
-            {showConditioning ? (
-              <p className="helper-copy">
-                This model conditions on a reference voice ({conditioning.join(", ")}). Reference
-                upload and cloned-speech generation arrive in a later update.
-              </p>
+            {/* Voice Clone (C4 sc-13411): reference-voice band + match strength. Pick a library audio
+                track whose voice is cloned; the prompt above is the script the base voice speaks, then
+                OpenVoice V2 transfers the reference's tone color onto it. Revealed only when the selected
+                converter advertises ReferenceAudio conditioning (isVoiceCloneConverter). */}
+            {showVoiceClone ? (
+              <div className="studio-source-band">
+                <AssetPickerField
+                  assets={audioAssets}
+                  buttonLabel="Select reference voice"
+                  changeLabel="Change"
+                  emptyLabel="No reference voice selected"
+                  label="Reference voice"
+                  onChange={setReferenceAudioAssetId}
+                  showCategories={false}
+                  value={referenceAudioAssetId}
+                />
+                <label className="settings-field settings-field-match-strength">
+                  Match strength
+                  <input
+                    max="1"
+                    min="0"
+                    onChange={(event) => setMatchStrength(event.target.value)}
+                    placeholder="0.3 (default)"
+                    step="0.05"
+                    type="number"
+                    value={matchStrength}
+                  />
+                  <span className="field-hint" role="note">
+                    OpenVoice tone-color sampling temperature (τ). Cleared → model default (0.3).
+                  </span>
+                </label>
+                <p className="helper-copy">
+                  The base voice speaks your script, then OpenVoice V2 converts it to match the reference
+                  clip&rsquo;s voice. Record or import a reference clip into the library to use it here.
+                </p>
+              </div>
             ) : null}
 
             <AdvancedSection

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -200,13 +200,36 @@ describe("AudioStudio shell (sc-13407)", () => {
     expect(fieldByLabelStart(container, "Voice")).toBeFalsy();
   });
 
-  it("surfaces the Voice Clone conditioning scaffold from audio.conditioning", async () => {
+  it("surfaces the Voice Clone reference band + match strength from the converter (sc-13411)", async () => {
     await render(baseContext());
     await click(modeTab(container, "Voice Clone"));
 
-    // Snaps to a conditioning model (OpenVoice), and shows the reference-voice scaffold copy.
+    // Snaps to the CONVERTER (OpenVoice V2 — ReferenceAudio conditioning); a bare embedder never reaches
+    // this tab. The reference-voice band + the match-strength control render for the real conversion.
     expect(modelSelect(container).value).toBe("openvoice_v2");
-    expect(container.textContent).toContain("ReferenceAudio");
+    const band = container.querySelector(".studio-source-band");
+    expect(band).toBeTruthy();
+    expect(band.textContent).toContain("Reference voice");
+    expect(band.querySelector(".settings-field-match-strength input")).toBeTruthy();
+  });
+
+  it("filters a bare speaker embedder (Chatterbox-VE) out of the Voice Clone picker (sc-13411)", async () => {
+    // Chatterbox-VE "serves" voiceclone conceptually (VoiceEmbedding) but cannot run the conversion, so
+    // it must never appear in the generate picker — only converters (ReferenceAudio) do.
+    const chatterbox = {
+      id: "chatterbox_ve",
+      name: "Chatterbox Voice Encoder",
+      type: "audio",
+      audio: { conditioning: ["VoiceEmbedding"] },
+      ui: { label: "Chatterbox Voice Encoder" },
+    };
+    await render(
+      baseContext({ audioModels: [...ALL_AUDIO, chatterbox], models: [...ALL_AUDIO, chatterbox] }),
+    );
+    await click(modeTab(container, "Voice Clone"));
+    const options = [...modelSelect(container).querySelectorAll("option")].map((o) => o.value);
+    expect(options).toContain("openvoice_v2");
+    expect(options).not.toContain("chatterbox_ve");
   });
 
   it("renders the studio body when an audio model is installed (gate open)", async () => {
@@ -438,16 +461,16 @@ describe("AudioStudio Speech generation (sc-13408)", () => {
     expect(results.textContent).not.toContain("No audio yet");
   });
 
-  it("does not submit on a still-scaffold tab (Voice Clone stays inert)", async () => {
+  it("Voice Clone needs a reference before Generate is enabled (sc-13411)", async () => {
     const createAudioJob = vi.fn(async () => ({ id: "nope" }));
     await render(
       baseContext({ createAudioJob, rememberLocalGenerationJob: vi.fn() }),
     );
-    // Voice Clone is served only by OpenVoice in the base fixture; switch to it, type a script. (Speech,
-    // Sound FX and Music are wired — C1/C2/C3 — so Voice Clone is the remaining scaffold tab.)
+    // Voice Clone is served by OpenVoice in the base fixture; switch to it, type a script. With NO
+    // reference selected the conversion has no target, so the CTA stays disabled and a direct submit is
+    // a no-op — the guard is a missing reference now, not an unwired tab.
     await click(modeTab(container, "Voice Clone"));
     await setTextarea(container.querySelector(".prompt-input"), "reference this voice");
-    // The CTA is disabled off a wired tab, and a direct form submit is a no-op there.
     expect(generateButton(container).disabled).toBe(true);
     await act(async () => {
       container
@@ -875,6 +898,123 @@ describe("AudioStudio Music generation (sc-13410)", () => {
     expect(payload.editRegionStartSecs).toBe(2);
     expect(payload.editRegionEndSecs).toBe(5);
     expect(payload.editStrength).toBe(0.7);
+  });
+});
+
+describe("AudioStudio Voice Clone generation (sc-13411)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <AudioStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const generateButton = (root) => buttonWithText(root, "Generate");
+  const setTextarea = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const setNumber = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const submitForm = async () => {
+    await act(async () => {
+      container
+        .querySelector("form")
+        .dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+    });
+  };
+
+  it("submits the Voice Clone chain: model=converter + referenceAudioAssetId + matchStrength + script, no voice", async () => {
+    // The reference is a persisted user selection, so it restores from the studio snapshot at mount (like
+    // the Music source band). Seed it, then the CTA is enabled and submit builds the conversion payload.
+    window.localStorage.setItem(
+      "sceneworks-studio-audio-project_1",
+      JSON.stringify({ referenceAudioAssetId: "ref-voice-1" }),
+    );
+    const referenceAsset = { id: "ref-voice-1", type: "audio", displayName: "My reference voice" };
+    const job = { id: "voiceclone-1", type: "audio_generate" };
+    const createAudioJob = vi.fn(async () => job);
+    const rememberLocalGenerationJob = vi.fn();
+    await render(
+      baseContext({
+        assets: [referenceAsset],
+        createAudioJob,
+        rememberLocalGenerationJob,
+      }),
+    );
+    await click(modeTab(container, "Voice Clone"));
+    await setTextarea(
+      container.querySelector(".prompt-input"),
+      "Clone this into my reference voice.",
+    );
+    // A discriminating, non-default match strength so the test can't false-green on a default.
+    await setNumber(container.querySelector(".settings-field-match-strength input"), "0.65");
+    expect(generateButton(container).disabled).toBe(false);
+    await submitForm();
+
+    expect(createAudioJob).toHaveBeenCalledTimes(1);
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.model).toBe("openvoice_v2");
+    expect(payload.prompt).toBe("Clone this into my reference voice.");
+    expect(payload.referenceAudioAssetId).toBe("ref-voice-1");
+    expect(payload.matchStrength).toBe(0.65);
+    // No base voice is sent from the voiceclone tab (Kokoro's default reads the script); no music/edit knobs.
+    expect(payload.voice).toBeUndefined();
+    expect(payload.sourceAudioAssetId).toBeUndefined();
+    expect(payload.bpm).toBeUndefined();
+    // The run lands in the audio local-job lane so it stacks in the results zone.
+    expect(rememberLocalGenerationJob).toHaveBeenCalledWith("audio", job);
+  });
+
+  it("omits matchStrength when cleared so the converter uses its own default", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-audio-project_1",
+      JSON.stringify({ referenceAudioAssetId: "ref-voice-1" }),
+    );
+    const referenceAsset = { id: "ref-voice-1", type: "audio", displayName: "Ref" };
+    const createAudioJob = vi.fn(async () => ({ id: "vc-default" }));
+    await render(
+      baseContext({ assets: [referenceAsset], createAudioJob, rememberLocalGenerationJob: vi.fn() }),
+    );
+    await click(modeTab(container, "Voice Clone"));
+    await setTextarea(container.querySelector(".prompt-input"), "default strength");
+    await submitForm();
+
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.referenceAudioAssetId).toBe("ref-voice-1");
+    expect(payload.matchStrength).toBeUndefined();
   });
 });
 

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -18,8 +18,8 @@
 use super::*;
 
 use gen_core::{
-    AudioEditMode, AudioParams, CancelFlag, Conditioning, GenerationOutput, GenerationRequest,
-    LoadSpec, Progress, TimeRegion, WeightsSource,
+    AudioEditMode, AudioParams, AudioTransformRequest, CancelFlag, Conditioning, GenerationOutput,
+    GenerationRequest, LoadSpec, Progress, TimeRegion, WeightsSource,
 };
 
 use crate::video_jobs::{write_wav_pcm16, AudioTrack};
@@ -68,6 +68,21 @@ struct AudioRequest {
     edit_region_end_secs: Option<f32>,
     /// Edit strength (0..=1). `None` ⇒ the model default.
     edit_strength: Option<f32>,
+    /// Voice Clone (sc-13411 C4): the reference-voice library `type: "audio"` asset whose timbre is
+    /// transferred onto the base TTS clip. Its presence is the discriminator that routes this job onto
+    /// the two-call Kokoro→OpenVoice chain (`run_voice_clone_synthesis`) instead of the single-generator
+    /// path. `None` ⇒ an ordinary Speech/SFX/Music generation.
+    reference_audio_asset_id: Option<String>,
+    /// Voice Clone base TTS model id (the "content" generator whose speech OpenVoice re-timbres). The API
+    /// injects its manifest entry as `baseModelManifestEntry`. Defaults to Kokoro (`kokoro_82m`).
+    base_model: String,
+    /// Voice Clone match strength — overrides OpenVoice V2's posterior-sampling temperature τ (rides
+    /// `AudioTransformRequest::strength`). `None` ⇒ the converter's own default (τ = 0.3).
+    match_strength: Option<f32>,
+    /// The resolved manifest entry for [`base_model`] (the base TTS), injected by the API on a voice-clone
+    /// request so the worker resolves the base generator's snapshot without re-parsing the jsonc. `{}` on a
+    /// non-voice-clone job.
+    base_model_manifest_entry: Value,
     seed: Option<i64>,
     model_manifest_entry: Value,
 }
@@ -132,11 +147,39 @@ impl AudioRequest {
                 .get("editStrength")
                 .and_then(Value::as_f64)
                 .map(|value| value as f32),
+            reference_audio_asset_id: string("referenceAudioAssetId"),
+            base_model: string("baseModel").unwrap_or_else(|| "kokoro_82m".to_owned()),
+            match_strength: payload
+                .get("matchStrength")
+                .and_then(Value::as_f64)
+                .map(|value| value as f32),
+            base_model_manifest_entry: payload
+                .get("baseModelManifestEntry")
+                .cloned()
+                .unwrap_or_else(|| json!({})),
             seed: payload.get("seed").and_then(Value::as_i64),
             model_manifest_entry: payload
                 .get("modelManifestEntry")
                 .cloned()
                 .unwrap_or_else(|| json!({})),
+        }
+    }
+
+    /// A voice-clone job carries a non-empty reference-voice asset id — the discriminator that routes it
+    /// onto the two-call Kokoro→OpenVoice chain rather than the single-generator path.
+    fn is_voice_clone(&self) -> bool {
+        self.reference_audio_asset_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty())
+    }
+
+    /// The generation mode recorded on the asset + generation set — `"voice_clone"` for a reference-
+    /// driven job, else `"text_to_audio"` (Speech / SFX / Music).
+    fn mode(&self) -> &'static str {
+        if self.is_voice_clone() {
+            "voice_clone"
+        } else {
+            "text_to_audio"
         }
     }
 
@@ -205,14 +248,38 @@ fn normalize_audio_language(language: &str) -> String {
 /// `kokoro-v1_0.pth` + `voices/`). Uses the same `resolve_app_managed_model_dir` seam the other
 /// worker jobs use, so it finds the HF-cache snapshot the manifest's normal install path populated.
 fn resolve_audio_model_dir(settings: &Settings, request: &AudioRequest) -> WorkerResult<PathBuf> {
-    let repo = audio_model_repo(&request.model_manifest_entry).ok_or_else(|| {
+    resolve_audio_model_dir_for(settings, &request.model_manifest_entry, &request.model)
+}
+
+/// Resolve an audio model's cached snapshot directory from an explicit manifest entry + id — the
+/// generalization of [`resolve_audio_model_dir`] the voice-clone chain uses to resolve BOTH its base
+/// TTS model (`baseModelManifestEntry`) and its converter (`modelManifestEntry`).
+fn resolve_audio_model_dir_for(
+    settings: &Settings,
+    entry: &Value,
+    model_id: &str,
+) -> WorkerResult<PathBuf> {
+    let repo = audio_model_repo(entry).ok_or_else(|| {
         WorkerError::InvalidPayload(format!(
-            "{}: the model manifest entry declares no Hugging Face download repo, so its audio \
-             weights cannot be resolved.",
-            request.model
+            "{model_id}: the model manifest entry declares no Hugging Face download repo, so its \
+             audio weights cannot be resolved."
         ))
     })?;
     crate::paths::resolve_app_managed_model_dir(settings, &repo, "Audio model")
+}
+
+/// OpenVoice V2's converter weights (`config.json` + `checkpoint.pth`) live under a `converter/`
+/// subdirectory of its `myshell-ai/OpenVoiceV2` snapshot (the manifest downloads them as
+/// `converter/*`), whereas the transform's `load` expects the directory that directly holds those two
+/// files. Descend into `converter/` when it carries the checkpoint; otherwise pass the root through
+/// (a future flat-layout repack still loads).
+fn openvoice_converter_dir(root: PathBuf) -> PathBuf {
+    let converter = root.join("converter");
+    if converter.join("checkpoint.pth").is_file() {
+        converter
+    } else {
+        root
+    }
 }
 
 /// The Hugging Face repo hosting an audio model's weights — the first `huggingface` download entry,
@@ -294,12 +361,25 @@ pub(crate) async fn run_audio_generate_job(
     .await?;
 
     check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
-    let model_dir = resolve_audio_model_dir(settings, &request)?;
-    // Extend/edit SOURCE band (sc-13410): resolve + decode the source track and build the
-    // `Conditioning::AudioEdit` here (in async, where the project path + store are in scope), then move
-    // it into the blocking synthesis. `None` ⇒ plain text-to-music. The per-model gates (edit mode ∈
-    // advertised, region inside the clip, 48 kHz source) run in the generator's `validate` at synthesis.
-    let audio_edit = build_audio_edit(settings, &request, &project_path)?;
+
+    // Voice Clone (sc-13411 C4) routes onto the two-call Kokoro→OpenVoice chain; every other mode runs
+    // the single-generator path. Both resolve their snapshot dir(s) up front so a missing install fails
+    // with a clear error before the job is marked Running.
+    let synthesis: AudioSynthesis = if request.is_voice_clone() {
+        let plan = resolve_voice_clone_plan(settings, &request, &project_path)?;
+        AudioSynthesis::VoiceClone(plan)
+    } else {
+        let model_dir = resolve_audio_model_dir(settings, &request)?;
+        // Extend/edit SOURCE band (sc-13410): resolve + decode the source track and build the
+        // `Conditioning::AudioEdit` here (in async, where the project path + store are in scope), then move
+        // it into the blocking synthesis. `None` ⇒ plain text-to-music. The per-model gates (edit mode ∈
+        // advertised, region inside the clip, 48 kHz source) run in the generator's `validate` at synthesis.
+        let audio_edit = build_audio_edit(settings, &request, &project_path)?;
+        AudioSynthesis::Single {
+            model_dir,
+            audio_edit,
+        }
+    };
 
     update_job(
         api,
@@ -319,9 +399,20 @@ pub(crate) async fn run_audio_generate_job(
     // the worker's async runtime stays responsive, and emit periodic keepalive heartbeats + progress
     // while it runs so a long synthesis (a cold pipeline build, a 30 s clip, or a slow host) is never
     // flagged stale and marked `interrupted` mid-flight. Mirrors the video path's interval keepalive
-    // for the no-progress cold-load phase.
-    let track =
-        run_audio_synthesis(api, settings, job, backend, &request, model_dir, audio_edit).await?;
+    // for the no-progress cold-load phase. The voice-clone chain runs TWO backend calls (base TTS then
+    // conversion) inside one blocking task, so the single keepalive loop spans both.
+    let track = match synthesis {
+        AudioSynthesis::Single {
+            model_dir,
+            audio_edit,
+        } => {
+            run_audio_synthesis(api, settings, job, backend, &request, model_dir, audio_edit)
+                .await?
+        }
+        AudioSynthesis::VoiceClone(plan) => {
+            run_voice_clone_synthesis(api, settings, job, backend, &request, plan).await?
+        }
+    };
 
     check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
     update_job(
@@ -464,6 +555,22 @@ async fn run_audio_synthesis(
             )),
         }
     });
+    await_audio_blocking(api, settings, job, backend, handle).await
+}
+
+/// Await a blocking audio-synthesis join handle while emitting periodic keepalive heartbeats +
+/// progress updates, so a long synthesis (a cold pipeline build, a slow host, or — for voice clone —
+/// two chained backend calls) is never flagged stale and swept to `interrupted` mid-flight. Shared by
+/// the single-generator path ([`run_audio_synthesis`]) and the voice-clone chain
+/// ([`run_voice_clone_synthesis`]); mirrors the video path's interval keepalive for the no-progress
+/// cold-load phase.
+async fn await_audio_blocking(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    backend: &str,
+    handle: tokio::task::JoinHandle<WorkerResult<gen_core::AudioTrack>>,
+) -> WorkerResult<gen_core::AudioTrack> {
     tokio::pin!(handle);
     let mut ticker = tokio::time::interval(Duration::from_secs(AUDIO_KEEPALIVE_SECS));
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -495,6 +602,152 @@ async fn run_audio_synthesis(
             }
         }
     }
+}
+
+/// Which synthesis path a resolved audio job takes — the single-generator lane (Speech / SFX / Music)
+/// or the two-call voice-clone chain (sc-13411 C4). Resolved before the job is marked Running so a
+/// missing install / reference surfaces as a clear preflight error.
+enum AudioSynthesis {
+    Single {
+        model_dir: PathBuf,
+        audio_edit: Option<Conditioning>,
+    },
+    VoiceClone(VoiceClonePlan),
+}
+
+/// A resolved voice-clone job: the base TTS snapshot dir, the OpenVoice converter snapshot dir, and
+/// the decoded reference-voice clip whose timbre is transferred. All three are resolved in async (where
+/// the settings + project path are in scope) so the blocking chain gets ready-to-load inputs.
+struct VoiceClonePlan {
+    base_model_dir: PathBuf,
+    converter_dir: PathBuf,
+    reference: gen_core::AudioTrack,
+}
+
+/// Resolve the base TTS snapshot, the OpenVoice converter snapshot, and the reference-voice clip for a
+/// voice-clone job (sc-13411 C4). Fails with a clear error when the reference asset can't be resolved to
+/// a decodable WAV, the base/converter isn't installed, or the manifest entries are missing — all before
+/// the job is marked Running.
+fn resolve_voice_clone_plan(
+    settings: &Settings,
+    request: &AudioRequest,
+    project_path: &Path,
+) -> WorkerResult<VoiceClonePlan> {
+    let base_model_dir = resolve_audio_model_dir_for(
+        settings,
+        &request.base_model_manifest_entry,
+        &request.base_model,
+    )?;
+    let converter_root = resolve_audio_model_dir(settings, request)?;
+    let converter_dir = openvoice_converter_dir(converter_root);
+    let reference_id = request
+        .reference_audio_asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "a voice-clone job needs a referenceAudioAssetId.".to_owned(),
+            )
+        })?;
+    // Resolve the reference through the same project-scoped guard the extend/edit source clip uses, then
+    // decode its PCM-16 WAV into the host AudioTrack OpenVoice consumes as its tone-color target.
+    let reference_path = crate::video_jobs::resolve_clip_media_path(
+        settings,
+        &request.project_id,
+        reference_id,
+        project_path,
+    )?;
+    let reference = read_wav_pcm16(&reference_path)?;
+    Ok(VoiceClonePlan {
+        base_model_dir,
+        converter_dir,
+        reference,
+    })
+}
+
+/// Run the two-call voice-clone chain on a blocking thread (sc-13411 C4): base TTS (Kokoro) speaks the
+/// script, then OpenVoice V2 transfers the reference clip's tone color onto that speech. This is the
+/// product-layer orchestration of two backend calls — a single worker job so the library sees exactly
+/// one asset (the converted clip). Returns the converted `gen_core::AudioTrack` for the caller to write
+/// + register, exactly like [`run_audio_synthesis`].
+async fn run_voice_clone_synthesis(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    backend: &str,
+    request: &AudioRequest,
+    plan: VoiceClonePlan,
+) -> WorkerResult<gen_core::AudioTrack> {
+    let VoiceClonePlan {
+        base_model_dir,
+        converter_dir,
+        reference,
+    } = plan;
+    let base_model = request.base_model.clone();
+    let converter_model = request.model.clone();
+    let script = request.prompt.clone();
+    // The base TTS voice (which Kokoro voice speaks the script) + language ride the base generator's
+    // AudioParams exactly as a Speech job does; OpenVoice then re-timbres the result toward the reference.
+    let voice = request.voice.clone();
+    let language = request.language.as_deref().map(normalize_audio_language);
+    // Match strength overrides OpenVoice's posterior-sampling temperature τ; `None` ⇒ the converter's
+    // own default (0.3). The converter range-checks it (finite, >= 0).
+    let strength = request.match_strength;
+    let seed = request.seed.map(|seed| seed as u64);
+    let handle = tokio::task::spawn_blocking(move || -> WorkerResult<gen_core::AudioTrack> {
+        // Call 1 — base TTS: synthesize the script in the requested base voice.
+        let base_spec = LoadSpec::new(WeightsSource::Dir(base_model_dir));
+        let base_generator = crate::inference_runtime::load_audio(&base_model, &base_spec)
+            .map_err(|error| {
+                crate::classify_engine_error("voice-clone base TTS load failed", error)
+            })?;
+        let base_req = GenerationRequest {
+            prompt: script,
+            audio: Some(AudioParams {
+                voice,
+                language,
+                ..Default::default()
+            }),
+            cancel: CancelFlag::new(),
+            ..Default::default()
+        };
+        let mut on_progress = |_progress: Progress| {};
+        let base_track = match base_generator
+            .generate(&base_req, &mut on_progress)
+            .map_err(|error| crate::classify_engine_error("voice-clone base TTS failed", error))?
+        {
+            GenerationOutput::Audio(track) => track,
+            _ => {
+                return Err(WorkerError::Engine(
+                    "voice-clone base TTS returned non-audio output".to_owned(),
+                ))
+            }
+        };
+
+        // Call 2 — OpenVoice V2 tone-color conversion: transfer the reference clip's timbre onto the
+        // base speech. The source (`audio`) carries content + prosody; `target_reference` is the voice.
+        let converter_spec = LoadSpec::new(WeightsSource::Dir(converter_dir));
+        let transform =
+            crate::inference_runtime::load_audio_transform(&converter_model, &converter_spec)
+                .map_err(|error| {
+                    crate::classify_engine_error("voice-clone converter load failed", error)
+                })?;
+        let transform_req = AudioTransformRequest {
+            audio: base_track,
+            target_reference: Some(reference),
+            strength,
+            seed,
+            ..Default::default()
+        };
+        transform
+            .apply(&transform_req, &mut on_progress)
+            .map_err(|error| crate::classify_engine_error("voice conversion failed", error))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| WorkerError::Engine("voice conversion produced no track".to_owned()))
+    });
+    await_audio_blocking(api, settings, job, backend, handle).await
 }
 
 /// Parse an edit-mode token (`inpaint` / `repaint` / `extend` / `cover`) into the gen-core
@@ -707,6 +960,11 @@ fn audio_asset_fact(
         "editRegionStartSecs": request.edit_region_start_secs,
         "editRegionEndSecs": request.edit_region_end_secs,
         "editStrength": request.edit_strength,
+        // Voice Clone (sc-13411 C4): the reference-voice asset, base TTS model, and match strength (τ) so a
+        // re-generate reconstructs the exact chain. `null` on a non-voice-clone run.
+        "referenceAudioAssetId": request.reference_audio_asset_id,
+        "baseModel": if request.is_voice_clone() { Some(request.base_model.as_str()) } else { None },
+        "matchStrength": request.match_strength,
         "sampleRate": sample_rate,
     });
     json!({
@@ -721,7 +979,7 @@ fn audio_asset_fact(
         "family": plan.family,
         "displayName": display_name,
         "createdAt": plan.created_at,
-        "mode": "text_to_audio",
+        "mode": request.mode(),
         "model": request.model,
         "adapter": adapter,
         "prompt": request.prompt,
@@ -745,6 +1003,10 @@ fn audio_asset_fact(
         "editRegionStartSecs": request.edit_region_start_secs,
         "editRegionEndSecs": request.edit_region_end_secs,
         "editStrength": request.edit_strength,
+        // Voice Clone replay record (sc-13411 C4) — `null` on a non-voice-clone run.
+        "referenceAudioAssetId": request.reference_audio_asset_id,
+        "baseModel": if request.is_voice_clone() { Some(request.base_model.as_str()) } else { None },
+        "matchStrength": request.match_strength,
         "seed": request.seed,
         "rawAdapterSettings": raw_adapter_settings,
     })
@@ -760,7 +1022,7 @@ fn audio_streaming_result(plan: &AudioPlan, request: &AudioRequest, fact: &Value
         "model": request.model,
         "generationSet": {
             "id": plan.genset_id,
-            "mode": "text_to_audio",
+            "mode": request.mode(),
             "model": request.model,
             "prompt": request.prompt,
             "count": 1,
@@ -1135,5 +1397,104 @@ mod tests {
         assert!(fact["voice"].is_null(), "SFX carries no voice");
         assert_eq!(fact["rawAdapterSettings"]["guidance"], 7.0);
         assert_eq!(fact["rawAdapterSettings"]["steps"], 80);
+    }
+
+    // ── Voice Clone (sc-13411 C4) ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn from_payload_reads_the_voice_clone_fields() {
+        // A voice-clone payload carries the reference-voice asset, an optional base TTS model, and the
+        // match strength (τ). Their presence flips `is_voice_clone` / `mode` onto the conversion path.
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "openvoice_v2",
+            "prompt": "Clone this into my reference voice.",
+            "referenceAudioAssetId": "ref-voice-1",
+            "baseModel": "kokoro_82m",
+            "matchStrength": 0.5,
+            "seed": 3,
+        })));
+        assert_eq!(request.model, "openvoice_v2");
+        assert_eq!(
+            request.reference_audio_asset_id.as_deref(),
+            Some("ref-voice-1")
+        );
+        assert_eq!(request.base_model, "kokoro_82m");
+        assert_eq!(request.match_strength, Some(0.5));
+        assert!(request.is_voice_clone());
+        assert_eq!(request.mode(), "voice_clone");
+
+        // A base model defaults to Kokoro when the payload omits it.
+        let defaulted = AudioRequest::from_payload(&payload(json!({
+            "model": "openvoice_v2",
+            "referenceAudioAssetId": "ref-voice-1",
+        })));
+        assert_eq!(defaulted.base_model, "kokoro_82m");
+        assert!(defaulted.is_voice_clone());
+
+        // No reference ⇒ an ordinary (non-voice-clone) run: a blank/whitespace id does not route.
+        let none = AudioRequest::from_payload(&payload(json!({ "model": "kokoro_82m" })));
+        assert!(!none.is_voice_clone());
+        assert_eq!(none.mode(), "text_to_audio");
+        let blank = AudioRequest::from_payload(&payload(json!({ "referenceAudioAssetId": "   " })));
+        assert!(!blank.is_voice_clone());
+    }
+
+    #[test]
+    fn openvoice_converter_dir_descends_into_the_converter_subdir() {
+        // The OpenVoice snapshot downloads its converter weights under `converter/`; the transform's
+        // `load` wants the dir that directly holds `checkpoint.pth`, so the resolver descends when the
+        // subdir carries the checkpoint and passes the root through otherwise.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let root = dir.path().to_path_buf();
+        // No converter/ ⇒ pass the root through unchanged.
+        assert_eq!(openvoice_converter_dir(root.clone()), root);
+        // converter/checkpoint.pth present ⇒ descend into converter/.
+        let converter = root.join("converter");
+        std::fs::create_dir_all(&converter).unwrap();
+        std::fs::write(converter.join("checkpoint.pth"), b"stub").unwrap();
+        assert_eq!(openvoice_converter_dir(root.clone()), converter);
+    }
+
+    #[test]
+    fn voice_clone_asset_fact_records_the_reference_base_and_strength_for_replay() {
+        // A voice-clone run records the reference asset, base model, and match strength in both the
+        // top-level replay record and rawAdapterSettings, and stamps mode = "voice_clone" (sc-13411).
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "openvoice_v2",
+            "prompt": "Clone this into my reference voice.",
+            "referenceAudioAssetId": "ref-voice-1",
+            "baseModel": "kokoro_82m",
+            "matchStrength": 0.5,
+            "seed": 3,
+        })));
+        let plan = AudioPlan::new(&request, Path::new("/tmp/project"));
+        let fact = audio_asset_fact(&plan, &request, 22_050, 1, 4.2);
+        assert_eq!(fact["mode"], "voice_clone");
+        assert_eq!(fact["model"], "openvoice_v2");
+        assert_eq!(fact["referenceAudioAssetId"], "ref-voice-1");
+        assert_eq!(fact["baseModel"], "kokoro_82m");
+        assert_eq!(fact["matchStrength"], 0.5);
+        // ...mirrored into rawAdapterSettings so the exact conversion request is reconstructable.
+        assert_eq!(
+            fact["rawAdapterSettings"]["referenceAudioAssetId"],
+            "ref-voice-1"
+        );
+        assert_eq!(fact["rawAdapterSettings"]["baseModel"], "kokoro_82m");
+        assert_eq!(fact["rawAdapterSettings"]["matchStrength"], 0.5);
+        // The streaming set carries the voice_clone mode too.
+        let result = audio_streaming_result(&plan, &request, &fact);
+        assert_eq!(result["generationSet"]["mode"], "voice_clone");
+
+        // A non-voice-clone run leaves the voice-clone fields null and baseModel null (not "kokoro_82m").
+        let plain = AudioRequest::from_payload(&payload(json!({ "model": "kokoro_82m" })));
+        let plain_plan = AudioPlan::new(&plain, Path::new("/tmp/project"));
+        let plain_fact = audio_asset_fact(&plain_plan, &plain, 24_000, 1, 3.0);
+        assert_eq!(plain_fact["mode"], "text_to_audio");
+        assert!(plain_fact["referenceAudioAssetId"].is_null());
+        assert!(
+            plain_fact["baseModel"].is_null(),
+            "baseModel is null on a non-voice-clone run"
+        );
+        assert!(plain_fact["matchStrength"].is_null());
     }
 }

--- a/crates/sceneworks-worker/src/inference_runtime.rs
+++ b/crates/sceneworks-worker/src/inference_runtime.rs
@@ -10,12 +10,12 @@ use std::sync::OnceLock;
 #[cfg(all(test, target_os = "macos"))]
 use gen_core::core_llm::TextLlmRegistration;
 use gen_core::core_llm::{LoadSpec as TextLoadSpec, ModelRequirements, TextLlm, TextLlmRegistry};
+use gen_core::{AudioTransform, Generator, LoadSpec, ProviderRegistry};
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 use gen_core::{Captioner, ImageEmbedder, ModelRegistration, TextEmbedder, Trainer};
-use gen_core::{Generator, LoadSpec, ProviderRegistry};
 
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use runtime_cuda as platform_runtime;
@@ -95,6 +95,25 @@ pub(crate) fn load_audio(id: &str, spec: &LoadSpec) -> gen_core::Result<Box<dyn 
             )
         })?
         .load(id, spec)
+}
+
+/// Load an audio [`AudioTransform`] by id from the runtime's candle audio registry — the
+/// non-prompt audio→audio lane (OpenVoice V2 tone-color voice conversion, sc-13411 C4). The audio
+/// twin of [`load_audio`]: errors clearly when this build ships no audio lane so the voice-clone job
+/// turns it into a loud job failure rather than a silent no-op.
+pub(crate) fn load_audio_transform(
+    id: &str,
+    spec: &LoadSpec,
+) -> gen_core::Result<Box<dyn AudioTransform>> {
+    audio()
+        .ok_or_else(|| {
+            gen_core::Error::Msg(
+                "no audio lane is linked in this runtime build (the candle audio registry is \
+                 unavailable)"
+                    .to_owned(),
+            )
+        })?
+        .load_audio_transform(id, spec)
 }
 
 pub(crate) fn text() -> &'static TextLlmRegistry {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -358,6 +358,12 @@ mod sana_mlx_smoke;
 // (the video job lane has no background heartbeat during a generation).
 #[cfg(all(test, target_os = "macos"))]
 mod mochi_mlx_smoke;
+// Real-weight smoke for the Voice Clone two-call chain (sc-13411, C4): Kokoro base TTS → OpenVoice V2
+// tone-color conversion → Chatterbox-VE evidence that the converted clip's speaker identity moved
+// toward the reference. Test-only + macOS-only; #[ignore]d — drives the exact
+// `runtime_macos::catalog().audio()` seams the worker's voice-clone job uses, minus the API/job plumbing.
+#[cfg(all(test, target_os = "macos"))]
+mod voiceclone_smoke;
 // On-device per-tier memory-footprint measurement harness (sc-8516, epic 8506). Test-only + macOS-only;
 // #[ignore]d real-weight smokes that drive `crate::inference_runtime::load(id)` + ONE generation while sampling the MLX
 // process-global memory counters (mlx_rs::memory::{reset_peak_memory, get_active_memory, get_peak_memory})

--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -1,0 +1,264 @@
+//! Local real-weight smoke for the **Voice Clone** two-call chain (epic 13400 / sc-13411, C4).
+//! `#[ignore]`d — run by hand on an Apple-Silicon Mac. It drives the exact runtime seams the
+//! worker's voice-clone job (`audio_jobs::run_voice_clone_synthesis`) uses, minus the API/job plumbing:
+//!
+//!   1. **Base TTS** — `runtime_macos::catalog().audio().load("kokoro_82m")` speaks the script in a
+//!      default voice (the "content" clip).
+//!   2. **Reference voice** — a SECOND real Kokoro clip in a distinctly different voice
+//!      (`am_michael`, male) stands in for a user-supplied reference-voice sample. Any real clip
+//!      works; a Kokoro clip in another voice gives a controlled, reproducible target timbre.
+//!   3. **OpenVoice V2 conversion** — `load_audio_transform("openvoice_v2")` +
+//!      `AudioTransform::apply` with the base clip as the source and the reference clip as
+//!      `target_reference`, `strength` overriding the posterior-sampling temperature τ. This is the
+//!      real tone-color transfer.
+//!   4. **Chatterbox-VE evidence** — `load_voice_embedder("chatterbox_ve")` embeds the base,
+//!      reference, and converted clips; the converted clip's speaker embedding must move measurably
+//!      TOWARD the reference (cosine(converted, ref) > cosine(base, ref)). That is the objective,
+//!      ear-free proof that the timbre moved toward the target — a true audible match still needs a
+//!      listen, so the WAVs are written out for that.
+//!
+//! Setup — the three snapshots install through the ordinary Audio Studio model download; this smoke
+//! resolves them from the HF hub cache (override with the env vars if they live elsewhere):
+//! ```text
+//! cargo test -p sceneworks-worker --release voiceclone_chain_smoke -- --ignored --nocapture
+//! # overrides: VOICECLONE_KOKORO_DIR / VOICECLONE_OPENVOICE_DIR (the converter/ dir) /
+//! #            VOICECLONE_CHATTERBOX_DIR, VOICECLONE_STRENGTH (τ, default 0.3),
+//! #            VOICECLONE_OUT_DIR (default /tmp/voiceclone_smoke)
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{
+    AudioParams, AudioTransformRequest, CancelFlag, GenerationOutput, GenerationRequest, LoadSpec,
+    Progress, WeightsSource,
+};
+
+use super::smoke_support::env_or;
+use crate::video_jobs::{write_wav_pcm16, AudioTrack};
+
+/// The script the base TTS speaks (and the converted clip preserves).
+const SCRIPT: &str = "SceneWorks turns a short reference clip into a cloned voiceover.";
+/// The reference-voice clip's script — content is irrelevant to tone-color extraction; a different
+/// sentence keeps it honest that the converter transfers TIMBRE, not content.
+const REFERENCE_SCRIPT: &str = "This is my natural speaking voice, captured for cloning.";
+/// The base (source/content) voice — Kokoro's default female voice.
+const BASE_VOICE: &str = "af_heart";
+/// The reference (target) voice — a distinctly different male voice, so the tone-color move is large
+/// and the Chatterbox-VE evidence is unambiguous.
+const REFERENCE_VOICE: &str = "am_michael";
+
+/// Find the single HF-hub snapshot dir for `models--<owner>--<repo>` under `~/.cache/huggingface`,
+/// or `None` if the cache is laid out elsewhere (then the caller falls back to the env override).
+fn hub_snapshot(owner_repo: &str) -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let cache_key = format!("models--{}", owner_repo.replace('/', "--"));
+    let snapshots = Path::new(&home)
+        .join(".cache/huggingface/hub")
+        .join(cache_key)
+        .join("snapshots");
+    let mut entries = std::fs::read_dir(&snapshots).ok()?;
+    entries
+        .find_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir())
+}
+
+/// Resolve a model dir from an env override or the HF hub cache, panicking with a clear message if
+/// neither resolves — this is a manual smoke, so a missing snapshot should say exactly what to install.
+fn resolve_dir(env_key: &str, owner_repo: &str, subdir: Option<&str>) -> PathBuf {
+    let base = match std::env::var(env_key).ok().filter(|v| !v.trim().is_empty()) {
+        Some(v) => PathBuf::from(v.trim()),
+        None => hub_snapshot(owner_repo).unwrap_or_else(|| {
+            panic!(
+                "{env_key} unset and no HF hub snapshot for {owner_repo} — install the model via the \
+                 Audio Studio (or `hf download {owner_repo}`) or set {env_key}"
+            )
+        }),
+    };
+    let dir = match subdir {
+        Some(sub) if base.join(sub).is_dir() => base.join(sub),
+        _ => base,
+    };
+    assert!(
+        dir.is_dir(),
+        "{env_key}: {} is not a directory",
+        dir.display()
+    );
+    dir
+}
+
+/// Generate one real Kokoro clip (the base TTS call), returning the produced `gen_core::AudioTrack`.
+fn kokoro_clip(dir: &Path, script: &str, voice: &str) -> gen_core::AudioTrack {
+    let audio = runtime_macos::catalog()
+        .expect("runtime catalog")
+        .audio()
+        .expect("audio lane")
+        .load(
+            "kokoro_82m",
+            &LoadSpec::new(WeightsSource::Dir(dir.to_path_buf())),
+        )
+        .expect("load kokoro");
+    let req = GenerationRequest {
+        prompt: script.to_owned(),
+        audio: Some(AudioParams {
+            voice: Some(voice.to_owned()),
+            language: Some("en-us".to_owned()),
+            ..Default::default()
+        }),
+        cancel: CancelFlag::new(),
+        ..Default::default()
+    };
+    let mut on_progress = |_p: Progress| {};
+    match audio
+        .generate(&req, &mut on_progress)
+        .expect("kokoro generate")
+    {
+        GenerationOutput::Audio(track) => track,
+        _ => panic!("kokoro returned non-audio output"),
+    }
+}
+
+/// Peak absolute sample amplitude — the "is it silent?" check.
+fn peak(samples: &[f32]) -> f32 {
+    samples.iter().fold(0.0f32, |m, &s| m.max(s.abs()))
+}
+
+/// Cosine similarity of two raw embedding vectors (both must be the same length).
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(&x, &y)| x * y).sum();
+    let na: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    let nb: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na * nb)
+}
+
+/// Write a `gen_core::AudioTrack` out as a PCM-16 WAV for a manual listen.
+fn dump_wav(track: &gen_core::AudioTrack, path: &Path) {
+    let wav = AudioTrack {
+        samples: track.samples.clone(),
+        sample_rate: track.sample_rate.max(1),
+        channels: track.channels.max(1),
+    };
+    write_wav_pcm16(&wav, path).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+#[test]
+#[ignore = "real-weight audio smoke: run by hand on an Apple-Silicon Mac"]
+fn voiceclone_chain_smoke() {
+    let kokoro_dir = resolve_dir("VOICECLONE_KOKORO_DIR", "hexgrad/Kokoro-82M", None);
+    // OpenVoice's converter files live under `converter/` in the snapshot.
+    let openvoice_dir = resolve_dir(
+        "VOICECLONE_OPENVOICE_DIR",
+        "myshell-ai/OpenVoiceV2",
+        Some("converter"),
+    );
+    let chatterbox_dir = resolve_dir("VOICECLONE_CHATTERBOX_DIR", "ResembleAI/chatterbox", None);
+    let out_dir = PathBuf::from(env_or("VOICECLONE_OUT_DIR", "/tmp/voiceclone_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let tau: f32 = env_or("VOICECLONE_STRENGTH", "0.3")
+        .parse()
+        .expect("τ float");
+
+    // ── Call 1: base TTS (the content clip) ──────────────────────────────────────────────────────
+    let base = kokoro_clip(&kokoro_dir, SCRIPT, BASE_VOICE);
+    assert!(!base.samples.is_empty(), "base clip is empty");
+    let base_peak = peak(&base.samples);
+    assert!(base_peak > 0.0, "base clip is silent");
+    dump_wav(&base, &out_dir.join("base_kokoro.wav"));
+
+    // A separate real clip in a DIFFERENT voice stands in for the user's reference-voice sample.
+    let reference = kokoro_clip(&kokoro_dir, REFERENCE_SCRIPT, REFERENCE_VOICE);
+    assert!(peak(&reference.samples) > 0.0, "reference clip is silent");
+    dump_wav(&reference, &out_dir.join("reference.wav"));
+
+    // ── Call 2: OpenVoice V2 tone-color conversion ───────────────────────────────────────────────
+    let converter = runtime_macos::catalog()
+        .expect("runtime catalog")
+        .audio()
+        .expect("audio lane")
+        .load_audio_transform(
+            "openvoice_v2",
+            &LoadSpec::new(WeightsSource::Dir(openvoice_dir.clone())),
+        )
+        .expect("load openvoice_v2 transform");
+    let req = AudioTransformRequest {
+        audio: base.clone(),
+        target_reference: Some(reference.clone()),
+        strength: Some(tau),
+        seed: Some(7),
+        ..Default::default()
+    };
+    let mut on_progress = |_p: Progress| {};
+    let converted = converter
+        .apply(&req, &mut on_progress)
+        .expect("openvoice apply")
+        .into_iter()
+        .next()
+        .expect("openvoice produced a track");
+    assert!(!converted.samples.is_empty(), "converted clip is empty");
+    let conv_peak = peak(&converted.samples);
+    assert!(conv_peak > 0.0, "converted clip is silent");
+    dump_wav(&converted, &out_dir.join("converted.wav"));
+
+    // The converted clip must NOT be a copy of the base clip: OpenVoice emits at its native 22.05 kHz
+    // (Kokoro is 24 kHz), so the rate alone already differs — but assert the WAVEFORM moved too.
+    assert_eq!(converted.sample_rate, 22_050, "openvoice native rate");
+    assert_eq!(converted.channels, 1, "openvoice mono output");
+
+    // ── Chatterbox-VE evidence: did the tone color move toward the reference? ─────────────────────
+    let embedder = runtime_macos::catalog()
+        .expect("runtime catalog")
+        .audio()
+        .expect("audio lane")
+        .load_voice_embedder(
+            "chatterbox_ve",
+            // Chatterbox-VE loads the single `ve.safetensors`, not a snapshot dir.
+            &LoadSpec::new(WeightsSource::File(chatterbox_dir.join("ve.safetensors"))),
+        )
+        .expect("load chatterbox_ve embedder");
+    let emb_base = embedder.embed(&base).expect("embed base");
+    let emb_ref = embedder.embed(&reference).expect("embed reference");
+    let emb_conv = embedder.embed(&converted).expect("embed converted");
+
+    let sim_base_ref = cosine(&emb_base, &emb_ref);
+    let sim_conv_ref = cosine(&emb_conv, &emb_ref);
+    let sim_conv_base = cosine(&emb_conv, &emb_base);
+
+    eprintln!("[voiceclone-smoke] out dir: {}", out_dir.display());
+    eprintln!(
+        "[voiceclone-smoke] base:      {} samples @ {} Hz, peak {:.4}",
+        base.samples.len(),
+        base.sample_rate,
+        base_peak
+    );
+    eprintln!(
+        "[voiceclone-smoke] reference: {} samples @ {} Hz",
+        reference.samples.len(),
+        reference.sample_rate
+    );
+    eprintln!(
+        "[voiceclone-smoke] converted: {} samples @ {} Hz, peak {:.4} (τ={tau})",
+        converted.samples.len(),
+        converted.sample_rate,
+        conv_peak
+    );
+    eprintln!(
+        "[voiceclone-smoke] Chatterbox-VE cosine — base↔ref {sim_base_ref:.4} | \
+         converted↔ref {sim_conv_ref:.4} | converted↔base {sim_conv_base:.4}"
+    );
+
+    // The core acceptance evidence: the converted clip's speaker identity is closer to the reference
+    // than the base clip's is — the tone color moved toward the target voice.
+    assert!(
+        sim_conv_ref > sim_base_ref,
+        "tone color did not move toward the reference: converted↔ref {sim_conv_ref:.4} \
+         must exceed base↔ref {sim_base_ref:.4}"
+    );
+    eprintln!(
+        "[voiceclone-smoke] PASS — tone color moved toward the reference by \
+         {:.4} cosine (listen: {})",
+        sim_conv_ref - sim_base_ref,
+        out_dir.join("converted.wav").display()
+    );
+}


### PR DESCRIPTION
## [C4] Voice Clone mode — reference + script via OpenVoice conversion pipeline (approach A)

Story: [sc-13411] · https://app.shortcut.com/trefry/story/13411 · epic 13400 (Audio Studio). The last story of the epic.

Wires the Audio Studio **Voice Clone** tab end to end: a reference-voice clip + a script → a cloned voiceover saved to the library, via **approach A** (OpenVoice V2 tone-color conversion now; upgrades to native clone-TTS via E1/sc-13412).

### Chain design + orchestration layer
**Worker-orchestrated single job** (not web-chained). A voice-clone `audio_generate` job runs a two-call chain inside one blocking task:
1. **Base TTS** — Kokoro (`load_audio`) speaks the script (the "content" clip).
2. **OpenVoice V2 conversion** — `load_audio_transform("openvoice_v2")` + `AudioTransform::apply` with the base clip as the source and the resolved reference clip as `target_reference`; `matchStrength` overrides OpenVoice's posterior-sampling temperature τ.

Why worker-orchestrated over web-chaining two `createAudioJob` calls: it reliably yields exactly **one** library asset (the converted clip, no intermediate base-clip pollution), reuses the worker's existing reference resolution (`resolve_clip_media_path` + `read_wav_pcm16`, C3), needs no client polling/re-enqueue, and keeps the whole chain under one keepalive loop. This is the epic's "product-layer orchestration of two backend calls" — the SceneWorks worker (the product layer above the inference monorepo) orchestrates Kokoro + OpenVoice. OpenVoice is a `gen_core::AudioTransform` (not a `Generator`); its target voice is supplied per-request via `AudioTransformRequest::target_reference`, so no weights are baked to a single voice.

### Walking skeleton (proven BEFORE the UI)
`crates/sceneworks-worker/src/voiceclone_smoke.rs` (`#[ignore]`d, macOS) drives the exact runtime seams and asserts the tone color moved toward the reference, using Chatterbox-VE as objective evidence:

| clip | facts |
|---|---|
| base (Kokoro `af_heart`) | 210000 samples @ 24000 Hz, peak ~0.45 |
| reference (Kokoro `am_michael`, different voice) | 104400 samples @ 24000 Hz |
| **converted** (τ=0.3) | **192768 samples @ 22050 Hz**, peak ~0.37, non-silent |

Chatterbox-VE speaker-embedding cosine: **converted↔reference 0.79 vs base↔reference 0.65** (+0.147) — the converted clip's identity moved measurably toward the reference while staying distinct from the base (converted↔base 0.66). The converted clip preserves the base's content length (~8.7s) at OpenVoice's native 22.05 kHz. A true audible match still needs an ear; the smoke writes all three WAVs for a listen.

### Mode UI
- **Reference-voice input**: pick a library audio asset (`AssetPickerField`). Upload/record land via the existing library import path (any imported audio asset is pickable). A named saved-voice registry is deferred (below).
- **Match strength**: control mapped to OpenVoice's τ (advertised `supports_strength`); cleared → converter default (0.3).
- Generate model is **filtered to converters** (`audio.conditioning ⊇ ReferenceAudio` = OpenVoice V2). A bare speaker **embedder** (Chatterbox-VE, `VoiceEmbedding` only) cannot run the conversion, so it is excluded from the tab/picker.
- Capability-driven; Speech / SFX / Music untouched.

**register-a-voice status (honest):** a persistent named Chatterbox-VE **embedding** registry is deferred to **sc-13517** (filed). Rationale: OpenVoice conversion is reference-**clip** based (re-extracts tone color from the clip at convert time) and consumes no precomputed embedding — the embedding's real consumer is E1's native clone-TTS (`Conditioning::VoiceEmbedding`), which does not exist yet. Building the registry now would be speculative. The Chatterbox-VE embedder seam is proven (the smoke), and pick-a-clip + convert is fully implemented, so any library audio clip is already a reusable reference.

### Backend
- `inference_runtime.rs`: `load_audio_transform` seam (audio lane).
- `audio_jobs.rs`: `run_voice_clone_synthesis`, `openvoice_converter_dir` (descends into the `converter/` snapshot subdir), `resolve_voice_clone_plan`; asset fact stamps `mode: "voice_clone"` + records `referenceAudioAssetId` / `baseModel` / `matchStrength` for replay.
- DTO/route: `AudioJobRequest` gains `referenceAudioAssetId` / `baseModel` (default `kokoro_82m`) / `matchStrength`; the audio route injects `baseModelManifestEntry` only on a voice-clone request; `matchStrength` bounded 0..=1 (converter re-checks).

### Tests
- Worker `audio_jobs` unit: **16 pass** (voice-clone parse/mode, `openvoice_converter_dir`, replay fact).
- rust-api audio route: **12 pass** (base-entry injection, no-entry on plain jobs, `matchStrength` 400).
- Web `AudioStudio`: **33 pass** (converter-filtered picker, reference band + match-strength, discriminating submit payload, reference-required gate); full web suite **2160 pass**; `web:build` green.
- `cargo clippy -p sceneworks-worker -p sceneworks-rust-api --all-targets -- -D warnings` green; `cargo fmt --all -- --check` green.

### Hygiene
No NUL bytes; all 11 changed files are text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
