### PR TITLE
chore(audio): catalog MOSS TTS + TTS-realtime with pinned codec coRequisites [sc-13681]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "image",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "cudaforge",
 ]
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -1820,7 +1820,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4035,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4059,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4106,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4213,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4308,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "core-llm",
  "half",
@@ -4379,7 +4379,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4504,7 +4504,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4620,7 +4620,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5981,7 +5981,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6039,7 +6039,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6156,7 +6156,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=9cb2492221be8f6c0ad83c1649e91abefc5f9bd8#9cb2492221be8f6c0ad83c1649e91abefc5f9bd8"
+source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -6733,7 +6733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7383,7 +7383,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7905,7 +7905,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8574,7 +8574,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe" }

--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -151,6 +151,54 @@
       "documents": [
         { "label": "MIT License", "key": "chatterbox-ve-mit" }
       ]
+    },
+    {
+      "id": "moss-ttsd-v05",
+      "name": "MOSS-TTSD v0.5 (Multi-Speaker Dialogue)",
+      "publisher": "OpenMOSS Team",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/OpenMOSS-Team/MOSS-TTSD-v0.5",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Multi-speaker / long-form dialogue text-to-speech model (Audio Studio → Speech). SceneWorks downloads the upstream Apache-2.0 AR weights on first use from OpenMOSS-Team/MOSS-TTSD-v0.5 and runs them natively (Candle) on every platform. Requires the XY_Tokenizer codec (listed separately below) as a pinned co-requisite. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "moss-ttsd-v05-apache" }
+      ]
+    },
+    {
+      "id": "xy-tokenizer-ttsd",
+      "name": "XY_Tokenizer (MOSS-TTSD codec)",
+      "publisher": "OpenMOSS Team",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/OpenMOSS-Team/XY_Tokenizer_TTSD_V0",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "RVQ delay-pattern audio codec that decodes MOSS-TTSD v0.5's frames into a 24 kHz waveform (Audio Studio → Speech). SceneWorks downloads the upstream Apache-2.0 xy_tokenizer.ckpt on first use from OpenMOSS-Team/XY_Tokenizer_TTSD_V0 as a pinned co-requisite of MOSS-TTSD v0.5 and runs it natively (Candle) on every platform. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "xy-tokenizer-ttsd-apache" }
+      ]
+    },
+    {
+      "id": "moss-tts-realtime",
+      "name": "MOSS-TTS-Realtime (Streaming Speech)",
+      "publisher": "OpenMOSS Team",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Realtime",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Streaming text-to-speech model (Audio Studio → Speech). SceneWorks downloads the upstream Apache-2.0 AR weights on first use from OpenMOSS-Team/MOSS-TTS-Realtime and runs them natively (Candle) on every platform. Requires the MOSS-Audio-Tokenizer codec (listed separately below) as a pinned co-requisite. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "moss-tts-realtime-apache" }
+      ]
+    },
+    {
+      "id": "moss-audio-tokenizer",
+      "name": "MOSS-Audio-Tokenizer (MOSS-TTS-Realtime codec)",
+      "publisher": "OpenMOSS Team",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/OpenMOSS-Team/MOSS-Audio-Tokenizer",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "RLFQ streaming audio codec that decodes MOSS-TTS-Realtime's RVQ frames into a 24 kHz waveform (Audio Studio → Speech). SceneWorks downloads the upstream Apache-2.0 codec weights on first use from OpenMOSS-Team/MOSS-Audio-Tokenizer as a pinned co-requisite of MOSS-TTS-Realtime and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "moss-audio-tokenizer-apache" }
+      ]
     }
   ]
 }

--- a/apps/desktop/licenses/moss-audio-tokenizer/Apache-2.0.txt
+++ b/apps/desktop/licenses/moss-audio-tokenizer/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/desktop/licenses/moss-tts-realtime/Apache-2.0.txt
+++ b/apps/desktop/licenses/moss-tts-realtime/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/desktop/licenses/moss-ttsd-v05/Apache-2.0.txt
+++ b/apps/desktop/licenses/moss-ttsd-v05/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/desktop/licenses/xy-tokenizer-ttsd/Apache-2.0.txt
+++ b/apps/desktop/licenses/xy-tokenizer-ttsd/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -30,6 +30,13 @@ import mossApache from "../../../desktop/licenses/moss-soundeffect-v2/Apache-2.0
 import acestepMit from "../../../desktop/licenses/acestep-v15-turbo/MIT.txt?raw";
 import openvoiceMit from "../../../desktop/licenses/openvoice-v2/MIT.txt?raw";
 import chatterboxMit from "../../../desktop/licenses/chatterbox-ve/MIT.txt?raw";
