### PR TITLE
fix(models): measure Boogu q8 candle VRAM + gate the default tier [sc-13533]

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2349,12 +2349,22 @@
         "quantize": 8,
         "repo": "SceneWorks/boogu-image-mlx"
       },
-      // Direct sc-13108 CUDA probes on RTX PRO 6000 Blackwell, exclusive GPU, 1024², seed 42,
-      // native 50-step Base path: q4 31.68 GB and bf16 54.40 GB from a 0.02 GB baseline.
-      // minMemoryGb 44 preserves the existing packed-tier headroom.
+      // Direct CUDA probes on RTX PRO 6000 Blackwell, exclusive GPU, 1024², seed 42, native 50-step
+      // Base path, from a 0.02 GB baseline: q4 31.68 and bf16 54.40 (sc-13108); q8 41.98 (sc-13533,
+      // same harness — candle-gen-boogu's `boogu-txt2img` example under `VramProbe`, one tier per
+      // process).
+      //
+      // sc-13533: q8 is this model's DEFAULT tier (`mlx.quantize: 8` — the shipped `base/` Q8 turnkey,
+      // and the ONLY variant `downloads` pulls), so shipping no q8 row here was the bug (Turbo's
+      // matching q8 gap is where it bit hard). `vram_gate::predicted_peak_gb` found no q8 row and fell
+      // through to `minMemoryGb`, returning a flat 44.0 GB. Base got LUCKY: 44.0 ≈ the real 41.98 peak
+      // + ~2 headroom, so its fit prediction is unchanged by this fix — but that was coincidence, not
+      // design (the fallback adds no headroom of its own and would drift the moment either number
+      // moved). The q8 row makes it principled: the gate now reads 41.98 + its 2 GB headroom for the
+      // exact tier the model defaults to. minMemoryGb 44 already covers 41.98 + ~2, so it is unchanged.
       "candle": {
         "minMemoryGb": 44,
-        "vramGbByTier": { "q4": 31.7, "bf16": 54.4 },
+        "vramGbByTier": { "q4": 31.7, "q8": 42.0, "bf16": 54.4 },
         "measured": true
       },
       "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Base",
@@ -2450,12 +2460,27 @@
         "quantize": 8,
         "repo": "SceneWorks/boogu-image-mlx"
       },
-      // Direct sc-13108 CUDA probes on RTX PRO 6000 Blackwell, exclusive GPU, 1024², seed 42,
-      // native 4-step Turbo path: q4 31.58 GB and bf16 54.46 GB from a 0.02 GB baseline.
-      // minMemoryGb 40 preserves the existing packed-tier headroom.
+      // Direct CUDA probes on RTX PRO 6000 Blackwell, exclusive GPU, 1024², seed 42, native 4-step
+      // Turbo path, from a 0.02 GB baseline: q4 31.58 and bf16 54.46 (sc-13108); q8 42.12 (sc-13533,
+      // same harness — candle-gen-boogu's `boogu-txt2img` example under `VramProbe`, one tier per
+      // process).
+      //
+      // sc-13533: q8 is this model's DEFAULT tier (`mlx.quantize: 8` — the shipped `turbo/` Q8
+      // turnkey, and the ONLY variant `downloads` pulls), so shipping no q8 row here was the bug.
+      // `vram_gate::predicted_peak_gb` found no q8 row and fell through to `minMemoryGb`, returning a
+      // flat 40.0 GB (the fallback adds no headroom) against a real 42.12 GB peak — 2.1 GB under, the
+      // PERMISSIVE direction (it admits a load that then OOMs), the outcome `predicted_peak_gb`'s own
+      // rustdoc warns the `minMemoryGb` fallthrough produces for a tier heavier than the lightest one.
+      // Adding the q8 row is the fix: the gate now predicts 42.12 + its 2 GB headroom = ~44.1 GB for a
+      // default Turbo render and sizes resident/sequential/reject correctly.
+      //
+      // minMemoryGb 40 → 44 is the secondary half: with all three tiers now rowed, minMemoryGb is only
+      // the fallback for an unrowed tier, but the schema still defines it as the DEFAULT (q8) tier's
+      // peak + headroom, and 40 sat BELOW the measured 42.12 default peak — an under-floor of its own.
+      // 44 clears the 42.12 peak (~1.9 GB margin) and matches Base.
       "candle": {
-        "minMemoryGb": 40,
-        "vramGbByTier": { "q4": 31.6, "bf16": 54.5 },
+        "minMemoryGb": 44,
+        "vramGbByTier": { "q4": 31.6, "q8": 42.1, "bf16": 54.5 },
         "measured": true
       },
       "licenseUrl": "https://huggingface.co/Boogu/Boogu-Image-0.1-Turbo",

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -562,6 +562,135 @@ fn every_image_model_with_a_candle_vram_block_declares_mlx_quantize() {
     }
 }
 
