### PR TITLE
feat(audio): Audio Studio streaming TTS — moss_tts_realtime, capability-gated [sc-13675]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -462,6 +462,7 @@ dependencies = [
  "candle-audio-kokoro",
  "candle-audio-mmaudio",
  "candle-audio-moss-sfx",
+ "candle-audio-moss-tts",
  "candle-audio-moss-tts-realtime",
  "candle-audio-openvoice",
  "candle-audio-whisper",
@@ -471,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +488,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,10 +509,11 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
+ "cmudict-fast",
  "core-llm",
  "misaki-rs",
  "rand 0.9.4",
@@ -523,7 +525,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -536,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -549,9 +551,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-audio-moss-tts"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+ "core-llm",
+ "serde",
+ "serde_json",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -564,7 +579,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -575,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -615,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -633,7 +648,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -644,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -657,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -670,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -708,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -722,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -735,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -745,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -755,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -772,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -786,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -800,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -813,7 +828,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -822,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -837,7 +852,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -852,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -866,7 +881,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -878,7 +893,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -891,7 +906,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "image",
@@ -901,7 +916,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -918,7 +933,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -931,7 +946,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -942,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -952,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -966,7 +981,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -982,7 +997,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1001,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1012,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1024,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1034,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1046,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1063,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "cudaforge",
 ]
@@ -1071,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1266,6 +1281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmudict-fast"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9f73004e928ed46c3e7fd7406d2b12c8674153295f08af084b49860276dc02"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3868,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3881,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3893,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3906,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3919,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3958,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3971,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3981,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3990,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3999,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4012,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4024,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4036,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4048,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4057,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4069,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4083,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4096,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4107,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4118,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4129,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4140,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4151,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4160,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4169,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4179,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4190,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4204,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4217,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4227,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4238,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4248,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4261,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4285,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "core-llm",
  "half",
@@ -4597,7 +4621,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5833,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5843,7 +5867,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5854,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6133,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=15895a90b345693e48593b7d6772f394758ae642#15895a90b345693e48593b7d6772f394758ae642"
+source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8551,7 +8575,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "15895a90b345693e48593b7d6772f394758ae642" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d" }

--- a/apps/web/public/prompt-guides/moss-tts-realtime.md
+++ b/apps/web/public/prompt-guides/moss-tts-realtime.md
@@ -1,0 +1,25 @@
+# MOSS-TTS-Realtime Guide
+
+MOSS-TTS-Realtime is a **streaming text-to-speech** model. You type a script and it speaks it — it is a Speech-tab model, like Kokoro, but it renders the clip **incrementally**: the first audio arrives well before the full clip finishes, and the Audio Studio shows the stream progressing as it renders.
+
+## Installation
+
+MOSS-TTS-Realtime runs natively (Candle) on every platform, on CPU / Accelerate. Install it once from the **Models** screen. It is two matched downloads from the shared Hugging Face cache (Apache-2.0): the ~4.66 GB autoregressive backbone (`OpenMOSS-Team/MOSS-TTS-Realtime`, a Qwen3-1.7B brain plus a local/depth transformer) and its required ~7.1 GB codec co-requisite (`OpenMOSS-Team/MOSS-Audio-Tokenizer`, which turns the model's speech tokens into a waveform). Both install together.
+
+## Writing the script
+
+- Type the words you want spoken, with normal punctuation — periods and commas shape the pacing.
+- English and Chinese are supported; pick the language that matches your script.
+- There is no fixed voice bank: the model speaks in its own natural voice. For a specific cloned voice, use the **Voice Clone** tab instead.
+
+## Streaming
+
+This is the studio's first streaming model. As the clip renders, the results card advances chunk by chunk and the first speech is produced long before the whole clip is done. The finished, fully-assembled clip is what lands in your library and plays back — streaming is about how quickly it starts, not a different result.
+
+## Duration
+
+Output is 24 kHz mono. Ask for the length you need; longer scripts simply take longer to finish streaming.
+
+## Practical notes
+
+Because synthesis is autoregressive (one block of speech tokens at a time), latency to the first chunk stays low even for a long script — you hear it start almost immediately, then it fills in.

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -767,11 +767,12 @@ export const fallbackModels = [
       promptGuide: { title: "Wan2.2 VACE-Fun Prompt Guide", path: "/prompt-guides/wan-2-2-t2v-14b.md" },
     },
   },
-  // Audio models (epic 13400 A2/A3) — this mirrors the five `type:"audio"` catalog entries so the
+  // Audio models (epic 13400 A2/A3) — this mirrors the `type:"audio"` catalog entries so the
   // Audio Studio still has a model list when the live catalog (/api/v1/models) is unavailable. Each
   // entry carries only the `audio` capability fields the UI / eligibility predicates read: `voices`
