### PR TITLE
chore(worker): formalize LTX gemma + PuLID identity + sensenova fast-LoRA provisioning at pin f3483f93 [sc-13683]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "hf-hub",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -553,7 +553,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -659,7 +659,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -672,7 +672,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -815,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -828,7 +828,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "image",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -967,7 +967,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "cudaforge",
 ]
@@ -1085,7 +1085,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3929,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4013,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4035,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4047,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4059,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4106,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4213,7 +4213,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4308,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "core-llm",
  "half",
@@ -4620,7 +4620,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6156,7 +6156,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=175cbea39bf1565c7b5a1892bc220be9957c4811#175cbea39bf1565c7b5a1892bc220be9957c4811"
+source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8574,7 +8574,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5" }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -6098,9 +6098,16 @@
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
           // Shared gemma-3-12b-it-bf16 text encoder (~26.4 GB); the worker points the engine at the
-          // sibling gemma/ (resolve_bundled_ltx_gemma_dir). Fetched with any tier, kept while any
-          // remains. Windows/Linux load Gemma from the resources.gemma repo instead, so macOS-only.
+          // sibling gemma/ (resolve_bundled_ltx_gemma_dir → LoadSpec::text_encoder). Fetched with any
+          // tier, kept while any remains. Windows/Linux load Gemma from the resources.gemma repo
+          // instead, so macOS-only. Pinned to the full 40-hex bundle commit (== the worker's
+          // LTX_BUNDLE_REVISION) so this first-install coRequisite download resolves the SAME
+          // snapshots/<sha>/ the worker's on-demand ensure_ltx_bundle_gemma_present fetches — one pinned
+          // snapshot, offline-clean. As of sc-13664 the MLX LTX provider REQUIRES this Gemma TE via
+          // LoadSpec::text_encoder (no $LTX_GEMMA_DIR / HF-cache fallback), so it MUST be provisioned;
+          // pinning keeps it reproducible + offline-resolvable.
           "coRequisite": true,
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "files": ["gemma/*"],
           "platforms": ["macos"],
           "estimatedSizeBytes": 26427894918

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -408,7 +408,8 @@ mod tests {
             "qwen_image",
             "SceneWorks/qwen-image-2512-fun-controlnet-union",
         ),
