### PR TITLE
fix(ci): make the Check lane green after the audio Voice Clone merge [sc-13523]

### DIFF
--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -682,7 +682,6 @@ describe("AudioStudio Music generation (sc-13410)", () => {
     await act(async () => {});
   }
 
-  const generateButton = (root) => buttonWithText(root, "Generate");
   const advancedFieldByLabel = (root, label) =>
     [...root.querySelectorAll(".advanced-panel label")].find((el) =>
       el.textContent.trim().startsWith(label),

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -8787,10 +8787,13 @@ fn build_video_clip_conditioning(
 /// Resolve an asset id to its on-disk media file path (the source clip mp4), mirroring the asset
 /// lookup in [`load_reference_image`] but returning the path for ffmpeg frame extraction (the
 /// Rust equivalent of the torch `source_asset_media_path`).
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
+///
+/// Ungated (compiled in every feature/target config): besides the macOS/candle video conditioning
+/// callers, the cross-platform `audio_jobs` path resolves the voice-clone reference and the
+/// audio-edit source clip through this same project-scoped guard (sc-13410 / sc-13411), so gating
+/// it to the video lanes broke the default Linux `parity` build with an unresolved reference
+/// (sc-13523). The body depends only on cross-platform helpers (`ProjectStore`,
+/// `safe_project_path`), so it compiles everywhere.
 pub(crate) fn resolve_clip_media_path(
     settings: &Settings,
     project_id: &str,


### PR DESCRIPTION
## Why

The epic 13400 audio work (sc-13410 audio-edit, sc-13411 Voice Clone) merged over a failing CI run (PR #1654), leaving `main`'s **Check** lane red on two independent gates. Both were masked because each story was signed off with *targeted* verification (macOS `cargo test -p sceneworks-worker --lib audio_jobs` + a scoped web run) that never hit the config/rule the full CI lanes exercise.

## Root cause 1 — parity (Rust), Linux default features / no `backend-candle`

```
error[E0425]: cannot find function `resolve_clip_media_path` in module `crate::video_jobs`
  --> crates/sceneworks-worker/src/audio_jobs.rs:655
  --> crates/sceneworks-worker/src/audio_jobs.rs:799
```

`audio_jobs.rs` is compiled on **every** platform (its dispatch arm is uniform — lib.rs:149-154). Both `resolve_voice_clone_plan` (the voice-clone reference) and `build_audio_edit` (the audio-edit source clip) resolve their asset through `crate::video_jobs::resolve_clip_media_path`. But that helper was cfg-gated to the **video conditioning lanes only**:

```rust
#[cfg(any(target_os = "macos", all(not(target_os = "macos"), feature = "backend-candle")))]
pub(crate) fn resolve_clip_media_path(...) -> WorkerResult<PathBuf>
```

So in the parity config (`not(macos)` + candle off) the function does not exist, and the two cross-platform audio call sites fail to resolve. macOS builds always had it via the `target_os = "macos"` arm, which is exactly why the story's macOS targeted test was green.

**Fix:** remove the gate so `resolve_clip_media_path` is compiled in every feature/target config. Its body depends only on cross-platform helpers (`ProjectStore` imported at the crate root, `safe_project_path` ungated in paths.rs), so it compiles everywhere; and because the uniform audio path calls it in every config, it is never dead code under `-D warnings`.

## Root cause 2 — web (eslint)

```
685:9  error  'generateButton' is assigned a value but never used  no-unused-vars
```

in `apps/web/src/screens/AudioStudio.test.jsx` — a duplicate test helper inside the *Music generation* `describe` block that is never called (the Speech/SFX/Voice-clone blocks each define and use their own). Removed. (The 54 pre-existing `react-hooks/exhaustive-deps` warnings are unchanged and allowed by the gate.)

## Faithful repro of the parity failure

Cross-compiling `sceneworks-worker` to `x86_64-unknown-linux-gnu` with candle off is the parity config. With the fix reverted it reproduces the exact break; with the fix it is clean:

```
$ git stash push -- crates/sceneworks-worker/src/video_jobs.rs
$ cargo clippy --target x86_64-unknown-linux-gnu -p sceneworks-worker --all-targets -- -D warnings
error[E0425]: cannot find function `resolve_clip_media_path` in module `crate::video_jobs`  (x2, lines 655 & 799)
error: could not compile `sceneworks-worker`
$ git stash pop   # fix restored → clean
```

## Full CI-equivalent checks (all green)

| Check | Command | Result |
| --- | --- | --- |
| rust fmt | `cargo fmt --all -- --check` | clean |
| clippy (macOS, full workspace) | `cargo clippy --all-targets -- -D warnings` | **Finished**, 0 warnings |
| clippy (parity: Linux, candle **off**) | `cargo clippy --target x86_64-unknown-linux-gnu -p sceneworks-worker -p sceneworks-rust-api --all-targets -- -D warnings` | **Finished**, clean |
| clippy (candle: Linux, candle **on**, nvcc-stub) | `npm run rust:check:candle` | `[candle] OK — the candle cfg typechecks … under -D warnings` |
| cargo build (workspace) | `cargo build` | **Finished** |
| worker tests (touched crate) | `cargo test -p sceneworks-worker --lib audio_jobs` | 16 passed, 0 failed |
| web lint | `npm --prefix apps/web run lint` | 0 errors (54 pre-existing warnings) |
| web test | `npm --prefix apps/web run test` | 152 files, 2160 tests passed |
| web build | `npm --prefix apps/web run build` | built OK |

Candle/off-Mac lane verified by the sanctioned nvcc-stub cross-compile (`scripts/check-candle-build.mjs`); the helper resolves in the candle config too. No other audio-work CI errors surfaced across the full-config clippy runs.

Story: [sc-13523]
https://app.shortcut.com/trefry/story/13523

🤖 Generated with [Claude Code](https://claude.com/claude-code)