+// MOSS TTS speech models + their pinned codec co-requisites (epic 13678, sc-13681).
+// Both the AR checkpoints and the codecs (XY_Tokenizer / MOSS-Audio-Tokenizer) are
+// Apache-2.0, downloaded on first use from the upstream OpenMOSS-Team repos.
+import mossTtsdApache from "../../../desktop/licenses/moss-ttsd-v05/Apache-2.0.txt?raw";
+import xyTokenizerApache from "../../../desktop/licenses/xy-tokenizer-ttsd/Apache-2.0.txt?raw";
+import mossTtsRealtimeApache from "../../../desktop/licenses/moss-tts-realtime/Apache-2.0.txt?raw";
+import mossAudioTokenizerApache from "../../../desktop/licenses/moss-audio-tokenizer/Apache-2.0.txt?raw";
 
 // Maps a manifest document `key` to its imported text. New components: add the
 // files under apps/desktop/licenses/<id>/, list them in manifest.json, and wire
@@ -50,6 +57,10 @@ const DOCUMENT_TEXT = {
   "acestep-v15-turbo-mit": acestepMit,
   "openvoice-v2-mit": openvoiceMit,
   "chatterbox-ve-mit": chatterboxMit,
+  "moss-ttsd-v05-apache": mossTtsdApache,
+  "xy-tokenizer-ttsd-apache": xyTokenizerApache,
+  "moss-tts-realtime-apache": mossTtsRealtimeApache,
+  "moss-audio-tokenizer-apache": mossAudioTokenizerApache,
 };
 
 // Resolve each component's document keys to its actual text once, at module load.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -8924,13 +8924,19 @@
       // signal rather than a voice list (modelEligibility.audioModelServesMode). Apache-2.0.
       //
       // Two pinned-revision downloads (the sc-13541 co-requisite pattern). The AR checkpoint is the
-      // primary; the ~7.1 GB MOSS-Audio-Tokenizer codec is a `coRequisite` the provider resolves at
-      // generate time via resolve_pinned_codec_snapshot() -> hf_get_pinned(OpenMOSS-Team/
-      // MOSS-Audio-Tokenizer @ 3cd226ba…). hf_get_pinned reads snapshots/<sha>/ and refuses a
-      // branch/tag, so a plain main-branch fetch would land in the wrong snapshot and offline
-      // generation would fail — both entries pin the exact 40-hex SHA the runtime resolves. The AR
-      // primary is pinned too because AR and codec are a MATCHED PAIR (the AR's 16-codebook RVQ frames
-      // are decoded by this exact codec revision); pinning both keeps a fresh install reproducible.
+      // primary; the ~7.1 GB MOSS-Audio-Tokenizer codec is a `coRequisite` the worker stages as the
+      // model's `codec` component (epic 13657 / sc-13662 / sc-13681): at the inference pin the provider
+      // NO LONGER self-fetches the codec mid-render — its descriptor advertises
+      // `required_components: ["codec"]` and the worker's generic `resolve_co_requisites` seam resolves
+      // this coRequisite from its cached pinned-SHA snapshot and stages it in `LoadSpec::components`
+      // (`with_component("codec", …)`), matched to the descriptor by the `componentId` below (never
+      // inferred from the repo name, sc-13679). An unprovisioned codec fails fast at load with an
+      // actionable error, never a mid-render hub fetch. The runtime reads
+      // `models--<org>--<name>/snapshots/<sha>/`, so a plain main-branch fetch would land in the WRONG
+      // snapshot and offline generation would fail — both entries pin the exact 40-hex SHA the runtime
+      // resolves. The AR primary is pinned too because AR and codec are a MATCHED PAIR (the AR's
+      // 16-codebook RVQ frames are decoded by this exact codec revision); pinning both keeps a fresh
+      // install reproducible.
       "id": "moss_tts_realtime",
       "name": "MOSS-TTS-Realtime (Streaming Speech)",
       "family": "moss_tts_realtime",
