### PR TITLE
fix(worker): candle Qwen-Image-Edit loads the packed turnkey tier its VRAM gate sizes [sc-13534]

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -647,6 +647,16 @@
       // is the dense 5-shard DiT + dense f32 TE (81.7 GB resident) — it fits a 96 GB card but overflows
       // the epic's small-card targets even sequentially, so the gate rejects it there. minMemoryGb 59
       // gates the DEFAULT (q4) tier (resident 56.7 GB).
+      //
+      // sc-13534: these rows only DESCRIBE what the candle lane loads as of that story. They were always
+      // measured against the staged `SceneWorks/qwen-image-edit-2511-mlx` tier subdirs below, but until
+      // sc-13534 `resolve_qwen_edit_candle_base` resolved the UPSTREAM `Qwen/Qwen-Image-Edit(-2511)`
+      // snapshot instead — a repo no `downloads` entry here ever fetches (so the lane was unreachable on
+      // a stock install) and, where a dev box happened to have it cached, a DENSE bf16 load budgeted
+      // against the q4 row: a ~25 GB under-prediction. The lane now descends into the tier subdir via
+      // `standard_tier_subdir` (like the `qwen_image` txt2img sibling) and the fit-gate keys off the
+      // RESOLVED dir (`gate_tier_key`), so the tier that loads is the tier that is budgeted. Keep that
+      // true when re-measuring: a row here is only honest if the lane can actually resolve that subdir.
       "candle": {
         "minMemoryGb": 59,
         "vramGbByTier": { "q4": 56.7, "q8": 69.0, "bf16": 81.7 },
@@ -770,6 +780,10 @@
       // distill LoRA. Resident/sequential pixels byte-identical per tier (q4 md5 08385ae1, q8 e78141a8, bf16
       // ea51b237). The edit fit-gate (qwen_edit_candle.rs, sc-10968) reads vramGbByTier vs free VRAM to choose
       // sequential-offload vs reject; minMemoryGb 59 gates the DEFAULT (q4) tier (resident 57.0).
+      //
+      // sc-13534: same reconciliation as `qwen_image_edit_2511` above (shared checkpoint, shared lane) —
+      // the candle lane resolved the upstream dense snapshot rather than these staged tier subdirs until
+      // that story pointed it at `standard_tier_subdir` and keyed the fit-gate off the resolved dir.
       "candle": {
         "minMemoryGb": 59,
         "vramGbByTier": { "q4": 57.0, "q8": 65.8, "bf16": 87.4 },

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -25,10 +25,14 @@ const QWEN_EDIT_CANDLE_LIGHTNING_STEPS: u32 = 4;
 const QWEN_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 4.0;
 /// The adapter/engine id recorded on candle Qwen-Image-Edit assets + telemetry.
 const QWEN_EDIT_CANDLE_ENGINE: &str = "candle_qwen_edit";
-/// Default Qwen-Image-Edit base repo when the manifest omits `repo`.
-const QWEN_EDIT_CANDLE_DEFAULT_REPO: &str = "Qwen/Qwen-Image-Edit";
-/// The Qwen-Image-Edit-2511 base repo — the Lightning distill is `-2511` + the lightx2v LoRA (sc-6220).
-const QWEN_EDIT_CANDLE_2511_REPO: &str = "Qwen/Qwen-Image-Edit-2511";
+/// The SceneWorks pre-packed Qwen-Image-Edit-2511 quant-matrix turnkey (sc-8669, epic 8506): self-
+/// contained `q4/` (manifest default) + `q8/` + `bf16/` subdirs, only the transformer packed (the
+/// Qwen2.5-VL TE + VAE stay dense bf16 in every tier). Shared by all four edit ids + the Lightning
+/// distill — one checkpoint, and the ONLY repo the manifest `downloads` for those ids ever fetch.
+///
+/// The last-resort fallback for an id that is somehow not in [`MODEL_TABLE`]; the live ids all carry
+/// this exact repo as their row `default_repo`, which [`qwen_edit_candle_repo`] reads first.
+const QWEN_EDIT_CANDLE_TURNKEY_REPO: &str = "SceneWorks/qwen-image-edit-2511-mlx";
 /// The lightx2v Qwen-Image-Edit-2511-Lightning distill LoRA (4-step bf16), fetched lazily into the HF
 /// cache on first use — mirrors the MLX `qwen_edit_lightning` (sc-3398) repo/file.
 const QWEN_EDIT_CANDLE_LIGHTNING_LORA_REPO: &str = "lightx2v/Qwen-Image-Edit-2511-Lightning";
@@ -67,28 +71,63 @@ fn qwen_edit_candle_mode(request: &ImageRequest) -> bool {
     request.mode == "edit_image" && non_empty(&request.source_asset_id)
 }
 
-/// The Qwen-Image-Edit base repo for this request: manifest `repo` else the family default — the
-/// Lightning distill's base is `-2511` (sc-6220); the other variants default to the `Qwen-Image-Edit` alias.
+/// The Qwen-Image-Edit base repo for this request: the manifest `repo` override, else this id's
+/// [`MODEL_TABLE`] row `default_repo` — the SceneWorks Edit-2511 quant-matrix turnkey every edit id's
+/// manifest `downloads` actually provision.
+///
+/// **sc-13534:** this used to default to the UPSTREAM `Qwen/Qwen-Image-Edit(-2511)` snapshot, which no
+/// download flow ever fetches — the `downloads` for `qwen_image_edit_2511` + `_2511_lightning` list only
+/// `SceneWorks/qwen-image-edit-2511-mlx`, and the manifest declares the turnkey under `paths.model`, NOT
+/// the top-level `modelPath` [`resolve_qwen_edit_candle_base`] reads (`modelManifestEntry` passes through
+/// verbatim — nothing flattens `paths.model` into `modelPath`). So the upstream default was reached on
+/// every request and produced three distinct defects:
+///
+/// 1. **The lane was dead after a normal install** — the upstream repo is absent, so the base never
+///    resolved and `qwen_edit_candle_available` was false. It only ever worked on a dev box that happened
+///    to have the upstream snapshot cached from measurement work.
+/// 2. **Wrong weights** — the non-Lightning ids defaulted to `Qwen/Qwen-Image-Edit`, the Aug-2025
+///    ORIGINAL, not 2511. The manifest + `MODEL_TABLE` alias every edit id to the 2511 checkpoint, and
+///    `zero_cond_t` is absent from the original's `transformer/config.json`, so a `qwen_image_edit_2511`
+///    render would have silently taken the 2509-style single-timestep modulation.
+/// 3. **The VRAM gate sized a tier that could not load** — see the fit-gate comment in
+///    [`generate_candle_qwen_edit_stream`].
+///
+/// Reading the row keeps this catalog-driven: `MODEL_TABLE` already points all four edit ids at the
+/// turnkey (the same repo the MLX lane loads), so the two lanes cannot drift apart again.
 fn qwen_edit_candle_repo(request: &ImageRequest) -> String {
-    let default = if is_qwen_edit_lightning(&request.model) {
-        QWEN_EDIT_CANDLE_2511_REPO
-    } else {
-        QWEN_EDIT_CANDLE_DEFAULT_REPO
-    };
     request
         .model_manifest_entry
         .get("repo")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(default)
-        .to_owned()
+        .map(str::to_owned)
+        .or_else(|| {
+            crate::engines::MODEL_TABLE
+                .iter()
+                .find(|row| row.sceneworks_id == request.model)
+                .map(|row| row.default_repo.to_owned())
+        })
+        .unwrap_or_else(|| QWEN_EDIT_CANDLE_TURNKEY_REPO.to_owned())
 }
 
 /// Resolve the Qwen-Image-Edit base snapshot: an explicit `modelPath` dir (advanced or manifest) wins,
-/// else the HF cache snapshot for the manifest `repo`. `None` means the base is not present locally, so
-/// the job is not candle-runnable. Mirrors `resolve_flux2_edit_candle_base`.
-fn resolve_qwen_edit_candle_base(
+/// else the requested TIER SUBDIR of the [`qwen_edit_candle_repo`] turnkey snapshot. `None` means the
+/// base is not present locally, so the job is not candle-runnable.
+///
+/// **sc-13534:** the tier descent is the fix's other half. `QwenEdit::load` takes no quant/tier argument —
+/// it packed-detects per `Linear` from `transformer/config.json` (`transformer_group_size` /
+/// `transformer_is_packed`), so the DIRECTORY alone decides the precision that loads. Pointing it at a
+/// turnkey ROOT would hand the loader a dir holding only `q4/ q8/ bf16/` and no `transformer/`; pointing
+/// it at the upstream dense snapshot (the old behavior) loaded DENSE bf16 while the fit-gate sized q4.
+/// It resolves the tier through the SAME two-step chain the txt2img sibling uses in
+/// [`resolve_weights_dir`] — the download RECEIPT first, then the tier descent — because those two steps
+/// pick DIFFERENT tiers and only the pair reproduces the sibling's behavior. See
+/// [`qwen_edit_candle_base_dir`] for why the receipt step is load-bearing.
+///
+/// `pub(crate)` so the real-weights GPU smoke can drive the exact seam it exercises in production
+/// (`qwen_edit_worker_lane_gpu_smoke`), like `resolve_weights_dir` for the txt2img lanes.
+pub(crate) fn resolve_qwen_edit_candle_base(
     request: &ImageRequest,
     settings: &Settings,
 ) -> WorkerResult<Option<PathBuf>> {
@@ -104,7 +143,61 @@ fn resolve_qwen_edit_candle_base(
         return resolve_app_managed_model_dir(settings, &path, "Qwen edit modelPath").map(Some);
     }
     let repo = qwen_edit_candle_repo(request);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, &repo))
+    let receipt = crate::model_jobs::huggingface_receipt_weights_dir(
+        &settings.data_dir,
+        &repo,
+        Some(&request.model),
+        requested_receipt_variant(request).as_deref(),
+    );
+    Ok(qwen_edit_candle_base_dir(
+        receipt,
+        huggingface_snapshot_dir(&settings.data_dir, &repo),
+        request,
+    ))
+}
+
+/// Pick the base dir from an already-resolved (`receipt`, `snapshot`) pair — the PURE half of
+/// [`resolve_qwen_edit_candle_base`], split out so both steps are unit-testable (the resolver itself
+/// needs a `Settings` plus the env-dependent HF cache lookup, which a test cannot drive without coupling
+/// to the developer's real cache). Mirrors why [`gate_tier_key`] was extracted out of
+/// `generate_candle_stream`. Production has exactly one caller, which passes the real lookups.
+///
+/// Order matches [`resolve_weights_dir`] exactly, and BOTH steps matter:
+///
+/// 1. **A tier RECEIPT wins outright.** [`requested_receipt_variant`] falls back to the manifest's
+///    `default: true` download — **q4** for this family — so a stock install resolves the q4 receipt dir
+///    and returns it as-is. This step is what honors the DECLARED default tier (sc-12155), and skipping it
+///    was a real defect in the first cut of sc-13534: `standard_tier_subdir` reads ONLY
+///    `advanced.mlxQuantize` and otherwise takes the app-wide **q8** default (sc-10726), so a box with
+///    q4+q8 both installed loaded **q8 on edit while txt2img loaded q4** — same manifest, same checkpoint,
+///    two different tiers, and ~12 GB more VRAM budgeted than the declared default needs.
+/// 2. **Else the tier descent**, which clamps to what is INSTALLED (q8 → bf16 → q4) so a partial install
+///    resolves a tier that exists instead of erroring on a missing one.
+///
+/// `QwenEdit::load` takes no quant/tier argument — it packed-detects per `Linear` from
+/// `transformer/config.json` (`transformer_group_size` / `transformer_is_packed`), so the DIRECTORY alone
+/// decides the precision. Both steps land on a self-contained tier subdir, which is EXACTLY what the
+/// sc-11019 / sc-11666 `candle.vramGbByTier` rows were measured against.
+///
+/// Everything `None` ⇒ `None`: an absent turnkey stays "not candle-runnable" rather than becoming a bogus
+/// path that fails deep inside the loader.
+fn qwen_edit_candle_base_dir(
+    receipt: Option<PathBuf>,
+    snapshot: Option<PathBuf>,
+    request: &ImageRequest,
+) -> Option<PathBuf> {
+    // A tier receipt already IS the exact self-contained tier dir — return it before the descent, so the
+    // tier the download recorded is the tier that loads (and no second q4/q8/bf16 descent runs).
+    if receipt
+        .as_deref()
+        .and_then(tier_key_from_resolved_dir)
+        .is_some()
+    {
+        return receipt;
+    }
+    receipt
+        .or(snapshot)
+        .map(|root| standard_tier_subdir(&root, request))
 }
 
 /// True when this is a candle-eligible Qwen edit job (a Qwen-Image-Edit `edit_image` job with a source)
@@ -146,10 +239,13 @@ fn qwen_edit_candle_guidance(request: &ImageRequest) -> f32 {
     )
 }
 
