### PR TITLE
fix(catalog): accurate per-tier completeness for no-model_index MLX turnkeys [sc-13513]

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1686,7 +1686,28 @@ fn install_state_for(
                     .as_ref()
                     .map(|health| health.missing_files.clone())
                     .unwrap_or_default();
-                (installed, incomplete, missing)
+                // sc-13513: a single-variant no-`model_index` turnkey (Boogu's `base/` default download,
+                // whose component globs match stray weights) reads coarse-installed while actually torn.
+                // Downgrade so the TOP-LEVEL badge agrees with the per-variant state and the worker's
+                // loader gate — otherwise `installState:"installed"`/`repairAvailable:false` renders a
+                // false green over an install that then fails to load. SANA (variant-matrix) is already
+                // covered by the aggregate branch above; Anima's exact-path filter catches torn coarsely.
+                let family = model
+                    .get("family")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                if installed
+                    && no_model_index_tier_is_torn(
+                        family,
+                        &download_context.files,
+                        cache_path.as_deref(),
+                        &managed_path,
+                    )
+                {
+                    (false, true, vec![torn_tier_marker(&download_context.files)])
+                } else {
+                    (installed, incomplete, missing)
+                }
             };
         // A quant-matrix model's top-level state is the aggregate of its tier-aware variant states
         // computed above (cache_installed = "any tier installed"). The repo-level managed marker must
@@ -1862,6 +1883,42 @@ fn no_model_index_family_predicate(family: &str) -> Option<fn(&FsPath) -> bool> 
     }
 }
 
+// Whether a no-`model_index` MLX turnkey tier that CLEARED the coarse presence check is actually TORN —
+// backbone present, but a text-encoder / VAE / tokenizer component missing per the shared family
+// predicate. `false` when the family has no bespoke predicate, the `files` filter isn't a single tier
+// subdir (e.g. the candle whole-repo SANA entry, `files: []`), or SOME candidate location holds a
+// complete tier. Drives the coarse `installed` → `incomplete` downgrade in BOTH the per-variant states
+// (`model_variant_states`) and the top-level aggregate (`install_state_for`), so the /models badge, the
+// variant state, and the worker's loader gate all agree (sc-13513). Every cache snapshot AND the managed
+// dir is checked with `any` — a SANA repo keeps two snapshots (tiered + flat), and a complete tier in one
+// location must not be dragged down by a sibling that lacks it.
+fn no_model_index_tier_is_torn(
+    family: &str,
+    files: &[String],
+    cache_path: Option<&FsPath>,
+    managed_path: &FsPath,
+) -> bool {
+    let Some(complete) = no_model_index_family_predicate(family) else {
+        return false;
+    };
+    let Some(tier) = tier_subdir_name(files) else {
+        return false;
+    };
+    let mut tier_bases = cache_path
+        .map(huggingface_snapshot_dirs)
+        .unwrap_or_default();
+    tier_bases.push(managed_path.to_path_buf());
+    !tier_bases.iter().any(|base| complete(&base.join(&tier)))
+}
+
+// The `missingRequiredFiles` marker for a torn no-`model_index` tier (`no_model_index_tier_is_torn`),
+// scoped to the tier subdir when the filter names one.
+fn torn_tier_marker(files: &[String]) -> String {
+    tier_subdir_name(files)
+        .map(|tier| format!("{tier}/ (incomplete: missing model components)"))
+        .unwrap_or_else(|| "incomplete: missing model components".to_owned())
+}
+
 // Build the per-variant install state for every supported download entry. A single-variant model
 // yields one entry keyed "default"; a quant-matrix model yields one per tier. Each entry's install
 // state is probed independently against the HF cache using that tier's own `files` filter, so the
@@ -1926,32 +1983,18 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
 
             // sc-13513: the coarse `<tier>/*` glob (and the managed presence check) is satisfied by ANY
             // single nested file, so a TORN tier of a no-`model_index` MLX turnkey (SANA/Boogu — backbone
