### PR TITLE
feat(styles): hide the Style axis for tag-convention models

### DIFF
--- a/apps/rust-api/src/styles.rs
+++ b/apps/rust-api/src/styles.rs
@@ -100,6 +100,34 @@ pub(crate) async fn apply_style_to_image_payload(
     else {
         return Ok(());
     };
+
+    // Booru-tag models (Anima, Illustrious — `captionStyle: "tags"`) take comma-separated tags, not
+    // prose, and every catalog style is a 600–900-char English prose paragraph. The studio hides the
+    // axis for them, so a `styleId` can only reach here from a headless/MCP caller: reject it by name
+    // rather than silently dropping the field, matching the unknown-style 400 below and the audio
+    // route's type gate (`generation.rs`).
+    //
+    // This runs BEFORE the client-side-resolved skip on purpose. That skip is a *fold* detail — it
+    // says "the prompt is already composed" — whereas this is a capability gate on the model, so a
+    // caller that sets both the flag and a styleId still gets told rather than quietly rendering a
+    // prose-wrapped prompt through a tag checkpoint.
+    //
+    // Keyed off the POST-preset `job_payload["model"]`, NOT `payload.model`: the recipe-preset fold
+    // that ran before us may have substituted the preset's own model when the caller named none, and
+    // reading the stale DTO field would resolve the DEFAULT model's entry (sc-12300). An unknown id
+    // resolves to `{}`, so it falls through to the normal path instead of a spurious rejection.
+    let model_id = job_payload
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or(payload.model.as_str())
+        .to_owned();
+    let model_entry = crate::models::resolve_model_manifest_entry(state, &model_id).await?;
+    if model_entry.get("captionStyle").and_then(Value::as_str) == Some("tags") {
+        return Err(ApiError::bad_request(format!(
+            "Model {model_id} uses tag-style prompts, so the Style catalog does not apply (remove styleId)"
+        )));
+    }
+
     // The client already composed the full prompt client-side (web path) — take it verbatim so we
     // never double-fold. Mirrors the preset skip.
     if payload.preset_prompt_resolved_client_side.unwrap_or(false) {

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -4901,6 +4901,23 @@ fn write_style_test_manifests(config_dir: &std::path::Path) {
               "limits": {},
               "loraCompatibility": { "families": ["z-image"] },
               "ui": { "label": "Img" }
+            },
+            {
+              "id": "tag-model",
+              "name": "Tag Model",
+              "family": "anima",
+              "type": "image",
+              "adapter": "anima",
+              "captionStyle": "tags",
+              "capabilities": ["text_to_image"],
+              "downloads": [
+                { "provider": "huggingface", "repo": "owner/tag", "files": ["*.safetensors"], "default": true }
+              ],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": { "families": ["anima"] },
+              "ui": { "label": "Tag" }
             }
           ]
         }
@@ -5029,6 +5046,70 @@ async fn styled_image_job_folds_style_server_side_from_style_id() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{err:?}");
+}
+
+#[tokio::test]
+async fn styled_image_job_rejects_a_style_on_a_tag_convention_model() {
+    // Booru-tag models (`captionStyle: "tags"`) take comma-separated tags, so the prose Style catalog
+    // does not apply. The studio hides the axis; a headless/MCP caller that sends a styleId anyway
+    // must get a named 400 rather than a silently prose-wrapped prompt.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_style_test_manifests(&temp_dir.path().join("config"));
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Tag Model Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    let body = json!({
+        "projectId": project_id,
+        "mode": "text_to_image",
+        "prompt": "1girl, solo, pink hair",
+        "model": "tag-model",
+        "count": 1,
+        "width": 1024,
+        "height": 1024,
+        "styleId": "test-ghibli"
+    });
+    let (status, err) = request(app.clone(), "POST", "/api/v1/image/jobs", body.clone()).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{err:?}");
+    let message = err["detail"].as_str().unwrap_or_default().to_owned();
+    assert!(
+        message.contains("tag-model") && message.contains("tag-style"),
+        "the rejection must name the model and the reason: {message}"
+    );
+
+    // The gate is a MODEL capability, not a fold detail: it fires even when the caller claims the
+    // prompt was already composed client-side (the flag that otherwise short-circuits the fold).
+    let mut claimed = body;
+    claimed["presetPromptResolvedClientSide"] = json!(true);
+    let (status, err) = request(app.clone(), "POST", "/api/v1/image/jobs", claimed).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{err:?}");
+
+    // Same model with NO styleId is untouched — the gate rejects the axis, not the model.
+    let (status, plain) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project["id"].as_str().expect("project id"),
+            "mode": "text_to_image",
+            "prompt": "1girl, solo, pink hair",
+            "model": "tag-model",
+            "count": 1,
+            "width": 1024,
+            "height": 1024
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{plain:?}");
+    assert_eq!(plain["payload"]["prompt"], "1girl, solo, pink hair");
 }
 
 #[tokio::test]

