### PR TITLE
chore(worker): co-requisite provisioning seam + rehome chatterbox perth+VE [sc-13679, sc-13680]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "image",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1027,7 +1027,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "cudaforge",
 ]
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3917,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3930,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3995,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4005,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4023,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4072,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4081,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4203,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4272,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "core-llm",
  "half",
@@ -4621,7 +4621,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5857,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5867,7 +5867,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6157,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9321dece9c87bff65ce2da27b5793c55c9e7c235#9321dece9c87bff65ce2da27b5793c55c9e7c235"
+source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8575,7 +8575,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "9321dece9c87bff65ce2da27b5793c55c9e7c235" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6" }

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1648,6 +1648,91 @@ mod download_receipt_tests {
             }
         }
     }
+
+    /// sc-13680: the AUDIO lane's install-state now accounts for chatterbox_tts's two HARD
+    /// co-requisites (the `perth` + `voice_embedding` companion weights). Previously no audio model
+    /// used a co-requisite, so this generic gate (shared with PiD-gemma / Wan-Lightning) was untested
+    /// on the audio lane. A present primary snapshot with the perth/ve co-requisites ABSENT must NOT
+    /// report installed (it must surface as a repairable partial), and staging both must flip it to
+    /// installed — proving the perth+VE rehoming is enforced end to end.
+    #[test]
+    fn chatterbox_tts_install_state_gates_on_the_perth_and_ve_co_requisites() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path();
+        // The primary chatterbox snapshot (T3 + S3Gen + tokenizer) is present…
+        let primary_repo = "ResembleAI/chatterbox";
+        let primary_snapshot = huggingface_repo_cache_path(data_dir, primary_repo)
+            .unwrap()
+            .join("snapshots/main");
+        std::fs::create_dir_all(&primary_snapshot).unwrap();
+        for file in ["t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json"] {
+            std::fs::write(primary_snapshot.join(file), b"weights").unwrap();
+        }
+
+        // …the chatterbox_tts catalog shape: primary + the two hard co-requisites (ve + perth),
+        // mirroring builtin.models.jsonc (componentId is inert to install-state, which gates on
+        // repo/files presence).
+        let model = json!({
+            "id": "chatterbox_tts",
+            "downloads": [
+                { "provider": "huggingface", "repo": primary_repo,
+                  "files": ["t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json"] },
+                { "provider": "huggingface", "repo": "ResembleAI/chatterbox",
+                  "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18", "coRequisite": true,
+                  "componentId": "voice_embedding", "files": ["ve.safetensors"] },
+                { "provider": "huggingface", "repo": "SceneWorks/perth-implicit",
+                  "revision": "80b60f9caead09b8d3b512bda0b24038f28c08ec", "coRequisite": true,
+                  "componentId": "perth", "files": ["perth_implicit.safetensors"] }
+            ]
+        });
+
+        // Co-requisites absent → NOT installed; both missing repos surface for repair.
+        let missing = install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+        assert!(
+            !missing.installed,
+            "a present primary with the perth+ve co-requisites absent must not report installed"
+        );
+        assert!(
+            missing.cache_incomplete,
+            "the missing hard co-requisites make this a repairable partial install"
+        );
+        assert!(
+            missing
+                .missing_required_files
+                .iter()
+                .any(|entry| entry.contains("SceneWorks/perth-implicit"))
+                && missing
+                    .missing_required_files
+                    .iter()
+                    .any(|entry| entry.contains("ResembleAI/chatterbox")),
+            "both missing co-requisite repos must be reported, got {:?}",
+            missing.missing_required_files
+        );
+
+        // Stage BOTH co-requisites at their pinned snapshots → install-state flips to installed.
+        let ve = huggingface_repo_cache_path(data_dir, "ResembleAI/chatterbox")
+            .unwrap()
+            .join("snapshots/5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18");
+        std::fs::create_dir_all(&ve).unwrap();
+        std::fs::write(ve.join("ve.safetensors"), b"weights").unwrap();
+        let perth = huggingface_repo_cache_path(data_dir, "SceneWorks/perth-implicit")
+            .unwrap()
+            .join("snapshots/80b60f9caead09b8d3b512bda0b24038f28c08ec");
+        std::fs::create_dir_all(&perth).unwrap();
+        std::fs::write(perth.join("perth_implicit.safetensors"), b"weights").unwrap();
+
+        let installed =
+            install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+        assert!(
+            installed.installed,
+            "primary + both hard co-requisites present must report installed"
+        );
+        assert!(
+            installed.missing_required_files.is_empty(),
+            "nothing is missing once the perth+ve co-requisites are staged, got {:?}",
+            installed.missing_required_files
+        );
+    }
 }
 
 // Resolve a model's install/cache state from its (optional) download source. A

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -8996,17 +8996,21 @@
       // gated purely on the audio catalog's registration + Capabilities, not a hardcoded id).
       //
       // `downloads` pins the three files the generator loads from its snapshot dir, PLUS the two
-      // companion weights the provider resolves at generate time via pinned-SHA hub fetches (NOT from
-      // the snapshot dir): the 256-d speaker embedder `ve.safetensors` (candle_audio_chatterbox_ve
-      // `hf_get_pinned(ResembleAI/chatterbox @ 5bb1f6ee…, ve.safetensors)`) and the PerTh provenance
-      // watermarker `perth_implicit.safetensors` (`hf_get_pinned(SceneWorks/perth-implicit @ 80b60f9c…)`;
-      // generate() ALWAYS watermarks, so a missing PerTh weight is a hard error). Both are declared as
-      // `coRequisite` downloads (sc-9696) with an explicit pinned `revision`: the runtime's `hf_get_pinned`
-      // rejects anything but a full 40-hex commit SHA and reads `models--<org>--<name>/snapshots/<sha>/`,
-      // so a plain main-branch predownload would land in the WRONG snapshot and offline generation would
-      // fail (sc-13541). Pinning `revision` to the exact SHA the resolver uses materializes each file in
-      // the same pinned-SHA snapshot the runtime resolves — so a fresh install is fully self-contained
-      // offline, matching every other seeded audio model.
+      // companion weights the generator requires as NAMED COMPONENTS at load (epic 13657 / sc-13680):
+      // the 256-d speaker embedder `ve.safetensors` (component id `voice_embedding`) and the PerTh
+      // provenance watermarker `perth_implicit.safetensors` (component id `perth`; generate() ALWAYS
+      // watermarks, so a missing PerTh weight is a hard error). At the inference pin the provider NO
+      // LONGER self-fetches these mid-render — it declares them in `ModelDescriptor::required_components`
+      // and the worker's generic `resolve_co_requisites` seam resolves each from its cached pinned-SHA
+      // snapshot and stages it in `LoadSpec::components` (`with_component("voice_embedding"/"perth", …)`),
+      // so an unprovisioned component fails fast at load with an actionable error, never a hub fetch.
+      // Both are declared as `coRequisite` downloads (sc-9696) carrying (a) an explicit pinned `revision`
+      // — the runtime reads `models--<org>--<name>/snapshots/<sha>/`, so a plain main-branch predownload
+      // would land in the WRONG snapshot and offline generation would fail (sc-13541) — and (b) an
+      // explicit `componentId` mapping the repo to the component id the seam stages (never inferred from
+      // the repo name, sc-13679). Pinning `revision` to the exact SHA materializes each file in the
+      // snapshot the resolver reads, so a fresh install is fully self-contained offline, matching every
+      // other seeded audio model.
       "id": "chatterbox_tts",
       "name": "Chatterbox (Cloned-Voice TTS)",
       "family": "chatterbox",