-            // present, text-encoder/VAE/tokenizer missing) read `installed`. Mirror the worker's shared
-            // family completeness predicate so a torn tier reports `incomplete` instead. This only ever
-            // DOWNGRADES a coarse `installed`; a clean-missing tier is never promoted, a family without a
-            // bespoke predicate (diffusers turnkeys, already accurate via the `model_index.json`
-            // augmentation) is untouched, and the candle whole-repo SANA entry has no single tier subdir
-            // (`tier_subdir_name` → None) so it is skipped. Checked across every cache snapshot AND the
-            // managed dir (a SANA repo keeps TWO snapshots — tiered + flat) with `any`, so a complete tier
-            // in one location isn't dragged down by a sibling snapshot that lacks it.
-            if installed {
-                if let (Some(complete), Some(tier)) = (
-                    no_model_index_family_predicate(family),
-                    tier_subdir_name(&files),
-                ) {
-                    let mut tier_bases = cache_path
-                        .as_ref()
-                        .map(|path| huggingface_snapshot_dirs(path))
-                        .unwrap_or_default();
-                    tier_bases.push(managed_path.clone());
-                    if !tier_bases.iter().any(|base| complete(&base.join(&tier))) {
-                        installed = false;
-                        cache_incomplete = true;
-                        let marker = format!("{tier}/ (incomplete: missing model components)");
-                        if !missing_required_files.contains(&marker) {
-                            missing_required_files.push(marker);
-                        }
-                    }
+            // present, text-encoder/VAE/tokenizer missing) read `installed`. The shared family predicate
+            // downgrades it to `incomplete`. Only ever downgrades a coarse `installed`; a clean-missing
+            // tier is never promoted, and a family without a bespoke predicate (diffusers turnkeys,
+            // accurate via the `model_index.json` augmentation) is untouched.
+            if installed
+                && no_model_index_tier_is_torn(family, &files, cache_path.as_deref(), &managed_path)
+            {
+                installed = false;
+                cache_incomplete = true;
+                let marker = torn_tier_marker(&files);
+                if !missing_required_files.contains(&marker) {
+                    missing_required_files.push(marker);
                 }
             }
 
@@ -3852,6 +3895,112 @@ mod variant_install_tests {
             states[0].installed,
             "complete boogu default reads installed"
         );
+    }
+
+    /// The TOP-LEVEL badge must agree with the per-variant state. Boogu is a single-variant download, so
+    /// `install_state_for` takes the non-matrix else branch — which, before sc-13513, used the coarse
+    /// cache health and rendered a false-green `installState:"installed"`/`repairAvailable:false` over a
+    /// torn install. The shared predicate must downgrade it there too.
+    #[test]
+    fn torn_boogu_top_level_badge_reads_incomplete_not_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "SceneWorks/boogu-image-mlx";
+        let model = boogu_model(repo);
+
+        seed_boogu_default(data_dir, repo, false);
+        let state = install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+        assert!(
+            !state.installed,
+            "a torn boogu install must NOT read installed at the top level"
+        );
+        assert!(
+            state.cache_incomplete,
+            "a torn boogu install is a repairable incomplete at the top level"
+        );
+
+        // Completing it flips the top-level badge to installed.
+        seed_boogu_default(data_dir, repo, true);
+        let state = install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+        assert!(
+            state.installed,
+            "a complete boogu install reads installed at the top level"
+        );
+        assert!(!state.cache_incomplete);
+    }
+
+    /// SANA repos keep TWO cached snapshots (a tiered one + an older flat one). A tier that is complete
+    /// in the tiered snapshot must read installed even though the flat snapshot has no tier subdir — the
+    /// check folds across snapshots with `any`, not `all` (guards the epic-13075 multi-snapshot trap).
+    #[test]
+    fn sana_tier_complete_in_one_of_two_snapshots_reads_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "SceneWorks/Sana_1600M_1024px_mlx";
+        let model = sana_matrix_model(repo);
+
+        // Tiered snapshot: a complete q4.
+        seed_sana_tier(data_dir, repo, "q4", true);
+        // A second, FLAT snapshot with weights at the root (no q4/ subdir) — must not drag q4 down.
+        let cache = huggingface_repo_cache_path(data_dir, repo).expect("cache path");
+        let flat = cache.join("snapshots").join("flat9999");
+        for rel in [
+            "transformer/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+        ] {
+            let path = flat.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"x").unwrap();
+        }
+
+        let states = model_variant_states(&model, data_dir);
+        let q4 = states.iter().find(|s| s.variant == "q4").unwrap();
+        assert!(
+            q4.installed,
+            "q4 complete in the tiered snapshot reads installed despite a flat sibling snapshot"
+        );
+        assert!(!q4.cache_incomplete);
+    }
+
+    /// Anima is convert-at-install; its variants[] "default" tracks the three exact `split_files/` SOURCE
+    /// files (not a tier subdir). `tier_subdir_name` resolves those to `split_files`, so the downgrade
+    /// RUNS — but must be a NO-OP: a complete source passes `anima_tier_complete` (the layout is
+    /// compatible), and a torn source is already coarse-missing (exact-path filter), so `if installed` is
+    /// false. This pins that no-op so a future divergence between the download filter and the predicate's
+    /// pinned filenames surfaces as a RED test, not a silent false-incomplete on the Anima source badge.
+    #[test]
+    fn anima_source_download_variant_stays_installed_predicate_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "circlestone-labs/Anima";
+        let model = json!({
+            "id": "anima_base",
+            "family": "anima",
+            "downloads": [
+                { "provider": "huggingface", "repo": repo, "files": [
+                    "split_files/diffusion_models/anima-base-v1.0.safetensors",
+                    "split_files/text_encoders/qwen_3_06b_base.safetensors",
+                    "split_files/vae/qwen_image_vae.safetensors"
+                ]}
+            ]
+        });
+
+        seed_cache(
+            data_dir,
+            repo,
+            &[
+                "split_files/diffusion_models/anima-base-v1.0.safetensors",
+                "split_files/text_encoders/qwen_3_06b_base.safetensors",
+                "split_files/vae/qwen_image_vae.safetensors",
+            ],
+        );
+        let states = model_variant_states(&model, data_dir);
+        assert_eq!(states.len(), 1);
+        assert!(
+            states[0].installed,
+            "a complete anima source reads installed — the predicate must not false-incomplete it"
+        );
+        assert!(!states[0].cache_incomplete);
     }
 
     /// A model whose ONLY on-disk tier is torn must read NOT installed at the model level — including

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1842,6 +1842,26 @@ fn model_has_variant_matrix(model: &Value) -> bool {
         })
 }
 
+// The shared per-tier completeness predicate for a no-`model_index` MLX turnkey
+// (`sceneworks_core::mlx_tier_completeness`), keyed on the manifest `family`, or `None` for a family
+// whose per-tier completeness is already accurate — diffusers turnkeys (flux/qwen/…) via the
+// `model_index.json` augmentation in `huggingface_filtered_cache_health`, or a family with no bespoke
+// per-tier layout. The catalog uses this to downgrade a tier that clears the coarse `<tier>/*` glob but
+// is actually torn (backbone present, text-encoder/VAE/tokenizer missing) to `incomplete`, so the
+// /models report agrees with the worker's tier resolvers, which gate on these SAME predicates
+// (sc-13513). Anima is included so its convert-output states (`mlx_convert_output_tier_states`) tighten;
+// on its variants[] source download the exact-path `files` filter already reports torn accurately, so
+// this is a no-op there.
+fn no_model_index_family_predicate(family: &str) -> Option<fn(&FsPath) -> bool> {
+    use sceneworks_core::mlx_tier_completeness as tc;
+    match family {
+        "anima" => Some(tc::anima_tier_complete),
+        "boogu" => Some(tc::boogu_tier_complete),
+        "sana" => Some(tc::sana_tier_complete),
+        _ => None,
+    }
+}
+
 // Build the per-variant install state for every supported download entry. A single-variant model
 // yields one entry keyed "default"; a quant-matrix model yields one per tier. Each entry's install
 // state is probed independently against the HF cache using that tier's own `files` filter, so the
@@ -1850,6 +1870,12 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
     let Some(downloads) = model.get("downloads").and_then(Value::as_array) else {
         return Vec::new();
     };
+    // sc-13513: the manifest `family` selects the shared per-tier completeness predicate for the
+    // no-`model_index` MLX turnkeys (SANA/Boogu) so a torn tier reads `incomplete`, not `installed`.
+    let family = model
+        .get("family")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     // Emitted variant keys must be unique: the single-variant case is exactly one "default", and a
     // quant matrix has one entry per distinct q4/q8/bf16 tier. Guard against a manifest that maps two
     // supported entries to the same key (unlabeled alternate sources both collapsing to "default", or
@@ -1880,11 +1906,11 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
             let cache_health = cache_path
                 .as_ref()
                 .map(|path| huggingface_cache_health(path, &files));
-            let installed = cache_health.as_ref().is_some_and(|health| health.installed);
-            let cache_incomplete = cache_health
+            let cache_installed = cache_health.as_ref().is_some_and(|health| health.installed);
+            let mut cache_incomplete = cache_health
                 .as_ref()
                 .is_some_and(|health| health.incomplete);
-            let missing_required_files = cache_health
+            let mut missing_required_files = cache_health
                 .as_ref()
                 .map(|health| health.missing_files.clone())
                 .unwrap_or_default();
@@ -1896,7 +1922,40 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
             // actually exist under the managed dir, not just the marker.
             let managed_path = data_dir.join("models").join(safe_download_dir(&repo));
             let managed_installed = managed_tier_installed(&managed_path, &files);
