### PR TITLE
test(worker): fast CI whisper-base fresh-install pinned-layout smoke [sc-13797]

### DIFF
--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -1147,3 +1147,148 @@ fn chatterbox_offline_install_parity_smoke() {
         real_hub.display()
     );
 }
+
+// ── sc-13797 (epic 13678): FAST, CI-runnable fresh-install-to-custom-cache layout smoke ──────────
+// The pinned-revision hub layout (models--<repo>/snapshots/<rev>/<file> + refs/<sha>) is proven end
+// to end by `chatterbox_offline_install_parity_smoke`, but that #[ignore]d smoke pulls the ~3.2 GB
+// chatterbox repo — too heavy for routine CI. `whisper_base` is the TINY cataloged pin (three small
+// allow-listed files, ~279 MB) that exercises the SAME `downloads.rs` provisioning seam, so the
+// smoke below gives the download/layout contract a cheap regression guard on EVERY PR (worker lane)
+// instead of only the weekly real-weights lane. Pin MIRRORS the `whisper_base` builtin-manifest
+// download (config/manifests/builtin.models.jsonc, sc-13684): openai/whisper-base @ the pinned
+// commit, files = config.json + tokenizer.json + model.safetensors.
+const WHISPER_REPO: &str = "openai/whisper-base";
+const WHISPER_REVISION: &str = "e37978b90ca9030d5170a5c07aadb050351a65bb";
+const WHISPER_FILES: &[&str] = &["config.json", "tokenizer.json", "model.safetensors"];
+
+/// sc-13797 (epic 13678) — **fast, CI-runnable fresh-install-to-custom-cache layout smoke**. NOT
+/// `#[ignore]d`: it runs inside `cargo test -p sceneworks-worker` on EVERY PR (the macOS worker
+/// lane), unlike the ~3.2 GB `chatterbox_offline_install_parity_smoke` it COMPLEMENTS. It provisions
+/// the TINY `whisper_base` pin (`openai/whisper-base` @ `e37978b…`, three small allow-listed files,
+/// ~279 MB) through the SAME real download executor a Models-screen install runs
+/// ([`install_snapshot`] → `HuggingFaceSnapshot::resolve` + `download_snapshot_into_cache`) into a
+/// FRESH custom `HF_HOME` (temp dir), then asserts the pinned-revision hub layout the runtime
+/// resolver reads: `models--openai--whisper-base/snapshots/<commit>/<file>` for EACH allow-listed
+/// file, plus the `refs/<rev>` pointer (recording the resolved commit). Network is allowed at test
+/// time; only the three allow-listed files download — NOT the whole `whisper-base` repo (which ships
+/// many more upstream) — which is what keeps it fast AND is asserted as a discriminating check.
+///
+/// This is the cheap regression guard for the download/layout contract (epic 13678): a break in how
+/// `download_snapshot_into_cache` materializes the pinned layout would turn this red on every PR,
+/// rather than surfacing only when someone runs the heavy chatterbox smoke by hand.
+#[test]
+fn whisper_base_fresh_install_pinned_layout_smoke() {
+    // ── Isolate the hub the downloader writes into: HF_HOME at a fresh temp root (the desktop's
+    //    sc-1904 default HF_HOME=<temp>/.cache/huggingface ⇒ hub at <HF_HOME>/hub, per
+    //    huggingface_hub_cache_dir). Clear every other HF cache var so cache-path resolution can't
+    //    diverge to another location or the data_dir fallback. EnvVars restores on drop — even on a
+    //    panicking assert — so a leaked HF_HOME can't poison sibling tests in the shared process.
+    let home_root = tempfile::tempdir().expect("temp HF_HOME root");
+    let data_dir = tempfile::tempdir().expect("temp data dir");
+    let hf_home = home_root.path().join(".cache").join("huggingface");
+    let hub = hf_home.join("hub");
+    let _env = crate::test_env::EnvVars::set(&[
+        ("HF_HOME", hf_home.to_str().expect("utf-8 HF_HOME")),
+        ("HF_HUB_CACHE", ""),
+        ("HUGGINGFACE_HUB_CACHE", ""),
+        ("HF_HUB_OFFLINE", ""),
+    ]);
+    let repo_slug = "models--openai--whisper-base";
+    assert!(
+        !hub.join(repo_slug).exists(),
+        "the smoke requires a FRESH (empty) isolated HF hub to start: {}",
+        hub.join(repo_slug).display()
+    );
+
+    let settings = crate::Settings {
+        api_url: "http://127.0.0.1:1".to_owned(),
+        access_token: None,
+        data_dir: data_dir.path().to_path_buf(),
+        config_dir: data_dir.path().join("config"),
+        worker_id: "sc-13797".to_owned(),
+        gpu_id: "gpu-0".to_owned(),
+        is_child_worker: false,
+        poll_seconds: 1,
+        heartbeat_seconds: 5,
+        shutdown_timeout_seconds: 1,
+        huggingface_base_url: crate::DEFAULT_HUGGINGFACE_BASE_URL.to_owned(),
+        huggingface_token: std::env::var("HF_TOKEN").ok(),
+        credentials: Vec::new(),
+        max_lora_url_bytes: crate::DEFAULT_MAX_LORA_URL_BYTES,
+        max_model_url_bytes: crate::DEFAULT_MAX_MODEL_URL_BYTES,
+        allow_private_lora_urls: false,
+        utility_workers: 1,
+        backend_mlx_enabled: true,
+        backend_candle_enabled: false,
+        gpu_memory_limit_bytes: 0,
+        external_model_roots: Vec::new(),
+    };
+
+    // ── Provision the pinned snapshot through the REAL download executor (online), filtered to the
+    //    manifest's three allow-listed files — NOT the whole repo. Returns the resolved commit SHA.
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let commit = rt.block_on(install_snapshot(
+        &settings,
+        WHISPER_REPO,
+        WHISPER_REVISION,
+        WHISPER_FILES,
+    ));
+    // A pinned commit-SHA revision resolves to itself: the snapshot dir the resolver reads is
+    // snapshots/<commit>, and here <commit> == the pinned <rev>.
+    assert_eq!(
+        commit, WHISPER_REVISION,
+        "a pinned commit revision must resolve to itself (got {commit})"
+    );
+
+    // ── Assert the pinned-revision hub layout the resolver reads — exactly what
+    //    download_snapshot_into_cache writes: refs/<rev> -> commit, snapshots/<commit>/<file>. ─────
+    let repo_dir = hub.join(repo_slug);
+    let snapshot_dir = repo_dir.join("snapshots").join(&commit);
+    for file in WHISPER_FILES {
+        let path = snapshot_dir.join(file);
+        assert!(
+            path.exists(),
+            "{file} must materialize at the pinned snapshot dir: {}",
+            path.display()
+        );
+    }
+    let refs_pointer = repo_dir.join("refs").join(WHISPER_REVISION);
+    assert!(
+        refs_pointer.exists(),
+        "the refs/<sha> pointer must exist: {}",
+        refs_pointer.display()
+    );
+    let recorded = std::fs::read_to_string(&refs_pointer).expect("read refs/<sha> pointer");
+    assert_eq!(
+        recorded.trim(),
+        commit,
+        "refs/<rev> must record the resolved commit SHA (the layout's rev→commit link)"
+    );
+
+    // Only the allow-listed files materialized — the smoke stays fast BECAUSE it never pulled the
+    // whole repo (whisper-base ships many more files upstream; the manifest allow-list is the lever).
+    // An exact match is the discriminating check: a regression that fetched the full repo, or dropped
+    // a requested file, would break this.
+    let mut installed: Vec<String> = std::fs::read_dir(&snapshot_dir)
+        .expect("read pinned snapshot dir")
+        .flatten()
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    installed.sort();
+    let mut expected: Vec<String> = WHISPER_FILES
+        .iter()
+        .map(|file| (*file).to_owned())
+        .collect();
+    expected.sort();
+    assert_eq!(
+        installed, expected,
+        "ONLY the manifest's allow-listed files must materialize (the whole repo is NOT pulled)"
+    );
+
+    eprintln!(
+        "[whisper-layout] PASS — provisioned {WHISPER_REPO}@{WHISPER_REVISION} ({} files) into the \
+         FRESH isolated hub {}; pinned layout snapshots/<commit>/<file> + refs/<sha> verified.",
+        WHISPER_FILES.len(),
+        hub.display()
+    );
+}

