### PR TITLE
chore(audio): catalog mmaudio + whisper-base + CLAP with pins + licenses [sc-13684]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "image",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "cudaforge",
 ]
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4035,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4059,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4106,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4213,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4308,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "core-llm",
  "half",
@@ -4620,7 +4620,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6156,7 +6156,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=58d9099303e431fa43ef83a9d96050e5f53bfcfe#58d9099303e431fa43ef83a9d96050e5f53bfcfe"
+source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8574,7 +8574,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811" }

--- a/apps/desktop/licenses/clap-htsat-unfused/Apache-2.0.txt
+++ b/apps/desktop/licenses/clap-htsat-unfused/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -199,6 +199,44 @@
       "documents": [
         { "label": "Apache License 2.0", "key": "moss-audio-tokenizer-apache" }
       ]
+    },
+    {
+      "id": "mmaudio",
+      "name": "MMAudio (video→audio / Foley)",
+      "publisher": "MMAudio / Sony Research · Apple · NVIDIA · V. Iashin",
+      "license": "Research / Non-Commercial (CC-BY-NC-4.0 · Apple ML Research · MIT)",
+      "homepage": "https://huggingface.co/hkchengrex/MMAudio",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Video→audio (Foley) model — RESEARCH / NON-COMMERCIAL USE ONLY. SceneWorks downloads on first use a five-checkpoint assembly across three repos: the MM-DiT / mel-VAE / in-repo BigVGAN weights (hkchengrex/MMAudio — CC-BY-NC-4.0, © Sony Research Inc.) with a bundled MIT Synchformer encoder (© V. Iashin), the DFN5B-CLIP conditioner (apple/DFN5B-CLIP-ViT-H-14-384 — Apple ML Research Model License, research-only), and the 44.1 kHz tier's external NVIDIA BigVGAN v2 vocoder (nvidia/bigvgan_v2_44khz_128band_512x — MIT). The EFFECTIVE license is the intersection (strictest) of these: research / non-commercial only, gated by the Apple ML Research license. SceneWorks is non-commercial, so the weights are usable, but this restriction is recorded and surfaced here — a legal read is warranted before any commercial use.",
+      "documents": [
+        { "label": "Creative Commons BY-NC 4.0 (MMAudio MM-DiT / VAE / BigVGAN weights)", "key": "mmaudio-cc-by-nc" },
+        { "label": "Apple ML Research Model License (DFN5B-CLIP conditioner — research-only)", "key": "mmaudio-apple-amlr" },
+        { "label": "MIT License (NVIDIA BigVGAN v2 vocoder, 44.1 kHz tier)", "key": "mmaudio-bigvgan-mit" }
+      ]
+    },
+    {
+      "id": "whisper-base",
+      "name": "Whisper base (ASR)",
+      "publisher": "OpenAI",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/openai/whisper-base",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Speech-to-text transcriber used as a utility dependency for audio validation / ASR round-trip checks (not a generation model). SceneWorks downloads the upstream Apache-2.0 weights on first use from openai/whisper-base and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "whisper-base-apache" }
+      ]
+    },
+    {
+      "id": "clap-htsat-unfused",
+      "name": "CLAP HTSAT-unfused (audio embedder)",
+      "publisher": "LAION",
+      "license": "Apache-2.0",
+      "homepage": "https://huggingface.co/laion/clap-htsat-unfused",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Joint audio-text embedding model used as a utility dependency for semantic audio validation (audio↔text similarity) — not a generation model. SceneWorks downloads the upstream Apache-2.0 weights on first use from laion/clap-htsat-unfused and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by Apache-2.0. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "Apache License 2.0", "key": "clap-htsat-unfused-apache" }
+      ]
     }
   ]
 }