-            let installed_path = if installed || cache_incomplete {
+            let mut installed = cache_installed || managed_installed;
+
+            // sc-13513: the coarse `<tier>/*` glob (and the managed presence check) is satisfied by ANY
+            // single nested file, so a TORN tier of a no-`model_index` MLX turnkey (SANA/Boogu — backbone
+            // present, text-encoder/VAE/tokenizer missing) read `installed`. Mirror the worker's shared
+            // family completeness predicate so a torn tier reports `incomplete` instead. This only ever
+            // DOWNGRADES a coarse `installed`; a clean-missing tier is never promoted, a family without a
+            // bespoke predicate (diffusers turnkeys, already accurate via the `model_index.json`
+            // augmentation) is untouched, and the candle whole-repo SANA entry has no single tier subdir
+            // (`tier_subdir_name` → None) so it is skipped. Checked across every cache snapshot AND the
+            // managed dir (a SANA repo keeps TWO snapshots — tiered + flat) with `any`, so a complete tier
+            // in one location isn't dragged down by a sibling snapshot that lacks it.
+            if installed {
+                if let (Some(complete), Some(tier)) = (
+                    no_model_index_family_predicate(family),
+                    tier_subdir_name(&files),
+                ) {
+                    let mut tier_bases = cache_path
+                        .as_ref()
+                        .map(|path| huggingface_snapshot_dirs(path))
+                        .unwrap_or_default();
+                    tier_bases.push(managed_path.clone());
+                    if !tier_bases.iter().any(|base| complete(&base.join(&tier))) {
+                        installed = false;
+                        cache_incomplete = true;
+                        let marker = format!("{tier}/ (incomplete: missing model components)");
+                        if !missing_required_files.contains(&marker) {
+                            missing_required_files.push(marker);
+                        }
+                    }
+                }
+            }
+
+            let installed_path = if cache_installed || cache_incomplete {
                 cache_path
             } else if managed_installed {
                 Some(managed_path)
@@ -1910,7 +1969,7 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
                     .map(|value| value.trim().to_owned())
                     .filter(|value| !value.is_empty())
                     .unwrap_or_else(|| "default".to_owned()),
-                installed: installed || managed_installed,
+                installed,
                 installed_path: installed_path.map(|path| path.display().to_string()),
                 cache_incomplete,
                 missing_required_files,
@@ -2035,21 +2094,37 @@ fn mlx_convert_output_tiers(converted_dir: &FsPath) -> Vec<&'static str> {
 /// Studio picker can show EVERY tier with the un-converted ones DISABLED — the same "show all, disable
 /// unavailable" rule the download-matrix `variants[]` array gives. Unlike [`mlx_convert_output_tiers`]
 /// (installed tiers only, which can only ever GROW the picker), this lists all three whether or not they
-/// are on disk. `installState` is `"installed"` when the tier holds loadable weights, else `"missing"`;
-/// `cacheState` mirrors it (`"complete"`/`"missing"`). NOTE the completeness here is as coarse as
-/// [`tier_subdir_has_weights`] — it can't yet flag a torn tier (backbone present, text-encoder/VAE gone)
-/// as `incomplete` the way the diffusers `variants[]` path does via `model_index.json`; a torn convert
-/// output would read `installed`. Tightening that needs the worker's family-specific completeness
-/// (anima/boogu/sana) mirrored here — tracked separately.
-fn mlx_convert_output_tier_states(converted_dir: &FsPath) -> Vec<Value> {
+/// are on disk. Three states per tier: `"installed"`/`"complete"` (loadable), `"missing"`/`"incomplete"`
+/// (a TORN tier — backbone present, a component gone; repairable by re-convert), and
+/// `"missing"`/`"missing"` (never converted for this tier).
+///
+/// Completeness is family-specific (sc-13513): a convert-at-install family with a bespoke no-`model_index`
+/// layout (Anima's `diffusion_models/ + text_encoders/ + vae/`) is gated on the SAME shared per-tier
+/// predicate the worker's `anima_tier_subdir` resolver uses ([`no_model_index_family_predicate`]), so a
+/// torn convert output reads `incomplete` rather than `installed`. Any other convert family keeps the
+/// coarse [`tier_subdir_has_weights`] backbone probe.
+fn mlx_convert_output_tier_states(converted_dir: &FsPath, family: &str) -> Vec<Value> {
+    let predicate = no_model_index_family_predicate(family);
     ["q4", "q8", "bf16"]
         .into_iter()
         .map(|tier| {
-            let installed = tier_subdir_has_weights(&converted_dir.join(tier));
+            let dir = converted_dir.join(tier);
+            let has_backbone = tier_subdir_has_weights(&dir);
+            let complete = match predicate {
+                Some(complete) => complete(&dir),
+                None => has_backbone,
+            };
+            let (install_state, cache_state) = if complete {
+                ("installed", "complete")
+            } else if has_backbone {
+                ("missing", "incomplete")
+            } else {
+                ("missing", "missing")
+            };
             json!({
                 "tier": tier,
-                "installState": if installed { "installed" } else { "missing" },
-                "cacheState": if installed { "complete" } else { "missing" },
+                "installState": install_state,
+                "cacheState": cache_state,
             })
         })
         .collect()
@@ -2123,6 +2198,13 @@ fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
         if let Some(converted) = status.converted_path.as_deref() {
             let tiers = mlx_convert_output_tiers(converted);
             if !tiers.is_empty() {
+                // Owned before the mutable inserts below so the `family` read doesn't overlap the borrow;
+                // it selects the per-tier completeness predicate for the states (sc-13513).
+                let family = object
+                    .get("family")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
                 object.insert("mlxTiers".to_owned(), json!(tiers));
                 // The FULL possible tier set with per-tier state, so the Studio shows un-converted tiers
                 // disabled rather than omitting them (the web reads `mlxTierStates` in preference to the
@@ -2130,7 +2212,7 @@ fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
                 // present), matching `mlxTiers` — an unconverted model still renders no picker.
                 object.insert(
                     "mlxTierStates".to_owned(),
-                    Value::Array(mlx_convert_output_tier_states(converted)),
+                    Value::Array(mlx_convert_output_tier_states(converted, &family)),
                 );
             }
         }
@@ -3635,6 +3717,143 @@ mod variant_install_tests {
         assert!(state.installed, "model installed via the complete q4 tier");
     }
 
+    /// A SANA quant-matrix turnkey (family `sana`). Ships NO `model_index.json`, so the diffusers
+    /// completeness augmentation is a no-op — the tightening comes from the shared `sana_tier_complete`.
+    fn sana_matrix_model(repo: &str) -> Value {
+        json!({
+            "id": "sana_sprint_1600m",
+            "family": "sana",
+            "downloads": [
+                { "provider": "huggingface", "repo": repo, "variant": "q4", "default": true, "files": ["q4/*"] },
+                { "provider": "huggingface", "repo": repo, "variant": "q8", "files": ["q8/*"] },
+                { "provider": "huggingface", "repo": repo, "variant": "bf16", "files": ["bf16/*"] }
+            ]
+        })
+    }
+
+    /// Seed a SANA quant tier: always the transformer + VAE weights, plus the Gemma text encoder + its
+    /// tokenizer only when `complete`. A `complete: false` tier is TORN — its `<tier>/*` glob matches
+    /// (transformer present) but the loader dies on the absent text encoder / tokenizer.
+    fn seed_sana_tier(data_dir: &FsPath, repo: &str, tier: &str, complete: bool) {
+        let cache = huggingface_repo_cache_path(data_dir, repo).expect("cache path");
+        let root = cache.join("snapshots").join("abc123").join(tier);
+        let write = |rel: &str| {
+            let path = root.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"x").unwrap();
+        };
+        write("transformer/diffusion_pytorch_model.safetensors");
+        write("vae/diffusion_pytorch_model.safetensors");
+        if complete {
+            write("text_encoder/gemma-2-2b-it.safetensors");
+            write("text_encoder/tokenizer.json");
+        }
+    }
+
+    /// The sc-13513 fix for a no-`model_index` quant-matrix turnkey: a torn SANA tier (its `<tier>/*`
+    /// glob matches the transformer, but the Gemma text encoder + tokenizer never landed) reported a
+    /// green "Installed" badge, then failed to load. It must read `incomplete`; a never-fetched tier
+    /// stays a clean `missing`.
+    #[test]
+    fn torn_sana_tier_reads_incomplete_not_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "SceneWorks/Sana_Sprint_1.6B_1024px_mlx";
+        let model = sana_matrix_model(repo);
+
+        // q4 complete (loads), q8 torn (text encoder + tokenizer missing), bf16 never fetched.
+        seed_sana_tier(data_dir, repo, "q4", true);
+        seed_sana_tier(data_dir, repo, "q8", false);
+
+        let states = model_variant_states(&model, data_dir);
+        let by_variant = |name: &str| states.iter().find(|s| s.variant == name).unwrap();
+
+        assert!(
+            by_variant("q4").installed,
+            "complete q4 tier must read installed"
+        );
+        assert!(
+            !by_variant("q8").installed,
+            "torn q8 tier must NOT read installed just because its transformer matched the glob"
+        );
+        assert!(
+            by_variant("q8").cache_incomplete,
+            "a torn (half-present) tier is a repairable incomplete, not a clean missing"
+        );
+        assert!(
+            !by_variant("bf16").installed && !by_variant("bf16").cache_incomplete,
+            "a never-fetched tier stays a clean missing (no spurious repair prompt)"
+        );
+
+        // Mutation check: completing q8 (add the Gemma text encoder + tokenizer) flips it to installed,
+        // proving the predicate discriminates on the text encoder, not merely the transformer glob.
+        seed_sana_tier(data_dir, repo, "q8", true);
+        let states = model_variant_states(&model, data_dir);
+        assert!(states.iter().find(|s| s.variant == "q8").unwrap().installed);
+    }
+
+    /// A Boogu turnkey (family `boogu`): a single unlabeled "default" download whose `files` filter
+    /// enumerates the three component subdirs of the shipped `base/` Q8 subfolder.
+    fn boogu_model(repo: &str) -> Value {
+        json!({
+            "id": "boogu_image",
+            "family": "boogu",
+            "downloads": [
+                { "provider": "huggingface", "repo": repo, "files": ["base/transformer/*", "base/mllm/*", "base/vae/*"] }
+            ]
+        })
+    }
+
+    /// Seed a Boogu `base/` subfolder: transformer (weights + config), mllm weights, and VAE, plus the
+    /// `mllm/tokenizer.json` only when `complete`. A `complete: false` tree is TORN — the loader crashes
+    /// first on the missing tokenizer, but each `base/<dir>/*` glob matches the stray weights.
+    fn seed_boogu_default(data_dir: &FsPath, repo: &str, complete: bool) {
+        let cache = huggingface_repo_cache_path(data_dir, repo).expect("cache path");
+        let base = cache.join("snapshots").join("abc123").join("base");
+        let write = |rel: &str| {
+            let path = base.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"x").unwrap();
+        };
+        write("transformer/diffusion_pytorch_model.safetensors");
+        write("transformer/config.json");
+        write("mllm/model.safetensors");
+        write("vae/diffusion_pytorch_model.safetensors");
+        if complete {
+            write("mllm/tokenizer.json");
+        }
+    }
+
+    #[test]
+    fn torn_boogu_default_reads_incomplete_not_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo = "SceneWorks/boogu-image-mlx";
+        let model = boogu_model(repo);
+
+        // Torn: transformer + mllm weights + vae present, but `mllm/tokenizer.json` never landed. Each
+        // `base/<dir>/*` glob matches the stray weights, so the coarse check reads installed.
+        seed_boogu_default(data_dir, repo, false);
+        let states = model_variant_states(&model, data_dir);
+        assert_eq!(states.len(), 1);
+        assert!(
+            !states[0].installed,
+            "torn boogu default must NOT read installed just because the component globs matched"
+        );
+        assert!(
+            states[0].cache_incomplete,
+            "a torn boogu default is a repairable incomplete"
+        );
+
+        // Mutation check: adding the tokenizer completes it.
+        seed_boogu_default(data_dir, repo, true);
+        let states = model_variant_states(&model, data_dir);
+        assert!(
+            states[0].installed,
+            "complete boogu default reads installed"
+        );
+    }
+
     /// A model whose ONLY on-disk tier is torn must read NOT installed at the model level — including
     /// via the "usable stale" receipt path (sc-13076 backfilled a receipt for whatever was on disk,
     /// so a metadata-only tier produced a receipt whose files all exist yet cannot load).
