### PR TITLE
fix(worker): confine kps sourcePath to keypoint-uploads, its actual staging cache (sc-13713)

### DIFF
--- a/apps/rust-api/src/keypoints.rs
+++ b/apps/rust-api/src/keypoints.rs
@@ -34,7 +34,7 @@ pub(crate) async fn create_keypoint_sources(
             continue;
         }
         let display_name = field.file_name().unwrap_or("image").to_owned();
-        let path = write_upload_field_to_dir(&state, field, "keypoint-uploads").await?;
+        let path = write_upload_field_to_dir(&state, field, KEYPOINT_UPLOADS_CACHE_DIR).await?;
         sources.push(serde_json::json!({
             "path": path.to_string_lossy(),
             "displayName": display_name,
@@ -105,5 +105,5 @@ pub(crate) async fn delete_keypoint_collection(
 /// never saved). Mirrors `sweep_stale_pose_uploads`.
 pub(crate) fn sweep_stale_keypoint_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
     let cutoff = SystemTime::now() - Duration::from_secs(STALE_UPLOAD_SECONDS);
-    sweep_stale_uploads(data_dir, "keypoint-uploads", cutoff)
+    sweep_stale_uploads(data_dir, KEYPOINT_UPLOADS_CACHE_DIR, cutoff)
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -47,7 +47,7 @@ use sceneworks_core::project_store::{
     AssetStatusPatch, AssetTagsPatch, CharacterCreateInput, CharacterLookInput,
     CharacterLookUpdateInput, CharacterLoraInput, CharacterLoraUpdateInput,
     CharacterReferenceInput, CharacterReferenceUpdateInput, CharacterUpdateInput, ProjectStore,
-    ProjectStoreError, UploadAsset,
+    ProjectStoreError, UploadAsset, KEYPOINT_UPLOADS_CACHE_DIR, POSE_UPLOADS_CACHE_DIR,
 };
 use sceneworks_core::time::{format_unix_seconds, now_unix_seconds};
 use sceneworks_core::training::{

--- a/apps/rust-api/src/poses.rs
+++ b/apps/rust-api/src/poses.rs
@@ -53,7 +53,7 @@ pub(crate) async fn create_pose_sources(
             continue;
         }
         let display_name = field.file_name().unwrap_or("image").to_owned();
-        let path = write_upload_field_to_dir(&state, field, "pose-uploads").await?;
+        let path = write_upload_field_to_dir(&state, field, POSE_UPLOADS_CACHE_DIR).await?;
         sources.push(serde_json::json!({
             "path": path.to_string_lossy(),
             "displayName": display_name,
@@ -73,7 +73,7 @@ pub(crate) async fn create_pose_sources(
 /// own sources after a successful detect). Mirrors `sweep_stale_lora_uploads`.
 pub(crate) fn sweep_stale_pose_uploads(data_dir: &FsPath) -> std::io::Result<usize> {
     let cutoff = SystemTime::now() - Duration::from_secs(STALE_UPLOAD_SECONDS);
-    sweep_stale_uploads(data_dir, "pose-uploads", cutoff)
+    sweep_stale_uploads(data_dir, POSE_UPLOADS_CACHE_DIR, cutoff)
 }
 
 /// Stream a worker pose-detect skeleton preview from the cache so the Create tab

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -75,6 +75,17 @@ pub const GLOBAL_KEYPOINTS_PROJECT_NAME: &str = "Key Point Library";
 /// The user angle-set collections store, relative to the global keypoints project.
 const KEYPOINT_COLLECTIONS_FILE: &str = "keypoint-collections.json";
 
+/// Staging cache dir (under `<data>/cache`) for Key Point Library source uploads. One
+/// constant shared by the API staging route (`create_keypoint_sources`), the store's
+/// save-preset guard ([`ProjectStore`]'s keypoint upload check), and the worker's
+/// `kps sourcePath` confinement — sc-13713 was these drifting apart (the worker confined
+/// to the pose lane's dir, rejecting every capture).
+pub const KEYPOINT_UPLOADS_CACHE_DIR: &str = "keypoint-uploads";
+/// Staging cache dir for Pose Library source uploads (the `pose_detect` lane's sibling of
+/// [`KEYPOINT_UPLOADS_CACHE_DIR`]): API staging route, startup sweep, and the worker's
+/// `pose sourcePath` confinement + post-detect cleanup.
+pub const POSE_UPLOADS_CACHE_DIR: &str = "pose-uploads";
+
 /// One resolved angle preset for generation (sc-4450): the kps to draw + a display name + (for
 /// built-ins) the canonical angle name that drives prompt augmentation. User presets have
 /// `angle: None` (no canonical prompt clause). Produced by [`ProjectStore::resolve_angle_collection`].
@@ -1786,7 +1797,7 @@ impl ProjectStore {
     /// Guard a staged source-image path under the keypoint-uploads cache (mirrors
     /// [`Self::pose_preview_path`]) so a save can't copy an arbitrary file into the library.
     fn keypoint_upload_path(&self, path: &str) -> ProjectStoreResult<PathBuf> {
-        let cache_root = self.data_dir.join("cache").join("keypoint-uploads");
+        let cache_root = self.data_dir.join("cache").join(KEYPOINT_UPLOADS_CACHE_DIR);
         let canonical_root = fs::canonicalize(&cache_root).map_err(|_| {
             ProjectStoreError::NotFound("Key Point upload cache is unavailable".to_owned())
         })?;

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -51,7 +51,7 @@ use crate::{
     update_job, ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
-use sceneworks_core::project_store::ProjectStore;
+use sceneworks_core::project_store::{ProjectStore, KEYPOINT_UPLOADS_CACHE_DIR};
 
 /// SCRFD detection confidence floor (InsightFace / `FaceAnalysis` default). Mac only — the candle
 /// `FaceAnalysis::detect` applies the same InsightFace defaults internally, so the off-Mac path never
@@ -338,8 +338,16 @@ fn load_source_image(settings: &Settings, job: &JobSnapshot) -> WorkerResult<Ima
         // picks the codec from the extension — would reject a perfectly valid JPEG/PNG. Read
         // the bytes and let the decoder sniff the format from the magic bytes; `decode_image_bytes_any`
         // additionally transcodes a valid-but-unsupported format (AVIF/HEIC/...) to PNG (sc-6143).
-        let source_path =
-            normalize_app_managed_cache_path(settings, path, "pose-uploads", "kps sourcePath")?;
+        // Confine to `keypoint-uploads` — the cache the API's `create_keypoint_sources`
+        // actually stages kps sources into. From 2e5b5562 (2026-06-15) until sc-13713
+        // this said `pose-uploads` (the pose_detect lane's staging dir), which rejected
+        // every Key Point Library capture on every install (GitHub #1658).
+        let source_path = normalize_app_managed_cache_path(
+            settings,
+            path,
+            KEYPOINT_UPLOADS_CACHE_DIR,
+            "kps sourcePath",
+        )?;
         let bytes = std::fs::read(&source_path).map_err(|error| {
             WorkerError::InvalidPayload(format!("kps extraction source {path}: {error}"))
         })?;
@@ -468,6 +476,113 @@ pub(crate) async fn run_kps_extract_job(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A queued `kps_extract` job carrying `payload` (mirrors `jobs_store`'s test constructor).
+    fn kps_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_kps",
+            "type": "kps_extract",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-07-20T00:00:00Z",
+            "updatedAt": "2026-07-20T00:00:00Z",
+        }))
+        .expect("valid JobSnapshot")
+    }
+
+    /// Write a tiny valid PNG at `path` (staged uploads are extensionless `upload-*.tmp`
+    /// files, so encode into a buffer and write the bytes rather than `save`, which
+    /// dispatches on the extension).
+    fn write_png(path: &Path, width: u32, height: u32) {
+        let mut bytes = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(image::RgbImage::new(width, height))
+            .write_to(&mut bytes, image::ImageFormat::Png)
+            .expect("encode png");
+        std::fs::write(path, bytes.into_inner()).expect("write staged png");
+    }
+
+    /// sc-13713 (GitHub #1658): kps sources are staged by the API's
+    /// `create_keypoint_sources` into `<data>/cache/keypoint-uploads`, but the worker
+    /// confined `sourcePath` to the pose-detect lane's `pose-uploads` cache, so every
+    /// Key Point Library capture failed the confinement check. Pin the lane to the
+    /// directory the API actually stages into.
+    #[test]
+    fn kps_source_path_accepts_keypoint_uploads_staging() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut settings = Settings::from_env();
+        settings.data_dir = temp.path().join("data");
+        let uploads = settings.data_dir.join("cache").join("keypoint-uploads");
+        std::fs::create_dir_all(&uploads).expect("uploads dir");
+        let staged = uploads.join("upload-abc123.tmp");
+        write_png(&staged, 3, 2);
+
+        let image = load_source_image(
+            &settings,
+            &kps_job(json!({ "sourcePath": staged.to_str().unwrap() })),
+        )
+        .expect("staged keypoint-uploads source accepted");
+        assert_eq!((image.width, image.height), (3, 2));
+    }
+
+    /// The confinement itself must survive the sc-13713 fix: a readable file outside the
+    /// staging cache is still rejected (the sc-5723-style arbitrary-file-read guard).
+    #[test]
+    fn kps_source_path_rejects_unstaged_file() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut settings = Settings::from_env();
+        settings.data_dir = temp.path().join("data");
+        std::fs::create_dir_all(&settings.data_dir).expect("data dir");
+        let outside = temp.path().join("outside.png");
+        write_png(&outside, 3, 2);
+
+        let error = load_source_image(
+            &settings,
+            &kps_job(json!({ "sourcePath": outside.to_str().unwrap() })),
+        )
+        .expect_err("unstaged source rejected");
+        // Pin the CONFINEMENT rejection specifically (the file is a readable, valid PNG,
+        // so a read/decode error here would mean the guard was bypassed).
+        assert!(
+            matches!(&error, WorkerError::InvalidPayload(message)
+                if message.contains("must be inside an app-managed directory")),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    /// sc-13713's reported shape: a data dir on an external volume reached through a
+    /// symlinked mount point with spaces in the path (`/Volumes/<Drive>/scene folder`).
+    /// The staged source's canonical form diverges from the lexical payload path, and
+    /// the confinement must still accept it (both root forms are admitted).
+    #[cfg(unix)]
+    #[test]
+    fn kps_source_path_accepts_symlinked_spaced_mount_data_dir() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let real_mount = temp.path().join("real mount");
+        std::fs::create_dir_all(&real_mount).expect("real mount");
+        let mount_link = temp.path().join("Volumes SSD");
+        std::os::unix::fs::symlink(&real_mount, &mount_link).expect("mount symlink");
+
+        let mut settings = Settings::from_env();
+        settings.data_dir = mount_link.join("scene folder");
+        let uploads = settings.data_dir.join("cache").join("keypoint-uploads");
+        std::fs::create_dir_all(&uploads).expect("uploads dir");
+        let staged = uploads.join("upload-def456.tmp");
+        write_png(&staged, 2, 2);
+
+        let image = load_source_image(
+            &settings,
+            &kps_job(json!({ "sourcePath": staged.to_str().unwrap() })),
+        )
+        .expect("spaced symlinked-mount source accepted");
+        assert_eq!((image.width, image.height), (2, 2));
+    }
 
     #[test]
     fn normalize_square_image_is_plain_fraction() {

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -46,7 +46,7 @@ use crate::{
     WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
-use sceneworks_core::project_store::ProjectStore;
+use sceneworks_core::project_store::{ProjectStore, POSE_UPLOADS_CACHE_DIR};
 
 // ---------------------------------------------------------------------------
 // detector constants (rtmlib performance preset)
@@ -971,8 +971,12 @@ fn resolve_source(
     if let Some(raw) = raw {
         let abs = Path::new(raw);
         if abs.is_absolute() {
-            let path =
-                normalize_app_managed_cache_path(settings, raw, "pose-uploads", "pose sourcePath")?;
+            let path = normalize_app_managed_cache_path(
+                settings,
+                raw,
+                POSE_UPLOADS_CACHE_DIR,
+                "pose sourcePath",
+            )?;
             if path.exists() {
                 return Ok(PoseSource {
                     asset_id,
@@ -1346,7 +1350,7 @@ async fn cleanup_temp_uploads(settings: &Settings, temp_paths: &[PathBuf]) {
     if temp_paths.is_empty() {
         return;
     }
-    let uploads_root = settings.data_dir.join("cache").join("pose-uploads");
+    let uploads_root = settings.data_dir.join("cache").join(POSE_UPLOADS_CACHE_DIR);
     let Ok(uploads_root) = uploads_root.canonicalize() else {
         return;
     };


### PR DESCRIPTION
## Summary

Fixes [sc-13713](https://app.shortcut.com/trefry/story/13713) / closes #1658 (the keypoint-extraction half; the z-image half was sc-13571).

Key Point Library capture (`kps_extract`) failed the worker's confinement check on **every install** since 2e5b5562 (2026-06-15): the API's `create_keypoint_sources` stages capture sources into `<data>/cache/keypoint-uploads`, but the worker confined `kps sourcePath` to the pose_detect lane's `pose-uploads` cache — a wrong constant. The reporting user's external volume (`/Volumes/SSD_Intenso_2_Tera/scene folder`) was incidental; the story's canonicalization-asymmetry hypothesis is disproven (`normalize_app_managed_cache_path` already canonicalizes the source and admits both lexical + canonical root forms — now pinned by a regression test with a symlinked, space-bearing mount-style data dir).

## Changes

- `kps_jobs.rs`: confine `sourcePath` to `keypoint-uploads`; add three regression tests:
  - accept a staged `keypoint-uploads` source — **red before the fix**, reproducing the user's exact error text;
  - reject an unstaged file with the confinement message (pins the sc-5723-style arbitrary-file-read guard);
  - accept a data dir behind a symlinked, spaced external-style mount (the story's reported shape).
- Hoist the staging-dir names into shared `sceneworks-core` constants (`KEYPOINT_UPLOADS_CACHE_DIR` / `POSE_UPLOADS_CACHE_DIR`) used by the API staging routes + startup sweeps, the save-preset guard, and both worker confinement lanes, so the duplicated names can't drift again (that drift *was* this bug). Tests deliberately keep the string literals so a constant mutation still turns them red.

## Validation

- `npm run rust:check` (fmt + clippy + test + build) green, re-run on the `origin/main` merge commit.
- Adversarial review (independent agent): APPROVE; mutation-verified — flipping the constant back to `pose-uploads` turns 2 of the 3 new tests red.
- Sibling audit: `pose_jobs.rs` correctly confines to `pose-uploads` (matches its `create_pose_sources` staging); `create_keypoint_asset`'s `sourceUploadPath` guard already used `keypoint-uploads`; `normalize_app_managed_path` / `normalize_app_managed_lora_path` are symmetric — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)