+/// sc-13533 — the sc-12155 lint above, strengthened from PRESENCE to COVERAGE: declaring
+/// `mlx.quantize` is not enough; the tier that declaration RESOLVES TO must itself have a measured
+/// `candle.vramGbByTier` row.
+///
+/// sc-12155 deliberately stopped at presence because a coverage check went RED on `boogu_image` /
+/// `boogu_image_turbo` — both declare `mlx.quantize: 8` (their shipped, and only auto-downloaded,
+/// Q8 `base/` / `turbo/` tier) while `vramGbByTier` carried only `{q4, bf16}`. With no `q8` row,
+/// [`vram_gate::predicted_peak_gb`](crate::vram_gate::predicted_peak_gb) fell past the row lookup to
+/// the `candle.minMemoryGb` floor — which that function's own rustdoc names as the WRONG number to
+/// land on, because the schema defines it as the DEFAULT (lightest) tier's peak and so it sizes a
+/// heavier tier PERMISSIVELY (an under-prediction admits a load that can OOM). sc-13533 measured the
+/// missing q8 rows on CUDA, so the check can now be enforced.
+///
+/// `advanced` is empty and `nvfp4` is false on purpose: this asks what a plain no-pick request
+/// budgets against — the manifest's OWN default tier. (NVFP4 is an explicit per-request opt-in that
+/// no shipping model packs, and it has a documented q8 degrade path of its own.)
+///
+/// Scoped to `type: "image"` for the same reason sc-12155 was: the video lane's resolvers
+/// (`video_jobs.rs`) never consult `manifest.mlx.quantize`, so a video entry's derived key here would
+/// be a fiction.
+///
+/// [`default_tier_key`] mirrors [`vram_gate::requested_tier_key`](crate::vram_gate) rather than
+/// calling it, because `vram_gate` is `backend-candle`-gated and this lint guards MANIFEST DATA that
+/// ships on every lane — gating it would stop it running in the default build, which is where a bad
+/// manifest edit lands first. The mirror cannot silently drift: the companion
+/// `default_tier_key_mirrors_the_production_resolver` below pins the two against each other across
+/// every shipped entry wherever the candle build exists.
+///
+/// Mutation check: delete the `q8` row from either boogu entry (or from `krea_2_raw`, whose default
+/// is also q8) → RED, naming the model and the tier it defaults to.
+#[test]
+fn every_image_model_budgets_its_default_tier_against_a_measured_row() {
+    let mut offenders = Vec::new();
+    for model in builtin_models_manifest() {
+        if model.get("type").and_then(Value::as_str) != Some("image") {
+            continue;
+        }
+        let Some(candle) = model.get("candle") else {
+            continue;
+        };
+        let id = model.get("id").and_then(Value::as_str).unwrap_or("<no id>");
+        let tier = default_tier_key(&model);
+        // Both stages of the gate, same invariant. `sequentialPeakGb` is OPTIONAL (absent ⇒
+        // `predicted_sequential_peak_gb` returns None and the Offload path stays best-effort by
+        // design, e.g. Boogu) — but a block that exists and skips the DEFAULT tier is the same
+        // silent hole as a missing `vramGbByTier` row, one stage further down.
+        for block in ["vramGbByTier", "sequentialPeakGb"] {
+            let Some(rows) = candle.get(block) else {
+                continue;
+            };
+            if rows.get(tier).and_then(Value::as_f64).is_none() {
+                let present = rows
+                    .as_object()
+                    .map(|rows| rows.keys().cloned().collect::<Vec<_>>().join(", "))
+                    .unwrap_or_default();
+                offenders.push(format!(
+                    "{id}.candle.{block} (defaults to {tier}; rows present: [{present}])"
+                ));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these image models default to a quant tier that has no measured `candle.vramGbByTier` row, \
+         so `predicted_peak_gb` falls through to the `candle.minMemoryGb` floor and sizes the \
+         DEFAULT tier against the LIGHTEST tier's number — a permissive under-prediction that can \
+         admit a load which then OOMs (sc-13533). Measure the tier and add its row: {offenders:?}"
+    );
+
+    // Pin the sc-13533 subjects on the value, not merely on the sweep above: both Boogu entries must
+    // still DERIVE q8 (the shipped `base/` / `turbo/` Q8 turnkey) and must carry a q8 row. Flipping
+    // `mlx.quantize` to dodge the lint, or dropping the row, both go RED here.
+    for id in ["boogu_image", "boogu_image_turbo"] {
+        let entry = builtin_model_entry(id);
+        assert_eq!(
+            default_tier_key(&entry),
+            "q8",
+            "{id} ships the Q8 turnkey as its only auto-downloaded tier, so a no-pick request must \
+             still derive q8 (sc-13533)"
+        );
+        assert!(
+            entry
+                .get("candle")
+                .and_then(|candle| candle.get("vramGbByTier"))
+                .and_then(|tiers| tiers.get("q8"))
+                .and_then(Value::as_f64)
+                .is_some(),
+            "{id} must carry a measured q8 `vramGbByTier` row — the tier it defaults to (sc-13533)"
+        );
+    }
+}
+
+/// The tier key a no-pick request derives for `model` from `mlx.quantize` alone — a lane-independent
+/// mirror of `vram_gate::requested_tier_key`'s bits map (`None`/`> 4` ⇒ q8, `<= 0` ⇒ bf16, `<= 4` ⇒
+/// q4) with `advanced` empty and `nvfp4` false. See the lint above for why this is a mirror and not a
+/// call; `default_tier_key_mirrors_the_production_resolver` keeps the two honest.
+fn default_tier_key(model: &Value) -> &'static str {
+    let bits = model
+        .get("mlx")
+        .and_then(|mlx| mlx.get("quantize"))
+        .and_then(Value::as_i64);
+    match bits {
+        None => "q8",
+        Some(bits) if bits <= 0 => "bf16",
+        Some(bits) if bits <= 4 => "q4",
+        Some(_) => "q8",
+    }
+}
+
+/// sc-13533: the ungated lint's [`default_tier_key`] mirror must agree with the real
+/// `vram_gate::requested_tier_key` on EVERY shipped manifest entry — so the always-on lint can never
+/// quietly guard a different rule than the resolver it exists to protect. Runs wherever the candle
+/// build does; the mirror itself runs everywhere.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn default_tier_key_mirrors_the_production_resolver() {
+    let no_advanced = serde_json::Map::new();
+    for model in builtin_models_manifest() {
+        let id = model.get("id").and_then(Value::as_str).unwrap_or("<no id>");
+        let entry = model.as_object().expect("manifest entries are JSON objects");
+        assert_eq!(
+            default_tier_key(&model),
+            crate::vram_gate::requested_tier_key(&no_advanced, entry, false),
+            "the gpu_and_manifest lint's tier mirror disagrees with vram_gate::requested_tier_key \
+             for {id} — update `default_tier_key` to match the resolver (sc-13533)"
+        );
+    }
+}
+
 /// epic 10765 sc-10920: the FLUX.2 `candle` blocks drive the dynamic fit-gate end-to-end against the
 /// SHIPPED manifest bytes — resident-fits → sequential-offload → reject-before-OOM. The pure
 /// `vram_gate` unit tests cover the decision logic on synthetic fixtures; THIS guards the data half:

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -554,6 +554,35 @@ def test_krea_2_turbo_candle_vram_tiers_match_measured_peaks():
     }
 
 