@@ -3758,39 +3977,65 @@ mod mlx_tier_probe_tests {
         assert!(mlx_convert_output_tiers(flat.path()).is_empty());
     }
 
-    #[test]
-    fn convert_output_tier_states_lists_the_full_set_marking_un_converted_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path();
-        // Only q4 + q8 are converted; bf16 is absent — but ALL THREE must appear so the picker can show
-        // bf16 disabled (the "show all, disable unavailable" rule for convert-at-install models).
-        write_weight(
-            &root.join("q4"),
-            "diffusion_models",
-            "anima-base-v1.0.safetensors",
-        );
-        write_weight(
-            &root.join("q8"),
-            "diffusion_models",
-            "anima-base-v1.0.safetensors",
-        );
-        let states = mlx_convert_output_tier_states(root);
-        assert_eq!(states.len(), 3);
-        let by_tier: std::collections::BTreeMap<_, _> = states
+    /// Seed a converted Anima tier: always the DiT (backbone), plus the dense text encoder + VAE only
+    /// when `complete`. A `complete: false` tier is TORN — its DiT satisfies the coarse
+    /// `tier_subdir_has_weights` probe, but the loader would die on the missing text-encoder/VAE.
+    fn seed_anima_tier(root: &std::path::Path, tier: &str, complete: bool) {
+        let dir = root.join(tier);
+        write_weight(&dir, "diffusion_models", "anima-base-v1.0.safetensors");
+        if complete {
+            write_weight(&dir, "text_encoders", "qwen_3_06b_base.safetensors");
+            write_weight(&dir, "vae", "qwen_image_vae.safetensors");
+        }
+    }
+
+    fn tier_state_map(states: &[Value]) -> std::collections::BTreeMap<String, (String, String)> {
+        states
             .iter()
             .map(|state| {
                 (
-                    state["tier"].as_str().unwrap(),
+                    state["tier"].as_str().unwrap().to_owned(),
                     (
-                        state["installState"].as_str().unwrap(),
-                        state["cacheState"].as_str().unwrap(),
+                        state["installState"].as_str().unwrap().to_owned(),
+                        state["cacheState"].as_str().unwrap().to_owned(),
                     ),
                 )
             })
-            .collect();
-        assert_eq!(by_tier["q4"], ("installed", "complete"));
-        assert_eq!(by_tier["q8"], ("installed", "complete"));
-        assert_eq!(by_tier["bf16"], ("missing", "missing"));
+            .collect()
+    }
+
+    #[test]
+    fn convert_output_tier_states_mark_complete_torn_and_absent_tiers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // q4 complete (loads), q8 TORN (DiT present but text-encoder/VAE never landed), bf16 absent — all
+        // THREE must appear so the picker can show each state (the "show all, disable unavailable" rule).
+        seed_anima_tier(root, "q4", true);
+        seed_anima_tier(root, "q8", false);
+
+        // family "anima" gates on the shared per-tier predicate: the torn q8 reads incomplete, NOT
+        // installed (sc-13513).
+        let anima = mlx_convert_output_tier_states(root, "anima");
+        assert_eq!(anima.len(), 3);
+        let a = tier_state_map(&anima);
+        assert_eq!(a["q4"], ("installed".into(), "complete".into()));
+        assert_eq!(
+            a["q8"],
+            ("missing".into(), "incomplete".into()),
+            "a torn DiT-only tier must read incomplete, not installed"
+        );
+        assert_eq!(a["bf16"], ("missing".into(), "missing".into()));
+
+        // A convert family with no bespoke predicate keeps the coarse backbone probe — a DiT-only tier
+        // reads installed (byte-identical to the pre-sc-13513 behavior for any non-anima convert family).
+        let coarse = tier_state_map(&mlx_convert_output_tier_states(root, "flux2"));
+        assert_eq!(coarse["q8"], ("installed".into(), "complete".into()));
+
+        // Mutation check: completing q8 (add the text encoder + VAE) flips it to installed — proving the
+        // predicate discriminates on the components, not merely the backbone.
+        seed_anima_tier(root, "q8", true);
+        let a2 = tier_state_map(&mlx_convert_output_tier_states(root, "anima"));
+        assert_eq!(a2["q8"], ("installed".into(), "complete".into()));
     }
 
     // Full catalog path: a converted convert-at-install model (Anima) emits `mlxTiers` from
