### PR TITLE
feat(image-studio): side-by-side Original↔Edited compare in the Image Viewer

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -887,6 +887,17 @@ export function App() {
     () => restrictFoldedToScope(foldedPreviewAssets, previewScopeIds),
     [foldedPreviewAssets, previewScopeIds],
   );
+  // The source image an edit was derived from (asset.lineage.sourceAssetId), resolved
+  // from the live asset set so the Image Viewer can offer an Original↔Edited side-by-side
+  // compare (the edit stays its own separate tile — this is a view link, not a fold).
+  // Null when the previewed asset isn't a derived edit or its source is gone (purged).
+  const previewSourceAsset = useMemo(() => {
+    const sourceId = previewedAsset?.lineage?.sourceAssetId;
+    if (!sourceId) {
+      return null;
+    }
+    return assets.find((candidate) => candidate.id === sourceId) ?? null;
+  }, [assets, previewedAsset]);
   const previewNavigation = useMemo(() => {
     if (!previewedAsset || previewScopeAssets.length < 2) {
       return { previous: null, next: null };
@@ -2749,6 +2760,7 @@ export function App() {
           }}
           onUseRecipe={sendAssetRecipeToStudio}
           previousAsset={previewNavigation.previous}
+          sourceAsset={previewSourceAsset}
           purgeAsset={async (asset) => {
             await purgeAsset(asset);
             closePreview();

--- a/apps/web/src/App.preview.test.jsx
+++ b/apps/web/src/App.preview.test.jsx
@@ -225,6 +225,119 @@ describe("SceneWorks app shell", () => {
     expect(document.body.querySelector(".preview-modal img").getAttribute("src")).toContain("original.png");
   });
 
+  it("toggles a side-by-side Original↔Edited compare for edits with a resolvable source", async () => {
+    const noop = () => {};
+    const original = {
+      id: "asset-original",
+      projectId: "project-1",
+      displayName: "Plate",
+      type: "image",
+      status: {},
+      file: { path: "assets/images/original.png" },
+    };
+    const edited = {
+      id: "asset-edited",
+      projectId: "project-1",
+      displayName: "Plate (edited)",
+      type: "image",
+      status: {},
+      file: { path: "assets/images/edited.png" },
+      recipe: { mode: "edit_image", model: "z_image_turbo" },
+      lineage: { sourceAssetId: "asset-original", parents: ["asset-original"] },
+    };
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={edited}
+          deleteAsset={noop}
+          nextAsset={null}
+          onClose={noop}
+          onPreviewAsset={noop}
+          previousAsset={null}
+          purgeAsset={noop}
+          sourceAsset={original}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+
+    // Single view to start; a compare toggle is offered because the source resolves.
+    expect(document.body.querySelector(".preview-compare")).toBeNull();
+    const toggle = document.body.querySelector(".preview-compare-toggle");
+    expect(toggle).not.toBeNull();
+
+    await act(async () => {
+      toggle.click();
+    });
+
+    // Both the original and edited image render side by side, each labelled.
+    const compare = document.body.querySelector(".preview-compare");
+    expect(compare).not.toBeNull();
+    const srcs = [...compare.querySelectorAll("img")].map((img) => img.getAttribute("src"));
+    expect(srcs.some((src) => src.includes("original.png"))).toBe(true);
+    expect(srcs.some((src) => src.includes("edited.png"))).toBe(true);
+    expect(compare.textContent).toContain("Original");
+    expect(compare.textContent).toContain("Edited");
+
+    // Toggling off collapses back to the single edited view.
+    await act(async () => {
+      document.body.querySelector(".preview-compare-toggle").click();
+    });
+    expect(document.body.querySelector(".preview-compare")).toBeNull();
+  });
+
+  it("offers no compare toggle when an edit's source is gone (purged) or the asset isn't an edit", async () => {
+    const noop = () => {};
+    const base = {
+      id: "asset-edited",
+      projectId: "project-1",
+      displayName: "Plate (edited)",
+      type: "image",
+      status: {},
+      file: { path: "assets/images/edited.png" },
+      lineage: { sourceAssetId: "asset-original" },
+    };
+
+    // An edit whose source is no longer in the gallery → App resolves sourceAsset to null.
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={{ ...base, recipe: { mode: "edit_image", model: "z_image_turbo" } }}
+          deleteAsset={noop}
+          nextAsset={null}
+          onClose={noop}
+          onPreviewAsset={noop}
+          previousAsset={null}
+          purgeAsset={noop}
+          sourceAsset={null}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+    expect(document.body.querySelector(".preview-compare-toggle")).toBeNull();
+
+    // A non-edit asset never gets the compare toggle, even with a source present.
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={{ ...base, recipe: { mode: "text_to_image", model: "z_image_turbo" } }}
+          deleteAsset={noop}
+          nextAsset={null}
+          onClose={noop}
+          onPreviewAsset={noop}
+          previousAsset={null}
+          purgeAsset={noop}
+          sourceAsset={{ id: "asset-original", projectId: "project-1", type: "image", status: {}, file: { path: "x.png" } }}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+    expect(document.body.querySelector(".preview-compare-toggle")).toBeNull();
+  });
+
   // sc-8728 zoom math is extracted into pure helpers so the cursor-anchoring can be
   // asserted precisely (jsdom has no layout, so DOM-level anchoring can't be exercised).
   describe("preview zoom helpers (sc-8728)", () => {

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -74,6 +74,8 @@ export const Icon = {
     </svg>
   ),
   ChevDown: (p) => <I {...p} d="M6 9l6 6 6-6" />,
+  // Two side-by-side panes — the Image Viewer's Original↔Edited compare toggle.
+  Columns: (p) => <I {...p} d="M4 4h7v16H4zM13 4h7v16h-7z" />,
   Sliders: (p) => <I {...p} d="M4 6h10M18 6h2M4 12h2M10 12h10M4 18h14M18 18h2M14 4v4M6 10v4M16 16v4" />,
   Play: (p) => <I {...p} fill d="M7 4l13 8-13 8z" />,
   Pause: (p) => <I {...p} fill d="M7 5h4v14H7zM13 5h4v14h-4z" />,

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -738,6 +738,7 @@ export function FullscreenPreview({
   onUseRecipe,
   previousAsset,
   purgeAsset,
+  sourceAsset,
   updateAssetStatus,
 }) {
   const hasUpscaleVariants = Boolean(asset.variants?.original && asset.variants?.upscaled);
@@ -763,6 +764,22 @@ export function FullscreenPreview({
   // Zoom/pan is IMAGES ONLY — video keeps its native <video> controls and gets no
   // zoom overlay/UI (sc-8728). `isVideo` gates the whole zoom surface.
   const isVideo = assetCanRenderAsVideo(displayedAsset);
+
+  // Side-by-side compare (Original vs Edited) for Image-Studio edits that link back
+  // to a source asset still present in the gallery (asset.lineage.sourceAssetId,
+  // resolved by App into `sourceAsset`). Unlike the upscale pair the edit stays its
+  // OWN Library tile — this is a view-only toggle, never a fold. Excluded for video
+  // and for the upscale-variant fold, which owns the footer Original/Upscaled toggle.
+  const canCompare =
+    !isVideo && !hasUpscaleVariants && asset.recipe?.mode === "edit_image" && Boolean(sourceAsset);
+  const [compareMode, setCompareMode] = React.useState(false);
+  const toggleCompare = React.useCallback(() => setCompareMode((on) => !on), []);
+  // Drop compare when navigating to another asset (prev/next) so it never persists
+  // onto a non-edit or an unrelated source pairing.
+  React.useEffect(() => {
+    setCompareMode(false);
+  }, [asset.id]);
+  const compareActive = canCompare && compareMode;
 
   const viewportRef = React.useRef(null);
   const [view, setView] = React.useState(PREVIEW_FIT_VIEW);
@@ -938,6 +955,13 @@ export function FullscreenPreview({
         label: isFullscreen ? "Exit full screen" : "Full screen",
         onSelect: isFullscreen ? exitFullscreen : enterFullscreen,
       });
+      if (canCompare) {
+        items.push({
+          key: "compare",
+          label: compareActive ? "Exit compare" : "Compare with original",
+          onSelect: toggleCompare,
+        });
+      }
       if (!isVideo) {
         items.push({ key: "zoom-in", label: "Zoom In", onSelect: zoomIn });
         items.push({ key: "zoom-out", label: "Zoom Out", onSelect: zoomOut });
@@ -965,6 +989,9 @@ export function FullscreenPreview({
       fitToView,
       onEditImage,
       onEditInStudio,
+      canCompare,
+      compareActive,
+      toggleCompare,
     ],
   );
 
@@ -999,7 +1026,18 @@ export function FullscreenPreview({
           >
             <Icon.ArrowLeft size={18} />
           </button>
-          {isVideo ? (
+          {compareActive ? (
+            <div className="preview-compare" role="group" aria-label="Original and edited image side by side">
+              <figure className="preview-compare-pane">
+                <AssetMedia asset={sourceAsset} controls={false} />
+                <figcaption>Original</figcaption>
+              </figure>
+              <figure className="preview-compare-pane">
+                <AssetMedia asset={asset} controls={false} />
+                <figcaption>Edited</figcaption>
+              </figure>
+            </div>
+          ) : isVideo ? (
             <AssetMedia asset={displayedAsset} />
           ) : (
             <div
@@ -1028,7 +1066,7 @@ export function FullscreenPreview({
           >
             <Icon.ArrowRight size={18} />
           </button>
-          {isVideo ? null : (
+          {isVideo || compareActive ? null : (
             <div className="preview-zoom-controls" role="group" aria-label="Zoom controls">
               <button
                 aria-label="Zoom out"
@@ -1090,6 +1128,18 @@ export function FullscreenPreview({
                 Upscaled
               </button>
             </div>
+          ) : null}
+          {canCompare ? (
+            <button
+              aria-pressed={compareActive}
+              className={`preview-compare-toggle${compareActive ? " active" : ""}`}
+              onClick={toggleCompare}
+              title={compareActive ? "Exit side-by-side compare" : "Compare this edit with the original image"}
+              type="button"
+            >
+              <Icon.Columns size={16} />
+              <span>{compareActive ? "Exit compare" : "Compare original"}</span>
+            </button>
           ) : null}
           <div className="preview-actions">
             {/* Simple, discoverable Save As path — present in desktop AND browser (sc-8729).

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -11016,6 +11016,69 @@ details[open] > summary.lora-scope-group-heading::before,
   min-width: 188px;
 }
 
+/* Original↔Edited side-by-side compare for edits (view-only; the edit stays its own
+   Library tile). Fills the stage's middle grid column with two contained panes. */
+.preview-compare {
+  display: flex;
+  gap: 12px;
+  min-width: 0;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-compare-pane {
+  flex: 1 1 0;
+  min-width: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.preview-compare-pane img,
+.preview-compare-pane video {
+  width: 100%;
+  min-width: 0;
+  max-height: 70vh;
+  object-fit: contain;
+}
+
+.preview-compare-pane figcaption {
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Compare toggle sits in the footer where the Original/Upscaled toggle would be
+   (the two are mutually exclusive — an edit is never an upscale fold). */
+.preview-compare-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 12px;
+  font-size: 12.5px;
+  white-space: nowrap;
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border-radius: var(--r-md);
+}
+
+.preview-compare-toggle.active {
+  color: var(--text);
+  background: color-mix(in oklch, var(--accent) 20%, var(--surface-2));
+}
+
+/* In compare mode both panes must fit the black fullscreen stage without cropping. */
+.preview-modal.is-fullscreen .preview-compare-pane img,
+.preview-modal.is-fullscreen .preview-compare-pane video {
+  max-height: 92vh;
+}
+
 .preview-actions {
   gap: 8px;
   justify-content: flex-end;

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1158,6 +1158,20 @@ pub(crate) fn write_image_asset(
         index + 1
     );
 
+    // The source image an edit was derived from, so the Image Viewer can offer an
+    // Original↔Edited side-by-side compare (the edit stays its own asset — this is
+    // lineage, not a fold). Single-source edits carry it as `sourceAssetId`; the
+    // multi-image reference pickers (FLUX.2-dev multi-select, Krea two-reference)
+    // send `referenceAssetIds` with no scalar source, so anchor to the first
+    // reference. Non-edit jobs keep their own `sourceAssetId` (usually none).
+    let source_asset_id = request.source_asset_id.clone().or_else(|| {
+        if request.mode == "edit_image" {
+            request.reference_asset_ids.first().cloned()
+        } else {
+            None
+        }
+    });
+
     let fact = json!({
         "assetId": fresh_asset_id(),
         "type": "image",
@@ -1182,7 +1196,7 @@ pub(crate) fn write_image_asset(
         "stylePreset": request.style_preset,
         "characterId": request.character_id,
         "characterLookId": request.character_look_id,
-        "sourceAssetId": request.source_asset_id,
+        "sourceAssetId": source_asset_id,
         "rawAdapterSettings": raw_settings,
     });
     Ok(fact.as_object().cloned().expect("json! object literal"))

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -131,6 +131,57 @@ fn render_and_save_writes_png_and_contract_fact() {
     );
 }
 
+/// The Image Viewer's Original↔Edited side-by-side compare needs every edit's produced asset
+/// to carry `sourceAssetId` pointing at the image it was derived from. Single-source edits pass
+/// the scalar through; the multi-image reference pickers (FLUX.2-dev multi-select, Krea
+/// two-reference) drop the scalar source in favour of `referenceAssetIds`, so the produced fact
+/// anchors to the first reference. A plain txt2img job records no source.
+#[test]
+fn edit_asset_records_its_source_for_the_viewer_compare() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path();
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+
+    let write = |req: &ImageRequest| {
+        let plan = ImagePlan::new(req);
+        let seed = resolve_seed(req, 0);
+        let pixels = stub_rgb8(req.width, req.height, seed);
+        write_image_asset(
+            &plan,
+            0,
+            seed,
+            req.width,
+            req.height,
+            pixels,
+            STUB_ADAPTER,
+            stub_raw_settings(req),
+            project_path,
+        )
+        .unwrap()
+    };
+
+    // Single-source edit: the scalar `sourceAssetId` is carried straight through.
+    let single = write(&request(json!({
+        "projectId": "p", "model": "z_image_turbo", "mode": "edit_image", "sourceAssetId": "orig_1"
+    })));
+    assert_eq!(single["sourceAssetId"], json!("orig_1"));
+
+    // Multi-image edit (no scalar source): anchor to the first reference so the edit still
+    // links back to an original for the compare.
+    let multi = write(&request(json!({
+        "projectId": "p", "model": "flux_2_dev", "mode": "edit_image",
+        "referenceAssetIds": ["ref_a", "ref_b"]
+    })));
+    assert_eq!(multi["sourceAssetId"], json!("ref_a"));
+
+    // Plain txt2img job: no source, and `referenceAssetIds` outside edit mode is never anchored.
+    let plain = write(&request(json!({
+        "projectId": "p", "model": "z_image_turbo", "prompt": "a hillside",
+        "referenceAssetIds": ["ignored"]
+    })));
+    assert_eq!(plain["sourceAssetId"], Value::Null);
+}
+
 /// F-003 / sc-11159: a path-traversal / absolute model id in the payload must NOT let the
 /// written PNG escape the project dir. The model id becomes a filename component, so a `../`,
 /// `..\`, or `/abs` id would otherwise land the asset (and its `create_dir_all` + rename)


### PR DESCRIPTION
## What

In the Image Studio, edits now stay **linked** to the image they were edited from, and the fullscreen **Image Viewer** gains a **Compare** toggle that expands to a side-by-side **Original | Edited** view (and collapses back).

The edited image remains its **own separate asset** in the Assets list — this is a view link only, *not* an upscale-style fold (both tiles stay visible in the Library).

## Why

You couldn't tell how faithful an edit was to its source without hunting down the original tile and eyeballing them separately. Now it's one click in the viewer.

## How

**Worker** (`crates/sceneworks-worker/src/image_jobs.rs`)
- `write_image_asset` records the produced edit's `sourceAssetId` for **any model**:
  - single-source edits pass the scalar `sourceAssetId` straight through (already did);
  - the multi-image reference pickers (FLUX.2-dev multi-select, Krea two-reference) drop the scalar in favour of `referenceAssetIds`, so the fact now **anchors to the first reference** so the edit still links back to an original;
  - non-edit txt2img jobs are unchanged (no source).

**Web**
- `App.jsx` resolves the previewed edit's `lineage.sourceAssetId` against the live asset set and passes it to `FullscreenPreview` as `sourceAsset` (null when the source was purged).
- `FullscreenPreview` (`components/assetPanels.jsx`) shows a **Compare original / Exit compare** toggle — a footer button **and** a right-click menu entry (so it's reachable in fullscreen, where the footer is hidden) — only for `edit_image` assets whose source is still present. Compare resets when navigating prev/next. New `Columns` icon + compare CSS.

## Scope notes
- Edits are **not** folded — both the original and the edit keep their own Library tiles, exactly as requested.
- The compare toggle never appears for videos or for the upscale-variant fold (which keeps its own Original/Upscaled toggle).

## Tests
- **Worker**: `edit_asset_records_its_source_for_the_viewer_compare` — asserts single-source passthrough, multi-image first-reference anchor, and no-source for plain txt2img.
- **Web**: compare toggle expand/collapse with both panes rendering; and the no-source (purged) / non-edit gates hide the toggle.

Verified locally: web vitest (preview + assetPanels context/fullscreen suites), worker `cargo test`, `rustfmt --check`, `cargo clippy --all-targets -D warnings`, and `eslint` (0 errors) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)