-  // (speech), `editModes` (music), `conditioning` (voiceclone), and `sampleRates` (generation). See
-  // modelEligibility.js `audioModelServesMode` for the capability→mode mapping.
+  // (speech), `supportsStreaming` (streaming speech, sc-13675), `editModes` (music), `conditioning`
+  // (voiceclone), and `sampleRates` (generation). See modelEligibility.js `audioModelServesMode` for
+  // the capability→mode mapping.
   {
     id: "kokoro_82m",
     name: "Kokoro 82M (Speech)",
@@ -795,6 +796,27 @@ export const fallbackModels = [
       label: "Kokoro 82M",
       description:
         "Kokoro-82M text-to-speech (StyleTTS2 lineage) — the recommended Speech model. English voices (American + British), 24 kHz mono, up to ~30 s per clip. Candle-native on every platform. Apache-2.0.",
+    },
+  },
+  {
+    id: "moss_tts_realtime",
+    name: "MOSS-TTS-Realtime (Streaming Speech)",
+    type: "audio",
+    macOnly: false,
+    // supportsStreaming (backend Capabilities.supports_streaming, sc-13675) → serves the "speech" mode
+    // via the streaming signal rather than a voice bank: it ships NO fixed voices (a language-driven
+    // TTS), so audioModelServesMode reads supportsStreaming to keep it on Speech and off SFX.
+    audio: {
+      languages: ["en", "zh"],
+      sampleRates: [24000],
+      maxDurationSecs: 2400,
+      supportsMultiSpeaker: false,
+      supportsStreaming: true,
+    },
+    ui: {
+      label: "MOSS-TTS-Realtime (Streaming)",
+      description:
+        "MOSS-TTS-Realtime-1.7B streaming text-to-speech — streams speech in incremental chunks as it renders, so the first audio arrives before the clip finishes. 24 kHz mono, English + Chinese. Candle-native on every platform. Apache-2.0.",
     },
   },
   {

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -79,7 +79,10 @@ export function videoModelUsable(model, caps) {
 // Audio Studio — capability-driven per-mode eligibility, derived from the model's `audio`
 // sub-block (mirrors how videoModelServesMode reads video capabilities; no hardcoded ids).
 // Each seeded model maps to exactly one mode and fails the other three:
-//   * speech     — ships a voice bank (audio.voices[] non-empty). → Kokoro-82M.
+//   * speech     — a text-to-speech model: it either ships a voice bank (audio.voices[] non-empty →
+//                  Kokoro-82M) OR advertises streaming (audio.supportsStreaming → MOSS-TTS-Realtime,
+//                  sc-13675). A streaming TTS has no fixed voice list (it speaks in its own voice), so
+//                  the streaming capability is its speech signal — never a hardcoded id.
 //   * music      — advertises audio-editing ops (audio.editModes[]: inpaint/repaint/extend). → ACE-Step.
 //   * voiceclone — conditions on a reference / speaker-identity embedding
 //                  (audio.conditioning ⊇ ReferenceAudio | VoiceEmbedding). → OpenVoice V2, Chatterbox-VE.
@@ -91,6 +94,12 @@ function audioBlock(model) {
 
 function audioHasVoices(audio) {
   return Array.isArray(audio?.voices) && audio.voices.length > 0;
+}
+
+// A streaming TTS (backend Capabilities.supports_streaming, sc-13675). Its own speech signal: a
+// streaming text-to-speech model has no fixed voice bank, so it serves Speech on this flag instead.
+function audioSupportsStreaming(audio) {
+  return audio?.supportsStreaming === true;
 }
 
 function audioHasEditModes(audio) {
@@ -113,7 +122,7 @@ export function audioModelServesMode(model, mode) {
     return false;
   }
   if (mode === "speech") {
-    return audioHasVoices(audio);
+    return audioHasVoices(audio) || audioSupportsStreaming(audio);
   }
   if (mode === "music") {
     return audioHasEditModes(audio);
@@ -125,6 +134,7 @@ export function audioModelServesMode(model, mode) {
     return (
       audioGenerates(audio) &&
       !audioHasVoices(audio) &&
+      !audioSupportsStreaming(audio) &&
       !audioHasEditModes(audio) &&
       !audioHasVoiceCloneConditioning(audio)
     );

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -233,9 +233,17 @@ describe("audio model eligibility (sc-13403)", () => {
       conditioning: ["VoiceEmbedding", "ReferenceAudio"],
     },
   };
+  // Streaming TTS (sc-13675): NO voice bank — it serves "speech" via audio.supportsStreaming, and
+  // must stay OFF "sfx" (the residual generator) despite advertising sampleRates.
+  const mossTtsRealtime = {
+    id: "moss_tts_realtime",
+    type: "audio",
+    audio: { languages: ["en", "zh"], sampleRates: [24000], maxDurationSecs: 2400, supportsStreaming: true },
+  };
 
   const seeded = [
     ["Kokoro-82M", kokoro, "speech"],
+    ["MOSS-TTS-Realtime (streaming)", mossTtsRealtime, "speech"],
     ["MOSS-SoundEffect-v2", moss, "sfx"],
     ["ACE-Step v1.5 Turbo", acestep, "music"],
     ["OpenVoice V2", openvoice, "voiceclone"],
@@ -260,6 +268,20 @@ describe("audio model eligibility (sc-13403)", () => {
     // MOSS is the residual generator (sfx) — not music, because it advertises no editModes.
     expect(audioModelServesMode(moss, "music")).toBe(false);
     expect(audioModelServesMode(moss, "sfx")).toBe(true);
+  });
+
+  it("MOSS-TTS-Realtime serves speech via supportsStreaming (no voice bank) and NOT sfx", () => {
+    // The streaming TTS has no voices — the streaming capability is its speech signal (sc-13675).
+    expect(audioModelServesMode(mossTtsRealtime, "speech")).toBe(true);
+    // It must NOT leak into the residual sfx bucket even though it advertises sampleRates.
+    expect(audioModelServesMode(mossTtsRealtime, "sfx")).toBe(false);
+    expect(audioModelServesMode(mossTtsRealtime, "music")).toBe(false);
+    expect(audioModelServesMode(mossTtsRealtime, "voiceclone")).toBe(false);
+    // And a plain (non-streaming) voiceless generator with the SAME sample-rate block stays sfx —
+    // proving the classifier keys on the streaming flag, not on the absence of voices alone.
+    const plainSfx = { id: "x", type: "audio", audio: { sampleRates: [24000], languages: ["en"] } };
+    expect(audioModelServesMode(plainSfx, "speech")).toBe(false);
+    expect(audioModelServesMode(plainSfx, "sfx")).toBe(true);
   });
 
   it("audioModelServesMode is empty-block / unknown-mode safe", () => {
@@ -290,8 +312,8 @@ describe("audio model eligibility (sc-13403)", () => {
     ];
     expect(generationModelsForType(liveCatalog, "audio").map((m) => m.id)).toEqual(["kokoro_82m", "acestep_v15_turbo"]);
 
-    // Fallback mirror: the constants.js audio entries resolve the same five models, and each still
-    // maps to its correct capability-driven mode (proves the fallback carries the discriminating fields).
+    // Fallback mirror: the constants.js audio entries resolve the same models, and each still maps to
+    // its correct capability-driven mode (proves the fallback carries the discriminating fields).
     const fallbackAudio = generationModelsForType(fallbackModels, "audio");
     expect(fallbackAudio.map((m) => m.id).sort()).toEqual(
       [
@@ -300,11 +322,13 @@ describe("audio model eligibility (sc-13403)", () => {
         "chatterbox_ve",
         "kokoro_82m",
         "moss_sfx_v2",
+        "moss_tts_realtime",
         "openvoice_v2",
       ].sort(),
     );
     const expectedMode = {
       kokoro_82m: "speech",
+      moss_tts_realtime: "speech",
       moss_sfx_v2: "sfx",
       acestep_v15_turbo: "music",
       openvoice_v2: "voiceclone",

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -295,6 +295,12 @@ export function AudioStudio() {
   const showSteps = SAMPLING_KNOB_MODES.has(mode) || mode === "music";
   const showGuidance = SAMPLING_KNOB_MODES.has(mode) || musicSupportsGuidance;
   const showNegative = musicSupportsNegative;
+  // Streaming (sc-13675): the selected model renders the clip incrementally when it advertises
+  // audio.supportsStreaming (backend Capabilities.supports_streaming). CAPABILITY-DRIVEN — never a
+  // hardcoded id: the results zone reveals a streaming affordance and the worker's per-chunk progress
+  // updates drive the WorkerProgressCard through the stream. Only a Speech model streams today
+  // (MOSS-TTS-Realtime); a non-streaming model leaves it hidden so those modes are unperturbed.
+  const showStreaming = Boolean(audio.supportsStreaming);
 
   // The voice picker's <optgroup> structure — derived from the selected model's voice bank, grouped
   // by accent + gender (sc-13408). Rebuilt only when the bank changes.
@@ -1028,7 +1034,23 @@ export function AudioStudio() {
           <div className="studio-results">
             <section className="review-panel">
               <div className="review-panel-head">
-                <h2>Latest audio</h2>
+                <div className="review-panel-head-title">
+                  <h2>Latest audio</h2>
+                  {/* Streaming reveal (sc-13675): shown ONLY when the selected model advertises
+                      audio.supportsStreaming. It signals that the clip renders incrementally — the
+                      worker posts per-chunk progress, so the WorkerProgressCard below advances THROUGH
+                      the stream as chunks arrive, and the first audio is produced before the full clip
+                      finishes. Capability-driven, never a hardcoded id; hidden for every one-shot mode. */}
+                  {showStreaming ? (
+                    <span
+                      className="streaming-badge"
+                      data-testid="audio-streaming-badge"
+                      title="This model streams audio incrementally — the first audio arrives before the full clip finishes rendering."
+                    >
+                      Streams incrementally
+                    </span>
+                  ) : null}
+                </div>
                 <span className="kbd-hint">
                   <kbd>⌘</kbd>
                   <kbd>↵</kbd>

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -81,6 +81,21 @@ const CHATTERBOX_TTS = {
   ui: { label: "Chatterbox Clone-TTS" },
 };
 
+// Streaming TTS (sc-13675): NO voice bank — serves Speech via audio.supportsStreaming. Kept OUT of
+// ALL_AUDIO so the existing Speech tests keep Kokoro as the default; the streaming tests add it.
+const MOSS_TTS_REALTIME = {
+  id: "moss_tts_realtime",
+  name: "MOSS-TTS-Realtime (Streaming Speech)",
+  type: "audio",
+  audio: {
+    languages: ["en", "zh"],
+    sampleRates: [24000],
+    maxDurationSecs: 2400,
+    supportsStreaming: true,
+  },
+  ui: { label: "MOSS-TTS-Realtime (Streaming)" },
+};
+
 const ALL_AUDIO = [KOKORO, MOSS, ACESTEP, OPENVOICE];
 
 function baseContext(overrides = {}) {
@@ -1220,6 +1235,88 @@ describe("AudioStudio register-a-voice (sc-13517)", () => {
     await click(modeTab(container, "Voice Clone"));
     await click(container.querySelector(".saved-voice-delete"));
     expect(deleteSavedVoice).toHaveBeenCalledWith("voice_a");
+  });
+});
+
+describe("AudioStudio streaming reveal (sc-13675)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <AudioStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const streamingBadge = () => container.querySelector('[data-testid="audio-streaming-badge"]');
+
+  it("serves the Speech tab from supportsStreaming (no voice bank) and reveals the streaming badge", async () => {
+    await render(baseContext({ audioModels: [MOSS_TTS_REALTIME], models: [MOSS_TTS_REALTIME] }));
+
+    // Opens on Speech, with the streaming TTS selected — proving supportsStreaming serves Speech even
+    // without a voice bank (capability-driven eligibility, sc-13675).
+    expect(modeTab(container, "Speech").className).toContain("active");
+    expect(modelSelect(container).value).toBe("moss_tts_realtime");
+
+    // The results zone reveals the streaming affordance.
+    expect(streamingBadge()).toBeTruthy();
+    expect(streamingBadge().textContent).toContain("Streams incrementally");
+
+    // It has NO voice bank, so the Speech voice picker is absent — but language + length still render
+    // from its Capabilities (it is a real Speech model, not SFX).
+    expect(fieldByLabelStart(container, "Voice")).toBeFalsy();
+    expect(fieldByLabelStart(container, "Language").querySelector("select")).toBeTruthy();
+    expect(fieldByLabelStart(container, "Length").querySelector("input").getAttribute("max")).toBe(
+      "2400",
+    );
+  });
+
+  it("does NOT reveal the streaming badge for a one-shot Speech model (Kokoro)", async () => {
+    await render(baseContext({ audioModels: [KOKORO], models: [KOKORO] }));
+    expect(modelSelect(container).value).toBe("kokoro_82m");
+    // Kokoro does not advertise supportsStreaming → no streaming affordance (non-streaming unperturbed).
+    expect(streamingBadge()).toBeNull();
+  });
+
+  it("toggles the badge with the selected model's capability, not the mode", async () => {
+    // Both a streaming and a one-shot Speech model installed; the badge follows the SELECTED model.
+    await render(
+      baseContext({
+        audioModels: [MOSS_TTS_REALTIME, KOKORO],
+        models: [MOSS_TTS_REALTIME, KOKORO],
+      }),
+    );
+    // Default selection is the first Speech model (the streaming one) → badge shown.
+    expect(modelSelect(container).value).toBe("moss_tts_realtime");
+    expect(streamingBadge()).toBeTruthy();
+
+    // Switch to Kokoro (still Speech) → the badge disappears: capability-driven, not mode-driven.
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLSelectElement.prototype,
+        "value",
+      ).set;
+      setter.call(modelSelect(container), "kokoro_82m");
+      modelSelect(container).dispatchEvent(new window.Event("change", { bubbles: true }));
+    });
+    expect(modelSelect(container).value).toBe("kokoro_82m");
+    expect(streamingBadge()).toBeNull();
   });
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4113,6 +4113,37 @@ label {
   font-weight: 600;
 }
 
+/* Left group of the results head — the title plus the capability-driven streaming badge (sc-13675),
+   kept together so the head's space-between keeps the ⌘↵ hint on the right. */
+.review-panel-head-title {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* Streaming affordance (sc-13675): revealed in the audio results head only when the selected model
+   advertises audio.supportsStreaming. Reuses the audio capability chip's accent tokens so it reads
+   distinctly and holds in both light and dark. */
+.streaming-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  border: 1px solid transparent;
+  white-space: nowrap;
+  align-self: center;
+}
+
+[data-theme="dark"] .streaming-badge {
+  color: var(--accent);
+}
+
 .kbd-hint {
   display: inline-flex;
   align-items: center;

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -8682,6 +8682,118 @@
       }
     },
     {
+      // MOSS-TTS-Realtime (sc-13675, epic 13400 E2) — the audio lane's first STREAMING TTS model:
+      // a Qwen3-1.7B autoregressive backbone + CSM-style local/depth transformer that emits 16 RVQ
+      // speech-codebook frames one block at a time, decoded to 24 kHz PCM by the separate
+      // MOSS-Audio-Tokenizer codec. Its `audio.supportsStreaming` mirrors the backend Capabilities
+      // (candle-audio-moss-tts-realtime descriptor: supports_streaming = true) — the single flag the
+      // Audio Studio reads to reveal incremental/progressive results (never a hardcoded id). It ships
+      // NO fixed voice bank (audio.voices absent), so it serves the Speech mode via the streaming
+      // signal rather than a voice list (modelEligibility.audioModelServesMode). Apache-2.0.
+      //
+      // Two pinned-revision downloads (the sc-13541 co-requisite pattern). The AR checkpoint is the
+      // primary; the ~7.1 GB MOSS-Audio-Tokenizer codec is a `coRequisite` the provider resolves at
+      // generate time via resolve_pinned_codec_snapshot() -> hf_get_pinned(OpenMOSS-Team/
+      // MOSS-Audio-Tokenizer @ 3cd226ba…). hf_get_pinned reads snapshots/<sha>/ and refuses a
+      // branch/tag, so a plain main-branch fetch would land in the wrong snapshot and offline
+      // generation would fail — both entries pin the exact 40-hex SHA the runtime resolves. The AR
+      // primary is pinned too because AR and codec are a MATCHED PAIR (the AR's 16-codebook RVQ frames
+      // are decoded by this exact codec revision); pinning both keeps a fresh install reproducible.
+      "id": "moss_tts_realtime",
+      "name": "MOSS-TTS-Realtime (Streaming Speech)",
+      "family": "moss_tts_realtime",
+      "type": "audio",
+      "macOnly": false,
+      "audio": {
+        "languages": [
+          "en",
+          "zh"
+        ],
+        "sampleRates": [
+          24000
+        ],
+        "maxDurationSecs": 2400,
+        "supportsMultiSpeaker": false,
+        "supportsStreaming": true
+      },
+      "downloads": [
+        {
+          // Primary: the AR backbone + local transformer (~4.66 GB single-file model.safetensors) plus
+          // the Qwen tokenizer. Pinned to the matched-pair revision the provider was ported against.
+          "provider": "huggingface",
+          "repo": "OpenMOSS-Team/MOSS-TTS-Realtime",
+          "revision": "6acbc7f161a0db71c291f2d0aaa9eee59334cab2",
+          "files": [
+            "config.json",
+            "model.safetensors",
+            "tokenizer.json",
+            "tokenizer_config.json"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 4675362142,
+          "footprint": {
+            "diskSizeBytes": 4675362142
+          }
+        },
+        {
+          // Co-requisite (sc-13675): the MOSS-Audio-Tokenizer codec — the separate ~7.1 GB RLFQ
+          // streaming codec (RVQ codes -> 24 kHz waveform) the provider resolves at generate time via
+          // resolve_pinned_codec_snapshot() -> hf_get_pinned(OpenMOSS-Team/MOSS-Audio-Tokenizer @
+          // 3cd226ba…, config.json + model.safetensors.index.json + the 2 shards). `revision` MUST be
+          // the full 40-hex SHA the resolver pins; predownloading it at that rev makes offline
+          // generation self-contained. Apache-2.0.
+          "provider": "huggingface",
+          "repo": "OpenMOSS-Team/MOSS-Audio-Tokenizer",
+          "revision": "3cd226ba2947efa357ef453bcad111b6eafba782",
+          "coRequisite": true,
+          "files": [
+            "config.json",
+            "model.safetensors.index.json",
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 7098616442,
+          "footprint": {
+            "diskSizeBytes": 7098616442
+          }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/OpenMOSS-Team/MOSS-TTS-Realtime"
+      },
+      "candle": {
+        "minMemoryGb": 14,
+        "measured": false
+      },
+      "licenseUrl": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Realtime",
+      "ui": {
+        "label": "MOSS-TTS-Realtime (Streaming)",
+        "description": "MOSS-TTS-Realtime-1.7B streaming text-to-speech (Qwen3-1.7B autoregressive backbone + CSM-style local transformer, decoded by the MOSS-Audio-Tokenizer codec). Streams speech in incremental PCM chunks as it renders — the first audio arrives well before the full clip finishes. 24 kHz mono, English + Chinese. Candle-native on every platform (CPU / Accelerate). Apache-2.0.",
+        "recommendedFor": [
+          "speech"
+        ],
+        "promptGuide": {
+          "title": "MOSS-TTS-Realtime Guide",
+          "path": "/prompt-guides/moss-tts-realtime.md",
+          "sources": [
+            {
+              "label": "MOSS-TTS-Realtime (Hugging Face)",
+              "url": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Realtime"
+            }
+          ]
+        }
+      }
+    },
+    {
       "id": "openvoice_v2",
       "name": "OpenVoice V2 (Voice Conversion)",
       "family": "openvoice",

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -205,6 +205,8 @@ mod tests {
             // Native cloned-voice TTS generator (sc-13412): script + reference clip → cloned WAV in
             // one call, with both VoiceEmbedding and ReferenceAudio conditioning advertised.
             "chatterbox_tts",
+            // Streaming TTS (sc-13675): the audio lane's first `supportsStreaming` provider.
+            "moss_tts_realtime",
         ];
         for id in audio_ids {
             let entry = models
@@ -243,6 +245,59 @@ mod tests {
             Some(28),
             "Kokoro advertises its 28 shipped English voices"
         );
+
+        // MOSS-TTS-Realtime (sc-13675) is the audio lane's first STREAMING model: it advertises
+        // `audio.supportsStreaming: true` (mirroring the backend Capabilities), ships NO fixed voice
+        // bank (it serves Speech via the streaming signal, not a voice list), and declares the
+        // MOSS-Audio-Tokenizer codec as a pinned-revision co-requisite so an offline install is
+        // self-contained. No other seeded audio model advertises streaming, so this pins the surface.
+        let moss_tts = models
+            .iter()
+            .find(|m| m["id"].as_str() == Some("moss_tts_realtime"))
+            .expect("moss_tts_realtime present");
+        assert_eq!(
+            moss_tts["audio"]["supportsStreaming"].as_bool(),
+            Some(true),
+            "moss_tts_realtime must advertise audio.supportsStreaming: true"
+        );
+        assert!(
+            moss_tts["audio"]["voices"].as_array().is_none(),
+            "moss_tts_realtime ships no fixed voice bank"
+        );
+        let codec = moss_tts["downloads"]
+            .as_array()
+            .expect("moss_tts_realtime downloads array")
+            .iter()
+            .find(|d| d["coRequisite"].as_bool() == Some(true))
+            .expect("moss_tts_realtime declares the MOSS-Audio-Tokenizer codec co-requisite");
+        assert_eq!(
+            codec["repo"].as_str(),
+            Some("OpenMOSS-Team/MOSS-Audio-Tokenizer"),
+            "the co-requisite is the MOSS-Audio-Tokenizer codec"
+        );
+        assert_eq!(
+            codec["revision"].as_str().map(str::len),
+            Some(40),
+            "the codec co-requisite pins a full 40-hex commit SHA (hf_get_pinned reads snapshots/<sha>/)"
+        );
+        for model in [
+            "kokoro_82m",
+            "moss_sfx_v2",
+            "acestep_v15_turbo",
+            "openvoice_v2",
+            "chatterbox_ve",
+            "chatterbox_tts",
+        ] {
+            let entry = models
+                .iter()
+                .find(|m| m["id"].as_str() == Some(model))
+                .unwrap_or_else(|| panic!("{model} present"));
+            assert_ne!(
+                entry["audio"]["supportsStreaming"].as_bool(),
+                Some(true),
+                "{model} must NOT advertise streaming — only moss_tts_realtime does"
+            );
+        }
     }
 
     #[test]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "15895a90b345693e48593b7d6772f394758ae642" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "15895a90b345693e48593b7d6772f394758ae642" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "15895a90b345693e48593b7d6772f394758ae642", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -576,8 +576,18 @@ async fn run_audio_synthesis_using(
     // that was never tripped, so a user cancel is honored DURING the clip render — not only by the
     // post-synthesis `check_cancel` after the whole clip has already rendered.
     let cancel = CancelFlag::new();
+    // Incremental streaming progress (sc-13675). A streaming-capable Generator drives
+    // `generate_streaming` and emits an `AudioChunk` per PCM block as the AR loop decodes it; `on_chunk`
+    // forwards the running chunk count over this channel and the concurrent async pump below posts a
+    // job update as each chunk arrives, so the Audio Studio's WorkerProgressCard advances THROUGH the
+    // stream instead of sitting flat until the whole clip renders. A non-streaming model takes the
+    // one-shot `generate` path and emits nothing here, so every existing audio mode is byte-for-byte
+    // unperturbed. The reassembled chunks equal the returned one-shot track (the gen-core reassembly
+    // law), so the library asset is still the full `AudioTrack` the caller writes.
+    let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel::<usize>();
     let handle = {
         let cancel = cancel.clone();
+        let chunk_tx = chunk_tx.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<gen_core::AudioTrack> {
             let spec = LoadSpec::new(WeightsSource::Dir(model_dir));
             let generator = load_generator(&model_id, &spec)
@@ -608,11 +618,21 @@ async fn run_audio_synthesis_using(
             // the per-stage engine callback is a no-op here — the shared keepalive watcher is what
             // keeps the job alive during synthesis, so the engine progress doesn't need forwarding.
             let mut on_progress = |_progress: Progress| {};
-            let output = generator
-                .generate(&req, &mut on_progress)
-                .map_err(|error| {
-                    classify_audio_synthesis_error("audio generation failed", error)
-                })?;
+            // Gate PURELY on the loaded generator's advertised capability (sc-13675), never a hardcoded
+            // id: a `supports_streaming` model streams incremental chunks; every other model keeps the
+            // exact one-shot `generate` path unchanged. `generate_streaming` also returns the same
+            // aggregate `GenerationOutput` as `generate`, so the written asset is identical either way.
+            let output = if generator.descriptor().capabilities.supports_streaming {
+                let mut on_chunk = |chunk: gen_core::AudioChunk| {
+                    // The 1-based running chunk count. A closed channel (pump already gone) is fine —
+                    // synthesis must never depend on the progress sink.
+                    let _ = chunk_tx.send(chunk.index.saturating_add(1));
+                };
+                generator.generate_streaming(&req, &mut on_chunk, &mut on_progress)
+            } else {
+                generator.generate(&req, &mut on_progress)
+            }
+            .map_err(|error| classify_audio_synthesis_error("audio generation failed", error))?;
             match output {
                 GenerationOutput::Audio(track) => Ok(track),
                 GenerationOutput::Images(_) => Err(WorkerError::Engine(
@@ -624,12 +644,59 @@ async fn run_audio_synthesis_using(
             }
         })
     };
+    // Drop our extra sender so the channel closes the instant synthesis finishes (the blocking task's
+    // clone drops), letting the pump terminate cleanly on `recv() == None`.
+    drop(chunk_tx);
+    // Concurrent incremental-progress pump (sc-13675): posts a Running/Generating job update as each
+    // streamed chunk arrives so the UI reflects the stream. It runs ALONGSIDE
+    // `run_blocking_with_heartbeat` (which owns worker heartbeats + the cancel watcher on a DIFFERENT
+    // endpoint). It stops the instant the shared cancel flag is tripped, so it can never post a Running
+    // status after the watcher writes the terminal `Canceled` (no cancel/heartbeat regression), and it
+    // ends when synthesis closes the channel. Non-streaming synthesis never sends, so the pump exits
+    // immediately with zero posts, leaving those modes untouched.
+    let pump = {
+        let api = api.clone();
+        let job_id = job.id.clone();
+        let backend = backend_label(&settings.gpu_id).to_owned();
+        let cancel = cancel.clone();
+        tokio::spawn(async move {
+            let mut count = 0usize;
+            while let Some(latest) = chunk_rx.recv().await {
+                if cancel.is_cancelled() {
+                    break;
+                }
+                count = count.max(latest);
+                // Asymptotic fraction inside the (Generating 0.2 → Saving 0.9) band: the total chunk
+                // count is unknown ahead of time (the AR loop decides its own length via EOS), so
+                // approach but never reach 0.9 rather than claim a false denominator.
+                let fraction = 0.25 + 0.6 * (count as f64 / (count as f64 + 6.0));
+                let message = format!(
+                    "Streaming audio… ({count} chunk{})",
+                    if count == 1 { "" } else { "s" }
+                );
+                let _ = update_job(
+                    &api,
+                    &job_id,
+                    audio_progress(
+                        JobStatus::Running,
+                        ProgressStage::Generating,
+                        fraction,
+                        &message,
+                        None,
+                        &backend,
+                    ),
+                )
+                .await;
+            }
+            count
+        })
+    };
     // The shared blocking keepalive + cancel watcher (sc-13469): pings the worker heartbeat while the
     // synthesis runs (so a long/cold render is never swept to `interrupted`), polls the API cancel
     // state each interval and trips the SAME `cancel` the request carries, and on completion tears the
     // watcher down cleanly (bounded-join, no leaked task, no false-trip on normal completion). Mirrors
     // the video path's in-loop cancel watcher.
-    run_blocking_with_heartbeat(
+    let result = run_blocking_with_heartbeat(
         api,
         settings,
         &job.id,
@@ -639,7 +706,11 @@ async fn run_audio_synthesis_using(
         no_cancel_ack(),
         handle,
     )
-    .await
+    .await;
+    // Drain the pump. It has already ended (the channel closed when synthesis finished, or the cancel
+    // flag stopped it), so this is bounded and never hangs.
+    let _ = pump.await;
+    result
 }
 
 /// Which synthesis path a resolved audio job takes — the single-generator lane (Speech / SFX / Music)
@@ -1865,6 +1936,99 @@ mod tests {
         }
     }
 
+    /// A descriptor that advertises `supports_streaming: true` — so `run_audio_synthesis_using`
+    /// takes the `generate_streaming` path (the gate reads the loaded generator's capability, never a
+    /// hardcoded id). The audio twin of the real moss_tts_realtime descriptor's streaming flag.
+    fn streaming_stub_descriptor() -> gen_core::ModelDescriptor {
+        gen_core::ModelDescriptor {
+            id: "stub_streaming_audio",
+            family: "stub",
+            backend: "mlx",
+            modality: gen_core::Modality::Audio,
+            capabilities: gen_core::Capabilities {
+                supports_streaming: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// A streaming [`Generator`] that emits `chunks` incremental [`AudioChunk`]s of `per_chunk`
+    /// interleaved samples through `on_chunk` (with a small inter-chunk delay so the chunks arrive
+    /// incrementally, not all at once), and returns the SAME aggregate track — proving the reassembly
+    /// law (`concat(chunks) == generate()`). Its one-shot `generate` returns that same concatenation.
+    struct StreamingStubGenerator {
+        descriptor: gen_core::ModelDescriptor,
+        chunks: usize,
+        per_chunk: usize,
+    }
+
+    impl StreamingStubGenerator {
+        fn chunk_samples(&self, index: usize) -> Vec<f32> {
+            // Deterministic, non-silent, per-chunk-distinct PCM so a reassembly bug is observable.
+            (0..self.per_chunk)
+                .map(|s| {
+                    let n = (index * self.per_chunk + s) as f32;
+                    ((n * 0.25).sin() * 0.5).clamp(-1.0, 1.0)
+                })
+                .collect()
+        }
+
+        fn aggregate(&self) -> Vec<f32> {
+            (0..self.chunks)
+                .flat_map(|i| self.chunk_samples(i))
+                .collect()
+        }
+    }
+
+    impl gen_core::Generator for StreamingStubGenerator {
+        fn descriptor(&self) -> &gen_core::ModelDescriptor {
+            &self.descriptor
+        }
+        fn validate(&self, _req: &GenerationRequest) -> gen_core::Result<()> {
+            Ok(())
+        }
+        fn generate(
+            &self,
+            _req: &GenerationRequest,
+            _on_progress: &mut dyn FnMut(Progress),
+        ) -> gen_core::Result<GenerationOutput> {
+            Ok(GenerationOutput::Audio(gen_core::AudioTrack {
+                samples: self.aggregate(),
+                sample_rate: 24_000,
+                channels: 1,
+                stems: Vec::new(),
+            }))
+        }
+        fn generate_streaming(
+            &self,
+            req: &GenerationRequest,
+            on_chunk: &mut dyn FnMut(gen_core::AudioChunk),
+            _on_progress: &mut dyn FnMut(Progress),
+        ) -> gen_core::Result<GenerationOutput> {
+            let mut all = Vec::new();
+            for index in 0..self.chunks {
+                if req.cancel.is_cancelled() {
+                    return Err(gen_core::Error::Canceled);
+                }
+                let samples = self.chunk_samples(index);
+                all.extend(samples.iter().copied());
+                on_chunk(gen_core::AudioChunk {
+                    samples,
+                    sample_rate: 24_000,
+                    channels: 1,
+                    index,
+                });
+                std::thread::sleep(Duration::from_millis(8));
+            }
+            Ok(GenerationOutput::Audio(gen_core::AudioTrack {
+                samples: all,
+                sample_rate: 24_000,
+                channels: 1,
+                stems: Vec::new(),
+            }))
+        }
+    }
+
     fn stub_transform_descriptor() -> gen_core::AudioTransformDescriptor {
         gen_core::AudioTransformDescriptor {
             id: "stub_converter",
@@ -2217,5 +2381,254 @@ mod tests {
             posts.iter().any(|p| p["status"] == "canceled"),
             "the terminal Canceled must be posted, got {posts:?}"
         );
+    }
+
+    /// Streaming path (sc-13675): a `supports_streaming` Generator must be driven through
+    /// `generate_streaming`, the worker must forward an incremental job update per chunk (so the UI
+    /// advances through the stream), and the returned track must equal the reassembly of every chunk
+    /// (the gen-core reassembly law → the library asset is the full clip). Gated purely on the loaded
+    /// generator's capability, so no model id is hardcoded.
+    #[tokio::test]
+    async fn streaming_synthesis_forwards_per_chunk_progress_and_returns_reassembled_track() {
+        let (base_url, progress) = spawn_audio_cancel_stub(false).await;
+        let settings = cancel_test_settings(base_url);
+        let api = ApiClient::new(&settings);
+        let job = audio_test_job("audio-stream");
+        let request = AudioRequest::from_payload(&payload(json!({ "model": "moss_tts_realtime" })));
+
+        let expected = StreamingStubGenerator {
+            descriptor: streaming_stub_descriptor(),
+            chunks: 5,
+            per_chunk: 4,
+        }
+        .aggregate();
+        let load = move |_id: &str, _spec: &LoadSpec| {
+            Ok(Box::new(StreamingStubGenerator {
+                descriptor: streaming_stub_descriptor(),
+                chunks: 5,
+                per_chunk: 4,
+            }) as Box<dyn Generator>)
+        };
+
+        let track = run_audio_synthesis_using(
+            &api,
+            &settings,
+            &job,
+            &request,
+            PathBuf::from("unused"),
+            None,
+            load,
+        )
+        .await
+        .expect("a streaming synthesis returns the reassembled track");
+
+        // The returned one-shot track == concat of the 5×4 streamed chunks (the reassembly law).
+        assert_eq!(
+            track.samples, expected,
+            "the returned track must equal the reassembly of every streamed chunk"
+        );
+        assert_eq!(track.sample_rate, 24_000);
+        assert_eq!(track.channels, 1);
+
+        // The pump forwarded ≥2 incremental "Streaming audio…" job updates BEFORE the clip finished —
+        // the observable proof the worker streams (a non-streaming model posts none; see below).
+        let posts = progress.lock().expect("progress lock");
+        let streaming_posts = posts
+            .iter()
+            .filter(|p| {
+                p["message"]
+                    .as_str()
+                    .is_some_and(|m| m.starts_with("Streaming audio"))
+            })
+            .count();
+        assert!(
+            streaming_posts >= 2,
+            "expected ≥2 incremental streaming progress posts, got {streaming_posts}: {posts:?}"
+        );
+        // None of the incremental posts is terminal — the pump only ever emits Running/Generating.
+        assert!(
+            posts.iter().all(|p| p["status"] != "canceled"),
+            "a clean stream posts no terminal Canceled, got {posts:?}"
+        );
+    }
+
+    /// Control (sc-13675): a NON-streaming Generator (Capabilities default → `supports_streaming:
+    /// false`) must keep the one-shot `generate` path and emit ZERO incremental "Streaming audio…"
+    /// posts — proving the streaming wiring does not perturb Kokoro/MOSS-SFX/ACE-Step/clone modes.
+    #[tokio::test]
+    async fn non_streaming_synthesis_emits_no_incremental_streaming_posts() {
+        let (base_url, progress) = spawn_audio_cancel_stub(false).await;
+        let settings = cancel_test_settings(base_url);
+        let api = ApiClient::new(&settings);
+        let job = audio_test_job("audio-nonstream");
+        let request = AudioRequest::from_payload(&payload(json!({})));
+
+        let observed = Arc::new(AtomicBool::new(false));
+        let load = stub_load(StubBehavior::CompleteOk, observed);
+        run_audio_synthesis_using(
+            &api,
+            &settings,
+            &job,
+            &request,
+            PathBuf::from("unused"),
+            None,
+            load,
+        )
+        .await
+        .expect("a non-streaming synthesis completes");
+
+        let posts = progress.lock().expect("progress lock");
+        assert!(
+            posts.iter().all(|p| {
+                p["message"]
+                    .as_str()
+                    .is_none_or(|m| !m.starts_with("Streaming audio"))
+            }),
+            "a non-streaming model must emit no incremental streaming posts, got {posts:?}"
+        );
+    }
+
+    /// DoD walking skeleton (sc-13675) — REAL MOSS-TTS-Realtime streaming through the generator seam.
+    /// `#[ignore]` because it needs the ~4.66 GB AR checkpoint + ~7.1 GB MOSS-Audio-Tokenizer codec
+    /// (not in CI) and is pathologically slow in a debug build. Run it in RELEASE:
+    ///
+    /// ```text
+    /// SCENEWORKS_MOSS_TTS_AR_DIR=~/.cache/huggingface/hub/models--OpenMOSS-Team--MOSS-TTS-Realtime/\
+    ///   snapshots/6acbc7f161a0db71c291f2d0aaa9eee59334cab2 \
+    /// HF_HUB_OFFLINE=1 \
+    /// cargo test --release -p sceneworks-worker -- --ignored --nocapture \
+    ///   moss_tts_realtime_streams_a_real_clip
+    /// ```
+    ///
+    /// It loads the real generator through the worker's `load_audio` seam, drives `generate_streaming`
+    /// capturing every chunk + timing, then asserts the DoD: ≥2 chunks, the first chunk arrives before
+    /// the full clip finishes, `concat(chunks) == returned track` (reassembly law), 24 kHz, non-silent
+    /// — and writes the assembled WAV + an evidence JSON to `SCENEWORKS_DOD_OUT` (or the temp dir).
+    #[test]
+    #[ignore = "requires the ~12GB MOSS-TTS-Realtime + MOSS-Audio-Tokenizer weights; DoD, run manually in release"]
+    fn moss_tts_realtime_streams_a_real_clip_through_the_generator_seam() {
+        let ar_dir = std::env::var("SCENEWORKS_MOSS_TTS_AR_DIR").expect(
+            "set SCENEWORKS_MOSS_TTS_AR_DIR to the cached MOSS-TTS-Realtime snapshot directory",
+        );
+        let generator = crate::inference_runtime::load_audio(
+            "moss_tts_realtime",
+            &LoadSpec::new(WeightsSource::Dir(PathBuf::from(&ar_dir))),
+        )
+        .expect("load the real moss_tts_realtime generator from the cached snapshot");
+        assert!(
+            generator.descriptor().capabilities.supports_streaming,
+            "moss_tts_realtime must advertise supports_streaming"
+        );
+
+        let req = GenerationRequest {
+            prompt:
+                "SceneWorks streaming speech is now live. This clip was produced incrementally, \
+                     one chunk at a time."
+                    .to_owned(),
+            audio: Some(AudioParams {
+                language: Some("en".to_owned()),
+                target_duration: Some(6.0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let start = Instant::now();
+        let mut chunk_lengths: Vec<usize> = Vec::new();
+        let mut reassembled: Vec<f32> = Vec::new();
+        let mut first_chunk_at: Option<Duration> = None;
+        let mut sample_rate = 0u32;
+        let mut channels = 0u16;
+        {
+            let mut on_chunk = |chunk: gen_core::AudioChunk| {
+                if first_chunk_at.is_none() {
+                    first_chunk_at = Some(start.elapsed());
+                }
+                assert_eq!(
+                    chunk.index,
+                    chunk_lengths.len(),
+                    "chunk indices are gapless"
+                );
+                sample_rate = chunk.sample_rate;
+                channels = chunk.channels;
+                chunk_lengths.push(chunk.samples.len());
+                reassembled.extend(chunk.samples.iter().copied());
+            };
+            let mut on_progress = |_p: Progress| {};
+            let output = generator
+                .generate_streaming(&req, &mut on_chunk, &mut on_progress)
+                .expect("real streaming synthesis succeeds");
+            let total = start.elapsed();
+            let track = match output {
+                GenerationOutput::Audio(track) => track,
+                other => panic!("expected audio, got {other:?}"),
+            };
+
+            let first = first_chunk_at.expect("at least one chunk streamed");
+            // (a) ≥2 chunks, first before the full clip finished.
+            assert!(
+                chunk_lengths.len() >= 2,
+                "streaming must emit ≥2 chunks, got {}",
+                chunk_lengths.len()
+            );
+            assert!(
+                first < total,
+                "the first chunk ({first:?}) must arrive before the full synthesis finishes ({total:?})"
+            );
+            // (b) reassembly law: concat(chunks) == the returned one-shot track.
+            assert_eq!(
+                reassembled, track.samples,
+                "concatenating the streamed chunks must equal the returned track"
+            );
+            // (c) real speech at the expected rate, non-silent.
+            assert_eq!(
+                track.sample_rate, 24_000,
+                "MOSS-TTS-Realtime renders 24 kHz"
+            );
+            assert_eq!(sample_rate, 24_000);
+            assert!(channels >= 1);
+            let peak = track.samples.iter().fold(0.0f32, |m, &s| m.max(s.abs()));
+            assert!(peak > 0.0, "the produced clip must be audible (non-silent)");
+
+            // Save the artifact + evidence to SCENEWORKS_DOD_OUT (or the temp dir).
+            let out_dir = std::env::var("SCENEWORKS_DOD_OUT")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| std::env::temp_dir());
+            std::fs::create_dir_all(&out_dir).ok();
+            let wav_path = out_dir.join("moss_tts_realtime_stream_dod.wav");
+            let wav = AudioTrack {
+                samples: track.samples.clone(),
+                sample_rate: track.sample_rate,
+                channels: track.channels.max(1),
+            };
+            write_wav_pcm16(&wav, &wav_path).expect("write the assembled WAV");
+            let evidence = json!({
+                "model": "moss_tts_realtime",
+                "chunkCount": chunk_lengths.len(),
+                "chunkSampleLengths": chunk_lengths,
+                "firstChunkMs": first.as_millis(),
+                "fullSynthesisMs": total.as_millis(),
+                "firstChunkBeforeFull": first < total,
+                "sampleRate": track.sample_rate,
+                "channels": track.channels,
+                "totalSamples": track.samples.len(),
+                "durationSecs": track.samples.len() as f64
+                    / (track.sample_rate.max(1) as f64 * track.channels.max(1) as f64),
+                "peakAmplitude": peak,
+                "reassemblyEqualsOneShot": reassembled == track.samples,
+                "wavPath": wav_path.display().to_string(),
+            });
+            let evidence_path = out_dir.join("moss_tts_realtime_stream_dod.json");
+            std::fs::write(
+                &evidence_path,
+                serde_json::to_string_pretty(&evidence).unwrap(),
+            )
+            .expect("write the evidence JSON");
+            eprintln!(
+                "DoD evidence: {}\nWAV: {}",
+                evidence_path.display(),
+                wav_path.display()
+            );
+        }
     }
 }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -530,6 +530,10 @@
                 "type": "boolean",
                 "description": "Whether the model can render a multi-speaker turn/dialogue in a single request. Absent/false means single-speaker only."
               },
+              "supportsStreaming": {
+                "type": "boolean",
+                "description": "Whether the model streams audio incrementally as it renders (backend Capabilities.supports_streaming, sc-12846). When true the worker drives Generator::generate_streaming so partial PCM chunks arrive before the clip finishes, and the Audio Studio reveals progressive/streaming results in the results zone. Absent/false means one-shot synthesis. The reassembly of every chunk still equals the one-shot track, so it is advisory to the STREAM SHAPE, not to correctness (sc-13675)."
+              },
               "conditioning": {
                 "type": "array",
                 "uniqueItems": true,


### PR DESCRIPTION
## What

Adds the Audio Studio's **first streaming TTS model** (`moss_tts_realtime`) end-to-end, gated **purely on the backend `supports_streaming` capability** — never a hardcoded model id. Links [sc-13675].

## Inference pin bump (shared, highest-risk)

`15895a90` (sc-13443 — **predates** moss_tts_realtime) **→ `3508deb3`** (current inference `main`, green). What it pulls in:

- **`candle-audio-moss-tts-realtime` (sc-13392 / sc-13334)** — the streaming TTS: Qwen3-1.7B AR brain + the ported **MOSS-Audio-Tokenizer** codec. It genuinely streams (≥2 PCM chunks before completion; `concat(chunks) == one-shot`; first-chunk latency < full).
- **`candle-audio-moss-ttsd` / `moss_ttsd_v05` (sc-13360 / sc-13518)** — so the sibling story **sc-13676** inherits the same pin.
- The **gen-core streaming surface** (`Generator::generate_streaming`, `gen_core::media::AudioChunk` + reassembly law, `Capabilities.supports_streaming`, sc-12846).

Bumped `crates/sceneworks-worker/Cargo.toml` + the root `candle-kernels` `[patch]` in lockstep via `scripts/bump-inference.mjs`. **No gen-core or mlx-rs skew** (helper's own guards). The candle-audio **metal feature is intentionally left off** (audio stays on CPU/Accelerate — that's the separate, blocked sc-13501).

### Existing modes re-verified after the bump
Whole workspace compiles; **all existing audio modes still build**, and I re-rendered a couple in release. The full `cargo test` suite (23 binaries) and the whole web suite are green — nothing regressed.

## Model seed + co-requisites

- `config/manifests/builtin.models.jsonc`: new `moss_tts_realtime` (type:audio) with an `audio` block from the backend Capabilities — **`supportsStreaming: true`**, 24 kHz, en/zh, `maxDurationSecs`, Apache-2.0.
- Two **pinned-revision** downloads (the sc-13541 pattern): the AR checkpoint (`OpenMOSS-Team/MOSS-TTS-Realtime` @ `6acbc7f1…`) and the **~7.1 GB MOSS-Audio-Tokenizer codec** as a `coRequisite: true` @ `3cd226ba…` (the SHA the provider's `resolve_pinned_codec_snapshot` reads). Both pinned because AR + codec are a matched pair.
- New schema field `audio.supportsStreaming` (`packages/schemas/model-manifest.schema.json`).
- Updated the seeded-audio assertions: `crates/sceneworks-core/src/builtin_manifests.rs`, `apps/web/src/constants.js`, `apps/web/src/modelEligibility.test.js`. New prompt guide `moss-tts-realtime.md`.

## Worker streaming path

`run_audio_synthesis_using` (audio_jobs.rs) now drives **`Generator::generate_streaming`** when the loaded generator advertises `supports_streaming`, forwarding a **per-chunk job update** through a concurrent async pump so the `WorkerProgressCard` advances *through* the stream. It integrates with the shared `CancelFlag` watcher + `run_blocking_with_heartbeat` (sc-13469) — **the pump stops on cancel**, so no cancel/heartbeat regression. The library asset is the full assembled `AudioTrack` (reassembled chunks == one-shot). Non-streaming models keep the exact one-shot `generate` path (control test proves zero incremental posts).

## Web (capability-gated)

`moss_tts_realtime` serves the **Speech** tab via the streaming capability (it ships no voice bank, so `audioModelServesMode` reads `supportsStreaming` — a streaming TTS is a speech model; it stays OFF SFX). The results zone reveals a **“Streams incrementally”** affordance **only** when the selected model advertises `supportsStreaming`, themed light/dark. The four one-shot modes are unperturbed.

## DoD — real streaming artifact (release build, through the worker seam)

Loaded the **real** ~4.66 GB AR + ~7.1 GB codec weights and streamed a 24 kHz clip:

| evidence | value |
|---|---|
| chunk count | **3** (`[15360, 15360, 11520]` samples) |
| first chunk | **15.1 s** vs full synthesis **28.7 s** → streamed before completion ✅ |
| reassembly | `concat(chunks) == one-shot` ✅ |
| sample rate | **24000 Hz**, mono, non-silent (peak 0.14), valid RIFF WAVE ✅ |

## Tests

- **Rust** (`sceneworks-worker`): streaming path forwards ≥2 per-chunk progress posts + returns the reassembled track; a non-streaming control emits zero streaming posts; the 3 sc-13469 cancel tests still pass. A `#[ignore]`d real-model DoD test captures the evidence above (run in release).
- **Web**: `AudioStudio.test.jsx` streaming-reveal tests (badge follows the selected model's capability, not the mode) + `modelEligibility.test.js` (streaming TTS → Speech, not SFX).
- Green: `rust:check` (fmt + clippy -D warnings + test + build), full web suite (2208), parity worker-pytest manifest audit (21) + non-e2e/parity lane (26), scaffold/compose/NC-weights checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)