@@ -3798,20 +4043,35 @@ mod mlx_tier_probe_tests {
     // probe is `cfg!(target_os = "macos")`).
     #[test]
     #[cfg(target_os = "macos")]
-    fn catalog_emits_mlxtiers_for_converted_anima() {
+    fn catalog_emits_mlxtiers_and_states_for_converted_anima() {
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let converted = data_dir.join("models").join("mlx").join("anima_base");
         std::fs::create_dir_all(&converted).unwrap();
         std::fs::write(converted.join("model_index.json"), b"{}").unwrap();
-        for tier in ["bf16", "q8", "q4"] {
-            let dm = converted.join(tier).join("diffusion_models");
-            std::fs::create_dir_all(&dm).unwrap();
-            std::fs::write(dm.join("anima-base-v1.0.safetensors"), b"x").unwrap();
-        }
+        // bf16 + q4 fully converted (DiT + text encoder + VAE); q8 is TORN (DiT only) — a realistic
+        // interrupted convert. The full `apply_mac_and_mlx_fields` path must carry the family predicate.
+        let seed_tier = |tier: &str, complete: bool| {
+            let base = converted.join(tier);
+            let write = |sub: &str, file: &str| {
+                let dir = base.join(sub);
+                std::fs::create_dir_all(&dir).unwrap();
+                std::fs::write(dir.join(file), b"x").unwrap();
+            };
+            write("diffusion_models", "anima-base-v1.0.safetensors");
+            if complete {
+                write("text_encoders", "qwen_3_06b_base.safetensors");
+                write("vae", "qwen_image_vae.safetensors");
+            }
+        };
+        seed_tier("bf16", true);
+        seed_tier("q4", true);
+        seed_tier("q8", false);
+
         let mut object = json!({
             "id": "anima_base",
             "type": "image",
+            "family": "anima",
             "mlx": { "requiresConversion": true }
         })
         .as_object()
@@ -3822,6 +4082,8 @@ mod mlx_tier_probe_tests {
             object.get("mlxConversionState").and_then(Value::as_str),
             Some("converted")
         );
+        // `mlxTiers` is the coarse installed-tier list — it drives whether the picker renders; the torn
+        // q8 still appears (backbone present) so the user sees it, disabled.
         let tiers: Vec<&str> = object
             .get("mlxTiers")
             .and_then(Value::as_array)
@@ -3830,6 +4092,17 @@ mod mlx_tier_probe_tests {
             .filter_map(Value::as_str)
             .collect();
         assert_eq!(tiers, vec!["bf16", "q8", "q4"]);
+        // `mlxTierStates` is authoritative: through the full catalog path the family predicate marks the
+        // torn q8 incomplete and the complete tiers installed (sc-13513).
+        let states = tier_state_map(
+            object
+                .get("mlxTierStates")
+                .and_then(Value::as_array)
+                .expect("mlxTierStates emitted"),
+        );
+        assert_eq!(states["bf16"], ("installed".into(), "complete".into()));
+        assert_eq!(states["q4"], ("installed".into(), "complete".into()));
+        assert_eq!(states["q8"], ("missing".into(), "incomplete".into()));
         // Decoupled from the download matrix — the picker must NOT flip `hasVariantMatrix`.
         assert!(object.get("hasVariantMatrix").is_none());
     }

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod jsonc;
 pub mod lora_family;
 pub mod lora_url;
 pub mod media_convert;
+pub mod mlx_tier_completeness;
 pub mod observability;
 pub mod payload_util;
 pub mod project_store;

--- a/crates/sceneworks-core/src/mlx_tier_completeness.rs
+++ b/crates/sceneworks-core/src/mlx_tier_completeness.rs
@@ -1,0 +1,226 @@
+//! Per-family tier-completeness predicates for the MLX turnkeys that ship NO `model_index.json`
+//! (Anima / Boogu / SANA).
+//!
+//! These families lay their weights out in a bespoke tree rather than a diffusers `model_index.json`
+//! pipeline, so the generic `<tier>/*` presence checks — the worker's `tier_components_present`
+//! (reads the tier's own `model_index.json`) and rust-api's coarse glob / `tier_subdir_has_weights`
+//! — are a no-op for them: a TORN tier (backbone present, text-encoder / VAE / tokenizer missing)
+//! passes the coarse check yet fails to load. Both the worker's tier resolvers (which pick a loadable
+//! tier) AND rust-api's catalog completeness (which reports `installed` vs `incomplete`) need the SAME
+//! concrete per-family predicate, so it lives here in the shared crate — a single source of truth that
+//! the two consumers cannot drift apart (sc-13513). Hidden AppleDouble `._*` sidecars never count
+//! (SceneWorks#1333).
+
+use std::path::Path;
+
+/// Whether `dir` holds at least one non-hidden file whose name ends with `suffix` (e.g. `.safetensors`
+/// / `.index.json`). The building block for the per-family completeness checks: a hidden AppleDouble
+/// `._*` sidecar never counts (SceneWorks#1333).
+pub fn dir_has_visible_file_ending(dir: &Path, suffix: &str) -> bool {
+    std::fs::read_dir(dir).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            !crate::lora_family::is_hidden_file(&entry.path())
+                && entry.file_name().to_string_lossy().ends_with(suffix)
+        })
+    })
+}
+
+/// Whether an Anima tier `dir` is COMPLETE and loadable (issue #850 class, generalized). Anima ships no
+/// `model_index.json`, so the shared presence guards are a no-op for it and a torn tier (DiT present,
+/// text-encoder/VAE absent) reached the loader, which then died with a raw "No such file or directory"
+/// (mlx-gen-anima `load_text_phase` / `load_vae`). A tier is complete when all three concrete inputs are
+/// present: the DiT (any visible `.safetensors` in `diffusion_models/`), the dense text encoder, and the
+/// VAE. Tokenizers are vendored into the binary, so there is no tokenizer file to check here.
+pub fn anima_tier_complete(dir: &Path) -> bool {
+    dir_has_visible_file_ending(&dir.join("diffusion_models"), ".safetensors")
+        && dir
+            .join("text_encoders/qwen_3_06b_base.safetensors")
+            .is_file()
+        && dir.join("vae/qwen_image_vae.safetensors").is_file()
+}
+
+/// Whether a Boogu tier `dir` is COMPLETE and loadable. Boogu ships no `model_index.json`, so the shared
+/// guard is a no-op; the loader crashes FIRST on a missing `mllm/tokenizer.json`, then on an absent
+/// `mllm`/`transformer`/`vae` weight. A tier is complete when the transformer (packed single-file OR
+/// sharded index) plus its `config.json`, the Qwen3-VL `mllm/` (weights + `tokenizer.json`), and the VAE
+/// weights are all present.
+pub fn boogu_tier_complete(dir: &Path) -> bool {
+    let transformer = dir.join("transformer");
+    let transformer_weights = transformer
+        .join("diffusion_pytorch_model.safetensors")
+        .is_file()
+        || transformer
+            .join("diffusion_pytorch_model.safetensors.index.json")
+            .is_file();
+    transformer_weights
+        && transformer.join("config.json").is_file()
+        && dir.join("mllm/tokenizer.json").is_file()
+        && dir_has_visible_file_ending(&dir.join("mllm"), ".safetensors")
+        && dir_has_visible_file_ending(&dir.join("vae"), ".safetensors")
+}
+
+/// Whether a SANA tier `dir` is COMPLETE and loadable. The `SceneWorks/Sana_*_mlx` turnkeys ship no
+/// `model_index.json`, so the standard-tier guard is a no-op for SANA specifically (flux/qwen/etc. DO
+/// ship one and stay protected by the `model_index.json` check); the SANA loader dies with a raw OS
+/// error on an absent Gemma text encoder or its tokenizer (mlx-gen-sana `SanaTextEncoder::from_snapshot`).
+/// A tier is complete when the Linear-DiT transformer, the DC-AE VAE, and the Gemma-2 text encoder + its
+/// tokenizer (both bundled inside `text_encoder/`) are all present.
+pub fn sana_tier_complete(dir: &Path) -> bool {
+    dir_has_visible_file_ending(&dir.join("transformer"), ".safetensors")
+        && dir_has_visible_file_ending(&dir.join("vae"), ".safetensors")
+        && dir.join("text_encoder/gemma-2-2b-it.safetensors").is_file()
+        && dir.join("text_encoder/tokenizer.json").is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    fn touch(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"x").unwrap();
+    }
+
+    /// Write a COMPLETE Anima tier tree, then return its dir. Callers delete one component to probe that
+    /// each is load-bearing (a mutation check — a torn tier must go RED, not pass on the backbone alone).
+    fn seed_anima(dir: &Path) {
+        touch(&dir.join("diffusion_models/anima-base-v1.0.safetensors"));
+        touch(&dir.join("text_encoders/qwen_3_06b_base.safetensors"));
+        touch(&dir.join("vae/qwen_image_vae.safetensors"));
+    }
+
+    fn seed_boogu(dir: &Path) {
+        touch(&dir.join("transformer/diffusion_pytorch_model.safetensors"));
+        touch(&dir.join("transformer/config.json"));
+        touch(&dir.join("mllm/model.safetensors"));
+        touch(&dir.join("mllm/tokenizer.json"));
+        touch(&dir.join("vae/diffusion_pytorch_model.safetensors"));
+    }
+
+    fn seed_sana(dir: &Path) {
+        touch(&dir.join("transformer/diffusion_pytorch_model.safetensors"));
+        touch(&dir.join("vae/diffusion_pytorch_model.safetensors"));
+        touch(&dir.join("text_encoder/gemma-2-2b-it.safetensors"));
+        touch(&dir.join("text_encoder/tokenizer.json"));
+    }
+
+    #[test]
+    fn anima_complete_true_each_component_load_bearing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q8");
+        seed_anima(&dir);
+        assert!(anima_tier_complete(&dir), "fully-seeded tier is complete");
+
+        // Mutation check: removing ANY single component must flip the verdict to incomplete.
+        for component in [
+            "diffusion_models/anima-base-v1.0.safetensors",
+            "text_encoders/qwen_3_06b_base.safetensors",
+            "vae/qwen_image_vae.safetensors",
+        ] {
+            let torn = tmp.path().join("torn");
+            seed_anima(&torn);
+            fs::remove_file(torn.join(component)).unwrap();
+            assert!(
+                !anima_tier_complete(&torn),
+                "removing {component} must read incomplete"
+            );
+            fs::remove_dir_all(&torn).ok();
+        }
+    }
+
+    #[test]
+    fn anima_wrong_text_encoder_filename_is_incomplete() {
+        // The predicate pins the EXACT dense-TE filename; a differently-named `.safetensors` in
+        // `text_encoders/` does not satisfy it (guards a typo'd rename from silently passing).
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q8");
+        seed_anima(&dir);
+        fs::remove_file(dir.join("text_encoders/qwen_3_06b_base.safetensors")).unwrap();
+        touch(&dir.join("text_encoders/some_other.safetensors"));
+        assert!(!anima_tier_complete(&dir));
+    }
+
+    #[test]
+    fn anima_ignores_appledouble_dit_sidecar() {
+        // A hidden `._` DiT sidecar is not a real weight (SceneWorks#1333).
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q8");
+        seed_anima(&dir);
+        fs::remove_file(dir.join("diffusion_models/anima-base-v1.0.safetensors")).unwrap();
+        touch(&dir.join("diffusion_models/._anima-base-v1.0.safetensors"));
+        assert!(!anima_tier_complete(&dir));
+    }
+
+    #[test]
+    fn boogu_complete_true_each_component_load_bearing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("base");
+        seed_boogu(&dir);
+        assert!(boogu_tier_complete(&dir));
+
+        for component in [
+            "transformer/diffusion_pytorch_model.safetensors",
+            "transformer/config.json",
+            "mllm/model.safetensors",
+            "mllm/tokenizer.json",
+            "vae/diffusion_pytorch_model.safetensors",
+        ] {
+            let torn = tmp.path().join("torn");
+            seed_boogu(&torn);
+            fs::remove_file(torn.join(component)).unwrap();
+            assert!(
+                !boogu_tier_complete(&torn),
+                "removing {component} must read incomplete"
+            );
+            fs::remove_dir_all(&torn).ok();
+        }
+    }
+
+    #[test]
+    fn boogu_accepts_sharded_transformer_index() {
+        // A sharded transformer (index.json, no single-file weight) is loadable too.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("base");
+        seed_boogu(&dir);
+        fs::remove_file(dir.join("transformer/diffusion_pytorch_model.safetensors")).unwrap();
+        touch(&dir.join("transformer/diffusion_pytorch_model.safetensors.index.json"));
+        assert!(boogu_tier_complete(&dir));
+    }
+
+    #[test]
+    fn sana_complete_true_each_component_load_bearing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q4");
+        seed_sana(&dir);
+        assert!(sana_tier_complete(&dir));
+
+        for component in [
+            "transformer/diffusion_pytorch_model.safetensors",
+            "vae/diffusion_pytorch_model.safetensors",
+            "text_encoder/gemma-2-2b-it.safetensors",
+            "text_encoder/tokenizer.json",
+        ] {
+            let torn = tmp.path().join("torn");
+            seed_sana(&torn);
+            fs::remove_file(torn.join(component)).unwrap();
+            assert!(
+                !sana_tier_complete(&torn),
+                "removing {component} must read incomplete"
+            );
+            fs::remove_dir_all(&torn).ok();
+        }
+    }
+
+    #[test]
+    fn missing_tier_dir_is_incomplete_for_every_family() {
+        // A tier subdir that does not exist at all (never converted / never downloaded) is incomplete,
+        // not a panic — the catalog treats it as a clean "missing".
+        let tmp = tempfile::tempdir().unwrap();
+        let absent = tmp.path().join("nope");
+        assert!(!anima_tier_complete(&absent));
+        assert!(!boogu_tier_complete(&absent));
+        assert!(!sana_tier_complete(&absent));
+    }
+}

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1219,65 +1219,11 @@ fn dir_has_visible_entry(dir: &Path) -> bool {
     })
 }
 
