### PR TITLE
feat(web): surface audio models in SetupWizard onboarding [sc-13480]

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2605,6 +2605,7 @@ export function App() {
         {showSetupWizard ? (
           <SetupWizard
             jobs={jobs}
+            macCapabilities={macCapabilities}
             models={models}
             onComplete={completeSetupWizard}
             onCreateProject={createProject}

--- a/apps/web/src/App.shell.test.jsx
+++ b/apps/web/src/App.shell.test.jsx
@@ -240,6 +240,108 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("different workspace folder");
   });
 
+  // sc-13480 (A3-followup): the SetupWizard used to enumerate only image|video|utility, so the
+  // audio models epic 13400 added were never offered during first-run onboarding. These models
+  // mix a usable audio model (Kokoro — voices[] ⇒ serves the "speech" mode) with a bare audio
+  // entry that serves NO mode. Onboarding must offer the usable one under a friendly "Audio
+  // models" group placed after video, and must NOT dangle the non-serving one (that is the
+  // audioModelUsable gate the Audio Studio already runs its download offers through).
+  const wizardAudioModels = [
+    {
+      id: "z_image_turbo",
+      name: "Z-Image-Turbo",
+      type: "image",
+      recommended: true,
+      downloadable: true,
+      installState: "missing",
+      downloadSizeLabel: "30.6 GB",
+      downloads: [{ repo: "Tongyi-MAI/Z-Image-Turbo" }],
+    },
+    {
+      id: "wan_2_2",
+      name: "Wan2.2",
+      type: "video",
+      downloadable: true,
+      installState: "missing",
+      downloadSizeLabel: "31.8 GB",
+      downloads: [{ repo: "Wan-AI/Wan2.2-TI2V-5B" }],
+    },
+    {
+      id: "kokoro_82m",
+      name: "Kokoro 82M",
+      type: "audio",
+      recommended: true,
+      downloadable: true,
+      installState: "missing",
+      downloadSizeLabel: "330 MB",
+      downloads: [{ repo: "hexgrad/Kokoro-82M" }],
+      // voices[] non-empty ⇒ audioModelUsable ⇒ serves the "speech" mode.
+      audio: { voices: [{ id: "af_heart", label: "Heart" }], languages: ["en-US"], sampleRates: [24000] },
+    },
+    {
+      id: "bare_audio",
+      name: "Bare Audio Entry",
+      type: "audio",
+      downloadable: true,
+      installState: "missing",
+      downloadSizeLabel: "10 MB",
+      downloads: [{ repo: "acme/bare-audio" }],
+      // No `audio` sub-block ⇒ serves no mode ⇒ audioModelUsable is false ⇒ NOT offered.
+    },
+  ];
+
+  it("offers usable audio models under an Audio group after video, gating non-serving entries (sc-13480)", async () => {
+    const props = renderWizard({ models: wizardAudioModels });
+    await act(async () => {
+      root.render(<SetupWizard {...props} />);
+    });
+    await settle();
+
+    // The friendly label — not the raw "audio" fallback — appears.
+    expect(container.textContent).toContain("Audio models");
+    // …and a usable audio model is actually surfaced for install.
+    expect(container.textContent).toContain("Kokoro 82M");
+    // The audioModelUsable gate drops the bare (no-mode) audio entry. This discriminates: with
+    // the gate removed, `bare_audio` is downloadable and WOULD render under Audio models.
+    expect(container.textContent).not.toContain("Bare Audio Entry");
+
+    // Canonical group order: image → video → audio (utility absent here).
+    const headings = [...document.body.querySelectorAll(".setup-wizard-group h3")].map(
+      (node) => node.textContent,
+    );
+    expect(headings).toEqual(["Image models", "Video models", "Audio models"]);
+  });
+
+  it("downloads a selected audio model through the same path as image/video (sc-13480)", async () => {
+    const props = renderWizard({ models: wizardAudioModels });
+    await act(async () => {
+      root.render(<SetupWizard {...props} />);
+    });
+    await settle();
+
+    // Kokoro is recommended ⇒ pre-checked. Its checkbox lives in the Audio group.
+    const kokoroLabel = [...document.body.querySelectorAll(".setup-wizard-model")].find((label) =>
+      label.textContent.includes("Kokoro 82M"),
+    );
+    expect(kokoroLabel).toBeTruthy();
+    expect(kokoroLabel.querySelector("input[type=checkbox]").checked).toBe(true);
+
+    const downloadButton = [...document.body.querySelectorAll("button")].find((button) =>
+      button.textContent.startsWith("Download"),
+    );
+    await act(async () => {
+      downloadButton.click();
+    });
+    await settle();
+
+    // Both recommended models (image + audio) fire through the shared onDownloadModel path…
+    const downloadedIds = props.onDownloadModel.mock.calls.map((call) => call[0].id);
+    expect(downloadedIds).toContain("kokoro_82m");
+    expect(downloadedIds).toContain("z_image_turbo");
+    // …and the gated, non-serving audio entry is never queued.
+    expect(downloadedIds).not.toContain("bare_audio");
+  });
+
   it("renders the app navigation against mocked API calls", async () => {
     root = createRoot(container);
     await act(async () => {

--- a/apps/web/src/screens/SetupWizard.jsx
+++ b/apps/web/src/screens/SetupWizard.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { Logo } from "../components/Logo.jsx";
 import { terminalStatuses } from "../constants.js";
+import { audioModelUsable } from "../modelEligibility.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
 
 // The curated "getting started" set is catalog-driven: a model is recommended when
@@ -21,6 +22,17 @@ function isDownloadable(model) {
   return model.downloadable !== false && Boolean(model.downloads?.[0]?.repo ?? model.repo);
 }
 
+// Which catalog models onboarding actually OFFERS. Image/video/utility ride the plain
+// downloadable check they always have. Audio is the new type (epic 13400 A3): an
+// `audio`-type entry is only offered when it's genuinely usable — i.e. it serves ≥1 Audio
+// Studio mode and isn't Mac-blocked — using the exact predicate the Audio Studio's own
+// download offers run through (modelEligibility.js `audioModelUsable`), so onboarding never
+// dangles a bare audio entry that no mode can drive. `audioModelUsable` already requires
+// `type === "audio"`, so the guard is a no-op for every other type.
+function isOfferable(model, caps) {
+  return isDownloadable(model) && (model.type !== "audio" || audioModelUsable(model, caps));
+}
+
 function downloadSizeText(model) {
   if (!model.downloadSizeLabel) {
     return "Size unavailable";
@@ -28,12 +40,12 @@ function downloadSizeText(model) {
   return model.downloadSizeEstimated ? `~${model.downloadSizeLabel}` : model.downloadSizeLabel;
 }
 
-function defaultSelection(models) {
+function defaultSelection(models, caps) {
   return new Set(
     models
       .filter(
         (model) =>
-          isDownloadable(model) &&
+          isOfferable(model, caps) &&
           model.installState !== "installed" &&
           isRecommended(model) &&
           !autoDownloadDisabled(model),
@@ -42,11 +54,34 @@ function defaultSelection(models) {
   );
 }
 
-const TYPE_LABELS = { image: "Image models", video: "Video models", utility: "Utility models" };
+const TYPE_LABELS = {
+  image: "Image models",
+  video: "Video models",
+  audio: "Audio models",
+  utility: "Utility models",
+};
 
-export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, onComplete, onOpenQueue }) {
+// Deterministic group order so audio always lands between video and utility regardless of
+// catalog iteration order. Types not listed here (future / "other") render after these, in
+// first-seen order.
+const TYPE_ORDER = ["image", "video", "audio", "utility"];
+
+function typeRank(type) {
+  const index = TYPE_ORDER.indexOf(type);
+  return index === -1 ? TYPE_ORDER.length : index;
+}
+
+export function SetupWizard({
+  models,
+  jobs,
+  macCapabilities,
+  onDownloadModel,
+  onCreateProject,
+  onComplete,
+  onOpenQueue,
+}) {
   const [step, setStep] = useState("models");
-  const [selected, setSelected] = useState(() => defaultSelection(models));
+  const [selected, setSelected] = useState(() => defaultSelection(models, macCapabilities));
   const [started, setStarted] = useState(() => new Set());
   const [projectName, setProjectName] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -62,12 +97,15 @@ export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, on
   // once it does (without clobbering a choice the user already made).
   useEffect(() => {
     if (!initializedRef.current && models.length) {
-      setSelected(defaultSelection(models));
+      setSelected(defaultSelection(models, macCapabilities));
       initializedRef.current = true;
     }
-  }, [models]);
+  }, [models, macCapabilities]);
 
-  const downloadable = useMemo(() => models.filter(isDownloadable), [models]);
+  const downloadable = useMemo(
+    () => models.filter((model) => isOfferable(model, macCapabilities)),
+    [models, macCapabilities],
+  );
   const grouped = useMemo(() => {
     const byType = new Map();
     for (const model of downloadable) {
@@ -77,7 +115,9 @@ export function SetupWizard({ models, jobs, onDownloadModel, onCreateProject, on
       }
       byType.get(key).push(model);
     }
-    return byType;
+    // Render groups in the canonical image → video → audio → utility order (then any
+    // other types, first-seen) so audio always slots in beside its peers.
+    return new Map([...byType.entries()].sort((a, b) => typeRank(a[0]) - typeRank(b[0])));
   }, [downloadable]);
 
   const activeDownloadJobs = useMemo(


### PR DESCRIPTION
## What changed

First-run onboarding (`SetupWizard`) enumerated model types as `image|video|utility` only, so the epic 13400 audio models (Kokoro, ACE-Step, etc.) were **never offered during onboarding**. Any `type: "audio"` catalog entry fell through to a raw `"audio"` heading with no friendly label and no ordered group placement.

This widens `SetupWizard` to a first-class `audio` category, mirroring image/video:

- **Friendly label + ordered placement** — added `"Audio models"` to `TYPE_LABELS` and a canonical `TYPE_ORDER` (`image → video → audio → utility`) so groups render deterministically regardless of catalog iteration order (unlisted/future types render after these, first-seen).
- **Offer driven off the A3 helper** — an `audio`-type entry is offered only when `audioModelUsable()` (from `modelEligibility.js`, shipped by A3/sc-13403) says it serves ≥1 Audio Studio mode and isn't Mac-blocked. This is the **exact predicate the Audio Studio's own download offers already run through** (`downloadOffersFor(models, audioModelUsable, caps)`), so onboarding never dangles a bare audio entry no mode can drive. Non-audio types keep their plain `isDownloadable` check — no behavior change for image/video/utility. `macCapabilities` is threaded through from `App.jsx` (the same value the Audio Studio uses; a no-op off Mac / pre-load).
- **Install path** — audio models install through the same `onDownloadModel` code path as image/video (checkbox → `pendingSelection` → `downloadSelected`); no new wiring.

## Reuses A3 helpers

No parallel audio logic invented. Offering is gated by the existing `audioModelUsable` from `apps/web/src/modelEligibility.js` (sc-13403), matching how `AudioStudio.jsx` gates its own download offers.

## Tests

Added to `apps/web/src/App.shell.test.jsx` (mirrors the existing image/video SetupWizard tests):
- Audio group renders under the **"Audio models"** label, positioned after Video, and drops a bare no-mode audio entry — **mutation-verified**: removing the gate re-surfaces `Bare Audio Entry` and the test fails.
- A usable audio model (Kokoro, `voices[]` ⇒ speech) is offered and downloads through the shared `onDownloadModel` path; the gated non-serving entry is never queued.

Full web suite green: **152 files / 2197 tests pass**. Lint: 0 errors on changed files.

## Light / dark

The render JSX is untouched — the audio group reuses the exact same themed `.setup-wizard-group` / `.setup-wizard-model` / `.setup-wizard-tag` markup as image/video, so light + dark theming is inherited automatically. No new markup or styles were added that could diverge in dark mode.

Closes [sc-13480](https://app.shortcut.com/trefry/story/13480).

🤖 Generated with [Claude Code](https://claude.com/claude-code)