### PR TITLE
fix(models): declare qwen edit lane q4 default + lint tiered image models [sc-12155]

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -622,6 +622,15 @@
         "families": ["qwen-image"],
         "types": ["style", "enhance", "character"]
       },
+      // Default generation tier q4 (sc-12155). Declared EXPLICITLY so the image-lane VRAM gate
+      // (`vram_gate::requested_tier_key`) and load quant (`resolve_quant`) don't fall through their
+      // `None => q8` arm — the omission that silently budgeted + quantized this edit lane one tier ABOVE
+      // its sibling `qwen_image` (which declares 4). Matches the `default: true` q4 download and the
+      // `candle` block below ("gates the DEFAULT (q4) tier"). Shared checkpoint with the Lightning
+      // variant, which carries the same declaration.
+      "mlx": {
+        "quantize": 4
+      },
       // candle/CUDA VRAM gate (epic 10765 sc-11019, the EDIT measure-sibling of the qwen txt2img sc-10969
       // + flux2 sc-10920) — MEASURED on an RTX PRO 6000 (Blackwell sm_120) at 1024²/8-step via the
       // candle-gen-qwen-image edit offload A/B harness (qwen_edit_probed_generate_for_offload_ab,
@@ -740,6 +749,12 @@
       "loraCompatibility": {
         "families": ["qwen-image"],
         "types": ["style", "enhance", "character"]
+      },
+      // Default generation tier q4 (sc-12155) — same rationale + shared checkpoint as `qwen_image_edit_2511`.
+      // Explicit so the image gate / `resolve_quant` never hit their `None => q8` fallthrough; matches the
+      // `default: true` q4 download and the `candle` block below ("gates the DEFAULT (q4) tier").
+      "mlx": {
+        "quantize": 4
       },
       // candle/CUDA VRAM gate (epic 10765) — MEASURED through the shared additive-LoRA path (sc-11666;
       // candle-gen #425 / sc-11091), replacing the sc-11019 base-copied estimate. q4/q8 apply the lightx2v

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -493,6 +493,75 @@ fn builtin_model_entry(id: &str) -> Value {
         .unwrap_or_else(|| panic!("{id} present in builtin.models.jsonc"))
 }
 