@@ -9047,17 +9051,19 @@
           }
         },
         {
-          // Co-requisite (sc-13541): the 256-d speaker embedder the provider resolves at generate time
-          // via candle_audio_chatterbox_ve::resolve_pinned_file() ->
-          // hf_get_pinned(ResembleAI/chatterbox @ 5bb1f6ee…, ve.safetensors). `revision` MUST be the full
-          // 40-hex SHA the resolver pins — hf_get_pinned refuses a branch/tag and reads
-          // snapshots/<sha>/, so a main-branch fetch would populate the wrong snapshot and offline
-          // generation would fail. Shares the ResembleAI/chatterbox repo cache with the primary download
-          // above but lands in its own pinned-SHA snapshot.
+          // Co-requisite (sc-13541 / sc-13680): the 256-d speaker embedder the worker stages as the
+          // `voice_embedding` component (`componentId` below) — resolve_co_requisites resolves it from
+          // this pinned-SHA snapshot and hands it to the generator via with_component. `revision` MUST be
+          // the full 40-hex SHA the resolver reads (snapshots/<sha>/), so a main-branch fetch would
+          // populate the wrong snapshot and offline generation would fail. Shares the ResembleAI/chatterbox
+          // repo cache with the primary download above but lands in its own pinned-SHA snapshot. The
+          // standalone `chatterbox_ve` model (voice-registration embedder) pins the SAME revision so the
+          // two declarations of ve.safetensors never diverge.
           "provider": "huggingface",
           "repo": "ResembleAI/chatterbox",
           "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
           "coRequisite": true,
+          "componentId": "voice_embedding",
           "files": [
             "ve.safetensors"
           ],
@@ -9072,16 +9078,17 @@
           }
         },
         {
-          // Co-requisite (sc-13541): the PerTh provenance watermarker the provider resolves at generate
-          // time via resolve_perth_weights() -> hf_get_pinned(SceneWorks/perth-implicit @ 80b60f9c…,
-          // perth_implicit.safetensors). generate() ALWAYS watermarks (no disable flag), so a missing
-          // PerTh weight is a hard error; predownloading it at the pinned rev makes offline generation
-          // self-contained. `PERTH_SNAPSHOT` is the runtime's offline-override escape hatch, but the
-          // pinned-SHA snapshot this materializes is resolved with no override needed. MIT-licensed.
+          // Co-requisite (sc-13541 / sc-13680): the PerTh provenance watermarker the worker stages as
+          // the `perth` component (`componentId` below) — resolve_co_requisites resolves it from this
+          // pinned-SHA snapshot and hands it to the generator via with_component. generate() ALWAYS
+          // watermarks (no disable flag), so a missing PerTh weight is a hard error; predownloading it at
+          // the pinned rev makes offline generation self-contained. `revision` MUST be the full 40-hex SHA
+          // the resolver reads (snapshots/<sha>/). MIT-licensed.
           "provider": "huggingface",
           "repo": "SceneWorks/perth-implicit",
           "revision": "80b60f9caead09b8d3b512bda0b24038f28c08ec",
           "coRequisite": true,
+          "componentId": "perth",
           "files": [
             "perth_implicit.safetensors"
           ],
@@ -9123,6 +9130,16 @@
       }
     },
     {
+      // Standalone Chatterbox voice ENCODER (sc-13680 reconciliation): kept as its own catalog entry
+      // rather than retired into chatterbox_tts's coRequisite, because it is a DISTINCT registered
+      // `VoiceEmbedder` used by a different flow — the Voice Clone "register a voice" path
+      // (voice_register::embed_reference_clip → load_voice_embedder("chatterbox_ve")) maps a reference
+      // clip to a 256-d speaker vector for near-duplicate detection, NOT clone synthesis. Retiring it
+      // would break voice registration, the voiceclone_smoke harness, and the Model Manager entry. It
+      // shares the ResembleAI/chatterbox repo + `ve.safetensors` with chatterbox_tts's `voice_embedding`
+      // coRequisite, so it pins the SAME `revision` (5bb1f6ee…, the encoder crate's HUB_REVISION) — the
+      // two declarations of ve.safetensors resolve the same immutable snapshot instead of diverging
+      // (unpinned here would install into a main-branch snapshot, an offline-resolution mismatch).
       "id": "chatterbox_ve",
       "name": "Chatterbox Voice Encoder (Voice Clone)",
       "family": "voice",
@@ -9138,6 +9155,7 @@
         {
           "provider": "huggingface",
           "repo": "ResembleAI/chatterbox",
+          "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
           "files": [
             "ve.safetensors"
           ],

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -508,6 +508,7 @@ mod tests {
             "files": ["perth_implicit.safetensors"],
             "revision": sha,
             "coRequisite": true,
+            "componentId": "perth",
         }))
         .expect("pinned co-requisite deserializes");
         assert_eq!(pinned.revision.as_deref(), Some(sha));
@@ -523,6 +524,17 @@ mod tests {
             serde_json::to_value(&pinned).expect("re-serialize")["revision"],
             serde_json::json!(sha)
         );
+        // sc-13679: `componentId` is likewise a first-class typed field (the repo→component mapping the
+        // co-requisite provisioning seam reads), so it round-trips through the typed slot, not `extra`.
+        assert_eq!(pinned.component_id.as_deref(), Some("perth"));
+        assert!(
+            !pinned.extra.contains_key("componentId"),
+            "componentId must land in the typed field, not the extra bag"
+        );
+        assert_eq!(
+            serde_json::to_value(&pinned).expect("re-serialize")["componentId"],
+            serde_json::json!("perth")
+        );
 
         let unpinned: ModelDownload = serde_json::from_value(serde_json::json!({
             "provider": "huggingface",
@@ -531,12 +543,20 @@ mod tests {
         }))
         .expect("unpinned entry deserializes");
         assert_eq!(unpinned.revision, None);
+        assert_eq!(unpinned.component_id, None);
         assert!(
             serde_json::to_value(&unpinned)
                 .expect("re-serialize")
                 .get("revision")
                 .is_none(),
             "an unpinned download must not serialize a revision key (main-branch default)"
+        );
+        assert!(
+            serde_json::to_value(&unpinned)
+                .expect("re-serialize")
+                .get("componentId")
+                .is_none(),
+            "a non-component download must not serialize a componentId key"
         );
     }
 

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -1622,6 +1622,17 @@ pub struct ModelDownload {
     /// enforced by the manifest audits, not by deserialization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
+    /// Optional stable component id this `coRequisite` download PROVISIONS for the
+    /// model's engine (epic 13657, sc-13679). When set, the worker stages the
+    /// resolved local path under this id in the engine's `LoadSpec::components`,
+    /// matched against the provider's `ModelDescriptor::required_components` — the
+    /// explicit repo→component mapping (never inferred from repo names) the generic
+    /// `resolve_co_requisites` seam reads. Lowercase snake_case; only meaningful on
+    /// `coRequisite: true` entries (e.g. chatterbox_tts's ve/perth →
+    /// `voice_embedding`/`perth`). A first-class typed field so it round-trips
+    /// through the contract type rather than the `extra` bag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component_id: Option<String>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "9321dece9c87bff65ce2da27b5793c55c9e7c235" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "9321dece9c87bff65ce2da27b5793c55c9e7c235" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "9321dece9c87bff65ce2da27b5793c55c9e7c235", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -665,11 +665,26 @@ async fn run_audio_synthesis_using(
     // unperturbed. The reassembled chunks equal the returned one-shot track (the gen-core reassembly
     // law), so the library asset is still the full `AudioTrack` the caller writes.
     let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel::<usize>();
+    // Named model components (epic 13657, sc-13679): resolve every coRequisite-provisioned component
+    // this model's descriptor advertises (`chatterbox_tts` → `perth` + `voice_embedding`; every other
+    // audio model advertises none → an empty map, a no-op) BEFORE the blocking load, so a missing
+    // co-requisite fails the JOB here with an actionable error rather than a mid-render hub fetch. The
+    // resolved paths are staged in `LoadSpec::components` for the generator's load-time
+    // `require_component` gate. Weights-free registry read; no-op when this build ships no audio lane.
+    let components = match crate::inference_runtime::audio_descriptor(&model_id) {
+        Some(descriptor) => {
+            resolve_co_requisites(&descriptor, &request.model_manifest_entry, settings)?
+        }
+        None => BTreeMap::new(),
+    };
     let handle = {
         let cancel = cancel.clone();
         let chunk_tx = chunk_tx.clone();
         tokio::task::spawn_blocking(move || -> WorkerResult<gen_core::AudioTrack> {
-            let spec = LoadSpec::new(WeightsSource::Dir(model_dir));
+            let spec = components.into_iter().fold(
+                LoadSpec::new(WeightsSource::Dir(model_dir)),
+                |spec, (id, source)| spec.with_component(id, source),
+            );
             let generator = load_generator(&model_id, &spec)
                 .map_err(|error| crate::classify_engine_error("audio model load failed", error))?;
             let req = GenerationRequest {
@@ -2049,6 +2064,7 @@ mod tests {
             backend: "mlx",
             modality: gen_core::Modality::Audio,
             capabilities: gen_core::Capabilities::default(),
+            required_components: &[],
         }
     }
 
@@ -2123,6 +2139,7 @@ mod tests {
                 supports_streaming: true,
                 ..Default::default()
             },
+            required_components: &[],
         }
     }
 
@@ -2496,6 +2513,7 @@ mod tests {
                 max_speakers: Some(2),
                 ..Default::default()
             },
+            required_components: &[],
         }
     }
 

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -1906,6 +1906,7 @@ mod tests {
             backend: "mlx",
             modality: gen_core::Modality::Image,
             capabilities: gen_core::Capabilities::default(),
+            required_components: &[],
         }
     }
     fn stub_mlx_load(_spec: &gen_core::LoadSpec) -> gen_core::Result<Box<dyn gen_core::Generator>> {
@@ -1927,6 +1928,7 @@ mod tests {
             backend: "candle",
             modality: gen_core::Modality::Image,
             capabilities: gen_core::Capabilities::default(),
+            required_components: &[],
         }
     }
     fn stub_candle_load(
@@ -1949,6 +1951,7 @@ mod tests {
             backend: "mlx",
             modality: gen_core::Modality::Image,
             capabilities: gen_core::Capabilities::default(),
+            required_components: &[],
         }
     }
     fn stub_unknown_load(

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -754,6 +754,7 @@ mod tests {
             backend: "stub",
             modality: gen_core::Modality::Image,
             capabilities: gen_core::Capabilities::default(),
+            required_components: &[],
         }
     }
 

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2796,6 +2796,36 @@ fn load_spec(
     spec
 }
 