+def test_boogu_candle_vram_tiers_cover_and_pin_the_default_q8_tier():
+    """sc-13533: both Boogu entries must carry a MEASURED q8 row — the tier they default to.
+
+    `mlx.quantize: 8` makes the image-lane resolvers derive q8 for a no-pick request, and the shipped
+    `base/`/`turbo/` Q8 turnkey is the ONLY variant `downloads` pulls. The candle blocks originally
+    shipped only {q4, bf16} (sc-13108 measured only those two), so
+    `vram_gate::predicted_peak_gb(entry, "q8")` found no row and fell through to the flat `minMemoryGb`
+    floor, sizing the default tier ~2 GB UNDER its real peak and without the fit gate's 2 GB headroom —
+    the permissive direction. The q8 rows below are the direct CUDA measurements (RTX PRO 6000
+    Blackwell, exclusive GPU, 1024², seed 42, native path) that close it. Never regress them, and never
+    drop the q8 key. Pairs with the Rust coverage lint
+    `every_image_model_budgets_its_default_tier_against_a_measured_row`.
+    """
+    manifest = _load_builtin_models_manifest()
+    expected = {
+        "boogu_image": {"q4": 31.7, "q8": 42.0, "bf16": 54.4},
+        "boogu_image_turbo": {"q4": 31.6, "q8": 42.1, "bf16": 54.5},
+    }
+    for model_id, tiers in expected.items():
+        entry = next(model for model in manifest["models"] if model["id"] == model_id)
+        assert {
+            tier: entry["candle"]["vramGbByTier"][tier] for tier in ("q4", "q8", "bf16")
+        } == tiers, model_id
+        # The coarse `minMemoryGb` floor must not sit BELOW the DEFAULT (q8) tier's measured peak —
+        # that under-floor (turbo shipped 40 < 42.1) was the second face of this bug, exposed whenever
+        # `predicted_peak_gb` falls back to `minMemoryGb`.
+        assert entry["candle"]["minMemoryGb"] >= tiers["q8"], model_id
+
+
 def test_wan_2_2_candle_vram_tiers_match_measured_peaks():
     """sc-13175: never regress the measured 5B SEQUENTIAL peaks (or slide back to the resident ones).
 


### PR DESCRIPTION
## Summary

`boogu_image` and `boogu_image_turbo` declare `mlx.quantize: 8`, so the image-lane no-pick default derives tier **q8** (the shipped `base/`/`turbo/` Q8 turnkey — the **only** variant the `downloads` block pulls). But their `candle.vramGbByTier` shipped only `{q4, bf16}`, with **no q8 row** — so the candle VRAM fit gate mis-sized the exact tier these models default to.

Fixes [sc-13533](https://app.shortcut.com/trefry/story/13533) (epic 10721 — stop hard-defaulting the generation quant tier).

## Correcting the story's stated mechanism

The story claims `vram_gate::predicted_peak_gb(entry, "q8")` returns `None` and the gate goes **inert**. It doesn't. I verified empirically (a throwaway probe test): the q8→fallback only fires for `nvfp4`; a plain q8 miss falls through to the flat `candle.minMemoryGb` floor. So the gate was **live but mis-sized**:

| model | old `predicted_peak_gb("q8")` | real q8 peak | direction |
|---|---|---|---|
| `boogu_image_turbo` | 40.0 (`minMemoryGb`, no headroom) | **42.12** | **permissive** — 2.1 GB under, admits a load that then OOMs |
| `boogu_image` | 44.0 (`minMemoryGb`) | **41.98** | coincidentally cleared the peak, but lost the gate's headroom / principled sizing |

## The fix — story option (a), measure q8

Option (b) (change the default tier) would route a no-pick request to q4 — a tier the `downloads` block doesn't even fetch. So I measured q8 on CUDA.

**Direct probes:** RTX PRO 6000 Blackwell, exclusive GPU, 1024², seed 42, native path, via `candle-gen-boogu`'s `boogu-txt2img` example under `VramProbe` (one tier per process). Both renders verified as real images.

- `boogu_image` (Base, 50-step): **q8 = 41.98 GB** (sits between q4 31.68 and bf16 54.40)
- `boogu_image_turbo` (Turbo, 4-step): **q8 = 42.12 GB** (between q4 31.58 and bf16 54.46)

## Changes

- **`config/manifests/builtin.models.jsonc`** — add the measured q8 rows (42.0 / 42.1) to both Boogu candle blocks; bump `boogu_image_turbo` `candle.minMemoryGb` 40 → 44 (its 40 was mis-derived as a q4 gate and sat below the q8 default peak). `boogu_image` stays 44 (already ≥ 41.98 + headroom). Full provenance in-place.
- **`crates/sceneworks-worker/src/tests/gpu_and_manifest.rs`** — strengthen the sc-12155 lint from **presence** to **coverage**: `every_image_model_budgets_its_default_tier_against_a_measured_row` asserts every tiered image model's *derived* default tier has a measured `vramGbByTier` (and `sequentialPeakGb`, when present) row. It runs in the **default build** via a `default_tier_key` mirror of the `backend-candle`-gated `vram_gate::requested_tier_key`, pinned to the real resolver on every entry by the candle-gated `default_tier_key_mirrors_the_production_resolver`.
- **`tests/test_builtin_manifest_audit.py`** — pin the measured Boogu q8 peaks and the `minMemoryGb >= q8` floor invariant.

## Validation

- New lint goes **RED** naming both Boogu entries before the manifest fix, **GREEN** after (mutation-checked: flipping `mlx.quantize` or dropping the q8 row both re-RED it).
- `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` clean (default lane); worker `--lib` tests pass in **both** the default lane (363) and `--features backend-candle` (730). `pytest tests/test_builtin_manifest_audit.py` — 21 passed.
- An independent, fresh subagent reviewed the full diff against the story's requirements (verdict: ship; two comment-accuracy nits addressed).
- Re-verified all lints/audit on the post-merge tree.

## Scope note / follow-up

`boogu_image_edit` also declares `mlx.quantize: 8` but has **no `candle` block at all**, so its candle fit gate is skipped entirely (unmeasured). Out of scope here (the story names only base + turbo) and would need its own edit-path measurement (lazy f32 Qwen3-VL vision tower). Flagged for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>