-        ("ltx_2_3", "SceneWorks/ltx-2.3-mlx"),
+        // ("ltx_2_3", "SceneWorks/ltx-2.3-mlx") pinned in sc-13683 (the gemma coRequisite now carries the
+        // full 40-hex LTX_BUNDLE_REVISION), so its migration row was removed here + in the Python twin.
         (
             "ltx_2_3_eros",
             "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "175cbea39bf1565c7b5a1892bc220be9957c4811", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/pulid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid.rs
@@ -9,9 +9,13 @@
 // What's bespoke is only the request mapping (a reference face → an
 // id-embedding via `Conditioning::Reference`, plus the PuLID-specific
 // `idWeight` / `timestepToStartCfg` knobs) and the weight provisioning: the
-// engine resolves the PuLID adapter + EVA tower + native face stack through its
-// env-var seam (`PULID_FLUX_WEIGHTS` / `PULID_EVA_WEIGHTS` /
-// `PULID_FACE_WEIGHTS_DIR`), which the worker fills from its cache here.
+// worker resolves the PuLID adapter + EVA tower + native face stack from its
+// cache and threads them onto the engine's typed `LoadSpec::identity`
+// {encoder, eva, face_dir} sub-slots (sc-8827 / F-025 — no process-global
+// `PULID_*` env mutation on the multithreaded runtime). As of sc-13664 the
+// `pulid_flux` loader REQUIRES those three identity sub-slots (no `PULID_*`
+// env / HF-cache fallback), so the worker's cache paths ARE the provisioning
+// path; each repo is pinned via `ensure_instantid_file` → `instantid_revision`.
 // ---------------------------------------------------------------------------
 
 /// SceneWorks model id for native PuLID-FLUX (FLUX.1-dev backbone + PuLID injection).

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -3987,6 +3987,11 @@ struct VideoGenInput {
     // `$LTX_GEMMA_DIR` env var (the old `set_var` seam was unsound on the multithreaded runtime,
     // F-025). `None` on every other model (they bundle their TE) and when no override resolves.
     text_encoder_dir: Option<PathBuf>,
+    /// LTX-only optional **amoral 4-bit Gemma enhancer** snapshot dir (sc-2845 `useUncensoredEnhancer`).
+    /// `Some` ⇒ staged in `LoadSpec::components["uncensored_enhancer"]` so the MLX LTX provider loads it
+    /// on demand when a request sets the flag (sc-13664 deleted the provider's `$LTX_UNCENSORED_GEMMA_DIR`
+    /// / HF-cache scan). `None` on every other model and when the enhancer is off or unprovisioned.
+    uncensored_enhancer_dir: Option<PathBuf>,
     /// In-place ComfyUI Wan MoE experts (epic 10451 Phase 2c, sc-10671). `Some` ⇒ [`generate_video`]
     /// takes the bespoke uncached load path (`load_from_comfyui_experts`) instead of the registry
     /// snapshot; `None` on every other job.
@@ -4036,6 +4041,7 @@ impl Default for VideoGenInput {
             conditioning_fps: None,
             softness: None,
             text_encoder_dir: None,
+            uncensored_enhancer_dir: None,
             comfyui: None,
             offload_policy: OffloadPolicy::Resident,
         }
@@ -4069,9 +4075,18 @@ fn video_load_spec(input: &VideoGenInput) -> LoadSpec {
         // 14B experts swap one-at-a-time and the load matches the SEQUENTIAL peak the manifest gate sized.
         // `apply_residency_policy` (the MLX cache seam) never downgrades a `Sequential` set here.
         offload_policy: input.offload_policy,
-        // Named model components (epic 13657): video providers advertise no `required_components`, so
-        // there is nothing to stage — an empty map keeps the video load path unchanged.
-        components: BTreeMap::new(),
+        // Named model components (epic 13657). Video providers advertise no `required_components`, so the
+        // map is empty by default. The one exception is LTX-2.3's OPTIONAL `uncensored_enhancer` (sc-2845
+        // / sc-13664): when a `useUncensoredEnhancer` job resolved the amoral 4-bit Gemma snapshot, stage
+        // it here so the provider loads it on demand instead of the deleted `$LTX_UNCENSORED_GEMMA_DIR` /
+        // HF-cache scan. Absent ⇒ empty map, the video load path unchanged.
+        components: input
+            .uncensored_enhancer_dir
+            .clone()
+            .map(|dir| {
+                BTreeMap::from([("uncensored_enhancer".to_owned(), WeightsSource::Dir(dir))])
+            })
+            .unwrap_or_default(),
     }
 }
 
@@ -8267,22 +8282,39 @@ fn bundled_ltx_gemma_dir(model_dir: &Path) -> Option<PathBuf> {
     gemma.is_dir().then_some(gemma)
 }
 
+/// The operator `$LTX_GEMMA_DIR` override as an existence-checked gemma snapshot path (pure over the
+/// raw env value so it is unit-testable without mutating the process-global env). As of sc-13664 the MLX
+/// LTX provider no longer reads this env itself — `LoadSpec::text_encoder` is the ONLY (now required) TE
+/// source — so the worker must resolve the override HERE and thread it onto the spec, rather than
+/// returning `None` and deferring to the deleted `$LTX_GEMMA_DIR` / HF-cache fallback. A set-but-incomplete
+/// override yields `None` so a good bundled / cache gemma still wins (a bad override never shadows it).
+#[cfg(target_os = "macos")]
+fn ltx_gemma_override_path(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let dir = PathBuf::from(raw?);
+    ltx_gemma_dir_is_complete(&dir).then_some(dir)
+}
+
+/// [`ltx_gemma_override_path`] applied to the live `$LTX_GEMMA_DIR`.
+#[cfg(target_os = "macos")]
+fn ltx_gemma_env_override() -> Option<PathBuf> {
+    ltx_gemma_override_path(std::env::var_os("LTX_GEMMA_DIR"))
+}
+
 /// Resolve the Gemma-3 text encoder bundled beside the resolved LTX dir (sc-5608), returning it so the
 /// caller can thread it onto `LoadSpec::text_encoder` (sc-8827) — a fresh install is self-contained (no
 /// separate `mlx-community/gemma` download) without mutating the process-global `$LTX_GEMMA_DIR` at job
-/// time on the multithreaded runtime (the old `set_var` seam was unsound, F-025). Best-effort +
-/// non-destructive: returns `None` when an explicit operator `$LTX_GEMMA_DIR` is set (the provider
-/// reads the env var itself), and `None` when no bundled `gemma/` sibling exists
-/// ([`bundled_ltx_gemma_dir`]) so the provider falls back to the HF-cache gemma snapshot.
+/// time on the multithreaded runtime (the old `set_var` seam was unsound, F-025). Resolution order: an
+/// operator `$LTX_GEMMA_DIR` override (existence-checked, [`ltx_gemma_env_override`]) — threaded onto the
+/// spec because the MLX provider dropped its own env read (sc-13664; the spec override already wins,
+/// sc-8827) — then the bundled `<parent>/gemma` sibling ([`bundled_ltx_gemma_dir`]). `None` only when
+/// neither resolves (a legacy local conversion with no co-located gemma), where the load now surfaces the
+/// provider's required-`LoadSpec::text_encoder` error rather than a silent HF-cache scan.
 ///
 /// `pub(crate)` so the LoRA trainer path reuses it (sc-9989): training resolves the TE identically to
 /// inference, so a self-contained install trains without a separate `mlx-community/gemma` download.
 #[cfg(target_os = "macos")]
 pub(crate) fn resolve_bundled_ltx_gemma_dir(model_dir: &Path) -> Option<PathBuf> {
-    if std::env::var_os("LTX_GEMMA_DIR").is_some() {
-        return None; // honor an explicit operator override (the provider reads the env var).
-    }
-    bundled_ltx_gemma_dir(model_dir)
+    ltx_gemma_env_override().or_else(|| bundled_ltx_gemma_dir(model_dir))
 }
 
 /// Resolve the Gemma-3 text encoder for an **eros** generation. Unlike the base model — whose turnkey
@@ -8290,13 +8322,16 @@ pub(crate) fn resolve_bundled_ltx_gemma_dir(model_dir: &Path) -> Option<PathBuf>
 /// is a bare local conversion under `models/mlx/ltx_2_3_eros/` with no bundled TE, so gemma is
 /// provisioned separately ([`ensure_ltx_gemma_present`]) and resolved here: a `models/mlx/gemma`
 /// sibling of the checkpoint (the `<parent>/gemma` convention [`bundled_ltx_gemma_dir`] already uses)
-/// first, then the fetched [`LTX_BUNDLE_REPO`] snapshot's `gemma/`. Returns `None` when an operator
-/// `$LTX_GEMMA_DIR` is set (the provider reads the env var) or nothing complete is on disk (the
-/// provider surfaces the clear "set LTX_GEMMA_DIR" error) — a partial dir never wins.
+/// first, then the fetched [`LTX_BUNDLE_REPO`] snapshot's `gemma/`. Resolution order: an operator
+/// `$LTX_GEMMA_DIR` override (existence-checked, [`ltx_gemma_env_override`]) — threaded onto the spec
+/// because the MLX provider dropped its own env read (sc-13664) — then the complete `<parent>/gemma`
+/// sibling, then the bundle snapshot's `gemma/`. `None` only when nothing complete is on disk (the
+/// provider then surfaces its required-`LoadSpec::text_encoder` error) — a partial dir never wins.
 #[cfg(target_os = "macos")]
 fn resolve_ltx_eros_gemma_dir(settings: &Settings, model_dir: &Path) -> Option<PathBuf> {
-    if std::env::var_os("LTX_GEMMA_DIR").is_some() {
-        return None; // honor an explicit operator override (the provider reads the env var).
+    if let Some(env_dir) = ltx_gemma_env_override() {
+        // Operator override rides the spec so it survives the sc-13664 provider env-read deletion.
+        return Some(env_dir);
     }
     if let Some(sibling) = bundled_ltx_gemma_dir(model_dir) {
         if ltx_gemma_dir_is_complete(&sibling) {
@@ -8305,6 +8340,34 @@ fn resolve_ltx_eros_gemma_dir(settings: &Settings, model_dir: &Path) -> Option<P
     }
     let bundle_gemma = huggingface_snapshot_dir(&settings.data_dir, LTX_BUNDLE_REPO)?.join("gemma");
     ltx_gemma_dir_is_complete(&bundle_gemma).then_some(bundle_gemma)
+}
+
+/// The amoral 4-bit Gemma prompt-enhancer snapshot the OPT-IN `useUncensoredEnhancer` path loads
+/// (sc-2845; the reference `--use-uncensored-enhancer`). A standalone mlx_lm checkpoint, distinct from
+/// the always-on Gemma TE. Not a first-class SceneWorks download (it is an uncataloged power-user
+/// opt-in — a manifest catalog entry with a pinned revision + license posture is a product decision,
+/// tracked separately); the worker resolves it only if the operator has staged it.
+#[cfg(target_os = "macos")]
+const LTX_UNCENSORED_GEMMA_REPO: &str = "TheCluster/amoral-gemma-3-12B-v2-mlx-4bit";
+
+/// Resolve the optional amoral 4-bit Gemma **enhancer** snapshot for a `useUncensoredEnhancer` LTX job
+/// (sc-2845), to be staged in `LoadSpec::components["uncensored_enhancer"]`. Mirrors the resolution the
+/// MLX LTX provider deleted at sc-13664 (moved into the worker): an operator `$LTX_UNCENSORED_GEMMA_DIR`
+/// override (existence-checked) wins, else the HF-cache snapshot for [`LTX_UNCENSORED_GEMMA_REPO`] if
+/// already on disk. `None` when neither resolves — the opt-in enhancer then surfaces the provider's
+/// actionable "provision the amoral snapshot" error rather than silently degrading. Reuses
+/// [`ltx_gemma_dir_is_complete`] (an mlx_lm gemma snapshot is `config.json` + shards, same shape as the
+/// TE), so a partial/half-downloaded dir never wins.
+#[cfg(target_os = "macos")]
+fn resolve_ltx_uncensored_enhancer_dir(settings: &Settings) -> Option<PathBuf> {
+    if let Some(raw) = std::env::var_os("LTX_UNCENSORED_GEMMA_DIR") {
+        let dir = PathBuf::from(raw);
+        if ltx_gemma_dir_is_complete(&dir) {
+            return Some(dir);
+        }
+    }
+    let snapshot = huggingface_snapshot_dir(&settings.data_dir, LTX_UNCENSORED_GEMMA_REPO)?;
+    ltx_gemma_dir_is_complete(&snapshot).then_some(snapshot)
 }
 
 /// On-demand fetch of the bundle's `q8/` subdir (sc-5679). The macOS default download is lean
@@ -9070,6 +9133,13 @@ async fn generate_ltx(
     } else {
         resolve_bundled_ltx_gemma_dir(&model_dir)
     };
+    // Optional amoral 4-bit Gemma enhancer (sc-2845): when the request opts in, resolve the staged
+    // amoral snapshot so it rides `LoadSpec::components["uncensored_enhancer"]` (sc-13664 deleted the
+    // provider's own `$LTX_UNCENSORED_GEMMA_DIR` / HF-cache scan). Off ⇒ `None`, no staging, no fetch.
+    let use_uncensored_enhancer = advanced::bool(&request.advanced, "useUncensoredEnhancer");
+    let uncensored_enhancer_dir = use_uncensored_enhancer
+        .then(|| resolve_ltx_uncensored_enhancer_dir(settings))
+        .flatten();
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -9090,10 +9160,11 @@ async fn generate_ltx(
         control_scale: None,
         video_mode,
         enhance_prompt: advanced::bool(&request.advanced, "enhancePrompt"),
-        use_uncensored_enhancer: advanced::bool(&request.advanced, "useUncensoredEnhancer"),
+        use_uncensored_enhancer,
         enhance_max_tokens,
         enhance_temperature,
         text_encoder_dir,
+        uncensored_enhancer_dir,
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, &request.advanced, input).await
@@ -17491,6 +17562,36 @@ mod tests {
         let _ = std::fs::remove_dir_all(&single);
     }
 
+    /// sc-13664: the operator `$LTX_GEMMA_DIR` override now RIDES `LoadSpec::text_encoder` (the MLX LTX
+    /// provider deleted its own env read), so the worker resolves it to a path instead of returning
+    /// `None` to defer to the deleted fallback. Pure over the raw env value (no process-global mutation):
+    /// a complete dir resolves to `Some`, an incomplete dir → `None` (a bad override never shadows a good
+    /// bundled/cache gemma), and an unset override → `None`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn ltx_gemma_override_path_requires_complete_dir() {
+        let complete =
+            std::env::temp_dir().join(format!("sw_gemma_ovr_ok_{}", Uuid::new_v4().simple()));
+        write_complete_gemma_dir(&complete);
+        assert_eq!(
+            ltx_gemma_override_path(Some(complete.clone().into_os_string())).as_deref(),
+            Some(complete.as_path()),
+            "a complete $LTX_GEMMA_DIR resolves to the TE path (rides the spec)"
+        );
+
+        // A set-but-incomplete override yields None so a good bundled/cache gemma still wins.
+        std::fs::remove_file(complete.join("model-00002-of-00002.safetensors")).unwrap();
+        assert!(
+            ltx_gemma_override_path(Some(complete.clone().into_os_string())).is_none(),
+            "an incomplete $LTX_GEMMA_DIR must not win"
+        );
+
+        // Unset override → None (the bundled/cache resolution proceeds).
+        assert!(ltx_gemma_override_path(None).is_none());
+
+        let _ = std::fs::remove_dir_all(&complete);
+    }
+
     /// `resolve_ltx_eros_gemma_dir`: a complete `models/mlx/gemma` sibling of the eros checkpoint wins;
     /// an incomplete/absent sibling with no bundle snapshot → `None` (provider surfaces the clear
     /// "set LTX_GEMMA_DIR" error). Skipped when an operator `$LTX_GEMMA_DIR` is set (the override path
@@ -17548,6 +17649,11 @@ mod tests {
             video_load_spec(&base).text_encoder.is_none(),
             "no text_encoder_dir ⇒ no spec override"
         );
+        // No uncensored enhancer ⇒ empty components map (video providers stage nothing by default).
+        assert!(
+            video_load_spec(&base).components.is_empty(),
+            "no uncensored_enhancer_dir ⇒ empty components"
+        );
         // An explicit gemma dir rides the spec as a Dir source.
         let gemma = PathBuf::from("/models/ltx/gemma");
         let with_te = VideoGenInput {
@@ -17557,6 +17663,27 @@ mod tests {
         assert!(
             matches!(video_load_spec(&with_te).text_encoder, Some(WeightsSource::Dir(ref p)) if *p == gemma),
             "text_encoder_dir rides LoadSpec::text_encoder as a Dir source"
+        );
+
+        // sc-13664: a resolved amoral-enhancer dir is staged as the `uncensored_enhancer` component so
+        // the MLX LTX provider loads it on demand (the provider's `$LTX_UNCENSORED_GEMMA_DIR` / HF-cache
+        // scan is deleted); no other components are added.
+        let amoral = PathBuf::from("/models/ltx/amoral-gemma");
+        let with_enh = VideoGenInput {
+            engine_id: "ltx_2_3",
+            model_dir: PathBuf::from("/models/ltx/q4"),
+            uncensored_enhancer_dir: Some(amoral.clone()),
+            ..VideoGenInput::default()
+        };
+        let spec = video_load_spec(&with_enh);
+        assert!(
+            matches!(spec.components.get("uncensored_enhancer"), Some(WeightsSource::Dir(p)) if *p == amoral),
+            "uncensored_enhancer_dir rides LoadSpec::components as a Dir source"
+        );
+        assert_eq!(
+            spec.components.len(),
+            1,
+            "only the enhancer component is staged"
         );
     }
 

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -327,7 +327,8 @@ _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _COREQUISITE_REVISION_MIGRATION_PENDING: frozenset[tuple[str, str]] = frozenset(
     {
         ("qwen_image", "SceneWorks/qwen-image-2512-fun-controlnet-union"),
-        ("ltx_2_3", "SceneWorks/ltx-2.3-mlx"),
+        # ("ltx_2_3", "SceneWorks/ltx-2.3-mlx") pinned in sc-13683 (the gemma coRequisite now carries
+        # the full 40-hex LTX_BUNDLE_REVISION); removed here + in the Rust twin to keep both green.
         ("ltx_2_3_eros", "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments"),
         ("wan_2_2_t2v_14b", "lightx2v/Wan2.2-Lightning"),
         ("wan_2_2_i2v_14b", "lightx2v/Wan2.2-Lightning"),


### PR DESCRIPTION
## sc-13683 — verify + formalize the fallback-covered deps (SceneWorks counterpart of inference **sc-13664**)

Pairs with inference **sc-13664**, whose merge (`f3483f93`) **deletes** the HF-cache-scan + env side-channel fallbacks for sensenova fast-LoRA, LTX gemma, and PuLID identity. After that bump, any SceneWorks render that doesn't pass its now-required slot fails at load. This PR bumps the pin and guarantees each affected path provisions + passes its slot.

### Pin bump
`npm run bump:inference -- --sha f3483f936ff539eb4877999dc8b342a9ca8e76f5` — self-test **PASS**; all 4 Cargo sites + Cargo.lock at `f3483f93`; **forward bump** from `175cbea3` (merge-base = 175cbea3); `git diff 175cbea3 f3483f93` = **sc-13664 only** (candle/mlx sensenova, mlx ltx, mlx pulid + gen-core doc) — no other provider newly requires a slot this PR doesn't cover.

### sensenova fast — EVIDENCE-ONLY
Every SceneWorks `_fast` tier (`sensenova_u1_8b_fast` + infographic v2/v3) is the **pre-merged MLX turnkey** `SceneWorks/sensenova-u1-8b-fast-mlx` shipping the 8-step distill LoRA baked in with a `distill_merged.json` marker → the MLX `load_fast` marker-skip means `resolve_distill_lora` (and the deleted cache scan) is **never reached**. There is no dense-fast tier that would hit it without a co-located file. No manifest/worker change.
- Follow-up noted below: the **candle** sensenova loader has no marker-skip and would call `resolve_distill_lora` for a fast id — latent (pre-dates this pin), filed as a follow-up.

### LTX gemma (typed `LoadSpec::text_encoder`, now REQUIRED)
- **Manifest**: pinned the macOS `SceneWorks/ltx-2.3-mlx` **gemma coRequisite** to the full 40-hex `LTX_BUNDLE_REVISION` (`01df27d3…`) so the first-install download resolves the SAME `snapshots/<sha>/` the worker's on-demand fetch uses — offline-clean. Removed the now-stale `(ltx_2_3, SceneWorks/ltx-2.3-mlx)` row from **both** migration allowlists (`COREQUISITE_REVISION_MIGRATION_PENDING` Rust + `_COREQUISITE_REVISION_MIGRATION_PENDING` Python) — the self-clean tests are green.
- **Worker**: the operator `$LTX_GEMMA_DIR` override now **rides the spec** (it used to return `None` and defer to the provider's now-deleted env read) for both the base + eros MLX resolvers.
- **Worker**: wired the opt-in **`uncensored_enhancer`** component — SceneWorks exposes `useUncensoredEnhancer`, so `generate_ltx` resolves the amoral 4-bit Gemma (`$LTX_UNCENSORED_GEMMA_DIR` / HF-cache) and stages it in `LoadSpec::components["uncensored_enhancer"]` (the provider's own env/scan is deleted). A first-class **pinned manifest catalog entry** for the amoral repo is a product/licensing decision → follow-up.
- The **candle** LTX lane (`ltx_2_3_distilled`) was **not** touched by sc-13664 (still reads `$LTX_GEMMA_DIR`), so its resolver is intentionally left unchanged.

### PuLID (`identity.{encoder,eva,face_dir}`, now REQUIRED)
Verified the worker **already** passes all three identity sub-slots via `LoadSpec::identity` (sc-8827), and each repo (`guozinan/PuLID`, `SceneWorks/pulid-flux-mlx`, `SceneWorks/instantid-mlx`) is pinned through `ensure_instantid_file → instantid_revision`. Doc-only fix to the stale "env-var seam" header. No functional change needed.

### Tests
- New/updated: LTX `$LTX_GEMMA_DIR` override resolution (`ltx_gemma_override_path`), `uncensored_enhancer` component staging in `video_load_spec`, allowlist self-clean (Rust + Python).
- Green locally: worker lib **928**, core lib **530** (allowlist reconciled), Python manifest audit **26**, clippy `--all-targets -D warnings`, `cargo fmt --all --check`.

### DoD split (joint with sc-13664)
Verified **here**: manifest-pinned gemma + worker-passes-slot (LTX text_encoder + uncensored_enhancer, PuLID identity) + missing-slot → provider's actionable error + install-state parity + allowlist reconciliation. **Deferred to sc-13686**: a real offline LTX/PuLID render with a custom HF cache — not attempted here (no local weights staged; did not fake a render).

> Note: full `npm run rust:check` can't complete in an isolated worktree — the Tauri desktop `build.rs` needs the staged `binaries/sceneworks-api-*` sidecar (environmental, unrelated to this change). CI (sidecar staged) will run the full workspace build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)