### PR TITLE
chore(sdxl): rehome CLIP-L/bigG tokenizers + fp16-VAE-fix as pinned coRequisites [sc-13682]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "image",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,14 +997,13 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
  "candle-gen-pid",
  "candle-nn",
  "candle-transformers",
- "hf-hub",
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "safetensors 0.7.0",
@@ -1016,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1027,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1039,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1049,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1061,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1078,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "cudaforge",
 ]
@@ -1086,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1390,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -1821,7 +1820,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2035,7 +2034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3892,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3905,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3917,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3930,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3943,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3982,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3995,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4005,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4014,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4023,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4036,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4048,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4060,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4072,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4081,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4093,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4107,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4120,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4131,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4142,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4153,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4164,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4175,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4184,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4193,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4203,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4214,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4228,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4241,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4251,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4262,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4272,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4285,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4309,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "core-llm",
  "half",
@@ -4380,7 +4379,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4505,7 +4504,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5857,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5867,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5878,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5982,7 +5981,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6040,7 +6039,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6157,7 +6156,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cb470156329f771d6b799ac02138642375fe38c6#cb470156329f771d6b799ac02138642375fe38c6"
+source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -6734,7 +6733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7384,7 +7383,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7906,7 +7905,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8" }

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1733,6 +1733,77 @@ mod download_receipt_tests {
             installed.missing_required_files
         );
     }
