### PR TITLE
chore(scaffold): reconcile ui.promptGuide requirement across schema + scaffold gate [sc-13783]

### DIFF
--- a/apps/web/src/promptGuideContract.js
+++ b/apps/web/src/promptGuideContract.js
@@ -1,0 +1,33 @@
+// Single source of truth for WHICH catalog entries must ship a `ui.promptGuide`.
+//
+// Two independent authorities gate the manifest and used to disagree (sc-13783, epic 13678):
+//   - scripts/check-scaffold.mjs (the web/scaffold CI gate) REQUIRED ui.promptGuide on EVERY
+//     model entry.
+//   - packages/schemas/model-manifest.schema.json treated ui.promptGuide as OPTIONAL for all.
+// A schema-valid entry could therefore still RED the scaffold lane — a latent trap that sc-13684
+// only papered over by hand-adding promptGuides to the new whisper/CLAP `type:"utility"` entries.
+//
+// The reconciled rule lives HERE and is consumed by BOTH authorities so neither can silently
+// drift again:
+//   - scripts/check-scaffold.mjs imports `promptGuideRequiredForModel` and skips exempt entries.
+//   - the schema encodes the SAME exemption as an if/then conditional, and
+//     promptGuideScaffoldSchemaContract.test.js asserts the schema's exemption set is byte-for-byte
+//     the one declared here.
+//
+// A promptGuide is a PICKER-ONLY surface: only image/video/audio generation models reach the
+// Image/Video Studio prompt entry that renders PromptGuideModal (selectedModel.ui.promptGuide).
+// `type:"utility"` entries (whisper-base, clap-htsat-unfused, tile ControlNet, vision captioners,
+// PiD checkpoints…) are provisioning/validation dependencies that never appear in a generation
+// picker (generationModelsForType filters on an exact type match), so a user-facing prompt guide
+// is meaningless for them and must NOT be required.
+
+// Model `type`s that are provisioning/validation dependencies rather than user-facing generation
+// pickers, and are therefore EXEMPT from the promptGuide requirement. Keep in lockstep with the
+// schema's if/then exemption (the contract test enforces the match).
+export const PROMPT_GUIDE_EXEMPT_TYPES = Object.freeze(["utility"]);
+
+// True when a catalog entry must declare `ui.promptGuide`. Exempts the non-picker
+// `type`s above; every other (picker) type is required to ship a guide.
+export function promptGuideRequiredForModel(model) {
+  return !PROMPT_GUIDE_EXEMPT_TYPES.includes(model?.type);
+}

--- a/apps/web/src/promptGuideScaffoldSchemaContract.test.js
+++ b/apps/web/src/promptGuideScaffoldSchemaContract.test.js
@@ -36,6 +36,15 @@ function thenRequiresPromptGuide(then) {
   );
 }
 
+// The fields the `then` conditional requires INSIDE ui.promptGuide (e.g. ["title","path"]).
+// scripts/check-scaffold.mjs (assertBuiltinPromptGuides) throws when either title or path is
+// missing, so the schema must demand the same at the conditional level — otherwise a picker with an
+// empty `promptGuide: {}` could satisfy the schema yet still RED the scaffold (the exact divergence
+// class sc-13783 exists to kill).
+function thenPromptGuideRequiredFields(then) {
+  return then?.properties?.ui?.properties?.promptGuide?.required ?? [];
+}
+
 // Minimal, faithful evaluation of a property constraint used inside the schema's `if`. Handles the
 // exact keywords the promptGuide conditional uses (`const`, `not.const`). Anything else THROWS so a
 // future schema refactor forces this test to be updated instead of silently false-passing.