--- a/apps/desktop/licenses/mmaudio/Apple-ML-Research-License.txt
+++ b/apps/desktop/licenses/mmaudio/Apple-ML-Research-License.txt
@@ -1,0 +1,20 @@
+DFN5B-CLIP conditioner — Apple Machine Learning Research Model License
+======================================================================
+
+MMAudio's semantic conditioner is the DFN5B-CLIP ViT-H/14-384 encoder from
+apple/DFN5B-CLIP-ViT-H-14-384
+(https://huggingface.co/apple/DFN5B-CLIP-ViT-H-14-384), © Apple Inc. It is
+distributed under the
+
+  Apple Machine Learning Research Model License (apple-amlr)
+
+which limits use of the model and its outputs to SCIENTIFIC RESEARCH AND
+ACADEMIC DEVELOPMENT and EXCLUDES any commercial product or service. This is
+the STRICTEST of the licenses in the assembled MMAudio pipeline and is what
+makes the composite MMAudio model RESEARCH / NON-COMMERCIAL ONLY.
+
+The authoritative and complete terms are Apple's license, published with the
+model repository (the LICENSE file at the URL above); this notice records the
+research-only restriction and does not replace those terms. SceneWorks is
+non-commercial, so the weights are usable here, but the restriction MUST be
+surfaced. A legal read is warranted before any commercial use.

--- a/apps/desktop/licenses/mmaudio/CC-BY-NC-4.0.txt
+++ b/apps/desktop/licenses/mmaudio/CC-BY-NC-4.0.txt
@@ -1,0 +1,28 @@
+MMAudio checkpoints — Creative Commons Attribution-NonCommercial 4.0
+===================================================================
+
+The MMAudio video→audio (Foley) models SceneWorks downloads on first use
+(mmaudio_small_16k, mmaudio_large_44k) assemble several checkpoints from
+hkchengrex/MMAudio (https://huggingface.co/hkchengrex/MMAudio): the MM-DiT
+flow-matching networks (mmaudio_small_16k / mmaudio_large_44k_v2), the 16 kHz
+and 44.1 kHz mel-VAEs, and the 16 kHz in-repo BigVGAN vocoder. These are
+© Sony Research Inc. / MMAudio and released under the
+
+  Creative Commons Attribution-NonCommercial 4.0 International License
+  (CC-BY-NC-4.0): https://creativecommons.org/licenses/by-nc/4.0/legalcode
+
+RESEARCH / NON-COMMERCIAL ONLY. CC-BY-NC-4.0 permits sharing and adaptation
+for NON-COMMERCIAL purposes only, with attribution. The Synchformer visual
+encoder bundled in the same repo is separately MIT-licensed (© 2024 Vladimir
+Iashin). The DFN5B-CLIP conditioner the pipeline also requires carries Apple's
+own, stricter research-only license — see Apple-ML-Research-License.txt. The
+44.1 kHz tier's external NVIDIA BigVGAN v2 vocoder is MIT — see MIT.txt.
+
+The EFFECTIVE license of the assembled MMAudio model is the INTERSECTION
+(strictest terms) of its components: research / non-commercial use only.
+SceneWorks is non-commercial, so the weights are usable here, but this
+restriction MUST be surfaced. A legal read is warranted before any commercial
+use.
+
+The authoritative and complete terms are the license linked above; this notice
+records the obligation and does not replace it.

--- a/apps/desktop/licenses/mmaudio/MIT.txt
+++ b/apps/desktop/licenses/mmaudio/MIT.txt
@@ -1,0 +1,32 @@
+NVIDIA BigVGAN v2 vocoder — MIT License
+=======================================
+
+The MMAudio 44.1 kHz tier (mmaudio_large_44k) uses the external NVIDIA BigVGAN
+v2 vocoder from nvidia/bigvgan_v2_44khz_128band_512x
+(https://huggingface.co/nvidia/bigvgan_v2_44khz_128band_512x, bigvgan_generator.pt),
+which is © 2024 NVIDIA CORPORATION & AFFILIATES and released under the MIT
+License reproduced below. This component is permissive; the assembled MMAudio
+model's overall research / non-commercial restriction comes from its OTHER
+components (see CC-BY-NC-4.0.txt and Apple-ML-Research-License.txt).
+
+MIT License
+
+Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/licenses/whisper-base/Apache-2.0.txt
+++ b/apps/desktop/licenses/whisper-base/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1734,6 +1734,98 @@ mod download_receipt_tests {
         );
     }
 
+    /// sc-13684: MMAudio is a PURE 5-component assembly, so each tier catalogs a non-coRequisite `dit`
+    /// primary anchor plus FIVE hard component coRequisites (clip/synchformer/dit/vae/vocoder). Because
+    /// install-state gates on the hard coRequisites, an mmaudio tier stays not-installed until ALL five
+    /// component snapshots are present — even with the primary anchor on disk. Binds to the LIVE
+    /// builtin manifest so a dropped/renamed component coRequisite (or a lost pinned revision) fails here.
+    #[test]
+    fn mmaudio_install_state_gates_on_all_five_component_co_requisites() {
+        fn builtin_models_entry(model_id: &str) -> Value {
+            let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+                .iter()
+                .find(|(name, _)| *name == "builtin.models.jsonc")
+                .map(|(_, contents)| *contents)
+                .expect("builtin.models.jsonc present");
+            let manifest: Value =
+                serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
+                    .expect("builtin.models.jsonc parses");
+            manifest["models"]
+                .as_array()
+                .expect("models array")
+                .iter()
+                .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
+                .cloned()
+                .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
+        }
+
+        for model_id in ["mmaudio_small_16k", "mmaudio_large_44k"] {
+            let temp = tempfile::tempdir().unwrap();
+            let data_dir = temp.path();
+            let model = builtin_models_entry(model_id);
+
+            // Every component is a hard coRequisite, and mmaudio catalogs FIVE of them.
+            let co_requisites = model_co_requisite_downloads(&model);
+            assert_eq!(
+                co_requisites.len(),
+                5,
+                "{model_id}: MMAudio must catalog all five component coRequisites"
+            );
+
+            // Stage ONLY the primary anchor (the `dit` file) — no component coRequisite yet.
+            let context = model_download_context(&model).unwrap().unwrap();
+            let anchor_snapshot = huggingface_repo_cache_path(data_dir, &context.repo)
+                .unwrap()
+                .join("snapshots/eb13a1a98fdbec91753775c57b074ccdfc60587c");
+            std::fs::create_dir_all(&anchor_snapshot).unwrap();
+            for file in &context.files {
+                let path = anchor_snapshot.join(file);
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(path, b"weights").unwrap();
+            }
+
+            let missing = install_state_for(Some(context.clone()), &model, data_dir);
+            assert!(
+                !missing.installed,
+                "{model_id}: a present anchor with the five components absent must not report installed"
+            );
+            assert!(
+                missing.cache_incomplete,
+                "{model_id}: missing hard component coRequisites make this a repairable partial install"
+            );
+
+            // Stage every component coRequisite at its pinned snapshot → install-state flips to installed.
+            for co_requisite in &co_requisites {
+                let repo = co_requisite.get("repo").and_then(Value::as_str).unwrap();
+                let revision = co_requisite
+                    .get("revision")
+                    .and_then(Value::as_str)
+                    .unwrap();
+                let snapshot = huggingface_repo_cache_path(data_dir, repo)
+                    .unwrap()
+                    .join("snapshots")
+                    .join(revision);
+                std::fs::create_dir_all(&snapshot).unwrap();
+                for file in string_array_field(co_requisite, "files") {
+                    let path = snapshot.join(&file);
+                    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                    std::fs::write(path, b"weights").unwrap();
+                }
+            }
+
+            let installed = install_state_for(Some(context), &model, data_dir);
+            assert!(
+                installed.installed,
+                "{model_id}: anchor + all five component coRequisites present must report installed"
+            );
+            assert!(
+                installed.missing_required_files.is_empty(),
+                "{model_id}: nothing is missing once every component is staged, got {:?}",
+                installed.missing_required_files
+            );
+        }
+    }
+
     /// sc-13682: the three SDXL shared components (CLIP-L/bigG tokenizers + fp16-fix VAE) are declared as
     /// candle-only (`platforms: [windows, linux]`) hard co-requisites on every candle-SDXL base +
     /// InstantID. On macOS `retain_downloads_for_os` strips them, so the self-contained MLX turnkey's

--- a/apps/web/public/prompt-guides/clap-htsat-unfused.md
+++ b/apps/web/public/prompt-guides/clap-htsat-unfused.md
@@ -1,0 +1,11 @@
+# CLAP HTSAT (audio embedder)
+
+LAION CLAP (HTSAT-unfused) is a joint audio-text embedding model. SceneWorks uses it as a small utility dependency — **it does not generate audio, and there is nothing to prompt.** It backs semantic audio validation: embedding an audio clip and a text description into one space to measure how well they match.
+
+## Installation
+
+Install once from the **Models** screen; it downloads the pinned `laion/clap-htsat-unfused` snapshot into the shared Hugging Face cache. The native worker loads it from that cached snapshot — it is never fetched mid-job.
+
+## Practical Notes
+
+There are no settings — the embedder runs automatically as part of audio validation. Apache-2.0, commercial-use OK.

--- a/apps/web/public/prompt-guides/mmaudio.md
+++ b/apps/web/public/prompt-guides/mmaudio.md
@@ -1,0 +1,13 @@
+# MMAudio (video→audio / Foley)
+
+MMAudio generates a **synchronized soundtrack for a silent video clip** (Foley). It is a pure five-component assembly — a DFN5B-CLIP semantic conditioner and a Synchformer frame-sync conditioner drive an MM-DiT flow-matching generator, decoded to a waveform by a mel-VAE + BigVGAN vocoder. Two tiers ship: **16 kHz (small)** and the **44.1 kHz (large)** quality ceiling.
+
+> **Research / non-commercial use only.** The assembled model's effective license is the intersection of its parts — CC-BY-NC-4.0 on the MMAudio checkpoints and the Apple ML Research Model License on the DFN5B-CLIP conditioner (the 44.1 kHz NVIDIA BigVGAN v2 vocoder is MIT). See **About → Licenses**. SceneWorks is non-commercial, so the weights are usable here, but the restriction is recorded and surfaced.
+
+## Installation
+
+Install from the **Models** screen. Each tier downloads its five components — the DFN5B-CLIP conditioner (`apple/DFN5B-CLIP-ViT-H-14-384`), the Synchformer / MM-DiT / mel-VAE weights (`hkchengrex/MMAudio`), and the vocoder (the in-repo BigVGAN for 16 kHz, or the external `nvidia/bigvgan_v2_44khz_128band_512x` for 44.1 kHz). Everything is pinned to exact revisions for a reproducible, offline-resolvable install.
+
+## Practical Notes
+
+There is nothing to prompt directly — MMAudio conditions on a video's frames (an optional text hint is supported by the model). The user-facing video→audio render lands in a later update; today the model is catalogued so it is installable and its components are provisioned for the rendering path.

--- a/apps/web/public/prompt-guides/whisper-base.md
+++ b/apps/web/public/prompt-guides/whisper-base.md
@@ -1,0 +1,11 @@
+# Whisper base (ASR)
+
+OpenAI Whisper base is a speech-to-text transcriber. SceneWorks uses it as a small utility dependency — **it does not generate audio, and there is nothing to prompt.** It backs audio-validation and ASR round-trip checks (transcribing generated speech to confirm it matches the requested text).
+
+## Installation
+
+Install once from the **Models** screen; it downloads the pinned `openai/whisper-base` snapshot into the shared Hugging Face cache, so other tools reuse it. The native worker loads it from that cached snapshot — it is never fetched mid-job.
+
+## Practical Notes
+
+There are no settings — the transcriber runs automatically as part of audio validation. Apache-2.0, commercial-use OK.

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -37,6 +37,15 @@ import mossTtsdApache from "../../../desktop/licenses/moss-ttsd-v05/Apache-2.0.t
 import xyTokenizerApache from "../../../desktop/licenses/xy-tokenizer-ttsd/Apache-2.0.txt?raw";
 import mossTtsRealtimeApache from "../../../desktop/licenses/moss-tts-realtime/Apache-2.0.txt?raw";
 import mossAudioTokenizerApache from "../../../desktop/licenses/moss-audio-tokenizer/Apache-2.0.txt?raw";
+// MMAudio video→audio (Foley) — RESEARCH / NON-COMMERCIAL only (epic 13678, sc-13684). Three upstream
+// licenses across three repos: CC-BY-NC-4.0 (hkchengrex/MMAudio weights), the Apple ML Research Model
+// License (apple/DFN5B-CLIP conditioner, the research-only gate), and MIT (nvidia/bigvgan_v2 44k vocoder).
+import mmaudioCcByNc from "../../../desktop/licenses/mmaudio/CC-BY-NC-4.0.txt?raw";
+import mmaudioAppleAmlr from "../../../desktop/licenses/mmaudio/Apple-ML-Research-License.txt?raw";
+import mmaudioBigvganMit from "../../../desktop/licenses/mmaudio/MIT.txt?raw";
+// Whisper base (ASR) + LAION CLAP (audio embedder) — Apache-2.0 audio-validation utility models (sc-13684).
+import whisperBaseApache from "../../../desktop/licenses/whisper-base/Apache-2.0.txt?raw";
+import clapHtsatApache from "../../../desktop/licenses/clap-htsat-unfused/Apache-2.0.txt?raw";
 
 // Maps a manifest document `key` to its imported text. New components: add the
 // files under apps/desktop/licenses/<id>/, list them in manifest.json, and wire
@@ -61,6 +70,11 @@ const DOCUMENT_TEXT = {
   "xy-tokenizer-ttsd-apache": xyTokenizerApache,
   "moss-tts-realtime-apache": mossTtsRealtimeApache,
   "moss-audio-tokenizer-apache": mossAudioTokenizerApache,
+  "mmaudio-cc-by-nc": mmaudioCcByNc,
+  "mmaudio-apple-amlr": mmaudioAppleAmlr,
+  "mmaudio-bigvgan-mit": mmaudioBigvganMit,
+  "whisper-base-apache": whisperBaseApache,
+  "clap-htsat-unfused-apache": clapHtsatApache,
 };
 
 // Resolve each component's document keys to its actual text once, at module load.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -9445,6 +9445,302 @@
           ]
         }
       }
