### PR TITLE
feat(audio): Voice Clone "register a voice" saved-voice registry [sc-13517]

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -8,6 +8,18 @@ pub(crate) struct JobsQuery {
     pub(crate) limit: Option<u32>,
 }
 
+/// Register a saved voice (Voice Clone registry, sc-13517): a name + the library audio asset whose
+/// voice is cloned. `dedupThreshold` optionally overrides the cosine-similarity cutoff used to warn
+/// about near-duplicate voices already saved in the project.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SavedVoiceCreateRequest {
+    pub(crate) name: String,
+    pub(crate) reference_audio_asset_id: String,
+    #[serde(default)]
+    pub(crate) dedup_threshold: Option<f32>,
+}
+
 /// Filters for the aggregate generation-metrics feed (epic 10402,
 /// `GET /api/v1/metrics`). All optional; the charts pass a subset.
 #[derive(Debug, Deserialize)]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -77,6 +77,8 @@ use uuid::Uuid;
 
 mod auth;
 use auth::{access_control, cors_layer, is_authorized, AuthThrottle};
+mod saved_voices;
+use saved_voices::{create_saved_voice, delete_saved_voice, list_saved_voices};
 mod characters;
 use characters::{
     add_character_reference, archive_character, attach_character_lora, create_character,
@@ -159,9 +161,9 @@ use dto::{
     LoraCatalogItemQuery, LoraImportRequest, LoraUpdateRequest, LorasQuery, MetricsQuery,
     ModelConvertRequest, ModelDownloadRequest, ModelImportRequest, PersonDetectionJobRequest,
     PersonTrackCorrectionsRequest, PersonTrackJobRequest, ProjectCreateRequest, PromptBatchesQuery,
-    PromptRefineRequest, QualityAckBody, ReadinessQuery, RecipePresetsQuery, TimelineCreateRequest,
-    TimelineExportRequest, TimelineSaveRequest, TrainingCaptionJobRequest, VerifyResponse,
-    VideoJobRequest, VqaJobRequest,
+    PromptRefineRequest, QualityAckBody, ReadinessQuery, RecipePresetsQuery,
+    SavedVoiceCreateRequest, TimelineCreateRequest, TimelineExportRequest, TimelineSaveRequest,
+    TrainingCaptionJobRequest, VerifyResponse, VideoJobRequest, VqaJobRequest,
 };
 mod manifest;
 use manifest::{
@@ -1128,6 +1130,14 @@ pub(crate) fn create_app_with_state(
         .route(
             "/api/v1/projects/:project_id/files/*relative_path",
             get(get_project_file),
+        )
+        .route(
+            "/api/v1/projects/:project_id/voices",
+            get(list_saved_voices).post(create_saved_voice),
+        )
+        .route(
+            "/api/v1/projects/:project_id/voices/:voice_id",
+            delete(delete_saved_voice),
         )
         .route(
             "/api/v1/projects/:project_id/characters",

--- a/apps/rust-api/src/saved_voices.rs
+++ b/apps/rust-api/src/saved_voices.rs
@@ -1,0 +1,110 @@
+//! HTTP handlers for the per-project **saved voices** registry (Voice Clone, sc-13517).
+//!
+//! Register: resolve the chosen library audio asset → compute its Chatterbox-VE speaker embedding on
+//! a blocking thread (the worker's embed path) → persist name + reference asset id + embedding, and
+//! run the near-duplicate check (the embedding's real consumer). List / delete round out the CRUD.
+//! Picking a saved voice in the Studio supplies `referenceAudioAssetId` to the existing audio-job
+//! pipeline, so no new generation wiring is needed here.
+
+use super::*;
+
+use sceneworks_core::voice_store::{SavedVoiceCreateInput, DEFAULT_VOICE_DEDUP_THRESHOLD};
+use sceneworks_worker::voice_register::{embed_reference_clip, VoiceEmbedError};
+
+fn map_voice_embed_error(error: VoiceEmbedError) -> ApiError {
+    match error {
+        // A missing install or an undecodable reference clip is client-actionable.
+        VoiceEmbedError::WeightsMissing(message) | VoiceEmbedError::Decode(message) => {
+            ApiError::bad_request(message)
+        }
+        // An embedder load/run failure is a server-side fault.
+        VoiceEmbedError::Embed(message) => ApiError::internal(message),
+    }
+}
+
+pub(crate) async fn list_saved_voices(
+    State(state): State<AppState>,
+    Path(project_id): Path<String>,
+) -> Result<Json<Vec<Value>>, ApiError> {
+    Ok(Json(
+        project_call(state, move |store| store.list_saved_voices(&project_id)).await?,
+    ))
+}
+
+pub(crate) async fn create_saved_voice(
+    State(state): State<AppState>,
+    Path(project_id): Path<String>,
+    ApiJson(payload): ApiJson<SavedVoiceCreateRequest>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    let name = payload.name.trim().to_owned();
+    if name.is_empty() {
+        return Err(ApiError::bad_request("Voice name must not be empty"));
+    }
+    let asset_id = payload.reference_audio_asset_id.trim().to_owned();
+    if asset_id.is_empty() {
+        return Err(ApiError::bad_request(
+            "A reference audio asset id is required",
+        ));
+    }
+    let threshold = payload
+        .dedup_threshold
+        .unwrap_or(DEFAULT_VOICE_DEDUP_THRESHOLD);
+
+    // 1. Resolve the reference clip to an absolute on-disk path (blocking store call).
+    let wav_path = project_call(state.clone(), {
+        let project_id = project_id.clone();
+        let asset_id = asset_id.clone();
+        move |store| store.resolve_asset_media_path(&project_id, &asset_id)
+    })
+    .await?;
+
+    // 2. Compute the Chatterbox-VE speaker embedding on a blocking thread (real inference).
+    let data_dir = state.settings.data_dir.clone();
+    let embedding = tokio::task::spawn_blocking(move || embed_reference_clip(&data_dir, &wav_path))
+        .await
+        .map_err(|error| ApiError::internal(format!("voice embed task panicked: {error}")))?
+        .map_err(map_voice_embed_error)?;
+
+    // 3. Persist + run near-duplicate detection (blocking store call).
+    let (voice, duplicate) = project_call(state, move |store| {
+        store.create_saved_voice(
+            &project_id,
+            SavedVoiceCreateInput {
+                name,
+                reference_audio_asset_id: asset_id,
+                embedding,
+            },
+            threshold,
+        )
+    })
+    .await?;
+
+    // Surface the dedup consumer's result inline so the UI can warn on register.
+    let mut body = voice;
+    if let Some(object) = body.as_object_mut() {
+        object.insert(
+            "nearDuplicate".to_owned(),
+            match duplicate {
+                Some(dup) => json!({
+                    "id": dup.id,
+                    "name": dup.name,
+                    "similarity": dup.similarity,
+                }),
+                None => Value::Null,
+            },
+        );
+    }
+    Ok((StatusCode::CREATED, Json(body)))
+}
+
+pub(crate) async fn delete_saved_voice(
+    State(state): State<AppState>,
+    Path((project_id, voice_id)): Path<(String, String)>,
+) -> Result<Json<sceneworks_core::voice_store::SavedVoiceMutationResult>, ApiError> {
+    Ok(Json(
+        project_call(state, move |store| {
+            store.delete_saved_voice(&project_id, &voice_id)
+        })
+        .await?,
+    ))
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -29,6 +29,7 @@ import { editModelForAsset, workflowModelType } from "./presetUtils.js";
 import { sortNewest, sortWorkers, upsertJobNewest } from "./sorters.js";
 import { useCharacters } from "./hooks/useCharacters.js";
 import { usePresets } from "./hooks/usePresets.js";
+import { useSavedVoices } from "./hooks/useSavedVoices.js";
 import { usePromptBatches } from "./hooks/usePromptBatches.js";
 import { useTraining } from "./hooks/useTraining.js";
 import { useModelsAndLoras } from "./hooks/useModelsAndLoras.js";
@@ -532,6 +533,7 @@ export function App() {
   // purge orphaned scratch/result assets from the SSE handler without re-subscribing.
   const purgeAssetRef = useRef(null);
   const refreshCharactersRef = useRef(null);
+  const refreshSavedVoicesRef = useRef(null);
   const refreshLorasRef = useRef(null);
   const refreshPresetsRef = useRef(null);
   const refreshPromptBatchesRef = useRef(null);
@@ -733,6 +735,14 @@ export function App() {
     duplicatePreset,
     deletePreset,
   } = usePresets({ token, activeProject, setError });
+
+  const {
+    savedVoices,
+    setSavedVoices,
+    refreshSavedVoices,
+    createSavedVoice,
+    deleteSavedVoice,
+  } = useSavedVoices({ token, activeProject, activeProjectRef, setError });
 
   const {
     promptBatches,
@@ -1227,6 +1237,7 @@ export function App() {
     if (!activeProject || !ready) {
       setAssets([]);
       setCharacters([]);
+      setSavedVoices([]);
       setPersonTracks([]);
       setTimelines([]);
       setTimelinesProjectId(null);
@@ -1245,6 +1256,7 @@ export function App() {
     const { signal } = controller;
     refreshAssetsRef.current?.(activeProject.id, { signal });
     refreshCharactersRef.current?.(activeProject.id, { signal });
+    refreshSavedVoicesRef.current?.(activeProject.id, { signal });
     refreshLorasRef.current?.(activeProject.id, { signal });
     refreshPresetsRef.current?.(activeProject.id, { signal });
     refreshPromptBatchesRef.current?.(activeProject.id, { signal });
@@ -1422,6 +1434,7 @@ export function App() {
     refreshDataRef.current = refreshData;
     refreshAssetsRef.current = refreshAssets;
     refreshCharactersRef.current = refreshCharacters;
+    refreshSavedVoicesRef.current = refreshSavedVoices;
     refreshLorasRef.current = refreshLoras;
     refreshPresetsRef.current = refreshPresets;
     refreshPromptBatchesRef.current = refreshPromptBatches;
@@ -2419,6 +2432,11 @@ export function App() {
     trackEditorScratchOp,
     releaseEditorScratchOp,
     registerEditorScratchClaim,
+    // Saved voices (Voice Clone registry, sc-13517)
+    savedVoices,
+    refreshSavedVoices,
+    createSavedVoice,
+    deleteSavedVoice,
     // Characters
     characters,
     createCharacter,
@@ -2466,7 +2484,8 @@ export function App() {
     updateTrainingDataset, batchRenameTrainingDataset, writeTrainingDatasetCaptionSidecars,
     createTrainingDatasetCaptionJob, createTrainingDatasetUpscaleJob, createTrainingDatasetAnalysisJob, createTrainingDatasetFaceAnalysisJob, smartCropTrainingDataset, stripExifTrainingDataset, createTrainingJob, trainingPresets, trainingPresetsError,
     trainingTargets, trainingTargetsError, setActiveView, registerLeaveGuard, registerProjectSwitchGuard,
-    trackEditorScratchOp, releaseEditorScratchOp, registerEditorScratchClaim, characters,
+    trackEditorScratchOp, releaseEditorScratchOp, registerEditorScratchClaim,
+    savedVoices, refreshSavedVoices, createSavedVoice, deleteSavedVoice, characters,
     createCharacter, updateCharacter, archiveCharacter, unarchiveCharacter, listArchivedCharacters,
     addCharacterReference, updateCharacterReference,
     removeCharacterReference, createCharacterLook, updateCharacterLook, deleteCharacterLook,

--- a/apps/web/src/hooks/useSavedVoices.js
+++ b/apps/web/src/hooks/useSavedVoices.js
@@ -1,0 +1,102 @@
+import { useCallback, useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+
+// Owns the project's Voice Clone "saved voices" roster + its create/delete mutations (sc-13517).
+// A saved voice is a named pointer to a library audio reference clip (plus its Chatterbox-VE speaker
+// embedding, computed + dedup-checked on the backend at register time). Extracted as a thin data
+// layer like useCharacters/usePresets; shared concerns (token, active project, error) are passed in.
+//
+// Every returned action is useCallback-wrapped with stable deps so appStaticValue can stay memoized
+// across App's SSE-driven re-renders (mirrors the sc-4194 note in useCharacters/useModelsAndLoras).
+export function useSavedVoices({ token, activeProject, activeProjectRef, setError }) {
+  const [savedVoices, setSavedVoices] = useState([]);
+
+  const refreshSavedVoices = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      if (!projectId) {
+        return;
+      }
+      try {
+        const items = await apiFetch(
+          `/api/v1/projects/${projectId}/voices`,
+          token,
+          { signal },
+        );
+        // Drop a stale response for a project the user already switched away from
+        // (mirrors refreshCharacters' guard).
+        if (activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
+          return;
+        }
+        setSavedVoices(Array.isArray(items) ? items : []);
+        setError("");
+      } catch (err) {
+        if (isAbortError(err)) return;
+        setError(err.message);
+      }
+    },
+    [token, activeProject, activeProjectRef, setError],
+  );
+
+  // Register a saved voice: the backend resolves the reference clip, computes its embedding, runs
+  // near-duplicate detection, and persists. Returns the created voice (with a `nearDuplicate` field)
+  // so the caller can surface the dedup warning, or null on error.
+  const createSavedVoice = useCallback(
+    async ({ name, referenceAudioAssetId }) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        const created = await apiFetch(
+          `/api/v1/projects/${activeProject.id}/voices`,
+          token,
+          {
+            method: "POST",
+            body: JSON.stringify({ name, referenceAudioAssetId }),
+          },
+        );
+        setSavedVoices((items) => [
+          created,
+          ...items.filter((item) => item.id !== created.id),
+        ]);
+        setError("");
+        return created;
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError],
+  );
+
+  const deleteSavedVoice = useCallback(
+    async (voiceId) => {
+      if (!activeProject) {
+        setError("Create or open a project first.");
+        return null;
+      }
+      try {
+        await apiFetch(
+          `/api/v1/projects/${activeProject.id}/voices/${encodeURIComponent(voiceId)}`,
+          token,
+          { method: "DELETE" },
+        );
+        setSavedVoices((items) => items.filter((item) => item.id !== voiceId));
+        setError("");
+        return { id: voiceId, status: "deleted" };
+      } catch (err) {
+        setError(err.message);
+        return null;
+      }
+    },
+    [token, activeProject, setError],
+  );
+
+  return {
+    savedVoices,
+    setSavedVoices,
+    refreshSavedVoices,
+    createSavedVoice,
+    deleteSavedVoice,
+  };
+}

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -160,6 +160,9 @@ export function AudioStudio() {
     setActiveView,
     setPreviewAsset,
     macCapabilities,
+    savedVoices = [],
+    createSavedVoice,
+    deleteSavedVoice,
   } = useAppContext();
 
   // Last-used settings for this workspace, restored on mount. The component is keyed by workspace in
@@ -204,6 +207,11 @@ export function AudioStudio() {
   // OpenVoice conversion strength (τ), empty ⇒ the converter default (0.3).
   const [referenceAudioAssetId, setReferenceAudioAssetId] = useState(saved.referenceAudioAssetId ?? "");
   const [matchStrength, setMatchStrength] = useState(saved.matchStrength ?? "");
+  // Register-a-voice affordance (sc-13517): a name for the saved voice built from the currently
+  // selected reference clip, an in-flight guard, and the post-register notice (dedup warning / info).
+  const [savedVoiceName, setSavedVoiceName] = useState("");
+  const [registeringVoice, setRegisteringVoice] = useState(false);
+  const [savedVoiceNotice, setSavedVoiceNotice] = useState(null);
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   // Guards a Speech run in flight so a second submit (double-click / ⌘↵) can't double-enqueue
   // (mirrors VideoStudio's `submitting`). Cleared in submit's finally.
@@ -296,6 +304,65 @@ export function AudioStudio() {
   // VideoStudio's `videoAssets` (type-scoped so the picker only offers real audio; the picker itself
   // runs with categories hidden since its `all/image/video` tabs carry no audio bucket).
   const audioAssets = useMemo(() => assets.filter((asset) => asset?.type === "audio"), [assets]);
+
+  // Saved voices (sc-13517): a saved voice is "selected" when the reference clip in play is the one
+  // it points to. Picking a saved voice just sets referenceAudioAssetId, which the existing pipeline
+  // routes to native chatterbox_tts / OpenVoice fallback — no new generation wiring.
+  const selectedSavedVoiceId = useMemo(() => {
+    if (!referenceAudioAssetId) return "";
+    const match = savedVoices.find(
+      (voice) => voice?.referenceAudioAssetId === referenceAudioAssetId,
+    );
+    return match?.id ?? "";
+  }, [savedVoices, referenceAudioAssetId]);
+
+  const canRegisterVoice =
+    Boolean(createSavedVoice) &&
+    referenceAudioAssetId.length > 0 &&
+    savedVoiceName.trim().length > 0 &&
+    !registeringVoice;
+
+  async function handleRegisterVoice() {
+    if (!canRegisterVoice) return;
+    setRegisteringVoice(true);
+    setSavedVoiceNotice(null);
+    try {
+      const created = await createSavedVoice({
+        name: savedVoiceName.trim(),
+        referenceAudioAssetId,
+      });
+      // A null result means the register failed — the error is surfaced by the app-level banner.
+      if (!created) return;
+      setSavedVoiceName("");
+      const duplicate = created.nearDuplicate;
+      if (duplicate) {
+        setSavedVoiceNotice({
+          tone: "warning",
+          message: `Saved “${created.name}”, but it looks very similar to “${duplicate.name}” (${Math.round(
+            duplicate.similarity * 100,
+          )}% match) — you may already have this voice registered.`,
+        });
+      } else {
+        setSavedVoiceNotice({
+          tone: "info",
+          message: `Saved “${created.name}” to this project’s voices.`,
+        });
+      }
+    } finally {
+      setRegisteringVoice(false);
+    }
+  }
+
+  function handleSelectSavedVoice(voice) {
+    setReferenceAudioAssetId(voice.referenceAudioAssetId);
+    setSavedVoiceNotice(null);
+  }
+
+  async function handleDeleteSavedVoice(voice) {
+    if (!deleteSavedVoice) return;
+    await deleteSavedVoice(voice.id);
+    setSavedVoiceNotice(null);
+  }
 
   // Generate is guarded (never a silent no-op): a run needs a wired mode, a non-empty prompt, an
   // installed model, and no run already in flight. The empty-prompt guard is the DoD's "disable on
@@ -780,6 +847,77 @@ export function AudioStudio() {
                   showCategories={false}
                   value={referenceAudioAssetId}
                 />
+                {savedVoices.length > 0 ? (
+                  <div className="saved-voices" role="group" aria-label="Saved voices">
+                    <span className="field-label">Saved voices</span>
+                    <div className="preset-chips saved-voices-chips">
+                      {savedVoices.map((voice) => (
+                        <span
+                          key={voice.id}
+                          className={`preset-chip saved-voice-chip${
+                            selectedSavedVoiceId === voice.id ? " is-selected" : ""
+                          }`}
+                        >
+                          <button
+                            type="button"
+                            className="saved-voice-select"
+                            aria-pressed={selectedSavedVoiceId === voice.id}
+                            onClick={() => handleSelectSavedVoice(voice)}
+                          >
+                            {voice.name}
+                          </button>
+                          <button
+                            type="button"
+                            className="saved-voice-delete"
+                            aria-label={`Delete saved voice ${voice.name}`}
+                            title="Delete saved voice"
+                            onClick={() => handleDeleteSavedVoice(voice)}
+                          >
+                            <Icon.Trash />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+                {createSavedVoice ? (
+                  <div className="register-voice">
+                    <label className="settings-field">
+                      Save this reference as a voice
+                      <div className="register-voice-row">
+                        <input
+                          onChange={(event) => setSavedVoiceName(event.target.value)}
+                          placeholder="Voice name (e.g. Narrator)"
+                          type="text"
+                          value={savedVoiceName}
+                        />
+                        <button
+                          className="secondary-action register-voice-save"
+                          disabled={!canRegisterVoice}
+                          onClick={handleRegisterVoice}
+                          type="button"
+                        >
+                          <Icon.Save />
+                          {registeringVoice ? "Saving…" : "Save voice"}
+                        </button>
+                      </div>
+                      <span className="field-hint" role="note">
+                        Registers the selected reference clip as a reusable named voice. We compute its
+                        speaker fingerprint and warn if it closely matches a voice you already saved.
+                      </span>
+                    </label>
+                    {savedVoiceNotice ? (
+                      <p
+                        className={
+                          savedVoiceNotice.tone === "warning" ? "inline-warning" : "field-hint"
+                        }
+                        role="status"
+                      >
+                        {savedVoiceNotice.message}
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
                 {showMatchStrength ? (
                   <label className="settings-field settings-field-match-strength">
                     Match strength

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -1094,6 +1094,135 @@ describe("AudioStudio Voice Clone generation (sc-13411)", () => {
   });
 });
 
+describe("AudioStudio register-a-voice (sc-13517)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <AudioStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const setInput = async (el, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+  const nameInput = () => container.querySelector(".register-voice-row input");
+  const saveButton = () => buttonWithText(container, "Save voice");
+
+  // A reference clip is a persisted selection, restored from the studio snapshot at mount.
+  const seedReference = () =>
+    window.localStorage.setItem(
+      "sceneworks-studio-audio-project_1",
+      JSON.stringify({ referenceAudioAssetId: "ref-voice-1" }),
+    );
+  const referenceAsset = { id: "ref-voice-1", type: "audio", displayName: "My reference voice" };
+
+  it("surfaces saved voices in the Voice Clone tab and selecting one sets the reference", async () => {
+    const savedVoices = [
+      { id: "voice_a", name: "Narrator", referenceAudioAssetId: "ref-voice-1" },
+      { id: "voice_b", name: "Villain", referenceAudioAssetId: "ref-voice-2" },
+    ];
+    await render(baseContext({ assets: [referenceAsset], savedVoices, createSavedVoice: vi.fn() }));
+    await click(modeTab(container, "Voice Clone"));
+
+    const chips = [...container.querySelectorAll(".saved-voice-chip")];
+    expect(chips.map((c) => c.querySelector(".saved-voice-select").textContent.trim())).toEqual([
+      "Narrator",
+      "Villain",
+    ]);
+    // None selected initially (no reference restored in this render).
+    const narratorSelect = chips[0].querySelector(".saved-voice-select");
+    await click(narratorSelect);
+    expect(narratorSelect.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("registers a voice and shows a near-duplicate WARNING when the backend flags one", async () => {
+    seedReference();
+    const createSavedVoice = vi.fn(async ({ name }) => ({
+      id: "voice_new",
+      name,
+      referenceAudioAssetId: "ref-voice-1",
+      nearDuplicate: { id: "voice_a", name: "Narrator", similarity: 0.97 },
+    }));
+    await render(baseContext({ assets: [referenceAsset], savedVoices: [], createSavedVoice }));
+    await click(modeTab(container, "Voice Clone"));
+
+    // Save is disabled until a name is typed.
+    expect(saveButton().disabled).toBe(true);
+    await setInput(nameInput(), "Narrator 2");
+    expect(saveButton().disabled).toBe(false);
+    await click(saveButton());
+
+    expect(createSavedVoice).toHaveBeenCalledWith({
+      name: "Narrator 2",
+      referenceAudioAssetId: "ref-voice-1",
+    });
+    const warning = container.querySelector(".inline-warning");
+    expect(warning).not.toBeNull();
+    expect(warning.textContent).toContain("Narrator");
+    expect(warning.textContent).toContain("97%");
+  });
+
+  it("registers a distinct voice with NO warning (info notice only)", async () => {
+    seedReference();
+    const createSavedVoice = vi.fn(async ({ name }) => ({
+      id: "voice_new",
+      name,
+      referenceAudioAssetId: "ref-voice-1",
+      nearDuplicate: null,
+    }));
+    await render(baseContext({ assets: [referenceAsset], savedVoices: [], createSavedVoice }));
+    await click(modeTab(container, "Voice Clone"));
+    await setInput(nameInput(), "Brand New Voice");
+    await click(saveButton());
+
+    expect(createSavedVoice).toHaveBeenCalledOnce();
+    expect(container.querySelector(".inline-warning")).toBeNull();
+    const notice = container.querySelector(".register-voice p[role='status']");
+    expect(notice.textContent).toContain("Brand New Voice");
+  });
+
+  it("deletes a saved voice via its delete affordance", async () => {
+    const savedVoices = [{ id: "voice_a", name: "Narrator", referenceAudioAssetId: "ref-voice-1" }];
+    const deleteSavedVoice = vi.fn(async () => ({ id: "voice_a", status: "deleted" }));
+    await render(
+      baseContext({
+        assets: [referenceAsset],
+        savedVoices,
+        createSavedVoice: vi.fn(),
+        deleteSavedVoice,
+      }),
+    );
+    await click(modeTab(container, "Voice Clone"));
+    await click(container.querySelector(".saved-voice-delete"));
+    expect(deleteSavedVoice).toHaveBeenCalledWith("voice_a");
+  });
+});
+
 describe("Audio nav registration (sc-13407)", () => {
   it("registers Audio in KEEP_ALIVE_VIEWS", () => {
     expect(KEEP_ALIVE_VIEWS.has("Audio")).toBe(true);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3400,6 +3400,100 @@ label {
   border-radius: var(--r-md);
 }
 
+/* Voice Clone saved-voices registry + register affordance (sc-13517). Reuses the .preset-chip pill
+   and .settings-field/.field-hint tokens; only the per-chip select+delete split and the register row
+   are bespoke. Theme-neutral: everything rides the shared CSS variables, so light/dark are inherited. */
+.saved-voices {
+  display: grid;
+  gap: 6px;
+}
+
+.saved-voices .field-label,
+.register-voice .field-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.saved-voices-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.saved-voice-chip {
+  gap: 6px;
+  padding-right: 4px;
+}
+
+.saved-voice-chip.is-selected {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.saved-voice-select {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.saved-voice-delete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast);
+}
+
+.saved-voice-delete:hover {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.saved-voice-delete svg {
+  width: 13px;
+  height: 13px;
+}
+
+.register-voice {
+  display: grid;
+  gap: 6px;
+}
+
+.register-voice-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.register-voice-row input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.register-voice-save {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.register-voice-save svg {
+  width: 14px;
+  height: 14px;
+}
+
 /* Strict-control panel (epic 8236, sc-8245): pose / canny / depth structure lock. Reuses the
    .studio-source-band shell, .reference-strength slider, .checkline toggle, and .asset-picker-field /
    .pose-library inner surfaces; only the mode tabs + section spacing are panel-specific. */

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod time;
 pub mod training;
 pub mod training_store;
 pub mod video_request;
+pub mod voice_store;
 
 pub const API_PREFIX: &str = "/api/v1";
 pub const HEALTH_ROUTE: &str = "/health";

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1066,6 +1066,61 @@ impl ProjectStore {
         Ok(assets)
     }
 
+    /// List the project's saved voices (Voice Clone registry, sc-13517).
+    pub fn list_saved_voices(&self, project_id: &str) -> ProjectStoreResult<Vec<Value>> {
+        let project_path = self.find_project_path(project_id)?;
+        crate::voice_store::SavedVoiceStore::new(project_path).list_saved_voices(project_id)
+    }
+
+    /// Register a saved voice; returns the hydrated voice plus any near-duplicate hit (sc-13517).
+    pub fn create_saved_voice(
+        &self,
+        project_id: &str,
+        input: crate::voice_store::SavedVoiceCreateInput,
+        dedup_threshold: f32,
+    ) -> ProjectStoreResult<(Value, Option<crate::voice_store::SavedVoiceDuplicate>)> {
+        let project_path = self.find_project_path(project_id)?;
+        crate::voice_store::SavedVoiceStore::new(project_path).create_saved_voice(
+            project_id,
+            input,
+            dedup_threshold,
+        )
+    }
+
+    /// Delete a saved voice (sc-13517).
+    pub fn delete_saved_voice(
+        &self,
+        project_id: &str,
+        voice_id: &str,
+    ) -> ProjectStoreResult<crate::voice_store::SavedVoiceMutationResult> {
+        let project_path = self.find_project_path(project_id)?;
+        crate::voice_store::SavedVoiceStore::new(project_path)
+            .delete_saved_voice(project_id, voice_id)
+    }
+
+    /// Resolve a library asset id to its absolute media file path, guarded against path traversal.
+    /// Used by the saved-voice register flow to hand the reference clip to the worker embed path
+    /// (sc-13517). Mirrors `get_asset`'s resolution but returns the on-disk path rather than the JSON.
+    pub fn resolve_asset_media_path(
+        &self,
+        project_id: &str,
+        asset_id: &str,
+    ) -> ProjectStoreResult<PathBuf> {
+        let project_path = self.find_project_path(project_id)?;
+        let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
+        let asset = normalize_asset(project_id, &project_path, &sidecar_path)?;
+        let media_rel = asset
+            .pointer("/file/path")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if media_rel.is_empty() || !is_safe_relative_path(media_rel) {
+            return Err(ProjectStoreError::BadRequest(
+                "Asset media path must be project-relative".to_owned(),
+            ));
+        }
+        Ok(project_path.join(media_rel))
+    }
+
     pub fn list_characters(
         &self,
         project_id: &str,
@@ -2664,7 +2719,12 @@ struct ReindexCounts {
 /// `ensure_project_db_ready`, which now heals inline-upscaled asset sidecars that
 /// were missing their fold lineage (`extra.upscaledFromAssetId` / `lineage`), so
 /// existing upscale pairs collapse in the Library on next open.
-const PROJECT_SCHEMA_VERSION: i64 = 4;
+///
+/// v5: sc-13517 — added the `saved_voices` table (Voice Clone "register a voice"
+/// registry). The bump lets existing DBs pick up the new table through the gated
+/// migration; the table is DB-authoritative (no sidecar), so the reindex the bump
+/// triggers — which only clears the sidecar-rebuilt tables — leaves it intact.
+const PROJECT_SCHEMA_VERSION: i64 = 5;
 
 fn project_schema_version(connection: &Connection) -> ProjectStoreResult<i64> {
     Ok(connection.query_row("pragma user_version", [], |row| row.get(0))?)
@@ -2722,6 +2782,7 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
     ensure_column(connection, "assets", "origin", "text")?;
     apply_character_migrations(connection)?;
     apply_training_dataset_migrations(connection)?;
+    crate::voice_store::apply_voice_migrations(connection)?;
     // Pragma assignment cannot be parameterized; the version is a trusted const.
     connection.execute_batch(&format!("pragma user_version = {PROJECT_SCHEMA_VERSION}"))?;
     Ok(())
@@ -4765,7 +4826,7 @@ mod tests {
     /// alongside a deliberate schema change — and when you do, you MUST bump
     /// `PROJECT_SCHEMA_VERSION` so the `user_version=` line below changes too.
     const EXPECTED_PROJECT_DB_SCHEMA: &str = concat!(
-        "user_version=4\n",
+        "user_version=5\n",
         "table assets: id TEXT notnull=0 default=NULL pk=1, type TEXT notnull=1 default=NULL pk=0, display_name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, generation_set_id TEXT notnull=0 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, favorite INTEGER notnull=1 default=0 pk=0, rating INTEGER notnull=1 default=0 pk=0, rejected INTEGER notnull=1 default=0 pk=0, trashed INTEGER notnull=1 default=0 pk=0, sidecar_path TEXT notnull=0 default=NULL pk=0, origin TEXT notnull=0 default=NULL pk=0\n",
         "table character_looks: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, description TEXT notnull=1 default='' pk=0, approved_reference_ids TEXT notnull=1 default='[]' pk=0, recipe_settings TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table character_loras: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, lora_id TEXT notnull=0 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, source_path TEXT notnull=0 default=NULL pk=0, project_path TEXT notnull=0 default=NULL pk=0, copied_into_project INTEGER notnull=1 default=0 pk=0, category TEXT notnull=1 default='character' pk=0, scope TEXT notnull=1 default='project' pk=0, trigger_words TEXT notnull=1 default='[]' pk=0, default_weight REAL notnull=1 default=1.0 pk=0, compatibility TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
@@ -4773,6 +4834,7 @@ mod tests {
         "table characters: id TEXT notnull=0 default=NULL pk=1, project_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, type TEXT notnull=1 default=NULL pk=0, description TEXT notnull=1 default='' pk=0, sidecar_path TEXT notnull=1 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0, archived INTEGER notnull=1 default=0 pk=0\n",
         "table generation_sets: id TEXT notnull=0 default=NULL pk=1, mode TEXT notnull=1 default=NULL pk=0, model TEXT notnull=1 default=NULL pk=0, prompt TEXT notnull=1 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, job_id TEXT notnull=0 default=NULL pk=0\n",
         "table project_metadata: key TEXT notnull=0 default=NULL pk=1, value TEXT notnull=1 default=NULL pk=0\n",
+        "table saved_voices: id TEXT notnull=0 default=NULL pk=1, project_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, reference_audio_asset_id TEXT notnull=1 default=NULL pk=0, embedding TEXT notnull=1 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0\n",
         "table timelines: id TEXT notnull=0 default=NULL pk=1, name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, aspect_ratio TEXT notnull=1 default=NULL pk=0, width INTEGER notnull=1 default=NULL pk=0, height INTEGER notnull=1 default=NULL pk=0, fps INTEGER notnull=1 default=NULL pk=0, duration REAL notnull=1 default=0 pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table training_datasets: id TEXT notnull=0 default=NULL pk=1, project_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, modality TEXT notnull=1 default=NULL pk=0, status TEXT notnull=1 default=NULL pk=0, version INTEGER notnull=1 default=NULL pk=0, item_count INTEGER notnull=1 default=0 pk=0, character_id TEXT notnull=0 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "index idx_training_datasets_project_updated on training_datasets",

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -6583,6 +6583,149 @@ mod tests {
         assert!(source_after.get("extra").is_none());
     }
 
+    /// sc-13517: the saved-voice id→clip hop end-to-end, cheaply. A saved voice's stored
+    /// `referenceAudioAssetId` resolves back to the exact library clip on disk through
+    /// `resolve_asset_media_path` — the link the register + generate flow relies on, proven directly
+    /// rather than only by composition in the release DoD render. `resolve_asset_media_path` is
+    /// media-type agnostic (it resolves the sidecar's `file.path`), so an imported image asset
+    /// exercises the identical id→path resolution the audio reference clip uses.
+    #[test]
+    fn saved_voice_reference_id_resolves_to_the_clip_path() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Voices").expect("project creates");
+
+        let src = temp_dir.path().join("clip.png");
+        std::fs::write(&src, b"\x89PNG reference clip bytes").expect("source writes");
+        let asset = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "clip.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: src,
+                    source_asset_id: None,
+                    provenance: None,
+                },
+            )
+            .expect("asset imports");
+        let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+
+        let (voice, _dup) = store
+            .create_saved_voice(
+                &project.id,
+                crate::voice_store::SavedVoiceCreateInput {
+                    name: "Narrator".to_owned(),
+                    reference_audio_asset_id: asset_id.clone(),
+                    embedding: vec![0.1, 0.2, 0.3, 0.4],
+                },
+                crate::voice_store::DEFAULT_VOICE_DEDUP_THRESHOLD,
+            )
+            .expect("register saved voice");
+        // The store persisted the reference pointer verbatim.
+        let stored_ref = voice["referenceAudioAssetId"].as_str().expect("ref id");
+        assert_eq!(stored_ref, asset_id);
+
+        // The stored referenceAudioAssetId resolves to the real clip file on disk.
+        let resolved = store
+            .resolve_asset_media_path(&project.id, stored_ref)
+            .expect("resolve clip");
+        assert!(
+            resolved.is_file(),
+            "resolved clip path must exist: {}",
+            resolved.display()
+        );
+        let expected_rel = store
+            .get_asset(&project.id, &asset_id)
+            .expect("asset")
+            .pointer("/file/path")
+            .and_then(Value::as_str)
+            .expect("file path")
+            .to_owned();
+        assert!(
+            resolved.ends_with(&expected_rel),
+            "resolved {} must end with the asset's relative path {expected_rel}",
+            resolved.display()
+        );
+    }
+
+    /// sc-13517: `resolve_asset_media_path` resolves a real asset AND rejects a path-traversal id
+    /// (the user-controlled `../` escape vector) before joining it into any filesystem path — the
+    /// direct unit test the review flagged as missing.
+    #[test]
+    fn resolve_asset_media_path_resolves_and_rejects_traversal() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Guard").expect("project creates");
+
+        let src = temp_dir.path().join("clip.png");
+        std::fs::write(&src, b"\x89PNG bytes").expect("source writes");
+        let asset = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "clip.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: src,
+                    source_asset_id: None,
+                    provenance: None,
+                },
+            )
+            .expect("asset imports");
+        let asset_id = asset["id"].as_str().expect("asset id").to_owned();
+
+        // Safe id → a real file under the project directory.
+        let resolved = store
+            .resolve_asset_media_path(&project.id, &asset_id)
+            .expect("resolve safe id");
+        assert!(resolved.is_file());
+        assert!(resolved.starts_with(temp_dir.path()));
+
+        // A `../` escape id is rejected outright (never joined into a path).
+        for escape in ["../../etc/passwd", "..", "a/../../b"] {
+            let result = store.resolve_asset_media_path(&project.id, escape);
+            assert!(
+                matches!(result, Err(ProjectStoreError::BadRequest(_))),
+                "traversal id {escape:?} must be rejected, got {result:?}"
+            );
+        }
+    }
+
+    /// sc-13517: `saved_voices` rows are DB-authoritative and MUST survive a reindex. The reindex
+    /// rebuilds the sidecar-backed tables (assets / generation_sets / timelines / characters) but must
+    /// leave `saved_voices` untouched — this guards that claim against a future schema bump that runs
+    /// the reindex on every existing project.
+    #[test]
+    fn saved_voices_survive_reindex() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Reindex").expect("project creates");
+
+        let (voice, _dup) = store
+            .create_saved_voice(
+                &project.id,
+                crate::voice_store::SavedVoiceCreateInput {
+                    name: "Narrator".to_owned(),
+                    reference_audio_asset_id: "asset_ref".to_owned(),
+                    embedding: vec![0.5, 0.5, 0.5],
+                },
+                crate::voice_store::DEFAULT_VOICE_DEDUP_THRESHOLD,
+            )
+            .expect("register saved voice");
+        let voice_id = voice["id"].as_str().expect("voice id").to_owned();
+        assert_eq!(store.list_saved_voices(&project.id).expect("list").len(), 1);
+
+        // An explicit reindex rebuilds the sidecar tables from disk.
+        store.reindex_project(&project.id).expect("reindex runs");
+
+        let after = store
+            .list_saved_voices(&project.id)
+            .expect("list after reindex");
+        assert_eq!(after.len(), 1, "the saved voice must survive reindex");
+        assert_eq!(after[0]["id"].as_str(), Some(voice_id.as_str()));
+        assert_eq!(after[0]["name"].as_str(), Some("Narrator"));
+    }
+
     /// sc-6143: a natively-supported image is stored byte-for-byte (no transcode, no re-encode),
     /// even when its declared content type is wrong — classification is by content.
     #[test]

--- a/crates/sceneworks-core/src/voice_store.rs
+++ b/crates/sceneworks-core/src/voice_store.rs
@@ -1,0 +1,483 @@
+//! Per-project **saved voices** registry (sc-13517, epic 13400 C4 follow-up).
+//!
+//! A "saved voice" is a named, reusable pointer to a library **reference audio clip** plus the
+//! Chatterbox-VE speaker **embedding** computed from it. The load-bearing element for generation is
+//! the reference audio asset id: picking a saved voice supplies `referenceAudioAssetId` to the
+//! existing Voice Clone pipeline (native `chatterbox_tts` with OpenVoice V2 fallback), both of which
+//! drive off the reference AUDIO — the stored embedding is NOT a generation input (VoiceEmbedding-only
+//! errors at S3Gen; see sc-13412). The embedding's real consumer is **near-duplicate detection**:
+//! at register time we cosine-compare the new embedding against the project's existing saved voices
+//! and flag a likely re-registration of the same speaker.
+//!
+//! Storage mirrors the training-dataset satellite precedent: a `saved_voices` table in the
+//! project.db, migrated through `apply_project_migrations` (schema-version gated). Unlike
+//! characters/assets/timelines there is no sidecar — a saved voice has no on-disk artifact of its
+//! own beyond the referenced asset, so the DB row is authoritative and survives the reindex that a
+//! schema bump triggers (the reindex only clears the sidecar-rebuilt tables, never this one).
+
+use std::path::PathBuf;
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::project_store::{connect_project_db_migrated, ProjectStoreError, ProjectStoreResult};
+use crate::store_util::{is_safe_id, random_hex};
+use crate::time::utc_now;
+
+/// The Chatterbox-VE (GE2E speaker encoder) embedding dimensionality.
+pub const VOICE_EMBEDDING_DIM: usize = 256;
+
+/// Default cosine-similarity threshold above which a newly-registered voice is flagged as a likely
+/// near-duplicate of an existing saved voice. Chatterbox-VE embeddings of the SAME speaker cluster
+/// high (the same clip ~1.0; the same speaker on a different clip typically > 0.9), while distinct
+/// speakers sit well below — the sc-13411 smoke measured converted-vs-reference 0.79 and
+/// base-vs-reference 0.65 across *different* Kokoro voices. 0.92 flags a re-registration of the same
+/// voice without tripping on merely-similar-but-distinct speakers. Callers may override per request.
+pub const DEFAULT_VOICE_DEDUP_THRESHOLD: f32 = 0.92;
+
+const MAX_VOICE_NAME_LEN: usize = 200;
+
+/// Inputs for registering a saved voice. The `embedding` is computed upstream (the worker's
+/// Chatterbox-VE embed path) from the chosen reference clip; the store treats it as opaque identity
+/// data for dedup and persistence.
+#[derive(Debug, Clone)]
+pub struct SavedVoiceCreateInput {
+    pub name: String,
+    pub reference_audio_asset_id: String,
+    pub embedding: Vec<f32>,
+}
+
+/// A near-duplicate hit surfaced at register time so the UI can warn the user.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SavedVoiceDuplicate {
+    pub id: String,
+    pub name: String,
+    pub similarity: f32,
+}
+
+/// The result of a delete.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SavedVoiceMutationResult {
+    pub id: String,
+    pub status: String,
+}
+
+/// Create the `saved_voices` table. Hooked into `apply_project_migrations` (schema-version gated), so
+/// this replays idempotently on existing DBs once `PROJECT_SCHEMA_VERSION` advances. `text` ids +
+/// `text` timestamps + the embedding as a JSON-encoded f32 array match every other project.db table.
+pub fn apply_voice_migrations(connection: &Connection) -> ProjectStoreResult<()> {
+    connection.execute_batch(
+        "
+        create table if not exists saved_voices (
+          id text primary key,
+          project_id text not null,
+          name text not null,
+          reference_audio_asset_id text not null,
+          embedding text not null,
+          created_at text not null
+        );
+        ",
+    )?;
+    Ok(())
+}
+
+/// L2-normalized cosine similarity in `[-1, 1]`. Chatterbox-VE returns raw (un-normalized) vectors, so
+/// both sides are normalized here (matches the `cosine` helper the sc-13411 smoke uses as evidence).
+/// Returns `0.0` when either vector has zero magnitude.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot / (norm_a * norm_b)
+    }
+}
+
+/// Per-project saved-voices data access. Constructed per call by [`crate::project_store::ProjectStore`]
+/// delegating methods (mirrors `CharacterStore`).
+pub struct SavedVoiceStore {
+    project_path: PathBuf,
+}
+
+impl SavedVoiceStore {
+    pub fn new(project_path: impl Into<PathBuf>) -> Self {
+        Self {
+            project_path: project_path.into(),
+        }
+    }
+
+    /// List the project's saved voices, newest first. The raw embedding is intentionally omitted from
+    /// the hydrated view — the UI needs only the identity + reference pointer, and the 256-float
+    /// vector is dedup-only internal data.
+    pub fn list_saved_voices(&self, project_id: &str) -> ProjectStoreResult<Vec<Value>> {
+        let connection = connect_project_db_migrated(&self.project_path)?;
+        let mut statement = connection.prepare(
+            "select id, name, reference_audio_asset_id, created_at
+             from saved_voices
+             where project_id = ?1
+             order by created_at desc, name asc",
+        )?;
+        let rows = statement
+            .query_map(params![project_id], |row| {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "name": row.get::<_, String>(1)?,
+                    "referenceAudioAssetId": row.get::<_, String>(2)?,
+                    "createdAt": row.get::<_, String>(3)?,
+                }))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Register a saved voice. Runs the near-duplicate check against the project's existing voices
+    /// FIRST (the embedding's real consumer), then persists the row. Returns the hydrated voice plus
+    /// the best duplicate hit at/above `dedup_threshold`, if any — the UI surfaces it as a warning.
+    pub fn create_saved_voice(
+        &self,
+        project_id: &str,
+        input: SavedVoiceCreateInput,
+        dedup_threshold: f32,
+    ) -> ProjectStoreResult<(Value, Option<SavedVoiceDuplicate>)> {
+        let name = input.name.trim();
+        if name.is_empty() {
+            return Err(ProjectStoreError::BadRequest(
+                "Voice name must not be empty".to_owned(),
+            ));
+        }
+        if name.chars().count() > MAX_VOICE_NAME_LEN {
+            return Err(ProjectStoreError::BadRequest(format!(
+                "Voice name must be at most {MAX_VOICE_NAME_LEN} characters"
+            )));
+        }
+        if !is_safe_id(&input.reference_audio_asset_id) {
+            return Err(ProjectStoreError::BadRequest(
+                "Invalid reference audio asset id".to_owned(),
+            ));
+        }
+        if input.embedding.is_empty() {
+            return Err(ProjectStoreError::BadRequest(
+                "Voice embedding must not be empty".to_owned(),
+            ));
+        }
+
+        let connection = connect_project_db_migrated(&self.project_path)?;
+        let duplicate =
+            nearest_existing_voice(&connection, project_id, &input.embedding, dedup_threshold)?;
+
+        let id = format!("voice_{}", random_hex(16)?);
+        let now = utc_now();
+        let embedding_json = serde_json::to_string(&input.embedding).map_err(|error| {
+            ProjectStoreError::BadRequest(format!("Voice embedding is not serializable: {error}"))
+        })?;
+        connection.execute(
+            "insert into saved_voices
+               (id, project_id, name, reference_audio_asset_id, embedding, created_at)
+             values (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                id,
+                project_id,
+                name,
+                input.reference_audio_asset_id,
+                embedding_json,
+                now
+            ],
+        )?;
+
+        let voice = json!({
+            "id": id,
+            "name": name,
+            "referenceAudioAssetId": input.reference_audio_asset_id,
+            "createdAt": now,
+        });
+        Ok((voice, duplicate))
+    }
+
+    /// Permanently delete a saved voice. `NotFound` when the id doesn't belong to the project.
+    pub fn delete_saved_voice(
+        &self,
+        project_id: &str,
+        voice_id: &str,
+    ) -> ProjectStoreResult<SavedVoiceMutationResult> {
+        if !is_safe_id(voice_id) {
+            return Err(ProjectStoreError::BadRequest("Invalid voice id".to_owned()));
+        }
+        let connection = connect_project_db_migrated(&self.project_path)?;
+        let affected = connection.execute(
+            "delete from saved_voices where id = ?1 and project_id = ?2",
+            params![voice_id, project_id],
+        )?;
+        if affected == 0 {
+            return Err(ProjectStoreError::NotFound(
+                "Saved voice not found".to_owned(),
+            ));
+        }
+        Ok(SavedVoiceMutationResult {
+            id: voice_id.to_owned(),
+            status: "deleted".to_owned(),
+        })
+    }
+}
+
+/// Return the existing saved voice whose embedding is most cosine-similar to `embedding`, but only
+/// when that similarity is at/above `threshold`. Rows whose stored embedding is unparseable or a
+/// different dimensionality are skipped (a saved voice from a different embedder must not false-match).
+fn nearest_existing_voice(
+    connection: &Connection,
+    project_id: &str,
+    embedding: &[f32],
+    threshold: f32,
+) -> ProjectStoreResult<Option<SavedVoiceDuplicate>> {
+    let mut statement =
+        connection.prepare("select id, name, embedding from saved_voices where project_id = ?1")?;
+    let candidates = statement
+        .query_map(params![project_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut best: Option<SavedVoiceDuplicate> = None;
+    for (id, name, embedding_json) in candidates {
+        let Ok(other) = serde_json::from_str::<Vec<f32>>(&embedding_json) else {
+            continue;
+        };
+        if other.len() != embedding.len() {
+            continue;
+        }
+        let similarity = cosine_similarity(embedding, &other);
+        let beats_current = match &best {
+            None => true,
+            Some(current) => similarity > current.similarity,
+        };
+        if similarity >= threshold && beats_current {
+            best = Some(SavedVoiceDuplicate {
+                id,
+                name,
+                similarity,
+            });
+        }
+    }
+    Ok(best)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn migrated_db() -> Connection {
+        let connection = Connection::open_in_memory().expect("in-memory db");
+        apply_voice_migrations(&connection).expect("voice migration runs");
+        connection
+    }
+
+    /// The store's public delegating layer opens the real project.db; the unit tests here drive the
+    /// SQL directly against an in-memory DB via small helpers that mirror the store methods, so they
+    /// don't need a project registry on disk.
+    fn insert(connection: &Connection, id: &str, project: &str, name: &str, embedding: &[f32]) {
+        connection
+            .execute(
+                "insert into saved_voices (id, project_id, name, reference_audio_asset_id, embedding, created_at)
+                 values (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    id,
+                    project,
+                    name,
+                    "asset_ref",
+                    serde_json::to_string(embedding).unwrap(),
+                    "2026-07-20T00:00:00Z"
+                ],
+            )
+            .expect("insert voice");
+    }
+
+    #[test]
+    fn cosine_similarity_is_one_for_identical_and_zero_for_orthogonal() {
+        let a = vec![1.0, 2.0, 3.0, 4.0];
+        assert!((cosine_similarity(&a, &a) - 1.0).abs() < 1e-6);
+        // Scale-invariant: a parallel vector is still 1.0.
+        let scaled: Vec<f32> = a.iter().map(|x| x * 7.5).collect();
+        assert!((cosine_similarity(&a, &scaled) - 1.0).abs() < 1e-6);
+        // Orthogonal → 0.
+        assert!(cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]).abs() < 1e-6);
+        // Zero magnitude → 0, never NaN.
+        assert_eq!(cosine_similarity(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+    }
+
+    #[test]
+    fn dedup_flags_a_near_identical_embedding_and_ignores_a_distinct_one() {
+        let connection = migrated_db();
+        // An existing "Narrator" voice.
+        let narrator = vec![0.9_f32, 0.1, 0.2, 0.05, 0.3];
+        insert(&connection, "voice_a", "project_1", "Narrator", &narrator);
+
+        // A near-identical clip (tiny perturbation) must trip the threshold.
+        let near: Vec<f32> = narrator.iter().map(|x| x + 0.001).collect();
+        let hit = nearest_existing_voice(
+            &connection,
+            "project_1",
+            &near,
+            DEFAULT_VOICE_DEDUP_THRESHOLD,
+        )
+        .expect("dedup query");
+        let hit = hit.expect("near-identical embedding should flag a duplicate");
+        assert_eq!(hit.id, "voice_a");
+        assert_eq!(hit.name, "Narrator");
+        assert!(hit.similarity >= DEFAULT_VOICE_DEDUP_THRESHOLD);
+
+        // A clearly distinct speaker (near-orthogonal) must NOT flag.
+        let distinct = vec![-0.2_f32, 0.8, -0.6, 0.7, -0.9];
+        let miss = nearest_existing_voice(
+            &connection,
+            "project_1",
+            &distinct,
+            DEFAULT_VOICE_DEDUP_THRESHOLD,
+        )
+        .expect("dedup query");
+        assert!(
+            miss.is_none(),
+            "a distinct speaker embedding must not be flagged as a duplicate (got {miss:?})"
+        );
+    }
+
+    #[test]
+    fn dedup_is_scoped_per_project() {
+        let connection = migrated_db();
+        let embedding = vec![0.5_f32, 0.5, 0.5, 0.5];
+        insert(&connection, "voice_a", "project_1", "Narrator", &embedding);
+        // The identical embedding registered under a DIFFERENT project must not match.
+        let hit =
+            nearest_existing_voice(&connection, "project_2", &embedding, 0.5).expect("dedup query");
+        assert!(hit.is_none(), "dedup must not cross project boundaries");
+    }
+
+    #[test]
+    fn dedup_skips_mismatched_dimensionality() {
+        let connection = migrated_db();
+        insert(
+            &connection,
+            "voice_a",
+            "project_1",
+            "Narrator",
+            &[1.0, 2.0, 3.0],
+        );
+        // A 4-d probe against a 3-d stored embedding must be skipped, not panic or false-match.
+        let hit = nearest_existing_voice(&connection, "project_1", &[1.0, 2.0, 3.0, 4.0], 0.0)
+            .expect("dedup query");
+        assert!(hit.is_none());
+    }
+
+    /// End-to-end create → list → delete round-trip against a real (temp) project.db — the exact
+    /// data path the rust-api create/list/delete handlers delegate to via `ProjectStore`. Also proves
+    /// the create-time dedup consumer fires on a re-register and stays quiet for a distinct voice.
+    #[test]
+    fn store_round_trips_create_list_delete_with_dedup() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let store = SavedVoiceStore::new(temp.path());
+
+        assert!(
+            store
+                .list_saved_voices("project_1")
+                .expect("empty list")
+                .is_empty(),
+            "a fresh project has no saved voices"
+        );
+
+        // First register: no existing voices, so no duplicate.
+        let (first, dup) = store
+            .create_saved_voice(
+                "project_1",
+                SavedVoiceCreateInput {
+                    name: "Narrator".to_owned(),
+                    reference_audio_asset_id: "asset_ref_1".to_owned(),
+                    embedding: vec![0.9, 0.1, 0.2, 0.05, 0.3],
+                },
+                DEFAULT_VOICE_DEDUP_THRESHOLD,
+            )
+            .expect("create first voice");
+        assert!(dup.is_none(), "first voice can't duplicate anything");
+        assert_eq!(first["name"], "Narrator");
+        assert_eq!(first["referenceAudioAssetId"], "asset_ref_1");
+        let first_id = first["id"].as_str().expect("voice id").to_owned();
+
+        // Re-register a near-identical embedding: the dedup consumer flags the existing voice.
+        let (_second, dup2) = store
+            .create_saved_voice(
+                "project_1",
+                SavedVoiceCreateInput {
+                    name: "Narrator (again)".to_owned(),
+                    reference_audio_asset_id: "asset_ref_2".to_owned(),
+                    embedding: vec![0.901, 0.099, 0.2, 0.05, 0.301],
+                },
+                DEFAULT_VOICE_DEDUP_THRESHOLD,
+            )
+            .expect("create near-duplicate voice");
+        let dup2 = dup2.expect("a near-identical embedding must be flagged");
+        assert_eq!(dup2.name, "Narrator");
+
+        // A distinct voice registers cleanly.
+        let (_third, dup3) = store
+            .create_saved_voice(
+                "project_1",
+                SavedVoiceCreateInput {
+                    name: "Villain".to_owned(),
+                    reference_audio_asset_id: "asset_ref_3".to_owned(),
+                    embedding: vec![-0.2, 0.8, -0.6, 0.7, -0.9],
+                },
+                DEFAULT_VOICE_DEDUP_THRESHOLD,
+            )
+            .expect("create distinct voice");
+        assert!(dup3.is_none(), "a distinct speaker must not be flagged");
+
+        // List reflects all three (embedding intentionally omitted from the view).
+        let listed = store.list_saved_voices("project_1").expect("list");
+        assert_eq!(listed.len(), 3);
+        assert!(listed.iter().all(|voice| voice.get("embedding").is_none()));
+
+        // Delete the first, then a re-delete is a clean NotFound.
+        let result = store
+            .delete_saved_voice("project_1", &first_id)
+            .expect("delete voice");
+        assert_eq!(result.status, "deleted");
+        assert_eq!(store.list_saved_voices("project_1").expect("list").len(), 2);
+        assert!(
+            store.delete_saved_voice("project_1", &first_id).is_err(),
+            "deleting a missing voice is NotFound"
+        );
+    }
+
+    #[test]
+    fn create_rejects_empty_name_and_bad_asset_id() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let store = SavedVoiceStore::new(temp.path());
+        assert!(store
+            .create_saved_voice(
+                "project_1",
+                SavedVoiceCreateInput {
+                    name: "   ".to_owned(),
+                    reference_audio_asset_id: "asset_ref".to_owned(),
+                    embedding: vec![1.0, 2.0],
+                },
+                DEFAULT_VOICE_DEDUP_THRESHOLD,
+            )
+            .is_err());
+        assert!(store
+            .create_saved_voice(
+                "project_1",
+                SavedVoiceCreateInput {
+                    name: "Ok".to_owned(),
+                    reference_audio_asset_id: "../escape".to_owned(),
+                    embedding: vec![1.0, 2.0],
+                },
+                DEFAULT_VOICE_DEDUP_THRESHOLD,
+            )
+            .is_err());
+    }
+}

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -979,7 +979,7 @@ fn audio_edit_region(
 /// the RIFF chunk list so a file carrying extra chunks (LIST/fact) still reads, requires PCM
 /// (`audio_format == 1`) 16-bit samples, and converts interleaved `i16` to `f32` in `[-1, 1)`.
 /// Non-PCM / non-16-bit inputs are a clear `Unsupported` rather than a silent mis-decode.
-fn read_wav_pcm16(path: &Path) -> WorkerResult<gen_core::AudioTrack> {
+pub(crate) fn read_wav_pcm16(path: &Path) -> WorkerResult<gen_core::AudioTrack> {
     let bytes = std::fs::read(path)?;
     if bytes.len() < 12 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
         return Err(WorkerError::InvalidPayload(format!(

--- a/crates/sceneworks-worker/src/inference_runtime.rs
+++ b/crates/sceneworks-worker/src/inference_runtime.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 #[cfg(all(test, target_os = "macos"))]
 use gen_core::core_llm::TextLlmRegistration;
 use gen_core::core_llm::{LoadSpec as TextLoadSpec, ModelRequirements, TextLlm, TextLlmRegistry};
-use gen_core::{AudioTransform, Generator, LoadSpec, ProviderRegistry};
+use gen_core::{AudioTransform, Generator, LoadSpec, ProviderRegistry, VoiceEmbedder};
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -138,6 +138,27 @@ pub(crate) fn load_audio_transform(
             )
         })?
         .load_audio_transform(id, spec)
+}
+
+/// Load an audio **voice embedder** (a speaker-encoder, e.g. `chatterbox_ve`) by id from the runtime's
+/// candle audio registry (sc-13517). It maps a reference audio clip to a raw 256-d speaker-identity
+/// vector — the identity twin of `load_image_embedder`. Errors clearly when this build ships no audio
+/// lane so the register-a-voice flow turns it into a loud failure rather than a silent no-op. Unlike
+/// the clone Generator's `Conditioning::ReferenceAudio` path (which the provider re-embeds internally),
+/// this seam exposes the embedding directly for the saved-voice registry's near-duplicate detection.
+pub(crate) fn load_voice_embedder(
+    id: &str,
+    spec: &LoadSpec,
+) -> gen_core::Result<Box<dyn VoiceEmbedder>> {
+    audio()
+        .ok_or_else(|| {
+            gen_core::Error::Msg(
+                "no audio lane is linked in this runtime build (the candle audio registry is \
+                 unavailable)"
+                    .to_owned(),
+            )
+        })?
+        .load_voice_embedder(id, spec)
 }
 
 pub(crate) fn text() -> &'static TextLlmRegistry {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -152,6 +152,11 @@ use video_jobs::*;
 // non-native desktop worker never advertises `audio_generate`, so the arm is unreachable there).
 mod audio_jobs;
 use audio_jobs::*;
+// The Voice Clone "register a voice" embed path (sc-13517): the rust-api calls
+// `voice_register::embed_reference_clip` to compute a reference clip's Chatterbox-VE speaker vector
+// for the saved-voice registry. Public because it is invoked from another crate (rust-api), not the
+// worker job loop.
+pub mod voice_register;
 // Replace-person mask pipeline (epic 3040, sc-3521): cross-platform mask rasterization /
 // resample / stored-seg-mask load, so the mask-port-vs-Python parity test runs on the
 // Linux CI lane. Its masks are consumed only by the macOS Wan-VACE path in `video_jobs`,

--- a/crates/sceneworks-worker/src/voice_register.rs
+++ b/crates/sceneworks-worker/src/voice_register.rs
@@ -1,0 +1,93 @@
+//! The **embed path** for the Voice Clone "register a voice" flow (sc-13517).
+//!
+//! A single blocking entry point, [`embed_reference_clip`], that the rust-api calls when a user
+//! registers a saved voice: it resolves the Chatterbox-VE speaker-encoder weights from the local HF
+//! cache, decodes the chosen reference clip to PCM-16, and runs the embedder
+//! ([`crate::inference_runtime::load_voice_embedder`]) to produce the raw 256-d speaker vector. That
+//! vector is stored as the voice's identity and consumed by the registry's near-duplicate detection
+//! (`sceneworks_core::voice_store`) — it is NOT fed into the clone Generator (VoiceEmbedding-only
+//! errors at S3Gen; both clone paths drive off the reference AUDIO clip, sc-13412).
+//!
+//! Lives in the worker crate because that is where the inference runtime (candle audio lane) is
+//! composed. The rust-api links this crate and invokes the function on a blocking thread; on a build
+//! with no audio lane (non-macOS without `backend-candle`) it returns [`VoiceEmbedError::Embed`]
+//! rather than silently succeeding.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use gen_core::{LoadSpec, WeightsSource};
+
+/// The Hugging Face repo hosting the Chatterbox voice encoder weights (shared with `chatterbox_tts`).
+pub const CHATTERBOX_VE_REPO: &str = "ResembleAI/chatterbox";
+/// The single-file weights the Chatterbox-VE embedder loads (`WeightsSource::File`, not a snapshot dir).
+pub const CHATTERBOX_VE_WEIGHTS_FILE: &str = "ve.safetensors";
+/// The registry id of the Chatterbox voice embedder.
+pub const CHATTERBOX_VE_MODEL_ID: &str = "chatterbox_ve";
+
+/// Why a reference clip couldn't be embedded. The rust-api maps these to HTTP status codes: a missing
+/// install is a client-actionable 400 ("install the encoder"), a bad clip is a 400, and an embedder
+/// runtime failure is a 500.
+#[derive(Debug)]
+pub enum VoiceEmbedError {
+    /// The Chatterbox-VE weights are not present in the local model cache.
+    WeightsMissing(String),
+    /// The reference clip couldn't be decoded to a PCM-16 WAV [`gen_core::AudioTrack`].
+    Decode(String),
+    /// The embedder failed to load or run (including "no audio lane in this build").
+    Embed(String),
+}
+
+impl fmt::Display for VoiceEmbedError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WeightsMissing(message) => write!(formatter, "{message}"),
+            Self::Decode(message) => write!(formatter, "{message}"),
+            Self::Embed(message) => write!(formatter, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for VoiceEmbedError {}
+
+/// Resolve the Chatterbox-VE `ve.safetensors` weights file inside the local HF hub cache under
+/// `data_dir`. The file rides in the shared `ResembleAI/chatterbox` snapshot (a co-requisite of the
+/// clone TTS install, sc-13541). Returns [`VoiceEmbedError::WeightsMissing`] when the snapshot or the
+/// file is absent, with an actionable message.
+pub fn resolve_chatterbox_ve_weights(data_dir: &Path) -> Result<PathBuf, VoiceEmbedError> {
+    let snapshot = crate::model_jobs::huggingface_snapshot_dir(data_dir, CHATTERBOX_VE_REPO)
+        .ok_or_else(|| {
+            VoiceEmbedError::WeightsMissing(format!(
+                "the Chatterbox voice encoder ({CHATTERBOX_VE_MODEL_ID}) is not installed — install \
+                 it from the Model Manager before registering a voice."
+            ))
+        })?;
+    let weights = snapshot.join(CHATTERBOX_VE_WEIGHTS_FILE);
+    if !weights.is_file() {
+        return Err(VoiceEmbedError::WeightsMissing(format!(
+            "the Chatterbox voice encoder weights ({CHATTERBOX_VE_WEIGHTS_FILE}) were not found in \
+             the cached {CHATTERBOX_VE_REPO} snapshot — reinstall the voice encoder."
+        )));
+    }
+    Ok(weights)
+}
+
+/// Compute the raw 256-d Chatterbox-VE speaker embedding for the reference clip at `wav_path`.
+///
+/// `data_dir` is the app data dir (the HF cache root is derived from it, exactly as the worker's own
+/// model loading does), and `wav_path` is the already-resolved absolute path to a PCM-16 WAV library
+/// asset. Blocking (mmaps weights, runs the GE2E encoder) — call it on a blocking thread.
+pub fn embed_reference_clip(data_dir: &Path, wav_path: &Path) -> Result<Vec<f32>, VoiceEmbedError> {
+    let weights = resolve_chatterbox_ve_weights(data_dir)?;
+    let track = crate::audio_jobs::read_wav_pcm16(wav_path)
+        .map_err(|error| VoiceEmbedError::Decode(error.to_string()))?;
+    let embedder = crate::inference_runtime::load_voice_embedder(
+        CHATTERBOX_VE_MODEL_ID,
+        &LoadSpec::new(WeightsSource::File(weights)),
+    )
+    .map_err(|error| VoiceEmbedError::Embed(error.to_string()))?;
+    let embedding = embedder
+        .embed(&track)
+        .map_err(|error| VoiceEmbedError::Embed(error.to_string()))?;
+    Ok(embedding)
+}

--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -420,6 +420,201 @@ fn native_voiceclone_chatterbox_smoke() {
     );
 }
 
+/// sc-13517 END-TO-END DoD: prove the "register a voice" feature drives a real cloned voiceover.
+///
+///   1. **Register (embed + store)** — embed a reference clip through the PUBLIC
+///      `voice_register::embed_reference_clip` (the exact seam the rust-api calls on register), then
+///      persist the saved voice through `SavedVoiceStore` — a real 256-d Chatterbox-VE embedding lands
+///      in a real project.db.
+///   2. **Near-duplicate consumer** — re-register the SAME clip: the store flags it as a near-duplicate
+///      (cosine ≥ threshold). Register a spectrally-DISTINCT clip: NOT flagged. This is the embedding's
+///      genuine consumer.
+///   3. **Render through the saved voice** — load `chatterbox_tts` and render the script with the saved
+///      voice's reference clip as `Conditioning::ReferenceAudio` (the referenceAudioAssetId → clone path
+///      the Studio drives when a saved voice is picked). Writes a real, audible cloned WAV.
+///
+/// Writes `saved_voice_reference.wav`, `distinct_reference.wav`, `saved_voice_cloned_voiceover.wav`, and
+/// `summary.json` to `$SAVED_VOICE_DOD_OUT` (default `/tmp/saved_voice_dod`). `#[ignore]`d real-weight
+/// smoke — run by hand on an Apple-Silicon Mac with the Chatterbox Clone-TTS model installed.
+#[test]
+#[ignore = "real-weight end-to-end DoD: needs the cached ResembleAI/chatterbox model"]
+fn saved_voice_register_render_dod() {
+    use sceneworks_core::voice_store::{
+        SavedVoiceCreateInput, SavedVoiceStore, DEFAULT_VOICE_DEDUP_THRESHOLD,
+    };
+
+    // The register embed path resolves ve.safetensors from the HF cache; point it at the OS hub cache.
+    if std::env::var_os("HF_HOME").is_none() {
+        if let Some(home) = sceneworks_core::hf_home::os_huggingface_home() {
+            std::env::set_var("HF_HOME", home);
+        }
+    }
+    let data_dir = std::env::temp_dir();
+    let chatterbox_dir = resolve_dir("VOICECLONE_CHATTERBOX_DIR", "ResembleAI/chatterbox", None);
+
+    let out_dir = PathBuf::from(env_or("SAVED_VOICE_DOD_OUT", "/tmp/saved_voice_dod"));
+    std::fs::create_dir_all(&out_dir).expect("out dir");
+    let project_dir = out_dir.join("project");
+    std::fs::create_dir_all(&project_dir).expect("project dir");
+
+    // The library audio assets a saved voice points to.
+    let reference = synthetic_reference();
+    let reference_wav = out_dir.join("saved_voice_reference.wav");
+    dump_wav(&reference, &reference_wav);
+    let distinct = distinct_reference();
+    let distinct_wav = out_dir.join("distinct_reference.wav");
+    dump_wav(&distinct, &distinct_wav);
+
+    // ── (a) REGISTER: real embed via the API's embed path + persist through the store ──
+    let emb_reference =
+        crate::voice_register::embed_reference_clip(&data_dir, &reference_wav).expect("embed ref");
+    assert_eq!(
+        emb_reference.len(),
+        256,
+        "Chatterbox-VE embedding is 256-dim"
+    );
+    let store = SavedVoiceStore::new(&project_dir);
+    let (narrator, dup_first) = store
+        .create_saved_voice(
+            "project_dod",
+            SavedVoiceCreateInput {
+                name: "Narrator".to_owned(),
+                reference_audio_asset_id: "asset_reference".to_owned(),
+                embedding: emb_reference.clone(),
+            },
+            DEFAULT_VOICE_DEDUP_THRESHOLD,
+        )
+        .expect("register Narrator");
+    assert!(dup_first.is_none(), "first registration can't duplicate");
+    let narrator_id = narrator["id"].as_str().expect("voice id").to_owned();
+
+    // ── (b) DEDUP consumer: the SAME clip warns; a DISTINCT clip does not ──
+    let emb_reference_again =
+        crate::voice_register::embed_reference_clip(&data_dir, &reference_wav)
+            .expect("re-embed ref");
+    let (_dup_voice, dup_hit) = store
+        .create_saved_voice(
+            "project_dod",
+            SavedVoiceCreateInput {
+                name: "Narrator (again)".to_owned(),
+                reference_audio_asset_id: "asset_reference_dup".to_owned(),
+                embedding: emb_reference_again,
+            },
+            DEFAULT_VOICE_DEDUP_THRESHOLD,
+        )
+        .expect("register duplicate");
+    let dup_hit = dup_hit.expect("re-registering the same clip must flag a near-duplicate");
+    assert_eq!(dup_hit.name, "Narrator");
+
+    let emb_distinct = crate::voice_register::embed_reference_clip(&data_dir, &distinct_wav)
+        .expect("embed distinct");
+    let (_distinct_voice, distinct_hit) = store
+        .create_saved_voice(
+            "project_dod",
+            SavedVoiceCreateInput {
+                name: "Villain".to_owned(),
+                reference_audio_asset_id: "asset_distinct".to_owned(),
+                embedding: emb_distinct.clone(),
+            },
+            DEFAULT_VOICE_DEDUP_THRESHOLD,
+        )
+        .expect("register distinct");
+    assert!(
+        distinct_hit.is_none(),
+        "a distinct speaker must NOT be flagged"
+    );
+    assert_eq!(
+        store.list_saved_voices("project_dod").expect("list").len(),
+        3
+    );
+
+    // ── (c) RENDER: the saved voice's reference clip → chatterbox_tts clone (the Studio's path) ──
+    let seed = 12_345u64;
+    let generator = runtime_macos::catalog()
+        .expect("runtime catalog")
+        .audio()
+        .expect("audio lane")
+        .load(
+            "chatterbox_tts",
+            &LoadSpec::new(WeightsSource::Dir(chatterbox_dir.clone())),
+        )
+        .expect("load chatterbox_tts generator");
+    let mut on_progress = |_p: Progress| {};
+    let clone = match generator
+        .generate(
+            &native_clone_request(NATIVE_CLONE_SCRIPT, reference.clone(), seed),
+            &mut on_progress,
+        )
+        .expect("clone generate")
+    {
+        GenerationOutput::Audio(track) => track,
+        other => panic!("expected audio, got {other:?}"),
+    };
+    let clone_peak = peak(&clone.samples);
+    assert!(clone_peak > 1e-2, "cloned voiceover is (near-)silent");
+    assert_eq!(clone.sample_rate, 24_000, "clone must be 24 kHz");
+    let clone_wav = out_dir.join("saved_voice_cloned_voiceover.wav");
+    dump_wav(&clone, &clone_wav);
+
+    // Objective evidence the rendered clone tracks the saved voice's reference (not the distinct one).
+    let emb_clone =
+        crate::voice_register::embed_reference_clip(&data_dir, &clone_wav).expect("embed clone");
+    let sim_clone_reference = cosine(&emb_clone, &emb_reference);
+    let sim_clone_distinct = cosine(&emb_clone, &emb_distinct);
+
+    let summary = serde_json::json!({
+        "story": "sc-13517",
+        "register": {
+            "narratorId": narrator_id,
+            "embeddingDim": emb_reference.len(),
+            "firstRegistrationDuplicate": null,
+        },
+        "dedupConsumer": {
+            "threshold": DEFAULT_VOICE_DEDUP_THRESHOLD,
+            "sameClipReRegisterFlagged": { "id": dup_hit.id, "name": dup_hit.name, "similarity": dup_hit.similarity },
+            "distinctClipFlagged": false,
+        },
+        "clonedVoiceover": {
+            "wav": clone_wav.display().to_string(),
+            "samples": clone.samples.len(),
+            "sampleRate": clone.sample_rate,
+            "peak": clone_peak,
+            "cosineCloneReference": sim_clone_reference,
+            "cosineCloneDistinct": sim_clone_distinct,
+        },
+        "artifacts": {
+            "referenceWav": reference_wav.display().to_string(),
+            "distinctWav": distinct_wav.display().to_string(),
+            "clonedWav": clone_wav.display().to_string(),
+        },
+    });
+    let summary_path = out_dir.join("summary.json");
+    std::fs::write(
+        &summary_path,
+        serde_json::to_string_pretty(&summary).unwrap(),
+    )
+    .expect("write summary");
+
+    eprintln!("[saved-voice-dod] out dir: {}", out_dir.display());
+    eprintln!(
+        "[saved-voice-dod] dedup: same-clip re-register flagged '{}' @ {:.4}; distinct NOT flagged",
+        dup_hit.name, dup_hit.similarity
+    );
+    eprintln!(
+        "[saved-voice-dod] cloned voiceover: {} samples @ {} Hz peak {clone_peak:.4} → {}",
+        clone.samples.len(),
+        clone.sample_rate,
+        clone_wav.display()
+    );
+    eprintln!(
+        "[saved-voice-dod] clone tracks reference: cosine clone↔ref {sim_clone_reference:.4} vs clone↔distinct {sim_clone_distinct:.4}"
+    );
+    assert!(
+        sim_clone_reference > sim_clone_distinct,
+        "the cloned voiceover must track the saved voice's reference more than a distinct clip"
+    );
+}
+
 // ── sc-13541: offline install-parity DoD ─────────────────────────────────────────────────────────
 // The chatterbox_tts provider resolves two companion weights at generate() time via pinned-SHA
 // `hf_get_pinned` fetches (candle_audio_chatterbox_ve + candle-audio-chatterbox/src/perth.rs at the
@@ -508,6 +703,80 @@ fn synthetic_reference() -> gen_core::AudioTrack {
         channels: 1,
         stems: Vec::new(),
     }
+}
+
+/// A spectrally-distinct synthetic clip (higher fundamental, different harmonic mix + envelope) so its
+/// Chatterbox-VE embedding differs from [`synthetic_reference`]'s — used by the sc-13517 embed-path
+/// smoke to prove the speaker vector discriminates.
+fn distinct_reference() -> gen_core::AudioTrack {
+    let sample_rate = 24_000u32;
+    let secs = 4.0f32;
+    let n = (sample_rate as f32 * secs) as usize;
+    let mut samples = Vec::with_capacity(n);
+    let mut seed = 0x7f4a_1122u32;
+    for i in 0..n {
+        let t = i as f32 / sample_rate as f32;
+        let vibrato = 1.0 + 0.03 * (2.0 * std::f32::consts::PI * 7.0 * t).sin();
+        let f0 = 320.0 * vibrato;
+        let mut s = 0.5 * (2.0 * std::f32::consts::PI * f0 * t).sin();
+        s += 0.35 * (2.0 * std::f32::consts::PI * 1.5 * f0 * t).sin();
+        seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        let noise = (seed >> 9) as f32 / (1u32 << 23) as f32 - 0.5;
+        s += 0.12 * noise;
+        let env = 0.5 - 0.5 * (2.0 * std::f32::consts::PI * 0.9 * t).cos();
+        samples.push(0.8 * env * s);
+    }
+    gen_core::AudioTrack {
+        samples,
+        sample_rate,
+        channels: 1,
+        stems: Vec::new(),
+    }
+}
+
+/// sc-13517 embed-path smoke: the PUBLIC `voice_register::embed_reference_clip` (what the rust-api
+/// calls to register a voice) resolves the cached Chatterbox-VE weights, decodes a WAV, and returns a
+/// 256-d speaker vector. Deterministic: the SAME clip self-embeds to cosine ~1.0, while a
+/// spectrally-distinct clip scores lower — objective evidence the embedding (the registry's dedup
+/// identity) discriminates. Run by hand on a Mac with the Chatterbox Clone-TTS model installed.
+#[test]
+#[ignore = "real-weight audio smoke: needs the cached ResembleAI/chatterbox ve.safetensors"]
+fn voice_register_embed_path_smoke() {
+    // Point HF cache resolution at the OS hub cache so embed_reference_clip's data_dir-based
+    // resolution finds the installed snapshot regardless of the (unused) data dir passed below.
+    if std::env::var_os("HF_HOME").is_none() {
+        if let Some(home) = sceneworks_core::hf_home::os_huggingface_home() {
+            std::env::set_var("HF_HOME", home);
+        }
+    }
+    let data_dir = std::env::temp_dir();
+
+    let tmp = std::env::temp_dir().join(format!("sw-voice-register-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    let ref_a = tmp.join("ref_a.wav");
+    let ref_b = tmp.join("ref_b.wav");
+    dump_wav(&synthetic_reference(), &ref_a);
+    dump_wav(&distinct_reference(), &ref_b);
+
+    let emb_a1 =
+        crate::voice_register::embed_reference_clip(&data_dir, &ref_a).expect("embed clip a");
+    let emb_a2 =
+        crate::voice_register::embed_reference_clip(&data_dir, &ref_a).expect("re-embed clip a");
+    let emb_b =
+        crate::voice_register::embed_reference_clip(&data_dir, &ref_b).expect("embed clip b");
+
+    assert_eq!(emb_a1.len(), 256, "Chatterbox-VE embedding is 256-dim");
+    let self_sim = cosine(&emb_a1, &emb_a2);
+    let cross_sim = cosine(&emb_a1, &emb_b);
+    eprintln!("voice_register embed smoke: self={self_sim:.4} cross={cross_sim:.4}");
+    assert!(
+        self_sim > 0.999,
+        "the same clip must self-embed to ~1.0 (got {self_sim})"
+    );
+    assert!(
+        cross_sim < self_sim,
+        "a spectrally-distinct clip must score below the self-similarity (self {self_sim}, cross {cross_sim})"
+    );
 }
 
 /// Sorted names directly under `dir` (empty when `dir` is absent) — a cheap fingerprint for asserting


### PR DESCRIPTION
## What

Implements **sc-13517** ([C4 follow-up] Register-a-voice), the last open story of epic 13400 (Audio Studio). Adds a per-project **saved voices** registry to the Voice Clone tab: the user names a reference audio clip, we compute its Chatterbox-VE speaker embedding, persist it, and make it reusable in the reference picker.

## Corrected data flow (established by E1 / sc-13412 — NOT the story's original premise)

The native `chatterbox_tts` clone's S3Gen stage **cannot** reconstruct its reference from a 256-d embedding — it needs the reference **audio** clip (`Conditioning::ReferenceAudio`). VoiceEmbedding-only errors at S3Gen. So in **both** clone paths (native chatterbox_tts and the OpenVoice V2 fallback) the reference **AUDIO** is what drives generation.

Therefore:
- The **load-bearing** element of a saved voice is its `referenceAudioAssetId`. Picking a saved voice just supplies that id to the **existing** E1 pipeline — no new generation wiring.
- The stored 256-d Chatterbox-VE embedding is the voice's **identity vector**, given a *real* consumer: **near-duplicate detection at register time** (cosine similarity vs the project's existing saved voices). It is never fed as `Conditioning::VoiceEmbedding`.

## Scope covered

**Persistence** — `crates/sceneworks-core/src/voice_store.rs`: a `saved_voices` table in `project.db` (`{ id, project_id, name, reference_audio_asset_id, embedding(JSON f32[]), created_at }`), migrated via the schema-version gate (`PROJECT_SCHEMA_VERSION` 4→5, `EXPECTED_PROJECT_DB_SCHEMA` snapshot updated). DB-authoritative (no sidecar) so it survives the reindex a version bump triggers. `ProjectStore` delegators + `resolve_asset_media_path`.

**Worker embed path** — `inference_runtime::load_voice_embedder` (added, mirrors `load_audio_transform`) + `voice_register::embed_reference_clip(data_dir, wav)` (public; resolves `ve.safetensors` from the HF cache, decodes the WAV, runs Chatterbox-VE → raw 256-d vector).

**API** — `GET/POST/DELETE /api/v1/projects/:project_id/voices`. Register resolves the clip → computes the embedding on a blocking thread → persists + runs dedup → returns the voice with a `nearDuplicate` field (`{id,name,similarity}` or null).

**Web** — `useSavedVoices` hook + `App` context wiring; AudioStudio Voice Clone tab gains a "Save this reference as a voice" affordance (name + Save), selectable saved-voice chips (pick → sets `referenceAudioAssetId`) with delete, and the near-duplicate warning banner. Capability-driven like the rest of the Studio; themed light/dark inherited.

## Tests

- **core**: cosine similarity, dedup flag/ignore/per-project/dim-mismatch, and a full create→list→delete + dedup round-trip against a real temp `project.db`. Schema-fingerprint test updated + passing.
- **web**: 4 new vitest cases (surface + select saved voices; register with near-duplicate **warning**; register distinct with **info** notice; delete). Full suite 2203/2203 green.
- **worker**: `#[ignore]`d real-weight smokes — `voice_register_embed_path_smoke` (256-d + discrimination) and `saved_voice_register_render_dod` (the end-to-end DoD below).
- `npm run rust:check` green (fmt --all --check, clippy -D warnings, test, build). Web lint/test/build green. No manifest/`*.schema.json` changes, so the parity manifest-audit lane is unaffected.

## DoD artifact (real, release build, real weights)

Ran `saved_voice_register_render_dod` (release, cached ResembleAI/chatterbox):
- **Register** → real 256-d embedding computed + stored (3 voices in a real `project.db`, `user_version=5`).
- **Dedup consumer** → re-registering the SAME clip flagged the existing voice at cosine **1.0000** (warn); a spectrally-distinct clip was **not** flagged.
- **Cloned voiceover** → real 24 kHz mono WAV, 123840 samples (~5.16 s), rendered via the saved voice's reference clip → `chatterbox_tts` `ReferenceAudio`. Clone tracks the reference (cosine 0.70) over the distinct clip (0.60).

Links sc-13517.