### PR TITLE
fix(cuda): re-apply the vendored multi-arch candle-kernels patch in the SceneWorks workspace [sc-13510]

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -27,6 +27,9 @@ name: Windows Candle worker
 # 14.51, sc-3676). The runner reuses its `_work` target dir, so candle compiles
 # once and is incremental across runs. The real-weight GPU smokes stay `#[ignore]`d
 # (the ~logic tests run driver-free); add `-- --ignored` by hand for a GPU pass.
+# Exception: `cuda_quant_smoke` (sc-13510) is weightless and fast, so it runs
+# un-ignored here — it exercises the patched candle-kernels quant kernels on the
+# real GPU every time this lane fires.
 #
 # Runner prerequisites: Windows 11 + NVIDIA driver, CUDA Toolkit 12.9, VS2022
 # BuildTools (MSVC 14.44), a Rust toolchain, registered with the `cuda` label.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
 dependencies = [
  "cudaforge",
 ]
@@ -1752,7 +1752,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1966,7 +1966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4310,7 +4310,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4435,7 +4435,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5912,7 +5912,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5970,7 +5970,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6664,7 +6664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7314,7 +7314,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7836,7 +7836,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8505,7 +8505,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,19 @@ unsafe_code = "forbid"
 
 [workspace.lints.clippy]
 all = "warn"
+
+# Vendored multi-arch CUDA kernel override (sc-7544 / sc-13510). candle-kernels compiles the
+# GGUF quant/moe kernels into a static `libmoe.a` of SASS with ONE `-gencode` derived from
+# CUDA_COMPUTE_CAP — at the cap=80 packaging baseline that is an Ampere-only cubin with no PTX,
+# so on Blackwell (sm_120) every quantized matmul silently returns zeros. The inference repo
+# vendors candle-kernels with a multi-arch fatbin build.rs (sm_80 + sm_90 + sm_120 SASS +
+# compute_120 PTX; see crates/media/candle-gen/vendor/candle-kernels/VENDORED.md there), but a
+# Cargo `[patch]` only takes effect in the TOP-LEVEL workspace — inference's own patch does not
+# apply when SceneWorks builds the graph, which is how the sc-7544 fix silently dropped out at
+# the candle-gen -> inference cutover. This patch re-applies it for every SceneWorks build.
+#
+# The rev MUST stay in lockstep with the inference pins in crates/sceneworks-worker/Cargo.toml
+# (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
+# candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
+[patch."https://github.com/huggingface/candle"]
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "d68b8b45" }

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -72,6 +72,74 @@ function findBuiltMetallib() {
   return existsSync(cached) ? cached : null;
 }
 