+/// Stage a media model's caller-provisioned components (epic 13657, sc-13679) onto its `LoadSpec` —
+/// the image/video twin of the audio seam (`audio_jobs.rs run_audio_synthesis_using`). It reads the
+/// model's descriptor `required_components` from the media registry and resolves each declared id to
+/// its cached `coRequisite` snapshot via [`crate::model_jobs::resolve_co_requisites`] (all-or-nothing:
+/// a missing co-requisite fails the job with an actionable error BEFORE the engine load), then stages
+/// each in `LoadSpec::components` for the engine's own load-time `require_component` gate.
+///
+/// DORMANT at this pin: every current image/video descriptor advertises `required_components: &[]`, so
+/// the early return keeps this a no-op (no manifest clone, no cache probe). It is a REAL generic path,
+/// not a stub — the first image provider to advertise components (SDXL, sc-13682) is provisioned
+/// through it with no new plumbing.
+fn attach_required_components(
+    spec: LoadSpec,
+    model_id: &str,
+    manifest_entry: &JsonObject,
+    settings: &Settings,
+) -> WorkerResult<LoadSpec> {
+    let Some(descriptor) = crate::inference_runtime::media_descriptor(model_id) else {
+        return Ok(spec);
+    };
+    if descriptor.required_components.is_empty() {
+        return Ok(spec);
+    }
+    let manifest_value = Value::Object(manifest_entry.clone());
+    let components = resolve_co_requisites(&descriptor, &manifest_value, settings)?;
+    Ok(components
+        .into_iter()
+        .fold(spec, |spec, (id, source)| spec.with_component(id, source)))
+}
+
 /// Registry-only generator load (epic 3720, sc-3724): resolve `engine_id` through the
 /// backend-neutral `crate::inference_runtime::load` seam and return a `Box<dyn gen_core::Generator>`. Optionally
 /// installs an IP-Adapter from `ip_adapter_dir` (`LoadSpec::with_ip_adapter`) — the FLUX.1 XLabs
@@ -4519,6 +4549,10 @@ async fn generate_stream(
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
     }
+    // Named model components (epic 13657, sc-13679): dormant on the image lane at this pin — a no-op
+    // until an image provider advertises `required_components` (SDXL, sc-13682) — but the generic seam
+    // is present so it lights up with no bespoke plumbing.
+    spec = attach_required_components(spec, &request.model, &request.model_manifest_entry, settings)?;
 
     // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the generic MLX lane serves
     // the remaining With-Character identity generators — Z-Image identity-init (`referenceAssetId` ⇒
@@ -5405,6 +5439,10 @@ async fn generate_candle_stream(
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
     }
+    // Named model components (epic 13657, sc-13679): the candle twin of the mlx attach above — dormant
+    // (every current candle image descriptor advertises no components) but present so SDXL (sc-13682)
+    // reuses the same generic seam.
+    spec = attach_required_components(spec, &request.model, &request.model_manifest_entry, settings)?;
     // INT8-ConvRot LoadSpec seam (sc-9300, epic 9083): ride the ConvRot DiT single-file on the shared,
     // already-optional `LoadSpec::text_encoder` as a `WeightsSource::File` while `spec.weights` stays the
     // canonical Krea 2 bf16 snapshot `Dir` (set as `weights_dir` above). The candle-gen krea engine's

--- a/crates/sceneworks-worker/src/inference_runtime.rs
+++ b/crates/sceneworks-worker/src/inference_runtime.rs
@@ -121,6 +121,18 @@ pub(crate) fn audio_generator_clones_from_reference(id: &str) -> bool {
     })
 }
 
+/// The audio **Generator** descriptor for `id` (epic 13657, sc-13679), or `None` when `id` is
+/// unknown or this build ships no audio lane. Weights-free — reads the registration's `descriptor`
+/// alone (like [`audio_generator_clones_from_reference`]), so the worker can read a model's
+/// [`gen_core::ModelDescriptor::required_components`] and stage its coRequisite-provisioned components
+/// BEFORE building the `LoadSpec` it loads with.
+pub(crate) fn audio_descriptor(id: &str) -> Option<gen_core::ModelDescriptor> {
+    audio()?
+        .generators()
+        .map(|registration| (registration.descriptor)())
+        .find(|descriptor| descriptor.id == id)
+}
+
 /// Load an audio [`AudioTransform`] by id from the runtime's candle audio registry — the
 /// non-prompt audio→audio lane (OpenVoice V2 tone-color voice conversion, sc-13411 C4). The audio
 /// twin of [`load_audio`]: errors clearly when this build ships no audio lane so the voice-clone job
@@ -190,6 +202,22 @@ pub(crate) fn text() -> &'static TextLlmRegistry {
 ))]
 pub(crate) fn generators() -> impl ExactSizeIterator<Item = &'static ModelRegistration> {
     media().generators()
+}
+
+/// The media (image/video) **Generator** descriptor for `id` (epic 13657, sc-13679), or `None` when
+/// `id` is unknown. The image/video twin of [`audio_descriptor`]: weights-free registry introspection
+/// so the generation harness can resolve a model's coRequisite-provisioned components before building
+/// its `LoadSpec`. Dormant until an image provider advertises `required_components` (SDXL, sc-13682);
+/// every current media descriptor advertises `&[]`, so the seam that reads this is a no-op today.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn media_descriptor(id: &str) -> Option<gen_core::ModelDescriptor> {
+    media()
+        .generators()
+        .map(|registration| (registration.descriptor)())
+        .find(|descriptor| descriptor.id == id)
 }
 
 // Only the macOS prompt-refine tests iterate the TextLlm registry; on the Windows/candle build

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1613,6 +1613,130 @@ pub(crate) fn huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<Pa
     Some(dir)
 }
 