@@ -8972,16 +8978,20 @@
           }
         },
         {
-          // Co-requisite (sc-13675): the MOSS-Audio-Tokenizer codec — the separate ~7.1 GB RLFQ
-          // streaming codec (RVQ codes -> 24 kHz waveform) the provider resolves at generate time via
-          // resolve_pinned_codec_snapshot() -> hf_get_pinned(OpenMOSS-Team/MOSS-Audio-Tokenizer @
-          // 3cd226ba…, config.json + model.safetensors.index.json + the 2 shards). `revision` MUST be
-          // the full 40-hex SHA the resolver pins; predownloading it at that rev makes offline
-          // generation self-contained. Apache-2.0.
+          // Co-requisite (sc-13675 / sc-13681): the MOSS-Audio-Tokenizer codec — the separate ~7.1 GB
+          // RLFQ streaming codec (RVQ codes -> 24 kHz waveform) the worker stages as the `codec`
+          // component (`componentId` below) — resolve_co_requisites resolves it from this pinned-SHA
+          // snapshot (config.json + model.safetensors.index.json + the 2 shards) and hands it to the
+          // generator via with_component, matched to the descriptor's `required_components: ["codec"]`.
+          // At the inference pin the provider no longer self-fetches it mid-render (epic 13657,
+          // sc-13662). `revision` MUST be the full 40-hex SHA the resolver reads (snapshots/<sha>/), so a
+          // main-branch fetch would populate the wrong snapshot and offline generation would fail;
+          // predownloading it at that rev makes offline generation self-contained. Apache-2.0.
           "provider": "huggingface",
           "repo": "OpenMOSS-Team/MOSS-Audio-Tokenizer",
           "revision": "3cd226ba2947efa357ef453bcad111b6eafba782",
           "coRequisite": true,
+          "componentId": "codec",
           "files": [
             "config.json",
             "model.safetensors.index.json",
@@ -9039,11 +9049,16 @@
       //
       // Two pinned-revision downloads (the sc-13541 / sc-13675 co-requisite pattern). The AR checkpoint
       // is the primary (single ~4.1 GB model.safetensors); the ~2.1 GB XY_Tokenizer codec is a
-      // `coRequisite` the provider resolves at generate time via resolve_pinned_codec_checkpoint() ->
-      // hf_get_pinned(OpenMOSS-Team/XY_Tokenizer_TTSD_V0 @ c8343372…, xy_tokenizer.ckpt). hf_get_pinned
-      // reads snapshots/<sha>/ and refuses a branch/tag, so both entries pin the exact 40-hex SHA the
-      // runtime resolves — the AR is pinned too because AR and codec are a MATCHED PAIR (this exact
-      // codec revision decodes the AR's delay-pattern frames), keeping a fresh install reproducible.
+      // `coRequisite` the worker stages as the model's `codec` component (epic 13657 / sc-13662 /
+      // sc-13681): at the inference pin the provider NO LONGER self-fetches it at generate time — its
+      // descriptor advertises `required_components: ["codec"]` and the worker's generic
+      // `resolve_co_requisites` seam resolves this coRequisite from its cached pinned-SHA snapshot and
+      // stages it in `LoadSpec::components` (`with_component("codec", …)`), matched to the descriptor by
+      // the `componentId` below (never inferred from the repo name, sc-13679); an unprovisioned codec
+      // fails fast at load with an actionable error. hf_get_pinned reads snapshots/<sha>/ and refuses a
+      // branch/tag, so both entries pin the exact 40-hex SHA the runtime resolves — the AR is pinned too
+      // because AR and codec are a MATCHED PAIR (this exact codec revision decodes the AR's
+      // delay-pattern frames), keeping a fresh install reproducible.
       "id": "moss_ttsd_v05",
       "name": "MOSS-TTSD v0.5 (Multi-Speaker Dialogue)",
       "family": "moss_ttsd",
@@ -9105,16 +9120,19 @@
           }
         },
         {
-          // Co-requisite (sc-13676): the XY_Tokenizer codec — a single raw-pickle ~2.1 GB
-          // xy_tokenizer.ckpt (RVQ delay-pattern frames -> 24 kHz waveform) the provider resolves at
-          // generate time via resolve_pinned_codec_checkpoint() -> hf_get_pinned(OpenMOSS-Team/
-          // XY_Tokenizer_TTSD_V0 @ c8343372…, xy_tokenizer.ckpt). `revision` MUST be the full 40-hex
-          // SHA the resolver pins; predownloading it at that rev makes offline generation
-          // self-contained. Apache-2.0.
+          // Co-requisite (sc-13676 / sc-13681): the XY_Tokenizer codec — a single raw-pickle ~2.1 GB
+          // xy_tokenizer.ckpt (RVQ delay-pattern frames -> 24 kHz waveform) the worker stages as the
+          // `codec` component (`componentId` below) — resolve_co_requisites resolves it from this
+          // pinned-SHA snapshot and hands it to the generator via with_component, matched to the
+          // descriptor's `required_components: ["codec"]`. At the inference pin the provider no longer
+          // self-fetches it at generate time (epic 13657, sc-13662). `revision` MUST be the full 40-hex
+          // SHA the resolver reads (snapshots/<sha>/); predownloading it at that rev makes offline
+          // generation self-contained. Apache-2.0.
           "provider": "huggingface",
           "repo": "OpenMOSS-Team/XY_Tokenizer_TTSD_V0",
           "revision": "c83433728e698ed0698e88cb5096bc221fb8f8c5",
           "coRequisite": true,
+          "componentId": "codec",
           "files": [
             "xy_tokenizer.ckpt"
           ],

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -283,6 +283,12 @@ mod tests {
             Some(40),
             "the codec co-requisite pins a full 40-hex commit SHA (hf_get_pinned reads snapshots/<sha>/)"
         );
+        assert_eq!(
+            codec["componentId"].as_str(),
+            Some("codec"),
+            "the codec co-requisite is tagged componentId: \"codec\" (sc-13681) so the worker's generic \
+             resolve_co_requisites seam stages it under the descriptor's required_components: [\"codec\"]"
+        );
 
         // MOSS-TTSD v0.5 (sc-13676) is the audio lane's first MULTI-SPEAKER model: it advertises
         // `audio.supportsMultiSpeaker: true` + `audio.maxSpeakers: 2` (mirroring the backend
@@ -328,6 +334,12 @@ mod tests {
             ttsd_codec["revision"].as_str().map(str::len),
             Some(40),
             "the codec co-requisite pins a full 40-hex commit SHA (hf_get_pinned reads snapshots/<sha>/)"
+        );
+        assert_eq!(
+            ttsd_codec["componentId"].as_str(),
+            Some("codec"),
+            "the codec co-requisite is tagged componentId: \"codec\" (sc-13681) so the worker's generic \
+             resolve_co_requisites seam stages it under the descriptor's required_components: [\"codec\"]"
         );
 
         for model in [

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "9cb2492221be8f6c0ad83c1649e91abefc5f9bd8", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -2372,6 +2372,79 @@ mod tests {
         settings
     }
 
+    /// Neutralize the ambient HF cache env so a co-requisite snapshot resolves under the test's own
+    /// `data_dir` rather than a developer's real `HF_HOME` (sc-13679 trap) — the audio twin of the
+    /// model_jobs co_requisite seam tests' `isolate_hf_cache`.
+    fn isolate_hf_cache() -> crate::test_env::EnvVars {
+        crate::test_env::EnvVars::set(&[
+            ("HF_HUB_CACHE", ""),
+            ("HUGGINGFACE_HUB_CACHE", ""),
+            ("HF_HOME", ""),
+        ])
+    }
+
+    /// Stage a co-requisite component file at `models--<repo>/snapshots/<revision>/<file>` under
+    /// `data_dir`, mirroring the model_jobs seam tests' `stage_snapshot_file`.
+    fn stage_snapshot_file(data_dir: &Path, repo: &str, revision: &str, file: &str) {
+        let snapshot = sceneworks_core::hf_home::huggingface_repo_cache_path(data_dir, repo)
+            .expect("repo cache path resolves")
+            .join("snapshots")
+            .join(revision);
+        std::fs::create_dir_all(&snapshot).expect("create snapshot dir");
+        std::fs::write(snapshot.join(file), b"weights").expect("write staged component file");
+    }
+
+    /// The staged `codec` component for a MOSS TTS model: the isolated HF-cache env guard + tempdir
+    /// (both must be kept alive for the whole test) and the `modelManifestEntry` — carrying the codec
+    /// `coRequisite` download — the payload must advertise.
+    struct StagedCodec {
+        _env: crate::test_env::EnvVars,
+        _data_dir: tempfile::TempDir,
+        manifest_entry: Value,
+    }
+
+    /// Stage a MOSS model's `codec` component under an isolated HF cache, point `settings.data_dir` at
+    /// it, and return the matching `modelManifestEntry`. After the inference codec-component pin bump
+    /// (sc-13681) the real MOSS descriptors advertise `required_components: ["codec"]`, so
+    /// `run_audio_synthesis_using` calls `resolve_co_requisites`, which resolves the codec from its
+    /// cached pinned-SHA snapshot; without a staged snapshot the JOB fails with `InvalidPayload`
+    /// BEFORE the behavior under test runs. This mirrors the model_jobs co_requisite seam tests'
+    /// `isolate_hf_cache` / `stage_snapshot_file` pattern — codec resolution actually SUCCEEDS here
+    /// (the seam is exercised, not stubbed), and the loaded generator is still the test's own stub, so
+    /// the staged bytes are never read. The returned guard + tempdir must be kept alive for the whole
+    /// test.
+    fn stage_moss_codec(
+        settings: &mut Settings,
+        model_id: &str,
+        codec_repo: &str,
+        codec_revision: &str,
+        codec_files: &[&str],
+    ) -> StagedCodec {
+        let env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        for file in codec_files {
+            stage_snapshot_file(data_dir.path(), codec_repo, codec_revision, file);
+        }
+        settings.data_dir = data_dir.path().to_path_buf();
+        let manifest_entry = json!({
+            "id": model_id,
+            "type": "audio",
+            "downloads": [{
+                "provider": "huggingface",
+                "repo": codec_repo,
+                "revision": codec_revision,
+                "coRequisite": true,
+                "componentId": "codec",
+                "files": codec_files,
+            }],
+        });
+        StagedCodec {
+            _env: env,
+            _data_dir: data_dir,
+            manifest_entry,
+        }
+    }
+
     fn stub_load(
         behavior: StubBehavior,
         observed: Arc<AtomicBool>,
@@ -2534,7 +2607,17 @@ mod tests {
     #[tokio::test]
     async fn single_synthesis_forwards_the_multi_speaker_script_to_audio_params() {
         let (base_url, _progress) = spawn_audio_cancel_stub(false).await;
-        let settings = cancel_test_settings(base_url);
+        let mut settings = cancel_test_settings(base_url);
+        // moss_ttsd_v05 now advertises `required_components: ["codec"]` (sc-13681), so the synthesis
+        // seam resolves the XY_Tokenizer codec co-requisite before the stub load — stage it (and
+        // advertise it on the payload) so resolution SUCCEEDS and the script-forwarding behavior runs.
+        let staged = stage_moss_codec(
+            &mut settings,
+            "moss_ttsd_v05",
+            "OpenMOSS-Team/XY_Tokenizer_TTSD_V0",
+            "c83433728e698ed0698e88cb5096bc221fb8f8c5",
+            &["xy_tokenizer.ckpt"],
+        );
         let api = ApiClient::new(&settings);
         let job = audio_test_job("audio-script");
         let request = AudioRequest::from_payload(&payload(json!({
@@ -2544,6 +2627,7 @@ mod tests {
                 { "text": "Hello, how are you today?", "speaker": "S1" },
                 { "text": "I'm doing great, thanks for asking!", "speaker": "S2" },
             ],
+            "modelManifestEntry": staged.manifest_entry.clone(),
         })));
 
         let captured = Arc::new(Mutex::new(None));
@@ -2727,10 +2811,29 @@ mod tests {
     #[tokio::test]
     async fn streaming_synthesis_forwards_per_chunk_progress_and_returns_reassembled_track() {
         let (base_url, progress) = spawn_audio_cancel_stub(false).await;
-        let settings = cancel_test_settings(base_url);
+        let mut settings = cancel_test_settings(base_url);
+        // moss_tts_realtime now advertises `required_components: ["codec"]` (sc-13681), so the
+        // synthesis seam resolves the MOSS-Audio-Tokenizer codec co-requisite before the stub load —
+        // stage it (and advertise it on the payload) so resolution SUCCEEDS and the streaming behavior
+        // runs.
+        let staged = stage_moss_codec(
+            &mut settings,
+            "moss_tts_realtime",
+            "OpenMOSS-Team/MOSS-Audio-Tokenizer",
+            "3cd226ba2947efa357ef453bcad111b6eafba782",
+            &[
+                "config.json",
+                "model.safetensors.index.json",
+                "model-00001-of-00002.safetensors",
+                "model-00002-of-00002.safetensors",
+            ],
+        );
         let api = ApiClient::new(&settings);
         let job = audio_test_job("audio-stream");
-        let request = AudioRequest::from_payload(&payload(json!({ "model": "moss_tts_realtime" })));
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "moss_tts_realtime",
+            "modelManifestEntry": staged.manifest_entry.clone(),
+        })));
 
         let expected = StreamingStubGenerator {
             descriptor: streaming_stub_descriptor(),

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -3820,4 +3820,100 @@ mod co_requisite_tests {
             "the error must name the missing component id + repo BEFORE engine load, got: {message}"
         );
     }
+
+    // --- MOSS TTS codec component (epic 13678, sc-13681) ---------------------------------------------
+
+    /// A candle MOSS TTS descriptor shape at the inference pin: it advertises the single caller-staged
+    /// `codec` component (`candle-audio-moss-tts` / `candle-audio-moss-tts-realtime` both declare
+    /// `required_components: &["codec"]`, `CODEC_COMPONENT_ID = "codec"`), which the worker resolves
+    /// from the model's codec coRequisite instead of the provider self-fetching it (sc-13662).
+    fn moss_descriptor(id: &'static str, family: &'static str) -> gen_core::ModelDescriptor {
+        gen_core::ModelDescriptor {
+            id,
+            family,
+            backend: "candle",
+            modality: gen_core::Modality::Audio,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &["codec"],
+        }
+    }
+
+    /// `(model_id, family, codec repo, pinned revision, a file in the codec snapshot)` — the exact codec
+    /// coRequisite each SHIPPED MOSS TTS entry pins (sc-13681). MOSS-TTSD's XY_Tokenizer is a single-file
+    /// checkpoint (resolves to a `File`); MOSS-TTS-Realtime's MOSS-Audio-Tokenizer is a multi-file
+    /// snapshot directory (resolves to a `Dir`). Binds these tests to the LIVE `builtin.models.jsonc`, so
+    /// a dropped codec coRequisite or a `componentId` that stops matching `required_components: ["codec"]`
+    /// fails HERE, not silently at candle synth time.
+    const MOSS_CODEC_SNAPSHOTS: &[(&str, &str, &str, &str, &str)] = &[
+        (
+            "moss_ttsd_v05",
+            "moss_ttsd",
+            "OpenMOSS-Team/XY_Tokenizer_TTSD_V0",
+            "c83433728e698ed0698e88cb5096bc221fb8f8c5",
+            "xy_tokenizer.ckpt",
+        ),
+        (
+            "moss_tts_realtime",
+            "moss_tts_realtime",
+            "OpenMOSS-Team/MOSS-Audio-Tokenizer",
+            "3cd226ba2947efa357ef453bcad111b6eafba782",
+            "config.json",
+        ),
+    ];
+
+    #[test]
+    fn moss_codec_co_requisite_resolves_from_every_live_moss_tts_entry() {
+        for &(model_id, family, repo, revision, file) in MOSS_CODEC_SNAPSHOTS {
+            let _env = isolate_hf_cache();
+            let data_dir = tempfile::tempdir().expect("temp data dir");
+            stage_snapshot_file(data_dir.path(), repo, revision, file);
+
+            let components = resolve_co_requisites(
+                &moss_descriptor(model_id, family),
+                &builtin_manifest_entry(model_id),
+                &settings_at(data_dir.path().to_path_buf()),
+            )
+            .unwrap_or_else(|error| {
+                panic!("{model_id}: the codec is staged, so resolution must succeed: {error:?}")
+            });
+
+            // The single key is EXACTLY the descriptor's advertised `codec` id — matched on the
+            // manifest's explicit `componentId`, never inferred from the repo name (sc-13679).
+            let keys: Vec<&str> = components.keys().map(String::as_str).collect();
+            assert_eq!(
+                keys,
+                vec!["codec"],
+                "{model_id}: the component map must carry exactly the `codec` id"
+            );
+            assert!(
+                components.contains_key("codec"),
+                "{model_id}: the `codec` component resolves to its staged snapshot"
+            );
+        }
+    }
+
+    #[test]
+    fn a_missing_moss_codec_fails_with_an_actionable_error_naming_codec_and_repo() {
+        for &(model_id, family, repo, _revision, _file) in MOSS_CODEC_SNAPSHOTS {
+            let _env = isolate_hf_cache();
+            let data_dir = tempfile::tempdir().expect("temp data dir");
+            // The codec snapshot is ABSENT — install-state gates on the hard codec coRequisite, so the
+            // job must fail HERE (before the engine load), not with a mid-render hub fetch.
+            let error = resolve_co_requisites(
+                &moss_descriptor(model_id, family),
+                &builtin_manifest_entry(model_id),
+                &settings_at(data_dir.path().to_path_buf()),
+            )
+            .expect_err("a missing codec must fail the job before the engine load");
+
+            let WorkerError::InvalidPayload(message) = error else {
+                panic!("{model_id}: a missing codec must surface as InvalidPayload, got {error:?}");
+            };
+            assert!(
+                message.contains("codec") && message.contains(repo),
+                "{model_id}: the error must name the `codec` component + its repo BEFORE engine load, \
+                 got: {message}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## What & why (sc-13681)

Counterpart of inference **sc-13662** (same-PR pairing). Bumps the inference pin to `58d90993`, where `candle-audio-moss-tts` (MOSS-TTSD v0.5) and `candle-audio-moss-tts-realtime` advertise `required_components: ["codec"]` and **no longer self-fetch the codec at synthesize time** — the caller now stages it as the `codec` component. This wires the SceneWorks catalog + worker seam to provision that codec.

## Re-validation of the (stale) story premise

The story text said "NO MOSS TTS catalog entry exists (grep=0)". That is **stale**: sc-13675 (`moss_tts_realtime`) and sc-13676 (`moss_ttsd_v05`) both shipped after that sweep. Current catalog state:

| model_id | provider (inference) | `required_components` @ 58d90993 | codec coReq |
| --- | --- | --- | --- |
| `moss_ttsd_v05` | `candle-audio-moss-tts` | `["codec"]` | `XY_Tokenizer_TTSD_V0` |
| `moss_tts_realtime` | `candle-audio-moss-tts-realtime` | `["codec"]` | `MOSS-Audio-Tokenizer` |
| `moss_sfx_v2` | `candle-audio-moss-sfx` | `[]` (no codec) | — |

So this is **not** a net-new catalog add — both entries already carried the primary + a pinned codec `coRequisite` (`coRequisite: true` + full-SHA `revision`). What was missing is the `componentId: "codec"` tag the generic `resolve_co_requisites` seam matches against the descriptor. **Bumping the pin without this would break MOSS renders** (codec now required, unprovisioned). No net-new entry was created; no shipped primary pin was changed.

## Changes

- **Pin bump** `9cb24922 → 58d90993` via `npm run bump:inference --sha <full40>` (all 4 Cargo sites + Cargo.lock; self-test PASS; forward-bump confirmed).
- **Catalog**: add `componentId: "codec"` to both MOSS codec coRequisites; reconcile the stale "provider self-fetches at generate time" comments to the worker-seam model.
- **Licenses** (About → Licenses, `apps/desktop/licenses/`): add entries for all four upstream repos — `MOSS-TTSD-v0.5`, `XY_Tokenizer_TTSD_V0`, `MOSS-TTS-Realtime`, `MOSS-Audio-Tokenizer` — all Apache-2.0 (verified via the HF API).
- **Tests**: assert `componentId: "codec"` on both codec coReqs in the seeded-audio manifest test; add worker seam tests (bound to the **live** manifest) that resolve the codec for both MOSS entries and assert a missing codec fails with an actionable error naming `codec` + repo **before** engine load.

## Seam reuse

MOSS rides the existing generic seam untouched: `run_audio_synthesis_using` → `resolve_co_requisites(descriptor, manifest_entry)` → `LoadSpec::with_component("codec", …)`. No seam changes.

## DoD split (honest)

Joint DoD: "MOSS batch + realtime renders with custom HF cache + offline; install-state gates on codec presence."

- **Verified here**: install-state gating + missing-codec-at-load actionable error (2 new worker tests, live-manifest-bound); `componentId ↔ required_components` resolution for both MOSS entries. All four pinned-SHA snapshots (AR + codec) are present on the dev machine with exactly the declared files, so **offline resolution is provable**.
- **Deferred to sc-13686**: a real end-to-end backend-candle render was **not** run this session — it needs a heavy `--features backend-candle` worker build + long CPU inference and is the inference-side render capability validated by sc-13662's conformance suite. Not faked.

## Checks

- `npm run rust:check` green (fmt + clippy + test + build; 2 new + 1 extended test pass).
- Python manifest audit green (26 passed).
- `LicensesScreen` vitest green (6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