-/// Whether `dir` holds at least one non-hidden file whose name ends with `suffix` (e.g. `.safetensors`
-/// / `.index.json`). The building block for the per-family completeness checks of turnkeys that ship
-/// no `model_index.json` (Anima / Boogu / SANA), where [`tier_components_present`] is a no-op. Hidden
-/// AppleDouble `._*` sidecars never count (SceneWorks#1333).
-fn dir_has_visible_file_ending(dir: &Path, suffix: &str) -> bool {
-    std::fs::read_dir(dir).is_ok_and(|entries| {
-        entries.flatten().any(|entry| {
-            !sceneworks_core::lora_family::is_hidden_file(&entry.path())
-                && entry.file_name().to_string_lossy().ends_with(suffix)
-        })
-    })
-}
-
-/// Whether an Anima tier `dir` is COMPLETE and loadable (issue #850 class, generalized). Anima ships no
-/// `model_index.json`, so the shared [`tier_components_present`] guard is a no-op for it and a torn tier
-/// (DiT present, text-encoder/VAE absent) reached the loader, which then died with a raw
-/// "No such file or directory" (mlx-gen-anima `load_text_phase` / `load_vae`). A tier is complete when
-/// all three concrete inputs are present: the DiT (any visible `.safetensors` in `diffusion_models/`),
-/// the dense text encoder, and the VAE. Tokenizers are vendored into the binary, so there is no
-/// tokenizer file to check here.
-#[cfg(any(target_os = "macos", feature = "backend-candle"))]
-fn anima_tier_complete(dir: &Path) -> bool {
-    dir_has_visible_file_ending(&dir.join("diffusion_models"), ".safetensors")
-        && dir.join("text_encoders/qwen_3_06b_base.safetensors").is_file()
-        && dir.join("vae/qwen_image_vae.safetensors").is_file()
-}
-
-/// Whether a Boogu tier `dir` is COMPLETE and loadable. Boogu ships no `model_index.json`, so the shared
-/// guard is a no-op; the loader crashes FIRST on a missing `mllm/tokenizer.json`, then on an absent
-/// `mllm`/`transformer`/`vae` weight. A tier is complete when the transformer (packed single-file OR
-/// sharded index) plus its `config.json`, the Qwen3-VL `mllm/` (weights + `tokenizer.json`), and the VAE
-/// weights are all present.
-fn boogu_tier_complete(dir: &Path) -> bool {
-    let transformer = dir.join("transformer");
-    let transformer_weights = transformer
-        .join("diffusion_pytorch_model.safetensors")
-        .is_file()
-        || transformer
-            .join("diffusion_pytorch_model.safetensors.index.json")
-            .is_file();
-    transformer_weights
-        && transformer.join("config.json").is_file()
-        && dir.join("mllm/tokenizer.json").is_file()
-        && dir_has_visible_file_ending(&dir.join("mllm"), ".safetensors")
-        && dir_has_visible_file_ending(&dir.join("vae"), ".safetensors")
-}
-
-/// Whether a SANA tier `dir` is COMPLETE and loadable. The `SceneWorks/Sana_*_mlx` turnkeys ship no
-/// `model_index.json`, so the standard-tier guard is a no-op for SANA specifically (flux/qwen/etc. DO
-/// ship one and stay protected by [`tier_components_present`]); the SANA loader dies with a raw OS error
-/// on an absent Gemma text encoder or its tokenizer (mlx-gen-sana `SanaTextEncoder::from_snapshot`). A
-/// tier is complete when the Linear-DiT transformer, the DC-AE VAE, and the Gemma-2 text encoder + its
-/// tokenizer (both bundled inside `text_encoder/`) are all present.
-fn sana_tier_complete(dir: &Path) -> bool {
-    dir_has_visible_file_ending(&dir.join("transformer"), ".safetensors")
-        && dir_has_visible_file_ending(&dir.join("vae"), ".safetensors")
-        && dir.join("text_encoder/gemma-2-2b-it.safetensors").is_file()
-        && dir.join("text_encoder/tokenizer.json").is_file()
-}
+// The per-family tier-completeness predicates for the no-`model_index` MLX turnkeys
+// (`anima_tier_complete` / `boogu_tier_complete` / `sana_tier_complete`, plus their
+// `dir_has_visible_file_ending` helper) live in `sceneworks_core::mlx_tier_completeness` and are
+// called fully-qualified below. They are shared with rust-api's catalog completeness so the worker's
+// tier resolvers and the /models `installed`-vs-`incomplete` report cannot drift apart (sc-13513).
 
 /// Whether the tier dir `resolve_weights_dir` resolved for `request` is COMPLETE — every component its
 /// loader reads is on disk. Used ONLY by [`mlx_weights_gap`] to turn a torn-tier load (which otherwise