+/// Resolve the local HF snapshot dir for a repo PINNED to an exact commit (`snapshots/<revision>/`) —
+/// the cache-only twin of [`huggingface_snapshot_dir`] for a download that carries an immutable
+/// `revision` (F-029). Unlike [`huggingface_snapshot_dir`] (which prefers `refs/main`), this reads the
+/// EXACT pinned snapshot, so a co-requisite pinned to a non-main commit in a SHARED repo (e.g.
+/// chatterbox's `ve.safetensors` @ 5bb1f6ee living alongside the primary `refs/main` snapshot) resolves
+/// to the right snapshot — mirroring the inference-side `hf_get_pinned`. Returns `None` when that
+/// pinned snapshot is not cached.
+pub(crate) fn huggingface_pinned_snapshot_dir(
+    data_dir: &Path,
+    repo: &str,
+    revision: &str,
+) -> Option<PathBuf> {
+    let dir = huggingface_repo_cache_path(data_dir, repo)?
+        .join("snapshots")
+        .join(revision);
+    if !dir.is_dir() {
+        return None;
+    }
+    #[cfg(windows)]
+    materialize_snapshot_hardlinks(&dir);
+    Some(dir)
+}
+
+/// Resolve a model's **caller-provisioned components** (epic 13657, sc-13679) — the generic worker
+/// seam that turns a provider's [`gen_core::ModelDescriptor::required_components`] advertisement into
+/// the resolved local paths a caller stages in [`gen_core::LoadSpec::components`] (via
+/// `LoadSpec::with_component`). It is the SceneWorks-side complement of the engine's own load-time
+/// [`gen_core::require_component`] gate: the descriptor advertises which component ids a model needs,
+/// the manifest declares WHERE each comes from (a `coRequisite` download tagged with an explicit
+/// `componentId`), and this resolves each to a local [`gen_core::WeightsSource`].
+///
+/// Driven PURELY by `descriptor.required_components`: for each declared id it finds the manifest
+/// `coRequisite` download whose `componentId` matches (never inferred from repo names, sc-13679),
+/// then resolves that repo's cached snapshot ENV-CORRECTLY via the cache-only
+/// [`huggingface_snapshot_dir`] — the same seam the PiD-gemma / Wan-Lightning co-requisites use, so
+/// a custom `HF_HOME`/hub is honored and nothing is fetched here.
+///
+/// All-or-nothing: a declared component whose co-requisite is not installed (snapshot absent, or the
+/// named file missing) returns a caller-actionable [`WorkerError::InvalidPayload`] naming the
+/// component id + repo, so the JOB fails BEFORE the engine load — never a mid-render hub fetch. An
+/// empty `required_components` (every image/video model and every single-file audio model except
+/// chatterbox today) returns an empty map with no filesystem access, so every existing lane is a
+/// no-op. A single-file co-requisite (`files: ["x.safetensors"]`, e.g. chatterbox
+/// `perth`/`voice_embedding`) resolves to `WeightsSource::File(<snapshot>/x.safetensors)`; a
+/// multi-file / whole-repo co-requisite resolves to `WeightsSource::Dir(<snapshot>)`.
+pub(crate) fn resolve_co_requisites(
+    descriptor: &gen_core::ModelDescriptor,
+    manifest_entry: &Value,
+    settings: &Settings,
+) -> WorkerResult<BTreeMap<String, gen_core::WeightsSource>> {
+    let mut components = BTreeMap::new();
+    if descriptor.required_components.is_empty() {
+        return Ok(components);
+    }
+    let model_id = descriptor.id;
+    let downloads: &[Value] = manifest_entry
+        .get("downloads")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    for &component_id in descriptor.required_components {
+        // The `coRequisite` download that PROVISIONS this component id — matched on the explicit
+        // `componentId` field the manifest sets (never inferred from repo names, sc-13679).
+        let download = downloads
+            .iter()
+            .find(|download| {
+                download.get("coRequisite").and_then(Value::as_bool) == Some(true)
+                    && download.get("componentId").and_then(Value::as_str) == Some(component_id)
+            })
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(format!(
+                    "{model_id} requires the model component '{component_id}', but its catalog entry \
+                     declares no `coRequisite` download tagged `componentId: \"{component_id}\"` — \
+                     the model manifest entry is misconfigured"
+                ))
+            })?;
+        let repo = download
+            .get("repo")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(format!(
+                    "{model_id}: the '{component_id}' co-requisite download declares no `repo`"
+                ))
+            })?;
+        // Resolve the co-requisite's snapshot cache-only. A co-requisite pins an immutable `revision`
+        // (F-029, required by sc-13659) — read THAT exact `snapshots/<sha>/` (like the inference-side
+        // `hf_get_pinned`), never `refs/main`, so a companion weight pinned to a non-main commit in a
+        // SHARED repo (chatterbox's `ve.safetensors` @ 5bb1f6ee, alongside the primary `refs/main`
+        // snapshot) resolves correctly. An unpinned co-requisite falls back to the `refs/main`-preferring
+        // resolver.
+        let snapshot = match download.get("revision").and_then(Value::as_str) {
+            Some(revision) => huggingface_pinned_snapshot_dir(&settings.data_dir, repo, revision),
+            None => huggingface_snapshot_dir(&settings.data_dir, repo),
+        }
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "{model_id}: the '{component_id}' component ({repo}) is not installed — install \
+                 {model_id} from the Model Manager (installing it pulls this co-requisite), or \
+                 predownload {repo} for an offline install"
+            ))
+        })?;
+        let files: Vec<&str> = download
+            .get("files")
+            .and_then(Value::as_array)
+            .map(|files| files.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        let source = match files.as_slice() {
+            [file] => {
+                let path = snapshot.join(file);
+                if !path.is_file() {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "{model_id}: the '{component_id}' component file {repo}/{file} is missing \
+                         from the cached snapshot — reinstall {model_id} to repair it"
+                    )));
+                }
+                gen_core::WeightsSource::File(path)
+            }
+            _ => gen_core::WeightsSource::Dir(snapshot),
+        };
+        components.insert(component_id.to_owned(), source);
+    }
+    Ok(components)
+}
+
 /// Resolve the exact snapshot/tier recorded by a completed model-download receipt.
 ///
 /// A manifest may rename files after an install.  In that case the catalog deliberately keeps the
@@ -3343,5 +3467,229 @@ mod tier_builder {
             deref_symlinks(&out);
         }
         eprintln!("[sc-8513] DONE {tier} at {}", out.display());
+    }
+}
+
+/// Generic co-requisite → component-provisioning seam (epic 13657, sc-13679). Weights-free and
+/// platform-neutral: it drives off a synthetic `ModelDescriptor` + manifest `Value` + an isolated
+/// temp HF cache, so it runs on every lane (macOS `cargo test` AND the Linux parity clippy build).
+#[cfg(test)]
+mod co_requisite_tests {
+    use super::*;
+
+    /// A `Settings` whose only field `resolve_co_requisites` reads is `data_dir`; everything else is
+    /// inert (no network, no engine).
+    fn settings_at(data_dir: PathBuf) -> Settings {
+        Settings {
+            api_url: "http://127.0.0.1:0".to_owned(),
+            access_token: None,
+            data_dir,
+            config_dir: PathBuf::from("config"),
+            worker_id: "sc-13679".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            is_child_worker: true,
+            poll_seconds: 1,
+            heartbeat_seconds: 5,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: "http://127.0.0.1:0".to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            max_lora_url_bytes: 0,
+            max_model_url_bytes: 0,
+            allow_private_lora_urls: false,
+            utility_workers: 1,
+            backend_mlx_enabled: false,
+            backend_candle_enabled: false,
+            gpu_memory_limit_bytes: 0,
+            external_model_roots: Vec::new(),
+        }
+    }
+
+    /// The chatterbox descriptor shape the resolver is driven by: it advertises the two named
+    /// components (`perth`, `voice_embedding`) exactly as the real `chatterbox_tts` descriptor does at
+    /// the inference pin (`required_components: &["perth", "voice_embedding"]`).
+    fn chatterbox_descriptor() -> gen_core::ModelDescriptor {
+        gen_core::ModelDescriptor {
+            id: "chatterbox_tts",
+            family: "chatterbox",
+            backend: "candle",
+            modality: gen_core::Modality::Audio,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &["perth", "voice_embedding"],
+        }
+    }
+
+    /// The chatterbox manifest entry shape the resolver reads: the two `coRequisite` downloads carry
+    /// an explicit `componentId` mapping repo → component id (never inferred from the repo name).
+    fn chatterbox_manifest_entry() -> Value {
+        json!({
+            "id": "chatterbox_tts",
+            "downloads": [
+                { "provider": "huggingface", "repo": "ResembleAI/chatterbox",
+                  "files": ["t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json"] },
+                { "provider": "huggingface", "repo": "ResembleAI/chatterbox",
+                  "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18", "coRequisite": true,
+                  "componentId": "voice_embedding", "files": ["ve.safetensors"] },
+                { "provider": "huggingface", "repo": "SceneWorks/perth-implicit",
+                  "revision": "80b60f9caead09b8d3b512bda0b24038f28c08ec", "coRequisite": true,
+                  "componentId": "perth", "files": ["perth_implicit.safetensors"] }
+            ]
+        })
+    }
+
+    /// Materialize `<file>` inside `repo`'s cached HF snapshot under `data_dir`, so the cache-only
+    /// `huggingface_snapshot_dir` resolves it — the disk state a completed co-requisite install leaves.
+    fn stage_snapshot_file(data_dir: &Path, repo: &str, revision: &str, file: &str) -> PathBuf {
+        let snapshot = huggingface_repo_cache_path(data_dir, repo)
+            .expect("repo cache path resolves")
+            .join("snapshots")
+            .join(revision);
+        std::fs::create_dir_all(&snapshot).expect("create snapshot dir");
+        let path = snapshot.join(file);
+        std::fs::write(&path, b"weights").expect("write staged component file");
+        path
+    }
+
+    /// Neutralize the ambient HF cache env so `huggingface_repo_cache_path` resolves under the
+    /// supplied `data_dir` (else a developer's real `HF_HOME` would win — sc-13679 traps).
+    fn isolate_hf_cache() -> crate::test_env::EnvVars {
+        crate::test_env::EnvVars::set(&[
+            ("HF_HUB_CACHE", ""),
+            ("HUGGINGFACE_HUB_CACHE", ""),
+            ("HF_HOME", ""),
+        ])
+    }
+
+    #[test]
+    fn present_co_requisites_resolve_to_a_component_map_matching_the_descriptor() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let ve = stage_snapshot_file(
+            data_dir.path(),
+            "ResembleAI/chatterbox",
+            "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
+            "ve.safetensors",
+        );
+        let perth = stage_snapshot_file(
+            data_dir.path(),
+            "SceneWorks/perth-implicit",
+            "80b60f9caead09b8d3b512bda0b24038f28c08ec",
+            "perth_implicit.safetensors",
+        );
+
+        let descriptor = chatterbox_descriptor();
+        let components = resolve_co_requisites(
+            &descriptor,
+            &chatterbox_manifest_entry(),
+            &settings_at(data_dir.path().to_path_buf()),
+        )
+        .expect("both co-requisites are installed, so resolution succeeds");
+
+        // The resolved map's keys are EXACTLY the descriptor's advertised component ids.
+        let keys: Vec<&str> = components.keys().map(String::as_str).collect();
+        assert_eq!(
+            keys, descriptor.required_components,
+            "the component map keys must match the descriptor's required_components"
+        );
+        // Each id resolves to the single-file WeightsSource at the staged snapshot path.
+        // (`WeightsSource` has no `PartialEq`, so match the `File` variant and compare its path.)
+        let file_path = |source: Option<&gen_core::WeightsSource>| match source {
+            Some(gen_core::WeightsSource::File(path)) => Some(path.clone()),
+            _ => None,
+        };
+        assert_eq!(
+            file_path(components.get("voice_embedding")),
+            Some(ve),
+            "voice_embedding maps to the staged ve.safetensors"
+        );
+        assert_eq!(
+            file_path(components.get("perth")),
+            Some(perth),
+            "perth maps to the staged perth_implicit.safetensors"
+        );
+    }
+
+    #[test]
+    fn a_missing_co_requisite_fails_with_an_actionable_error_before_the_engine() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        // Stage ONLY voice_embedding; perth's snapshot is absent.
+        stage_snapshot_file(
+            data_dir.path(),
+            "ResembleAI/chatterbox",
+            "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
+            "ve.safetensors",
+        );
+
+        let error = resolve_co_requisites(
+            &chatterbox_descriptor(),
+            &chatterbox_manifest_entry(),
+            &settings_at(data_dir.path().to_path_buf()),
+        )
+        .expect_err("a missing co-requisite must fail the job before the engine load");
+
+        let WorkerError::InvalidPayload(message) = error else {
+            panic!(
+                "a missing co-requisite must surface as user-facing InvalidPayload, got {error:?}"
+            );
+        };
+        // Actionable: names the missing component id AND the repo to install/predownload.
+        assert!(
+            message.contains("perth") && message.contains("SceneWorks/perth-implicit"),
+            "the error must name the missing component id + repo, got: {message}"
+        );
+    }
+
+    #[test]
+    fn a_required_component_with_no_matching_component_id_is_a_manifest_error() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        // A manifest entry whose co-requisites carry NO componentId → the perth id can't be mapped.
+        let manifest_entry = json!({
+            "id": "chatterbox_tts",
+            "downloads": [
+                { "provider": "huggingface", "repo": "SceneWorks/perth-implicit",
+                  "revision": "80b60f9caead09b8d3b512bda0b24038f28c08ec", "coRequisite": true,
+                  "files": ["perth_implicit.safetensors"] }
+            ]
+        });
+        let error = resolve_co_requisites(
+            &chatterbox_descriptor(),
+            &manifest_entry,
+            &settings_at(data_dir.path().to_path_buf()),
+        )
+        .expect_err("a required id with no componentId mapping is a manifest misconfiguration");
+        let WorkerError::InvalidPayload(message) = error else {
+            panic!("expected InvalidPayload, got {error:?}");
+        };
+        assert!(
+            message.contains("componentId") && message.contains("perth"),
+            "the error must name the unmapped component id + the missing componentId tag, got: {message}"
+        );
+    }
+
+    #[test]
+    fn an_empty_required_components_set_is_a_no_op() {
+        let _env = isolate_hf_cache();
+        // Every current image/video model + single-file audio model advertises no components: the
+        // resolver must return an empty map WITHOUT touching the filesystem (a nonexistent data_dir).
+        let descriptor = gen_core::ModelDescriptor {
+            id: "kokoro_82m",
+            family: "kokoro",
+            backend: "candle",
+            modality: gen_core::Modality::Audio,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &[],
+        };
+        let components = resolve_co_requisites(
+            &descriptor,
+            &json!({ "id": "kokoro_82m", "downloads": [] }),
+            &settings_at(PathBuf::from("/nonexistent/sc-13679")),
+        )
+        .expect("an empty required_components set never fails");
+        assert!(
+            components.is_empty(),
+            "no components are staged for a model that requires none"
+        );
     }
 }

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -4069,6 +4069,9 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
         // 14B experts swap one-at-a-time and the load matches the SEQUENTIAL peak the manifest gate sized.
         // `apply_residency_policy` (the MLX cache seam) never downgrades a `Sequential` set here.
         offload_policy: input.offload_policy,