@@ -105,6 +114,22 @@ describe("promptGuide scaffold ↔ schema contract (sc-13783)", () => {
     const picker = { id: "probe_image", name: "Probe image", type: "image" };
     expect(promptGuideRequiredForModel(picker)).toBe(true);
     expect(schemaRequiresPromptGuide(picker)).toBe(true);
+  });
+
+  it("requires a promptGuide title AND path at the picker conditional, matching check-scaffold.mjs", () => {
+    // The scaffold gate (scripts/check-scaffold.mjs assertBuiltinPromptGuides) throws unless
+    // ui.promptGuide has BOTH a title and a path. The schema's picker `then` must demand the same at
+    // the conditional level so a picker with an empty `promptGuide: {}` cannot satisfy the schema yet
+    // still RED the scaffold. Read the required set straight out of the committed schema branch.
+    const pickerBranch = (modelItemSchema.allOf ?? []).find(
+      (branch) =>
+        thenRequiresPromptGuide(branch.then) &&
+        ifMatches(branch.if, { id: "probe", name: "Probe", type: "image" }),
+    );
+    expect(pickerBranch, "schema must carry a picker promptGuide conditional").toBeTruthy();
+    const requiredFields = thenPromptGuideRequiredFields(pickerBranch.then);
+    expect(requiredFields).toContain("title");
+    expect(requiredFields).toContain("path");
   });
 
   it("exempts a utility entry from the promptGuide requirement in BOTH authorities", () => {

--- a/apps/web/src/promptGuideScaffoldSchemaContract.test.js
+++ b/apps/web/src/promptGuideScaffoldSchemaContract.test.js
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import JSON5 from "json5";
+import { describe, expect, it } from "vitest";
+import { PROMPT_GUIDE_EXEMPT_TYPES, promptGuideRequiredForModel } from "./promptGuideContract.js";
+
+// Contract guard for sc-13783 (epic 13678).
+//
+// TWO authorities decide whether a catalog entry must ship `ui.promptGuide`:
+//   1. scripts/check-scaffold.mjs — the web/scaffold CI gate (assertBuiltinPromptGuides).
+//   2. packages/schemas/model-manifest.schema.json — the authoring JSON Schema.
+// They used to disagree: the scaffold REQUIRED a guide on every entry while the schema treated it
+// as OPTIONAL, so a schema-valid entry could still RED the scaffold lane. This test reads the rule
+// out of BOTH real source files and asserts they encode the *same* exemption, so the two can never
+// silently diverge again. If either authority is edited without the other, one of these assertions
+// fails.
+//
+// The scaffold side reads apps/web/src/promptGuideContract.js (the shared predicate the scaffold
+// imports). The schema side is derived by evaluating the schema's own if/then conditional against a
+// candidate entry — i.e. it reads the exemption VALUE out of the committed schema, not a copy of it.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = resolve(HERE, "../../../packages/schemas/model-manifest.schema.json");
+const MANIFEST_PATH = resolve(HERE, "../../../config/manifests/builtin.models.jsonc");
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+const manifestModels = JSON5.parse(readFileSync(MANIFEST_PATH, "utf8")).models;
+
+const modelItemSchema = schema.properties.models.items;
+
+// Does `then` impose the ui.promptGuide requirement (ui present AND ui contains promptGuide)?
+function thenRequiresPromptGuide(then) {
+  return Boolean(
+    then?.required?.includes("ui") && then?.properties?.ui?.required?.includes("promptGuide"),
+  );
+}
+
+// Minimal, faithful evaluation of a property constraint used inside the schema's `if`. Handles the
+// exact keywords the promptGuide conditional uses (`const`, `not.const`). Anything else THROWS so a
+// future schema refactor forces this test to be updated instead of silently false-passing.
+function propertyConstraintMatches(constraint, value) {
+  if (constraint && typeof constraint === "object") {
+    if ("const" in constraint) return value === constraint.const;
+    if (constraint.not && "const" in constraint.not) return value !== constraint.not.const;
+  }
+  throw new Error(
+    `promptGuide contract test cannot evaluate schema property constraint ${JSON.stringify(
+      constraint,
+    )}; update this test to match the schema's new conditional shape.`,
+  );
+}
+
+// Does the schema's `if` subschema match a candidate entry?
+function ifMatches(ifSchema, entry) {
+  for (const key of ifSchema.required ?? []) {
+    if (!(key in entry)) return false;
+  }
+  for (const [prop, constraint] of Object.entries(ifSchema.properties ?? {})) {
+    if (!propertyConstraintMatches(constraint, entry[prop])) return false;
+  }
+  return true;
+}
+
+// The schema side of the contract: does the committed schema REQUIRE ui.promptGuide for `entry`?
+// Derived by scanning the model-item `allOf` for the conditional whose `then` imposes the
+// promptGuide requirement and evaluating its `if`. Returns false when no such satisfied conditional
+// exists (e.g. someone deleted the schema requirement) — which would then mismatch the scaffold
+// predicate for picker entries and fail the agreement assertions below.
+function schemaRequiresPromptGuide(entry) {
+  for (const branch of modelItemSchema.allOf ?? []) {
+    if (thenRequiresPromptGuide(branch.then) && ifMatches(branch.if, entry)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const modelTypes = modelItemSchema.properties.type.enum;
+
+describe("promptGuide scaffold ↔ schema contract (sc-13783)", () => {
+  it("exposes a non-empty exemption set that includes the utility type", () => {
+    // The whole point of the reconciliation: utility entries are exempt. If this regresses, the
+    // scaffold would demand a meaningless prompt guide on validation dependencies again.
+    expect(PROMPT_GUIDE_EXEMPT_TYPES.length).toBeGreaterThan(0);
+    expect(PROMPT_GUIDE_EXEMPT_TYPES).toContain("utility");
+  });
+
+  it("schema and scaffold agree on the requirement for EVERY declared model type", () => {
+    // The core anti-divergence assertion. For each type in the schema's own enum, the scaffold
+    // predicate and the schema-derived requirement must return the same boolean. Deleting the schema
+    // conditional (schema→false for pickers) or dropping utility from the exempt set (scaffold→true
+    // for utility) breaks this.
+    expect(modelTypes.length).toBeGreaterThan(0);
+    for (const type of modelTypes) {
+      const entry = { id: `probe_${type}`, name: `Probe ${type}`, type };
+      expect(
+        schemaRequiresPromptGuide(entry),
+        `schema requiredness for type=${type}`,
+      ).toBe(promptGuideRequiredForModel(entry));
+    }
+  });
+
+  it("requires a promptGuide for a picker (image) entry in BOTH authorities", () => {
+    const picker = { id: "probe_image", name: "Probe image", type: "image" };
+    expect(promptGuideRequiredForModel(picker)).toBe(true);
+    expect(schemaRequiresPromptGuide(picker)).toBe(true);
+  });
+
+  it("exempts a utility entry from the promptGuide requirement in BOTH authorities", () => {
+    const utility = { id: "probe_utility", name: "Probe utility", type: "utility" };
+    expect(promptGuideRequiredForModel(utility)).toBe(false);
+    expect(schemaRequiresPromptGuide(utility)).toBe(false);
+  });
+
+  it("treats the sc-13684 utility entries (whisper-base, clap-htsat-unfused) as exempt", () => {
+    // These real entries carry a promptGuide today (the sc-13684 workaround), but the reconciled
+    // rule must NOT REQUIRE one — a later cleanup that drops their guide must stay green.
+    for (const id of ["whisper_base", "clap_htsat_unfused"]) {
+      const entry = manifestModels.find((model) => model.id === id);
+      expect(entry, `manifest must contain ${id}`).toBeTruthy();
+      expect(entry.type).toBe("utility");
+      expect(promptGuideRequiredForModel(entry)).toBe(false);
+      expect(schemaRequiresPromptGuide(entry)).toBe(false);
+    }
+  });
+
+  it("still requires a promptGuide for real picker (non-utility) manifest entries", () => {
+    const picker = manifestModels.find((model) => model.type !== "utility");
+    expect(picker, "manifest must contain a non-utility entry").toBeTruthy();
+    expect(promptGuideRequiredForModel(picker)).toBe(true);
+    expect(schemaRequiresPromptGuide(picker)).toBe(true);
+  });
+});

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -128,14 +128,19 @@
         "additionalProperties": false,
         "allOf": [
           {
-            "$comment": "sc-13783: reconcile with scripts/check-scaffold.mjs (which enforces ui.promptGuide on every PICKER entry). A promptGuide is a picker-only surface; type:\"utility\" provisioning/validation dependencies never appear in a Studio picker, so they are EXEMPT. The exempt set here MUST match apps/web/src/promptGuideContract.js PROMPT_GUIDE_EXEMPT_TYPES — promptGuideScaffoldSchemaContract.test.js fails if the two authorities diverge.",
+            "$comment": "sc-13783: reconcile with scripts/check-scaffold.mjs (which enforces ui.promptGuide WITH a title/path on every PICKER entry). A promptGuide is a picker-only surface; type:\"utility\" provisioning/validation dependencies never appear in a Studio picker, so they are EXEMPT. The exempt set here MUST match apps/web/src/promptGuideContract.js PROMPT_GUIDE_EXEMPT_TYPES — promptGuideScaffoldSchemaContract.test.js fails if the two authorities diverge. The `then` requires title/path at the CONDITIONAL level (matching check-scaffold.mjs), not only via the unconditional #/properties/ui/promptGuide definition, so a picker can never satisfy the schema with an empty promptGuide that would still RED the scaffold.",
             "if": {
               "required": ["type"],
               "properties": { "type": { "not": { "const": "utility" } } }
             },
             "then": {
               "required": ["ui"],
-              "properties": { "ui": { "required": ["promptGuide"] } }
+              "properties": {
+                "ui": {
+                  "required": ["promptGuide"],
+                  "properties": { "promptGuide": { "required": ["title", "path"] } }
+                }
+              }
             }
           }
         ],

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -126,6 +126,19 @@
         "type": "object",
         "required": ["id", "name", "type"],
         "additionalProperties": false,
+        "allOf": [
+          {
+            "$comment": "sc-13783: reconcile with scripts/check-scaffold.mjs (which enforces ui.promptGuide on every PICKER entry). A promptGuide is a picker-only surface; type:\"utility\" provisioning/validation dependencies never appear in a Studio picker, so they are EXEMPT. The exempt set here MUST match apps/web/src/promptGuideContract.js PROMPT_GUIDE_EXEMPT_TYPES — promptGuideScaffoldSchemaContract.test.js fails if the two authorities diverge.",
+            "if": {
+              "required": ["type"],
+              "properties": { "type": { "not": { "const": "utility" } } }
+            },
+            "then": {
+              "required": ["ui"],
+              "properties": { "ui": { "required": ["promptGuide"] } }
+            }
+          }
+        ],
         "properties": {
           "id": { "type": "string", "minLength": 1 },
           "name": { "type": "string", "minLength": 1 },

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -1,6 +1,7 @@
 import { access, constants, readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { promptGuideRequiredForModel } from "../apps/web/src/promptGuideContract.js";
 
 const root = process.cwd();
 
@@ -190,6 +191,14 @@ async function assertBuiltinPromptGuides() {
   const manifestPath = "config/manifests/builtin.models.jsonc";
   const manifest = await readJsonc(manifestPath);
   for (const model of manifest.models ?? []) {
+    // Non-picker entries (type:"utility") never reach a Studio prompt-guide surface, so the schema
+    // exempts them and this gate must too — otherwise a schema-valid utility entry REDs the lane
+    // (sc-13783). The shared predicate is the single source of truth both authorities read; the
+    // schema encodes the identical exemption and promptGuideScaffoldSchemaContract.test.js asserts
+    // they can't diverge.
+    if (!promptGuideRequiredForModel(model)) {
+      continue;
+    }
     const guide = model.ui?.promptGuide;
     if (!guide?.title || !guide?.path) {
       throw new Error(`${manifestPath} model ${model.id} is missing ui.promptGuide title/path`);

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -127,6 +127,15 @@ def _sample_audio_model_entry() -> dict:
         "id": "sample_audio_speech",
         "name": "Sample Audio Speech",
         "type": "audio",
+        # `audio` is a picker (non-utility) type, so the schema now requires a
+        # `ui.promptGuide` with a title/path (sc-13783, reconciled with
+        # scripts/check-scaffold.mjs). Kept minimal; this fixture never ships.
+        "ui": {
+            "promptGuide": {
+                "title": "Sample Audio Prompt Guide",
+                "path": "/prompt-guides/sample-audio.md",
+            }
+        },
         "audio": {
             "voices": [
                 {
@@ -406,6 +415,15 @@ def _model_entry_with_download(download: dict) -> dict:
         "id": "sample_pinned_model",
         "name": "Sample Pinned Model",
         "type": "image",
+        # `image` is a picker (non-utility) type, so the schema now requires a
+        # `ui.promptGuide` with a title/path (sc-13783, reconciled with
+        # scripts/check-scaffold.mjs). Kept minimal; this fixture never ships.
+        "ui": {
+            "promptGuide": {
+                "title": "Sample Prompt Guide",
+                "path": "/prompt-guides/sample.md",
+            }
+        },
         "downloads": [download],
     }
 


### PR DESCRIPTION
## What / Why

`scripts/check-scaffold.mjs` (the web/scaffold CI gate) **required** `ui.promptGuide` on **every** model entry, while `packages/schemas/model-manifest.schema.json` treated it as **OPTIONAL**. A schema-valid manifest entry could therefore still RED the scaffold lane — a latent trap for anyone adding a model. sc-13684 only papered over it by hand-adding promptGuides to the new mmaudio/whisper/CLAP entries, including the `type:"utility"` whisper/CLAP validation entries where a user-facing prompt guide is meaningless.

## Authority changed & decision

Both authorities now encode **one identical rule**: `ui.promptGuide` is **required for picker (image/video/audio) models** and **EXEMPT for `type:"utility"`** non-picker entries.

Rationale (confirmed by reading the consumers): a promptGuide is a picker-only surface. Only `ImageStudio.jsx` / `VideoStudio.jsx` render `PromptGuideModal` from `selectedModel?.ui?.promptGuide`, and `generationModelsForType` filters pickers on an exact `type` match — so `type:"utility"` provisioning/validation dependencies (whisper-base, CLAP, tile ControlNet, vision captioners, PiD checkpoints…) never reach a prompt-guide surface. Requiring a guide for them is meaningless. This is the lower-risk direction the story recommended, and I *also* tightened the schema so the two truly agree (previously the schema required a guide for *no* entry, so the trap would persist for picker models).

## Changes

- **`apps/web/src/promptGuideContract.js`** (new) — single source of truth: `PROMPT_GUIDE_EXEMPT_TYPES` (`["utility"]`) + `promptGuideRequiredForModel(model)`. Both authorities read it.
- **`scripts/check-scaffold.mjs`** — imports the predicate; `assertBuiltinPromptGuides` skips exempt entries instead of demanding a guide on all.
- **`packages/schemas/model-manifest.schema.json`** — adds a model-item `allOf` `if/then`: for non-utility entries, `ui` is required and must contain `promptGuide`. This is now CI-enforced against the real manifest by the existing Python jsonschema audit (`tests/test_builtin_manifest_audit.py`).
- **`apps/web/src/promptGuideScaffoldSchemaContract.test.js`** (new contract test) — reads the requirement out of **both** real sources (the shared predicate for the scaffold side; the committed schema's `if/then`, evaluated, for the schema side) and asserts they agree for **every** declared model type. Also pins the sc-13684 utility entries (whisper_base, clap_htsat_unfused) as exempt and a real picker entry as required.

## Utility entries

whisper-base and clap-htsat-unfused (`type:"utility"`) are exempt in both authorities. They keep their existing guides today, but the reconciled rule no longer *requires* one — a later cleanup dropping their guide stays green. Verified: removing `ui.promptGuide` from either still validates.

## Verification

- `node scripts/check-scaffold.mjs` → **green**.
- Full web vitest suite → **153 files / 2220 tests pass** (incl. the new contract test's 6 assertions).
- `jsonschema.Draft202012Validator.check_schema` → **OK** (valid draft 2020-12); real `builtin.models.jsonc` validates with **0 errors**.
- Discrimination: a picker (`image`) entry without `ui.promptGuide` is now **rejected** (`'ui' is a required property`); a `utility` entry without it is **accepted**; whisper_base/clap_htsat_unfused stay valid with the guide removed.
- **Mutation-tested both directions**: changing the schema's exempt value → contract test RED (3 tests); emptying the scaffold exempt set → contract test RED (4 tests). Restored → green.

Refs sc-13678, sc-13783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up (adversarial review, commit 5c26ba0f)

The schema tightening above red-lined three **existing** Python audit tests in `tests/test_builtin_manifest_audit.py` that build `type:"audio"` / `type:"image"` sample entries with **no `ui` block**. These run in the web CI job (`check.yml` → `pytest -m "not e2e and not parity"`), so the lane was RED. This commit greens it and closes a residual title/path gap.

- **`tests/test_builtin_manifest_audit.py`** — give both fixture helpers (`_sample_audio_model_entry`, `_model_entry_with_download`) a valid `ui.promptGuide {title, path}` so the picker-type samples satisfy the new requirement. Fixes `test_schema_accepts_audio_type_and_audio_sub_block`, `test_schema_pins_download_revision_to_a_40hex_sha`, `test_schema_accepts_a_component_id_on_a_corequisite_download`.
- **`packages/schemas/model-manifest.schema.json`** — make the picker `if/then` require `ui.promptGuide.{title,path}` at the **conditional** level. title/path were *already* enforced by the unconditional `#/properties/ui/promptGuide` definition (`required:[title,path]`, `title.minLength`, `path.pattern`) — so an empty `promptGuide:{}` never actually passed the schema — but tying it to the picker conditional makes it robust to any future loosening of that definition and self-documents the exact agreement with `check-scaffold.mjs` (which throws on a missing title/path).
- **`apps/web/src/promptGuideScaffoldSchemaContract.test.js`** — new assertion that the picker conditional requires **both** title and path, mirroring `check-scaffold.mjs`. Mutation-tested: dropping title/path from the `then` block turns it red.

### Follow-up verification
- `pytest tests/test_builtin_manifest_audit.py` → **26/26 green**; CI web-filter `pytest -m "not e2e and not parity"` → **31 passed / 17 deselected**.
- `node scripts/check-scaffold.mjs` + `npm run check:compose` → **green**.
- Full web vitest → **2221 pass** (2220 + the new contract assertion); contract test **7 green** and discriminating.
- Live `builtin.models.jsonc` validates with **0 errors** under the tightened schema.
