### PR TITLE
chore(manifest): pin download revision to 40-hex SHA + require it on co-requisites (F-029, sc-13659)

### DIFF
--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -375,6 +375,171 @@ mod tests {
         }
     }
 
+    /// A full 40-char lowercase-hex commit SHA — the only revision shape the F-029 pin
+    /// authority accepts (`^[0-9a-f]{40}$`, mirrored from model-manifest.schema.json).
+    fn is_full_sha_revision(revision: &str) -> bool {
+        revision.len() == 40
+            && revision
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    }
+
+    /// `(model_id, repo)` co-requisite download pairs whose F-029 pin migration is
+    /// still IN FLIGHT under sc-13591. Each is a KNOWN, tracked gap: the immutable
+    /// commit SHA lives in the sc-13591 inventory but is applied by a later
+    /// per-family story, not sc-13659 (which is schema + plumbing + enforcement only
+    /// and must not add real pins). A brand-new co-requisite may NOT join this list —
+    /// pin its `revision` instead. Kept in lockstep with the identical Python audit
+    /// allowlist in tests/test_builtin_manifest_audit.py.
+    const COREQUISITE_REVISION_MIGRATION_PENDING: &[(&str, &str)] = &[
+        (
+            "qwen_image",
+            "SceneWorks/qwen-image-2512-fun-controlnet-union",
+        ),
+        ("ltx_2_3", "SceneWorks/ltx-2.3-mlx"),
+        (
+            "ltx_2_3_eros",
+            "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",
+        ),
+        ("wan_2_2_t2v_14b", "lightx2v/Wan2.2-Lightning"),
+        ("wan_2_2_i2v_14b", "lightx2v/Wan2.2-Lightning"),
+        ("pid_qwenimage", "SceneWorks/gemma-2-2b-it"),
+        ("pid_flux", "SceneWorks/gemma-2-2b-it"),
+        ("pid_flux2", "SceneWorks/gemma-2-2b-it"),
+        ("pid_sdxl", "SceneWorks/gemma-2-2b-it"),
+    ];
+
+    /// Every `(model_id, repo)` co-requisite pair in the live manifest that is NOT
+    /// pinned to a full 40-hex commit SHA. Shared by the enforcement test and its
+    /// self-cleaning allowlist audit so both read the same signal.
+    fn corequisite_revision_gaps(models: &[serde_json::Value]) -> Vec<(String, String)> {
+        let mut gaps = Vec::new();
+        for model in models {
+            let id = model["id"].as_str().unwrap_or_default();
+            let Some(downloads) = model["downloads"].as_array() else {
+                continue;
+            };
+            for download in downloads {
+                if download["coRequisite"].as_bool() != Some(true) {
+                    continue;
+                }
+                let pinned = download["revision"]
+                    .as_str()
+                    .is_some_and(is_full_sha_revision);
+                if !pinned {
+                    let repo = download["repo"].as_str().unwrap_or_default();
+                    gaps.push((id.to_owned(), repo.to_owned()));
+                }
+            }
+        }
+        gaps
+    }
+
+    #[test]
+    fn corequisite_downloads_pin_a_full_sha_revision() {
+        // F-029 (sc-13659): a coRequisite: true download is a FETCH-ALL companion the runtime
+        // resolves offline via a pinned-SHA `hf_get_pinned` reading `snapshots/<sha>/`. Leaving it
+        // on `main` lands the wrong snapshot and hard-fails offline, so every co-requisite MUST pin a
+        // full 40-hex commit — the Rust-side backstop to the identical Python manifest audit. The
+        // only tolerated gaps are the sc-13591 pins still being migrated by later stories.
+        let stripped = crate::jsonc::strip_jsonc_comments(embedded("builtin.models.jsonc"));
+        let manifest: serde_json::Value =
+            serde_json::from_str(&stripped).expect("builtin.models.jsonc parses as JSON");
+        let models = manifest["models"]
+            .as_array()
+            .expect("builtin.models.jsonc has a models array");
+
+        let allowlist: std::collections::HashSet<(&str, &str)> =
+            COREQUISITE_REVISION_MIGRATION_PENDING
+                .iter()
+                .copied()
+                .collect();
+        let unexpected: Vec<(String, String)> = corequisite_revision_gaps(models)
+            .into_iter()
+            .filter(|(id, repo)| !allowlist.contains(&(id.as_str(), repo.as_str())))
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "co-requisite downloads must pin a 40-hex commit SHA (F-029, sc-13659); \
+             these are unpinned and NOT tracked for the sc-13591 migration: {unexpected:?}"
+        );
+    }
+
+    #[test]
+    fn corequisite_revision_migration_allowlist_has_no_stale_entries() {
+        // Self-cleaning guard: the moment a later sc-13591 story pins one of these companions (or
+        // removes the entry), its allowlist row stops matching an actual gap and MUST be deleted —
+        // otherwise the allowlist would silently keep excusing a co-requisite that is already
+        // compliant, masking a future regression. This asserts every allowlisted pair still names a
+        // live, unpinned co-requisite. (This is why a test asserting a default value is a false green:
+        // the allowlist must be forced to shrink, not linger.)
+        let stripped = crate::jsonc::strip_jsonc_comments(embedded("builtin.models.jsonc"));
+        let manifest: serde_json::Value =
+            serde_json::from_str(&stripped).expect("builtin.models.jsonc parses as JSON");
+        let models = manifest["models"]
+            .as_array()
+            .expect("builtin.models.jsonc has a models array");
+
+        let gaps: std::collections::HashSet<(String, String)> =
+            corequisite_revision_gaps(models).into_iter().collect();
+        let stale: Vec<&(&str, &str)> = COREQUISITE_REVISION_MIGRATION_PENDING
+            .iter()
+            .filter(|(id, repo)| !gaps.contains(&((*id).to_owned(), (*repo).to_owned())))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "stale F-029 migration allowlist entries (now pinned or removed) must be deleted from \
+             COREQUISITE_REVISION_MIGRATION_PENDING: {stale:?}"
+        );
+    }
+
+    #[test]
+    fn model_download_revision_is_a_typed_round_tripping_field() {
+        use crate::contracts::ModelDownload;
+
+        // sc-13659: `revision` is a first-class typed field on ModelDownload, not an `extra` bag key,
+        // so the F-029 pin round-trips through the contract type. A pinned entry deserializes into the
+        // typed field (leaving `extra` free of it) and re-serializes the same key; an entry with no
+        // revision keeps it `None` and serializes no `revision` key (main-branch default preserved).
+        let sha = "80b60f9caead09b8d3b512bda0b24038f28c08ec";
+        let pinned: ModelDownload = serde_json::from_value(serde_json::json!({
+            "provider": "huggingface",
+            "repo": "SceneWorks/perth-implicit",
+            "files": ["perth_implicit.safetensors"],
+            "revision": sha,
+            "coRequisite": true,
+        }))
+        .expect("pinned co-requisite deserializes");
+        assert_eq!(pinned.revision.as_deref(), Some(sha));
+        assert!(
+            !pinned.extra.contains_key("revision"),
+            "revision must land in the typed field, not the extra bag"
+        );
+        assert_eq!(
+            pinned.extra.get("coRequisite"),
+            Some(&serde_json::json!(true))
+        );
+        assert_eq!(
+            serde_json::to_value(&pinned).expect("re-serialize")["revision"],
+            serde_json::json!(sha)
+        );
+
+        let unpinned: ModelDownload = serde_json::from_value(serde_json::json!({
+            "provider": "huggingface",
+            "repo": "black-forest-labs/FLUX.1-dev",
+            "files": [],
+        }))
+        .expect("unpinned entry deserializes");
+        assert_eq!(unpinned.revision, None);
+        assert!(
+            serde_json::to_value(&unpinned)
+                .expect("re-serialize")
+                .get("revision")
+                .is_none(),
+            "an unpinned download must not serialize a revision key (main-branch default)"
+        );
+    }
+
     #[test]
     fn seeds_every_manifest_into_a_fresh_dir() {
         let temp = tempfile::tempdir().expect("temp dir");

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -1613,6 +1613,15 @@ pub struct ModelDownload {
     pub provider: String,
     pub repo: String,
     pub files: Vec<String>,
+    /// Optional pinned 40-hex git commit SHA — the F-029 pin authority for this
+    /// download (sc-13659). When present the API forwards it into the worker's
+    /// `ModelDownload` job so the fetch lands in `snapshots/<sha>/`; absent means
+    /// the worker resolves `main` at install time. A first-class typed field (not
+    /// an `extra` bag key) so the pin round-trips through the contract type; the
+    /// authoring-time 40-hex format and the coRequisite-requires-revision rule are
+    /// enforced by the manifest audits, not by deserialization.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -574,7 +574,8 @@
                 },
                 "revision": {
                   "type": "string",
-                  "description": "Optional pinned git revision for this entry: the download job forwards it so the worker fetches that exact commit into snapshots/<sha>/; the worker defaults to `main` when omitted. For a companion co-requisite whose weight the runtime resolves via a pinned-SHA hf_get_pinned (e.g. chatterbox_tts's ve/perth), this MUST be the full 40-hex commit SHA the resolver reads — a branch/tag/short SHA resolves online but hard-fails offline. See sc-13541."
+                  "pattern": "^[0-9a-f]{40}$",
+                  "description": "Optional pinned 40-hex git commit SHA — the F-029 pin authority for this download (sc-13659). When present the download job forwards it so the worker fetches that exact IMMUTABLE commit into snapshots/<sha>/; absent means the worker resolves `main` at install time, so the ~200 existing non-pinned models need no migration. MUST be a full 40-char lowercase-hex commit: a branch/tag/short SHA is rejected by the pattern above because it resolves online but hard-fails the offline pinned-SHA resolver (hf_get_pinned reads snapshots/<sha>/). REQUIRED on coRequisite: true entries — the F-029 guarantee that a companion weight (e.g. chatterbox_tts's ve/perth) installs to a deterministic, offline-resolvable snapshot; that conditional is enforced by tests/test_builtin_manifest_audit.py and crates/sceneworks-core/src/builtin_manifests.rs rather than JSON Schema, which cannot grandfather the sc-13591 pin migration still in flight. See sc-13541, sc-13591."
                 },
                 "default": {
                   "type": "boolean",

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -304,6 +304,146 @@ def test_download_default_guard_rejects_an_ambiguous_platform_mutation():
     assert _duplicate_default_downloads(manifest) == ["wan_2_2:windows", "wan_2_2:linux"]
 
 
+# ---------------------------------------------------------------------------
+# F-029 download-revision pin authority (sc-13659).
+#
+# A download entry's optional `revision` is the immutable-commit pin the worker
+# fetches into `snapshots/<sha>/`; absent means the worker resolves `main`. The
+# JSON Schema constrains its FORMAT (`^[0-9a-f]{40}$`), but the
+# "coRequisite: true REQUIRES a revision" invariant lives here (and in the Rust
+# builtin_manifests.rs backstop) because JSON Schema cannot grandfather the
+# sc-13591 pin migration still in flight.
+# ---------------------------------------------------------------------------
+
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# `(model_id, repo)` co-requisite download pairs whose F-029 pin migration is
+# still IN FLIGHT under sc-13591. Each is a KNOWN, tracked gap: the immutable
+# commit SHA lives in the sc-13591 inventory but is applied by a later per-family
+# story, not sc-13659 (schema + plumbing + enforcement only — it must not add
+# real pins). A brand-new co-requisite may NOT join this list; pin its `revision`
+# instead. Kept in lockstep with the identical Rust allowlist in
+# crates/sceneworks-core/src/builtin_manifests.rs.
+_COREQUISITE_REVISION_MIGRATION_PENDING: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("qwen_image", "SceneWorks/qwen-image-2512-fun-controlnet-union"),
+        ("ltx_2_3", "SceneWorks/ltx-2.3-mlx"),
+        ("ltx_2_3_eros", "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments"),
+        ("wan_2_2_t2v_14b", "lightx2v/Wan2.2-Lightning"),
+        ("wan_2_2_i2v_14b", "lightx2v/Wan2.2-Lightning"),
+        ("pid_qwenimage", "SceneWorks/gemma-2-2b-it"),
+        ("pid_flux", "SceneWorks/gemma-2-2b-it"),
+        ("pid_flux2", "SceneWorks/gemma-2-2b-it"),
+        ("pid_sdxl", "SceneWorks/gemma-2-2b-it"),
+    }
+)
+
+
+def _corequisite_revision_gaps(manifest: dict) -> set[tuple[str, str]]:
+    """`(model_id, repo)` co-requisite pairs NOT pinned to a full 40-hex SHA."""
+    gaps: set[tuple[str, str]] = set()
+    for model in manifest["models"]:
+        for download in model.get("downloads", []):
+            if download.get("coRequisite") is not True:
+                continue
+            revision = download.get("revision")
+            if not (isinstance(revision, str) and _FULL_SHA_RE.match(revision)):
+                gaps.add((model["id"], download.get("repo", "")))
+    return gaps
+
+
+def test_corequisite_downloads_pin_a_full_sha_revision():
+    """F-029 (sc-13659): every coRequisite download pins an immutable 40-hex commit.
+
+    A co-requisite is a FETCH-ALL companion the runtime resolves offline via a
+    pinned-SHA `hf_get_pinned` reading `snapshots/<sha>/`; leaving it on `main`
+    lands the wrong snapshot and hard-fails offline. The only tolerated gaps are
+    the sc-13591 pins still being migrated by later stories.
+    """
+    manifest = _load_builtin_models_manifest()
+    unexpected = _corequisite_revision_gaps(manifest) - _COREQUISITE_REVISION_MIGRATION_PENDING
+    assert not unexpected, (
+        "co-requisite downloads must pin a 40-hex commit SHA (F-029, sc-13659); these are "
+        f"unpinned and NOT tracked for the sc-13591 migration: {sorted(unexpected)}"
+    )
+
+
+def test_corequisite_revision_migration_allowlist_has_no_stale_entries():
+    """Self-cleaning guard: an allowlist row that no longer names an unpinned
+    co-requisite must be deleted, so pinning one in a later sc-13591 story forces
+    its removal instead of the allowlist silently excusing an already-compliant
+    entry (a test asserting a default is a false green — the allowlist must shrink).
+    """
+    manifest = _load_builtin_models_manifest()
+    stale = _COREQUISITE_REVISION_MIGRATION_PENDING - _corequisite_revision_gaps(manifest)
+    assert not stale, (
+        "stale F-029 migration allowlist entries (now pinned or removed) must be deleted from "
+        f"_COREQUISITE_REVISION_MIGRATION_PENDING: {sorted(stale)}"
+    )
+
+
+def test_corequisite_revision_guard_flags_a_new_unpinned_corequisite():
+    """Mutation guard: the rule is LIVE for new entries, not decoration. A brand-new
+    co-requisite with no revision (and not on the migration allowlist) is caught.
+    """
+    manifest = _load_builtin_models_manifest()
+    kokoro = next(model for model in manifest["models"] if model["id"] == "kokoro_82m")
+    kokoro.setdefault("downloads", []).append(
+        {"provider": "huggingface", "repo": "example/new-corequisite", "coRequisite": True}
+    )
+    new_pair = ("kokoro_82m", "example/new-corequisite")
+    assert new_pair in _corequisite_revision_gaps(manifest)
+    assert new_pair not in _COREQUISITE_REVISION_MIGRATION_PENDING
+    unexpected = _corequisite_revision_gaps(manifest) - _COREQUISITE_REVISION_MIGRATION_PENDING
+    assert new_pair in unexpected
+
+
+def _model_entry_with_download(download: dict) -> dict:
+    """A minimal schema-valid model entry carrying a single `downloads` entry, for
+    exercising the download-item schema in isolation."""
+    return {
+        "id": "sample_pinned_model",
+        "name": "Sample Pinned Model",
+        "type": "image",
+        "downloads": [download],
+    }
+
+
+def test_schema_pins_download_revision_to_a_40hex_sha():
+    """sc-13659: the authoring schema constrains `revision` to a full 40-hex commit
+    (the F-029 pin authority), accepting a valid SHA and rejecting a branch/tag/
+    short/uppercase/wrong-length value via the `pattern` keyword.
+    """
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    validator = jsonschema.Draft202012Validator(schema)
+
+    def revision_errors(revision: str) -> list:
+        manifest = {
+            "schemaVersion": 1,
+            "models": [
+                _model_entry_with_download(
+                    {
+                        "provider": "huggingface",
+                        "repo": "namespace/model",
+                        "files": [],
+                        "revision": revision,
+                    }
+                )
+            ],
+        }
+        return list(validator.iter_errors(manifest))
+
+    assert not revision_errors("a" * 40), "a full 40-hex SHA must satisfy the schema"
+    for bad in ("main", "v1.0", "abc123", "A" * 40, "g" * 40, "a" * 39, "a" * 41):
+        errors = revision_errors(bad)
+        # Discriminate on the failing keyword so a full schema revert (dropping the
+        # pattern) turns this red rather than passing on some unrelated error.
+        assert any(error.validator == "pattern" for error in errors), (
+            f"revision {bad!r} must be rejected by the 40-hex pattern"
+        )
+
+
 def test_manifest_constraint_contract_registry_is_complete_and_live():
     """sc-12304: constraint declarations may not silently become decoration.
 


### PR DESCRIPTION
## What does this PR do?

Makes the download-entry `revision` field the **F-029 pin authority** for SceneWorks manifests: a full, immutable 40-hex commit the worker fetches into `snapshots/<sha>/`, so the pins moved out of the inference workspace survive the move into the manifests.

**Verify-first finding:** most of this was already in place from sc-13541 / sc-13675 / sc-13676:
- The schema already *declared* `revision` (but as an unconstrained string).
- `apps/rust-api/src/models.rs::build_model_download_job_payload` already forwards the manifest `revision` into the `ModelDownload` job payload (primary + every co-requisite).
- The worker already threads it end-to-end: `run_model_download_job` reads `revision` from the payload -> `HuggingFaceSnapshot::resolve(..., revision, ...)` -> `download_snapshot_into_cache` writes `refs/<rev>` + `snapshots/<commit>`; the cache-only `model_jobs::huggingface_snapshot_dir` resolves pinned `snapshots/<commit>` dirs for install-state.
- 4 co-requisites already carry 40-hex pins (MOSS-Audio-Tokenizer, XY_Tokenizer, chatterbox, perth).

This PR closes the remaining **gaps**:
- **Schema** (`packages/schemas/model-manifest.schema.json`): tighten `revision` from an unconstrained string to `pattern: ^[0-9a-f]{40}$` (branch/tag/short/uppercase SHAs now rejected) and document the pin authority. Absent still means `main`, so the ~200 existing non-pinned models need no migration; all 6 current pins are already 40-hex so the live manifest still validates.
- **Rust typed struct** (`crates/sceneworks-core/src/contracts.rs`): add a first-class typed `revision: Option<String>` to `ModelDownload` so the pin round-trips through the contract type rather than landing in the `extra` bag.
- **Enforcement — `revision` REQUIRED on `coRequisite: true`** (the F-029 offline guarantee). Enforced where manifest invariants live — the Python audit **and** a Rust `builtin_manifests` backstop — **not** JSON Schema, which cannot grandfather the sc-13591 pin migration still in flight. A documented, **self-cleaning** allowlist tracks the 11 co-requisites (qwen ControlNet / ltx / wan Lightning / pid-gemma) whose pins land in later sc-13591 stories; a new co-requisite may not join it.

Scope vs acceptance criteria: schema + typed field + enforcement + evidence only. **No real pin values added and the inference pin is not bumped** — that is the later sc-13591 migration.

## Related issue

Refs sc-13659 (also sc-13541, sc-13591). Closes #

## Type of change

- [x] Refactor / chore (no user-facing behavior change)

## How was this tested?

- `npm run rust:check` — **green** (fmt `--all --check`, clippy `-D warnings`, test, build). All Rust suites pass, including the new `sceneworks-core` tests.
- Python manifest audit (`tests/test_builtin_manifest_audit.py`, `pytest==9.0.2 jsonschema==4.25.1`) — **25 passed**, including the 4 new tests.
- `npm run check` (scaffold) — **passed**.
- Mutation-checked the guards: removing the schema `pattern` makes the accept/reject test go red; the co-requisite allowlist exactly equals the live unpinned set (9 pairs), so pinning one in a later story forces its allowlist row to be deleted.

New/updated tests:
- Python: `test_corequisite_downloads_pin_a_full_sha_revision`, `test_corequisite_revision_migration_allowlist_has_no_stale_entries` (self-cleaning), `test_corequisite_revision_guard_flags_a_new_unpinned_corequisite` (mutation guard), `test_schema_pins_download_revision_to_a_40hex_sha`.
- Rust (`builtin_manifests.rs`): `corequisite_downloads_pin_a_full_sha_revision`, `corequisite_revision_migration_allowlist_has_no_stale_entries`, `model_download_revision_is_a_typed_round_tripping_field`.

- [x] macOS (Apple Silicon / MLX)
- [x] Not platform-specific (shared crate / schema / manifest audit)

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed
- [ ] I ran the web app lint/test/build (no web changes)
- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant (schema description + doc comments record the F-029 pin authority)
- [x] All my commits are signed off (`git commit -s`)
- [x] My PR is focused on a single logical change

## Follow-ups

- sc-13591: migrate the remaining co-requisite pins (qwen ControlNet, ltx / ltx-eros, wan Lightning x2, pid-gemma x4 — the 9 allowlisted pairs) and remove each from the self-cleaning allowlist as its pin lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)