+        // Named model components (epic 13657): video providers advertise no `required_components`, so
+        // there is nothing to stage — an empty map keeps the video load path unchanged.
+        components: BTreeMap::new(),
     }
 }
 
@@ -12602,6 +12605,7 @@ mod tests {
                         backend: "probe",
                         modality: gen_core::Modality::Video,
                         capabilities: gen_core::Capabilities::default(),
+                        required_components: &[],
                     },
                     request: seen_request,
                 }))

--- a/crates/sceneworks-worker/src/voice_register.rs
+++ b/crates/sceneworks-worker/src/voice_register.rs
@@ -22,6 +22,12 @@ use gen_core::{LoadSpec, WeightsSource};
 pub const CHATTERBOX_VE_REPO: &str = "ResembleAI/chatterbox";
 /// The single-file weights the Chatterbox-VE embedder loads (`WeightsSource::File`, not a snapshot dir).
 pub const CHATTERBOX_VE_WEIGHTS_FILE: &str = "ve.safetensors";
+/// The pinned commit `ve.safetensors` is installed to (the encoder crate's `HUB_REVISION`, and the
+/// `revision` on both the chatterbox_tts `voice_embedding` co-requisite and the standalone
+/// `chatterbox_ve` download — sc-13680). `ve.safetensors` lives in `snapshots/<this>/`, which is NOT
+/// `refs/main` when the chatterbox_tts primary (t3/s3gen/tokenizer @ main) shares this repo cache, so
+/// the register path must resolve THIS pinned snapshot rather than preferring `refs/main`.
+pub const CHATTERBOX_VE_REVISION: &str = "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18";
 /// The registry id of the Chatterbox voice embedder.
 pub const CHATTERBOX_VE_MODEL_ID: &str = "chatterbox_ve";
 