+
+    /// sc-13682: the three SDXL shared components (CLIP-L/bigG tokenizers + fp16-fix VAE) are declared as
+    /// candle-only (`platforms: [windows, linux]`) hard co-requisites on every candle-SDXL base +
+    /// InstantID. On macOS `retain_downloads_for_os` strips them, so the self-contained MLX turnkey's
+    /// install state does NOT gate on them; on the candle OSes all three are retained and gate the entry.
+    /// Binds to the LIVE builtin manifest so a lost platform tag or a dropped component fails here.
+    #[test]
+    fn sdxl_shared_components_are_candle_only_and_gate_install_state_off_macos() {
+        use std::collections::BTreeSet;
+
+        fn builtin_models_entry(model_id: &str) -> Value {
+            let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+                .iter()
+                .find(|(name, _)| *name == "builtin.models.jsonc")
+                .map(|(_, contents)| *contents)
+                .expect("builtin.models.jsonc present");
+            let manifest: Value =
+                serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
+                    .expect("builtin.models.jsonc parses");
+            manifest["models"]
+                .as_array()
+                .expect("models array")
+                .iter()
+                .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
+                .cloned()
+                .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
+        }
+
+        let want: BTreeSet<String> = ["tokenizer_clip_l", "tokenizer_clip_bigg", "vae_fp16_fix"]
+            .iter()
+            .map(|id| (*id).to_owned())
+            .collect();
+
+        for model_id in [
+            "sdxl",
+            "realvisxl",
+            "realvisxl_lightning",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+            "instantid_realvisxl",
+        ] {
+            let entry = builtin_models_entry(model_id);
+
+            // macOS: the candle-only components are filtered out, so the MLX turnkey gates on NO coReq.
+            let mut macos = entry.clone();
+            retain_downloads_for_os(&mut macos, "macos");
+            assert!(
+                model_co_requisite_downloads(&macos).is_empty(),
+                "{model_id}: the SDXL CLIP/VAE components must not gate the macOS MLX turnkey install state",
+            );
+
+            // Windows + Linux: all three components are retained and gate the candle entry.
+            for os in ["windows", "linux"] {
+                let mut candle = entry.clone();
+                retain_downloads_for_os(&mut candle, os);
+                let ids: BTreeSet<String> = model_co_requisite_downloads(&candle)
+                    .iter()
+                    .filter_map(|download| {
+                        download
+                            .get("componentId")
+                            .and_then(Value::as_str)
+                            .map(str::to_owned)
+                    })
+                    .collect();
+                assert_eq!(
+                    ids, want,
+                    "{model_id} on {os}: the candle SDXL entry must gate on all three shared components",
+                );
+            }
+        }
+    }
 }
 
 // Resolve a model's install/cache state from its (optional) download source. A

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -5084,6 +5084,51 @@
           "files": ["bf16/*"],
           "estimatedSizeBytes": 6941187536,
           "footprint": { "diskSizeBytes": 6941187536, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Candle-SDXL shared components (epic 13657, sc-13682): the two model-agnostic CLIP tokenizers
+        // (CLIP-L + OpenCLIP-bigG) + the fp16-fix VAE the Windows/CUDA candle `sdxl` engine consumes as
+        // caller-staged components (inference sc-13663 deleted the old pinned `hf_get` self-fetch, so the
+        // candle txt2img / edit / IP-Adapter / trainer lanes now REQUIRE them). Each `componentId` maps
+        // to the provider's `ModelDescriptor::required_components` via the generic `resolve_co_requisites`
+        // seam; the pinned `revision` resolves the exact snapshot cache-only (offline). Platform-gated to
+        // the candle OSes: the self-contained macOS MLX turnkey above must NOT be gated on them — a hard
+        // coReq on macOS would wrongly mark an already-installed MLX SDXL not-ready (install-state gates
+        // on hard coReqs). Shared verbatim across every candle-SDXL base (realvisxl / illustrious / …) and
+        // deduped at download by the HF-cache blob layout, so a per-model declaration is correct (settled
+        // decision — do not try to centralize). `tokenizer_clip_l` shares the `openai/clip-vit-large-patch14`
+        // repo cache with the `clip_vit_l14` utility model, which pins the SAME revision so the blobs dedup.
+        {
+          "provider": "huggingface",
+          "repo": "openai/clip-vit-large-patch14",
+          "revision": "32bd64288804d66eefd0ccbe215aa642df71cc41",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_l",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+          "revision": "743c27bd53dfe508a0ade0f50698f99b39d03bec",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_bigg",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "madebyollin/sdxl-vae-fp16-fix",
+          "revision": "207b116dae70ace3637169f1ddd2434b91b3a8cd",
+          "coRequisite": true,
+          "componentId": "vae_fp16_fix",
+          "files": ["diffusion_pytorch_model.safetensors"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 167335590,
+          "footprint": { "diskSizeBytes": 167335590 }
         }
       ],
       "paths": {
@@ -5212,6 +5257,42 @@
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108692804,
           "footprint": { "diskSizeBytes": 7108692804, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Candle-SDXL shared components (epic 13657, sc-13682) — CLIP-L/bigG tokenizers + fp16-fix VAE the
+        // candle `sdxl` engine stages as caller-provided components; platform-gated to candle so the macOS
+        // MLX turnkey stays self-contained. See the `sdxl` entry for the full rationale.
+        {
+          "provider": "huggingface",
+          "repo": "openai/clip-vit-large-patch14",
+          "revision": "32bd64288804d66eefd0ccbe215aa642df71cc41",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_l",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+          "revision": "743c27bd53dfe508a0ade0f50698f99b39d03bec",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_bigg",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "madebyollin/sdxl-vae-fp16-fix",
+          "revision": "207b116dae70ace3637169f1ddd2434b91b3a8cd",
+          "coRequisite": true,
+          "componentId": "vae_fp16_fix",
+          "files": ["diffusion_pytorch_model.safetensors"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 167335590,
+          "footprint": { "diskSizeBytes": 167335590 }
         }
       ],
       "paths": {
@@ -5324,6 +5405,42 @@
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108692804,
           "footprint": { "diskSizeBytes": 7108692804, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Candle-SDXL shared components (epic 13657, sc-13682) — CLIP-L/bigG tokenizers + fp16-fix VAE the
+        // candle `sdxl` engine stages as caller-provided components; platform-gated to candle so the macOS
+        // MLX turnkey stays self-contained. See the `sdxl` entry for the full rationale.
+        {
+          "provider": "huggingface",
+          "repo": "openai/clip-vit-large-patch14",
+          "revision": "32bd64288804d66eefd0ccbe215aa642df71cc41",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_l",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+          "revision": "743c27bd53dfe508a0ade0f50698f99b39d03bec",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_bigg",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "madebyollin/sdxl-vae-fp16-fix",
+          "revision": "207b116dae70ace3637169f1ddd2434b91b3a8cd",
+          "coRequisite": true,
+          "componentId": "vae_fp16_fix",
+          "files": ["diffusion_pytorch_model.safetensors"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 167335590,
+          "footprint": { "diskSizeBytes": 167335590 }
         }
       ],
       "paths": {
@@ -5414,6 +5531,42 @@
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108498305,
           "footprint": { "diskSizeBytes": 7108498305, "residentMemoryBytes": 6954313820, "peakMemoryBytes": 22025741200 }
+        },
+        // Candle-SDXL shared components (epic 13657, sc-13682) — CLIP-L/bigG tokenizers + fp16-fix VAE the
+        // candle `sdxl` engine stages as caller-provided components; platform-gated to candle so the macOS
+        // MLX turnkey stays self-contained. See the `sdxl` entry for the full rationale.
+        {
+          "provider": "huggingface",
+          "repo": "openai/clip-vit-large-patch14",
+          "revision": "32bd64288804d66eefd0ccbe215aa642df71cc41",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_l",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+          "revision": "743c27bd53dfe508a0ade0f50698f99b39d03bec",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_bigg",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "madebyollin/sdxl-vae-fp16-fix",
+          "revision": "207b116dae70ace3637169f1ddd2434b91b3a8cd",
+          "coRequisite": true,
+          "componentId": "vae_fp16_fix",
+          "files": ["diffusion_pytorch_model.safetensors"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 167335590,
+          "footprint": { "diskSizeBytes": 167335590 }
         }
       ],
       "paths": {
@@ -5506,6 +5659,42 @@
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108498177,
           "footprint": { "diskSizeBytes": 7108498177, "residentMemoryBytes": 6954313820, "peakMemoryBytes": 22025741200 }
+        },
+        // Candle-SDXL shared components (epic 13657, sc-13682) — CLIP-L/bigG tokenizers + fp16-fix VAE the
+        // candle `sdxl` engine stages as caller-provided components; platform-gated to candle so the macOS
+        // MLX turnkey stays self-contained. See the `sdxl` entry for the full rationale.
+        {
+          "provider": "huggingface",
+          "repo": "openai/clip-vit-large-patch14",
+          "revision": "32bd64288804d66eefd0ccbe215aa642df71cc41",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_l",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+          "revision": "743c27bd53dfe508a0ade0f50698f99b39d03bec",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_bigg",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "madebyollin/sdxl-vae-fp16-fix",
+          "revision": "207b116dae70ace3637169f1ddd2434b91b3a8cd",
+          "coRequisite": true,
+          "componentId": "vae_fp16_fix",
+          "files": ["diffusion_pytorch_model.safetensors"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 167335590,
+          "footprint": { "diskSizeBytes": 167335590 }
         }
       ],
       "paths": {
@@ -5608,6 +5797,43 @@
           "files": ["q4/*"],
           "estimatedSizeBytes": 3911656467,
           "footprint": { "diskSizeBytes": 3911656467, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Candle-SDXL shared components (epic 13657, sc-13682) — the candle InstantID lane reuses the SDXL
+        // conditioner + VAE (candle-gen-instantid, sc-13663), so it stages the SAME CLIP-L/bigG tokenizers
+        // + fp16-fix VAE. Platform-gated to candle so the self-contained macOS MLX InstantID turnkey is
+        // NOT gated on them. See the `sdxl` entry for the full rationale.
+        {
+          "provider": "huggingface",
+          "repo": "openai/clip-vit-large-patch14",
+          "revision": "32bd64288804d66eefd0ccbe215aa642df71cc41",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_l",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+          "revision": "743c27bd53dfe508a0ade0f50698f99b39d03bec",
+          "coRequisite": true,
+          "componentId": "tokenizer_clip_bigg",
+          "files": ["tokenizer.json"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 2224003,
+          "footprint": { "diskSizeBytes": 2224003 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "madebyollin/sdxl-vae-fp16-fix",
+          "revision": "207b116dae70ace3637169f1ddd2434b91b3a8cd",
+          "coRequisite": true,
+          "componentId": "vae_fp16_fix",
+          "files": ["diffusion_pytorch_model.safetensors"],
+          "platforms": ["windows", "linux"],
+          "estimatedSizeBytes": 167335590,
+          "footprint": { "diskSizeBytes": 167335590 }
         }
       ],
       "paths": {
@@ -7787,6 +8013,12 @@
         {
           "provider": "huggingface",
           "repo": "openai/clip-vit-large-patch14",
+          // Pinned to align with the SDXL `tokenizer_clip_l` co-requisite (sc-13682), which pins this
+          // SAME repo @ 32bd6428… for its `tokenizer.json`. Sharing one revision means the two consumers
+          // resolve the SAME `snapshots/32bd6428…/` and share the underlying HF-cache blobs (frozen model,
+          // so an older pinned SHA is equivalent for the Dataset Doctor / FLUX IP-Adapter image encoder).
+          // Non-coRequisite entries MAY carry a revision (only coRequisites REQUIRE one, F-029 sc-13659).
+          "revision": "32bd64288804d66eefd0ccbe215aa642df71cc41",
           "files": [],
           "estimatedSizeBytes": 7000000000
         }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "cb470156329f771d6b799ac02138642375fe38c6", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2826,6 +2826,47 @@ fn attach_required_components(
         .fold(spec, |spec, (id, source)| spec.with_component(id, source)))
 }
 
+/// Resolve SDXL's three caller-staged components (`tokenizer_clip_l` / `tokenizer_clip_bigg` /
+/// `vae_fp16_fix`, epic 13657 / sc-13682) for a BESPOKE candle lane whose provider takes explicit
+/// component paths (`SdxlEditPaths` / `IpAdapterSdxlPaths` / `InstantIdPaths` — InstantID reuses the
+/// candle SDXL conditioner + VAE) rather than a [`LoadSpec`]. Rides the SAME
+/// generic [`crate::model_jobs::resolve_co_requisites`] seam the txt2img [`attach_required_components`]
+/// path uses: it reads the registered candle `sdxl` descriptor's `required_components` (the exact three
+/// ids the edit / IP-Adapter / trainer providers also consume) and maps each to this model's pinned
+/// `coRequisite` download by `componentId`. All-or-nothing — a missing component fails the job BEFORE the
+/// engine load with the seam's actionable error naming the component id + repo. Candle-only, because the
+/// bespoke `SdxlEdit` / `IpAdapterSdxl` providers are (macOS keeps the self-contained MLX SDXL lane).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn resolve_sdxl_components(
+    manifest_entry: &JsonObject,
+    settings: &Settings,
+) -> WorkerResult<(WeightsSource, WeightsSource, WeightsSource)> {
+    // The bespoke edit / IP-Adapter providers ARE the candle `sdxl` engine, so resolve that descriptor
+    // (id == "sdxl") and let its `required_components` advertisement drive the ids — never hardcoded here.
+    let descriptor = crate::inference_runtime::media_descriptor("sdxl").ok_or_else(|| {
+        WorkerError::Engine(
+            "candle SDXL generator is not registered — cannot resolve its required components"
+                .to_owned(),
+        )
+    })?;
+    let manifest_value = Value::Object(manifest_entry.clone());
+    let mut components =
+        crate::model_jobs::resolve_co_requisites(&descriptor, &manifest_value, settings)?;
+    let mut take = |id: &str| -> WorkerResult<WeightsSource> {
+        components.remove(id).ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "SDXL requires the '{id}' component, but its catalog entry declares no matching \
+                 `coRequisite` download — the model manifest entry is misconfigured"
+            ))
+        })
+    };
+    Ok((
+        take("tokenizer_clip_l")?,
+        take("tokenizer_clip_bigg")?,
+        take("vae_fp16_fix")?,
+    ))
+}
+
 /// Registry-only generator load (epic 3720, sc-3724): resolve `engine_id` through the
 /// backend-neutral `crate::inference_runtime::load` seam and return a `Box<dyn gen_core::Generator>`. Optionally
 /// installs an IP-Adapter from `ip_adapter_dir` (`LoadSpec::with_ip_adapter`) — the FLUX.1 XLabs
@@ -4549,10 +4590,12 @@ async fn generate_stream(
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
     }
-    // Named model components (epic 13657, sc-13679): dormant on the image lane at this pin — a no-op
-    // until an image provider advertises `required_components` (SDXL, sc-13682) — but the generic seam
-    // is present so it lights up with no bespoke plumbing.
-    spec = attach_required_components(spec, &request.model, &request.model_manifest_entry, settings)?;
+    // Named model components (epic 13657, sc-13682): stage a provider's caller-staged components (SDXL's
+    // `tokenizer_clip_l` / `tokenizer_clip_bigg` / `vae_fp16_fix`) via the generic seam. Keyed on the
+    // resolved `engine_id` (the DESCRIPTOR id) rather than `request.model`, so a finetune sibling that
+    // shares one engine under a distinct catalog id resolves the same descriptor (media_descriptor matches
+    // on descriptor.id). Inert on macOS: the MLX SDXL turnkey is self-contained (no `required_components`).
+    spec = attach_required_components(spec, engine_id, &request.model_manifest_entry, settings)?;
 
     // Identity-likeness scoring (epic 4406, sc-4411 plain With-Character): the generic MLX lane serves
     // the remaining With-Character identity generators — Z-Image identity-init (`referenceAssetId` ⇒
@@ -5439,10 +5482,13 @@ async fn generate_candle_stream(
     if let Some(pid) = pid_weights {
         spec = spec.with_pid(pid.checkpoint, pid.gemma);
     }
-    // Named model components (epic 13657, sc-13679): the candle twin of the mlx attach above — dormant
-    // (every current candle image descriptor advertises no components) but present so SDXL (sc-13682)
-    // reuses the same generic seam.
-    spec = attach_required_components(spec, &request.model, &request.model_manifest_entry, settings)?;
+    // Named model components (epic 13657, sc-13682): the candle twin of the mlx attach above — stages
+    // SDXL's three caller-provided components on the Windows/CUDA candle `sdxl` engine. Keyed on the
+    // resolved `engine_id` (the DESCRIPTOR id), NOT `request.model`, so the finetune siblings that share
+    // the candle `sdxl` engine under distinct catalog ids — realvisxl / illustrious_xl_v1|v2 /
+    // realvisxl_lightning — resolve the same descriptor and get the components staged. A no-op for every
+    // engine that advertises no `required_components`.
+    spec = attach_required_components(spec, engine_id, &request.model_manifest_entry, settings)?;
     // INT8-ConvRot LoadSpec seam (sc-9300, epic 9083): ride the ConvRot DiT single-file on the shared,
     // already-optional `LoadSpec::text_encoder` as a `WeightsSource::File` while `spec.weights` stays the
     // canonical Krea 2 bf16 snapshot `Dir` (set as `weights_dir` above). The candle-gen krea engine's

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -850,6 +850,14 @@ async fn generate_instantid_stream(
         allow(unused_variables)
     )]
     let face_likeness_source_ref = reference_id.to_owned();
+    // InstantID reuses the candle SDXL conditioner + VAE (candle-gen-instantid, sc-13663), so it stages
+    // the SAME three SDXL components (epic 13657, sc-13682): CLIP-L/bigG tokenizers + fp16-fix VAE.
+    // Resolved before the blocking closure (a missing one fails fast) and moved in. `InstantIdPaths`
+    // carries these fields ONLY on the candle build — the macOS MLX InstantID lane is self-contained — so
+    // both the resolve and the struct fields are candle-gated.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    let (tokenizer_clip_l, tokenizer_clip_bigg, vae_fp16_fix) =
+        resolve_sdxl_components(&request.model_manifest_entry, settings)?;
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "instantid",
@@ -864,6 +872,13 @@ async fn generate_instantid_stream(
                 // pin now 19d5522, candle pin c98609f). Populated for BOTH backends — superseding the
                 // earlier candle-only `Vec::new()` stopgap from #730.
                 adapters,
+                // The three caller-staged SDXL components (candle only — see above).
+                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+                tokenizer_clip_l,
+                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+                tokenizer_clip_bigg,
+                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+                vae_fp16_fix,
             };
             let model = InstantId::load(&paths)
                 .map_err(|error| WorkerError::Engine(format!("InstantID load failed: {error}")))?;

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -328,13 +328,25 @@ async fn generate_candle_sdxl_edit_stream(
     let total = work.len();
     let negative = request.negative_prompt.clone();
 
+    // SDXL's three caller-staged components (epic 13657, sc-13682): the CLIP-L/bigG tokenizers + fp16-fix
+    // VAE the candle `SdxlEdit` provider now REQUIRES (inference sc-13663 deleted its `hf_get` self-fetch).
+    // Resolved here — before the engine load inside the blocking closure — so a missing one fails fast with
+    // an actionable error naming the component id + repo, then moved into the closure beside `sdxl_base`.
+    let (tokenizer_clip_l, tokenizer_clip_bigg, vae_fp16_fix) =
+        resolve_sdxl_components(&request.model_manifest_entry, settings)?;
+
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "sdxl_edit",
         0,
         move || {
-            let model = SdxlEdit::load(&SdxlEditPaths { sdxl_base })
-                .map_err(|error| WorkerError::Engine(format!("SDXL edit load failed: {error}")))?;
+            let model = SdxlEdit::load(&SdxlEditPaths {
+                sdxl_base,
+                tokenizer_clip_l,
+                tokenizer_clip_bigg,
+                vae_fp16_fix,
+            })
+            .map_err(|error| WorkerError::Engine(format!("SDXL edit load failed: {error}")))?;
             // Attach the optional PiD decoder (sc-8044): `Some` only when this generation opted in AND the
             // snapshots are cached, so a native-VAE edit is a no-op here.
             let model = match &pid_weights {

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -334,6 +334,13 @@ async fn generate_candle_sdxl_ipadapter_stream(
     let total = work.len();
     let negative_prompt = request.negative_prompt.clone();
 
+    // SDXL's three caller-staged components (epic 13657, sc-13682): the CLIP-L/bigG tokenizers + fp16-fix
+    // VAE the candle `IpAdapterSdxl` provider now REQUIRES (inference sc-13663 deleted its `hf_get`
+    // self-fetch). Resolved before the engine load in the blocking closure so a missing one fails fast
+    // with an actionable error naming the component id + repo, then moved into the closure with the paths.
+    let (tokenizer_clip_l, tokenizer_clip_bigg, vae_fp16_fix) =
+        resolve_sdxl_components(&request.model_manifest_entry, settings)?;
+
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "sdxl_ipadapter",
@@ -343,6 +350,9 @@ async fn generate_candle_sdxl_ipadapter_stream(
                 sdxl_base,
                 ip_adapter: ip_bundle,
                 image_encoder,
+                tokenizer_clip_l,
+                tokenizer_clip_bigg,
+                vae_fp16_fix,
             };
             let model = IpAdapterSdxl::load(&paths).map_err(|error| {
                 WorkerError::Engine(format!("SDXL IP-Adapter load failed: {error}"))

--- a/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
@@ -203,7 +203,7 @@ fn assert_pid_output(
 }
 
 #[test]
-#[ignore = "real-weight GPU smoke; needs RealVisXL + InstantX IdentityNet + instantid-mlx face/ip + NC pid_sdxl + gemma-2-2b-it (+ optional OpenPose CN) (cap=120)"]
+#[ignore = "real-weight GPU smoke; needs RealVisXL + InstantX IdentityNet + instantid-mlx face/ip + NC pid_sdxl + gemma-2-2b-it + the CLIP-L/bigG tokenizer + fp16-fix VAE component dirs (SDXL_TOKENIZER_CLIP_{L,BIGG}_DIR / SDXL_VAE_FP16_FIX_DIR) (+ optional OpenPose CN) (cap=120)"]
 fn instantid_pid_gpu_smoke() {
     let base = env_path("INSTANTID_PID_BASE");
     assert!(
@@ -255,11 +255,16 @@ fn instantid_pid_gpu_smoke() {
     );
 
     println!("[smoke] loading InstantId from {} ...", base.display());
+    // InstantID reuses the candle SDXL conditioner + VAE, so it stages the SAME three SDXL components
+    // (epic 13657, sc-13682): CLIP-L/bigG tokenizers + fp16-fix VAE, from env dirs (mirrors inference).
     let model = InstantId::load(&InstantIdPaths {
         sdxl_base: base.clone(),
         identitynet: WeightsSource::Dir(identitynet.clone()),
         ip_adapter: ip_adapter.clone(),
         adapters: Vec::new(),
+        tokenizer_clip_l: WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_L_DIR")),
+        tokenizer_clip_bigg: WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_BIGG_DIR")),
+        vae_fp16_fix: WeightsSource::Dir(env_path("SDXL_VAE_FP16_FIX_DIR")),
     })
     .expect("load candle InstantId");
     // Attach OpenPose (pose mode) BEFORE the face stack — the engine's documented order. Harmless for

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -3692,4 +3692,132 @@ mod co_requisite_tests {
             "no components are staged for a model that requires none"
         );
     }
+
+    // --- SDXL shared components (epic 13657, sc-13682) -----------------------------------------------
+
+    /// The candle `sdxl` generator descriptor shape at the inference pin: it advertises the three
+    /// caller-staged SDXL components the edit / IP-Adapter / InstantID / trainer providers also consume.
+    fn sdxl_descriptor() -> gen_core::ModelDescriptor {
+        gen_core::ModelDescriptor {
+            id: "sdxl",
+            family: "sdxl",
+            backend: "candle",
+            modality: gen_core::Modality::Image,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &["tokenizer_clip_l", "tokenizer_clip_bigg", "vae_fp16_fix"],
+        }
+    }
+
+    /// The LIVE `builtin.models.jsonc` entry for `model_id` — binds these tests to the SHIPPED manifest so
+    /// a dropped/renamed SDXL co-requisite (or a `componentId` that stops matching the descriptor's
+    /// `required_components`) fails HERE, not silently at candle render time.
+    fn builtin_manifest_entry(model_id: &str) -> Value {
+        let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+            .iter()
+            .find(|(name, _)| *name == "builtin.models.jsonc")
+            .map(|(_, contents)| *contents)
+            .expect("builtin.models.jsonc present");
+        let manifest: Value =
+            serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
+                .expect("builtin.models.jsonc parses");
+        manifest["models"]
+            .as_array()
+            .expect("models array")
+            .iter()
+            .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
+            .cloned()
+            .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
+    }
+
+    /// `(repo, pinned revision, single file)` for each of the three SDXL components — the exact
+    /// snapshots the manifest co-requisites pin (sc-13682, sc-13658 registry).
+    const SDXL_COMPONENT_SNAPSHOTS: &[(&str, &str, &str)] = &[
+        (
+            "openai/clip-vit-large-patch14",
+            "32bd64288804d66eefd0ccbe215aa642df71cc41",
+            "tokenizer.json",
+        ),
+        (
+            "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k",
+            "743c27bd53dfe508a0ade0f50698f99b39d03bec",
+            "tokenizer.json",
+        ),
+        (
+            "madebyollin/sdxl-vae-fp16-fix",
+            "207b116dae70ace3637169f1ddd2434b91b3a8cd",
+            "diffusion_pytorch_model.safetensors",
+        ),
+    ];
+
+    #[test]
+    fn sdxl_co_requisites_resolve_all_three_from_every_live_candle_sdxl_entry() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        for (repo, revision, file) in SDXL_COMPONENT_SNAPSHOTS {
+            stage_snapshot_file(data_dir.path(), repo, revision, file);
+        }
+
+        // Every candle-SDXL base + InstantID declares the SAME three coRequisites by `componentId`, so
+        // resolving the candle `sdxl` descriptor against each live entry must map ALL THREE.
+        for model_id in [
+            "sdxl",
+            "realvisxl",
+            "realvisxl_lightning",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+            "instantid_realvisxl",
+        ] {
+            let components = resolve_co_requisites(
+                &sdxl_descriptor(),
+                &builtin_manifest_entry(model_id),
+                &settings_at(data_dir.path().to_path_buf()),
+            )
+            .unwrap_or_else(|error| {
+                panic!("{model_id}: all three components are staged, so resolution must succeed: {error:?}")
+            });
+
+            // The map keys are EXACTLY the descriptor's advertised ids (order-independent — a BTreeMap).
+            let mut keys: Vec<&str> = components.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            let mut want = sdxl_descriptor().required_components.to_vec();
+            want.sort_unstable();
+            assert_eq!(
+                keys, want,
+                "{model_id}: the component map keys must match the descriptor's required_components"
+            );
+            // Each single-file component resolves to a `File` at the staged snapshot path.
+            assert!(
+                matches!(
+                    components.get("vae_fp16_fix"),
+                    Some(gen_core::WeightsSource::File(_))
+                ),
+                "{model_id}: vae_fp16_fix resolves to its single-file snapshot"
+            );
+        }
+    }
+
+    #[test]
+    fn a_missing_sdxl_component_fails_with_an_actionable_error_naming_id_and_repo() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        // Stage only the two tokenizers; the fp16-fix VAE snapshot is ABSENT.
+        for (repo, revision, file) in &SDXL_COMPONENT_SNAPSHOTS[..2] {
+            stage_snapshot_file(data_dir.path(), repo, revision, file);
+        }
+
+        let error = resolve_co_requisites(
+            &sdxl_descriptor(),
+            &builtin_manifest_entry("sdxl"),
+            &settings_at(data_dir.path().to_path_buf()),
+        )
+        .expect_err("a missing SDXL component must fail the job before the engine load");
+
+        let WorkerError::InvalidPayload(message) = error else {
+            panic!("a missing component must surface as user-facing InvalidPayload, got {error:?}");
+        };
+        assert!(
+            message.contains("vae_fp16_fix") && message.contains("madebyollin/sdxl-vae-fp16-fix"),
+            "the error must name the missing component id + repo BEFORE engine load, got: {message}"
+        );
+    }
 }

--- a/crates/sceneworks-worker/src/sdxl_edit_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/sdxl_edit_pid_gpu_smoke.rs
@@ -123,7 +123,7 @@ fn inpaint(model: &SdxlEdit, source: &Image, mask: &Image, w: u32, h: u32, use_p
 }
 
 #[test]
-#[ignore = "real-weight GPU smoke; needs the SDXL base + NC pid_sdxl + gemma-2-2b-it snapshots (cap=120)"]
+#[ignore = "real-weight GPU smoke; needs the SDXL base + NC pid_sdxl + gemma-2-2b-it snapshots + the CLIP-L/bigG tokenizer + fp16-fix VAE component dirs (SDXL_TOKENIZER_CLIP_{L,BIGG}_DIR / SDXL_VAE_FP16_FIX_DIR) (cap=120)"]
 fn sdxl_edit_pid_gpu_smoke() {
     let base = env_path("SDXL_PID_BASE");
     assert!(
@@ -144,8 +144,14 @@ fn sdxl_edit_pid_gpu_smoke() {
     let mask = center_box_mask(w, h);
 
     println!("[smoke] loading SdxlEdit from {} ...", base.display());
+    // SDXL's three caller-staged components (epic 13657, sc-13682): CLIP-L/bigG tokenizers + fp16-fix VAE
+    // the provider now requires (never self-fetched). Staged from env dirs (a `tokenizer.json`/`.safetensors`
+    // file or its dir both resolve), mirroring the inference-side edit harness.
     let model = SdxlEdit::load(&SdxlEditPaths {
         sdxl_base: base.clone(),
+        tokenizer_clip_l: WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_L_DIR")),
+        tokenizer_clip_bigg: WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_BIGG_DIR")),
+        vae_fp16_fix: WeightsSource::Dir(env_path("SDXL_VAE_FP16_FIX_DIR")),
     })
     .expect("load candle SdxlEdit");
     let model = model

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -618,6 +618,62 @@ fn training_text_encoder(engine_id: &str, weights_dir: &std::path::Path) -> Opti
     None
 }
 
+/// The shipped `builtin.models.jsonc` entry for `model_id`, parsed from the embedded manifest — the
+/// source of truth for a base model's pinned `coRequisite` downloads (the app seeds its live catalog
+/// from these bytes). The training plan carries the base model id, not its manifest entry, so the trainer
+/// resolves components off this. `None` when the id is not a builtin model.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn builtin_model_manifest_entry(model_id: &str) -> Option<serde_json::Value> {
+    let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)?;
+    let manifest: serde_json::Value =
+        serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw)).ok()?;
+    manifest
+        .get("models")?
+        .as_array()?
+        .iter()
+        .find(|entry| entry.get("id").and_then(serde_json::Value::as_str) == Some(model_id))
+        .cloned()
+}
+
+/// Resolve a trainer's caller-staged components (epic 13657, sc-13682) from the base model's pinned
+/// `coRequisite` downloads, so the [`LoadSpec`] handed to [`crate::inference_runtime::load_trainer`]
+/// carries them for the engine's load-time `require_component` gate. Driven by the registered GENERATOR
+/// descriptor's `required_components`: SDXL's candle trainer consumes exactly the SAME three ids its
+/// generator advertises (the CLIP-L/bigG tokenizers + fp16-fix VAE, inference sc-13663), so the generator
+/// descriptor is the correct driver at this pin. Empty for every engine that advertises none — INCLUDING
+/// the self-contained macOS MLX SDXL trainer (descriptor `&[]`), so this never reads the manifest on
+/// macOS. All-or-nothing: a missing component fails the job with an actionable error BEFORE the trainer
+/// load (never a mid-train hub fetch).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn resolve_trainer_components(
+    engine_id: &str,
+    base_model_id: &str,
+    settings: &Settings,
+) -> WorkerResult<std::collections::BTreeMap<String, WeightsSource>> {
+    let Some(descriptor) = crate::inference_runtime::media_descriptor(engine_id) else {
+        return Ok(std::collections::BTreeMap::new());
+    };
+    if descriptor.required_components.is_empty() {
+        return Ok(std::collections::BTreeMap::new());
+    }
+    let manifest_entry = builtin_model_manifest_entry(base_model_id).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "training base model '{base_model_id}' has no builtin catalog entry to resolve its \
+             '{engine_id}' components from"
+        ))
+    })?;
+    crate::model_jobs::resolve_co_requisites(&descriptor, &manifest_entry, settings)
+}
+
 /// Execute a real training run on the in-process native engine (mlx-gen on macOS, candle-gen
 /// off-Mac via `backend-candle`, sc-7817). Loads the (frozen) base model via a [`LoadSpec`] (exactly
 /// as inference's `load_engine`), runs the family trainer on a blocking thread, streams staged