@@ -1293,16 +1239,17 @@ fn sana_tier_complete(dir: &Path) -> bool {
 #[cfg(target_os = "macos")]
 fn resolved_tier_is_complete(request: &ImageRequest, dir: &Path) -> bool {
     if is_anima_model(&request.model) {
-        return anima_tier_complete(dir);
+        return sceneworks_core::mlx_tier_completeness::anima_tier_complete(dir);
     }
     if matches!(
         request.model.as_str(),
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit"
     ) {
-        return boogu_tier_complete(dir);
+        return sceneworks_core::mlx_tier_completeness::boogu_tier_complete(dir);
     }
     if matches!(request.model.as_str(), "sana_1600m" | "sana_sprint_1600m") {
-        return tier_components_present(dir) && sana_tier_complete(dir);
+        return tier_components_present(dir)
+            && sceneworks_core::mlx_tier_completeness::sana_tier_complete(dir);
     }
     tier_components_present(dir)
 }
@@ -1449,7 +1396,10 @@ fn standard_tier_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: b
     // torn SANA tier is demoted too. Flat unified tiers (SenseNova-U1 MoT) ship no `model_index.json`
     // either but are not SANA, so they resolve on the backbone probe exactly as before.
     let is_sana = matches!(request.model.as_str(), "sana_1600m" | "sana_sprint_1600m");
-    let complete = |dir: &Path| tier_components_present(dir) && (!is_sana || sana_tier_complete(dir));
+    let complete = |dir: &Path| {
+        tier_components_present(dir)
+            && (!is_sana || sceneworks_core::mlx_tier_completeness::sana_tier_complete(dir))
+    };
     pick_loadable_tier(&[preferred, "q8", "bf16", "q4"], &present, &complete)
         .unwrap_or_else(|| root.to_path_buf())
 }