@@ -55,13 +61,22 @@ impl std::error::Error for VoiceEmbedError {}
 /// clone TTS install, sc-13541). Returns [`VoiceEmbedError::WeightsMissing`] when the snapshot or the
 /// file is absent, with an actionable message.
 pub fn resolve_chatterbox_ve_weights(data_dir: &Path) -> Result<PathBuf, VoiceEmbedError> {
-    let snapshot = crate::model_jobs::huggingface_snapshot_dir(data_dir, CHATTERBOX_VE_REPO)
-        .ok_or_else(|| {
-            VoiceEmbedError::WeightsMissing(format!(
-                "the Chatterbox voice encoder ({CHATTERBOX_VE_MODEL_ID}) is not installed — install \
-                 it from the Model Manager before registering a voice."
-            ))
-        })?;
+    // Resolve the PINNED snapshot first (ve.safetensors @ CHATTERBOX_VE_REVISION) — robust to the
+    // chatterbox_tts primary occupying `refs/main` in the shared repo cache (sc-13680). Fall back to
+    // the `refs/main`-preferring resolver for a legacy install that predates the pin (ve materialized
+    // into a main-branch snapshot).
+    let snapshot = crate::model_jobs::huggingface_pinned_snapshot_dir(
+        data_dir,
+        CHATTERBOX_VE_REPO,
+        CHATTERBOX_VE_REVISION,
+    )
+    .or_else(|| crate::model_jobs::huggingface_snapshot_dir(data_dir, CHATTERBOX_VE_REPO))
+    .ok_or_else(|| {
+        VoiceEmbedError::WeightsMissing(format!(
+            "the Chatterbox voice encoder ({CHATTERBOX_VE_MODEL_ID}) is not installed — install \
+             it from the Model Manager before registering a voice."
+        ))
+    })?;
     let weights = snapshot.join(CHATTERBOX_VE_WEIGHTS_FILE);
     if !weights.is_file() {
         return Err(VoiceEmbedError::WeightsMissing(format!(

--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -94,6 +94,18 @@ fn resolve_dir(env_key: &str, owner_repo: &str, subdir: Option<&str>) -> PathBuf
     dir
 }
 
+/// Build the `chatterbox_tts` LoadSpec at the inference pin's component contract (epic 13657 /
+/// sc-13680): the generator loads T3/S3Gen/tokenizer from `snapshot_dir` and REQUIRES the two
+/// companion weights staged as NAMED COMPONENTS — `voice_embedding` (ve.safetensors) and `perth`
+/// (perth_implicit.safetensors). At this pin the provider no longer self-fetches them mid-render, so a
+/// caller (the worker's resolve_co_requisites seam, or a by-hand smoke) MUST stage them here or the
+/// load fails fast with an actionable `with_component` error.
+fn chatterbox_load_spec(snapshot_dir: &Path, ve_file: PathBuf, perth_file: PathBuf) -> LoadSpec {
+    LoadSpec::new(WeightsSource::Dir(snapshot_dir.to_path_buf()))
+        .with_component("voice_embedding", WeightsSource::File(ve_file))
+        .with_component("perth", WeightsSource::File(perth_file))
+}
+
 /// Generate one real Kokoro clip (the base TTS call), returning the produced `gen_core::AudioTrack`.
 fn kokoro_clip(dir: &Path, script: &str, voice: &str) -> gen_core::AudioTrack {
     let audio = runtime_macos::catalog()
@@ -326,6 +338,9 @@ fn native_voiceclone_chatterbox_smoke() {
     // The chatterbox_tts generator loads its T3 + S3Gen + tokenizer from a snapshot DIR; the
     // Chatterbox-VE embedder loads the single `ve.safetensors` from that same dir.
     let chatterbox_dir = resolve_dir("VOICECLONE_CHATTERBOX_DIR", "ResembleAI/chatterbox", None);
+    // At the inference pin the generator requires ve + perth staged as named components (it no longer
+    // self-fetches). ve.safetensors rides the chatterbox snapshot; perth ships its own repo.
+    let perth_dir = resolve_dir("VOICECLONE_PERTH_DIR", "SceneWorks/perth-implicit", None);
     let out_dir = PathBuf::from(env_or("VOICECLONE_OUT_DIR", "/tmp/voiceclone_smoke"));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     let seed: u64 = 20260720;
@@ -353,7 +368,11 @@ fn native_voiceclone_chatterbox_smoke() {
         .expect("audio lane")
         .load(
             "chatterbox_tts",
-            &LoadSpec::new(WeightsSource::Dir(chatterbox_dir.clone())),
+            &chatterbox_load_spec(
+                &chatterbox_dir,
+                chatterbox_dir.join("ve.safetensors"),
+                perth_dir.join("perth_implicit.safetensors"),
+            ),
         )
         .expect("load chatterbox_tts generator");
     let mut on_progress = |_p: Progress| {};
@@ -451,6 +470,8 @@ fn saved_voice_register_render_dod() {
     }
     let data_dir = std::env::temp_dir();
     let chatterbox_dir = resolve_dir("VOICECLONE_CHATTERBOX_DIR", "ResembleAI/chatterbox", None);
+    // The generator requires ve + perth staged as named components at this pin (no self-fetch).
+    let perth_dir = resolve_dir("VOICECLONE_PERTH_DIR", "SceneWorks/perth-implicit", None);
 
     let out_dir = PathBuf::from(env_or("SAVED_VOICE_DOD_OUT", "/tmp/saved_voice_dod"));
     std::fs::create_dir_all(&out_dir).expect("out dir");
@@ -536,7 +557,11 @@ fn saved_voice_register_render_dod() {
         .expect("audio lane")
         .load(
             "chatterbox_tts",
-            &LoadSpec::new(WeightsSource::Dir(chatterbox_dir.clone())),
+            &chatterbox_load_spec(
+                &chatterbox_dir,
+                chatterbox_dir.join("ve.safetensors"),
+                perth_dir.join("perth_implicit.safetensors"),
+            ),
         )
         .expect("load chatterbox_tts generator");
     let mut on_progress = |_p: Progress| {};
@@ -804,8 +829,8 @@ fn real_cache_fingerprint(chatterbox_dir: &Path, perth_dir: &Path) -> Vec<Vec<St
     ]
 }
 
-/// sc-13541 (epic 13400 / E1 follow-up) — **offline install-parity DoD**. `#[ignore]`d; run by hand
-/// on an Apple-Silicon Mac (downloads ~3.2 GB into an ISOLATED temp HF cache):
+/// sc-13541 + sc-13680 (epic 13400 / E1 follow-up) — **offline install-parity DoD**. `#[ignore]`d;
+/// run by hand on an Apple-Silicon Mac (downloads ~3.2 GB into an ISOLATED temp HF cache):
 /// ```text
 /// cargo test -p sceneworks-worker chatterbox_offline_install_parity_smoke -- --ignored --nocapture
 /// ```
@@ -814,38 +839,39 @@ fn real_cache_fingerprint(chatterbox_dir: &Path, perth_dir: &Path) -> Vec<Vec<St
 /// machine's real `~/.cache/huggingface` (which already held ve/perth), so it passed even though the
 /// install under test was never actually exercised.
 ///
-/// Two facts — verified against the pinned inference rev and hf-hub 0.4.3 — drive the design:
-///   * The runtime resolver is `candle_audio::hub::hf_get_pinned` → hf-hub `Api::new()` →
-///     `Cache::default()`, which is HARD-CODED to `dirs::home_dir()/.cache/huggingface/hub` and reads
-///     NEITHER `HF_HOME` NOR `HF_ENDPOINT` (only `ApiBuilder::from_env()` reads those). On unix
-///     `dirs::home_dir()` is `$HOME`, so the ONLY lever that redirects the resolver's cache is `$HOME`.
-///     This test points `$HOME` at a fresh temp root ⇒ the resolver reads `<temp>/.cache/huggingface/
-///     hub` and the real `~/.cache/huggingface` is never touched (asserted). `HF_HOME` is set to
-///     `<temp>/.cache/huggingface` — exactly what the desktop injects (sc-1904) — so the SceneWorks
-///     downloader (`HF_HOME/hub`) writes the SAME hub the resolver reads: the DEFAULT shipped alignment.
-///   * hf-hub 0.4.3 has no `HF_HUB_OFFLINE` and `Api::new()` ignores `HF_ENDPOINT`, so the old
-///     black-hole `HF_ENDPOINT` was INERT. But both hf-hub agents are built with ureq
-///     `try_proxy_from_env(true)`, so a black-hole `ALL_PROXY`/`HTTPS_PROXY` DOES route (and fail)
-///     every resolver `download()`, while a cache HIT short-circuits before the agent is constructed.
-///     That makes "offline" deterministic and independent of the box's real connectivity.
+/// CONTRACT UPDATE (sc-13680, the inference component pin): the generator no longer self-fetches
+/// ve/perth mid-render — the WORKER's `resolve_co_requisites` seam resolves each from its pinned
+/// `snapshots/<sha>/` (cache-only, `huggingface_pinned_snapshot_dir`, HF_HOME-scoped) and stages it in
+/// `LoadSpec::components`. So this smoke drives the REAL production seam: the offline render is
+/// zero-network by construction, and the discrimination is that deleting a component snapshot makes
+/// `resolve_co_requisites` return the actionable job-level error (naming the missing component).
+///
+/// Two facts drive the isolation design:
+///   * The worker's cache resolver (`huggingface_hub_cache_dir`) reads `HF_HOME`/`HF_HUB_CACHE`, and the
+///     install downloader writes `HF_HOME/hub`. This test points BOTH `$HOME` and `HF_HOME` at a fresh
+///     temp root — `HF_HOME=<temp>/.cache/huggingface`, exactly what the desktop injects (sc-1904) — so
+///     install and resolution share ONE isolated hub and the real `~/.cache/huggingface` is never
+///     touched (asserted). ($HOME is pinned too so any residual `dirs::home_dir()` reader stays isolated.)
+///   * A black-hole `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` fails any residual network agent, so even if
+///     some path tried to fetch, it could not — belt-and-suspenders. At this pin the render never
+///     constructs a hub agent (the seam is cache-only + the provider consumes staged files), so a
+///     successful offline render is the "no runtime hub fetch" proof independent of connectivity.
 ///
 ///   1. **Isolate** — `$HOME` + `HF_HOME` at a fresh temp root; clear every other HF cache + proxy
 ///      var. Assert the isolated hub starts empty and differs from the real `~/.cache/huggingface`.
 ///   2. **Install** — run the REAL download executor (online) for the primary snapshot (`main`) PLUS
 ///      the two pinned companion co-requisites: `ve.safetensors` @ 5bb1f6ee… and
 ///      `perth_implicit.safetensors` @ 80b60f9c…. Assert each pinned `snapshots/<sha>/…` + `refs/<sha>`
-///      materialized where `hf_get_pinned` reads (the hf-hub layout `download_snapshot_into_cache`
-///      writes: `refs/<rev>` → commit, `snapshots/<commit>/<file>`).
-///   3. **Go offline, HARD** — black-hole `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` (any resolver fetch
-///      now fails through a dead proxy). Load `chatterbox_tts` from the installed snapshot dir and
-///      `generate()` one clone from a `Conditioning::ReferenceAudio` → MUST SUCCEED: ve
-///      (embed_reference) and perth (always-on watermark) resolve cache-first with zero network. A
-///      success with the dead proxy set IS the "no runtime hub fetch" proof.
-///   4. **Discriminate** — with the dead proxy still set, delete ONLY the PerTh snapshot, RELOAD the
-///      generator (its lazy ve/perth caches reset) and re-render → MUST HARD-FAIL (perth cache-miss →
-///      dead proxy). Then delete the ve snapshot + `refs/<sha>` and re-render → MUST HARD-FAIL (ve
-///      cache-miss). Deleting from the ISOLATED cache breaking the render is the proof the resolver
-///      reads THAT cache, not the real one. The 3.2 GB primary snapshot is reused — nothing re-downloads.
+///      materialized where the seam reads (`snapshots/<commit>/<file>`).
+///   3. **Go offline, HARD** — black-hole `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY`, then render through the
+///      worker's `resolve_co_requisites` seam: it resolves ve + perth cache-first from their pinned
+///      snapshots and stages them in `LoadSpec::components`; chatterbox_tts loads + `generate()`s one
+///      clone → MUST SUCCEED with zero network.
+///   4. **Discriminate** — delete ONLY the ve snapshot file + `refs/<sha>` (perth stays) and re-render →
+///      MUST HARD-FAIL with `resolve_co_requisites`' actionable error naming `voice_embedding`; then
+///      delete the PerTh dir and re-render → MUST HARD-FAIL naming `perth`. Deleting from the ISOLATED
+///      cache breaking the render is the proof the seam reads THAT cache, not the real one. The 3.2 GB
+///      primary snapshot is reused — nothing re-downloads.
 #[test]
 #[ignore = "real-weight offline-install-parity DoD: downloads ~3.2 GB into an ISOLATED temp HF cache; run by hand on an Apple-Silicon Mac"]
 fn chatterbox_offline_install_parity_smoke() {
@@ -994,12 +1020,37 @@ fn chatterbox_offline_install_parity_smoke() {
         "primary chatterbox snapshot dir must hold the generator weights"
     );
 
-    // One offline render from the installed primary snapshot, RELOADING the generator each call: the
-    // provider caches its ve/perth embedders lazily in a Mutex on first use, so a second generate() on
-    // the SAME generator would reuse them and never re-touch the cache — the discrimination below MUST
-    // reload to force re-resolution. The primary weights load from the local DIR (no hub), so a reload
-    // never re-downloads the 3.2 GB primary.
+    // The chatterbox_tts catalog shape the worker's co-requisite seam reads — the two pinned companion
+    // downloads tagged with the component ids the generator requires at load (sc-13679/13680). Built
+    // from the same repos/revisions/files installed above, so resolve_co_requisites resolves each from
+    // its pinned `snapshots/<sha>/` (via huggingface_pinned_snapshot_dir — NOT refs/main, which points
+    // at the primary).
+    let manifest_entry = serde_json::json!({
+        "id": "chatterbox_tts",
+        "downloads": [
+            { "provider": "huggingface", "repo": CHATTERBOX_REPO, "revision": VE_REVISION,
+              "coRequisite": true, "componentId": "voice_embedding", "files": ["ve.safetensors"] },
+            { "provider": "huggingface", "repo": PERTH_REPO, "revision": PERTH_REVISION,
+              "coRequisite": true, "componentId": "perth", "files": ["perth_implicit.safetensors"] }
+        ]
+    });
+
+    // One offline render through the PRODUCTION seam, RE-RESOLVING components each call: the worker's
+    // `resolve_co_requisites` resolves ve+perth cache-first from their pinned snapshots and stages them
+    // in `LoadSpec::components` (the generator no longer self-fetches at this pin), then chatterbox_tts
+    // loads from the local primary DIR + the two staged files and renders — ZERO network by
+    // construction (the dead proxy is belt-and-suspenders). Deleting a component's snapshot below makes
+    // resolve_co_requisites return the actionable job-level error, which is the new discrimination.
     let render_offline = || -> Result<gen_core::AudioTrack, String> {
+        let descriptor = crate::inference_runtime::audio_descriptor("chatterbox_tts")
+            .ok_or_else(|| "chatterbox_tts is not in the audio registry".to_owned())?;
+        let components =
+            crate::model_jobs::resolve_co_requisites(&descriptor, &manifest_entry, &settings)
+                .map_err(|e| e.to_string())?;
+        let spec = components.into_iter().fold(
+            LoadSpec::new(WeightsSource::Dir(main_snapshot_dir.clone())),
+            |spec, (id, source)| spec.with_component(id, source),
+        );
         let request = GenerationRequest {
             prompt: "This cloned voice was rendered fully offline from a fresh install.".to_owned(),
             seed: Some(13541),
@@ -1015,10 +1066,7 @@ fn chatterbox_offline_install_parity_smoke() {
             .map_err(|e| format!("runtime catalog: {e}"))?
             .audio()
             .ok_or_else(|| "audio lane missing from the runtime catalog".to_owned())?
-            .load(
-                "chatterbox_tts",
-                &LoadSpec::new(WeightsSource::Dir(main_snapshot_dir.clone())),
-            )
+            .load("chatterbox_tts", &spec)
             .map_err(|e| format!("load chatterbox_tts: {e}"))?
             .generate(&request, &mut on_progress)
             .map_err(|e| format!("generate: {e}"))?;
@@ -1032,7 +1080,8 @@ fn chatterbox_offline_install_parity_smoke() {
     let clone = render_offline().unwrap_or_else(|e| {
         panic!(
             "offline native clone generate MUST succeed from the installed isolated cache \
-             (ve + perth resolve cache-first with zero network; the dead proxy proves no fetch): {e}"
+             (resolve_co_requisites resolves ve + perth cache-first with zero network; the dead proxy \
+             proves no fetch): {e}"
         )
     });
     assert!(!clone.samples.is_empty(), "offline clone is empty");
@@ -1051,34 +1100,38 @@ fn chatterbox_offline_install_parity_smoke() {
         out_dir.join("offline_parity_clone.wav").display()
     );
 
-    // ── Step 4b: discrimination — prove the INSTALL (not the real ~/.cache) is load-bearing ──────
-    // #1: remove ONLY the PerTh snapshot (ve stays). A reload + render must reach the always-on
-    // watermark, cache-miss PerTh, and hard-fail through the dead proxy.
-    std::fs::remove_dir_all(&perth_dir).expect("remove the isolated PerTh model dir");
-    let perth_err = render_offline().expect_err(
-        "with the PerTh snapshot deleted from the ISOLATED cache the offline render MUST hard-fail — \
-         a success would mean the resolver read some OTHER cache (e.g. the real ~/.cache): a false pass",
-    );
-    assert!(
-        perth_err.contains("PerTh"),
-        "the discrimination failure must be the missing PerTh weight resolving through the dead proxy, got: {perth_err}"
-    );
-    eprintln!(
-        "[offline-parity] step 4b#1 PASS — PerTh removed ⇒ hard-fail as required: {perth_err}"
-    );
-
-    // #2: also remove the ve snapshot pointer + its refs/<sha>. A reload + render now cache-misses ve
-    // at embed_reference (the first companion the clone path touches) and hard-fails through the proxy.
+    // ── Step 4b: discrimination — prove the INSTALL (not the real ~/.cache) is load-bearing, and that
+    //    a missing co-requisite fails at the JOB level with an actionable error (the seam's contract).
+    //    resolve_co_requisites iterates required_components as [perth, voice_embedding], so delete ve
+    //    FIRST (perth still present) to surface the voice_embedding failure, then perth.
+    // #1: remove ONLY the ve snapshot file + its refs/<sha> (perth stays). resolve_co_requisites now
+    // cache-misses voice_embedding and fails with an actionable error naming the component.
     std::fs::remove_file(&ve_snapshot).expect("remove the isolated ve.safetensors pointer");
     std::fs::remove_file(&ve_ref).expect("remove the isolated ve refs/<sha>");
     let ve_err = render_offline().expect_err(
-        "with the ve snapshot deleted from the ISOLATED cache the offline render MUST hard-fail",
+        "with the ve snapshot deleted from the ISOLATED cache the offline render MUST hard-fail at the \
+         co-requisite seam — a success would mean the resolver read some OTHER cache: a false pass",
     );
     assert!(
-        ve_err.contains("chatterbox_ve"),
-        "the discrimination failure must be the missing ve embedder resolving through the dead proxy, got: {ve_err}"
+        ve_err.contains("voice_embedding"),
+        "the discrimination failure must name the missing voice_embedding component, got: {ve_err}"
     );
-    eprintln!("[offline-parity] step 4b#2 PASS — ve removed ⇒ hard-fail as required: {ve_err}");
+    eprintln!(
+        "[offline-parity] step 4b#1 PASS — ve removed ⇒ actionable job-level failure: {ve_err}"
+    );
+
+    // #2: also remove the PerTh model dir. resolve_co_requisites hits `perth` first and fails naming it.
+    std::fs::remove_dir_all(&perth_dir).expect("remove the isolated PerTh model dir");
+    let perth_err = render_offline().expect_err(
+        "with the PerTh snapshot also deleted the offline render MUST hard-fail naming the perth component",
+    );
+    assert!(
+        perth_err.contains("perth"),
+        "the discrimination failure must name the missing perth component, got: {perth_err}"
+    );
+    eprintln!(
+        "[offline-parity] step 4b#2 PASS — PerTh removed ⇒ actionable job-level failure: {perth_err}"
+    );
 
     // ── The machine's real ~/.cache/huggingface must be neither read into nor written by any of the
     //    above: install targeted HF_HOME=<temp>/hub and the resolver's Cache::default() targeted

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -577,6 +577,11 @@
                   "pattern": "^[0-9a-f]{40}$",
                   "description": "Optional pinned 40-hex git commit SHA — the F-029 pin authority for this download (sc-13659). When present the download job forwards it so the worker fetches that exact IMMUTABLE commit into snapshots/<sha>/; absent means the worker resolves `main` at install time, so the ~200 existing non-pinned models need no migration. MUST be a full 40-char lowercase-hex commit: a branch/tag/short SHA is rejected by the pattern above because it resolves online but hard-fails the offline pinned-SHA resolver (hf_get_pinned reads snapshots/<sha>/). REQUIRED on coRequisite: true entries — the F-029 guarantee that a companion weight (e.g. chatterbox_tts's ve/perth) installs to a deterministic, offline-resolvable snapshot; that conditional is enforced by tests/test_builtin_manifest_audit.py and crates/sceneworks-core/src/builtin_manifests.rs rather than JSON Schema, which cannot grandfather the sc-13591 pin migration still in flight. See sc-13541, sc-13591."
                 },
+                "componentId": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_]*$",
+                  "description": "Optional stable component id this coRequisite download PROVISIONS for the model's engine (epic 13657, sc-13679). When set (only meaningful on `coRequisite: true` entries), the worker stages the resolved local path under this id in the engine's `LoadSpec::components`, matched against the provider's `ModelDescriptor::required_components` advertisement — the explicit repo→component mapping (never inferred from repo names) that the generic `resolve_co_requisites` seam reads. Lowercase snake_case, same shape as a descriptor id. Examples: chatterbox_tts's ve/perth co-requisites carry `voice_embedding`/`perth`; SDXL's carry `tokenizer_clip_l`/`tokenizer_clip_bigg`/`vae_fp16_fix` (sc-13682). Absent on a co-requisite the engine does not read as a named component (e.g. the PiD-gemma / Wan-Lightning shared weights)."
+                },
                 "default": {
                   "type": "boolean",
                   "description": "Marks the canonical alternate used for displayed size, install path, and download jobs. For a quant matrix this marks the DEFAULT tier (the one that installs when no explicit variant is requested)."

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -444,6 +444,44 @@ def test_schema_pins_download_revision_to_a_40hex_sha():
         )
 
 
+def test_schema_accepts_a_component_id_on_a_corequisite_download():
+    """sc-13679: a coRequisite download may carry a `componentId` — the explicit repo→component
+    mapping the worker's `resolve_co_requisites` seam reads to stage `LoadSpec::components`. The
+    authoring schema constrains it to lowercase snake_case (same shape as a descriptor id), accepting
+    a valid id and rejecting capitals / hyphens / a leading digit / empty via the `pattern` keyword.
+    """
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    validator = jsonschema.Draft202012Validator(schema)
+
+    def component_errors(component_id: str) -> list:
+        manifest = {
+            "schemaVersion": 1,
+            "models": [
+                _model_entry_with_download(
+                    {
+                        "provider": "huggingface",
+                        "repo": "ResembleAI/chatterbox",
+                        "files": ["ve.safetensors"],
+                        "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
+                        "coRequisite": True,
+                        "componentId": component_id,
+                    }
+                )
+            ],
+        }
+        return list(validator.iter_errors(manifest))
+
+    assert not component_errors("voice_embedding"), "a lowercase snake_case componentId must validate"
+    for bad in ("Perth", "voice-embedding", "1codec", ""):
+        errors = component_errors(bad)
+        # Discriminate on the failing keyword so dropping the pattern turns this red rather than
+        # passing on some unrelated error.
+        assert any(error.validator == "pattern" for error in errors), (
+            f"componentId {bad!r} must be rejected by the snake_case pattern"
+        )
+
+
 def test_manifest_constraint_contract_registry_is_complete_and_live():
     """sc-12304: constraint declarations may not silently become decoration.
 


### PR DESCRIPTION
Two tightly-coupled chore stories landed as ONE atomic PR — **sc-13679** (generic co-requisite provisioning seam) and **sc-13680** (rehome chatterbox perth+VE as pinned coRequisites).

## Why one PR (git ancestry forces it)
The old inference pin `9321dece` and the gen-core contract commit `5691f53f` are divergent siblings off base `5332c414`, reconverging at `cb470156`. So `cb470156` is the first forward commit that BOTH (a) carries the `with_component` / `required_components` / `require_component` / `reject_unknown_components` contract the seam compiles against AND (b) deletes chatterbox's perth+VE provider self-fetch. Bumping the pin makes chatterbox require passed-in components, so the seam (sc-13679) and the chatterbox provisioning (sc-13680) must ship together or chatterbox renders break.

## sc-13679 — generic seam + pin → cb470156
- `resolve_co_requisites(descriptor, manifest_entry, settings)` — driven by the provider's `required_components`, maps each declared component id to its manifest `coRequisite` download via an explicit `componentId` field (never inferred from repo names), resolving the download's **pinned** snapshot cache-only (`huggingface_pinned_snapshot_dir` reads `snapshots/<revision>/`, so a companion pinned to a non-main commit in a SHARED repo resolves correctly). All-or-nothing: a missing co-requisite fails the job BEFORE the engine load with an actionable error naming the component id + repo.
- Manifest expression: a first-class typed `componentId` on `ModelDownload` + the model-manifest JSON schema (lowercase snake_case) + the Python manifest audit.
- Attached at the audio seam (`audio_jobs`) and the image lane (`base.rs`, dormant until an image provider advertises components — SDXL, sc-13682 — but a real generic path). Weights-free descriptor lookups added to `inference_runtime`.
- Pin-bump fallout: `required_components` / `components` added to SceneWorks-side `ModelDescriptor` / `LoadSpec` literals.

## sc-13680 — chatterbox provisioning
- `chatterbox_tts`'s ve (@`5bb1f6ee`) and perth (@`80b60f9c`) coRequisites tagged with `componentId` `voice_embedding` / `perth`; stale self-fetch comments rewritten to the component contract.
- **chatterbox_ve reconciliation — keep-both-dedup**: it is a distinct registered `VoiceEmbedder` (register-a-voice flow, `voiceclone_smoke`, seeded-audio audits, Model Manager), so it is kept — but its `ve.safetensors` download is pinned to the SAME `5bb1f6ee` so the two declarations of the shared repo don't diverge; the register path now resolves that pinned snapshot (robust to the primary occupying `refs/main`).
- Voice-clone smokes updated to stage the two components; the offline install-parity DoD now drives the real `resolve_co_requisites` seam.

## DoD split (verified vs deferred)
**Verified (unit-testable, weights-free — all green):**
- missing co-req → actionable error before the engine (`resolve_co_requisites` tests)
- present co-reqs → component map matches the descriptor
- unmapped id → manifest error; empty `required_components` → no-op
- `componentId` typed round-trip + schema accept/reject
- chatterbox_tts install-state gates on both hard co-requisites (audio lane was previously untested for coRequisites)

**Deferred (real-weight, cannot run here — no cached weights / no GPU):** the custom-`HF_HOME` + network-disabled real voice-clone render. The `chatterbox_offline_install_parity_smoke` harness was rewritten to the new contract (drives the production seam; offline render + missing-co-req = actionable job-level error) but is `#[ignore]`d and unrunnable in this environment. Additionally covered by the epic's end-to-end matrix story **sc-13686**.

## Checks
`npm run rust:check` GREEN (fmt / clippy -D warnings / test / build); the parity "neither" lane reproduced via a native Linux cross-clippy (candle off, `base.rs` excluded) GREEN; Python manifest audit 26 passed. Squash-merge.

Refs sc-13679, sc-13680, sc-13660.