+/// sc-12155 lint: every `type: "image"` model that carries a candle VRAM budget
+/// (`candle.vramGbByTier`) MUST declare `mlx.quantize` explicitly.
+///
+/// The image-lane tier/quant resolvers — `vram_gate::requested_tier_key` (candle VRAM sizing) and
+/// `image_jobs::base::resolve_quant` (load quant) — read `advanced.mlxQuantize` → `manifest.mlx.quantize`
+/// and fall through to a `None => q8` arm when BOTH are absent. For a tiered model that arm should never
+/// be reachable: it silently budgets + quantizes at q8 regardless of the model's actual default tier.
+/// That silent fallthrough is exactly how `qwen_image_edit_2511` (+`_lightning`) shipped a q8 default
+/// while their sibling `qwen_image` — and every other tiered image model — declares q4 (sc-12155).
+///
+/// Scoped to `type: "image"` deliberately: the video lane (Wan/LTX/…) has its own q4-default resolvers
+/// (`video_jobs.rs`) that read `advanced.mlxQuantize` only and never consult `manifest.mlx.quantize`, so
+/// the `None => q8` arm is unreachable there — video models carry a `candle.vramGbByTier` block yet
+/// correctly declare no `mlx.quantize`, and folding them in would flag a non-bug.
+///
+/// Mutation check: delete `mlx.quantize` from any tiered image model → this test goes RED naming it.
+/// Pairs with the sc-10732 default-tier precedence guard (`26f40824`).
+#[test]
+fn every_image_model_with_a_candle_vram_block_declares_mlx_quantize() {
+    let mut offenders = Vec::new();
+    for model in builtin_models_manifest() {
+        if model.get("type").and_then(Value::as_str) != Some("image") {
+            continue;
+        }
+        // A tiered model = one the candle VRAM gate budgets against a per-tier row.
+        let has_vram_block = model
+            .get("candle")
+            .and_then(|candle| candle.get("vramGbByTier"))
+            .is_some();
+        if !has_vram_block {
+            continue;
+        }
+        let id = model.get("id").and_then(Value::as_str).unwrap_or("<no id>");
+        // Schema: `mlx.quantize` is an integer >= 1. A missing/zero/non-integer value re-opens the
+        // `None => q8` fallthrough that this lint exists to close.
+        let declared = model
+            .get("mlx")
+            .and_then(|mlx| mlx.get("quantize"))
+            .and_then(Value::as_u64)
+            .is_some_and(|bits| bits >= 1);
+        if !declared {
+            offenders.push(id.to_owned());
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these image models carry `candle.vramGbByTier` but do not declare a valid `mlx.quantize` \
+         (integer >= 1), so the image-lane `requested_tier_key` / `resolve_quant` `None => q8` \
+         fallthrough silently budgets + quantizes them at q8 instead of their intended default tier \
+         (sc-12155): {offenders:?}"
+    );
+
+    // Lock the sc-12155 decision itself: both Qwen edit ids default to q4 — matching the sibling
+    // `qwen_image`, their `default: true` q4 download, and their own `candle` "DEFAULT (q4) tier"
+    // comment — NOT the q8 the `None` fallthrough used to produce. Pinning this non-default value makes
+    // the guard discriminate on the value, not merely on presence.
+    for id in ["qwen_image_edit_2511", "qwen_image_edit_2511_lightning"] {
+        let entry = builtin_model_entry(id);
+        assert_eq!(
+            entry
+                .get("mlx")
+                .and_then(|mlx| mlx.get("quantize"))
+                .and_then(Value::as_u64),
+            Some(4),
+            "{id} must declare mlx.quantize: 4 (sc-12155 — q4 default, matching `qwen_image`)"
+        );
+    }
+}
+
 /// epic 10765 sc-10920: the FLUX.2 `candle` blocks drive the dynamic fit-gate end-to-end against the
 /// SHIPPED manifest bytes — resident-fits → sequential-offload → reject-before-OOM. The pure
 /// `vram_gate` unit tests cover the decision logic on synthetic fixtures; THIS guards the data half:


### PR DESCRIPTION
## Story
[sc-12155](https://app.shortcut.com/trefry/story/12155) — *qwen_image_edit_2511 (+lightning) omit mlx.quantize — silently default to q8 via the None fallback; declare intent + lint it* (bug, epic 10721).

## The bug
`qwen_image_edit_2511` and `qwen_image_edit_2511_lightning` shipped with **no `mlx` block**. The image-lane tier/quant resolvers — `vram_gate::requested_tier_key` (candle VRAM sizing) and `image_jobs::base::resolve_quant` (load quant) — read `advanced.mlxQuantize` → `manifest.mlx.quantize` → and fall through a **`None => "q8"`** arm when both are absent. So these two models silently defaulted to **q8**, one tier *above* their sibling `qwen_image` (which declares `quantize: 4`).

Blast radius (candle edit lane, `qwen_edit_candle.rs`, which calls `requested_tier_key` directly): the fit gate sized q8 (69.0 GB) instead of q4 (56.7 GB), **falsely rejecting q4 jobs that would run** in the 58.7–71.0 GB free-VRAM window. On macOS, `resolve_quant` (qwen.rs) also mislabeled the q4 `default: true` weights as Q8 (harmless — on-disk precision wins — but a latent mismatch).

## Decision: q4
Verified the "verify before changing" items. Declaring **q4** (not q8) because it converges with every signal:
- Sibling `qwen_image` declares `quantize: 4`.
- Both edit models ship **`q4` as the `default: true` download**.
- Their own `candle` block comment literally says *"gates the DEFAULT (q4) tier."*
- **Every** other `type: image` model carrying a `candle.vramGbByTier` block declares `mlx.quantize` — only these two omitted it.
- `requested_tier_key` and `resolve_quant` read the **same** manifest field, so gate-sizing and load-quant move in lockstep — declaring q4 cannot desync them.

Git history: the entries were added in `26b6ceb4` (sc-2160) with **no `mlx` block ever present** — never-added, not a deliberate removal.

**sc-12090 note:** already merged (#1548), but its on-disk-tier gate (`gate_tier_key`) only covers lanes that resolve a tier subdir; the qwen edit lane bypasses it and uses `requested_tier_key` directly, so the omission was **not** closed by side effect.

## Changes
- **`config/manifests/builtin.models.jsonc`** — add `"mlx": { "quantize": 4 }` to both edit entries, with rationale comments.
- **`crates/sceneworks-worker/src/tests/gpu_and_manifest.rs`** — new lint `every_image_model_with_a_candle_vram_block_declares_mlx_quantize`: asserts every `type: image` model with a `candle.vramGbByTier` block declares a valid `mlx.quantize` (integer ≥ 1), so the `None => q8` fallthrough is never silently reachable for a tiered image model; pins both edit ids to q4 (discriminating value, not just presence).

### Why the lint is image-scoped (deliberate, not scope-dodging)
Three **video** models (`wan_2_2`, `wan_2_2_t2v_14b`, `wan_2_2_i2v_14b`) also carry `candle.vramGbByTier` without `mlx.quantize`, but the video lane (`video_jobs.rs`) defaults **q4** ("q4-first") and reads only `advanced.mlxQuantize` — it never consults `manifest.mlx.quantize` (its sole `get("mlx")` reads `autoDistillLora`). So the `None => q8` arm is unreachable for video, and declaring on Wan would be inert + break the existing video convention.

## Testing
- New lint **passes**, and is **mutation-checked**: removing either declaration turns it RED naming the offending model.
- `cargo test -p sceneworks-worker --lib` (899 pass) · `-p sceneworks-rust-api -p sceneworks-core --lib` (327 pass) · 31 manifest-audit tests (wan/sd3.5/sana/bernini/kolors) unchanged.
- `cargo fmt --all --check` clean · `cargo clippy -p sceneworks-worker` clean.
- Reviewed by an independent adversarial subagent: **SHIP** (q8 alternative refuted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)