### PR TITLE
chore(worker): harden co-req seam review nits [sc-13771]

### DIFF
--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1646,8 +1646,10 @@ pub(crate) fn huggingface_pinned_snapshot_dir(
 ///
 /// Driven PURELY by `descriptor.required_components`: for each declared id it finds the manifest
 /// `coRequisite` download whose `componentId` matches (never inferred from repo names, sc-13679),
-/// then resolves that repo's cached snapshot ENV-CORRECTLY via the cache-only
-/// [`huggingface_snapshot_dir`] — the same seam the PiD-gemma / Wan-Lightning co-requisites use, so
+/// then resolves that repo's cached snapshot ENV-CORRECTLY, cache-only. A co-requisite that pins an
+/// immutable `revision` (F-029) reads that exact `snapshots/<sha>/` via
+/// [`huggingface_pinned_snapshot_dir`]; an unpinned one falls back to the `refs/main`-preferring
+/// [`huggingface_snapshot_dir`] — the same seams the PiD-gemma / Wan-Lightning co-requisites use, so
 /// a custom `HF_HOME`/hub is honored and nothing is fetched here.
 ///
 /// All-or-nothing: a declared component whose co-requisite is not installed (snapshot absent, or the
@@ -3591,11 +3593,17 @@ mod co_requisite_tests {
         )
         .expect("both co-requisites are installed, so resolution succeeds");
 
-        // The resolved map's keys are EXACTLY the descriptor's advertised component ids.
-        let keys: Vec<&str> = components.keys().map(String::as_str).collect();
+        // The resolved map's keys are EXACTLY the descriptor's advertised component ids — compared as
+        // a SET, since callers key by id (order-independent) and a future descriptor whose ids are not
+        // alphabetical must not false-fail against the BTreeMap's sorted key order. Still fully
+        // discriminating: a missing or extra component id breaks set equality.
+        let keys: std::collections::BTreeSet<&str> =
+            components.keys().map(String::as_str).collect();
+        let required: std::collections::BTreeSet<&str> =
+            descriptor.required_components.iter().copied().collect();
         assert_eq!(
-            keys, descriptor.required_components,
-            "the component map keys must match the descriptor's required_components"
+            keys, required,
+            "the component map keys must match the descriptor's required_components (as a set)"
         );
         // Each id resolves to the single-file WeightsSource at the staged snapshot path.
         // (`WeightsSource` has no `PartialEq`, so match the `File` variant and compare its path.)

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -579,6 +579,14 @@
                     "properties": { "coRequisite": { "const": true } },
                     "required": ["coRequisite"]
                   }
