### PR TITLE
feat(styles): compose prompts as Subject-then-Style

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -648,7 +648,7 @@ pub(crate) struct ImageJobRequest {
     pub(crate) style_preset: String,
     // The Style-catalog id the caller picked (sc-13134): a group id or a sub-style id. A
     // headless/MCP client sends this + a raw prompt and the server folds the catalog style text
-    // into `prompt` (the `Style:`/`Description:` splice). The web app composes the prompt
+    // into `prompt` (the `Subject:`/`Style:` splice). The web app composes the prompt
     // client-side and sends `presetPromptResolvedClientSide` instead, so it omits this top-level
     // id (it records the picked id under `advanced.styleId` for replay) and is never re-folded.
     // Dedicated field over the dead `stylePreset`.

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -24,7 +24,7 @@ pub(crate) async fn create_image_job(
     let catalogs = JobCatalogSnapshot::default();
     apply_recipe_preset_to_image_payload(&state, &payload, &mut job_payload, &catalogs).await?;
     // Style-catalog fold (sc-13134): a headless/MCP client that sends a `styleId` + raw prompt gets
-    // the SAME `Style:`/`Description:` composition the web app does. Runs AFTER the preset fold so it
+    // the SAME `Subject:`/`Style:` composition the web app does. Runs AFTER the preset fold so it
     // wraps the preset-composed prompt exactly as the web's composeStyledPrompt is the LAST wrap; a
     // no-op for a web request (which sends the already-composed prompt + presetPromptResolvedClientSide
     // and no top-level styleId), so a web-composed prompt is never double-folded.

--- a/apps/rust-api/src/styles.rs
+++ b/apps/rust-api/src/styles.rs
@@ -78,7 +78,7 @@ pub(crate) fn style_text_for_id(catalog: &Value, id: &str) -> Option<String> {
 /// when the request carries a top-level `styleId` AND the client did NOT already compose the prompt
 /// (mirrors the `presetPromptResolvedClientSide` skip in `apply_recipe_preset_to_image_payload`),
 /// resolve the id to its catalog style text and apply it to the current `prompt`. A prose prompt is
-/// spliced into the `Style:`/`Description:` template with `compose_styled_prompt`; a structured
+/// spliced into the `Subject:`/`Style:` template with `compose_styled_prompt`; a structured
 /// JSON-caption prompt (Ideogram 4) has the style MERGED into `style_description.aesthetics` via
 /// `merge_style_into_caption` and re-serialized. Both are the Rust twins of the web path, so a
 /// headless/MCP client gets a byte-identical result to the studio.
@@ -125,7 +125,7 @@ pub(crate) async fn apply_style_to_image_payload(
 /// unit-tested without an `AppState`. A structured JSON-caption prompt (Ideogram 4, sc-13224) gets the
 /// style MERGED into `style_description.aesthetics` and re-serialized (the server twin of the web's
 /// `injectStyleIntoCaption` → `serializeCaption`); a prose prompt is spliced into the
-/// `Style:`/`Description:` template. Byte-identical to the web path in either branch.
+/// `Subject:`/`Style:` template. Byte-identical to the web path in either branch.
 fn apply_style_text_to_prompt(style_text: &str, prompt: &str) -> String {
     if let Ok(caption) = serde_json::from_str::<Value>(prompt) {
         if sceneworks_core::ideogram_caption::is_caption(&caption) {
@@ -179,11 +179,11 @@ mod tests {
     }
 
     #[test]
-    fn prose_prompt_gets_the_style_description_template() {
-        // A non-caption prompt keeps the sc-13134 prose fold, unchanged.
+    fn prose_prompt_gets_the_subject_style_template() {
+        // A non-caption prompt keeps the sc-13134 prose fold: Subject leads, Style trails.
         assert_eq!(
             apply_style_text_to_prompt("cinematic watercolor", "a fox in the snow"),
-            "Style: cinematic watercolor\nDescription: a fox in the snow"
+            "Subject: a fox in the snow\nStyle: cinematic watercolor"
         );
     }
 

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -4920,7 +4920,7 @@ fn write_style_test_manifests(config_dir: &std::path::Path) {
         {
           "schemaVersion": 1,
           "source": "documents/style.txt",
-          "promptTemplate": "Style: {style}\nDescription: {description}",
+          "promptTemplate": "Subject: {subject}\nStyle: {style}",
           "groups": [
             {
               "id": "test-anime",
@@ -4940,9 +4940,9 @@ fn write_style_test_manifests(config_dir: &std::path::Path) {
 #[tokio::test]
 async fn styled_image_job_folds_style_server_side_from_style_id() {
     // Headless/MCP parity (sc-13134): a client that sends a `styleId` + a RAW prompt gets the
-    // exact `Style:`/`Description:` composition the web composer produces — including the
+    // exact `Subject:`/`Style:` composition the web composer produces — including the
     // directive-collision splice (a user `Setting:` line stays a top-level sibling, the free text
-    // folds into Description). This is the whole point of the story: the same styled prompt whether
+    // folds into Subject). This is the whole point of the story: the same styled prompt whether
     // the fold happens on the web or on the server.
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -4958,8 +4958,9 @@ async fn styled_image_job_folds_style_server_side_from_style_id() {
     .await;
     let project_id = project["id"].as_str().expect("project id").to_owned();
 
-    // Sub-style id → its `prompt` ("gentle hand-painted"); the user's `Setting:` directive is kept
-    // as a sibling and "a fox" becomes the Description — byte-identical to composeStyledPrompt.
+    // Sub-style id → its `prompt` ("gentle hand-painted"); "a fox" becomes the leading Subject and
+    // the user's `Setting:` directive is kept as a trailing sibling — byte-identical to
+    // composeStyledPrompt.
     let (status, styled) = request(
         app.clone(),
         "POST",
@@ -4983,7 +4984,7 @@ async fn styled_image_job_folds_style_server_side_from_style_id() {
     );
     assert_eq!(
         styled["payload"]["prompt"],
-        "Style: gentle hand-painted\nSetting: snowy field\nDescription: a fox",
+        "Subject: a fox\nStyle: gentle hand-painted\nSetting: snowy field",
         "server-side fold must match the web composer output"
     );
 
@@ -5007,7 +5008,7 @@ async fn styled_image_job_folds_style_server_side_from_style_id() {
     assert_eq!(status, StatusCode::CREATED, "{group_styled:?}");
     assert_eq!(
         group_styled["payload"]["prompt"],
-        "Style: broad test anime look\nDescription: a fox"
+        "Subject: a fox\nStyle: broad test anime look"
     );
 
     // An unknown styleId is a clean 400, not a silent no-op.
@@ -5035,7 +5036,7 @@ async fn styled_image_job_skips_fold_when_prompt_resolved_client_side() {
     // The web app composes the styled prompt CLIENT-side and sends it verbatim plus
     // presetPromptResolvedClientSide (mirroring the preset skip). The server must take the prompt
     // as-is and NOT re-fold — even when a `styleId` rides along (the studio records it for replay).
-    // Otherwise a web-submitted "Style: …\nDescription: …" would be double-wrapped.
+    // Otherwise a web-submitted "Subject: …\nStyle: …" would be double-wrapped.
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     write_style_test_manifests(&temp_dir.path().join("config"));
@@ -5050,7 +5051,7 @@ async fn styled_image_job_skips_fold_when_prompt_resolved_client_side() {
     .await;
     let project_id = project["id"].as_str().expect("project id").to_owned();
 
-    let already_composed = "Style: gentle hand-painted\nDescription: a fox";
+    let already_composed = "Subject: a fox\nStyle: gentle hand-painted";
     let (status, verbatim) = request(
         app.clone(),
         "POST",

--- a/apps/web/scripts/generate-style-thumbnails.test.js
+++ b/apps/web/scripts/generate-style-thumbnails.test.js
@@ -115,8 +115,8 @@ describe("composeThumbnailPrompt", () => {
     const expected = composeStyledPrompt({ styleText: styleTextForId(id), userPrompt: REF });
     const actual = composeThumbnailPrompt(id, REF);
     expect(actual).toBe(expected);
-    expect(actual.startsWith("Style: ")).toBe(true);
-    expect(actual).toContain(`\nDescription: ${REF}`);
+    expect(actual.startsWith(`Subject: ${REF}`)).toBe(true);
+    expect(actual).toContain("\nStyle: ");
   });
 
   it("matches composeStyledPrompt for a GROUP id (resolves the group description)", () => {
@@ -125,8 +125,8 @@ describe("composeThumbnailPrompt", () => {
     const expected = composeStyledPrompt({ styleText: styleTextForId(id), userPrompt: REF });
     const actual = composeThumbnailPrompt(id, REF);
     expect(actual).toBe(expected);
-    expect(actual.startsWith("Style: ")).toBe(true);
-    expect(actual).toContain(`\nDescription: ${REF}`);
+    expect(actual.startsWith(`Subject: ${REF}`)).toBe(true);
+    expect(actual).toContain("\nStyle: ");
   });
 });
 

--- a/apps/web/src/App.imageStudioStylePreview.test.jsx
+++ b/apps/web/src/App.imageStudioStylePreview.test.jsx
@@ -129,8 +129,8 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
     await selectStyle(firstStyle.name);
 
     const shown = previewText();
-    expect(shown).toContain("Style: ");
-    expect(shown).toContain("\nDescription: a fox in the snow");
+    expect(shown).toContain("Subject: a fox in the snow");
+    expect(shown).toContain("\nStyle: ");
 
     const submittedPrompt = await submitAndReadPayloadPrompt();
     // The DoD: what the user SEES is exactly what is SENT.
@@ -191,7 +191,7 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
     await typePrompt("a wolf on a ridge at dusk");
     const second = previewText();
     expect(second).not.toBe(first);
-    expect(second).toContain("\nDescription: a wolf on a ridge at dusk");
+    expect(second).toContain("Subject: a wolf on a ridge at dusk");
 
     const submittedPrompt = await submitAndReadPayloadPrompt();
     expect(second).toBe(submittedPrompt);
@@ -205,7 +205,7 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
     const shown = previewText();
     // Catalog style leads, the user's own style words merge after ", " in the same Style block.
     expect(shown).toContain(", neon rimlight");
-    expect(shown).toContain("\nDescription: a fox in the snow");
+    expect(shown).toContain("Subject: a fox in the snow");
 
     const submittedPrompt = await submitAndReadPayloadPrompt();
     expect(shown).toBe(submittedPrompt);

--- a/apps/web/src/components/StyledPromptPreview.jsx
+++ b/apps/web/src/components/StyledPromptPreview.jsx
@@ -5,7 +5,7 @@ import { promptBudget } from "../styleComposer.js";
 // sc-13131 — Live composed-prompt preview for the selected Style Catalog entry.
 //
 // Shows the EXACT outgoing `prompt` string the run will send once a style is active — the
-// `Style:`/`Description:` composition, any preserved sibling directive lines, and (when the user
+// `Subject:`/`Style:` composition, any preserved sibling directive lines, and (when the user
 // typed their own `Style:` line) the MERGE — so the splice is never silent (R4). It updates live
 // as the user types, swaps the selected style, or changes presets because the caller recomputes
 // `composedPrompt` on every render from the SAME `buildJobRequest` the single Generate submit
@@ -16,7 +16,7 @@ import { promptBudget } from "../styleComposer.js";
 //
 // Visual idiom mirrors PresetStackPreview (generationStudio.jsx): the same framed
 // `preset-stack-preview` container + `preset-stack-prompt` monospace block, with `pre-wrap` so the
-// Style/Description line breaks stay legible (styles.css `.styled-prompt-preview`).
+// Subject/Style line breaks stay legible (styles.css `.styled-prompt-preview`).
 // sc-13133: a style wraps ~700–900 chars around the user's prompt, and the backend rejects a
 // composed prompt over the cap (see promptBudget / PROMPT_MAX_CHARS). Because a style is active
 // exactly when this preview renders, the composed length / remaining budget belongs here: a live

--- a/apps/web/src/components/StyledPromptPreview.test.jsx
+++ b/apps/web/src/components/StyledPromptPreview.test.jsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { StyledPromptPreview } from "./StyledPromptPreview.jsx";
 
 // sc-13131 — The preview component's ONE job: display the composed prompt string it is handed,
-// byte-for-byte (including the Style:/Description: newlines), and render nothing when inactive.
+// byte-for-byte (including the Subject:/Style: newlines), and render nothing when inactive.
 // The anti-drift guarantee lives one level up (ImageStudio feeds it the same buildJobRequest output
 // that is submitted); this file pins that the component itself never mangles or hides that string.
 describe("StyledPromptPreview", () => {
@@ -35,13 +35,13 @@ describe("StyledPromptPreview", () => {
   const node = () => container.querySelector('[data-testid="styled-prompt-preview"]');
 
   it("renders nothing when no style is active", () => {
-    render(<StyledPromptPreview active={false} composedPrompt={"Style: x\nDescription: y"} />);
+    render(<StyledPromptPreview active={false} composedPrompt={"Subject: y\nStyle: x"} />);
     expect(node()).toBeNull();
     expect(container.textContent).toBe("");
   });
 
-  it("shows the composed prompt byte-for-byte, preserving Style/Description line breaks", () => {
-    const composed = "Style: cinematic watercolor\nDescription: a fox in the snow";
+  it("shows the composed prompt byte-for-byte, preserving Subject/Style line breaks", () => {
+    const composed = "Subject: a fox in the snow\nStyle: cinematic watercolor";
     render(<StyledPromptPreview active composedPrompt={composed} />);
     const paragraph = node().querySelector(".preset-stack-prompt p");
     // textContent must equal the source string exactly — no trimming, no whitespace collapse,
@@ -50,7 +50,7 @@ describe("StyledPromptPreview", () => {
   });
 
   it("reflects a multi-directive merge composition verbatim", () => {
-    const composed = "Style: oil painting, moody\nLighting: soft\nDescription: a portrait";
+    const composed = "Subject: a portrait\nStyle: oil painting, moody\nLighting: soft";
     render(<StyledPromptPreview active composedPrompt={composed} />);
     expect(node().querySelector(".preset-stack-prompt p").textContent).toBe(composed);
   });
@@ -65,7 +65,7 @@ describe("StyledPromptPreview", () => {
   const budget = () => container.querySelector('[data-testid="styled-prompt-budget"]');
 
   it("shows the composed length / cap for an under-budget prompt, with no warning", () => {
-    const composed = "Style: cinematic\nDescription: a fox in the snow";
+    const composed = "Subject: a fox in the snow\nStyle: cinematic";
     render(<StyledPromptPreview active composedPrompt={composed} />);
     // Measured on the composed string the component was handed (Unicode scalar values).
     expect(budget().textContent).toContain(`${[...composed].length} / 4000`);
@@ -74,7 +74,7 @@ describe("StyledPromptPreview", () => {
   });
 
   it("flips to an over-budget warning (with alert role) when the composed prompt exceeds the cap", () => {
-    const composed = `Style: ${"x".repeat(4000)}\nDescription: a fox`;
+    const composed = `Subject: a fox\nStyle: ${"x".repeat(4000)}`;
     render(<StyledPromptPreview active composedPrompt={composed} />);
     const over = [...composed].length;
     expect(over).toBeGreaterThan(4000);

--- a/apps/web/src/data/parseStyleCatalog.js
+++ b/apps/web/src/data/parseStyleCatalog.js
@@ -10,7 +10,7 @@
 // colon (e.g. "Cyberpunk: Edgerunners Style") — the name regex tolerates one
 // extra short "…: Xxx Style" segment before the description colon.
 
-export const PROMPT_TEMPLATE = "Style: {style}\nDescription: {description}";
+export const PROMPT_TEMPLATE = "Subject: {subject}\nStyle: {style}";
 export const CATALOG_VERSION = 1;
 export const CATALOG_SOURCE = "documents/style.txt";
 

--- a/apps/web/src/data/styleCatalog.test.js
+++ b/apps/web/src/data/styleCatalog.test.js
@@ -60,7 +60,7 @@ describe("style catalog: structural invariants", () => {
 
   it("carries the two-field prompt template", () => {
     expect(styles.promptTemplate).toBe(PROMPT_TEMPLATE);
-    expect(styles.promptTemplate).toBe("Style: {style}\nDescription: {description}");
+    expect(styles.promptTemplate).toBe("Subject: {subject}\nStyle: {style}");
   });
 
   it("every group has a non-empty id, name, and description", () => {

--- a/apps/web/src/data/styles.json
+++ b/apps/web/src/data/styles.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "source": "documents/style.txt",
-  "promptTemplate": "Style: {style}\nDescription: {description}",
+  "promptTemplate": "Subject: {subject}\nStyle: {style}",
   "groups": [
     {
       "id": "anime-style",

--- a/apps/web/src/ideogramCaption.js
+++ b/apps/web/src/ideogramCaption.js
@@ -232,7 +232,7 @@ export function isCaption(value) {
 // ----- Style Catalog injection into a caption (sc-13224) --------------------
 //
 // The Style axis (epic 13129/sc-13130) folds a catalog style into a PROSE prompt via the
-// `Style:`/`Description:` composer. Structured JSON-caption models (Ideogram 4) don't take prose —
+// `Subject:`/`Style:` composer. Structured JSON-caption models (Ideogram 4) don't take prose —
 // their prompt is a caption. Instead of skipping the Style axis for them, we merge the selected
 // catalog style text into `style_description.aesthetics`: the ONE field present in BOTH the photo
 // and non-photo style variants, so injecting it never touches the `photo`/`art_style` discriminator

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -242,7 +242,7 @@ export function buildImageJobAdvanced(state) {
       : {}),
     // Style Catalog recipe round-trip (sc-13132): when a catalog style is applied client-side, the
     // outgoing top-level `prompt` is the COMPOSED string (styleComposer wraps it into a `Style:` /
-    // `Description:` template — see imageJobRequest.js). Recording only the composed prompt would lose
+    // `Subject:` template — see imageJobRequest.js). Recording only the composed prompt would lose
     // the two facts needed to reproduce the studio state on replay: WHICH style the user picked, and
     // the RAW pre-style prompt. Persist both here (they ride `advanced`, which the worker clones
     // verbatim into rawAdapterSettings — no backend change), so rehydrate can re-select the Style

--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -106,7 +106,7 @@ export function buildImageJobRequest(state) {
   // no-op when no style is selected (empty styleText → promptToSend unchanged). There are two
   // application paths depending on the model:
   //  - PROSE models (sc-13130): composeStyledPrompt wraps the already-preset-composed prompt as the
-  //    `Description:` block under the selected style's `Style:` block.
+  //    leading `Subject:` block above the selected style's `Style:` block.
   //  - STRUCTURED JSON-caption models (Ideogram 4, sc-13224): `promptToSend` is a serialized caption,
   //    not prose. Instead of skipping the Style axis, parse the caption and MERGE the style text into
   //    `style_description.aesthetics` (the field common to both photo/non-photo variants, so the

--- a/apps/web/src/imageJobRequest.style.test.js
+++ b/apps/web/src/imageJobRequest.style.test.js
@@ -114,18 +114,18 @@ describe("buildImageJobRequest — Style Catalog fold (sc-13130)", () => {
     const state = baseState({ styleText: STYLE_TEXT });
     const req = buildImageJobRequest(state);
     expect(req.prompt).toBe(composeStyledPrompt({ styleText: STYLE_TEXT, userPrompt: "a fox in the snow" }));
-    // Sanity: the composed prompt actually carries the Style:/Description: template.
-    expect(req.prompt).toBe(`Style: ${STYLE_TEXT}\nDescription: a fox in the snow`);
+    // Sanity: the composed prompt actually carries the Subject:/Style: template.
+    expect(req.prompt).toBe(`Subject: a fox in the snow\nStyle: ${STYLE_TEXT}`);
     expect(req.presetPromptResolvedClientSide).toBe(true);
   });
 
   it("style composes on top of an already-preset-composed prompt (composer runs LAST)", () => {
     // The caller (ImageStudio fold) passes the preset-composed prompt as promptToSend; the builder
-    // wraps THAT as the Description block — proving the ordering the story requires.
+    // wraps THAT as the Subject block — proving the ordering the story requires.
     const presetComposed = "cinematic, moody. a fox in the snow";
     const req = buildImageJobRequest(baseState({ styleText: STYLE_TEXT, promptToSend: presetComposed }));
     expect(req.prompt).toBe(composeStyledPrompt({ styleText: STYLE_TEXT, userPrompt: presetComposed }));
-    expect(req.prompt).toBe(`Style: ${STYLE_TEXT}\nDescription: ${presetComposed}`);
+    expect(req.prompt).toBe(`Subject: ${presetComposed}\nStyle: ${STYLE_TEXT}`);
   });
 
   it("preserves an existing presetPromptResolvedClientSide=true even with no style", () => {
@@ -146,14 +146,15 @@ describe("buildImageJobRequest — Style Catalog fold (sc-13130)", () => {
     );
 
     // The outgoing prompt is the caption with the style merged into style_description.aesthetics —
-    // exactly what injectStyleIntoCaption + serializeCaption produce (NOT the prose Style:/Description:
+    // exactly what injectStyleIntoCaption + serializeCaption produce (NOT the prose Subject:/Style:
     // wrap, which would be wrong for a JSON-caption model).
     const expected = serializeCaption(
       injectStyleIntoCaption(parseCaption(caption).caption, STYLE_TEXT),
     );
     expect(req.prompt).toBe(expected);
     expect(req.prompt).not.toBe(caption); // the caption was actually transformed
-    expect(req.prompt.startsWith("Style:")).toBe(false); // no prose composer
+    expect(req.prompt.startsWith("Subject:")).toBe(false); // no prose composer
+    expect(req.prompt).not.toContain("\nStyle: ");
     expect(req.prompt).toContain(STYLE_TEXT); // style folded into aesthetics
 
     // An injection actually happened, so the client is authoritative and records the picker id.
@@ -256,6 +257,6 @@ describe("buildImageJobRequest — Style Catalog recipe round-trip (sc-13132)", 
       baseState({ styleText: STYLE_TEXT, styleId: SUBSTYLE_ID, promptToSend: composed }),
     ).prompt;
     expect(doubleWrapped).not.toBe(composed);
-    expect(doubleWrapped.startsWith(`Style: ${STYLE_TEXT}, ${STYLE_TEXT}`)).toBe(true);
+    expect(doubleWrapped).toContain(`Style: ${STYLE_TEXT}, ${STYLE_TEXT}`);
   });
 });

--- a/apps/web/src/imageJobRequest.test.js
+++ b/apps/web/src/imageJobRequest.test.js
@@ -221,7 +221,7 @@ describe("buildImageJobRequest — Style axis on a structured caption model", ()
         styleText: "cinematic watercolor",
       }),
     );
-    expect(request.prompt).toBe("Style: cinematic watercolor\nDescription: a fox in the snow");
+    expect(request.prompt).toBe("Subject: a fox in the snow\nStyle: cinematic watercolor");
     expect(request.presetPromptResolvedClientSide).toBe(true);
   });
 });

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -42,7 +42,7 @@ export function imageGenerateValidation({
   editSourceMissing = false,
   editLoraMissing = false,
   // sc-13133 / sc-13224: the COMPOSED outgoing prompt and whether a Style Catalog entry is active.
-  // `composedPrompt` is the exact string that will be sent — the Style:/Description: composition for a
+  // `composedPrompt` is the exact string that will be sent — the Subject:/Style: composition for a
   // prose model, or the style-injected re-serialized caption for a structured model — so the cap is
   // measured on IT, not the raw prompt field: a ~700–900 char style wrapped around a long-but-under-cap
   // prompt, or merged into a caption, can push past 4000.

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -113,7 +113,7 @@ describe("imageGenerateValidation", () => {
   // not the raw prompt field, and only when a style is active — styleless behavior is unchanged.
   describe("composed-prompt budget (sc-13133)", () => {
     // A raw prompt that is itself well UNDER the cap, but a style long enough that the composed
-    // Style:/Description: string runs OVER it. The whole point of the guard.
+    // Subject:/Style: string runs OVER it. The whole point of the guard.
     const rawPrompt = "a fox in the snow"; // 17 chars — nowhere near the cap on its own
     const longStyle = "x".repeat(PROMPT_MAX_CHARS); // composed will exceed the cap by the wrapper + prompt
     const overComposed = composeStyledPrompt({ styleText: longStyle, userPrompt: rawPrompt });

--- a/apps/web/src/imageStylePreview.parity.test.js
+++ b/apps/web/src/imageStylePreview.parity.test.js
@@ -71,13 +71,13 @@ describe("Style preview ↔ payload prompt parity (sc-13131)", () => {
     return buildImageJobRequest(baseState({ promptToSend, styleText })).prompt;
   }
 
-  it("plain prompt: payload prompt equals the composer's Style/Description block", () => {
+  it("plain prompt: payload prompt equals the composer's Subject/Style block", () => {
     const prompt = "a fox in the snow";
     const payload = payloadPromptFor({ prompt });
     // The payload prompt IS what composeStyledPrompt produces for the same inputs — this is the
     // string the preview renders. If the builder ever stopped using composeStyledPrompt, this breaks.
     expect(payload).toBe(composeStyledPrompt({ styleText, userPrompt: prompt }));
-    expect(payload).toBe(`Style: ${styleText}\nDescription: ${prompt}`);
+    expect(payload).toBe(`Subject: ${prompt}\nStyle: ${styleText}`);
   });
 
   it("MERGE case: the user's own Style: line merges into the catalog style, visibly", () => {
@@ -85,27 +85,27 @@ describe("Style preview ↔ payload prompt parity (sc-13131)", () => {
     const payload = payloadPromptFor({ prompt });
     expect(payload).toBe(composeStyledPrompt({ styleText, userPrompt: prompt }));
     // The catalog style leads; the user's own style words follow after ", " in the SAME Style block.
-    expect(payload).toBe(`Style: ${styleText}, neon rimlight\nDescription: a fox in the snow`);
+    expect(payload).toBe(`Subject: a fox in the snow\nStyle: ${styleText}, neon rimlight`);
     expect(payload).toContain(", neon rimlight");
   });
 
-  it("sibling directive stays a top-level sibling, not demoted under Description", () => {
+  it("sibling directive stays a top-level sibling, not demoted under Subject", () => {
     const prompt = "Lighting: soft window light\na fox in the snow";
     const payload = payloadPromptFor({ prompt });
     expect(payload).toBe(composeStyledPrompt({ styleText, userPrompt: prompt }));
-    expect(payload).toBe(`Style: ${styleText}\nLighting: soft window light\nDescription: a fox in the snow`);
+    expect(payload).toBe(`Subject: a fox in the snow\nStyle: ${styleText}\nLighting: soft window light`);
   });
 
-  it("active preset: preset fragments fold into the Description FIRST, style wraps LAST", () => {
+  it("active preset: preset fragments fold into the Subject FIRST, style wraps LAST", () => {
     const stack = [{ id: "cine", name: "Cinematic", prompt: { prefix: "cinematic", suffix: "film grain" } }];
     const prompt = "a fox in the snow";
     const presetFolded = composePreset({ generalStack: stack, userText: prompt }).prompt;
     const payload = payloadPromptFor({ prompt, stack });
-    // The preset-folded prompt is what lands inside Description; the style still wraps it last.
+    // The preset-folded prompt is what lands inside Subject; the style still wraps it last.
     expect(payload).toBe(composeStyledPrompt({ styleText, userPrompt: presetFolded }));
-    expect(payload).toBe(`Style: ${styleText}\nDescription: cinematic, a fox in the snow, film grain`);
+    expect(payload).toBe(`Subject: cinematic, a fox in the snow, film grain\nStyle: ${styleText}`);
     // Discriminates a wrong composition order (style folded before the preset, or preset lost).
-    expect(payload).toContain("Description: cinematic, a fox in the snow, film grain");
+    expect(payload).toContain("Subject: cinematic, a fox in the snow, film grain");
   });
 
   it("no style selected: payload prompt is the plain prompt, unwrapped", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1581,7 +1581,7 @@ export function ImageStudio() {
     } else if (hasRawStylePrompt) {
       // Styled recipe (sc-13132): seed the box with the RAW pre-style prompt, NOT the composed
       // `recipe.prompt`. With the picker re-selected above, submit recomposes the identical
-      // `Style:`/`Description:` prompt — recording the raw prompt is what prevents a double-wrap
+      // `Subject:`/`Style:` prompt — recording the raw prompt is what prevents a double-wrap
       // (composing over the already-composed prompt would nest a second `Style:` block).
       setPrompt(rawSettings.stylePrompt);
     } else {
@@ -2042,7 +2042,7 @@ export function ImageStudio() {
       // sc-13130: the selected Style Catalog entry's prompt text (or null for None). The pure
       // builder applies composeStyledPrompt as the LAST wrap — after the preset fold above has
       // produced `promptToSend` — so the style's `Style:` block wraps the already-preset-composed
-      // user prompt as `Description:`. Null → pass-through (prompt sent unchanged). Structured
+      // user prompt as `Subject:`. Null → pass-through (prompt sent unchanged). Structured
       // caption models ignore it (the builder skips composition when sendStructured is true).
       styleText: styleTextForId(styleId),
       // sc-13132: the opaque style id travels with the recipe so replay can re-select the picker.
@@ -2289,10 +2289,10 @@ export function ImageStudio() {
   // the composition here — we run the SAME buildJobRequest the single Generate submit calls (with the
   // live prompt as promptToSend) and read its `.prompt`, so the previewed/measured string is
   // byte-for-byte the prompt that will be sent (preset stack folds into the prompt FIRST, the style's
-  // Style:/Description: wrap is applied LAST — see imageJobRequest.js). It recomputes every render, so
+  // Subject:/Style: wrap is applied LAST — see imageJobRequest.js). It recomputes every render, so
   // it tracks the prompt text, the selected style, and the active preset stack live. Only active for
   // free-text models with a style actually selected: structured-caption models (Ideogram) merge the
-  // style into the caption's `aesthetics` instead (sc-13224), so there's no Style:/Description: prose
+  // style into the caption's `aesthetics` instead (sc-13224), so there's no Subject:/Style: prose
   // to preview, and a null/empty styleText is a pass-through with nothing extra to preview and no
   // style-composition budget to guard.
   const styledPreviewPrompt = stylePreviewActive ? buildJobRequest({ promptToSend: prompt }).prompt : null;
@@ -2303,7 +2303,7 @@ export function ImageStudio() {
       captionHasContent,
       prompt,
       // sc-13133 / sc-13224: measure the COMPOSED outgoing prompt against the cap, but only when a
-      // style is active (styleless behavior unchanged). For prose that is the Style:/Description:
+      // style is active (styleless behavior unchanged). For prose that is the Subject:/Style:
       // composition; for a structured model it is the style-injected, re-serialized caption. Either
       // string is exactly what the run submits, so the cap is measured on IT.
       styleActive: stylePreviewActive || structuredStyleActive,
@@ -3154,7 +3154,7 @@ export function ImageStudio() {
             ) : null}
           </div>
 
-          {/* sc-13131: the EXACT composed prompt (Style:/Description:, preserved sibling directives,
+          {/* sc-13131: the EXACT composed prompt (Subject:/Style:, preserved sibling directives,
               and the own-`Style:` MERGE) the run will send once a style is active — reuses
               buildJobRequest so it can never drift from the payload. Sits under the Style axis row.
               Hidden when no style applies. */}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -722,7 +722,7 @@ export function VideoStudio() {
 
     // Style Catalog round-trip (sc-13136): re-select the picker to the recorded style id ONLY when
     // the raw pre-style prompt was also recorded, and seed the box with THAT raw prompt (not the
-    // composed recipe.prompt) so the next submit recomposes the identical Style:/Description: prompt
+    // composed recipe.prompt) so the next submit recomposes the identical Subject:/Style: prompt
     // with no double-wrap. A styleless recipe clears any stale selection and uses recipe.prompt.
     const restoredStyleId = rawSettings.styleId ?? null;
     const hasRawStylePrompt = restoredStyleId != null && typeof rawSettings.stylePrompt === "string";
@@ -1061,7 +1061,7 @@ export function VideoStudio() {
 
   // Style Catalog axis (sc-13136): mirror the Image Studio's Style picker into the Video Studio.
   // composeStyledPrompt wraps the outgoing prompt LAST — AFTER the general-preset stack fold above —
-  // so the style's Style:/Description: block sits around the already-preset-composed prompt. Video
+  // so the style's Subject:/Style: block sits around the already-preset-composed prompt. Video
   // has no structured-caption or batch modes (the two the image lane gates the composer off for), so
   // the only exclusion here is a promptless (image-conditioned) model, which sends no text prompt to
   // wrap. `stylePromptBase` is the SAME base the styleless submit sends, so the live preview and the
@@ -1613,7 +1613,7 @@ export function VideoStudio() {
             </div>
             {/* Style axis (sc-13135): the Style Catalog picker leads this row (hidden for promptless
                 image-conditioned models), followed by the model's Style presets — mirrors the Image
-                Studio. The catalog wraps the outgoing prompt (Style:/Description:); "None" resets. */}
+                Studio. The catalog wraps the outgoing prompt (Subject:/Style:); "None" resets. */}
             <div className="settings-bar-styles settings-bar-style-axis">
               {promptless ? null : (
                 <div className="style-axis-field style-axis-catalog">

--- a/apps/web/src/screens/VideoStudio.style.test.jsx
+++ b/apps/web/src/screens/VideoStudio.style.test.jsx
@@ -18,7 +18,7 @@ import { STYLE_GROUPS, styleTextForId } from "../data/styleCatalog.js";
 // sc-13136 — the Style axis (proven in the Image Studio) mirrored into the Video Studio. These
 // tests drive the REAL StylePicker in the rendered screen and assert the outgoing video job the
 // client submits, so they cover the DoD end-to-end: a picked style composes the video `prompt` as
-// `Style:/Description:`, sets the client-authoritative flag, records the recipe round-trip fields,
+// `Subject:/Style:`, sets the client-authoritative flag, records the recipe round-trip fields,
 // and clears back to an untouched prompt (identity). Video has no structured-caption/batch modes,
 // so the only exclusion is a promptless model (covered elsewhere).
 
@@ -141,7 +141,7 @@ describe("VideoStudio — Style Catalog integration (sc-13136)", () => {
     expect(payload.advanced.stylePrompt).toBeUndefined();
   });
 
-  it("style selected → prompt composes as Style:/Description: and sets the client flag", async () => {
+  it("style selected → prompt composes as Subject:/Style: and sets the client flag", async () => {
     const context = baseContext();
     await render(context);
     await selectStyle(container, GROUP_NAME, SUBSTYLE.name);
@@ -151,7 +151,7 @@ describe("VideoStudio — Style Catalog integration (sc-13136)", () => {
     const payload = context.createVideoJob.mock.calls[0][0];
     const styleText = styleTextForId(SUBSTYLE.id);
     expect(payload.prompt).toBe(composeStyledPrompt({ styleText, userPrompt: DEFAULT_PROMPT }));
-    expect(payload.prompt).toBe(`Style: ${styleText}\nDescription: ${DEFAULT_PROMPT}`);
+    expect(payload.prompt).toBe(`Subject: ${DEFAULT_PROMPT}\nStyle: ${styleText}`);
     // Client-authoritative: the server must not re-fold the composed prompt.
     expect(payload.presetPromptResolvedClientSide).toBe(true);
     // Recipe round-trip fields ride advanced → rawAdapterSettings.
@@ -198,7 +198,7 @@ describe("VideoStudio — Style Catalog integration (sc-13136)", () => {
 // imageJobRequest.style.test.js replay cases). A recorded video recipe carries the picked style id
 // and the RAW pre-style prompt on `rawAdapterSettings.{styleId, stylePrompt}`. On replay the
 // VideoStudio effect (VideoStudio.jsx ~L710-713) re-selects the picker to that id and seeds the box
-// with the RAW prompt — so the very next submit recomposes the byte-identical Style:/Description:
+// with the RAW prompt — so the very next submit recomposes the byte-identical Subject:/Style:
 // prompt with EXACTLY ONE Style: block (no double-wrap). These tests drive a real replay through
 // context.studioLaunch and assert the outgoing job, for a sub-style id AND a group id, plus the
 // hardening case where the id is present but the raw prompt was not recorded.

--- a/apps/web/src/styleComposer.js
+++ b/apps/web/src/styleComposer.js
@@ -1,26 +1,30 @@
-// sc-13129 — Prompt composer: Style/Description template + directive-collision splice.
+// sc-13129 — Prompt composer: Subject/Style template + directive-collision splice.
 //
 // Pure, side-effect-free composition of the outgoing `prompt` from a catalog-selected style
 // text and the user's own prompt. This is the LAST wrap applied to a prompt: it runs AFTER
 // preset prefix/suffix folding (see composePreset in presetUtils.js). By the time this sees
 // `userPrompt`, any active presets have already been folded into it — so the folded preset
-// text lives inside what becomes the `Description:` block. This module never applies presets
-// itself; it only wraps an already-preset-folded prompt in the Style/Description template.
+// text lives inside what becomes the `Subject:` block. This module never applies presets
+// itself; it only wraps an already-preset-folded prompt in the Subject/Style template.
 //
 // Rules (R3/R5/R6/R7):
 //  - No style selected → return userPrompt unchanged.
-//  - Style selected, no directives → `Style: {styleText}\nDescription: {userPrompt}`.
-//  - Directives detected → emit our `Style:` block first, keep the user's directive lines as
-//    top-level siblings (never demoted under Description), and wrap only the free-text prose
-//    remainder as `Description:`.
+//  - Style selected, no directives → `Subject: {userPrompt}\nStyle: {styleText}`. The user's
+//    subject leads; the catalog style follows it as the trailing modifier.
+//  - Directives detected → wrap the free-text prose remainder as the leading `Subject:` block,
+//    then our `Style:` block, then the user's other directive lines as top-level siblings
+//    (never demoted under Subject).
 //  - User already has their own `Style:` line → MERGE: catalog style first, then the user's
 //    own style content appended after `, ` in the same block (their words get the refinement
 //    position). The `Style:` label is never duplicated.
+//  - User already has their own `Subject:` line → its content folds into the prose that becomes
+//    our `Subject:` block, in line order. The `Subject:` label is never duplicated either.
 
 // The recognized directive set that seeds the parser. A line only counts as a directive when
 // its line-anchored key is one of these. Easily extensible: add a Capitalized key here.
 export const STYLE_DIRECTIVE_KEYS = [
   "Style",
+  "Subject",
   "Description",
   "Setting",
   "Environment",
@@ -33,7 +37,7 @@ export const STYLE_DIRECTIVE_KEYS = [
 ];
 
 const STYLE_KEY = "Style";
-const DESCRIPTION_KEY = "Description";
+const SUBJECT_KEY = "Subject";
 
 // Longest recognized key we will treat as a directive (~20 chars, 1–3 short words). Guards the
 // line-anchored detector against long "Sentence-case sentence: ..." prose that happens to start
@@ -57,7 +61,7 @@ export function parseDirectiveLines(text) {
   // Normalize newlines before classifying so CRLF (\r\n) and lone-CR (\r) line breaks split the
   // same as LF. Splitting on "\n" alone would keep a trailing "\r" on every non-final CRLF line,
   // which fails the anchored DIRECTIVE_LINE_RE, misclassifies the line as prose, and leaks a
-  // literal "\r" into the composed Description.
+  // literal "\r" into the composed Subject.
   return source.split(/\r\n?|\n/).map((raw) => {
     const match = DIRECTIVE_LINE_RE.exec(raw);
     if (match) {
@@ -84,8 +88,9 @@ export function composeStyledPrompt({ styleText, userPrompt } = {}) {
   const prompt = String(userPrompt ?? "");
   const parsed = parseDirectiveLines(prompt);
 
-  // The user's own Style content (may be several lines) merges into our Style block; every
-  // other directive line is preserved verbatim as a top-level sibling.
+  // The user's own Style content (may be several lines) merges into our Style block; their own
+  // Subject content folds into the prose that becomes our Subject block (in line order, so the
+  // label is never doubled); every other directive line is preserved verbatim as a sibling.
   const userStyleParts = [];
   const siblingDirectives = [];
   const proseLines = [];
@@ -95,6 +100,10 @@ export function composeStyledPrompt({ styleText, userPrompt } = {}) {
         if (line.content.trim()) {
           userStyleParts.push(line.content.trim());
         }
+      } else if (line.key === SUBJECT_KEY) {
+        if (line.content.trim()) {
+          proseLines.push(line.content);
+        }
       } else {
         siblingDirectives.push(line.raw);
       }
@@ -103,16 +112,19 @@ export function composeStyledPrompt({ styleText, userPrompt } = {}) {
     }
   }
 
+  // Subject leads, Style follows, the user's other directives trail as siblings.
+  const blocks = [];
+
+  const subject = proseLines.join("\n").trim();
+  if (subject) {
+    blocks.push(`${SUBJECT_KEY}: ${subject}`);
+  }
+
   const styleContent = [style, ...userStyleParts].join(", ");
-  const blocks = [`${STYLE_KEY}: ${styleContent}`];
+  blocks.push(`${STYLE_KEY}: ${styleContent}`);
 
   for (const sibling of siblingDirectives) {
     blocks.push(sibling);
-  }
-
-  const description = proseLines.join("\n").trim();
-  if (description) {
-    blocks.push(`${DESCRIPTION_KEY}: ${description}`);
   }
 
   return blocks.join("\n");

--- a/apps/web/src/styleComposer.test.js
+++ b/apps/web/src/styleComposer.test.js
@@ -13,9 +13,10 @@ import {
 // and JSON.parsed so both languages read the exact same bytes.
 import composerFixturesRaw from "../../../documents/style-composer.fixtures.json?raw";
 
-// sc-13129: the style composer wraps an already-preset-folded userPrompt in a Style/Description
-// template, splicing around any directive lines the user typed. These pin the exact composed
-// string the studio sends. Table-driven: {name, styleText, userPrompt, want}.
+// sc-13129: the style composer wraps an already-preset-folded userPrompt in a Subject/Style
+// template — the user's prose leads, the catalog style trails it — splicing around any directive
+// lines the user typed. These pin the exact composed string the studio sends. Table-driven:
+// {name, styleText, userPrompt, want}.
 describe("composeStyledPrompt", () => {
   const cases = [
     {
@@ -37,92 +38,123 @@ describe("composeStyledPrompt", () => {
       want: "a fox in the snow",
     },
     {
-      name: "clean prompt → basic Style/Description",
+      // The template order itself: Subject block first, Style block second. Fails if the two
+      // blocks are ever emitted Style-first again.
+      name: "clean prompt → Subject leads, Style trails",
       styleText: "cinematic watercolor",
       userPrompt: "a fox in the snow",
-      want: "Style: cinematic watercolor\nDescription: a fox in the snow",
+      want: "Subject: a fox in the snow\nStyle: cinematic watercolor",
     },
     {
       name: "mid-sentence colon is NOT a directive",
       styleText: "oil painting",
       userPrompt: "a portrait: dramatic lighting on her face",
-      want: "Style: oil painting\nDescription: a portrait: dramatic lighting on her face",
+      want: "Subject: a portrait: dramatic lighting on her face\nStyle: oil painting",
     },
     {
       name: "lowercase line-start colon is NOT a directive",
       styleText: "oil painting",
       userPrompt: "style: not really a directive",
-      want: "Style: oil painting\nDescription: style: not really a directive",
+      want: "Subject: style: not really a directive\nStyle: oil painting",
     },
     {
-      name: "unrecognized capitalized key is NOT a directive (folds into Description)",
+      name: "unrecognized capitalized key is NOT a directive (folds into Subject)",
       styleText: "oil painting",
       userPrompt: "Note: this is a plain sentence",
-      want: "Style: oil painting\nDescription: Note: this is a plain sentence",
+      want: "Subject: Note: this is a plain sentence\nStyle: oil painting",
     },
     {
       // Discriminates the LINE-ANCHOR (^) rule for a RECOGNIZED key: "Lighting" appears
-      // mid-line, so it must stay prose and fold into Description, never become a sibling
+      // mid-line, so it must stay prose and fold into Subject, never become a sibling
       // directive. Fails if the `^` anchor is dropped from DIRECTIVE_LINE_RE.
       name: "recognized key mid-line is NOT a directive (stays prose)",
       styleText: "oil painting",
       userPrompt: "a photo with dramatic Lighting: soft",
-      want: "Style: oil painting\nDescription: a photo with dramatic Lighting: soft",
+      want: "Subject: a photo with dramatic Lighting: soft\nStyle: oil painting",
     },
     {
       // Same anchor rule with "Setting" preceded by a word on the same line.
       name: "recognized key after leading word is NOT a directive (stays prose)",
       styleText: "oil painting",
       userPrompt: "The Setting: was perfect",
-      want: "Style: oil painting\nDescription: The Setting: was perfect",
+      want: "Subject: The Setting: was perfect\nStyle: oil painting",
     },
     {
       // CRLF (\r\n) line breaks must classify recognized keys as directives (issue 1). A
       // trailing "\r" on the non-final lines would break the anchored regex and leak into
-      // Description. Fails if the newline normalization in parseDirectiveLines is reverted.
+      // Subject. Fails if the newline normalization in parseDirectiveLines is reverted.
       name: "CRLF directive lines classify correctly, no stray carriage return",
       styleText: "noir",
       userPrompt: "Setting: alley\r\nAngle: low\r\nsomething",
-      want: "Style: noir\nSetting: alley\nAngle: low\nDescription: something",
+      want: "Subject: something\nStyle: noir\nSetting: alley\nAngle: low",
     },
     {
       name: "CRLF prose-then-directive splices cleanly",
       styleText: "noir",
       userPrompt: "a detective\r\nSetting: a foggy alley",
-      want: "Style: noir\nSetting: a foggy alley\nDescription: a detective",
+      want: "Subject: a detective\nStyle: noir\nSetting: a foggy alley",
     },
     {
-      name: "foreign directive preserved as sibling, remainder → Description",
+      name: "foreign directive preserved as sibling, remainder → Subject",
       styleText: "noir",
       userPrompt: "a detective in the rain\nSetting: a foggy alley",
-      want: "Style: noir\nSetting: a foggy alley\nDescription: a detective in the rain",
+      want: "Subject: a detective in the rain\nStyle: noir\nSetting: a foggy alley",
     },
     {
       name: "multiple foreign directives preserved as siblings in order",
       styleText: "noir",
       userPrompt: "a detective\nSetting: a foggy alley\nAngle: low angle\nLighting: single streetlamp",
-      want: "Style: noir\nSetting: a foggy alley\nAngle: low angle\nLighting: single streetlamp\nDescription: a detective",
+      want: "Subject: a detective\nStyle: noir\nSetting: a foggy alley\nAngle: low angle\nLighting: single streetlamp",
     },
     {
       name: "own Style line merges — catalog first, user words appended after comma",
       styleText: "oil painting",
       userPrompt: "Style: loose brushwork\na castle on a hill",
-      want: "Style: oil painting, loose brushwork\nDescription: a castle on a hill",
+      want: "Subject: a castle on a hill\nStyle: oil painting, loose brushwork",
     },
     {
       name: "own Style line merges alongside other foreign directives",
       styleText: "noir",
       userPrompt: "Style: high contrast\nSetting: alley\na detective",
-      want: "Style: noir, high contrast\nSetting: alley\nDescription: a detective",
+      want: "Subject: a detective\nStyle: noir, high contrast\nSetting: alley",
     },
     {
-      name: "empty userPrompt with a style → Style only, no Description",
+      // A user-typed Subject: line folds into the prose rather than becoming a sibling, so the
+      // label is never emitted twice. Fails if "Subject" is dropped from STYLE_DIRECTIVE_KEYS
+      // (the line would stay prose → "Subject: Subject: a detective").
+      name: "own Subject line folds into the prose without doubling the label",
+      styleText: "noir",
+      userPrompt: "Subject: a detective\nunder a streetlamp",
+      want: "Subject: a detective\nunder a streetlamp\nStyle: noir",
+    },
+    {
+      name: "own Subject line keeps line order alongside surrounding prose",
+      styleText: "noir",
+      userPrompt: "in the rain\nSubject: a detective\nSetting: alley",
+      want: "Subject: in the rain\na detective\nStyle: noir\nSetting: alley",
+    },
+    {
+      name: "own bare Subject line (no user words) is dropped, no blank line",
+      styleText: "noir",
+      userPrompt: "Subject:\na detective",
+      want: "Subject: a detective\nStyle: noir",
+    },
+    {
+      // "Description" stays a RECOGNIZED key so a user-typed one is preserved verbatim as a
+      // sibling rather than being swallowed into our Subject block.
+      name: "own Description line stays a sibling (not folded into Subject)",
+      styleText: "noir",
+      userPrompt: "a detective\nDescription: shot on film",
+      want: "Subject: a detective\nStyle: noir\nDescription: shot on film",
+    },
+    {
+      name: "empty userPrompt with a style → Style only, no Subject",
       styleText: "cinematic",
       userPrompt: "",
       want: "Style: cinematic",
     },
     {
-      name: "whitespace-only userPrompt with a style → Style only, no Description",
+      name: "whitespace-only userPrompt with a style → Style only, no Subject",
       styleText: "cinematic",
       userPrompt: "   \n  \t",
       want: "Style: cinematic",
@@ -131,28 +163,28 @@ describe("composeStyledPrompt", () => {
       name: "styleText is trimmed before templating",
       styleText: "  cinematic watercolor  ",
       userPrompt: "a fox",
-      want: "Style: cinematic watercolor\nDescription: a fox",
+      want: "Subject: a fox\nStyle: cinematic watercolor",
     },
     {
-      name: "unicode content is preserved in Description",
+      name: "unicode content is preserved in Subject",
       styleText: "浮世絵",
       userPrompt: "富士山と桜、朝の光",
-      want: "Style: 浮世絵\nDescription: 富士山と桜、朝の光",
+      want: "Subject: 富士山と桜、朝の光\nStyle: 浮世絵",
     },
     {
       name: "unicode prose alongside a foreign directive",
       styleText: "浮世絵",
       userPrompt: "富士山と桜\nSetting: 早朝",
-      want: "Style: 浮世絵\nSetting: 早朝\nDescription: 富士山と桜",
+      want: "Subject: 富士山と桜\nStyle: 浮世絵\nSetting: 早朝",
     },
     {
       name: "leading whitespace before a directive key still detects it",
       styleText: "noir",
       userPrompt: "a detective\n   Angle: low",
-      want: "Style: noir\nAngle: low\nDescription: a detective",
+      want: "Subject: a detective\nStyle: noir\nAngle: low",
     },
     {
-      name: "directive-only prompt (no prose) → Style + siblings, no Description",
+      name: "directive-only prompt (no prose) → Style + siblings, no Subject",
       styleText: "noir",
       userPrompt: "Setting: alley\nAngle: low",
       want: "Style: noir\nSetting: alley\nAngle: low",
@@ -161,13 +193,13 @@ describe("composeStyledPrompt", () => {
       name: "own bare Style line (no user words) does not append a trailing comma",
       styleText: "oil painting",
       userPrompt: "Style:\na castle",
-      want: "Style: oil painting\nDescription: a castle",
+      want: "Subject: a castle\nStyle: oil painting",
     },
     {
       name: "multi-line prose remainder is preserved across lines",
       styleText: "noir",
       userPrompt: "a detective\nunder a streetlamp\nSetting: alley",
-      want: "Style: noir\nSetting: alley\nDescription: a detective\nunder a streetlamp",
+      want: "Subject: a detective\nunder a streetlamp\nStyle: noir\nSetting: alley",
     },
   ];
 
@@ -207,6 +239,7 @@ describe("STYLE_DIRECTIVE_KEYS", () => {
   it("exposes the recognized directive set", () => {
     expect(STYLE_DIRECTIVE_KEYS).toEqual([
       "Style",
+      "Subject",
       "Description",
       "Setting",
       "Environment",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -8232,7 +8232,7 @@ details[open] > summary.lora-scope-group-heading::before,
 }
 
 /* sc-13131 — Live style-composed prompt preview. Reuses the preset-stack preview idiom but
-   preserves the Style:/Description: line breaks so the composition stays legible. */
+   preserves the Subject:/Style: line breaks so the composition stays legible. */
 .styled-prompt-preview .preset-stack-prompt p {
   white-space: pre-wrap;
 }

--- a/apps/web/src/videoStudioValidation.js
+++ b/apps/web/src/videoStudioValidation.js
@@ -21,7 +21,7 @@ export function videoGenerateValidation({
   hasLtxIcLora,
   replaceReady,
   modelName,
-  // sc-13136: the COMPOSED outgoing prompt (Style:/Description: wrap + preset fold) and whether a
+  // sc-13136: the COMPOSED outgoing prompt (Subject:/Style: wrap + preset fold) and whether a
   // Style Catalog entry is active. `composedPrompt` is the exact string that will be sent — the same
   // string the live preview shows — so the cap is measured on IT, not the raw prompt field: a
   // ~700–900 char style wrapped around a long-but-under-cap prompt can compose past the backend cap.

--- a/apps/web/src/videoStudioValidation.style.test.js
+++ b/apps/web/src/videoStudioValidation.style.test.js
@@ -36,7 +36,7 @@ describe("videoGenerateValidation — Style Catalog budget gate (sc-13136)", () 
   });
 
   it("style active + composed prompt within budget → ready", () => {
-    const composed = `Style: a gentle style\nDescription: ${"x".repeat(200)}`;
+    const composed = `Subject: ${"x".repeat(200)}\nStyle: a gentle style`;
     const issues = videoGenerateValidation({ ...whole, styleActive: true, composedPrompt: composed });
     expect(summarize(issues).ready).toBe(true);
     expect(errorMessages(issues)).toEqual([]);

--- a/config/manifests/builtin.styles.jsonc
+++ b/config/manifests/builtin.styles.jsonc
@@ -2,7 +2,7 @@
   "$schema": "../../packages/schemas/styles.schema.json",
   "schemaVersion": 1,
   "source": "documents/style.txt",
-  "promptTemplate": "Style: {style}\nDescription: {description}",
+  "promptTemplate": "Subject: {subject}\nStyle: {style}",
   "groups": [
     {
       "id": "anime-style",

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -125,7 +125,7 @@ pub struct ImageRequest {
     pub style_preset: String,
     /// The Style-catalog id the caller selected (sc-13134), a group id or a sub-style id, or
     /// `None`. Dedicated field over the dead `style_preset`: the API resolves it to the catalog
-    /// style text and folds it into `prompt` (the `Style:`/`Description:` splice) before the
+    /// style text and folds it into `prompt` (the `Subject:`/`Style:` splice) before the
     /// worker sees the payload, so the worker mainly records it for lineage/replay. The web sends
     /// the already-composed prompt and omits this top-level id, so a re-parse never double-folds.
     pub style_id: Option<String>,

--- a/crates/sceneworks-core/src/style_composer.rs
+++ b/crates/sceneworks-core/src/style_composer.rs
@@ -1,12 +1,13 @@
 //! Rust port of the web Style composer (`apps/web/src/styleComposer.js`, sc-13129),
 //! so a headless/MCP job that carries a `styleId` + a raw prompt is folded into the
-//! SAME `Style:`/`Description:` composition the web app sends (sc-13134).
+//! SAME `Subject:`/`Style:` composition the web app sends (sc-13134).
 //!
 //! This is a byte-for-byte port of `composeStyledPrompt`: the directive-collision splice
 //! (line-anchored directive detection over a fixed recognized key set; the caller's own
-//! `Style:` line MERGES — catalog text first, the user's words appended after `", "`; every
-//! other recognized directive is kept as a top-level sibling; free text folds into a single
-//! `Description:` block; CRLF/lone-CR safe; identity when no style is selected).
+//! `Style:` line MERGES — catalog text first, the user's words appended after `", "`; their own
+//! `Subject:` line folds into the prose in line order; every other recognized directive is kept
+//! as a top-level sibling; free text folds into a single leading `Subject:` block followed by the
+//! `Style:` block; CRLF/lone-CR safe; identity when no style is selected).
 //!
 //! Cross-language parity is pinned by the shared golden fixtures in
 //! `documents/style-composer.fixtures.json`, exercised by both this module's test and
@@ -14,8 +15,9 @@
 
 /// The recognized directive keys that seed the parser. A line only counts as a directive
 /// when its line-anchored key is one of these — identical to the JS `STYLE_DIRECTIVE_KEYS`.
-pub const STYLE_DIRECTIVE_KEYS: [&str; 10] = [
+pub const STYLE_DIRECTIVE_KEYS: [&str; 11] = [
     "Style",
+    "Subject",
     "Description",
     "Setting",
     "Environment",
@@ -28,7 +30,7 @@ pub const STYLE_DIRECTIVE_KEYS: [&str; 10] = [
 ];
 
 const STYLE_KEY: &str = "Style";
-const DESCRIPTION_KEY: &str = "Description";
+const SUBJECT_KEY: &str = "Subject";
 
 /// Longest recognized key we treat as a directive (mirrors the JS guard). Redundant with the
 /// set membership below, but keeps the structural rule explicit.
@@ -156,7 +158,7 @@ fn parse_directive_lines(text: &str) -> Vec<Line> {
 /// (already preset-folded) prompt — the Rust port of `composeStyledPrompt`.
 ///
 /// Returns the untouched `user_prompt` when `style_text` is empty/whitespace (identity, "no
-/// style selected"), else the spliced `Style:`/siblings/`Description:` composition.
+/// style selected"), else the spliced `Subject:`/`Style:`/siblings composition.
 pub fn compose_styled_prompt(style_text: &str, user_prompt: &str) -> String {
     let style = style_text.trim();
     if style.is_empty() {
@@ -165,7 +167,8 @@ pub fn compose_styled_prompt(style_text: &str, user_prompt: &str) -> String {
 
     let parsed = parse_directive_lines(user_prompt);
 
-    // The user's own `Style:` content merges into our block; every other directive is a sibling.
+    // The user's own `Style:` content merges into our block; their own `Subject:` content folds
+    // into the prose (in line order); every other directive is a sibling.
     let mut user_style_parts: Vec<String> = Vec::new();
     let mut sibling_directives: Vec<String> = Vec::new();
     let mut prose_lines: Vec<String> = Vec::new();
@@ -176,6 +179,10 @@ pub fn compose_styled_prompt(style_text: &str, user_prompt: &str) -> String {
                     if !content.trim().is_empty() {
                         user_style_parts.push(content.trim().to_owned());
                     }
+                } else if key == SUBJECT_KEY {
+                    if !content.trim().is_empty() {
+                        prose_lines.push(content);
+                    }
                 } else {
                     sibling_directives.push(raw);
                 }
@@ -184,20 +191,23 @@ pub fn compose_styled_prompt(style_text: &str, user_prompt: &str) -> String {
         }
     }
 
+    // Subject leads, Style follows, the user's other directives trail as siblings.
+    let mut blocks: Vec<String> = Vec::new();
+
+    let subject = prose_lines.join("\n");
+    let subject = subject.trim();
+    if !subject.is_empty() {
+        blocks.push(format!("{SUBJECT_KEY}: {subject}"));
+    }
+
     let mut style_content = String::from(style);
     for part in &user_style_parts {
         style_content.push_str(", ");
         style_content.push_str(part);
     }
+    blocks.push(format!("{STYLE_KEY}: {style_content}"));
 
-    let mut blocks: Vec<String> = vec![format!("{STYLE_KEY}: {style_content}")];
     blocks.extend(sibling_directives);
-
-    let description = prose_lines.join("\n");
-    let description = description.trim();
-    if !description.is_empty() {
-        blocks.push(format!("{DESCRIPTION_KEY}: {description}"));
-    }
 
     blocks.join("\n")
 }
@@ -267,10 +277,30 @@ mod tests {
     #[test]
     fn no_space_after_colon_is_prose_not_a_directive() {
         // `Setting:x` fails the JS `[ \t]+` separator requirement, so it stays prose and folds
-        // into Description — discriminates the separator rule the port must preserve.
+        // into Subject — discriminates the separator rule the port must preserve.
         assert_eq!(
             compose_styled_prompt("noir", "Setting:x"),
-            "Style: noir\nDescription: Setting:x"
+            "Subject: Setting:x\nStyle: noir"
+        );
+    }
+
+    #[test]
+    fn subject_leads_the_style_block() {
+        // The template order itself: the user's prose is the LEADING block, the catalog style
+        // trails it. Fails if the two blocks are emitted in the pre-sc-13129-rework order.
+        assert_eq!(
+            compose_styled_prompt("cinematic watercolor", "a fox in the snow"),
+            "Subject: a fox in the snow\nStyle: cinematic watercolor"
+        );
+    }
+
+    #[test]
+    fn own_subject_line_folds_in_without_doubling_the_label() {
+        // A caller-typed `Subject:` line contributes its content to the prose in line order
+        // rather than becoming a sibling, so the label is never emitted twice.
+        assert_eq!(
+            compose_styled_prompt("noir", "Subject: a detective\nunder a streetlamp"),
+            "Subject: a detective\nunder a streetlamp\nStyle: noir"
         );
     }
 }

--- a/documents/style-composer.fixtures.json
+++ b/documents/style-composer.fixtures.json
@@ -1,5 +1,5 @@
 {
-  "description": "sc-13134 cross-language golden fixtures for the Style composer (Style:/Description: directive-collision splice). Consumed by BOTH apps/web/src/styleComposer.test.js (composeStyledPrompt) AND crates/sceneworks-core/src/style_composer.rs (compose_styled_prompt) so the JS composer and its Rust port produce byte-identical `expected` output. A null `styleText` means no style was selected (identity pass-through). Add a case here to pin new behavior in both languages at once.",
+  "description": "sc-13134 cross-language golden fixtures for the Style composer (Subject:/Style: directive-collision splice). Consumed by BOTH apps/web/src/styleComposer.test.js (composeStyledPrompt) AND crates/sceneworks-core/src/style_composer.rs (compose_styled_prompt) so the JS composer and its Rust port produce byte-identical `expected` output. A null `styleText` means no style was selected (identity pass-through). Add a case here to pin new behavior in both languages at once.",
   "cases": [
     {
       "name": "no style selected -> passthrough unchanged",
@@ -20,85 +20,109 @@
       "expected": "a fox in the snow"
     },
     {
-      "name": "clean prompt -> basic Style/Description",
+      "name": "clean prompt -> Subject leads, Style trails",
       "styleText": "cinematic watercolor",
       "userPrompt": "a fox in the snow",
-      "expected": "Style: cinematic watercolor\nDescription: a fox in the snow"
+      "expected": "Subject: a fox in the snow\nStyle: cinematic watercolor"
     },
     {
       "name": "mid-sentence colon is NOT a directive",
       "styleText": "oil painting",
       "userPrompt": "a portrait: dramatic lighting on her face",
-      "expected": "Style: oil painting\nDescription: a portrait: dramatic lighting on her face"
+      "expected": "Subject: a portrait: dramatic lighting on her face\nStyle: oil painting"
     },
     {
       "name": "lowercase line-start colon is NOT a directive",
       "styleText": "oil painting",
       "userPrompt": "style: not really a directive",
-      "expected": "Style: oil painting\nDescription: style: not really a directive"
+      "expected": "Subject: style: not really a directive\nStyle: oil painting"
     },
     {
-      "name": "unrecognized capitalized key is NOT a directive (folds into Description)",
+      "name": "unrecognized capitalized key is NOT a directive (folds into Subject)",
       "styleText": "oil painting",
       "userPrompt": "Note: this is a plain sentence",
-      "expected": "Style: oil painting\nDescription: Note: this is a plain sentence"
+      "expected": "Subject: Note: this is a plain sentence\nStyle: oil painting"
     },
     {
       "name": "recognized key mid-line is NOT a directive (stays prose)",
       "styleText": "oil painting",
       "userPrompt": "a photo with dramatic Lighting: soft",
-      "expected": "Style: oil painting\nDescription: a photo with dramatic Lighting: soft"
+      "expected": "Subject: a photo with dramatic Lighting: soft\nStyle: oil painting"
     },
     {
       "name": "recognized key after leading word is NOT a directive (stays prose)",
       "styleText": "oil painting",
       "userPrompt": "The Setting: was perfect",
-      "expected": "Style: oil painting\nDescription: The Setting: was perfect"
+      "expected": "Subject: The Setting: was perfect\nStyle: oil painting"
     },
     {
       "name": "CRLF directive lines classify correctly, no stray carriage return",
       "styleText": "noir",
       "userPrompt": "Setting: alley\r\nAngle: low\r\nsomething",
-      "expected": "Style: noir\nSetting: alley\nAngle: low\nDescription: something"
+      "expected": "Subject: something\nStyle: noir\nSetting: alley\nAngle: low"
     },
     {
       "name": "CRLF prose-then-directive splices cleanly",
       "styleText": "noir",
       "userPrompt": "a detective\r\nSetting: a foggy alley",
-      "expected": "Style: noir\nSetting: a foggy alley\nDescription: a detective"
+      "expected": "Subject: a detective\nStyle: noir\nSetting: a foggy alley"
     },
     {
-      "name": "foreign directive preserved as sibling, remainder -> Description",
+      "name": "foreign directive preserved as sibling, remainder -> Subject",
       "styleText": "noir",
       "userPrompt": "a detective in the rain\nSetting: a foggy alley",
-      "expected": "Style: noir\nSetting: a foggy alley\nDescription: a detective in the rain"
+      "expected": "Subject: a detective in the rain\nStyle: noir\nSetting: a foggy alley"
     },
     {
       "name": "multiple foreign directives preserved as siblings in order",
       "styleText": "noir",
       "userPrompt": "a detective\nSetting: a foggy alley\nAngle: low angle\nLighting: single streetlamp",
-      "expected": "Style: noir\nSetting: a foggy alley\nAngle: low angle\nLighting: single streetlamp\nDescription: a detective"
+      "expected": "Subject: a detective\nStyle: noir\nSetting: a foggy alley\nAngle: low angle\nLighting: single streetlamp"
     },
     {
       "name": "own Style line merges - catalog first, user words appended after comma",
       "styleText": "oil painting",
       "userPrompt": "Style: loose brushwork\na castle on a hill",
-      "expected": "Style: oil painting, loose brushwork\nDescription: a castle on a hill"
+      "expected": "Subject: a castle on a hill\nStyle: oil painting, loose brushwork"
     },
     {
       "name": "own Style line merges alongside other foreign directives",
       "styleText": "noir",
       "userPrompt": "Style: high contrast\nSetting: alley\na detective",
-      "expected": "Style: noir, high contrast\nSetting: alley\nDescription: a detective"
+      "expected": "Subject: a detective\nStyle: noir, high contrast\nSetting: alley"
     },
     {
-      "name": "empty userPrompt with a style -> Style only, no Description",
+      "name": "own Subject line folds into the prose without doubling the label",
+      "styleText": "noir",
+      "userPrompt": "Subject: a detective\nunder a streetlamp",
+      "expected": "Subject: a detective\nunder a streetlamp\nStyle: noir"
+    },
+    {
+      "name": "own Subject line keeps line order alongside surrounding prose",
+      "styleText": "noir",
+      "userPrompt": "in the rain\nSubject: a detective\nSetting: alley",
+      "expected": "Subject: in the rain\na detective\nStyle: noir\nSetting: alley"
+    },
+    {
+      "name": "own bare Subject line (no user words) is dropped, no blank line",
+      "styleText": "noir",
+      "userPrompt": "Subject:\na detective",
+      "expected": "Subject: a detective\nStyle: noir"
+    },
+    {
+      "name": "own Description line stays a sibling (not folded into Subject)",
+      "styleText": "noir",
+      "userPrompt": "a detective\nDescription: shot on film",
+      "expected": "Subject: a detective\nStyle: noir\nDescription: shot on film"
+    },
+    {
+      "name": "empty userPrompt with a style -> Style only, no Subject",
       "styleText": "cinematic",
       "userPrompt": "",
       "expected": "Style: cinematic"
     },
     {
-      "name": "whitespace-only userPrompt with a style -> Style only, no Description",
+      "name": "whitespace-only userPrompt with a style -> Style only, no Subject",
       "styleText": "cinematic",
       "userPrompt": "   \n  \t",
       "expected": "Style: cinematic"
@@ -107,28 +131,28 @@
       "name": "styleText is trimmed before templating",
       "styleText": "  cinematic watercolor  ",
       "userPrompt": "a fox",
-      "expected": "Style: cinematic watercolor\nDescription: a fox"
+      "expected": "Subject: a fox\nStyle: cinematic watercolor"
     },
     {
-      "name": "unicode content is preserved in Description",
+      "name": "unicode content is preserved in Subject",
       "styleText": "浮世絵",
       "userPrompt": "富士山と桜、朝の光",
-      "expected": "Style: 浮世絵\nDescription: 富士山と桜、朝の光"
+      "expected": "Subject: 富士山と桜、朝の光\nStyle: 浮世絵"
     },
     {
       "name": "unicode prose alongside a foreign directive",
       "styleText": "浮世絵",
       "userPrompt": "富士山と桜\nSetting: 早朝",
-      "expected": "Style: 浮世絵\nSetting: 早朝\nDescription: 富士山と桜"
+      "expected": "Subject: 富士山と桜\nStyle: 浮世絵\nSetting: 早朝"
     },
     {
       "name": "leading whitespace before a directive key still detects it",
       "styleText": "noir",
       "userPrompt": "a detective\n   Angle: low",
-      "expected": "Style: noir\nAngle: low\nDescription: a detective"
+      "expected": "Subject: a detective\nStyle: noir\nAngle: low"
     },
     {
-      "name": "directive-only prompt (no prose) -> Style + siblings, no Description",
+      "name": "directive-only prompt (no prose) -> Style + siblings, no Subject",
       "styleText": "noir",
       "userPrompt": "Setting: alley\nAngle: low",
       "expected": "Style: noir\nSetting: alley\nAngle: low"
@@ -137,13 +161,13 @@
       "name": "own bare Style line (no user words) does not append a trailing comma",
       "styleText": "oil painting",
       "userPrompt": "Style:\na castle",
-      "expected": "Style: oil painting\nDescription: a castle"
+      "expected": "Subject: a castle\nStyle: oil painting"
     },
     {
       "name": "multi-line prose remainder is preserved across lines",
       "styleText": "noir",
       "userPrompt": "a detective\nunder a streetlamp\nSetting: alley",
-      "expected": "Style: noir\nSetting: alley\nDescription: a detective\nunder a streetlamp"
+      "expected": "Subject: a detective\nunder a streetlamp\nStyle: noir\nSetting: alley"
     }
   ]
 }

--- a/packages/schemas/styles.schema.json
+++ b/packages/schemas/styles.schema.json
@@ -14,7 +14,7 @@
     },
     "promptTemplate": {
       "type": "string",
-      "description": "The two-field composition template the client and server both apply: \"Style: {style}\\nDescription: {description}\"."
+      "description": "The two-field composition template the client and server both apply: \"Subject: {subject}\\nStyle: {style}\"."
     },
     "groups": {
       "type": "array",


### PR DESCRIPTION
## What

The style picker composed the outgoing prompt as `Style:` first with the user''s prose folded into a trailing `Description:` block. This renames that block to `Subject:` and moves it to the front:

```
Subject: {user prompt}
Style: {selected style prompt}
```

## Details

- **Block order** — `Subject:` leads, `Style:` follows. The user''s other directive lines (`Setting:`, `Lighting:`, `Camera:`, …) keep their existing position as top-level siblings after the Style block, so only the two named blocks moved.
- **`Subject` is now a recognized directive key.** Without it, a user typing `Subject: a fox` would fall through as prose and compose to `Subject: Subject: a fox`. It folds into the prose in line order instead, so the label is never doubled — the same protection `Style:` already had.
- **`Description` stays recognized.** A user-typed `Description:` line is still preserved verbatim as a sibling rather than being swallowed into our Subject block.

## Scope

Both implementations moved together — the JS composer (`apps/web/src/styleComposer.js`) and its hand-ported Rust twin (`crates/sceneworks-core/src/style_composer.rs`) — plus the shared golden fixtures in `documents/style-composer.fixtures.json` that pin them byte-identical, the declared `promptTemplate` in all four places it is mirrored (`parseStyleCatalog.js`, `styles.json`, `builtin.styles.jsonc`, `styles.schema.json`), and every downstream assertion across the web studios and the rust-api server-side fold.

Four fixture cases were added covering the new `Subject:` key: fold-without-doubling, line-order preservation, a bare `Subject:` line, and `Description:` still behaving as a sibling.

## Verification

- `vitest run --environment jsdom` from `apps/web` — **152 files / 2188 tests pass**
- `vite build` — clean
- `cargo fmt --all -- --check` and `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets` — clean
- `cargo test -p sceneworks-core -p sceneworks-rust-api` — all pass, including `golden_fixtures_match_the_js_composer` (the cross-language parity gate)
- Re-ran `generate-styles.mjs` — reproduces the checked-in catalog exactly, so the hand-edited `promptTemplate` is not generator drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)