+    },
+    {
+      // MMAudio video→audio (Foley) — 16 kHz "small" tier (mmaudio_small_16k). Inference sc-13666: the
+      // provider is a PURE 5-component assembly — `spec.weights` is UNUSED; it reads `clip` /
+      // `synchformer` / `dit` / `vae` / `vocoder` from `LoadSpec::components` via `require_component`.
+      // So EACH of the five checkpoints is provisioned by its OWN `coRequisite` download tagged with the
+      // matching `componentId`, and the worker's generic `resolve_co_requisites` seam (sc-13679) stages
+      // all five by id. The five span two repos: the DFN5B-CLIP conditioner (apple/DFN5B-CLIP-ViT-H-14-384)
+      // and synchformer/dit/vae + the in-repo BigVGAN vocoder (hkchengrex/MMAudio). The install/download
+      // flow requires ONE non-coRequisite primary anchor (`model_download()` returns None otherwise), yet
+      // mmaudio has no primary checkpoint — so the `dit` network doubles as the anchor (the most-primary
+      // component). Its bytes are counted once via the identical `dit` coRequisite below, so the anchor
+      // carries NO footprint (avoids double-counting the aggregate download size). type:"utility" because
+      // mmaudio is provisioning-ready but has NO SceneWorks video→audio job path yet (the user-facing
+      // render is a future epic-12833 story and runs on the inference real-weights lane) — utility keeps
+      // it installable via Model Manager without falsely surfacing it in the Audio Studio SFX picker
+      // (which requires type:"audio"). RESEARCH / NON-COMMERCIAL only (Apple ML Research + CC-BY-NC-4.0);
+      // see About → Licenses. sc-13684 (pairs with inference sc-13666).
+      "id": "mmaudio_small_16k",
+      "autoDownload": false,
+      "name": "MMAudio 16 kHz (video→audio, small)",
+      "family": "mmaudio",
+      "type": "utility",
+      "capabilities": [],
+      "downloads": [
+        {
+          // Primary anchor: the small_16k MM-DiT network (the most-primary component). mmaudio's
+          // `spec.weights` is UNUSED (pure component assembly), so this exists ONLY to satisfy the
+          // install/download flow's non-coRequisite-primary requirement + provide the model dir. Its
+          // bytes are counted once via the identical `dit` coRequisite below — footprint omitted here so
+          // the aggregate download size is not double-counted.
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "files": ["weights/mmaudio_small_16k.pth"],
+          "platforms": ["macos", "windows", "linux"]
+        },
+        {
+          "provider": "huggingface",
+          "repo": "apple/DFN5B-CLIP-ViT-H-14-384",
+          "revision": "01b771ed0d1395ca5ffdd279897d665ebe00dfd2",
+          "coRequisite": true,
+          "componentId": "clip",
+          "files": ["open_clip_pytorch_model.bin"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 3947081637,
+          "footprint": { "diskSizeBytes": 3947081637 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "coRequisite": true,
+          "componentId": "synchformer",
+          "files": ["ext_weights/synchformer_state_dict.pth"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 950058171,
+          "footprint": { "diskSizeBytes": 950058171 }
+        },
+        {
+          // The `dit` component — same file the primary anchor above pins; this is the entry the
+          // `resolve_co_requisites` seam matches on `componentId: "dit"` and the one that carries the
+          // footprint (so the aggregate size counts the DiT exactly once).
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "coRequisite": true,
+          "componentId": "dit",
+          "files": ["weights/mmaudio_small_16k.pth"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 629395261,
+          "footprint": { "diskSizeBytes": 629395261 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "coRequisite": true,
+          "componentId": "vae",
+          "files": ["ext_weights/v1-16.pth"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 686652758,
+          "footprint": { "diskSizeBytes": 686652758 }
+        },
+        {
+          // 16k in-repo BigVGAN vocoder (best_netG.pt) from hkchengrex/MMAudio — the 44k tier swaps this
+          // for the external nvidia/bigvgan_v2 vocoder.
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "coRequisite": true,
+          "componentId": "vocoder",
+          "files": ["ext_weights/best_netG.pt"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 449217313,
+          "footprint": { "diskSizeBytes": 449217313 }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/hkchengrex/MMAudio"
+      },
+      "licenseUrl": "https://huggingface.co/hkchengrex/MMAudio",
+      "ui": {
+        "label": "MMAudio 16 kHz (video→audio)",
+        "description": "MMAudio video→audio (Foley) — generates a synchronized 16 kHz soundtrack for a silent video clip. A pure 5-component assembly: DFN5B-CLIP + Synchformer conditioners → MM-DiT flow-matching → mel-VAE + BigVGAN vocoder. RESEARCH / NON-COMMERCIAL use only (Apple ML Research license on the CLIP conditioner + CC-BY-NC-4.0 on the MMAudio checkpoints). Provisioning-ready — the user-facing video→audio render lands in a later update.",
+        "recommendedFor": [],
+        "promptGuide": {
+          "title": "MMAudio (video→audio) Guide",
+          "path": "/prompt-guides/mmaudio.md",
+          "sources": [
+            { "label": "MMAudio (Hugging Face)", "url": "https://huggingface.co/hkchengrex/MMAudio" }
+          ]
+        }
+      }
+    },
+    {
+      // MMAudio video→audio (Foley) — 44.1 kHz "large" quality-ceiling tier (mmaudio_large_44k). Same
+      // 5-component contract as the 16k tier (see mmaudio_small_16k above): `dit` doubles as the primary
+      // anchor, the five components are provisioned as `componentId`-tagged coRequisites the generic
+      // `resolve_co_requisites` seam stages by id. Differences vs 16k (inference generator_44k::load):
+      // `clip` + `synchformer` are the SAME shared checkpoints; `dit` = weights/mmaudio_large_44k_v2.pth,
+      // `vae` = ext_weights/v1-44.pth, and `vocoder` = the EXTERNAL nvidia/bigvgan_v2_44khz_128band_512x
+      // (bigvgan_generator.pt) rather than the in-repo BigVGAN. RESEARCH / NON-COMMERCIAL only. type:
+      // "utility" for the same reason as the 16k tier. sc-13684 (pairs with inference sc-13666).
+      "id": "mmaudio_large_44k",
+      "autoDownload": false,
+      "name": "MMAudio 44.1 kHz (video→audio, large)",
+      "family": "mmaudio",
+      "type": "utility",
+      "capabilities": [],
+      "downloads": [
+        {
+          // Primary anchor: the large_44k_v2 MM-DiT network. See the 16k tier's anchor note — footprint
+          // omitted; carried once by the `dit` coRequisite below.
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "files": ["weights/mmaudio_large_44k_v2.pth"],
+          "platforms": ["macos", "windows", "linux"]
+        },
+        {
+          "provider": "huggingface",
+          "repo": "apple/DFN5B-CLIP-ViT-H-14-384",
+          "revision": "01b771ed0d1395ca5ffdd279897d665ebe00dfd2",
+          "coRequisite": true,
+          "componentId": "clip",
+          "files": ["open_clip_pytorch_model.bin"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 3947081637,
+          "footprint": { "diskSizeBytes": 3947081637 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "coRequisite": true,
+          "componentId": "synchformer",
+          "files": ["ext_weights/synchformer_state_dict.pth"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 950058171,
+          "footprint": { "diskSizeBytes": 950058171 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "coRequisite": true,
+          "componentId": "dit",
+          "files": ["weights/mmaudio_large_44k_v2.pth"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 4122474715,
+          "footprint": { "diskSizeBytes": 4122474715 }
+        },
+        {
+          "provider": "huggingface",
+          "repo": "hkchengrex/MMAudio",
+          "revision": "eb13a1a98fdbec91753775c57b074ccdfc60587c",
+          "coRequisite": true,
+          "componentId": "vae",
+          "files": ["ext_weights/v1-44.pth"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 1221942998,
+          "footprint": { "diskSizeBytes": 1221942998 }
+        },
+        {
+          // 44k vocoder — the EXTERNAL NVIDIA BigVGAN v2 (bigvgan_generator.pt), its own repo + pinned
+          // revision (MIT). This is the one component whose repo differs from the 16k tier.
+          "provider": "huggingface",
+          "repo": "nvidia/bigvgan_v2_44khz_128band_512x",
+          "revision": "95a9d1dcb12906c03edd938d77b9333d6ded7dfb",
+          "coRequisite": true,
+          "componentId": "vocoder",
+          "files": ["bigvgan_generator.pt"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 489041291,
+          "footprint": { "diskSizeBytes": 489041291 }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/hkchengrex/MMAudio"
+      },
+      "licenseUrl": "https://huggingface.co/hkchengrex/MMAudio",
+      "ui": {
+        "label": "MMAudio 44.1 kHz (video→audio)",
+        "description": "MMAudio video→audio (Foley) — the 44.1 kHz quality-ceiling tier. Same pipeline as the 16 kHz model with the larger large_44k_v2 MM-DiT, the 44k mel-VAE, and the external NVIDIA BigVGAN v2 vocoder. RESEARCH / NON-COMMERCIAL use only (Apple ML Research + CC-BY-NC-4.0; the NVIDIA vocoder is MIT). Provisioning-ready — the user-facing video→audio render lands in a later update.",
+        "recommendedFor": [],
+        "promptGuide": {
+          "title": "MMAudio (video→audio) Guide",
+          "path": "/prompt-guides/mmaudio.md",
+          "sources": [
+            { "label": "MMAudio (Hugging Face)", "url": "https://huggingface.co/hkchengrex/MMAudio" }
+          ]
+        }
+      }
+    },
+    {
+      // OpenAI Whisper base — ASR transcriber (audio→text). Inference sc-12850: a candle Transcriber
+      // (candle-audio-whisper) that loads config.json + tokenizer.json + model.safetensors from a
+      // passed-in snapshot dir (LoadSpec::weights) — NEVER self-resolved by inference. Cataloged here so
+      // it is installable + pinned; it backs audio-validation / ASR round-trip gates (sc-13433). No
+      // SceneWorks generation job consumes it today (the validation harness lives on the inference
+      // real-weights lane), so it is provisioning-ready. type:"utility" (a validation dependency, not a
+      // generation model). Apache-2.0. sc-13684.
+      "id": "whisper_base",
+      "autoDownload": false,
+      "name": "Whisper base (ASR)",
+      "family": "whisper",
+      "type": "utility",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "openai/whisper-base",
+          "revision": "e37978b90ca9030d5170a5c07aadb050351a65bb",
+          "files": ["config.json", "tokenizer.json", "model.safetensors"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 292886385,
+          "footprint": { "diskSizeBytes": 292886385 }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/openai/whisper-base"
+      },
+      "licenseUrl": "https://huggingface.co/openai/whisper-base",
+      "ui": {
+        "label": "Whisper base (ASR)",
+        "description": "OpenAI Whisper base speech-to-text transcriber. A small utility dependency used for audio validation / ASR round-trip checks — not a generation model. Apache-2.0, commercial-use OK.",
+        "recommendedFor": [],
+        "promptGuide": {
+          "title": "Whisper base (ASR)",
+          "path": "/prompt-guides/whisper-base.md",
+          "sources": [
+            { "label": "openai/whisper-base model card", "url": "https://huggingface.co/openai/whisper-base" }
+          ]
+        }
+      }
+    },
+    {
+      // LAION CLAP (HTSAT-unfused) — semantic audio↔text embedder. Inference sc-12851: a candle
+      // AudioEmbedder (candle-audio-clap) that loads config.json + tokenizer.json + pytorch_model.bin
+      // from a passed-in snapshot DIR (LoadSpec::weights → WeightsSource::Dir) — NEVER self-resolved.
+      // Cataloged for install + pinning; backs semantic audio validation (sc-13433). No SceneWorks
+      // generation job consumes it today — provisioning-ready. type:"utility". Apache-2.0. sc-13684.
+      "id": "clap_htsat_unfused",
+      "autoDownload": false,
+      "name": "CLAP HTSAT (audio embedder)",
+      "family": "clap",
+      "type": "utility",
+      "capabilities": [],
+      "downloads": [
+        {
+          "provider": "huggingface",
+          "repo": "laion/clap-htsat-unfused",
+          "revision": "8fa0f1c6d0433df6e97c127f64b2a1d6c0dcda8a",
+          "files": ["config.json", "tokenizer.json", "pytorch_model.bin"],
+          "platforms": ["macos", "windows", "linux"],
+          "estimatedSizeBytes": 616639969,
+          "footprint": { "diskSizeBytes": 616639969 }
+        }
+      ],
+      "paths": {
+        "model": "${HF_CACHE}/laion/clap-htsat-unfused"
+      },
+      "licenseUrl": "https://huggingface.co/laion/clap-htsat-unfused",
+      "ui": {
+        "label": "CLAP HTSAT (audio embedder)",
+        "description": "LAION CLAP (HTSAT-unfused) joint audio-text embedding model. A small utility dependency used for semantic audio validation (audio↔text similarity) — not a generation model. Apache-2.0, commercial-use OK.",
+        "recommendedFor": [],
+        "promptGuide": {
+          "title": "CLAP HTSAT (audio embedder)",
+          "path": "/prompt-guides/clap-htsat-unfused.md",
+          "sources": [
+            { "label": "laion/clap-htsat-unfused model card", "url": "https://huggingface.co/laion/clap-htsat-unfused" }
+          ]
+        }
+      }
     }
   ]
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "58d9099303e431fa43ef83a9d96050e5f53bfcfe", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -3546,6 +3546,12 @@ mod co_requisite_tests {
             .join(revision);
         std::fs::create_dir_all(&snapshot).expect("create snapshot dir");
         let path = snapshot.join(file);
+        // Some component files live under a subdir of the snapshot (mmaudio's `weights/…`,
+        // `ext_weights/…` — sc-13684); create the parent so the write succeeds. A no-op for the
+        // single-level component files (ve.safetensors, tokenizer.json) whose parent is the snapshot.
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create component parent dir");
+        }
         std::fs::write(&path, b"weights").expect("write staged component file");
         path
     }
@@ -3913,6 +3919,184 @@ mod co_requisite_tests {
                 message.contains("codec") && message.contains(repo),
                 "{model_id}: the error must name the `codec` component + its repo BEFORE engine load, \
                  got: {message}"
+            );
+        }
+    }
+
+    // --- MMAudio video→audio 5-component assembly (epic 13678, sc-13684) ------------------------------
+
+    /// A candle MMAudio generator descriptor shape at the inference pin: it advertises the FIVE
+    /// caller-staged components mmaudio assembles (`candle-audio-mmaudio` `generator::REQUIRED_COMPONENTS`
+    /// / `generator_44k` both declare `required_components: &["clip", "synchformer", "dit", "vae",
+    /// "vocoder"]`). mmaudio is a PURE assembly — `spec.weights` is unused — so ALL FIVE must resolve
+    /// from `componentId`-tagged coRequisites via the generic `resolve_co_requisites` seam.
+    fn mmaudio_descriptor(id: &'static str) -> gen_core::ModelDescriptor {
+        gen_core::ModelDescriptor {
+            id,
+            family: "mmaudio",
+            backend: "candle",
+            modality: gen_core::Modality::Audio,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &["clip", "synchformer", "dit", "vae", "vocoder"],
+        }
+    }
+
+    /// `(model_id, [(componentId, repo, pinned revision, file)])` — the exact five component snapshots
+    /// each SHIPPED MMAudio tier pins (sc-13684). Binds these tests to the LIVE `builtin.models.jsonc`,
+    /// so a dropped component coRequisite or a `componentId` that stops matching the descriptor's
+    /// `required_components` fails HERE, not silently at a future video→audio render. The 44k tier shares
+    /// `clip` + `synchformer`, has its own `dit`/`vae`, and swaps the in-repo 16k BigVGAN `vocoder` for
+    /// the external NVIDIA BigVGAN v2 repo.
+    #[allow(clippy::type_complexity)]
+    fn mmaudio_component_snapshots() -> Vec<(
+        &'static str,
+        Vec<(&'static str, &'static str, &'static str, &'static str)>,
+    )> {
+        const MMAUDIO_REV: &str = "eb13a1a98fdbec91753775c57b074ccdfc60587c";
+        const CLIP: (&str, &str, &str, &str) = (
+            "clip",
+            "apple/DFN5B-CLIP-ViT-H-14-384",
+            "01b771ed0d1395ca5ffdd279897d665ebe00dfd2",
+            "open_clip_pytorch_model.bin",
+        );
+        let synchformer = (
+            "synchformer",
+            "hkchengrex/MMAudio",
+            MMAUDIO_REV,
+            "ext_weights/synchformer_state_dict.pth",
+        );
+        vec![
+            (
+                "mmaudio_small_16k",
+                vec![
+                    CLIP,
+                    synchformer,
+                    (
+                        "dit",
+                        "hkchengrex/MMAudio",
+                        MMAUDIO_REV,
+                        "weights/mmaudio_small_16k.pth",
+                    ),
+                    (
+                        "vae",
+                        "hkchengrex/MMAudio",
+                        MMAUDIO_REV,
+                        "ext_weights/v1-16.pth",
+                    ),
+                    (
+                        "vocoder",
+                        "hkchengrex/MMAudio",
+                        MMAUDIO_REV,
+                        "ext_weights/best_netG.pt",
+                    ),
+                ],
+            ),
+            (
+                "mmaudio_large_44k",
+                vec![
+                    CLIP,
+                    synchformer,
+                    (
+                        "dit",
+                        "hkchengrex/MMAudio",
+                        MMAUDIO_REV,
+                        "weights/mmaudio_large_44k_v2.pth",
+                    ),
+                    (
+                        "vae",
+                        "hkchengrex/MMAudio",
+                        MMAUDIO_REV,
+                        "ext_weights/v1-44.pth",
+                    ),
+                    (
+                        "vocoder",
+                        "nvidia/bigvgan_v2_44khz_128band_512x",
+                        "95a9d1dcb12906c03edd938d77b9333d6ded7dfb",
+                        "bigvgan_generator.pt",
+                    ),
+                ],
+            ),
+        ]
+    }
+
+    #[test]
+    fn mmaudio_co_requisites_resolve_all_five_components_from_every_live_tier() {
+        for (model_id, components) in mmaudio_component_snapshots() {
+            let _env = isolate_hf_cache();
+            let data_dir = tempfile::tempdir().expect("temp data dir");
+            for (_id, repo, revision, file) in &components {
+                stage_snapshot_file(data_dir.path(), repo, revision, file);
+            }
+
+            let resolved = resolve_co_requisites(
+                &mmaudio_descriptor(model_id),
+                &builtin_manifest_entry(model_id),
+                &settings_at(data_dir.path().to_path_buf()),
+            )
+            .unwrap_or_else(|error| {
+                panic!("{model_id}: all five components are staged, so resolution must succeed: {error:?}")
+            });
+
+            // The map keys are EXACTLY the descriptor's five advertised ids (order-independent BTreeMap).
+            let mut keys: Vec<&str> = resolved.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            let mut want = mmaudio_descriptor(model_id).required_components.to_vec();
+            want.sort_unstable();
+            assert_eq!(
+                keys, want,
+                "{model_id}: the component map keys must match the descriptor's required_components"
+            );
+            // Each single-file component resolves to a `File` at the staged snapshot path — the exact
+            // file the tier's `componentId` download pins (matched on `componentId`, never repo name).
+            for (id, _repo, _revision, file) in &components {
+                match resolved.get(*id) {
+                    Some(gen_core::WeightsSource::File(path)) => assert!(
+                        path.ends_with(file),
+                        "{model_id}: component `{id}` must resolve to {file}, got {path:?}"
+                    ),
+                    other => {
+                        panic!("{model_id}: component `{id}` must resolve to a File, got {other:?}")
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_missing_mmaudio_component_fails_with_an_actionable_error_naming_id_and_repo() {
+        for (model_id, components) in mmaudio_component_snapshots() {
+            let _env = isolate_hf_cache();
+            let data_dir = tempfile::tempdir().expect("temp data dir");
+            // Stage every component EXCEPT the vocoder, whose snapshot is ABSENT — install-state gates on
+            // the hard component coRequisites, so the job must fail HERE (before the engine load), naming
+            // the missing id + its repo, not with a mid-render hub fetch.
+            let (_vid, vocoder_repo, _vrev, _vfile) = *components
+                .iter()
+                .find(|(id, _, _, _)| *id == "vocoder")
+                .expect("vocoder component present");
+            for (id, repo, revision, file) in &components {
+                if *id == "vocoder" {
+                    continue;
+                }
+                stage_snapshot_file(data_dir.path(), repo, revision, file);
+            }
+
+            let error = resolve_co_requisites(
+                &mmaudio_descriptor(model_id),
+                &builtin_manifest_entry(model_id),
+                &settings_at(data_dir.path().to_path_buf()),
+            )
+            .expect_err("a missing mmaudio component must fail the job before the engine load");
+
+            let WorkerError::InvalidPayload(message) = error else {
+                panic!(
+                    "{model_id}: a missing component must surface as InvalidPayload, got {error:?}"
+                );
+            };
+            assert!(
+                message.contains("vocoder") && message.contains(vocoder_repo),
+                "{model_id}: the error must name the missing `vocoder` component + its repo BEFORE engine \
+                 load, got: {message}"
             );
         }
     }


### PR DESCRIPTION
Catalogs the three previously-unhomed auto-downloaded audio dependencies and bumps the inference pin. Pairs with **inference sc-13666** (which component-izes mmaudio and defines the `clip`/`synchformer`/`dit`/`vae`/`vocoder` component ids this manifest feeds).

## Pin bump
`58d90993` → `175cbea3` (inference sc-13666 merge). Forward bump; the `58d90993..175cbea3` delta is **candle-audio-mmaudio only** (no other provider gained a non-empty `required_components`). 4 Cargo sites + Cargo.lock, `bump:inference:self-test` PASS.

## Manifest-shape decisions (report)
**mmaudio is a pure 5-component assembly** — inference `spec.weights` is unused; `load` reads all five from `LoadSpec::components` via `require_component`. The generic `resolve_co_requisites` seam matches components **only** on `coRequisite:true` + `componentId`, so:

- Each mmaudio tier declares its **5 components as `coRequisite:true` downloads**, each tagged with its `componentId` + pinned `revision` + real `footprint` (from the HF tree API).
- `apps/rust-api` install/download requires **one non-coRequisite primary** (`model_download()` returns `None` otherwise), yet mmaudio has no primary checkpoint. Resolution: the **`dit` network doubles as the primary anchor** — its footprint is omitted (carried once by the identical `dit` coReq) so the aggregate download size isn't double-counted. **The seam is left unmodified — mmaudio rides it.**
- Per tier (16k / 44k): `clip`=apple/DFN5B `open_clip_pytorch_model.bin`; `synchformer`=hkchengrex `ext_weights/synchformer_state_dict.pth` (shared); `dit`=`weights/mmaudio_small_16k.pth` / `weights/mmaudio_large_44k_v2.pth`; `vae`=`ext_weights/v1-16.pth` / `ext_weights/v1-44.pth`; `vocoder`=hkchengrex `ext_weights/best_netG.pt` (16k in-repo BigVGAN) / **nvidia** `bigvgan_generator.pt` (44k external).
- **`type:"utility"`, not `type:"audio"`**: mmaudio is video→audio with **no SceneWorks job path yet** (future epic-12833; the real render runs on the inference real-weights lane). `audioModelUsable` would otherwise surface it in the Audio Studio SFX picker where it'd fail. Utility keeps it installable via Model Manager without a broken picker entry. Flip to `type:"audio"` when the job path lands.

**whisper-base + CLAP = `type:"utility"`** (validation dependencies, not generation models). Both are single-dir models — inference `load(spec)` reads a passed-in `WeightsSource::Dir`, never self-resolves; `downloads.rs` (fully generic) provisions them. No SceneWorks consumer today → provisioning-ready.

## Licenses (About → Licenses)
One `mmaudio` component **flagged RESEARCH / NON-COMMERCIAL** with three docs — CC-BY-NC-4.0 (MMAudio weights), the **Apple ML Research Model License** (DFN5B-CLIP, the research-only gate, per the epic-12833 / sc-13493 decision), and MIT (NVIDIA BigVGAN v2) — plus `whisper-base` and `clap-htsat-unfused` (both Apache-2.0). All licenses verified via the HF API.

## Tests
- **mmaudio component-map seam** (both tiers resolve all five by `componentId` from the LIVE manifest; a missing component fails with an actionable error naming id + repo before the engine).
- **install-state gating** on all five hard coRequisites (both tiers).
- `rust:check` green (fmt + clippy + test + build against inference 175cbea3), Python manifest audit green, web LicensesScreen test green.

## DoD split
Manifest + pins + `componentId` provisioning + licenses + install-state gating + component-map resolution are **verified here**. A **real mmaudio video→audio render is real-weight + inference-only (sc-13666)** → deferred to the inference real-weight harness / **sc-13686**. No worker attach is wired (no job path exists) — the attach is **provisioning-ready** and rides the existing seam once a job path lands.

Refs sc-13684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)