### PR TITLE
fix(audio): predownload chatterbox_tts ve+perth co-requisites for offline install parity [sc-13541]

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -280,6 +280,20 @@ fn build_model_download_job_payload(
     );
     job_payload.insert("repo".to_owned(), Value::String(repo.clone()));
     job_payload.insert("files".to_owned(), json!(files));
+    // Forward an explicit pinned `revision` (sc-13541) so the worker fetches the exact commit SHA the
+    // runtime resolver reads, not `main`. The worker defaults to `main` when this is absent, so
+    // omitting `revision` on an entry keeps its behavior unchanged. Required for companion weights a
+    // provider resolves via a pinned-SHA `hf_get_pinned` (chatterbox_tts's ve/perth co-requisites): the
+    // resolver refuses a non-SHA revision and reads `snapshots/<sha>/`, so a main-branch predownload
+    // would land in the wrong snapshot and offline generation would fail.
+    if let Some(revision) = download
+        .get("revision")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        job_payload.insert("revision".to_owned(), Value::String(revision.to_owned()));
+    }
     // Record which quant tier this job installs (sc-8508) so the download record + per-variant
     // install tracking agree on the tier. Falls back to the selected entry's own `variant` when the
     // request omitted one (the default tier may still be a labeled variant).

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -2353,6 +2353,94 @@ async fn model_download_job_enqueues_co_requisite_dependencies() {
 }
 
 #[tokio::test]
+async fn model_download_job_forwards_pinned_revision_for_co_requisite() {
+    // sc-13541: a co-requisite whose weight the runtime resolves via a pinned-SHA `hf_get_pinned`
+    // (chatterbox_tts's ve/perth) must have its `revision` forwarded to the download job, so the worker
+    // fetches that exact commit into `snapshots/<sha>/` — where the resolver reads offline. The planner
+    // historically dropped `revision` and the worker defaulted to `main`, which would populate the wrong
+    // snapshot. The primary download declares NO revision and must keep the `main` default (no
+    // `revision` key), so this change is additive and can't perturb the other seeded models.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+            {
+              "schemaVersion": 1,
+              "models": [{
+                "id": "chatterbox_tts",
+                "name": "Chatterbox",
+                "type": "audio",
+                "family": "chatterbox",
+                "downloads": [
+                  { "provider": "huggingface", "repo": "ResembleAI/chatterbox", "files": ["t3_cfg.safetensors"] },
+                  { "provider": "huggingface", "repo": "ResembleAI/chatterbox", "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18", "coRequisite": true, "files": ["ve.safetensors"] },
+                  { "provider": "huggingface", "repo": "SceneWorks/perth-implicit", "revision": "80b60f9caead09b8d3b512bda0b24038f28c08ec", "coRequisite": true, "files": ["perth_implicit.safetensors"] }
+                ]
+              }]
+            }
+            "#,
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, primary) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/chatterbox_tts/download",
+        json!({ "requestedGpu": "auto" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    // The primary download stays on main: no `revision` key is forwarded.
+    assert_eq!(primary["payload"]["repo"], "ResembleAI/chatterbox");
+    assert!(
+        primary["payload"]
+            .get("revision")
+            .map_or(true, Value::is_null),
+        "the primary download must not carry a pinned revision (defaults to main)"
+    );
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    let download_jobs = jobs
+        .as_array()
+        .expect("jobs is an array")
+        .iter()
+        .filter(|job| job["type"] == "model_download")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        download_jobs.len(),
+        3,
+        "the primary plus its two pinned companion co-requisites each get a download job"
+    );
+    for (repo, files, sha) in [
+        (
+            "ResembleAI/chatterbox",
+            "ve.safetensors",
+            "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
+        ),
+        (
+            "SceneWorks/perth-implicit",
+            "perth_implicit.safetensors",
+            "80b60f9caead09b8d3b512bda0b24038f28c08ec",
+        ),
+    ] {
+        let job = download_jobs
+            .iter()
+            .find(|job| job["payload"]["repo"] == repo && job["payload"]["files"][0] == files)
+            .unwrap_or_else(|| panic!("a download job for the {repo} co-requisite is enqueued"));
+        assert_eq!(
+            job["payload"]["revision"], sha,
+            "the {repo} co-requisite job must forward its pinned revision so the worker fetches the \
+             exact snapshot the runtime resolver reads offline"
+        );
+    }
+}
+
+#[tokio::test]
 async fn model_catalog_gates_install_state_on_co_requisite() {
     // sc-9696: the entry is "installed" only when the primary AND every co-requisite are cached.
     // Primary present but the gemma-2-2b-it caption encoder missing → not-installed + repairable, so
@@ -3016,6 +3104,120 @@ fn builtin_manifest_registers_wan_a14b_lightning_corequisite() {
         assert!(
             lightning.get("variant").is_none(),
             "{model_id} Lightning coRequisite is not a quant tier"
+        );
+    }
+}
+
+#[test]
+fn builtin_manifest_pins_chatterbox_companion_corequisites() {
+    // sc-13541 (epic 13400 / E1 follow-up): the chatterbox_tts generator resolves two companion
+    // weights at generate() time via pinned-SHA `hf_get_pinned` fetches, NOT from its snapshot dir —
+    // the ve.safetensors speaker embedder (ResembleAI/chatterbox @ 5bb1f6ee…) and the PerTh
+    // watermarker (SceneWorks/perth-implicit @ 80b60f9c…; generate() ALWAYS watermarks, so a missing
+    // PerTh weight is a hard error). Both must install as `coRequisite` downloads pinned to the EXACT
+    // full 40-hex commit SHA the resolver uses: `hf_get_pinned` refuses a branch/tag/short SHA and
+    // reads `models--<org>--<name>/snapshots/<sha>/`, so a main-branch predownload lands in the wrong
+    // snapshot and offline generation fails. This test guards both the presence AND the exact pinned
+    // revisions (a SHA drift here silently reintroduces the offline gap this story closed).
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../config/manifests/builtin.models.jsonc");
+    let raw = std::fs::read_to_string(&manifest_path).expect("read builtin.models.jsonc");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(&raw)).expect("parse builtin.models.jsonc");
+    let models = manifest["models"].as_array().expect("models array");
+    let chatterbox = models
+        .iter()
+        .find(|entry| entry["id"] == "chatterbox_tts")
+        .expect("chatterbox_tts is registered in the catalog");
+    let downloads = chatterbox["downloads"].as_array().expect("downloads array");
+
+    // The primary download (the three files the generator loads from its snapshot dir) is NOT a
+    // co-requisite and carries NO revision — it stays on `main`, unchanged by this story.
+    let primary = downloads
+        .iter()
+        .find(|download| download.get("coRequisite").and_then(Value::as_bool) != Some(true))
+        .expect("chatterbox_tts has a primary download");
+    assert_eq!(primary["repo"], "ResembleAI/chatterbox");
+    assert!(
+        primary.get("revision").is_none(),
+        "the primary chatterbox download must stay on main (no pinned revision)"
+    );
+
+    // (repo, file, expected full-SHA revision) for each companion co-requisite. The SHAs are the exact
+    // pins in the inference resolvers at the SceneWorks-pinned inference commit (candle_audio_chatterbox_ve
+    // and candle-audio-chatterbox/src/perth.rs).
+    let cases = [
+        (
+            "ResembleAI/chatterbox",
+            "ve.safetensors",
+            "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
+        ),
+        (
+            "SceneWorks/perth-implicit",
+            "perth_implicit.safetensors",
+            "80b60f9caead09b8d3b512bda0b24038f28c08ec",
+        ),
+    ];
+    let co_requisites: Vec<&Value> = downloads
+        .iter()
+        .filter(|download| download.get("coRequisite").and_then(Value::as_bool) == Some(true))
+        .collect();
+    assert_eq!(
+        co_requisites.len(),
+        cases.len(),
+        "chatterbox_tts declares exactly the ve + PerTh companion co-requisites"
+    );
+    for (repo, file, sha) in cases {
+        let entry = co_requisites
+            .iter()
+            .find(|download| download["repo"] == repo && download["files"][0] == file)
+            .unwrap_or_else(|| panic!("chatterbox_tts declares the {repo} / {file} co-requisite"));
+        assert_eq!(entry["provider"], "huggingface");
+        let files: Vec<&str> = entry["files"]
+            .as_array()
+            .expect("co-requisite files array")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(
+            files,
+            vec![file],
+            "{repo} co-requisite fetches exactly the one companion weight"
+        );
+        let revision = entry["revision"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{repo} co-requisite pins a revision"));
+        assert_eq!(
+            revision, sha,
+            "{repo} co-requisite must pin the exact SHA the runtime's hf_get_pinned resolves"
+        );
+        // hf_get_pinned rejects anything but a full 40-hex commit SHA, so a short/branch revision would
+        // resolve online but hard-fail offline — assert the shape the resolver requires.
+        assert_eq!(
+            revision.len(),
+            40,
+            "{repo} revision must be a full commit SHA"
+        );
+        assert!(
+            revision.chars().all(|c| c.is_ascii_hexdigit()),
+            "{repo} revision must be a hex commit SHA"
+        );
+        // A co-requisite is never a selectable quant tier, and it must be fetched on every platform the
+        // model supports (candle-native everywhere), matching the primary download's platform set.
+        assert!(
+            entry.get("variant").is_none(),
+            "{repo} co-requisite is not a quant tier"
+        );
+        let platforms: Vec<&str> = entry["platforms"]
+            .as_array()
+            .expect("co-requisite platforms array")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert_eq!(
+            platforms,
+            vec!["macos", "windows", "linux"],
+            "{repo} co-requisite installs on every platform"
         );
     }
 }

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -3144,8 +3144,11 @@ fn builtin_manifest_pins_chatterbox_companion_corequisites() {
     );
 
     // (repo, file, expected full-SHA revision) for each companion co-requisite. The SHAs are the exact