@@ -669,6 +725,14 @@ pub(crate) async fn run_training_execution(
     // LTX-2.3's Gemma-3 text encoder lives OUTSIDE `weights_dir` — thread the bundled sibling onto the
     // trainer `LoadSpec` so a self-contained install trains without a separate gemma download (sc-9989).
     let ltx_text_encoder = training_text_encoder(engine_id, &weights_dir);
+
+    // Caller-staged model components (epic 13657, sc-13682): the base model's pinned `coRequisite`
+    // downloads the trainer's engine consumes — SDXL's CLIP-L/bigG tokenizers + fp16-fix VAE on candle.
+    // Resolved BEFORE the blocking thread (a missing one fails the job with an actionable error naming the
+    // component id + repo), then moved into the closure and folded onto the trainer `LoadSpec`. Empty for
+    // the self-contained macOS MLX SDXL trainer (its descriptor advertises none), so a no-op on macOS.
+    let train_components =
+        resolve_trainer_components(engine_id, &plan.target.base_model, settings)?;
 
     let output_dir =
         resolve_training_output_dir(settings, &plan.output.output_dir, "Training outputDir")?;
@@ -733,19 +797,22 @@ pub(crate) async fn run_training_execution(
             } else {
                 Precision::Bf16
             };
-            let mut trainer = crate::inference_runtime::load_trainer(
-                engine_id,
-                &LoadSpec {
-                    precision: load_precision,
-                    // LTX-2.3's bundled Gemma-3 TE (sc-9989); `None` for every other family (TE lives
-                    // inside `weights_dir`) and for legacy/env-override LTX installs.
-                    text_encoder: ltx_text_encoder,
-                    ..LoadSpec::new(WeightsSource::Dir(weights_dir))
-                },
-            )
-            .map_err(|error| {
-                WorkerError::Engine(format!("{engine_id} trainer load failed: {error}"))
-            })?;
+            let spec = LoadSpec {
+                precision: load_precision,
+                // LTX-2.3's bundled Gemma-3 TE (sc-9989); `None` for every other family (TE lives
+                // inside `weights_dir`) and for legacy/env-override LTX installs.
+                text_encoder: ltx_text_encoder,
+                ..LoadSpec::new(WeightsSource::Dir(weights_dir))
+            };
+            // Fold the caller-staged components (epic 13657, sc-13682) resolved above onto the spec — the
+            // trainer's load-time gate requires them (SDXL on candle); an empty map is a no-op otherwise.
+            let spec = train_components
+                .into_iter()
+                .fold(spec, |spec, (id, source)| spec.with_component(id, source));
+            let mut trainer =
+                crate::inference_runtime::load_trainer(engine_id, &spec).map_err(|error| {
+                    WorkerError::Engine(format!("{engine_id} trainer load failed: {error}"))
+                })?;
             let request = TrainingRequest {
                 items,
                 config,


### PR DESCRIPTION
Rehomes SDXL's three model-agnostic shared deps — the CLIP-L / OpenCLIP-bigG tokenizers + the fp16-fix VAE — as **pinned manifest co-requisites**, and wires every SceneWorks candle-SDXL consumer to stage them through the existing generic seam. **Counterpart of inference sc-13663**, paired with the inference pin bump to `9cb24922` in this same PR.

## Why now
At `9cb24922`, `candle-gen-sdxl` deletes its `hf_get`/`HUB_PINS` self-fetch and advertises `required_components: ["tokenizer_clip_l","tokenizer_clip_bigg","vae_fp16_fix"]`; the SDXL **edit / IP-Adapter / InstantID / trainer** providers take the same three as passed-in paths. Without this PR the candle SDXL family would fail to load (or fail to compile) against the new pin.

## Manifest (`config/manifests/builtin.models.jsonc`)
- Add the 3 downloads as `coRequisite: true` with an explicit `componentId` + a pinned 40-hex `revision` to **every candle-SDXL entry** — `sdxl`, `realvisxl`, `realvisxl_lightning`, `illustrious_xl_v1`, `illustrious_xl_v2` — **and `instantid_realvisxl`** (its candle lane reuses the SDXL conditioner + VAE).
- **Platform-gated to `["windows","linux"]`** so the self-contained macOS MLX turnkeys' install state is NOT gated on them (a hard coReq on macOS would wrongly mark an installed MLX SDXL not-ready).
- **`clip_vit_l14` reconciliation:** aligned its `openai/clip-vit-large-patch14` download to the same `32bd6428…` revision the SDXL `tokenizer_clip_l` coReq pins, so the shared-repo blobs dedup. (Non-coReq entries may carry a revision; only coReqs require one.)

## Worker
- **txt2img (base.rs, mlx + candle):** key `attach_required_components` on the resolved `engine_id` (the descriptor id) instead of `request.model`, so the finetune siblings that share the candle `sdxl` engine under distinct catalog ids resolve the same descriptor. **The seam functions themselves are unchanged.**
- **Bespoke candle lanes (edit / IP-Adapter / InstantID):** thread the three components into `SdxlEditPaths` / `IpAdapterSdxlPaths` / `InstantIdPaths` via a new `resolve_sdxl_components` helper that rides `resolve_co_requisites`.
- **SDXL LoRA trainer:** fold the resolved components onto the trainer `LoadSpec` (empty/no-op on the self-contained macOS MLX trainer).

## Tests
- `componentId` ↔ `required_components` resolves all three from **every live candle-SDXL entry**; a missing one → the seam's actionable error naming the component id + repo **before** engine load.
- Platform-gating: the components gate the candle entry on windows/linux and are **stripped on macOS** (MLX turnkey unaffected).
- Rust + Python manifest audits stay green — the new coReqs are pinned from day one (**not** added to the sc-13659 migration allowlist).

## DoD split
The joint DoD — candle real-weight renders (txt2img + img2img/inpaint + IP-Adapter, custom HF cache + offline) and the training smoke — is a **CUDA/CPU real-weight matrix not runnable on this Apple-Silicon host**. Deferred to the epic's end-to-end lane (**sc-13686**). Verified here: macOS `rust:check` (clippy all-targets), the candle cross-typecheck (incl. test targets), both manifest audits, and the new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)