+// Packaging-time regression guard for the quant/moe kernel fatbin (sc-7544 / sc-13510).
+// candle-kernels' GGUF quant/moe kernels are a static `libmoe.a` of SASS (no PTX): built
+// un-patched at the cap=80 baseline it holds an sm_80-only cubin, and on Blackwell every
+// quantized matmul silently returns zeros (models render solid black — nothing else fails).
+// The multi-arch fatbin comes from the root Cargo.toml [patch] onto the inference repo's
+// vendored candle-kernels; that patch was silently lost once already (sc-13510), so trusting
+// the build graph is not enough — inspect the artifact we are about to package. Requires
+// `cuobjdump`, which ships in the same CUDA toolkit bin dir as the nvcc this build just ran.
+function verifyCandleQuantFatbin(computeCap) {
+  const buildRoot = join(repoRoot, "target", "release", "build");
+  const candidates = [];
+  if (existsSync(buildRoot)) {
+    for (const entry of readdirSync(buildRoot)) {
+      if (!entry.startsWith("candle-kernels-")) continue;
+      const lib = join(buildRoot, entry, "out", "libmoe.a");
+      if (existsSync(lib)) candidates.push([lib, statSync(lib).mtimeMs]);
+    }
+  }
+  if (!candidates.length) {
+    console.error(
+      "build-sidecar: candle build left no candle-kernels-*/out/libmoe.a under " +
+        `${buildRoot} — cannot verify the quant kernel fatbin`,
+    );
+    process.exit(1);
+  }
+  candidates.sort((a, b) => b[1] - a[1]);
+  const lib = candidates[0][0];
+  const dump = (flag) => {
+    try {
+      return execFileSync("cuobjdump", [flag, lib], { encoding: "utf8" });
+    } catch (err) {
+      console.error(
+        `build-sidecar: cuobjdump ${flag} failed (${err?.message ?? err}) — it ships in the ` +
+          `same CUDA toolkit bin dir as the nvcc this build just used; ensure that dir is on PATH`,
+      );
+      process.exit(1);
+    }
+  };
+  const elf = dump("--list-elf");
+  const ptx = dump("--list-ptx");
+  // The vendored build.rs always adds sm_90 + sm_120 SASS and compute_120 PTX on top of
+  // cudaforge's one CUDA_COMPUTE_CAP-derived baseline arch (sm_80 at the packaging default).
+  // cuobjdump lists cubins as `libmoe.N.sm_XX.cubin`; the compute_120 PTX entry is listed
+  // as `libmoe.N.sm_120.ptx` (cuobjdump names PTX by target arch, not virtual arch).
+  const required = [...new Set([`sm_${computeCap}`, "sm_90", "sm_120"])];
+  const missing = required.filter((arch) => !elf.includes(`${arch}.cubin`));
+  const problems = [];
+  if (missing.length) {
+    problems.push(`libmoe.a lacks ${missing.join(", ")} SASS (has:\n${elf.trim()})`);
+  }
+  if (!ptx.includes("sm_120.ptx")) {
+    problems.push(`libmoe.a lacks compute_120 PTX (forward-JIT for post-Blackwell archs)`);
+  }
+  if (problems.length) {
+    console.error(
+      `build-sidecar: ${lib} is not the multi-arch quant fatbin — quantized models would ` +
+        `silently render black on unsupported GPU architectures (sc-7544 / sc-13510):\n` +
+        problems.map((p) => `  - ${p}`).join("\n") +
+        `\nThe root Cargo.toml [patch] onto the inference repo's vendored candle-kernels is ` +
+        `probably not in effect; see crates/sceneworks-worker/tests/candle_kernels_patch_guard.rs.`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `build-sidecar: quant kernel fatbin verified (${required.join("+")} SASS + compute_120 PTX) at ${lib}`,
+  );
+}
+
 // Host target triple, e.g. aarch64-apple-darwin or x86_64-pc-windows-msvc.
 const triple = execFileSync("rustc", ["-vV"], { encoding: "utf8" }).match(
   /host:\s*(\S+)/,
@@ -139,8 +207,15 @@ const candle =
   process.platform === "win32" && process.env.SCENEWORKS_DESKTOP_CANDLE !== "0";
 if (candle) {
   // CUDA_COMPUTE_CAP=80 builds `compute_80` PTX the driver JITs forward to sm_120
-  // (Blackwell) — one binary covers Ampere→Blackwell (per sc-3676). Honor an
-  // explicit override (e.g. a single-arch dev build) if the env already set it.
+  // (Blackwell) — one binary covers Ampere→Blackwell (per sc-3676). That claim holds
+  // for candle-kernels' dense build_ptx() kernels only: the GGUF quant/moe kernels are
+  // a static SASS `libmoe.a` with NO PTX, which at cap=80 alone is Ampere-only and
+  // silently zeros every quantized matmul on Blackwell (sc-7544). Multi-arch coverage
+  // for those comes from the root Cargo.toml [patch] onto the inference repo's
+  // vendored candle-kernels (sm_80+sm_90+sm_120 SASS + compute_120 PTX), verified
+  // below after the build (sc-13510 — the patch already dropped out silently once).
+  // Honor an explicit override (e.g. a native-cap dev build; the vendored extra gencodes
+  // are unconditional, so the quant fatbin stays multi-arch at any cap) if the env set it.
   const candleEnv = { VITE_API_BASE_URL: "" };
   if (!process.env.CUDA_COMPUTE_CAP) {
     candleEnv.CUDA_COMPUTE_CAP = "80";
@@ -182,6 +257,7 @@ if (candle) {
       CUDAFORGE_THREADS: "1",
     });
   }
+  verifyCandleQuantFatbin(process.env.CUDA_COMPUTE_CAP || candleEnv.CUDA_COMPUTE_CAP);
 } else {
   run(npmCmd, ["run", "api:build:embedded"], { VITE_API_BASE_URL: "" });
 }

--- a/crates/sceneworks-worker/tests/candle_kernels_patch_guard.rs
+++ b/crates/sceneworks-worker/tests/candle_kernels_patch_guard.rs
@@ -1,0 +1,198 @@
+//! Structural guard for the vendored multi-arch candle-kernels `[patch]` (sc-7544 / sc-13510).
+//!
+//! candle-kernels compiles the GGUF quant/moe kernels into a static `libmoe.a` of SASS with a
+//! single `-gencode` derived from `CUDA_COMPUTE_CAP`. At the cap=80 packaging baseline that is an
+//! Ampere-only cubin with no PTX, so on Blackwell (sm_120) every quantized matmul silently
+//! returns zeros — quantized models render solid black. The fix is the inference repo's vendored
+//! candle-kernels (multi-arch fatbin build.rs), applied here through the root `Cargo.toml`
+//! `[patch."https://github.com/huggingface/candle"]`.
+//!
+//! That patch only takes effect in the top-level workspace, and it already silently dropped out
+//! once (sc-13510: the candle-gen -> inference cutover rebuilt the workspace without it, and
+//! nothing failed). This test makes the loss loud: it asserts, from the committed `Cargo.lock`,
+//! that candle-kernels resolves through the patch AND at the same inference revision as the
+//! worker's direct pins. It parses files only — no CUDA, no GPU — so every CI lane runs it.
+//!
+//! If it fails after a pin bump: re-run `node scripts/bump-inference.mjs` (it rewrites the root
+//! [patch] rev in lockstep with crates/sceneworks-worker/Cargo.toml and refreshes the lock).
+
+use std::path::Path;
+
+const UPSTREAM_CANDLE: &str = "github.com/huggingface/candle";
+const INFERENCE_REPO: &str = "git+https://github.com/SceneWorks/inference";
+
+/// `(name, source)` for every `[[package]]` block in a Cargo.lock. Path dependencies have no
+/// `source` line and yield `None`. `[[patch.unused]]` blocks are ignored — an unused patch is
+/// exactly the failure this guard exists to catch, so it must not satisfy the lookup.
+fn parse_lock_packages(lock: &str) -> Vec<(String, Option<String>)> {
+    let mut packages = Vec::new();
+    let mut in_package = false;
+    let mut name: Option<String> = None;
+    let mut source: Option<String> = None;
+    for line in lock.lines() {
+        let line = line.trim();
+        if line.starts_with("[[") {
+            if in_package {
+                if let Some(n) = name.take() {
+                    packages.push((n, source.take()));
+                }
+            }
+            in_package = line == "[[package]]";
+            name = None;
+            source = None;
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        if let Some(v) = line.strip_prefix("name = ") {
+            name = Some(v.trim_matches('"').to_string());
+        } else if let Some(v) = line.strip_prefix("source = ") {
+            source = Some(v.trim_matches('"').to_string());
+        }
+    }
+    if in_package {
+        if let Some(n) = name {
+            packages.push((n, source));
+        }
+    }
+    packages
+}
+
+/// The resolved commit a git source locked to (the `#<sha>` fragment).
+fn resolved_commit(source: &str) -> Option<&str> {
+    source.split('#').nth(1)
+}
+
+/// Core check, separated from file I/O so the red paths below are testable: candle-kernels must
+/// resolve from the inference repo (the patch is live) at the same resolved commit as
+/// sceneworks-gen-core (the patch rev is in lockstep with the worker's inference pins).
+fn check_lock(lock: &str) -> Result<(), String> {
+    let packages = parse_lock_packages(lock);
+    let kernels: Vec<&Option<String>> = packages
+        .iter()
+        .filter(|(n, _)| n == "candle-kernels")
+        .map(|(_, s)| s)
+        .collect();
+    let [kernels_source] = kernels.as_slice() else {
+        return Err(format!(
+            "expected exactly one candle-kernels package in Cargo.lock, found {}",
+            kernels.len()
+        ));
+    };
+    let Some(kernels_source) = kernels_source else {
+        // A path source would mean a SceneWorks-local vendor copy this guard doesn't know about.
+        return Err("candle-kernels has no source (unexpected path dependency)".to_string());
+    };
+    if kernels_source.contains(UPSTREAM_CANDLE) {
+        return Err(format!(
+            "candle-kernels resolves from upstream candle ({kernels_source}): the root Cargo.toml \
+             [patch] to the inference repo's vendored multi-arch copy is not in effect, so \
+             packaged quantized models silently break on Blackwell (sc-7544 / sc-13510)"
+        ));
+    }
+    // The repo path must END at the repo name (`?rev=` query or fragment), so a lookalike
+    // repo (e.g. .../inference-archive) cannot satisfy the check.
+    let after_repo = kernels_source.strip_prefix(INFERENCE_REPO);
+    if !matches!(after_repo, Some(rest) if rest.is_empty() || rest.starts_with('?') || rest.starts_with('#'))
+    {
+        return Err(format!(
+            "candle-kernels resolves from an unexpected source: {kernels_source}"
+        ));
+    }
+    let gen_core = packages
+        .iter()
+        .find(|(n, _)| n == "sceneworks-gen-core")
+        .and_then(|(_, s)| s.as_deref())
+        .ok_or("sceneworks-gen-core not found in Cargo.lock")?;
+    match (resolved_commit(kernels_source), resolved_commit(gen_core)) {
+        (Some(k), Some(g)) if k == g => Ok(()),
+        (k, g) => Err(format!(
+            "candle-kernels [patch] rev skews from the worker's inference pin \
+             (candle-kernels {k:?} vs sceneworks-gen-core {g:?}): the vendored kernels no longer \
+             match the pinned candle-core. Re-run `node scripts/bump-inference.mjs`."
+        )),
+    }
+}
+
+/// The committed workspace lockfile passes the guard.
+#[test]
+fn candle_kernels_resolves_through_the_inference_patch() {
+    let lock_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../Cargo.lock");
+    let lock = std::fs::read_to_string(&lock_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", lock_path.display()));
+    if let Err(msg) = check_lock(&lock) {
+        panic!("{msg}");
+    }
+}
+
+// Red-path coverage: each canned lockfile is the guard's target failure, so a regression in the
+// parser or the check itself cannot silently turn the real test above into a false green.
+
+const GOOD_LOCK: &str = r#"
+[[package]]
+name = "candle-kernels"
+version = "0.10.2"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
+
+[[package]]
+name = "sceneworks-gen-core"
+version = "0.1.0"
+source = "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd"
+"#;
+
+#[test]
+fn guard_accepts_a_patched_lockstep_lock() {
+    assert_eq!(check_lock(GOOD_LOCK), Ok(()));
+}
+
+#[test]
+fn guard_rejects_upstream_candle_kernels() {
+    // The sc-13510 regression verbatim: the patch dropped, candle-kernels back on upstream.
+    let lock = GOOD_LOCK.replace(
+        "git+https://github.com/SceneWorks/inference?rev=d68b8b45#d68b8b457d76e0472393f0d7bfe0e79ae68278dd\"\n\n[[package]]",
+        "git+https://github.com/huggingface/candle?rev=1e6aa85e#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d\"\n\n[[package]]",
+    );
+    let err = check_lock(&lock).unwrap_err();
+    assert!(err.contains("upstream candle"), "{err}");
+}
+
+#[test]
+fn guard_rejects_a_lookalike_repo() {
+    // The repo check must not accept a source whose path merely starts with the inference repo's.
+    let lock = GOOD_LOCK.replacen(
+        "github.com/SceneWorks/inference?rev=d68b8b45",
+        "github.com/SceneWorks/inference-archive?rev=d68b8b45",
+        1,
+    );
+    let err = check_lock(&lock).unwrap_err();
+    assert!(err.contains("unexpected source"), "{err}");
+}
+
+#[test]
+fn guard_rejects_a_rev_skew() {
+    // Worker pins bumped, root [patch] left behind: same repo, different resolved commit.
+    let lock = GOOD_LOCK.replacen(
+        "#d68b8b457d76e0472393f0d7bfe0e79ae68278dd",
+        "#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        1,
+    );
+    let err = check_lock(&lock).unwrap_err();
+    assert!(err.contains("skews"), "{err}");
+}
+
+#[test]
+fn guard_rejects_a_missing_candle_kernels_package() {
+    let lock = GOOD_LOCK.replacen("name = \"candle-kernels\"", "name = \"renamed\"", 1);
+    let err = check_lock(&lock).unwrap_err();
+    assert!(err.contains("exactly one candle-kernels"), "{err}");
+}
+
+#[test]
+fn guard_ignores_patch_unused_blocks() {
+    // An unused patch records the package under [[patch.unused]] — that must NOT count as a
+    // resolution, it is precisely the broken state.
+    let lock = GOOD_LOCK.replacen("[[package]]", "[[patch.unused]]", 1);
+    let err = check_lock(&lock).unwrap_err();
+    assert!(err.contains("exactly one candle-kernels"), "{err}");
+}

--- a/crates/sceneworks-worker/tests/cuda_quant_smoke.rs
+++ b/crates/sceneworks-worker/tests/cuda_quant_smoke.rs
@@ -1,0 +1,139 @@
+//! Weightless CUDA quantized-matmul smoke for the SceneWorks workspace build (sc-7544 / sc-13510).
+//!
+//! candle-kernels compiles its GGUF `QMatMul` kernels (`mmq_gguf/*`, `moe/*`, `mmvq_gguf`) into a
+//! static `libmoe.a` of SASS with no PTX. Un-patched, that archive holds a single
+//! `CUDA_COMPUTE_CAP`-derived cubin; at the cap=80 packaging baseline a Blackwell (sm_120) GPU
+//! then has no compatible code and nothing to JIT, so every quantized matmul **silently returns
+//! zeros** (quantized models render solid black while dense models work). The fix is the root
+//! Cargo.toml `[patch]` onto the inference repo's vendored multi-arch candle-kernels.
+//!
+//! The inference repo has carried this exact smoke since sc-7544 — but it guards the *inference*
+//! workspace, and the regression (sc-13510) happened in the *SceneWorks* workspace build, which
+//! resolved candle-kernels from upstream with nothing watching. This copy closes that gap: it
+//! exercises the actual kernels linked into the worker's own graph, on the GPU, in the
+//! windows-candle CI lane (`cargo test -p sceneworks-worker --features backend-candle` on the
+//! self-hosted CUDA box). It is weightless (no checkpoints) and skips gracefully when no CUDA
+//! device is available, so non-GPU builds stay green.
+//!
+//! Note the lane builds at the box's native cap=120, where even a single-arch build would pass —
+//! the cap=80 *fatbin* guarantees are held by `candle_kernels_patch_guard.rs` (lockfile) and the
+//! packaging-time `cuobjdump` check in apps/desktop/scripts/build-sidecar.mjs. This smoke proves
+//! the linked quant kernels actually launch and compute correctly on real hardware.
+#![cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+
+use runtime_cuda::media::candle_core::quantized::{GgmlDType, QMatMul, QTensor};
+use runtime_cuda::media::candle_core::{Device, Module, Tensor};
+
+/// Deterministic, launch-portable pseudo-random f32 in roughly [-1, 1] (splitmix64-style hash of
+/// the index). Avoids a device RNG so the CPU reference and the CUDA result quantize
+/// byte-identical data.
+fn pseudo_random(n: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| {
+            let mut z = (i as u64).wrapping_add(0x9E37_79B9_7F4A_7C15);
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^= z >> 31;
+            ((z >> 40) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0
+        })
+        .collect()
+}
+
+/// Cosine similarity of two tensors over all elements (flattened, on the CPU).
+fn cosine(a: &Tensor, b: &Tensor) -> f32 {
+    let a = a.flatten_all().unwrap();
+    let b = b.flatten_all().unwrap();
+    let dot = (&a * &b)
+        .unwrap()
+        .sum_all()
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    let na = (&a * &a)
+        .unwrap()
+        .sum_all()
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap()
+        .sqrt();
+    let nb = (&b * &b)
+        .unwrap()
+        .sum_all()
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap()
+        .sqrt();
+    dot / (na * nb).max(1e-12)
+}
+
+fn all_finite(t: &Tensor) -> bool {
+    t.flatten_all()
+        .unwrap()
+        .to_vec1::<f32>()
+        .unwrap()
+        .iter()
+        .all(|v| v.is_finite())
+}
+
+/// The GGUF Q4_0/Q8_0 `QMatMul` on the CUDA device matches the CPU reference (cos≈1, all-finite).
+///
+/// On the broken single-arch packaging the CUDA result is all-zeros/garbage (cos≈0) — this fails
+/// loudly. With the multi-arch fatbin (native sm_120 cubin) it passes.
+#[test]
+fn cuda_qmatmul_matches_cpu() {
+    let device = match Device::new_cuda(0) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("SKIP cuda_qmatmul_matches_cpu: no CUDA device ({e})");
+            return;
+        }
+    };
+    eprintln!("[quant-smoke] device={device:?}");
+
+    // out=N, in=K, rows=M. K is a multiple of 32 (Q4_0/Q8_0 block) and 256 (k-quant QK_K), so the
+    // shapes stay valid for every GGUF dtype should we extend the sweep later.
+    let (n, k, m) = (512usize, 1024usize, 8usize);
+    let w_cpu = Tensor::from_vec(pseudo_random(n * k), (n, k), &Device::Cpu).expect("w");
+    let x_cpu = Tensor::from_vec(pseudo_random(m * k), (m, k), &Device::Cpu).expect("x");
+
+    // Q4 quantization-noise floor is wider; Q8 is near-lossless.
+    for (dtype, min_cos, label) in [
+        (GgmlDType::Q8_0, 0.999f32, "Q8_0"),
+        (GgmlDType::Q4_0, 0.99f32, "Q4_0"),
+    ] {
+        // CPU reference: quantize + matmul entirely on the CPU.
+        let mm_cpu = QMatMul::from_qtensor(QTensor::quantize(&w_cpu, dtype).expect("cpu quantize"))
+            .expect("cpu qmatmul");
+        let y_cpu = mm_cpu.forward(&x_cpu).expect("cpu forward");
+
+        // CUDA: quantize the SAME cpu source straight onto the device, matmul on the device.
+        let mm_cuda = QMatMul::from_qtensor(
+            QTensor::quantize_onto(&w_cpu, dtype, &device).expect("cuda quantize_onto"),
+        )
+        .expect("cuda qmatmul");
+        let x_cuda = x_cpu.to_device(&device).expect("x->cuda");
+        let y_cuda = mm_cuda
+            .forward(&x_cuda)
+            .expect("cuda forward")
+            .to_device(&Device::Cpu)
+            .expect("y->cpu");
+
+        let cos = cosine(&y_cpu, &y_cuda);
+        let finite = all_finite(&y_cuda);
+        eprintln!("[quant-smoke] {label}: cos(CUDA, CPU)={cos:.5} all_finite={finite}");
+
+        assert!(
+            finite,
+            "{label} CUDA QMatMul produced non-finite values — likely no compatible cubin for \
+             this arch (single-arch SASS build on a newer GPU). The root Cargo.toml [patch] onto \
+             the vendored multi-arch candle-kernels is probably not in effect (sc-13510)."
+        );
+        assert!(
+            cos > min_cos,
+            "{label} CUDA QMatMul does not match the CPU reference (cos={cos:.5} <= {min_cos}). \
+             On Blackwell sm_120 this means candle-kernels' libmoe.a has no native sm_120 cubin \
+             (the quant kernels silently no-op). The root Cargo.toml [patch] onto the vendored \
+             multi-arch candle-kernels is probably not in effect (sc-13510)."
+        );
+    }
+}

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -99,8 +99,12 @@ CMD ["sceneworks-rust-worker"]
 # toolchain the candle lane builds + validates against (server-candle-linux.yml + the
 # dev box). CUDA_COMPUTE_CAP=80 emits compute_80 PTX the driver JITs forward to sm_120
 # (RTX PRO 6000) — one binary covers Ampere→Blackwell, matching the Windows desktop
-# bundle (build-sidecar.mjs) and the Linux candle CI lane. The backend-candle feature
-# lives on the sceneworks-worker library crate, enabled through the thin binary
+# bundle (build-sidecar.mjs) and the Linux candle CI lane. NB: that forward-JIT story
+# holds for the DENSE (PTX) kernels only; the GGUF quant/moe kernels are a static SASS
+# libmoe.a whose multi-arch coverage (sm_80+sm_90+sm_120 + compute_120 PTX) comes from
+# the root Cargo.toml [patch] onto the inference repo's vendored candle-kernels
+# (sc-7544 / sc-13510 — guarded by candle_kernels_patch_guard). The backend-candle
+# feature lives on the sceneworks-worker library crate, enabled through the thin binary
 # (epic 5483 Phase 7 / sc-5503 — the Docker torch→candle cutover).
 FROM nvidia/cuda:12.9.1-devel-ubuntu22.04 AS candle-builder
 ENV DEBIAN_FRONTEND=noninteractive

--- a/scripts/bump-inference.mjs
+++ b/scripts/bump-inference.mjs
@@ -5,8 +5,11 @@
 // the two repos -- releases stay for durable/shareable snapshots (inference's cut_release.py).
 //
 // The pins live in crates/sceneworks-worker/Cargo.toml: sceneworks-gen-core + the runtime-macos /
-// runtime-cuda bundles, all on https://github.com/SceneWorks/inference. This rewrites each of those
-// `tag = "..."` / `rev = "..."` pins to `rev = "<sha>"` and regenerates the lockfile.
+// runtime-cuda bundles, all on https://github.com/SceneWorks/inference. The root Cargo.toml
+// additionally `[patch]`es candle-kernels to the multi-arch vendored copy inside the same
+// inference revision (sc-7544 / sc-13510) — that rev must move in lockstep or the patched kernels
+// skew against the pinned candle-core. This rewrites each of those `tag = "..."` / `rev = "..."`
+// pins (in BOTH manifests) to `rev = "<sha>"` and regenerates the lockfile.
 //
 // The direct `mlx-rs` pin (michaeltrefry/mlx-rs, a DIFFERENT url) is intentionally left alone -- but
 // it must resolve to the same fork the pinned inference uses or Cargo builds two mlx-rs and the
@@ -25,13 +28,18 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const MANIFEST = join(repoRoot, "crates/sceneworks-worker/Cargo.toml");
+// Root workspace manifest: holds the candle-kernels [patch] pin (same repo, same rev).
+const ROOT_MANIFEST = join(repoRoot, "Cargo.toml");
 const INFERENCE_GIT = "https://github.com/SceneWorks/inference";
 const INFERENCE_CRATES = ["sceneworks-gen-core", "runtime-macos", "runtime-cuda"];
+// Resolved through the root [patch], not a direct dependency — still pinned to the inference
+// repo, so its lock entry must be refreshed on every bump.
+const PATCHED_CRATES = ["candle-kernels"];
 const SHA_RE = /^[0-9a-f]{40}$/;
 
 // --- pure: rewrite the inference pins to rev=<sha> (self-tested; no fs/network) ---------------
 
-function repin(manifestText, sha) {
+function repin(manifestText, sha, manifestPath = MANIFEST) {
   let inferenceLines = 0;
   let rewrote = 0;
   const out = manifestText.split("\n").map((line) => {
@@ -45,7 +53,7 @@ function repin(manifestText, sha) {
     });
   });
   if (inferenceLines === 0) {
-    throw new Error(`no inference pins found (looked for ${INFERENCE_GIT} in ${MANIFEST})`);
+    throw new Error(`no inference pins found (looked for ${INFERENCE_GIT} in ${manifestPath})`);
   }
   if (rewrote !== inferenceLines) {
     throw new Error(`expected to rewrite ${inferenceLines} inference pin(s), rewrote ${rewrote}`);
@@ -63,7 +71,7 @@ function latestInferenceSha() {
 }
 
 function cargoUpdate() {
-  const spec = INFERENCE_CRATES.flatMap((crate) => ["-p", crate]);
+  const spec = [...INFERENCE_CRATES, ...PATCHED_CRATES].flatMap((crate) => ["-p", crate]);
   console.log(`$ cargo update ${spec.join(" ")}`);
   execFileSync("cargo", ["update", ...spec], { cwd: repoRoot, stdio: "inherit" });
 }
@@ -136,6 +144,11 @@ function selfTest() {
       SHA,
     ).match(new RegExp(`rev = "${SHA}"`, "g")) || []).length === 2,
   );
+  check(
+    "root-manifest candle-kernels [patch] pin bumps",
+    repin(`candle-kernels = { git = "${INFERENCE_GIT}", rev = "d68b8b45" }`, SHA) ===
+      `candle-kernels = { git = "${INFERENCE_GIT}", rev = "${SHA}" }`,
+  );
   let threw = false;
   try {
     repin(`foo = "bar"`, SHA);
@@ -162,19 +175,31 @@ function main() {
     process.exit(2);
   }
 
-  const current = readFileSync(MANIFEST, "utf8");
-  const bumped = repin(current, sha);
-  if (bumped === current) {
+  // Both manifests carry inference pins: the worker's direct deps and the root's
+  // candle-kernels [patch]. They must land on the same rev, so bump them as one unit.
+  const manifests = [MANIFEST, ROOT_MANIFEST].map((path) => {
+    const current = readFileSync(path, "utf8");
+    return { path, current, bumped: repin(current, sha, path) };
+  });
+  if (manifests.every((m) => m.bumped === m.current)) {
     console.log(`bump-inference: already pinned at ${sha}`);
     return;
   }
-  console.log(`bump-inference: pinning inference (${INFERENCE_CRATES.join(", ")}) -> ${sha}`);
+  console.log(
+    `bump-inference: pinning inference (${[...INFERENCE_CRATES, ...PATCHED_CRATES].join(", ")}) -> ${sha}`,
+  );
   if (dryRun) {
     console.log("bump-inference: dry run, no files written");
     return;
   }
-  writeFileSync(MANIFEST, bumped);
-  console.log("  wrote crates/sceneworks-worker/Cargo.toml");
+  for (const m of manifests) {
+    if (m.bumped === m.current) {
+      console.log(`  unchanged ${m.path} (already at ${sha})`);
+      continue;
+    }
+    writeFileSync(m.path, m.bumped);
+    console.log(`  wrote ${m.path}`);
+  }
   cargoUpdate();
   verifyNoSkew();
   console.log("bump-inference: done");


### PR DESCRIPTION
Fixes [sc-13510](https://app.shortcut.com/trefry/story/13510) — REGRESSION of sc-7544: every SceneWorks-workspace build (including desktop packaging) resolved candle-kernels from upstream candle, shipping an sm_80-only, no-PTX `libmoe.a` at the cap=80 baseline. On Blackwell (RTX 50-series / RTX PRO 6000) every packaged quantized model's QMatMul silently returns zeros (renders solid black).

### Root cause
A Cargo `[patch]` only takes effect in the **top-level** workspace. sc-7544's fix (vendored multi-arch candle-kernels + `[patch]`) lives in the inference repo's workspace and still guards *that* repo's builds — but SceneWorks consumes inference crates as git deps, **never had its own patch**, and packaging moved into this workspace at the candle-gen → inference cutover. Nothing on the SceneWorks side was watching.

### Fix
- Root `Cargo.toml`: `[patch."https://github.com/huggingface/candle"]` → the vendored copy inside the pinned inference rev (`d68b8b45`, same repo+rev as the worker's pins; same private-repo auth, zero new surface). Lock regenerated (`--locked` verified; note: cargo 1.97's re-resolve also re-unified a few crates' windows-sys dependency *edges* — package versions unchanged).
- `scripts/bump-inference.mjs`: rewrites the patch rev in lockstep with the worker pins and refreshes candle-kernels in the lock; self-test extended.

### Guards (AC 3 — fires automatically on a pin bump)
1. **`candle_kernels_patch_guard.rs`** (every CI lane, incl. Linux parity): asserts from `Cargo.lock` that candle-kernels resolves through the patch at the **same** inference commit as `sceneworks-gen-core`; 7 red-path unit tests (upstream source, rev skew, lookalike repo, `[[patch.unused]]`, …).
2. **`cuda_quant_smoke.rs`** (windows-candle GPU lane): weightless Q4_0/Q8_0 QMatMul CUDA-vs-CPU cosine — the sc-7544 canary, now on the SceneWorks side where the regression actually happened.
3. **`build-sidecar.mjs`**: packaging-time `cuobjdump` assertion on the actual `libmoe.a` (cap-baseline + sm_90 + sm_120 SASS, compute_120 PTX — listed by cuobjdump as `sm_120.ptx`). Validated **red** against the regressed artifact and green against the fixed one.

### GPU validation (RTX PRO 6000, sm_120, built at CUDA_COMPUTE_CAP=80 — the packaging baseline)
- `cuobjdump --list-elf`: **15/15 kernels × sm_80 + sm_90 + sm_120** cubins; `--list-ptx`: 15 × compute_120 PTX (AC 1)
- Smoke: **Q8_0 cos(CUDA,CPU)=1.00000, Q4_0=0.99999**, all finite (AC 2; was 0.00000 pre-fix)
- Full gate green locally on this branch merged with #1655: fmt, workspace clippy, 23/23 test suites, build, candle clippy `--all-targets`, GPU tests. (Workspace `rust:test` needs `HF_HOME` unset on the dev box — machine env leaks the real HF cache into the rust-api install-state tests; unrelated, reproduced on plain main.)

Also updated the stale "one binary covers Ampere→Blackwell" comments (build-sidecar.mjs, rust.Dockerfile) — true for the dense PTX kernels only; the quant fatbin coverage comes from this patch.

**Merge order**: [#1656](https://github.com/SceneWorks/SceneWorks/pull/1656) first (sc-13523 — pre-existing main breakage from the audio train; parity/web red on main without it; my equivalent #1655 closed as its duplicate). Companion doc fix: [inference#161](https://github.com/SceneWorks/inference/pull/161) (VENDORED.md lineage + the third delta + the consumer-patch caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