-    // pins in the inference resolvers at the SceneWorks-pinned inference commit (candle_audio_chatterbox_ve
-    // and candle-audio-chatterbox/src/perth.rs).
+    // pins in the inference resolvers at the SceneWorks-pinned inference commit:
+    //   ve   -> candle_audio_chatterbox_ve::{HUB_REPO, HUB_REVISION}      (crates/audio/candle-audio-chatterbox-ve/src/model.rs)
+    //   perth-> candle_audio_chatterbox::perth::{PERTH_HUB_REPO, PERTH_HUB_REVISION} (crates/audio/candle-audio-chatterbox/src/perth.rs)
+    // This test hardcodes them (it cannot link the git-dep consts), so a drift between the manifest and
+    // the resolver still needs the offline DoD smoke (voiceclone_smoke.rs) to catch it end to end.
     let cases = [
         (
             "ResembleAI/chatterbox",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -8714,10 +8714,18 @@
       // clone model, and falls back to the Kokoro→OpenVoice conversion chain otherwise (the routing is
       // gated purely on the audio catalog's registration + Capabilities, not a hardcoded id).
       //
-      // `downloads` pins the three files the generator loads from its snapshot dir. The 256-d speaker
-      // embedder (ve.safetensors, the sibling `chatterbox_ve` model) and the PerTh watermarker
-      // (SceneWorks/perth-implicit, MIT) are pinned-SHA hub co-requisites the provider resolves at
-      // generate time, exactly as the inference lane does (offline predownload parity: sc-13541).
+      // `downloads` pins the three files the generator loads from its snapshot dir, PLUS the two
+      // companion weights the provider resolves at generate time via pinned-SHA hub fetches (NOT from
+      // the snapshot dir): the 256-d speaker embedder `ve.safetensors` (candle_audio_chatterbox_ve
+      // `hf_get_pinned(ResembleAI/chatterbox @ 5bb1f6ee…, ve.safetensors)`) and the PerTh provenance
+      // watermarker `perth_implicit.safetensors` (`hf_get_pinned(SceneWorks/perth-implicit @ 80b60f9c…)`;
+      // generate() ALWAYS watermarks, so a missing PerTh weight is a hard error). Both are declared as
+      // `coRequisite` downloads (sc-9696) with an explicit pinned `revision`: the runtime's `hf_get_pinned`
+      // rejects anything but a full 40-hex commit SHA and reads `models--<org>--<name>/snapshots/<sha>/`,
+      // so a plain main-branch predownload would land in the WRONG snapshot and offline generation would
+      // fail (sc-13541). Pinning `revision` to the exact SHA the resolver uses materializes each file in
+      // the same pinned-SHA snapshot the runtime resolves — so a fresh install is fully self-contained
+      // offline, matching every other seeded audio model.
       "id": "chatterbox_tts",
       "name": "Chatterbox (Cloned-Voice TTS)",
       "family": "chatterbox",
@@ -8755,6 +8763,55 @@
           "estimatedSizeBytes": 3186163834,
           "footprint": {
             "diskSizeBytes": 3186163834
+          }
+        },
+        {
+          // Co-requisite (sc-13541): the 256-d speaker embedder the provider resolves at generate time
+          // via candle_audio_chatterbox_ve::resolve_pinned_file() ->
+          // hf_get_pinned(ResembleAI/chatterbox @ 5bb1f6ee…, ve.safetensors). `revision` MUST be the full
+          // 40-hex SHA the resolver pins — hf_get_pinned refuses a branch/tag and reads
+          // snapshots/<sha>/, so a main-branch fetch would populate the wrong snapshot and offline
+          // generation would fail. Shares the ResembleAI/chatterbox repo cache with the primary download
+          // above but lands in its own pinned-SHA snapshot.
+          "provider": "huggingface",
+          "repo": "ResembleAI/chatterbox",
+          "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
+          "coRequisite": true,
+          "files": [
+            "ve.safetensors"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 5695784,
+          "footprint": {
+            "diskSizeBytes": 5695784
+          }
+        },
+        {
+          // Co-requisite (sc-13541): the PerTh provenance watermarker the provider resolves at generate
+          // time via resolve_perth_weights() -> hf_get_pinned(SceneWorks/perth-implicit @ 80b60f9c…,
+          // perth_implicit.safetensors). generate() ALWAYS watermarks (no disable flag), so a missing
+          // PerTh weight is a hard error; predownloading it at the pinned rev makes offline generation
+          // self-contained. `PERTH_SNAPSHOT` is the runtime's offline-override escape hatch, but the
+          // pinned-SHA snapshot this materializes is resolved with no override needed. MIT-licensed.
+          "provider": "huggingface",
+          "repo": "SceneWorks/perth-implicit",
+          "revision": "80b60f9caead09b8d3b512bda0b24038f28c08ec",
+          "coRequisite": true,
+          "files": [
+            "perth_implicit.safetensors"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 37392704,
+          "footprint": {
+            "diskSizeBytes": 37392704
           }
         }
       ],

--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -510,44 +510,127 @@ fn synthetic_reference() -> gen_core::AudioTrack {
     }
 }
 
+/// Sorted names directly under `dir` (empty when `dir` is absent) — a cheap fingerprint for asserting
+/// that a directory was neither added to nor removed from.
+fn dir_entry_names(dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Fingerprint of the machine's REAL HF cache's chatterbox + perth entries (`snapshots/` and `refs/`
+/// listings). The offline DoD smoke captures this before/after to prove it never reads into or writes
+/// the real `~/.cache/huggingface` — everything must stay inside the isolated temp cache.
+fn real_cache_fingerprint(chatterbox_dir: &Path, perth_dir: &Path) -> Vec<Vec<String>> {
+    vec![
+        dir_entry_names(&chatterbox_dir.join("snapshots")),
+        dir_entry_names(&chatterbox_dir.join("refs")),
+        dir_entry_names(&perth_dir.join("snapshots")),
+        dir_entry_names(&perth_dir.join("refs")),
+    ]
+}
+
 /// sc-13541 (epic 13400 / E1 follow-up) — **offline install-parity DoD**. `#[ignore]`d; run by hand
 /// on an Apple-Silicon Mac (downloads ~3.2 GB into an ISOLATED temp HF cache):
 /// ```text
 /// cargo test -p sceneworks-worker chatterbox_offline_install_parity_smoke -- --ignored --nocapture
 /// ```
-/// Proves the acceptance criterion end to end: install `chatterbox_tts` on a machine with an EMPTY
-/// HF cache, go offline, render a Voice Clone — it succeeds with NO runtime hub fetch.
+/// Proves the acceptance criterion end to end AND that it is DISCRIMINATING — it would fail if the
+/// co-requisite install were skipped, which the first cut did NOT: that version resolved off the
+/// machine's real `~/.cache/huggingface` (which already held ve/perth), so it passed even though the
+/// install under test was never actually exercised.
 ///
-///   1. **Empty cache** — point `HF_HOME` at a fresh temp dir and clear every other HF cache var so
-///      both the SceneWorks downloader and the runtime's hf-hub resolver share one empty hub cache.
-///   2. **Install** — run the REAL download executor for the three primary files (`main`) PLUS the two
-///      pinned companion co-requisites: `ve.safetensors` @ 5bb1f6ee… and `perth_implicit.safetensors`
-///      @ 80b60f9c…. Assert each pinned snapshot (`snapshots/<sha>/…`) + its `refs/<sha>` pointer is
-///      materialized exactly where `hf_get_pinned` reads.
-///   3. **Go offline, hard** — set `HF_HUB_OFFLINE=1` AND point `HF_ENDPOINT` at a black hole
-///      (`127.0.0.1:1`). Cache-first `hf_get_pinned` returns the cached file without a fetch; if it
-///      instead tried the hub (the pre-fix behavior when ve/perth were absent) it would hit the black
-///      hole and hard-fail. So a successful render IS the "no hub fetch" proof.
-///   4. **Render** — load `chatterbox_tts` from its snapshot dir and `generate()` one clone from a
-///      `Conditioning::ReferenceAudio`. generate() resolves ve (embed_reference) + perth (always-on
-///      watermark) internally; success ⇒ both resolved offline from the installed cache.
+/// Two facts — verified against the pinned inference rev and hf-hub 0.4.3 — drive the design:
+///   * The runtime resolver is `candle_audio::hub::hf_get_pinned` → hf-hub `Api::new()` →
+///     `Cache::default()`, which is HARD-CODED to `dirs::home_dir()/.cache/huggingface/hub` and reads
+///     NEITHER `HF_HOME` NOR `HF_ENDPOINT` (only `ApiBuilder::from_env()` reads those). On unix
+///     `dirs::home_dir()` is `$HOME`, so the ONLY lever that redirects the resolver's cache is `$HOME`.
+///     This test points `$HOME` at a fresh temp root ⇒ the resolver reads `<temp>/.cache/huggingface/
+///     hub` and the real `~/.cache/huggingface` is never touched (asserted). `HF_HOME` is set to
+///     `<temp>/.cache/huggingface` — exactly what the desktop injects (sc-1904) — so the SceneWorks
+///     downloader (`HF_HOME/hub`) writes the SAME hub the resolver reads: the DEFAULT shipped alignment.
+///   * hf-hub 0.4.3 has no `HF_HUB_OFFLINE` and `Api::new()` ignores `HF_ENDPOINT`, so the old
+///     black-hole `HF_ENDPOINT` was INERT. But both hf-hub agents are built with ureq
+///     `try_proxy_from_env(true)`, so a black-hole `ALL_PROXY`/`HTTPS_PROXY` DOES route (and fail)
+///     every resolver `download()`, while a cache HIT short-circuits before the agent is constructed.
+///     That makes "offline" deterministic and independent of the box's real connectivity.
+///
+///   1. **Isolate** — `$HOME` + `HF_HOME` at a fresh temp root; clear every other HF cache + proxy
+///      var. Assert the isolated hub starts empty and differs from the real `~/.cache/huggingface`.
+///   2. **Install** — run the REAL download executor (online) for the primary snapshot (`main`) PLUS
+///      the two pinned companion co-requisites: `ve.safetensors` @ 5bb1f6ee… and
+///      `perth_implicit.safetensors` @ 80b60f9c…. Assert each pinned `snapshots/<sha>/…` + `refs/<sha>`
+///      materialized where `hf_get_pinned` reads (the hf-hub layout `download_snapshot_into_cache`
+///      writes: `refs/<rev>` → commit, `snapshots/<commit>/<file>`).
+///   3. **Go offline, HARD** — black-hole `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` (any resolver fetch
+///      now fails through a dead proxy). Load `chatterbox_tts` from the installed snapshot dir and
+///      `generate()` one clone from a `Conditioning::ReferenceAudio` → MUST SUCCEED: ve
+///      (embed_reference) and perth (always-on watermark) resolve cache-first with zero network. A
+///      success with the dead proxy set IS the "no runtime hub fetch" proof.
+///   4. **Discriminate** — with the dead proxy still set, delete ONLY the PerTh snapshot, RELOAD the
+///      generator (its lazy ve/perth caches reset) and re-render → MUST HARD-FAIL (perth cache-miss →
+///      dead proxy). Then delete the ve snapshot + `refs/<sha>` and re-render → MUST HARD-FAIL (ve
+///      cache-miss). Deleting from the ISOLATED cache breaking the render is the proof the resolver
+///      reads THAT cache, not the real one. The 3.2 GB primary snapshot is reused — nothing re-downloads.
 #[test]
-#[ignore = "real-weight offline-install-parity DoD: downloads ~3.2 GB into a temp cache; run by hand on an Apple-Silicon Mac"]
+#[ignore = "real-weight offline-install-parity DoD: downloads ~3.2 GB into an ISOLATED temp HF cache; run by hand on an Apple-Silicon Mac"]
 fn chatterbox_offline_install_parity_smoke() {
-    let cache_home = tempfile::tempdir().expect("temp HF home");
+    // ── Step 1: isolate the cache the RUNTIME RESOLVER actually reads ─────────────────────────────
+    // The resolver is hf_get_pinned -> hf-hub Api::new() -> Cache::default() = dirs::home_dir()/.cache/
+    // huggingface/hub, which reads NEITHER HF_HOME NOR HF_ENDPOINT (only ApiBuilder::from_env() does)
+    // and on unix takes home_dir() from $HOME. So $HOME is the only lever that moves the resolver's
+    // cache. Point it — and, for the downloader, HF_HOME=$HOME/.cache/huggingface, the desktop's
+    // sc-1904 default — at a fresh temp root so BOTH sides share one empty, isolated hub.
+    let home_root = tempfile::tempdir().expect("temp HOME root");
     let data_dir = tempfile::tempdir().expect("temp data dir");
-    // One shared, EMPTY hub cache for both the downloader and the runtime resolver: HF_HOME/hub.
-    std::env::set_var("HF_HOME", cache_home.path());
-    std::env::remove_var("HF_HUB_CACHE");
-    std::env::remove_var("HUGGINGFACE_HUB_CACHE");
-    std::env::remove_var("HF_HUB_OFFLINE");
-    std::env::remove_var("HF_ENDPOINT");
-    std::env::remove_var("PERTH_SNAPSHOT");
-    let hub = cache_home.path().join("hub");
+
+    // Capture the machine's REAL hub BEFORE the override so we can prove it is never touched.
+    let real_home = std::env::var("HOME").expect("HOME must be set (we isolate against it)");
+    let real_hub = PathBuf::from(&real_home)
+        .join(".cache")
+        .join("huggingface")
+        .join("hub");
+    let real_chatterbox = real_hub.join("models--ResembleAI--chatterbox");
+    let real_perth = real_hub.join("models--SceneWorks--perth-implicit");
+    let real_before = real_cache_fingerprint(&real_chatterbox, &real_perth);
+    assert_ne!(
+        PathBuf::from(&real_home),
+        home_root.path(),
+        "the temp HOME must differ from the real home"
+    );
+
+    let hf_home = home_root.path().join(".cache").join("huggingface");
+    let hub = hf_home.join("hub");
+    // Pin the env for the whole test; EnvVars restores it on drop (Drop runs even on a panicking
+    // assert, so a leaked $HOME can't poison sibling tests). Every HF cache var except HF_HOME is
+    // cleared so neither the downloader nor the resolver can diverge to another location; proxy vars
+    // are cleared now (install must reach the real hub) and set to a black hole in step 3.
+    let _env = crate::test_env::EnvVars::set(&[
+        ("HOME", home_root.path().to_str().expect("utf-8 HOME")),
+        ("HF_HOME", hf_home.to_str().expect("utf-8 HF_HOME")),
+        ("HF_HUB_CACHE", ""),
+        ("HUGGINGFACE_HUB_CACHE", ""),
+        ("HF_HUB_OFFLINE", ""),
+        ("HF_ENDPOINT", ""),
+        ("PERTH_SNAPSHOT", ""),
+        ("ALL_PROXY", ""),
+        ("all_proxy", ""),
+        ("HTTPS_PROXY", ""),
+        ("https_proxy", ""),
+        ("HTTP_PROXY", ""),
+        ("http_proxy", ""),
+        ("NO_PROXY", ""),
+        ("no_proxy", ""),
+    ]);
     assert!(
         !hub.join("models--ResembleAI--chatterbox").exists()
             && !hub.join("models--SceneWorks--perth-implicit").exists(),
-        "the DoD requires an EMPTY HF cache to start"
+        "the DoD requires an EMPTY isolated HF cache to start"
     );
 
     let settings = crate::Settings {
@@ -574,7 +657,7 @@ fn chatterbox_offline_install_parity_smoke() {
         external_model_roots: Vec::new(),
     };
 
-    // ── Step 2: install (the exact executor a Models-screen install runs) ────────────────────────
+    // ── Step 2: install (the exact executor a Models-screen install runs), into the ISOLATED cache ─
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let main_commit = rt.block_on(install_snapshot(
         &settings,
@@ -595,25 +678,20 @@ fn chatterbox_offline_install_parity_smoke() {
         &["perth_implicit.safetensors"],
     ));
 
-    // ── Assert the pinned companion snapshots landed where hf_get_pinned reads ───────────────────
-    let ve_snapshot = hub
-        .join("models--ResembleAI--chatterbox")
+    // ── Assert the pinned companion snapshots landed where hf_get_pinned reads (the hf-hub layout
+    //    download_snapshot_into_cache writes: refs/<rev> -> commit + snapshots/<commit>/<file>) ────
+    let chatterbox_dir = hub.join("models--ResembleAI--chatterbox");
+    let perth_dir = hub.join("models--SceneWorks--perth-implicit");
+    let ve_snapshot = chatterbox_dir
         .join("snapshots")
         .join(VE_REVISION)
         .join("ve.safetensors");
-    let ve_ref = hub
-        .join("models--ResembleAI--chatterbox")
-        .join("refs")
-        .join(VE_REVISION);
-    let perth_snapshot = hub
-        .join("models--SceneWorks--perth-implicit")
+    let ve_ref = chatterbox_dir.join("refs").join(VE_REVISION);
+    let perth_snapshot = perth_dir
         .join("snapshots")
         .join(PERTH_REVISION)
         .join("perth_implicit.safetensors");
-    let perth_ref = hub
-        .join("models--SceneWorks--perth-implicit")
-        .join("refs")
-        .join(PERTH_REVISION);
+    let perth_ref = perth_dir.join("refs").join(PERTH_REVISION);
     assert!(
         ve_snapshot.exists(),
         "ve.safetensors must materialize at the pinned snapshot: {}",
@@ -627,51 +705,67 @@ fn chatterbox_offline_install_parity_smoke() {
     );
     assert!(perth_ref.exists(), "perth refs/<sha> pointer must exist");
     eprintln!(
-        "[offline-parity] installed pinned snapshots:\n  {}\n  {}",
+        "[offline-parity] installed pinned snapshots into the ISOLATED hub {}:\n  {}\n  {}",
+        hub.display(),
         ve_snapshot.display(),
         perth_snapshot.display()
     );
 
-    // ── Step 3: go offline, HARD — any attempted hub fetch now fails loudly ──────────────────────
-    std::env::set_var("HF_HUB_OFFLINE", "1");
-    std::env::set_var("HF_ENDPOINT", "http://127.0.0.1:1");
+    // ── Step 3: go offline, HARD — a black-hole proxy fails EVERY resolver download() (both hf-hub
+    //    agents are built with ureq try_proxy_from_env), while a cache HIT never constructs the agent.
+    //    Set AFTER install (which needed the real hub). Api::new() ignores HF_ENDPOINT, so the proxy —
+    //    not an endpoint — is the lever that actually blocks the resolver. ────────────────────────
+    std::env::set_var("ALL_PROXY", "http://127.0.0.1:1");
+    std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:1");
+    std::env::set_var("HTTP_PROXY", "http://127.0.0.1:1");
 
-    // ── Step 4: the single native clone call (resolves ve + perth internally, offline) ───────────
-    let main_snapshot_dir = hub
-        .join("models--ResembleAI--chatterbox")
-        .join("snapshots")
-        .join(&main_commit);
+    let main_snapshot_dir = chatterbox_dir.join("snapshots").join(&main_commit);
     assert!(
         main_snapshot_dir.join("s3gen.safetensors").exists(),
         "primary chatterbox snapshot dir must hold the generator weights"
     );
-    let generator = runtime_macos::catalog()
-        .expect("runtime catalog")
-        .audio()
-        .expect("audio lane")
-        .load(
-            "chatterbox_tts",
-            &LoadSpec::new(WeightsSource::Dir(main_snapshot_dir.clone())),
+
+    // One offline render from the installed primary snapshot, RELOADING the generator each call: the
+    // provider caches its ve/perth embedders lazily in a Mutex on first use, so a second generate() on
+    // the SAME generator would reuse them and never re-touch the cache — the discrimination below MUST
+    // reload to force re-resolution. The primary weights load from the local DIR (no hub), so a reload
+    // never re-downloads the 3.2 GB primary.
+    let render_offline = || -> Result<gen_core::AudioTrack, String> {
+        let request = GenerationRequest {
+            prompt: "This cloned voice was rendered fully offline from a fresh install.".to_owned(),
+            seed: Some(13541),
+            conditioning: vec![Conditioning::ReferenceAudio {
+                audio: synthetic_reference(),
+                strength: None,
+            }],
+            cancel: CancelFlag::new(),
+            ..Default::default()
+        };
+        let mut on_progress = |_p: Progress| {};
+        let output = runtime_macos::catalog()
+            .map_err(|e| format!("runtime catalog: {e}"))?
+            .audio()
+            .ok_or_else(|| "audio lane missing from the runtime catalog".to_owned())?
+            .load(
+                "chatterbox_tts",
+                &LoadSpec::new(WeightsSource::Dir(main_snapshot_dir.clone())),
+            )
+            .map_err(|e| format!("load chatterbox_tts: {e}"))?
+            .generate(&request, &mut on_progress)
+            .map_err(|e| format!("generate: {e}"))?;
+        match output {
+            GenerationOutput::Audio(track) => Ok(track),
+            other => Err(format!("expected audio, got {other:?}")),
+        }
+    };
+
+    // ── Step 4a: the positive proof — ve + perth resolve cache-first, zero network ───────────────
+    let clone = render_offline().unwrap_or_else(|e| {
+        panic!(
+            "offline native clone generate MUST succeed from the installed isolated cache \
+             (ve + perth resolve cache-first with zero network; the dead proxy proves no fetch): {e}"
         )
-        .expect("load chatterbox_tts generator (offline, from the installed snapshot)");
-    let request = GenerationRequest {
-        prompt: "This cloned voice was rendered fully offline from a fresh install.".to_owned(),
-        seed: Some(13541),
-        conditioning: vec![Conditioning::ReferenceAudio {
-            audio: synthetic_reference(),
-            strength: None,
-        }],
-        cancel: CancelFlag::new(),
-        ..Default::default()
-    };
-    let mut on_progress = |_p: Progress| {};
-    let clone = match generator
-        .generate(&request, &mut on_progress)
-        .expect("offline native clone generate (ve + perth must resolve from the installed cache)")
-    {
-        GenerationOutput::Audio(track) => track,
-        other => panic!("expected audio, got {other:?}"),
-    };
+    });
     assert!(!clone.samples.is_empty(), "offline clone is empty");
     assert!(
         peak(&clone.samples) > 1e-3,
@@ -682,9 +776,52 @@ fn chatterbox_offline_install_parity_smoke() {
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     dump_wav(&clone, &out_dir.join("offline_parity_clone.wav"));
     eprintln!(
-        "[offline-parity] PASS — offline render succeeded with a black-hole HF endpoint: {} samples @ {} Hz (listen: {})",
+        "[offline-parity] step 4a PASS — offline render succeeded through a black-hole proxy: {} samples @ {} Hz (listen: {})",
         clone.samples.len(),
         clone.sample_rate,
         out_dir.join("offline_parity_clone.wav").display()
+    );
+
+    // ── Step 4b: discrimination — prove the INSTALL (not the real ~/.cache) is load-bearing ──────
+    // #1: remove ONLY the PerTh snapshot (ve stays). A reload + render must reach the always-on
+    // watermark, cache-miss PerTh, and hard-fail through the dead proxy.
+    std::fs::remove_dir_all(&perth_dir).expect("remove the isolated PerTh model dir");
+    let perth_err = render_offline().expect_err(
+        "with the PerTh snapshot deleted from the ISOLATED cache the offline render MUST hard-fail — \
+         a success would mean the resolver read some OTHER cache (e.g. the real ~/.cache): a false pass",
+    );
+    assert!(
+        perth_err.contains("PerTh"),
+        "the discrimination failure must be the missing PerTh weight resolving through the dead proxy, got: {perth_err}"
+    );
+    eprintln!(
+        "[offline-parity] step 4b#1 PASS — PerTh removed ⇒ hard-fail as required: {perth_err}"
+    );
+
+    // #2: also remove the ve snapshot pointer + its refs/<sha>. A reload + render now cache-misses ve
+    // at embed_reference (the first companion the clone path touches) and hard-fails through the proxy.
+    std::fs::remove_file(&ve_snapshot).expect("remove the isolated ve.safetensors pointer");
+    std::fs::remove_file(&ve_ref).expect("remove the isolated ve refs/<sha>");
+    let ve_err = render_offline().expect_err(
+        "with the ve snapshot deleted from the ISOLATED cache the offline render MUST hard-fail",
+    );
+    assert!(
+        ve_err.contains("chatterbox_ve"),
+        "the discrimination failure must be the missing ve embedder resolving through the dead proxy, got: {ve_err}"
+    );
+    eprintln!("[offline-parity] step 4b#2 PASS — ve removed ⇒ hard-fail as required: {ve_err}");
+
+    // ── The machine's real ~/.cache/huggingface must be neither read into nor written by any of the
+    //    above: install targeted HF_HOME=<temp>/hub and the resolver's Cache::default() targeted
+    //    $HOME=<temp>. Its chatterbox/perth entries must match the pre-test fingerprint exactly. ───
+    let real_after = real_cache_fingerprint(&real_chatterbox, &real_perth);
+    assert_eq!(
+        real_before, real_after,
+        "the real ~/.cache/huggingface was modified — the test must be fully isolated under $HOME/HF_HOME=<temp>"
+    );
+    eprintln!(
+        "[offline-parity] PASS — install→offline render is self-contained in the isolated cache, is \
+         DISCRIMINATING (removing ve or perth hard-fails), and left the real {} untouched.",
+        real_hub.display()
     );
 }

--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -29,8 +29,8 @@
 use std::path::{Path, PathBuf};
 
 use gen_core::{
-    AudioParams, AudioTransformRequest, CancelFlag, GenerationOutput, GenerationRequest, LoadSpec,
-    Progress, WeightsSource,
+    AudioParams, AudioTransformRequest, CancelFlag, Conditioning, GenerationOutput,
+    GenerationRequest, LoadSpec, Progress, WeightsSource,
 };
 
 use super::smoke_support::env_or;
@@ -417,5 +417,274 @@ fn native_voiceclone_chatterbox_smoke() {
         "[native-clone-smoke] PASS — clone tracks the reference by {:.4} cosine (listen: {})",
         sim_clone_ref - sim_clone_control,
         out_dir.join("native_clone.wav").display()
+    );
+}
+
+// ── sc-13541: offline install-parity DoD ─────────────────────────────────────────────────────────
+// The chatterbox_tts provider resolves two companion weights at generate() time via pinned-SHA
+// `hf_get_pinned` fetches (candle_audio_chatterbox_ve + candle-audio-chatterbox/src/perth.rs at the
+// SceneWorks-pinned inference commit). The manifest co-requisites (sc-13541) pin these EXACT SHAs.
+const CHATTERBOX_REPO: &str = "ResembleAI/chatterbox";
+const VE_REVISION: &str = "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18";
+const PERTH_REPO: &str = "SceneWorks/perth-implicit";
+const PERTH_REVISION: &str = "80b60f9caead09b8d3b512bda0b24038f28c08ec";
+
+/// Materialize one HF snapshot (`repo` @ `revision`, filtered to `files`) into the hub cache via the
+/// worker's REAL model-download executor — `HuggingFaceSnapshot::resolve` + `download_snapshot_into_cache`,
+/// the exact seam `run_model_download_job` drives for a Models-screen install. Returns the resolved
+/// commit SHA. Proving the pinned snapshots land here proves the install materializes them (sc-13541).
+async fn install_snapshot(
+    settings: &crate::Settings,
+    repo: &str,
+    revision: &str,
+    files: &[&str],
+) -> String {
+    use crate::downloads::{
+        download_snapshot_into_cache, DownloadContext, DownloadProgress, HuggingFaceSnapshot,
+    };
+    let client = crate::downloads::streaming_download_client();
+    let api = crate::ApiClient::new(settings);
+    let repo_dir = sceneworks_core::hf_home::huggingface_repo_cache_path(&settings.data_dir, repo)
+        .expect("resolve hub cache path");
+    let file_patterns: Vec<String> = files.iter().map(|f| (*f).to_owned()).collect();
+    let snapshot = HuggingFaceSnapshot::resolve(&client, settings, repo, revision, &file_patterns)
+        .await
+        .expect("resolve HF snapshot listing");
+    assert!(
+        !snapshot.files.is_empty(),
+        "{repo}@{revision} resolved zero files for {file_patterns:?}"
+    );
+    let context = DownloadContext {
+        api: &api,
+        client: &client,
+        settings,
+        job_id: "sc-13541-offline-parity",
+        cancel_message: "canceled",
+        fresh_download: false,
+    };
+    // A report interval longer than any real transfer so the in-loop progress POST never fires: this
+    // harness has no job API (the executor's heartbeat/progress are best-effort and only reached via
+    // the interval tick), and cancel polls already swallow transport errors. The download itself only
+    // talks to the HF hub, which is exactly what we are exercising.
+    let mut progress = DownloadProgress::new(
+        repo,
+        0,
+        snapshot.total_bytes(),
+        std::time::Duration::from_secs(86_400),
+    );
+    download_snapshot_into_cache(&context, &repo_dir, revision, &snapshot, &mut progress)
+        .await
+        .unwrap_or_else(|e| panic!("materialize {repo}@{revision}: {e}"))
+}
+
+/// A short, non-trivial synthetic speech-like reference clip (a vibrato'd fundamental plus two
+/// harmonics and light noise), 24 kHz mono — enough content for the provider to derive a speaker
+/// embedding + prompt tokens without pulling in a second TTS model. Clone quality is irrelevant to
+/// this DoD; the point is that generate() completes with no hub fetch.
+fn synthetic_reference() -> gen_core::AudioTrack {
+    let sample_rate = 24_000u32;
+    let secs = 4.0f32;
+    let n = (sample_rate as f32 * secs) as usize;
+    let mut samples = Vec::with_capacity(n);
+    let mut seed = 0x2b41_53c7u32;
+    for i in 0..n {
+        let t = i as f32 / sample_rate as f32;
+        let vibrato = 1.0 + 0.02 * (2.0 * std::f32::consts::PI * 5.0 * t).sin();
+        let f0 = 165.0 * vibrato;
+        let mut s = 0.6 * (2.0 * std::f32::consts::PI * f0 * t).sin();
+        s += 0.25 * (2.0 * std::f32::consts::PI * 2.0 * f0 * t).sin();
+        s += 0.15 * (2.0 * std::f32::consts::PI * 3.0 * f0 * t).sin();
+        // Cheap LCG noise for a little broadband energy.
+        seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let noise = (seed >> 9) as f32 / (1u32 << 23) as f32 - 0.5;
+        s += 0.05 * noise;
+        // Gentle amplitude envelope so it is not a steady tone.
+        let env = 0.5 - 0.5 * (2.0 * std::f32::consts::PI * 0.5 * t).cos();
+        samples.push(0.8 * env * s);
+    }
+    gen_core::AudioTrack {
+        samples,
+        sample_rate,
+        channels: 1,
+        stems: Vec::new(),
+    }
+}
+
+/// sc-13541 (epic 13400 / E1 follow-up) — **offline install-parity DoD**. `#[ignore]`d; run by hand
+/// on an Apple-Silicon Mac (downloads ~3.2 GB into an ISOLATED temp HF cache):
+/// ```text
+/// cargo test -p sceneworks-worker chatterbox_offline_install_parity_smoke -- --ignored --nocapture
+/// ```
+/// Proves the acceptance criterion end to end: install `chatterbox_tts` on a machine with an EMPTY
+/// HF cache, go offline, render a Voice Clone — it succeeds with NO runtime hub fetch.
+///
+///   1. **Empty cache** — point `HF_HOME` at a fresh temp dir and clear every other HF cache var so
+///      both the SceneWorks downloader and the runtime's hf-hub resolver share one empty hub cache.
+///   2. **Install** — run the REAL download executor for the three primary files (`main`) PLUS the two
+///      pinned companion co-requisites: `ve.safetensors` @ 5bb1f6ee… and `perth_implicit.safetensors`
+///      @ 80b60f9c…. Assert each pinned snapshot (`snapshots/<sha>/…`) + its `refs/<sha>` pointer is
+///      materialized exactly where `hf_get_pinned` reads.
+///   3. **Go offline, hard** — set `HF_HUB_OFFLINE=1` AND point `HF_ENDPOINT` at a black hole
+///      (`127.0.0.1:1`). Cache-first `hf_get_pinned` returns the cached file without a fetch; if it
+///      instead tried the hub (the pre-fix behavior when ve/perth were absent) it would hit the black
+///      hole and hard-fail. So a successful render IS the "no hub fetch" proof.
+///   4. **Render** — load `chatterbox_tts` from its snapshot dir and `generate()` one clone from a
+///      `Conditioning::ReferenceAudio`. generate() resolves ve (embed_reference) + perth (always-on
+///      watermark) internally; success ⇒ both resolved offline from the installed cache.
+#[test]
+#[ignore = "real-weight offline-install-parity DoD: downloads ~3.2 GB into a temp cache; run by hand on an Apple-Silicon Mac"]
+fn chatterbox_offline_install_parity_smoke() {
+    let cache_home = tempfile::tempdir().expect("temp HF home");
+    let data_dir = tempfile::tempdir().expect("temp data dir");
+    // One shared, EMPTY hub cache for both the downloader and the runtime resolver: HF_HOME/hub.
+    std::env::set_var("HF_HOME", cache_home.path());
+    std::env::remove_var("HF_HUB_CACHE");
+    std::env::remove_var("HUGGINGFACE_HUB_CACHE");
+    std::env::remove_var("HF_HUB_OFFLINE");
+    std::env::remove_var("HF_ENDPOINT");
+    std::env::remove_var("PERTH_SNAPSHOT");
+    let hub = cache_home.path().join("hub");
+    assert!(
+        !hub.join("models--ResembleAI--chatterbox").exists()
+            && !hub.join("models--SceneWorks--perth-implicit").exists(),
+        "the DoD requires an EMPTY HF cache to start"
+    );
+
+    let settings = crate::Settings {
+        api_url: "http://127.0.0.1:1".to_owned(),
+        access_token: None,
+        data_dir: data_dir.path().to_path_buf(),
+        config_dir: data_dir.path().join("config"),
+        worker_id: "sc-13541".to_owned(),
+        gpu_id: "gpu-0".to_owned(),
+        is_child_worker: false,
+        poll_seconds: 1,
+        heartbeat_seconds: 5,
+        shutdown_timeout_seconds: 1,
+        huggingface_base_url: crate::DEFAULT_HUGGINGFACE_BASE_URL.to_owned(),
+        huggingface_token: std::env::var("HF_TOKEN").ok(),
+        credentials: Vec::new(),
+        max_lora_url_bytes: crate::DEFAULT_MAX_LORA_URL_BYTES,
+        max_model_url_bytes: crate::DEFAULT_MAX_MODEL_URL_BYTES,
+        allow_private_lora_urls: false,
+        utility_workers: 1,
+        backend_mlx_enabled: true,
+        backend_candle_enabled: false,
+        gpu_memory_limit_bytes: 0,
+        external_model_roots: Vec::new(),
+    };
+
+    // ── Step 2: install (the exact executor a Models-screen install runs) ────────────────────────
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let main_commit = rt.block_on(install_snapshot(
+        &settings,
+        CHATTERBOX_REPO,
+        "main",
+        &["t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json"],
+    ));
+    rt.block_on(install_snapshot(
+        &settings,
+        CHATTERBOX_REPO,
+        VE_REVISION,
+        &["ve.safetensors"],
+    ));
+    rt.block_on(install_snapshot(
+        &settings,
+        PERTH_REPO,
+        PERTH_REVISION,
+        &["perth_implicit.safetensors"],
+    ));
+
+    // ── Assert the pinned companion snapshots landed where hf_get_pinned reads ───────────────────
+    let ve_snapshot = hub
+        .join("models--ResembleAI--chatterbox")
+        .join("snapshots")
+        .join(VE_REVISION)
+        .join("ve.safetensors");
+    let ve_ref = hub
+        .join("models--ResembleAI--chatterbox")
+        .join("refs")
+        .join(VE_REVISION);
+    let perth_snapshot = hub
+        .join("models--SceneWorks--perth-implicit")
+        .join("snapshots")
+        .join(PERTH_REVISION)
+        .join("perth_implicit.safetensors");
+    let perth_ref = hub
+        .join("models--SceneWorks--perth-implicit")
+        .join("refs")
+        .join(PERTH_REVISION);
+    assert!(
+        ve_snapshot.exists(),
+        "ve.safetensors must materialize at the pinned snapshot: {}",
+        ve_snapshot.display()
+    );
+    assert!(ve_ref.exists(), "ve refs/<sha> pointer must exist");
+    assert!(
+        perth_snapshot.exists(),
+        "perth_implicit.safetensors must materialize at the pinned snapshot: {}",
+        perth_snapshot.display()
+    );
+    assert!(perth_ref.exists(), "perth refs/<sha> pointer must exist");
+    eprintln!(
+        "[offline-parity] installed pinned snapshots:\n  {}\n  {}",
+        ve_snapshot.display(),
+        perth_snapshot.display()
+    );
+
+    // ── Step 3: go offline, HARD — any attempted hub fetch now fails loudly ──────────────────────
+    std::env::set_var("HF_HUB_OFFLINE", "1");
+    std::env::set_var("HF_ENDPOINT", "http://127.0.0.1:1");
+
+    // ── Step 4: the single native clone call (resolves ve + perth internally, offline) ───────────
+    let main_snapshot_dir = hub
+        .join("models--ResembleAI--chatterbox")
+        .join("snapshots")
+        .join(&main_commit);
+    assert!(
+        main_snapshot_dir.join("s3gen.safetensors").exists(),
+        "primary chatterbox snapshot dir must hold the generator weights"
+    );
+    let generator = runtime_macos::catalog()
+        .expect("runtime catalog")
+        .audio()
+        .expect("audio lane")
+        .load(
+            "chatterbox_tts",
+            &LoadSpec::new(WeightsSource::Dir(main_snapshot_dir.clone())),
+        )
+        .expect("load chatterbox_tts generator (offline, from the installed snapshot)");
+    let request = GenerationRequest {
+        prompt: "This cloned voice was rendered fully offline from a fresh install.".to_owned(),
+        seed: Some(13541),
+        conditioning: vec![Conditioning::ReferenceAudio {
+            audio: synthetic_reference(),
+            strength: None,
+        }],
+        cancel: CancelFlag::new(),
+        ..Default::default()
+    };
+    let mut on_progress = |_p: Progress| {};
+    let clone = match generator
+        .generate(&request, &mut on_progress)
+        .expect("offline native clone generate (ve + perth must resolve from the installed cache)")
+    {
+        GenerationOutput::Audio(track) => track,
+        other => panic!("expected audio, got {other:?}"),
+    };
+    assert!(!clone.samples.is_empty(), "offline clone is empty");
+    assert!(
+        peak(&clone.samples) > 1e-3,
+        "offline clone is (near-)silent: peak {:.6}",
+        peak(&clone.samples)
+    );
+    let out_dir = PathBuf::from(env_or("VOICECLONE_OUT_DIR", "/tmp/voiceclone_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    dump_wav(&clone, &out_dir.join("offline_parity_clone.wav"));
+    eprintln!(
+        "[offline-parity] PASS — offline render succeeded with a black-hole HF endpoint: {} samples @ {} Hz (listen: {})",
+        clone.samples.len(),
+        clone.sample_rate,
+        out_dir.join("offline_parity_clone.wav").display()
     );
 }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -563,6 +563,10 @@
                   "type": "string",
                   "description": "Provider repository or model identifier used when queueing a download."
                 },
+                "revision": {
+                  "type": "string",
+                  "description": "Optional pinned git revision for this entry: the download job forwards it so the worker fetches that exact commit into snapshots/<sha>/; the worker defaults to `main` when omitted. For a companion co-requisite whose weight the runtime resolves via a pinned-SHA hf_get_pinned (e.g. chatterbox_tts's ve/perth), this MUST be the full 40-hex commit SHA the resolver reads — a branch/tag/short SHA resolves online but hard-fails offline. See sc-13541."
+                },
                 "default": {
                   "type": "boolean",
                   "description": "Marks the canonical alternate used for displayed size, install path, and download jobs. For a quant matrix this marks the DEFAULT tier (the one that installs when no explicit variant is requested)."


### PR DESCRIPTION
## sc-13541 — offline install-parity for the Chatterbox Voice Clone (epic 13400 / E1 follow-up)

Makes a fresh/offline `chatterbox_tts` install render a Voice Clone with **no runtime hub fetch**, by pre-downloading the two companion weights the provider resolves at generate time — the `chatterbox_ve` speaker embedder and the always-on PerTh watermarker — into the same pinned-SHA snapshots the runtime resolver reads.

### What ships
- **Manifest** (`config/manifests/builtin.models.jsonc`): `ve.safetensors` @ `5bb1f6ee…` and `perth_implicit.safetensors` @ `80b60f9c…` declared as `coRequisite` downloads, each with an explicit pinned `revision` — the exact full 40-hex commit SHAs the inference resolvers pin (`candle_audio_chatterbox_ve::{HUB_REPO,HUB_REVISION}` and `candle_audio_chatterbox::perth::{PERTH_HUB_REPO,PERTH_HUB_REVISION}`).
- **Planner** (`apps/rust-api/src/models.rs`): forwards an explicit `revision` to the download job so the worker fetches the exact commit into `snapshots/<sha>/` (where `hf_get_pinned` reads), not `main`. The primary download declares no `revision` and stays on `main` — additive, no behavior change for other models.
- **Unit tests** (`apps/rust-api/src/tests/catalog.rs`): guard the manifest pins and the planner revision-forwarding.
- **Authoring schema** (`packages/schemas/model-manifest.schema.json`): the download-entry object is `additionalProperties: false`, so the Python manifest-audit test (run by the parity lane's worker test suite) rejected the new `revision` field. Added an optional `revision` string property (keeping `additionalProperties: false`), documenting the full-40-hex-SHA requirement for pinned-SHA co-requisites.

### Review fix — the offline DoD smoke was a false pass
The prior smoke set a temp `HF_HOME` + a black-hole `HF_ENDPOINT`, but the runtime resolver is `candle_audio::hub::hf_get_pinned` → hf-hub `Api::new()` → `Cache::default()`, which is **hard-coded** to `dirs::home_dir()/.cache/huggingface/hub` and reads **neither** `HF_HOME` **nor** `HF_ENDPOINT` (only `ApiBuilder::from_env()` reads those — verified against hf-hub 0.4.3). So the render resolved off the machine's **real** `~/.cache/huggingface` (which already held ve/perth) and would have passed even if the co-requisite install were skipped.

`chatterbox_offline_install_parity_smoke` is rewritten to be honest and discriminating:
- **Isolate the cache the resolver actually reads** by pointing `$HOME` at a fresh temp root (`dirs::home_dir()` = `$HOME` on unix), with `HF_HOME=$HOME/.cache/huggingface` so the SceneWorks downloader writes the same hub — exactly the default shipped alignment. Asserts the real `~/.cache/huggingface` is byte-for-byte unchanged.
- **Deterministic offline via a black-hole proxy.** hf-hub 0.4.3 has no `HF_HUB_OFFLINE` and `Api::new()` ignores `HF_ENDPOINT`, so the old endpoint trick was inert. Both hf-hub agents build with ureq `try_proxy_from_env(true)`, so a black-hole `ALL_PROXY`/`HTTPS_PROXY` fails every resolver `download()` while a cache hit short-circuits before the agent is constructed — independent of the box's real connectivity.
- **Discrimination.** After the positive render, delete only the PerTh snapshot → reload → re-render **hard-fails** (perth load-bearing); then delete the ve snapshot+ref → reload → re-render **hard-fails** (ve load-bearing). Deleting from the *isolated* cache breaking the render is the proof the resolver reads that cache, not the real one.

Run by hand on Apple Silicon (SMOKE_EXIT=0):
```
[offline-parity] installed pinned snapshots into the ISOLATED hub …/T/.tmpowHjGI/.cache/huggingface/hub
[offline-parity] step 4a PASS — offline render succeeded through a black-hole proxy: 89280 samples @ 24000 Hz
[offline-parity] step 4b#1 PASS — PerTh removed ⇒ hard-fail: … Connection refused (os error 61)
[offline-parity] step 4b#2 PASS — ve removed ⇒ hard-fail: … Connection refused (os error 61)
[offline-parity] PASS — self-contained, DISCRIMINATING, real /Users/michael/.cache/huggingface/hub untouched.
```

### Cache-alignment finding (production)
The shipped app uses the **OS-default** HF cache by default, so this fix delivers offline parity in production:
- The desktop injects `HF_HOME` into both sidecars, defaulting to `$HOME/.cache/huggingface` when the user has not chosen a custom location (`apps/desktop/src/setup.rs::huggingface_home` → `shared_huggingface_home`).
- The host-mode worker defaults `HF_HOME` to the OS HF home when unset (`crates/sceneworks-core/src/hf_home.rs::ensure_default_huggingface_home`, called from `run()`).

In that default, the downloader (`HF_HOME/hub`) and the resolver (`Cache::default()` = `$HOME/.cache/huggingface/hub`) **agree**, and the downloader already writes an hf-hub-compatible layout (`refs/<rev>`→commit, `snapshots/<commit>/<file>`) — confirmed end-to-end by the smoke.

**Known limitation (narrow power-user gap).** If a user selects a **custom** HF cache (first-run splash → `settings.hf_home`, or `HF_HUB_CACHE`), the downloader honors it but the audio resolver's `Api::new()`/`Cache::default()` still reads `~/.cache/huggingface/hub` — so ve/perth land where the resolver does not look and offline render fails. The clean fix is **inference-side**: switch `crates/audio/candle-audio/src/hub.rs::hf_get_pinned` from `hf_hub::api::sync::Api::new()` to `ApiBuilder::from_env().build()` (honors `HF_HOME`/`HF_ENDPOINT`, aligning the resolver with the downloader in all cases). Tracked as an inference follow-up.

### Tests
`cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo build` all green on the merged tree. The `#[ignore]`d offline DoD smoke passed by hand on Apple Silicon as shown above.

The parity lane's worker test suite (which `rust:check` does NOT run) was reproduced locally with the CI-pinned deps (`jsonschema==4.25.1`, `pytest==9.0.2`): `python -m pytest -q tests/ -m "not e2e and not parity" --strict-markers` → **26 passed, 17 deselected** (the manifest-audit `test_builtin_models_manifest_satisfies_authoring_schema` now passes after the schema fix).
