### PR TITLE
chore(deps): bump inference pin — z-image tiled VAE decode + DiT-drop, fits 8 GB Macs (sc-13571)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "image",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "cudaforge",
 ]
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3930,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4005,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4023,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4203,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4272,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "core-llm",
  "half",
@@ -4621,7 +4621,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5857,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5867,7 +5867,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6157,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=3508deb3d94a9b307a6e5c7a47352ef6e677a55d#3508deb3d94a9b307a6e5c7a47352ef6e677a55d"
+source = "git+https://github.com/SceneWorks/inference?rev=47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f#47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8575,7 +8575,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f" }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "3508deb3d94a9b307a6e5c7a47352ef6e677a55d", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "47c0ffad9b5bbe5dae41b1348f56b1ed1bf2d50f", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
Bumps the inference pin `15895a90 → 47c0ffad` to ship [SceneWorks/inference#169](https://github.com/SceneWorks/inference/pull/169), which fixes [#1658](https://github.com/SceneWorks/SceneWorks/issues/1658) (z-image renders a flat **violet image** / Metal-OOMs on every prompt on 8 GB Macs). Story: [sc-13571](https://app.shortcut.com/trefry/story/13571).

## What #169 does
On an 8 GB Mac the fit-gate correctly downtiers z-image-turbo to q4, but the **VAE decode was untiled** — it materialized a ~14 GiB activation transient at 1024² in one shot (measured: TE 2.57 / DiT 4.78 / **decode 17.37 GiB**). The `weights_fit_floor` admitted q4 betting the transient pages, but it can't — so single images page for minutes and corrupt to violet, and batches hard-OOM.

The inference PR lands two composable fixes:
- **`Vae::decode_tiled`** — tiles the spatially-local upsample tail via the shared sc-11747 facility (head/global-attention runs once). The Flux1/Z-Image VAE is shared, so z-image, FLUX.1, Boogu, Chroma all gain it.
- **`Residency::run_staged` + `StagedHeavy`** — under `Sequential`, free the DiT after denoise and before the tiled decode.

Result: 1024² q4 whole-generate peak **17.37 → 4.90 GiB**.

## Why no SceneWorks code change
The tiled decode + DiT-drop key off `OffloadPolicy::Sequential` — the signal the MLX fit-gate already sets on memory-constrained Macs (sc-12179 `weights_fit_floor`). Large-memory Macs stay on `Resident` and decode exactly (untiled), so nothing changes for them.

## Verification
- Bump spans 29 inference commits (`15895a90..47c0ffad`); `bump-inference.mjs` gen-core/mlx-rs skew check clean.
- `cargo check -p sceneworks-worker` clean against the new rev.
- Inference#169 CI green (incl. the macOS MLX/Metal build lane); z-image + residency unit tests + a real-weights tiled-decode parity test pass there.

Note: **#1653 (Auto default) does not fix #1658** — the machine already loads q4 either way; the untiled q4 decode was the OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)