### PR TITLE
fix: unbreak main — un-gate resolve_clip_media_path for the audio edit lane + drop an unused test helper

### DIFF
--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -682,7 +682,6 @@ describe("AudioStudio Music generation (sc-13410)", () => {
     await act(async () => {});
   }
 
-  const generateButton = (root) => buttonWithText(root, "Generate");
   const advancedFieldByLabel = (root, label) =>
     [...root.querySelectorAll(".advanced-panel label")].find((el) =>
       el.textContent.trim().startsWith(label),

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -8785,12 +8785,13 @@ fn build_video_clip_conditioning(
 }
 
 /// Resolve an asset id to its on-disk media file path (the source clip mp4), mirroring the asset
-/// lookup in [`load_reference_image`] but returning the path for ffmpeg frame extraction (the
+/// lookup in `load_reference_image` but returning the path for ffmpeg frame extraction (the
 /// Rust equivalent of the torch `source_asset_media_path`).
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
+///
+/// Deliberately NOT gated to the macOS/candle video lanes (unlike its original callers): the audio
+/// edit lane (`audio_jobs::build_audio_edit`, sc-13410) resolves its source clip through this on
+/// every platform and feature combination, so gating it broke the Linux-no-candle "neither" build
+/// (E0425 on main). Everything it touches (`ProjectStore`, `safe_project_path`) is backend-neutral.
 pub(crate) fn resolve_clip_media_path(
     settings: &Settings,
     project_id: &str,


### PR DESCRIPTION
Main's parity + web-lint lanes are red (last two pushes) from two audio-train slips; neither open PR fixes them. Merge this ahead of other PRs to clear CI.

- **Rust (E0425, red since [#1651](https://github.com/SceneWorks/SceneWorks/pull/1651))**: [sc-13410] added an ungated call to `video_jobs::resolve_clip_media_path` from `audio_jobs::build_audio_edit`, but the function was cfg-gated to the macOS/candle video lanes, so any off-Mac no-candle build of the worker lib fails to compile. The function is pure `ProjectStore` + `safe_project_path` resolution with no backend dependency and the audio edit lane needs it everywhere → the gate is removed, with a doc comment explaining why it must stay ungated (also swapped the intra-doc link to a cfg-gated item for plain code font — the rustdoc-lane trap).
- **Web lint (red since [#1654](https://github.com/SceneWorks/SceneWorks/pull/1654))**: [sc-13411] left an unused `generateButton` helper in the Voice Clone describe block of `AudioStudio.test.jsx` → removed.

Validated on the box: workspace `cargo clippy --all-targets -- -D warnings` green (the exact failing parity config), `rust:check:neither` green, `cargo fmt` green, `eslint` on the file green, AudioStudio vitest 33/33 green.

Found while working [sc-13510](https://app.shortcut.com/trefry/story/13510) (whose PR follows; its parity CI stays red until this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)