--- a/apps/web/src/App.imageStudioStylePreview.test.jsx
+++ b/apps/web/src/App.imageStudioStylePreview.test.jsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { withImageStudioContext, settle } from "./main.testSupport.jsx";
-import { STYLE_GROUPS, styleHintForId } from "./data/styleCatalog.js";
+import { STYLE_GROUPS, styleHintForId, styleTextForId } from "./data/styleCatalog.js";
 
 // sc-13131 — End-to-end wiring guard for the live Style preview. Renders the real ImageStudio,
 // types a prompt, picks a style through the actual StylePicker, and asserts that the on-screen
@@ -34,7 +34,7 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
     vi.restoreAllMocks();
   });
 
-  async function renderStudio() {
+  async function renderStudio(model = IMAGE_MODEL) {
     root = createRoot(container);
     await act(async () => {
       root.render(
@@ -46,7 +46,7 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
           deleteAsset: () => {},
           purgeAsset: () => {},
           gpuOptions: ["auto"],
-          imageModels: [IMAGE_MODEL],
+          imageModels: [model],
           latestAssets: [],
           localJobs: [],
           loras: [],
@@ -209,5 +209,70 @@ describe("Image Studio — live Style preview parity (sc-13131)", () => {
 
     const submittedPrompt = await submitAndReadPayloadPrompt();
     expect(shown).toBe(submittedPrompt);
+  });
+
+  // Booru-tag models (`captionStyle: "tags"`) take comma-separated tags, so the prose Style catalog
+  // is hidden for them. The gate is DERIVED from the model, not a state clear — which is what lets it
+  // cover a persisted/replayed styleId, the path a [model]-effect clear would miss entirely.
+  describe("tag-convention models", () => {
+    const TAG_MODEL = {
+      id: "anima_base",
+      name: "Anima",
+      type: "image",
+      family: "anima",
+      captionStyle: "tags",
+    };
+    const TAGS = "1girl, solo, pink hair, detailed background";
+    const styleAxis = () => document.body.querySelector(".style-axis-catalog");
+
+    // Seed the studio's persisted state with a style already picked, as if the user chose one on a
+    // prose model and then switched. This is the hole a picker-only gate would leave open.
+    function seedPersistedStyle() {
+      window.localStorage.setItem(
+        "sceneworks-studio-image-project-1",
+        JSON.stringify({ styleId: firstStyle.id, prompt: TAGS }),
+      );
+    }
+
+    it("hides the Style picker entirely", async () => {
+      await renderStudio(TAG_MODEL);
+      expect(styleAxis()).toBeNull();
+      expect(document.body.querySelector('button[aria-label="Style"]')).toBeNull();
+      // The rest of the style row (the model's own Style presets) is untouched.
+      expect(document.body.querySelector(".style-axis-presets")).toBeTruthy();
+    });
+
+    it("does not compose a PERSISTED style into the submitted prompt", async () => {
+      seedPersistedStyle();
+      await renderStudio(TAG_MODEL);
+      // Hidden, and — the part that matters — inert: the tags go out exactly as typed.
+      expect(styleAxis()).toBeNull();
+      expect(document.body.querySelector('[data-testid="styled-prompt-preview"]')).toBeNull();
+      const submittedPrompt = await submitAndReadPayloadPrompt();
+      expect(submittedPrompt).toBe(TAGS);
+      expect(submittedPrompt).not.toContain("Style:");
+      expect(submittedPrompt).not.toContain("Subject:");
+    });
+
+    it("the SAME persisted style still composes on a prose model (proves the gate is what suppressed it)", async () => {
+      // Discriminator for the test above: without this, a broken seed would make it pass vacuously.
+      seedPersistedStyle();
+      await renderStudio();
+      expect(styleAxis()).toBeTruthy();
+      const submittedPrompt = await submitAndReadPayloadPrompt();
+      expect(submittedPrompt).toBe(`Subject: ${TAGS}\nStyle: ${styleTextForId(firstStyle.id)}`);
+    });
+
+    it("keeps the style-hint suggestion pill off, so no prose hint leaks in", async () => {
+      // The pill swap is driven by the same gated id; a stale style would otherwise offer a prose
+      // subject prompt on a model that wants tags.
+      seedPersistedStyle();
+      await renderStudio(TAG_MODEL);
+      const hint = styleHintForId(firstStyle.id);
+      expect(hint).toEqual(expect.any(String));
+      const pills = [...document.body.querySelectorAll(".suggestion-row .suggestion")];
+      expect(pills.some((pill) => pill.textContent.includes(hint))).toBe(false);
+      expect(pills.length).toBeGreaterThan(1);
+    });
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -418,15 +418,6 @@ export function ImageStudio() {
     // Editing the idea clears a stale auto-expand error (sc-6501).
     setSubmitError("");
   };
-  // sc-13366: when a style is selected, replace the generic scene/character suggestion pills with a
-  // single hint pill carrying that style's tailored subject prompt (styleThumbnailPrompts.json) — a
-  // strong, style-fitting starting point. Falls back to the normal suggestions with no style.
-  const styleHint = styleHintForId(styleId);
-  const suggestions = styleHint
-    ? [styleHint]
-    : mode === "character_image"
-      ? characterSuggestions
-      : sceneSuggestions;
   const [count, setCount] = useState(saved.count ?? 4);
 
   // Batch Prompt Processing (epic 9952). Batch mode is orthogonal to the T2I/Edit/
@@ -1031,6 +1022,30 @@ export function ImageStudio() {
   // declares `structuredPrompt`, the prompt hero swaps the plain textarea for the
   // builder and the engine receives the canonically-ordered JSON caption string.
   const structuredPromptModel = Boolean(selectedModel?.structuredPrompt);
+  // Booru-tag models (Anima, Illustrious) declare `captionStyle: "tags"` — they are trained on
+  // comma-separated tags, and their own promptHint warns that "a plain sentence renders low-effort
+  // art". Every Style Catalog entry is a 600–900-char English prose paragraph, so the axis does not
+  // fit them and the picker is hidden.
+  //
+  // The gate is DERIVED, never a state clear. Two reasons:
+  //  - The user's pick survives passing through a tag model and comes back when they switch to a
+  //    prose model, matching how the picker behaves across every other model change.
+  //  - A render-time gate covers the paths a [model]-effect clear cannot: a localStorage restore and
+  //    a recipe replay both seed styleId with no model change, and on a fresh mount `selectedModel`
+  //    is briefly undefined while the catalog resolves (sc-11962 / sc-12034).
+  // Downstream consumers read `effectiveStyleId`, so the axis cannot leak into a submit.
+  const tagConventionModel = selectedModel?.captionStyle === "tags";
+  const styleAxisAvailable = !tagConventionModel;
+  const effectiveStyleId = styleAxisAvailable ? styleId : null;
+  // sc-13366: when a style is selected, replace the generic scene/character suggestion pills with a
+  // single hint pill carrying that style's tailored subject prompt (styleThumbnailPrompts.json) — a
+  // strong, style-fitting starting point. Falls back to the normal suggestions with no style.
+  const styleHint = styleHintForId(effectiveStyleId);
+  const suggestions = styleHint
+    ? [styleHint]
+    : mode === "character_image"
+      ? characterSuggestions
+      : sceneSuggestions;
   const captionValidation = useMemo(
     () => (structuredPromptModel ? validateCaption(caption, { plainText: prompt }) : null),
     [structuredPromptModel, caption, prompt],
@@ -2044,9 +2059,9 @@ export function ImageStudio() {
       // produced `promptToSend` — so the style's `Style:` block wraps the already-preset-composed
       // user prompt as `Subject:`. Null → pass-through (prompt sent unchanged). Structured
       // caption models ignore it (the builder skips composition when sendStructured is true).
-      styleText: styleTextForId(styleId),
+      styleText: styleTextForId(effectiveStyleId),
       // sc-13132: the opaque style id travels with the recipe so replay can re-select the picker.
-      styleId,
+      styleId: effectiveStyleId,
       characterId,
       characterLookId,
       multiReference,
@@ -2248,7 +2263,7 @@ export function ImageStudio() {
   // auto-write a caption per resolved prompt (sc-9980).
   const batchStructuredExpandBlocked =
     structuredPromptModel && (magicModelMissing || typeof magicPrompt !== "function");
-  const activeStyleText = styleTextForId(styleId);
+  const activeStyleText = styleTextForId(effectiveStyleId);
   const styleSelected = typeof activeStyleText === "string" && activeStyleText.trim() !== "";
   const stylePreviewActive = !structuredPromptModel && styleSelected;
   // sc-13224: structured JSON-caption models apply the Style axis by merging into the caption's
@@ -3106,12 +3121,15 @@ export function ImageStudio() {
                 model's Style presets — both are style controls, so they share one row instead of the
                 catalog picker floating in a standalone row under the composer. The Style Catalog
                 composes the prompt (free-text) or merges into the caption (Ideogram, sc-13224); "None"
-                resets to pass-through. NB: distinct from Krea's numeric "text style" (textStyleGain). */}
+                resets to pass-through. Hidden for booru-tag models, whose convention the catalog's prose
+                entries do not fit. NB: distinct from Krea's numeric "text style" (textStyleGain). */}
             <div className="settings-bar-styles settings-bar-style-axis">
-              <div className="style-axis-field style-axis-catalog">
-                <span className="settings-bar-label">Style</span>
-                <StylePicker groups={STYLE_GROUPS} selectedId={styleId} onSelect={setStyleId} label="Style" />
-              </div>
+              {styleAxisAvailable ? (
+                <div className="style-axis-field style-axis-catalog">
+                  <span className="settings-bar-label">Style</span>
+                  <StylePicker groups={STYLE_GROUPS} selectedId={styleId} onSelect={setStyleId} label="Style" />
+                </div>
+              ) : null}
               <div className="style-axis-field style-axis-presets">
                 <span className="settings-bar-label">Style preset</span>
                 <div className="preset-chips">

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1063,11 +1063,15 @@ export function VideoStudio() {
   // composeStyledPrompt wraps the outgoing prompt LAST — AFTER the general-preset stack fold above —
   // so the style's Subject:/Style: block sits around the already-preset-composed prompt. Video
   // has no structured-caption or batch modes (the two the image lane gates the composer off for), so
-  // the only exclusion here is a promptless (image-conditioned) model, which sends no text prompt to
-  // wrap. `stylePromptBase` is the SAME base the styleless submit sends, so the live preview and the
-  // submit compose from one string and can never drift.
-  const activeStyleText = styleTextForId(styleId);
-  const styleApplied = !promptless && typeof activeStyleText === "string" && activeStyleText.trim() !== "";
+  // the exclusions here are a promptless (image-conditioned) model, which sends no text prompt to
+  // wrap, and a booru-tag model, whose comma-separated-tag convention the catalog's prose entries do
+  // not fit (mirrors the Image Studio gate). No video model declares `captionStyle: "tags"` today, so
+  // the tag arm is inert — it is here so a future tag-convention video model inherits the gate rather
+  // than silently acquiring a mismatched axis. `stylePromptBase` is the SAME base the styleless submit
+  // sends, so the live preview and the submit compose from one string and can never drift.
+  const styleAxisAvailable = !promptless && selectedModel?.captionStyle !== "tags";
+  const activeStyleText = styleTextForId(styleAxisAvailable ? styleId : null);
+  const styleApplied = styleAxisAvailable && typeof activeStyleText === "string" && activeStyleText.trim() !== "";
   const stylePromptBase = stackActive ? composedStack.prompt : prompt;
   const composedStylePrompt = styleApplied
     ? composeStyledPrompt({ styleText: activeStyleText, userPrompt: stylePromptBase })
@@ -1612,15 +1616,16 @@ export function VideoStudio() {
               </label>
             </div>
             {/* Style axis (sc-13135): the Style Catalog picker leads this row (hidden for promptless
-                image-conditioned models), followed by the model's Style presets — mirrors the Image
-                Studio. The catalog wraps the outgoing prompt (Subject:/Style:); "None" resets. */}
+                image-conditioned models and for booru-tag models), followed by the model's Style
+                presets — mirrors the Image Studio. The catalog wraps the outgoing prompt
+                (Subject:/Style:); "None" resets. */}
             <div className="settings-bar-styles settings-bar-style-axis">
-              {promptless ? null : (
+              {styleAxisAvailable ? (
                 <div className="style-axis-field style-axis-catalog">
                   <span className="settings-bar-label">Style</span>
                   <StylePicker groups={STYLE_GROUPS} selectedId={styleId} onSelect={setStyleId} label="Style" />
                 </div>
-              )}
+              ) : null}
               <div className="style-axis-field style-axis-presets">
                 <span className="settings-bar-label">Style preset</span>
                 <div className="preset-chips">


### PR DESCRIPTION
## What

Anima and Illustrious declare `captionStyle: "tags"` — they're trained on comma-separated booru tags, and their own `promptHint` warns that *"a plain sentence renders low-effort art"*. Every Style Catalog entry is a 600–900-character English prose paragraph. The axis doesn't fit them, so it's now hidden.

Follow-on to #1660, which surfaced the mismatch: those models were being sent `Subject: 1girl, solo, pink hair\nStyle: <800-char English prose paragraph>`.

## The gate is derived, not a state clear

`effectiveStyleId = styleAxisAvailable ? styleId : null`, computed from the selected model alongside the existing `structuredPromptModel` capability. Two reasons this beats clearing `styleId` in the `[model]` effect:

- **The user's pick survives** passing through a tag model and comes back when they switch to a prose model.
- **It covers paths an effect-clear cannot.** A localStorage restore and a recipe replay both re-seed `styleId` with *no model change*, so a `[model]`-keyed clear never fires for either. On a fresh mount `selectedModel` is also briefly `undefined` while the catalog resolves (the trap sc-11962 and sc-12034 both document). Hiding only the picker would have left a stale style silently composing on a tag checkpoint.

Image Studio routes every consumer through `effectiveStyleId` — job build, live preview, and the style-hint suggestion pill — so the axis cannot leak into a submit.

## Video Studio

Same gate, alongside the existing `promptless` exclusion. **No video model declares `captionStyle: "tags"` today, so that arm is inert by design** — it's there so a future tag-convention video model inherits the gate rather than silently acquiring a mismatched axis. Flagging it explicitly since it's dead code at merge time.

## Server side

A `styleId` on a tag model is now a named 400 rather than a silent drop, matching the unknown-style 400 immediately beside it and the audio route's type gate in `generation.rs`.

Two placement details that matter:
- It runs **before** the `presetPromptResolvedClientSide` skip. That skip is a *fold* detail ("the prompt is already composed"); this is a *model capability*, so a caller setting both the flag and a `styleId` still gets told.
- It reads the **post-preset** `job_payload["model"]`, not `payload.model` — the recipe-preset fold that runs first may have substituted the preset's own model, and the stale DTO field would resolve the default model's entry (sc-12300).

Only headless/MCP callers can reach it; the web path sends no top-level `styleId`.

## Verification

- Web vitest **2192/2192** pass (4 new). The set includes a deliberate discriminator — *"the SAME persisted style still composes on a prose model"* — so the "doesn't compose on a tag model" test can't pass vacuously off a broken seed.
- rust-api style suite **11/11**, including a new test that covers the plain rejection, the rejection-despite-the-client-side-resolved-flag, and that the same model with no `styleId` is untouched.
- `cargo fmt --all -- --check` and `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets` clean; `cargo test` for both crates passes.
- `vite build` clean.
- Re-verified after rebasing onto current `main` (post-#1659, post-#1660).

## Not in scope

The wider question this came out of — that T5/CLIP-family encoders don't parse directive labels either, and SDXL's 77-token window truncates the `Style:` block outright — is a separate design decision (a `promptFormat` descriptor read by the composer, touching ~45 model entries). Not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