+                },
+                {
+                  "$comment": "sc-13771: a componentId names a component PROVISIONED by a coRequisite download, so it is valid ONLY on coRequisite: true entries — a manifest-local invariant that JSON Schema CAN enforce without inference-descriptor knowledge (contrast the componentId ⟺ some descriptor.required_components match, which the manifest audit cannot see and stays a runtime resolve_co_requisites check).",
+                  "if": { "required": ["componentId"] },
+                  "then": {
+                    "properties": { "coRequisite": { "const": true } },
+                    "required": ["coRequisite"]
+                  }
                 }
               ],
               "properties": {
@@ -598,7 +606,7 @@
                 "componentId": {
                   "type": "string",
                   "pattern": "^[a-z][a-z0-9_]*$",
-                  "description": "Optional stable component id this coRequisite download PROVISIONS for the model's engine (epic 13657, sc-13679). When set (only meaningful on `coRequisite: true` entries), the worker stages the resolved local path under this id in the engine's `LoadSpec::components`, matched against the provider's `ModelDescriptor::required_components` advertisement — the explicit repo→component mapping (never inferred from repo names) that the generic `resolve_co_requisites` seam reads. Lowercase snake_case, same shape as a descriptor id. Examples: chatterbox_tts's ve/perth co-requisites carry `voice_embedding`/`perth`; SDXL's carry `tokenizer_clip_l`/`tokenizer_clip_bigg`/`vae_fp16_fix` (sc-13682). Absent on a co-requisite the engine does not read as a named component (e.g. the PiD-gemma / Wan-Lightning shared weights)."
+                  "description": "Optional stable component id this coRequisite download PROVISIONS for the model's engine (epic 13657, sc-13679). When set (valid ONLY on `coRequisite: true` entries — schema-enforced by the allOf conditional above, sc-13771), the worker stages the resolved local path under this id in the engine's `LoadSpec::components`, matched against the provider's `ModelDescriptor::required_components` advertisement — the explicit repo→component mapping (never inferred from repo names) that the generic `resolve_co_requisites` seam reads. Lowercase snake_case, same shape as a descriptor id. Examples: chatterbox_tts's ve/perth co-requisites carry `voice_embedding`/`perth`; SDXL's carry `tokenizer_clip_l`/`tokenizer_clip_bigg`/`vae_fp16_fix` (sc-13682). Absent on a co-requisite the engine does not read as a named component (e.g. the PiD-gemma / Wan-Lightning shared weights)."
                 },
                 "default": {
                   "type": "boolean",

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -501,6 +501,79 @@ def test_schema_accepts_a_component_id_on_a_corequisite_download():
         )
 
 
+def test_schema_rejects_a_component_id_on_a_non_corequisite_download():
+    """sc-13771: a `componentId` names a component PROVISIONED by a coRequisite, so it is valid ONLY on
+    `coRequisite: true` entries. This is a MANIFEST-LOCAL invariant (checkable without any inference-side
+    descriptor knowledge), so the authoring schema enforces it via an allOf conditional — catching a
+    mis-tagged manifest at authoring time instead of only at runtime in `resolve_co_requisites`.
+
+    The COMPLEMENTARY half — that a `componentId` matches some model's `ModelDescriptor::required_components`
+    (and vice-versa) — is deliberately NOT enforced here: the manifest audit has no visibility into the
+    inference-side descriptor `required_components` sets, so that cross-check stays a runtime error (covered
+    by the `a_required_component_with_no_matching_component_id_is_a_manifest_error` unit test in
+    crates/sceneworks-worker/src/model_jobs.rs).
+    """
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    validator = jsonschema.Draft202012Validator(schema)
+
+    base = {
+        "provider": "huggingface",
+        "repo": "ResembleAI/chatterbox",
+        "files": ["ve.safetensors"],
+        "revision": "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18",
+    }
+
+    def errors_for(download: dict) -> list:
+        manifest = {
+            "schemaVersion": 1,
+            "models": [_model_entry_with_download(download)],
+        }
+        return list(validator.iter_errors(manifest))
+
+    # Valid: componentId ON a coRequisite: true entry.
+    assert not errors_for({**base, "coRequisite": True, "componentId": "voice_embedding"}), (
+        "a componentId on a coRequisite: true download must validate"
+    )
+
+    # Invalid: componentId with NO coRequisite flag — the allOf conditional requires coRequisite.
+    missing = errors_for({**base, "componentId": "voice_embedding"})
+    assert any(
+        error.validator == "required" and "coRequisite" in error.message for error in missing
+    ), (
+        "a componentId with no coRequisite flag must be rejected (coRequisite required); "
+        f"got {[(e.validator, e.message) for e in missing]}"
+    )
+
+    # Invalid: componentId with coRequisite: false — the allOf conditional pins coRequisite to true.
+    false_flag = errors_for({**base, "coRequisite": False, "componentId": "voice_embedding"})
+    assert any(
+        error.validator == "const" and error.absolute_path and error.absolute_path[-1] == "coRequisite"
+        for error in false_flag
+    ), (
+        "a componentId on a coRequisite: false download must be rejected (coRequisite must be true); "
+        f"got {[(e.validator, list(e.absolute_path)) for e in false_flag]}"
+    )
+
+
+def test_builtin_manifest_component_ids_are_all_on_corequisite_downloads():
+    """sc-13771 mutation guard: the schema invariant above is LIVE against the real catalog. Every
+    `componentId` in builtin.models.jsonc must sit on a `coRequisite: true` download — proving the guard
+    is not merely decoration on a synthetic fixture, and that no real entry mis-tags a componentId.
+    """
+    manifest = _load_builtin_models_manifest()
+    misplaced = [
+        (model["id"], download.get("repo"), download["componentId"])
+        for model in manifest["models"]
+        for download in model.get("downloads", [])
+        if "componentId" in download and download.get("coRequisite") is not True
+    ]
+    assert not misplaced, (
+        "a componentId may appear only on a coRequisite: true download (sc-13771); these are "
+        f"mis-tagged: {sorted(misplaced)}"
+    )
+
+
 def test_manifest_constraint_contract_registry_is_complete_and_live():
     """sc-12304: constraint declarations may not silently become decoration.
 


### PR DESCRIPTION
## Summary

Follow-up hardening for the co-requisite resolution seam (epic **sc-13678**, story **sc-13771**), addressing three MINOR non-blocking nits from the adversarial review of PR #1678. **Runtime behavior is unchanged** — the code was already correct and CI was green; these are doc/test/schema hardening items.

### 1. Doc/code drift (fixed)
`resolve_co_requisites` (crates/sceneworks-worker/src/model_jobs.rs) — the leading doc paragraph named only the cache-only `huggingface_snapshot_dir`, but the body uses `huggingface_pinned_snapshot_dir` when a co-requisite carries a `revision` (F-029). The doc now names both: pinned reads `snapshots/<sha>/` via `huggingface_pinned_snapshot_dir`, unpinned falls back to the `refs/main`-preferring `huggingface_snapshot_dir`.

### 2. Order-sensitive test (fixed)
`present_co_requisites…` asserted the resolved BTreeMap keys equal `descriptor.required_components` **in order** — passing only because `["perth","voice_embedding"]` happens to be alphabetical. A future non-alphabetical descriptor would false-fail even though callers key by id order-independently. Now compares as a `BTreeSet`. Still fully discriminating: a missing/extra component id breaks set equality (verified with a temporary mutation probe — the injected extra id failed the assertion, then reverted).

### 3. Manifest-audit / schema cross-check (implemented + descriptor-half closed)
Nothing enforced at authoring time that `componentId` only appears on `coRequisite: true` entries — a mis-tagged manifest errored only at runtime.

- **Implemented** the manifest-LOCAL invariant `componentId ⟹ coRequisite: true`: a schema `allOf` conditional in packages/schemas/model-manifest.schema.json (mirroring the existing `required`→`coRequisite` pattern), plus a schema-level audit test and a real-catalog mutation guard in tests/test_builtin_manifest_audit.py. The live builtin.models.jsonc (32 componentId entries) validates with 0 errors.
- **Explicitly closed** the complementary half — `componentId` ⟺ some model's `ModelDescriptor::required_components` — because the Python manifest audit has **no visibility into the inference-side descriptor `required_components` sets**. That cross-check stays a runtime error (already covered by the `a_required_component_with_no_matching_component_id_is_a_manifest_error` unit test). Reason recorded in the schema `$comment` and the audit test docstring.

## Verification
- `cargo test -p sceneworks-worker` co-req suite: 10/10 pass
- `cargo fmt --all --check`: clean
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`: clean
- `pytest tests/test_builtin_manifest_audit.py`: 28 pass; full web-filter `pytest -q tests/ -m "not e2e and not parity"`: 33 pass / 17 deselected (incl. real-manifest schema validation, 0 errors)
- `node scripts/check-scaffold.mjs`: passed
- Item-2 discrimination proven via mutation probe (extra id → assertion fails)

Story: sc-13771 · Epic: sc-13678

🤖 Generated with [Claude Code](https://claude.com/claude-code)