@@ -1530,7 +1480,11 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // sc-12279 generalized: Anima ships no `model_index.json`, so route the chain through the concrete
     // `anima_tier_complete` predicate — a torn tier (DiT present, text-encoder/VAE absent) now falls
     // through to a complete sibling instead of reaching the loader and dying on the missing file.
-    pick_loadable_tier(&[preferred, "q8", "bf16", "q4"], &present, &anima_tier_complete)
+    pick_loadable_tier(
+        &[preferred, "q8", "bf16", "q4"],
+        &present,
+        &sceneworks_core::mlx_tier_completeness::anima_tier_complete,
+    )
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -1687,7 +1641,11 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // missing tokenizer. Chain is folder names (`<variant>`, `<variant>-q4`, `<variant>-bf16`).
     let chain = [variant_folder(preferred), variant.to_owned(), q4, bf16];
     let chain_refs: Vec<&str> = chain.iter().map(String::as_str).collect();
-    pick_loadable_tier(&chain_refs, &present, &boogu_tier_complete)
+    pick_loadable_tier(
+        &chain_refs,
+        &present,
+        &sceneworks_core::mlx_tier_completeness::boogu_tier_complete,
+    )
         .unwrap_or_else(|| root.to_path_buf())
 }
 


### PR DESCRIPTION
## What & why

Closes the deferred sc-13513 (epic [13511](https://app.shortcut.com/trefry/epic/13511)). The catalog's per-tier completeness for the MLX turnkeys that ship **no `model_index.json`** — SANA, Anima, Boogu — used a coarse `<tier>/*` glob (and `tier_subdir_has_weights`), which matches *any* single nested file. So a **torn** tier (backbone present, text-encoder / VAE / tokenizer missing) read `installState: installed` / `cacheState: complete`, then failed to load at generation. Diffusers-shaped turnkeys (flux/qwen/…) were already accurate via the `model_index.json` augmentation in `huggingface_filtered_cache_health`.

The **worker** already gates these families on concrete per-family predicates (`anima_tier_complete` / `boogu_tier_complete` / `sana_tier_complete`); rust-api had drifted to the coarse check. This story is that drift.

## Approach — shared crate (drift-proof)

Rather than duplicate the predicates into rust-api (which would re-create the exact worker↔rust-api drift this story exists to close), the three predicates + their `dir_has_visible_file_ending` helper **move out of the worker** into a new **`sceneworks_core::mlx_tier_completeness`** module, consumed by **both** the worker (6 fully-qualified call sites) and rust-api. One source of truth; the tier resolvers and the `/models` `installed`-vs-`incomplete` report can't drift again.

rust-api applies them via `no_model_index_family_predicate` + a shared `no_model_index_tier_is_torn` on:

- **`model_variant_states`** (variants[] path) — **SANA** quant-matrix tiers (`q4/*`…) and the **Boogu** `base/` default download. A coarse-`installed` torn tier downgrades to `incomplete`. Only ever downgrades; a clean-missing tier is never promoted; diffusers turnkeys are untouched; the candle whole-repo SANA entry (`files:[]` → no tier subdir) is skipped. Checked across every cache snapshot **and** the managed dir with `any` (a SANA repo keeps two snapshots — tiered + flat, the epic-13075 case).
- **`install_state_for`** (top-level badge) — Boogu is single-variant, so the badge took a coarse `else` branch that bypassed the fix; now downgraded there too, so the badge, the per-variant state, and the loader gate agree. *(Found by adversarial review.)*
- **`mlx_convert_output_tier_states`** (mlxTierStates path) — **Anima** convert outputs now report three states: installed/complete, torn → missing/incomplete, never-converted → missing/missing. `mlxTiers` (the installed-tier list gating whether the picker renders) is deliberately left coarse so the picker still shows a torn tier, disabled.

## Verification

Real weights on disk were checked to confirm the predicates match the actual per-tier layouts (Anima: `diffusion_models/ + text_encoders/qwen_3_06b_base.safetensors + vae/qwen_image_vae.safetensors`; SANA: `transformer/*.safetensors + vae/*.safetensors + text_encoder/{gemma-2-2b-it.safetensors,tokenizer.json}`), so a complete real install can't false-flag.

Local gate (Apple-Silicon macOS lane): `cargo fmt --all --check` ✓, `cargo clippy -p sceneworks-core -p sceneworks-worker -p sceneworks-rust-api --all-targets -- -D warnings` ✓, core module tests ✓, rust-api lib **333** ✓, worker tier-resolver tests ✓ (behavior preserved through the predicate move). Mutation-checked unit tests in core (each component load-bearing) + rust-api torn-tier tests for SANA, Boogu (per-variant **and** top-level), and Anima (incl. the full `apply_mac_and_mlx_fields` catalog path), plus a two-snapshot SANA test and an Anima source-download no-op pin.

⚠️ The `backend-candle` worker lane needs CUDA and cannot build on this Mac — the candle/Windows lanes are covered by CI (the worker change is a mechanical call-site swap to an un-gated core module, which *reduces* cfg-gating). **Do not merge until `gh pr checks` is green on those lanes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)