-/// Flat telemetry recorded on candle Qwen-Image-Edit assets.
+/// Flat telemetry recorded on candle Qwen-Image-Edit assets. `base_dir` is the RESOLVED base
+/// ([`resolve_qwen_edit_candle_base`]) — the tier label is read back off it, so the record names the
+/// weights that actually loaded.
 fn qwen_edit_candle_raw_settings(
     request: &ImageRequest,
     repo: &str,
+    base_dir: &Path,
     steps: u32,
     guidance: f32,
 ) -> JsonObject {
@@ -163,6 +259,16 @@ fn qwen_edit_candle_raw_settings(
         "editEngine".to_owned(),
         Value::String(QWEN_EDIT_CANDLE_ENGINE.to_owned()),
     );
+    // sc-13534: record the TIER that ran, not just the repo. Every tier of this family lives in one
+    // turnkey repo, so `repo` is constant while the tier is the thing that varies — without this the
+    // asset record cannot say whether q4 or q8 produced the image, which is precisely the question this
+    // story exists to answer. Read from the RESOLVED dir (the same basename the fit-gate budgets), so
+    // the label describes what loaded rather than what was requested — mirroring `nvfp4_selected`'s
+    // "the recorded label is gated on the resolver's own output" rule. `None` for a `modelPath` override
+    // or any dir with no recognizable tier basename: omit the key rather than assert a tier we can't see.
+    if let Some(tier) = tier_key_from_resolved_dir(base_dir) {
+        raw.insert("quantTier".to_owned(), Value::String(tier.to_owned()));
+    }
     raw
 }
 