--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -652,13 +652,15 @@ const PERTH_REVISION: &str = "80b60f9caead09b8d3b512bda0b24038f28c08ec";
 /// Materialize one HF snapshot (`repo` @ `revision`, filtered to `files`) into the hub cache via the
 /// worker's REAL model-download executor — `HuggingFaceSnapshot::resolve` + `download_snapshot_into_cache`,
 /// the exact seam `run_model_download_job` drives for a Models-screen install. Returns the resolved
-/// commit SHA. Proving the pinned snapshots land here proves the install materializes them (sc-13541).
-async fn install_snapshot(
+/// commit SHA, or the [`crate::WorkerError`] the download seam surfaced (the caller decides whether a
+/// transient transport failure should skip vs. hard-fail — see [`is_transient_transport_error`]).
+/// Proving the pinned snapshots land here proves the install materializes them (sc-13541).
+async fn try_install_snapshot(
     settings: &crate::Settings,
     repo: &str,
     revision: &str,
     files: &[&str],
-) -> String {
+) -> crate::WorkerResult<String> {
     use crate::downloads::{
         download_snapshot_into_cache, DownloadContext, DownloadProgress, HuggingFaceSnapshot,
     };
@@ -667,13 +669,16 @@ async fn install_snapshot(
     let repo_dir = sceneworks_core::hf_home::huggingface_repo_cache_path(&settings.data_dir, repo)
         .expect("resolve hub cache path");
     let file_patterns: Vec<String> = files.iter().map(|f| (*f).to_owned()).collect();
-    let snapshot = HuggingFaceSnapshot::resolve(&client, settings, repo, revision, &file_patterns)
-        .await
-        .expect("resolve HF snapshot listing");
-    assert!(
-        !snapshot.files.is_empty(),
-        "{repo}@{revision} resolved zero files for {file_patterns:?}"
-    );
+    let snapshot =
+        HuggingFaceSnapshot::resolve(&client, settings, repo, revision, &file_patterns).await?;
+    if snapshot.files.is_empty() {
+        // A resolve that SUCCEEDED but matched zero files is a CONTRACT/layout break (a wrong pin or a
+        // wrong file allow-list), NOT a transport blip — return a non-transport error so the caller
+        // hard-fails on it (`is_transient_transport_error` returns `false` for `InvalidPayload`).
+        return Err(crate::WorkerError::InvalidPayload(format!(
+            "{repo}@{revision} resolved zero files for {file_patterns:?}"
+        )));
+    }
     let context = DownloadContext {
         api: &api,
         client: &client,
@@ -692,9 +697,57 @@ async fn install_snapshot(
         snapshot.total_bytes(),
         std::time::Duration::from_secs(86_400),
     );
-    download_snapshot_into_cache(&context, &repo_dir, revision, &snapshot, &mut progress)
+    download_snapshot_into_cache(&context, &repo_dir, revision, &snapshot, &mut progress).await
+}
+
+/// Panicking wrapper around [`try_install_snapshot`] for the heavy `#[ignore]d` real-weight smokes,
+/// which are run by hand on a stable network and want ANY failure to be a loud panic.
+async fn install_snapshot(
+    settings: &crate::Settings,
+    repo: &str,
+    revision: &str,
+    files: &[&str],
+) -> String {
+    try_install_snapshot(settings, repo, revision, files)
         .await
         .unwrap_or_else(|e| panic!("materialize {repo}@{revision}: {e}"))
+}
+
+/// Classify a [`crate::WorkerError`] from the model-download seam ([`HuggingFaceSnapshot::resolve`] /
+/// `download_snapshot_into_cache`) as a **transient transport failure** — the HF hub was unreachable or
+/// returned a transient server error — vs. a layout/integrity/contract failure the smoke MUST catch.
+///
+/// The set is deliberately NARROW, and by construction can NEVER match a layout regression: the
+/// pinned-layout checks in [`whisper_base_fresh_install_pinned_layout_smoke`] are plain `assert!`s in
+/// the test body (never `WorkerError`s), and every integrity failure the download seam raises is a
+/// `WorkerError::InvalidPayload` (a sha256 or a size mismatch) or the zero-files contract error above —
+/// none of which this returns `true` for. Transient means ONLY:
+///   * a `reqwest` transport error with no usable HTTP response — connection refused / DNS failure /
+///     TLS error / timeout / a reset before or mid-body (`is_connect`/`is_timeout`/`is_body`); OR
+///   * an HTTP response carrying a transient server status — 5xx, 429 Too Many Requests, or 408
+///     Request Timeout. A 4xx is NOT transient (a wrong pin/file is a 404, auth a 401/403) and stays a
+///     hard failure; OR
+///   * the download stall watchdog's hung-source signal (a `WorkerError::Io` of kind `TimedOut`).
+///
+/// Everything else — `InvalidPayload` (integrity/contract), `Json`, `Api`, `Engine`, `Canceled`, and
+/// any other `Io` (e.g. a local filesystem error) — is a real regression and returns `false`.
+fn is_transient_transport_error(error: &crate::WorkerError) -> bool {
+    match error {
+        crate::WorkerError::Http(http) => {
+            if http.is_timeout() || http.is_connect() || http.is_body() {
+                return true;
+            }
+            matches!(
+                http.status(),
+                Some(status)
+                    if status.is_server_error()
+                        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+            )
+        }
+        crate::WorkerError::Io(io) => io.kind() == std::io::ErrorKind::TimedOut,
+        _ => false,
+    }
 }
 
 /// A short, non-trivial synthetic speech-like reference clip (a vibrato'd fundamental plus two
@@ -1176,6 +1229,22 @@ const WHISPER_FILES: &[&str] = &["config.json", "tokenizer.json", "model.safeten
 /// This is the cheap regression guard for the download/layout contract (epic 13678): a break in how
 /// `download_snapshot_into_cache` materializes the pinned layout would turn this red on every PR,
 /// rather than surfacing only when someone runs the heavy chatterbox smoke by hand.
+///
+/// TRANSIENT-FAILURE POLICY (sc-13797 adversarial review, issue 1): the test's PURPOSE is to guard the
+/// cache-LAYOUT code, not the hub's uptime. It therefore SKIPS (logs + returns, no failure) when the HF
+/// hub is unreachable or returns a transient server error (connection/DNS/timeout/reset, or 5xx/429/408
+/// — see [`is_transient_transport_error`]), so a transient outage can't redden UNRELATED PRs on this
+/// merge-gating lane. The skip is upstream of EVERY layout/integrity assertion and matches ONLY
+/// transport-transient errors, so it can never mask a wrong-snapshot-path / missing-refs /
+/// wrong-file-set / corrupt-download regression — all of those still hard-fail.
+///
+/// LANE CONFINEMENT (sc-13797 adversarial review, issue 2): this test lives in the
+/// `#[cfg(all(test, target_os = "macos"))]` module, so it runs ONLY on the stable self-hosted macOS
+/// worker lane — deliberately NOT on the hosted Windows worker-test lane or untrusted fork PRs.
+/// Confining the LIVE ~279 MiB HF download to a runner with a stable network + warm cache is what keeps
+/// this guard reliable; spreading it onto hosted/fork infra we don't control would AMPLIFY the
+/// transient flakiness the skip above already has to work around. Network-free cross-platform layout
+/// coverage via a LOCAL fixture is deferred to a follow-up story.
 #[test]
 fn whisper_base_fresh_install_pinned_layout_smoke() {
     // ── Isolate the hub the downloader writes into: HF_HOME at a fresh temp root (the desktop's
@@ -1227,12 +1296,34 @@ fn whisper_base_fresh_install_pinned_layout_smoke() {
     // ── Provision the pinned snapshot through the REAL download executor (online), filtered to the
     //    manifest's three allow-listed files — NOT the whole repo. Returns the resolved commit SHA.
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let commit = rt.block_on(install_snapshot(
+    let commit = match rt.block_on(try_install_snapshot(
         &settings,
         WHISPER_REPO,
         WHISPER_REVISION,
         WHISPER_FILES,
-    ));
+    )) {
+        Ok(commit) => commit,
+        // GUARD, not gate (issue 1): a transient HF-hub transport failure (unreachable / DNS / timeout
+        // / reset / 5xx / 429) SKIPS rather than reddening this merge-gating lane on an UNRELATED PR.
+        // This arm is upstream of every layout/integrity assertion below and matches ONLY
+        // transport-transient errors, so it can never mask a wrong-snapshot-path / missing-refs /
+        // wrong-file-set / corrupt-download regression — those are non-transient and hard-fail below.
+        Err(error) if is_transient_transport_error(&error) => {
+            eprintln!(
+                "[whisper-layout] SKIP — the HF hub was unreachable or returned a transient error while \
+                 provisioning {WHISPER_REPO}@{WHISPER_REVISION}: {error}. The cache-LAYOUT assertions \
+                 were NOT exercised (this guards our download code, not the hub's uptime); re-run when \
+                 the hub is reachable."
+            );
+            return;
+        }
+        // Any NON-transient failure — a wrong pin (404), a corrupt download (sha256/size mismatch), a
+        // zero-files contract break, a local filesystem error — is a REAL regression: hard-fail.
+        Err(error) => panic!(
+            "provisioning {WHISPER_REPO}@{WHISPER_REVISION} failed with a NON-transient error \
+             (a real download/layout regression, not a hub outage): {error}"
+        ),
+    };
     // A pinned commit-SHA revision resolves to itself: the snapshot dir the resolver reads is
     // snapshots/<commit>, and here <commit> == the pinned <rev>.
     assert_eq!(
@@ -1290,5 +1381,53 @@ fn whisper_base_fresh_install_pinned_layout_smoke() {
          FRESH isolated hub {}; pinned layout snapshots/<commit>/<file> + refs/<sha> verified.",
         WHISPER_FILES.len(),
         hub.display()
+    );
+}
+
+/// sc-13797 (issue 1) — lock in the SAFETY-CRITICAL half of [`is_transient_transport_error`]: every
+/// integrity/contract error class the download seam raises (and every non-timeout local error) must
+/// classify NON-transient, so the whisper smoke's transient-SKIP can NEVER swallow a real
+/// download/layout regression. This is a mutation guard: flip the classifier to return `true` for
+/// `InvalidPayload` (masking a corrupt/zero-files install) and this test goes red. (The
+/// `WorkerError::Http` transport variants have no public `reqwest::Error` constructor to build here, so
+/// they can't be exercised without real network; they are covered by the classifier's narrow match on
+/// `is_timeout`/`is_connect`/`is_body`/transient-status and the reasoning in its doc comment.)
+#[test]
+fn transient_classifier_never_skips_integrity_or_contract_failures() {
+    use crate::WorkerError;
+
+    // An integrity failure (a sha256/size mismatch surfaces as `InvalidPayload`) MUST hard-fail.
+    assert!(
+        !is_transient_transport_error(&WorkerError::InvalidPayload(
+            "ve.safetensors failed its integrity check (sha256 …)".to_owned()
+        )),
+        "an integrity mismatch must never be classified transient (it would mask a corrupt install)"
+    );
+    // The zero-files CONTRACT break (also `InvalidPayload`) MUST hard-fail.
+    assert!(
+        !is_transient_transport_error(&WorkerError::InvalidPayload(
+            "openai/whisper-base@… resolved zero files".to_owned()
+        )),
+        "a zero-files contract break must never be classified transient"
+    );
+    // A generic local filesystem error is NOT transient.
+    assert!(!is_transient_transport_error(&WorkerError::Io(
+        std::io::Error::new(std::io::ErrorKind::PermissionDenied, "fs")
+    )));
+    // Cancellation and engine failures are NOT transient.
+    assert!(!is_transient_transport_error(&WorkerError::Canceled(
+        "canceled".to_owned()
+    )));
+    assert!(!is_transient_transport_error(&WorkerError::Engine(
+        "engine".to_owned()
+    )));
+
+    // The ONLY non-Http transient signal is the download stall watchdog's hung-source `Io(TimedOut)`.
+    assert!(
+        is_transient_transport_error(&WorkerError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "download stalled: no forward progress"
+        ))),
+        "the stall watchdog's Io(TimedOut) is the one non-Http transient signal"
     );
 }


### PR DESCRIPTION
## What

Adds a small, **NON-`#[ignore]d`** worker smoke —
`whisper_base_fresh_install_pinned_layout_smoke` in
`crates/sceneworks-worker/src/voiceclone_smoke.rs` — that provisions the TINY
cataloged `whisper_base` pin into a **fresh custom `HF_HOME`** (temp dir) through
the **same** `downloads.rs` provisioning path the real code uses, then asserts
the pinned-revision hub cache layout.

## Why it's cheap (and why it exists)

The fresh-install-to-custom-cache pinned-revision layout
(`models--<repo>/snapshots/<rev>/<file>` + `refs/<sha>`) is already proven end
to end by the SHIPPED `chatterbox_offline_install_parity_smoke` — but that smoke
is `#[ignore]d` because it pulls the **~3.2 GB** chatterbox repo, far too heavy
for routine CI. So the download/layout contract has only had a *weekly,
run-by-hand* guard.

`whisper_base` (openai/whisper-base @ `e37978b…`) is the tiny cataloged pin
(sc-13684): `config.json` + `tokenizer.json` + `model.safetensors`, ~279 MiB of
small files. Exercising the **same** seam with it gives the contract a cheap
regression guard that runs on **every PR**.

## What it proves

- Provisions via the REAL executor: `install_snapshot` →
  `HuggingFaceSnapshot::resolve` + `download_snapshot_into_cache` (the exact seam
  a Models-screen install runs) — **not** a hand-rolled fetch.
- Asserts the pinned-revision layout: `snapshots/<commit>/<file>` for **each**
  allow-listed file, plus `refs/<rev>` (and that the ref records the resolved
  commit SHA).
- Discriminating: an exact snapshot-dir file-set match proves **only** the
  manifest's three allow-listed files materialize — the whole repo is NOT pulled
  (which is also what keeps it fast).
- Isolated: `HF_HOME` pinned at a fresh temp root via the crate's shared
  `test_env::EnvVars` (restored on drop, even on a panicking assert); asserts the
  hub starts empty.

## Not ignored — runs in CI

`#[ignore]`: **no**. It runs inside `cargo test -p sceneworks-worker` on the
macOS worker lane (`.github/workflows/macos-mlx.yml`), which triggers on every PR
touching `crates/**` / `config/manifests/**`.

## Timing / size

- Test wall-clock: **~15 s** (includes the ~279 MiB download over the network).
- Download: only the 3 allow-listed files (`config.json`, `tokenizer.json`,
  `model.safetensors`).

## Adversarial review resolution (sc-13797)

Two design/risk issues were raised; the reviewer found **no correctness blocker**
(the layout assertions are genuinely discriminating). Both are now resolved.

### Issue 1 — transient HF-hub failure would redden UNRELATED PRs (fixed in code)

Because this smoke now runs on every same-repo PR (a **merge-gating** lane) and
hits the **live** HF hub, a transient hub outage (connection error / DNS failure
/ timeout / connection reset / HTTP 5xx) would have `.expect`-panicked and turned
unrelated PRs red. The test's purpose is to guard the cache-**layout** code, not
the hub's uptime, so it now **classifies the download-seam error and SKIPS
(logs + early return, no failure) on exactly the transient-transport class**,
while still **hard-failing on any layout/integrity problem**.

- `install_snapshot` was split into `try_install_snapshot` (returns
  `WorkerResult<String>`) + a thin panicking wrapper the heavy by-hand smokes
  keep using unchanged.
- New `is_transient_transport_error` classifier — **SKIP** only for: a `reqwest`
  transport error with no usable HTTP response
  (`is_connect`/`is_timeout`/`is_body` — connection refused / DNS / TLS / timeout
  / reset before or mid-body), an HTTP response carrying a **transient server
  status** (5xx, 429, 408), or the download stall watchdog's `Io(TimedOut)`.
  **FAIL** for everything else: `InvalidPayload` (sha256/size integrity mismatch,
  or the zero-files contract break), a **4xx** (a wrong pin/file is a 404, auth a
  401/403), local `Io`, `Json`, `Api`, `Engine`, `Canceled`.
- **Skip can't mask a layout regression:** the skip arm sits **upstream of every
  layout/integrity assertion**, and all those assertions are plain `assert!`s in
  the test body (never `WorkerError`s) while every integrity failure the seam
  raises is an `InvalidPayload` — for which the classifier returns `false`. So a
  wrong-snapshot-path / missing-refs / wrong-file-set / corrupt-download
  regression still hard-fails.
- Added a **network-free mutation guard**
  (`transient_classifier_never_skips_integrity_or_contract_failures`) that pins
  the safety-critical property (integrity/contract errors are never transient);
  verified it goes **red** when `InvalidPayload` is deliberately misclassified as
  transient.

### Issue 2 — kept on the self-hosted macOS lane (documented justification, test NOT moved)

The test lives in the `#[cfg(all(test, target_os = "macos"))]` module, so it runs
**only** on the stable self-hosted macOS worker lane — deliberately **not** on the
hosted Windows worker-test lane or on untrusted fork PRs. This is intentional:
confining a live ~279 MiB HF download to a runner with a **stable network + warm
cache** is what keeps the guard reliable. Spreading it onto hosted Windows +
untrusted fork infrastructure we don't control would **amplify** exactly the
transient flakiness Issue 1 already has to work around. A code comment on the test
now records this justification. **Follow-up:** network-free **cross-platform**
layout coverage via a local fixture is deferred to a separate story (to be filed
by the coordinator).

## Verification

- `cargo test -p sceneworks-worker whisper_base_fresh_install_pinned_layout_smoke` — **PASS** (~14.3 s, happy path, layout assertions intact)
- `cargo test -p sceneworks-worker transient_classifier_never_skips_integrity_or_contract_failures` — **PASS** (network-free classifier mutation guard)
- `cargo fmt --all --check` — clean
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` — clean

Complements, does **not** replace, `chatterbox_offline_install_parity_smoke`.

Epic [sc-13678] / story [sc-13797].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
