### PR TITLE
chore(licenses): record chatterbox_tts primary + Perth watermarker in About→Licenses [sc-13778]

### DIFF
--- a/apps/desktop/licenses/chatterbox-perth/MIT.txt
+++ b/apps/desktop/licenses/chatterbox-perth/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Resemble AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/licenses/chatterbox-tts/MIT.txt
+++ b/apps/desktop/licenses/chatterbox-tts/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Resemble AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -141,6 +141,18 @@
       ]
     },
     {
+      "id": "chatterbox-tts",
+      "name": "Chatterbox (Cloned-Voice TTS)",
+      "publisher": "Resemble AI",
+      "license": "MIT",
+      "homepage": "https://huggingface.co/ResembleAI/chatterbox",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Native cloned-voice text-to-speech model (Audio Studio → VoiceClone). SceneWorks downloads the upstream MIT primary weights on first use from ResembleAI/chatterbox — the T3 speech-token LM (t3_cfg.safetensors) and the S3Gen flow-matching token→waveform + HiFTNet vocoder stack (s3gen.safetensors) — and runs them natively (Candle) on every platform. Uses the Chatterbox voice encoder (listed separately below) for speaker conditioning. Redistributed with attribution as permitted by MIT. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "MIT License", "key": "chatterbox-tts-mit" }
+      ]
+    },
+    {
       "id": "chatterbox-ve",
       "name": "Chatterbox Voice Encoder (Voice Clone)",
       "publisher": "Resemble AI",
@@ -150,6 +162,18 @@
       "usage": "Speaker voice-identity encoder for cloned-voice conditioning (Audio Studio → VoiceClone). SceneWorks downloads the upstream MIT ve.safetensors weights on first use from ResembleAI/chatterbox and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by MIT. Permissive — commercial use allowed.",
       "documents": [
         { "label": "MIT License", "key": "chatterbox-ve-mit" }
+      ]
+    },
+    {
+      "id": "chatterbox-perth",
+      "name": "Perth Watermarker (Chatterbox provenance)",
+      "publisher": "Resemble AI",
+      "license": "MIT",
+      "homepage": "https://huggingface.co/SceneWorks/perth-implicit",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Perceptual-threshold (Perth) implicit audio watermarker that embeds a provenance watermark into every Chatterbox cloned-voice render (Audio Studio → VoiceClone). SceneWorks downloads the upstream MIT perth_implicit.safetensors weights on first use as a pinned co-requisite of the Chatterbox Cloned-Voice TTS model, re-hosted at SceneWorks/perth-implicit, and runs them natively (Candle) on every platform. Redistributed with attribution as permitted by MIT. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "MIT License", "key": "chatterbox-perth-mit" }
       ]
     },
     {

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -29,7 +29,14 @@ import kokoroApache from "../../../desktop/licenses/kokoro-82m/Apache-2.0.txt?ra
 import mossApache from "../../../desktop/licenses/moss-soundeffect-v2/Apache-2.0.txt?raw";
 import acestepMit from "../../../desktop/licenses/acestep-v15-turbo/MIT.txt?raw";
 import openvoiceMit from "../../../desktop/licenses/openvoice-v2/MIT.txt?raw";
+// Chatterbox (Resemble AI, epic 13678): all three components are MIT (Copyright (c)
+// 2025 Resemble AI). chatterboxTtsMit covers the PRIMARY T3/s3gen weights
+// (t3_cfg.safetensors + s3gen.safetensors from ResembleAI/chatterbox); chatterboxMit
+// covers the voice encoder (ve.safetensors, same repo); chatterboxPerthMit covers the
+// Perth provenance watermarker staged on every clone render (SceneWorks/perth-implicit).
+import chatterboxTtsMit from "../../../desktop/licenses/chatterbox-tts/MIT.txt?raw";
 import chatterboxMit from "../../../desktop/licenses/chatterbox-ve/MIT.txt?raw";
+import chatterboxPerthMit from "../../../desktop/licenses/chatterbox-perth/MIT.txt?raw";
 // MOSS TTS speech models + their pinned codec co-requisites (epic 13678, sc-13681).
 // Both the AR checkpoints and the codecs (XY_Tokenizer / MOSS-Audio-Tokenizer) are
 // Apache-2.0, downloaded on first use from the upstream OpenMOSS-Team repos.
@@ -65,7 +72,9 @@ const DOCUMENT_TEXT = {
   "moss-soundeffect-v2-apache": mossApache,
   "acestep-v15-turbo-mit": acestepMit,
   "openvoice-v2-mit": openvoiceMit,
+  "chatterbox-tts-mit": chatterboxTtsMit,
   "chatterbox-ve-mit": chatterboxMit,
+  "chatterbox-perth-mit": chatterboxPerthMit,
   "moss-ttsd-v05-apache": mossTtsdApache,
   "xy-tokenizer-ttsd-apache": xyTokenizerApache,
   "moss-tts-realtime-apache": mossTtsRealtimeApache,


### PR DESCRIPTION
## What

Records the **chatterbox_tts PRIMARY (T3/s3gen) weights** in the About→Licenses product page — a license-coverage gap discovered during sc-13681. The page previously recorded only the chatterbox voice-ENCODER file (`chatterbox-ve`, `ve.safetensors`), not the primary weights SceneWorks ships and downloads on first use. While there, the audio-domain sweep (epic 13678) surfaced one more clear-cut chatterbox-pipeline gap — the **Perth provenance watermarker** — which is recorded too.

Two entries added, both **MIT**, wired through the same mechanism sc-13681 used for the four MOSS repos (new `apps/desktop/licenses/<id>/` dir + text file → `manifest.json` component → `bundledLicenses.js` import + `DOCUMENT_TEXT` key):

| id | repo | files | license | verification |
|----|------|-------|---------|--------------|
| `chatterbox-tts` | `ResembleAI/chatterbox` | `t3_cfg.safetensors`, `s3gen.safetensors` | **MIT** | HF API cardData `license: "mit"` + `license:mit` tag; same repo already recorded MIT for `ve.safetensors`; MIT text `Copyright (c) 2025 Resemble AI` |
| `chatterbox-perth` | `SceneWorks/perth-implicit` | `perth_implicit.safetensors` | **MIT** | HF API cardData `license: "mit"` + `license:mit` tag; repo's own `LICENSE` file fetched and confirmed verbatim MIT, `Copyright (c) 2025 Resemble AI` |

`chatterbox-perth` is the `perth` co-requisite of `chatterbox_tts` (staged on every cloned-voice render). Recording a primary *and* its co-requisite components mirrors sc-13681, which recorded each MOSS primary alongside its codec.

## License verification

- `ResembleAI/chatterbox`: `curl https://huggingface.co/api/models/ResembleAI/chatterbox` → `cardData.license = "mit"`, tag `license:mit`.
- `SceneWorks/perth-implicit`: same API → `cardData.license = "mit"`, tag `license:mit`; additionally fetched `resolve/main/LICENSE` → standard MIT, `Copyright (c) 2025 Resemble AI`. Not gated/private.

## Sweep findings (DoD)

**Audio domain (epic 13678): now COMPLETE.** All 8 audio primaries (acestep, chatterbox_tts, chatterbox_ve, kokoro, moss_sfx_v2, moss_tts_realtime, moss_ttsd_v05, openvoice_v2) and every audio co-requisite (VE, XY/MOSS codecs, Perth) are recorded.

**Outside the audio domain: large PRE-EXISTING gap → filed as sc-13803.** The About→Licenses page records only bundled binaries + Wan2.2/LTX video + audio. It is missing ~40 image primaries, 5 video primaries (bernini, ltx_2_3_eros, scail2_14b, svd, wan_2_2_vace_fun_14b), and ~11 utility primaries — despite the page's own stated "record every re-hosted model's license" policy. That audit is out of scope for this chore (many are SceneWorks-rehosted MLX conversions whose upstream license must be traced, several likely restricted/NC) and needs its own verification pass. Filed as **sc-13803** under epic 13678. There is currently no automated catalog↔licenses coverage guard, which is why this drifted.

## Tests

- `apps/web` `vitest run src/screens/LicensesScreen.test.jsx` → **6/6 pass** (corpus now includes both new entries; the `?raw` imports resolve, and `items.length === bundledLicenses.length` holds).
- `eslint src/data/bundledLicenses.js` → clean (exit 0).
- `manifest.json` validates: 21 components, no duplicate ids.

Refs sc-13778, epic sc-13678. Follow-up: sc-13803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