@@ -328,7 +434,8 @@ async fn generate_candle_qwen_edit_stream(
     // This closes the candle edit-LoRA gap for the Qwen-Image-Edit family; the SDXL / FLUX.2 /
     // Z-Image candle edit engines still need an `adapters` field in candle-gen (tracked).
     adapters.extend(resolve_adapters(request, settings)?);
-    let mut raw_settings = qwen_edit_candle_raw_settings(request, &repo, steps, guidance);
+    let mut raw_settings =
+        qwen_edit_candle_raw_settings(request, &repo, &qwen_base, steps, guidance);
     // Record the Lightning recipe for telemetry / A-B parity (matches the MLX `distillLora` key format).
     if lightning {
         raw_settings.insert("sampler".to_owned(), Value::String("lightning".to_owned()));
@@ -361,14 +468,28 @@ async fn generate_candle_qwen_edit_stream(
             crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
             crate::vram_gate::cuda_vram_cap_gb(),
         );
-        // sc-11042: `nvfp4 = false` — the Qwen-Image-Edit lane resolves no standard tier subdir (it
-        // loads the edit repo snapshot directly), so no `nvfp4/` tier can be what runs here and the
-        // bits-derived key is the honest one. Wire `nvfp4_selected` with the resolved dir if this lane
-        // ever grows a tier layout.
-        let tier = crate::vram_gate::requested_tier_key(
+        // sc-13534: key the budget off the tier `resolve_qwen_edit_candle_base` ACTUALLY landed on, not
+        // the bits the request asked for — this lane now grows the tier layout the old `nvfp4 = false`
+        // note said to wire when it did. `gate_tier_key` is the shared txt2img helper (sc-12090 /
+        // sc-12425), and the aliasing it exists to prevent was live here in two ways:
+        //
+        // * The lane loaded a DENSE upstream snapshot while the gate sized q4 — 56.7 GB budgeted
+        //   (`vramGbByTier["q4"]`, measured on the PACKED turnkey q4) against a real bf16 peak of 81.7
+        //   (base) / 87.4 (Lightning). A ~25-30 GB UNDER-prediction, i.e. permissive: exactly the
+        //   reactive OOM the sc-10856 second-stage sequential gate exists to reject before.
+        // * `standard_tier_subdir` clamps to the INSTALLED tier, so a q4 request on a box holding only
+        //   `q8/` loads q8 (69.0) while the bits-derived key still said q4 (56.7) — the same
+        //   under-prediction, now reachable through a perfectly ordinary partial install.
+        //
+        // Reading the resolved basename makes both cases self-correcting. `convrot_resolved = false`:
+        // ConvRot is a Krea tier, not a Qwen-Image-Edit one. `nvfp4_selected` takes the resolved dir, so
+        // an `nvfp4/` pick that fell back to an installed tier is budgeted as what it fell back TO.
+        let tier = gate_tier_key(
+            /* convrot_resolved */ false,
+            &qwen_base,
             &request.advanced,
             &request.model_manifest_entry,
-            /* nvfp4 */ false,
+            nvfp4_selected(request, nvfp4_host_eligible(), Some(&qwen_base)),
         );
         let needed = crate::vram_gate::predicted_peak_gb(&request.model_manifest_entry, tier);
         match crate::vram_gate::resolve_offload(
@@ -494,4 +615,338 @@ async fn generate_candle_qwen_edit_stream(
         asset_writes,
     )
     .await
+}
+
+/// sc-13534: the candle Qwen-Image-Edit lane must LOAD the tier its `candle.vramGbByTier` gate SIZES.
+///
+/// Every assertion pins a NON-default value, so "the repo is non-empty" / "the gate returns some tier"
+/// style false greens are avoided. What is and is not actually mutation-killed, verified by running the
+/// mutations rather than assuming:
+///
+/// * **Killed** — reverting [`qwen_edit_candle_repo`] to the upstream default, reverting the receipt step
+///   or the tier descent inside [`qwen_edit_candle_base_dir`], or breaking [`gate_tier_key`]'s
+///   resolved-dir mapping. (Confirmed RED: 4 of these tests fail with the pre-sc-13534 bodies restored.)
+/// * **NOT killed** — rewiring the CALL SITES: `resolve_qwen_edit_candle_base` swapping back to a bare
+///   `huggingface_snapshot_dir`, or the fit-gate swapping `gate_tier_key` back to `requested_tier_key`.
+///   Both need an api/settings/job the unit layer cannot build, so they are held by compilation + review,
+///   exactly as `gate_tier_key`'s own extraction note in base.rs describes. That is the residual gap here.
+#[cfg(test)]
+mod qwen_edit_tier_reconcile_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The upstream repos this lane used to default to. No download flow ever fetches either — they are
+    /// named here ONLY so the tests can assert we never resolve them again.
+    const UPSTREAM_ORIGINAL: &str = "Qwen/Qwen-Image-Edit";
+    const UPSTREAM_2511: &str = "Qwen/Qwen-Image-Edit-2511";
+
+    fn request(model: &str, manifest: serde_json::Value, advanced: serde_json::Value) -> ImageRequest {
+        ImageRequest::from_payload(
+            json!({
+                "model": model,
+                "modelManifestEntry": manifest,
+                "advanced": advanced,
+            })
+            .as_object()
+            .unwrap(),
+        )
+    }
+
+    /// The real manifest shape for both live edit ids (config/manifests/builtin.models.jsonc): the
+    /// turnkey lives under `paths.model`, there is NO top-level `repo` and NO top-level `modelPath`, and
+    /// `mlx.quantize: 4` (sc-12155) declares q4 the default tier. This exact shape is what fell through
+    /// to the upstream default before sc-13534.
+    fn live_manifest() -> serde_json::Value {
+        json!({
+            // The real `downloads` shape: ONE turnkey repo, three tier variants, q4 flagged `default`.
+            // Load-bearing, not decoration — `requested_receipt_variant` derives the default tier from
+            // the `default: true` entry, and there is no upstream-repo entry anywhere in this list.
+            "downloads": [
+                { "provider": "huggingface", "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+                  "variant": "q4", "default": true, "files": ["q4/*"] },
+                { "provider": "huggingface", "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+                  "variant": "q8", "files": ["q8/*"] },
+                { "provider": "huggingface", "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+                  "variant": "bf16", "files": ["bf16/*"] }
+            ],
+            "paths": { "model": "${HF_CACHE}/SceneWorks/qwen-image-edit-2511-mlx" },
+            "mlx": { "quantize": 4 },
+            "candle": {
+                "minMemoryGb": 59,
+                "vramGbByTier": { "q4": 56.7, "q8": 69.0, "bf16": 81.7 },
+                "sequentialPeakGb": { "q4": 36.9, "q8": 39.3, "bf16": 52.2 },
+                "measured": true
+            }
+        })
+    }
+
+    /// Defect 1 + 2: every edit id resolves the SceneWorks turnkey — the repo the manifest `downloads`
+    /// actually provision — not an upstream snapshot nothing fetches.
+    ///
+    /// The `qwen_image_edit_2511` case is the wrong-WEIGHTS half: it used to fall to the family default
+    /// `Qwen/Qwen-Image-Edit`, the Aug-2025 ORIGINAL rather than 2511.
+    #[test]
+    fn every_edit_id_resolves_the_packed_turnkey_not_an_upstream_snapshot() {
+        for model in [
+            "qwen_image_edit",
+            "qwen_image_edit_2509",
+            "qwen_image_edit_2511",
+            "qwen_image_edit_2511_lightning",
+        ] {
+            let repo = qwen_edit_candle_repo(&request(model, live_manifest(), json!({})));
+            assert_eq!(
+                repo, QWEN_EDIT_CANDLE_TURNKEY_REPO,
+                "{model} must load the turnkey its downloads provision"
+            );
+            assert_ne!(repo, UPSTREAM_ORIGINAL, "{model} regressed to the ORIGINAL upstream weights");
+            assert_ne!(repo, UPSTREAM_2511, "{model} regressed to an upstream snapshot nothing downloads");
+        }
+    }
+
+    /// `paths.model` is NOT a top-level `modelPath`, and nothing flattens it — the precise reason the
+    /// old resolver never saw the turnkey. Pinned so a future "just read paths.model" refactor that
+    /// removes the `MODEL_TABLE` lookup cannot quietly reintroduce the upstream fallthrough.
+    #[test]
+    fn the_manifest_declares_paths_model_not_a_top_level_model_path() {
+        let request = request("qwen_image_edit_2511", live_manifest(), json!({}));
+        assert!(
+            request.model_manifest_entry.get("modelPath").is_none(),
+            "if this ever becomes Some, the modelPath branch — not the MODEL_TABLE row — resolves the base"
+        );
+        assert!(request.model_manifest_entry.get("repo").is_none());
+    }
+
+    /// An explicit manifest `repo` still wins over the catalog row (the pre-existing override contract).
+    #[test]
+    fn an_explicit_manifest_repo_overrides_the_catalog_row() {
+        let mut manifest = live_manifest();
+        manifest["repo"] = json!("SceneWorks/some-other-edit-rehost");
+        assert_eq!(
+            qwen_edit_candle_repo(&request("qwen_image_edit_2511", manifest, json!({}))),
+            "SceneWorks/some-other-edit-rehost"
+        );
+    }
+
+    /// Build a turnkey root holding only the named tiers, each with a packed `transformer/`.
+    fn turnkey_root(tiers: &[&str]) -> tempfile::TempDir {
+        let root = tempfile::tempdir().unwrap();
+        for tier in tiers {
+            let dir = root.path().join(tier).join("transformer");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("model.safetensors"), b"packed").unwrap();
+        }
+        root
+    }
+
+    /// Defect 3, part 1: the lane descends into a TIER SUBDIR. `QwenEdit::load` packed-detects from
+    /// `transformer/config.json`, so the directory alone decides the precision — and these subdirs are
+    /// exactly what the `vramGbByTier` rows were measured against.
+    ///
+    /// Drives THIS LANE's own [`qwen_edit_candle_base_dir`] — not the shared helper underneath it — so
+    /// deleting the descent from `resolve_qwen_edit_candle_base` (the pre-sc-13534 shape, which handed
+    /// the loader a bare repo root) turns this RED. No receipt here: this is the descent step alone.
+    #[test]
+    fn the_base_resolves_a_tier_subdir_never_the_turnkey_root() {
+        let root = turnkey_root(&["q4", "q8", "bf16"]);
+        let at = |advanced: serde_json::Value| {
+            qwen_edit_candle_base_dir(
+                None,
+                Some(root.path().to_path_buf()),
+                &request("qwen_image_edit_2511", live_manifest(), advanced),
+            )
+            .expect("a present snapshot resolves a tier dir")
+        };
+
+        assert_eq!(at(json!({ "mlxQuantize": 4 })), root.path().join("q4"));
+        assert_eq!(at(json!({ "mlxQuantize": 0 })), root.path().join("bf16"));
+
+        // Whatever the default resolves to, it must be a real tier dir — the root has no `transformer/`,
+        // so returning it (the old behavior) is not even loadable.
+        let resolved = at(json!({}));
+        assert_ne!(
+            resolved,
+            root.path(),
+            "the turnkey root is not loadable — it holds no transformer/"
+        );
+        assert!(resolved.join("transformer").is_dir());
+
+        // An absent turnkey stays absent — the lane reports "not candle-runnable" rather than
+        // manufacturing a path that would fail deep inside `QwenEdit::load`.
+        assert!(qwen_edit_candle_base_dir(
+            None,
+            None,
+            &request("qwen_image_edit_2511", live_manifest(), json!({}))
+        )
+        .is_none());
+    }
+
+    /// Defect 3, part 2 — the under-prediction this story is named for.
+    ///
+    /// `gate_tier_key` must budget the tier that RESOLVED, not the bits requested. Both halves matter:
+    ///
+    /// * A q4 request that CLAMPS to an installed q8 (a perfectly ordinary partial install —
+    ///   `standard_tier_subdir` falls back q8 → bf16 → q4) must budget q8's 69.0 GB, not q4's 56.7.
+    ///   The bits-derived key said q4 and under-predicted by 12 GB.
+    /// * A dir with no recognizable tier basename (the old upstream-snapshot shape) still falls back to
+    ///   the request key — pinned so the fallback contract stays visible.
+    #[test]
+    fn the_gate_budgets_the_resolved_tier_not_the_requested_bits() {
+        let manifest = live_manifest();
+        let req = request("qwen_image_edit_2511", manifest.clone(), json!({ "mlxQuantize": 4 }));
+        let entry = &req.model_manifest_entry;
+
+        // Only q8 installed: the q4 REQUEST resolves q8 on disk, so the gate must size q8.
+        let partial = turnkey_root(&["q8"]);
+        let resolved = standard_tier_subdir_gated(partial.path(), &req, false);
+        assert_eq!(resolved, partial.path().join("q8"));
+        let tier = gate_tier_key(false, &resolved, &req.advanced, entry, false);
+        assert_eq!(tier, "q8", "a q4 request that loaded q8 must be budgeted as q8");
+        assert_eq!(
+            crate::vram_gate::predicted_peak_gb(entry, tier),
+            Some(69.0 + 2.0),
+            "budgeting the requested q4 (56.7) for a q8 load under-predicts by ~12 GB"
+        );
+
+        // The bits-derived key — what the lane used before sc-13534 — disagrees. That disagreement IS
+        // the defect; pin it so nobody "simplifies" the gate back to it.
+        assert_eq!(
+            crate::vram_gate::requested_tier_key(&req.advanced, entry, false),
+            "q4"
+        );
+
+        // An unrecognizable basename (the old dense upstream snapshot dir) → fall back to the request key.
+        let opaque = tempfile::tempdir().unwrap();
+        assert_eq!(
+            gate_tier_key(false, opaque.path(), &req.advanced, entry, false),
+            "q4"
+        );
+    }
+
+    /// The PRODUCTION default path, end to end: a stock install fetches only the `default: true` q4
+    /// download, so a request with no `advanced.mlxQuantize` resolves `q4/` and the gate budgets q4's
+    /// 56.7 + 2.0 GB — the manifest's declared default tier (sc-12155), the tier the sc-11019 row was
+    /// measured on, and the tier that actually loads. All three finally name the same thing.
+    ///
+    /// This is the test that would have caught sc-13534: before the fix the load was a dense upstream
+    /// bf16 snapshot (81.7 GB) while the gate said 56.7.
+    #[test]
+    fn a_stock_q4_only_install_loads_and_budgets_q4() {
+        let stock = turnkey_root(&["q4"]);
+        let req = request("qwen_image_edit_2511", live_manifest(), json!({}));
+
+        let resolved = qwen_edit_candle_base_dir(None, Some(stock.path().to_path_buf()), &req)
+            .expect("the stock turnkey resolves");
+        assert_eq!(resolved, stock.path().join("q4"));
+
+        let tier = gate_tier_key(false, &resolved, &req.advanced, &req.model_manifest_entry, false);
+        assert_eq!(tier, "q4");
+        assert_eq!(
+            crate::vram_gate::predicted_peak_gb(&req.model_manifest_entry, tier),
+            Some(56.7 + 2.0)
+        );
+    }
+
+    /// **Sibling parity — the receipt step is what delivers it.** The txt2img `qwen_image` lane reaches
+    /// its tier through [`resolve_weights_dir`], which resolves a download RECEIPT keyed by
+    /// [`requested_receipt_variant`] and returns that tier dir BEFORE any `standard_tier_subdir` descent.
+    /// With no `advanced.mlxQuantize`, that variant is the manifest's `default: true` download — **q4**.
+    ///
+    /// The first cut of sc-13534 wired only the descent, so on a box with q4 AND q8 installed the edit
+    /// lane loaded **q8** while its txt2img sibling loaded **q4** — same checkpoint, same manifest, two
+    /// tiers, and ~12 GB more VRAM budgeted than the declared default needs. Mirroring the receipt step
+    /// fixes that; this test is the gate on it.
+    #[test]
+    fn a_tier_receipt_wins_over_the_descent_so_edit_matches_txt2img() {
+        let all_tiers = turnkey_root(&["q4", "q8", "bf16"]);
+        let req = request("qwen_image_edit_2511", live_manifest(), json!({}));
+
+        // The declared default is q4 — both from the manifest `mlx.quantize` the gate reads …
+        assert_eq!(
+            crate::vram_gate::requested_tier_key(&req.advanced, &req.model_manifest_entry, false),
+            "q4"
+        );
+        // … and from the `default: true` download the receipt variant resolves.
+        assert_eq!(requested_receipt_variant(&req).as_deref(), Some("q4"));
+
+        // A q4 receipt wins outright: the tier the download recorded is the tier that loads, even though
+        // q8 is installed and the bare descent would have preferred it.
+        let receipt = all_tiers.path().join("q4");
+        let resolved = qwen_edit_candle_base_dir(
+            Some(receipt.clone()),
+            Some(all_tiers.path().to_path_buf()),
+            &req,
+        )
+        .expect("the receipt resolves");
+        assert_eq!(resolved, receipt);
+
+        // Gate and load still agree, now on the DECLARED tier rather than the app-wide default.
+        let tier = gate_tier_key(false, &resolved, &req.advanced, &req.model_manifest_entry, false);
+        assert_eq!(tier, "q4");
+        assert_eq!(
+            crate::vram_gate::predicted_peak_gb(&req.model_manifest_entry, tier),
+            Some(56.7 + 2.0)
+        );
+
+        // Without a receipt the descent takes the app-wide q8 default (sc-10726) — the residual
+        // `mlx.quantize` vs `standard_tier_subdir` asymmetry tracked in sc-13542. Not an
+        // under-prediction: the gate follows the load either way, asserted here so that stays true.
+        let no_receipt = qwen_edit_candle_base_dir(None, Some(all_tiers.path().to_path_buf()), &req)
+            .expect("the turnkey resolves");
+        assert_eq!(no_receipt, all_tiers.path().join("q8"));
+        let fallback_tier = gate_tier_key(
+            false,
+            &no_receipt,
+            &req.advanced,
+            &req.model_manifest_entry,
+            false,
+        );
+        assert_eq!(fallback_tier, "q8");
+        assert_eq!(
+            crate::vram_gate::predicted_peak_gb(&req.model_manifest_entry, fallback_tier),
+            Some(69.0 + 2.0)
+        );
+    }
+
+    /// sc-13534: the asset record names the TIER, read off the resolved dir. Every tier of this family
+    /// shares one turnkey repo, so `repo` alone cannot answer "which weights made this image".
+    #[test]
+    fn telemetry_records_the_tier_that_actually_loaded() {
+        let root = turnkey_root(&["q4", "q8"]);
+        let req = request("qwen_image_edit_2511", live_manifest(), json!({}));
+
+        let q4 = qwen_edit_candle_raw_settings(
+            &req,
+            QWEN_EDIT_CANDLE_TURNKEY_REPO,
+            &root.path().join("q4"),
+            40,
+            4.0,
+        );
+        assert_eq!(q4.get("quantTier").and_then(Value::as_str), Some("q4"));
+
+        // A different tier from the SAME repo must record differently — the point of the field.
+        let q8 = qwen_edit_candle_raw_settings(
+            &req,
+            QWEN_EDIT_CANDLE_TURNKEY_REPO,
+            &root.path().join("q8"),
+            40,
+            4.0,
+        );
+        assert_eq!(q8.get("quantTier").and_then(Value::as_str), Some("q8"));
+        assert_eq!(
+            q4.get("repo"),
+            q8.get("repo"),
+            "repo is constant across tiers — which is why quantTier has to carry the signal"
+        );
+
+        // An unrecognizable dir (a `modelPath` override) omits the key rather than guessing.
+        let opaque = tempfile::tempdir().unwrap();
+        let unknown = qwen_edit_candle_raw_settings(
+            &req,
+            QWEN_EDIT_CANDLE_TURNKEY_REPO,
+            opaque.path(),
+            40,
+            4.0,
+        );
+        assert!(unknown.get("quantTier").is_none());
+    }
 }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -261,6 +261,13 @@ mod anima_gpu_smoke;
 // hardware evidence backing `macOnly: false` / `candle_routed = true`.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod sana_candle_gpu_smoke;
+// Real-weight GPU smoke for the candle Qwen-Image-Edit lane (sc-13534). Test-only + candle-only; drives
+// the WORKER's `resolve_qwen_edit_candle_base` (the tier/gate reconciliation this story landed) + a
+// bespoke `runtime_cuda::providers::qwen_image::QwenEdit` load + render, proving the resolver lands on the
+// packed q4 tier subdir of the `SceneWorks/qwen-image-edit-2511-mlx` turnkey (NOT the upstream snapshot
+// the pre-fix code reached) and that q4 packed-loads + renders a coherent edit on real CUDA.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod qwen_edit_candle_gpu_smoke;
 // Real-weight GPU smoke for the candle InstantID + PiD super-resolving decode (epic 7840, sc-8386).
 // Test-only + candle-only; drives the bespoke `runtime_cuda::providers::instantid::InstantId` provider across
 // Identity/Angle/Pose with the `pid_sdxl` student attached, asserting the PiD decode 4×-super-resolves

--- a/crates/sceneworks-worker/src/qwen_edit_candle_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/qwen_edit_candle_gpu_smoke.rs
@@ -1,0 +1,193 @@
+//! Local real-weight GPU smoke for the candle **Qwen-Image-Edit** worker lane (sc-13534 — the
+//! hardware-gated acceptance for the tier/gate reconciliation). `#[ignore]`d — run by hand on the RTX
+//! PRO 6000 (Blackwell sm_120). It drives the ACTUAL worker seam this story fixed —
+//! [`crate::image_jobs::resolve_qwen_edit_candle_base`] — then loads the bespoke
+//! `runtime_cuda::providers::qwen_image::QwenEdit` provider at the resolved dir and renders one real
+//! reference-conditioned edit.
+//!
+//! ## Why this smoke exists
+//!
+//! Before sc-13534 the lane resolved the UPSTREAM `Qwen/Qwen-Image-Edit(-2511)` snapshot — a repo no
+//! download flow fetches. So on a normal install the lane was dead, and on a dev box that happened to
+//! have the dense upstream snapshot cached it loaded DENSE bf16 while the fit-gate had sized q4. This
+//! smoke is the "the packed turnkey tier actually resolves + loads + renders" evidence:
+//!
+//!   1. The worker resolver lands on the `q4/` tier subdir of `SceneWorks/qwen-image-edit-2511-mlx`
+//!      (NOT the upstream repo, NOT the turnkey root that holds no `transformer/`).
+//!   2. `QwenEdit::load` packed-detects that tier from `transformer/config.json` and renders a coherent,
+//!      non-degenerate edit — proving the packed q4 path the sc-11019 `vramGbByTier` rows were measured
+//!      against is the path that runs.
+//!
+//! Build with `CUDA_COMPUTE_CAP=120` (native Blackwell sm_120). The HF cache env points at the real
+//! snapshot — no explicit weights path (the worker resolver finds it and, on Windows, hardlink-repairs
+//! the `hf`-populated blob symlinks candle can't traverse):
+//! ```text
+//! $env:HF_HOME="E:\huggingface"                # or HF_HUB_CACHE="E:\huggingface\hub"
+//! $env:QWEN_EDIT_OUT_DIR="D:\sceneworks-qwen-edit-validate"
+//! # optional: QWEN_EDIT_STEPS=8  QWEN_EDIT_GUIDANCE=4.0  QWEN_EDIT_SEED=42  QWEN_EDIT_W=768  QWEN_EDIT_H=768
+//! #           QWEN_EDIT_MODEL=qwen_image_edit_2511  QWEN_EDIT_PROMPT="..."
+//! cargo test -p sceneworks-worker --no-default-features --features backend-candle --release \
+//!   qwen_edit_worker_lane_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use gen_core::{CancelFlag, Image, OffloadPolicy, Progress};
+use runtime_cuda::providers::qwen_image::{QwenEdit, QwenEditPaths, QwenEditRequest};
+
+use super::smoke_support::{env_or, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
+
+/// sc-13534 worker-lane E2E: drive the ACTUAL worker base resolution + `QwenEdit::load` + render for the
+/// candle Qwen-Image-Edit lane on real CUDA. Calls the WORKER's
+/// [`crate::image_jobs::resolve_qwen_edit_candle_base`] the way `generate_candle_qwen_edit_stream` does,
+/// asserts it resolves the `q4/` tier subdir of the `SceneWorks/qwen-image-edit-2511-mlx` turnkey (NOT
+/// the upstream snapshot the pre-fix code reached, NOT the tier-less root), then packed-loads q4 and
+/// renders a coherent true-CFG edit against a synthetic reference.
+#[test]
+#[ignore = "real-weight worker-lane GPU smoke; needs the SceneWorks/qwen-image-edit-2511-mlx turnkey in \
+            the HF cache (HF_HUB_CACHE/HF_HOME) + a CUDA device (cap=120)"]
+fn qwen_edit_worker_lane_gpu_smoke() {
+    use crate::image_jobs::resolve_qwen_edit_candle_base;
+    use crate::settings::Settings;
+    use sceneworks_core::image_request::ImageRequest;
+    use serde_json::json;
+
+    let out_dir = std::path::PathBuf::from(env_or("QWEN_EDIT_OUT_DIR", "/tmp/qwen_edit_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let settings = Settings::from_env();
+
+    let model = env_or("QWEN_EDIT_MODEL", "qwen_image_edit_2511");
+    let steps: usize = env_or("QWEN_EDIT_STEPS", "8")
+        .parse()
+        .expect("QWEN_EDIT_STEPS");
+    let guidance: f32 = env_or("QWEN_EDIT_GUIDANCE", "4.0")
+        .parse()
+        .expect("QWEN_EDIT_GUIDANCE");
+    let seed: u64 = env_or("QWEN_EDIT_SEED", "42")
+        .parse()
+        .expect("QWEN_EDIT_SEED");
+    let w: u32 = env_or("QWEN_EDIT_W", "768").parse().expect("QWEN_EDIT_W");
+    let h: u32 = env_or("QWEN_EDIT_H", "768").parse().expect("QWEN_EDIT_H");
+    let prompt = env_or(
+        "QWEN_EDIT_PROMPT",
+        "turn the plain gray card into a lush watercolor painting of a mountain lake at sunrise",
+    );
+    let negative = env_or(
+        "QWEN_EDIT_NEG",
+        "blurry, low quality, jpeg artifacts, deformed",
+    );
+
+    // The minimal job payload the router hands `generate_candle_qwen_edit_stream`: an `edit_image` job on
+    // a Qwen-Image-Edit id with a source asset. `mlxQuantize: 4` pins the q4 tier deterministically —
+    // both the receipt-variant step and the `standard_tier_subdir` descent resolve q4 regardless of
+    // whether an app download receipt exists in this cache (an `hf`-populated cache has none). No
+    // manifest `repo`, so `qwen_edit_candle_repo` reads the turnkey off the MODEL_TABLE row — the exact
+    // production default this story restored.
+    let payload = json!({
+        "model": model,
+        "mode": "edit_image",
+        "sourceAssetId": "smoke-src",
+        "prompt": prompt,
+        "width": w,
+        "height": h,
+        "advanced": { "mlxQuantize": 4 },
+    });
+    let request = ImageRequest::from_payload(payload.as_object().unwrap());
+
+    // THE worker resolver (the sc-13534 change): edit lane → the q4 tier subdir of the packed turnkey.
+    let dir = resolve_qwen_edit_candle_base(&request, &settings)
+        .expect("resolve_qwen_edit_candle_base")
+        .unwrap_or_else(|| {
+            panic!(
+                "{model}: SceneWorks/qwen-image-edit-2511-mlx turnkey not in the HF cache — set \
+                 HF_HUB_CACHE/HF_HOME"
+            )
+        });
+    assert!(
+        dir.ends_with("q4"),
+        "{model}: worker must descend into the q4 tier subdir, got {}",
+        dir.display()
+    );
+    assert!(
+        dir.join("transformer").is_dir(),
+        "{model}: resolved tier dir must hold transformer/ (packed-detect reads its config.json), got {}",
+        dir.display()
+    );
+    // The exact defect this story fixed: never the upstream snapshot, never the tier-less turnkey root.
+    let dir_str = dir.to_string_lossy().replace('\\', "/");
+    assert!(
+        dir_str.contains("qwen-image-edit-2511-mlx"),
+        "{model}: must resolve the SceneWorks turnkey, not an upstream snapshot, got {dir_str}"
+    );
+    assert!(
+        !dir_str.contains("models--Qwen--Qwen-Image-Edit"),
+        "{model}: resolved the UPSTREAM repo — the pre-sc-13534 bug, got {dir_str}"
+    );
+    println!(
+        "[worker-smoke] {model}: resolve_qwen_edit_candle_base -> {}",
+        dir.display()
+    );
+
+    // Packed q4 load, resident residency (the default cross-request-cached path). No adapters — this is
+    // the production (non-distilled) true-CFG edit path; QwenEdit packed-detects q4 from the tier's
+    // transformer/config.json (group_size 64).
+    let model_engine = QwenEdit::load(&QwenEditPaths {
+        root: dir.clone(),
+        adapters: Vec::new(),
+        offload_policy: OffloadPolicy::Resident,
+    })
+    .unwrap_or_else(|e| panic!("QwenEdit::load({}): {e}", dir.display()));
+
+    // A synthetic reference: a flat mid-gray card. The prompt asks for a strong stylization, so a live
+    // edit must diverge from the flat input (a degenerate/black decode stays flat and fails the floor).
+    let reference = Image {
+        width: w,
+        height: h,
+        pixels: vec![128u8; (w * h * 3) as usize],
+    };
+
+    let cancel = CancelFlag::new();
+    let req = QwenEditRequest {
+        prompt: prompt.clone(),
+        negative: negative.clone(),
+        width: w,
+        height: h,
+        steps,
+        guidance,
+        seed,
+        lightning: false,
+        cancel: cancel.clone(),
+    };
+    println!(
+        "[worker-smoke] {model}: rendering {w}x{h} @ {steps} steps, guidance {guidance}, seed {seed} ..."
+    );
+    let started = std::time::Instant::now();
+    let mut steps_seen = 0u32;
+    let out = model_engine
+        .generate(&req, std::slice::from_ref(&reference), &mut |p| {
+            if let Progress::Step { current, .. } = p {
+                steps_seen = steps_seen.max(current);
+            }
+        })
+        .unwrap_or_else(|e| panic!("{model} generate: {e}"));
+    let elapsed = started.elapsed();
+
+    assert_eq!((out.width, out.height), (w, h), "output dims");
+    assert_eq!(out.pixels.len(), (w * h * 3) as usize, "RGB8 pixel count");
+    assert!(steps_seen >= 1, "expected denoise step progress");
+
+    // Degenerate-decode floor: a coherent edit clears the general per-pixel std-dev bar by a wide
+    // margin; a NaN / all-black / flat collapse pulls it toward 0.
+    let std = image_std(&out);
+    assert!(
+        std >= DEGENERATE_STD_FLOOR_DEFAULT,
+        "{model}: decode looks degenerate (per-pixel std {std:.3} < {DEGENERATE_STD_FLOOR_DEFAULT}) — \
+         the packed q4 tier did not render a live image"
+    );
+
+    let png = out_dir.join(format!("{model}_q4_{w}x{h}_s{seed}.png"));
+    save_png(&out, &png);
+    println!(
+        "[worker-smoke] {model}: q4 edit OK in {:.1}s (std {std:.2}) -> {}",
+        elapsed.as_secs_f32(),
+        png.display()
+    );
+}


### PR DESCRIPTION
## Story
[sc-13534](https://app.shortcut.com/trefry/story/13534) — verify the candle Qwen-Image-Edit lane loads the tier its `candle.vramGbByTier` gate sizes (dense upstream vs packed turnkey).

## What was wrong
`resolve_qwen_edit_candle_base` read a top-level `modelPath`, but the manifest declares the `SceneWorks/qwen-image-edit-2511-mlx` turnkey under **`paths.model`** — and `modelManifestEntry` passes through verbatim, so nothing flattens one into the other. Every request fell through to a hardcoded **upstream** `Qwen/Qwen-Image-Edit(-2511)` default that no `downloads` entry ever fetches. Three defects followed:

1. **Dead lane on a stock install** — the upstream repo is never downloaded, so the base never resolved and `qwen_edit_candle_available` was false. It only worked on a dev box with that snapshot cached from measurement work.
2. **Wrong weights** — the non-Lightning ids defaulted to `Qwen/Qwen-Image-Edit`, the **Aug-2025 original** (no `zero_cond_t` → silently 2509-style modulation), not 2511.
3. **The VRAM gate sized a tier that couldn't load** — budgeted q4 (56.7 GB) against a dense bf16 load (81.7 / 87.4 GB). A ~25–30 GB **under**-prediction — the permissive direction, i.e. the reactive OOM the sc-10856 sequential gate exists to reject before.

`QwenEdit::load` takes no tier argument — it packed-detects per `Linear` from `transformer/config.json`, so the **directory alone** decides the precision. (Confirmed on disk: all three turnkey tiers carry `zero_cond_t: true`; q4/q8 declare `quantization.group_size: 64`.)

## The fix — mirror the qwen txt2img sibling
- `qwen_edit_candle_repo` reads the turnkey off the `MODEL_TABLE` row (catalog-driven; the two lanes can't drift apart again).
- `resolve_qwen_edit_candle_base` resolves the tier the **same two-step way** `resolve_weights_dir` does: the download **receipt** (`default: true` → q4) first, then `standard_tier_subdir`. Both steps split into a pure `qwen_edit_candle_base_dir` for unit testing.
- The fit-gate keys off the **resolved dir** (`gate_tier_key`) — the tier that loads is the tier that's budgeted. This also fixes a second under-prediction: a q4 request that clamps to an installed q8 now budgets q8, not q4.
- Telemetry records `quantTier` (read off the resolved dir); the repo alone is constant across tiers.

## Tests + validation
- **8 unit tests**, mutation-verified: reverting either half of the fix (upstream repo default / dropping the tier resolution) turns 4 of them RED (checked by applying the pre-fix bodies and re-running).
- **Real-weights GPU smoke** (`qwen_edit_worker_lane_gpu_smoke`, `#[ignore]`d) driving the actual worker seam.
- **GPU-validated on an RTX PRO 6000 (sm_120):** the resolver lands on the `q4/` tier subdir of the turnkey (not the upstream repo, not the tier-less root), q4 packed-loads, and renders a **coherent 768² sunrise-lake edit** (40 steps, per-pixel std 46.0 — far above the degenerate floor).

## Gates
`cargo fmt --all --check`, default-lane `clippy`/`test`/`build`, the neither-build parity check, and candle-lane `clippy` + the full worker lib test (737 pass) all green.

## Follow-up
[sc-13542](https://app.shortcut.com/trefry/story/13542) (filed, `relates`): the `mlx.quantize` declaration is authoritative for the gate but inert for the load default (carried by the receipt/`default: true` chain) — catalog-wide across the standard-tier models, so it's its own story. A regression test here pins the current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)