### PR TITLE
fix(worker): route krea_2_raw candle txt2img to real inference, not the procedural stub [sc-13831]

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -425,9 +425,10 @@ fn resolve_candle_image_route(
         Some(CandleImageRoute::KreaControl)
     } else if krea_edit_candle_available(request, settings) {
         // Krea 2 Kontext-style edit (epic 10871): `krea_2_raw` + `edit_image` + a source is the bespoke
-        // candle `KreaEdit` lane (`generate_candle_krea_edit_stream`), NOT txt2img — `krea_2_raw` is
-        // MLX-only for t2i (absent from `is_candle_engine`), so without this arm an off-Mac Krea edit had
-        // no candle lane. Mirrors `jobs_store::krea_edit_candle_eligible`.
+        // candle `KreaEdit` lane (`generate_candle_krea_edit_stream`), NOT the generic t2i stream. Diverted
+        // BEFORE the generic `is_candle_engine` t2i arm below (which `krea_2_raw` now matches, sc-9994/epic
+        // 9992) so an edit job runs the dual-conditioning Kontext render instead of being flattened to plain
+        // txt2img. Mirrors `jobs_store::krea_edit_candle_eligible`.
         Some(CandleImageRoute::KreaEdit)
     } else if zimage_comfyui_available(request, settings) {
         // In-place ComfyUI Z-Image base (sc-10668): an `external_base_*` id, so it matches no
@@ -4811,6 +4812,20 @@ fn is_candle_engine(model: &str) -> bool {
             // shapes; on-the-fly quant stays descriptor-gated (`supported_quants` still `&[]` — the
             // packed turnkey self-describes its tier at load).
             | "krea_2_turbo"
+            // Krea 2 Raw (sc-9994, epic 9992): the UNDISTILLED full-CFG base sibling of Turbo, now a
+            // registered candle txt2img generator (`candle-gen-krea` `render_base` — two DiT forwards/step,
+            // 52 steps, resolution-dynamic mu). Arch-identical to Turbo (only the DiT weights differ), so it
+            // rides the SAME generic candle lane: `generate_candle_stream` resolves its repo/tier/steps/
+            // guidance/negative from the descriptor + the shared `krea_model_subdir` turnkey resolver, and
+            // the img2img `Reference` init (sc-10226 `render_base_img2img`). It is ALSO the LoRA-training
+            // base (Path 1). This entry was MISSING when epic 9992 landed the generator — the scheduler
+            // routes `krea_2_raw` to candle (`IMAGE_MODEL_CAPS` candle_routed=true, mirroring Turbo), but
+            // `resolve_candle_image_route`'s generic arm gates on THIS list, so plain Raw t2i fell through to
+            // `None` and the worker emitted a `procedural_preview` STUB gradient (`realModelInference:false`)
+            // instead of running the real model — the classic router/worker list skew. Turbo was unaffected
+            // (it was in the list); the Raw edit lane (`krea_edit_candle_available`, checked first) hid the
+            // gap for edit jobs, and there was no `krea_2_raw` t2i routing test to catch it.
+            | "krea_2_raw"
             // Stable Diffusion 3.5 (sc-7880, epic 7982): Large / Large Turbo / Medium all ride the generic
             // candle txt2img lane (the `candle-gen-sd3` provider). `generate_candle_stream` resolves Q4/Q8
             // from the descriptor + manifest (`mlx.quantize` 8) — the dense MMDiT folds to Q4_0/Q8_0 at
@@ -6201,6 +6216,9 @@ mod candle_label_tests {
             "boogu_image_edit",
             // Krea 2 Turbo (sc-7581): pure txt2img on the generic candle lane.
             "krea_2_turbo",
+            // Krea 2 Raw (sc-9994, epic 9992): the undistilled full-CFG base rides the SAME generic candle
+            // lane as Turbo (`render_base`). Was missing here, so plain Raw t2i stubbed a procedural gradient.
+            "krea_2_raw",
             // SD3.5 (sc-7880): Large / Large Turbo / Medium ride the generic candle txt2img lane.
             "sd3_5_large",
             "sd3_5_large_turbo",

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -5325,6 +5325,29 @@ fn candle_image_route_sends_krea_img2img_to_txt2img() {
         resolve_candle_image_route(&krea_t2i, &settings),
         Some(CandleImageRoute::CandleTxt2Img),
     );
+
+    // Plain krea_2_raw txt2img (sc-9994, epic 9992) MUST reach the real candle lane, not the procedural
+    // stub. `krea_2_raw` is the undistilled full-CFG base candle generator (`render_base`); it was missing
+    // from `is_candle_engine`, so this arm returned `None` and the worker emitted a `procedural_preview`
+    // gradient (`realModelInference:false`) instead of running the model. Locks the fix + the router/worker
+    // parity (the scheduler routes it to candle via `IMAGE_MODEL_CAPS`).
+    let krea_raw_t2i = request(json!({ "projectId": "p", "model": "krea_2_raw", "count": 1 }));
+    assert_eq!(
+        resolve_candle_image_route(&krea_raw_t2i, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+    );
+
+    // Krea 2 Raw img2img (a `referenceAssetId` in a non-edit mode, sc-10226) rides the same generic lane —
+    // `generate_candle_stream` resolves the reference init into `render_base_img2img`.
+    let krea_raw_img2img = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "referenceAssetId": "asset_1",
+        "advanced": { "strength": 0.5 }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&krea_raw_img2img, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+    );
 }
 
 /// Isolate the HF hub-cache env (`HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME`) to an explicit


### PR DESCRIPTION
## Symptom (reported)
On the candle/CUDA backend, **Krea 2 Raw** text-to-image produced a smooth per-seed **gradient** "super fast, like it's not generating anything at all." Krea 2 Turbo was fine on candle; both Raw + Turbo were fine on MLX. Reproduced on **both bf16 and q8** (tier-independent).

## Root cause
The output was the worker's `procedural_preview` **stub** (`generate_stub_stream`, a seeded gradient), not a real render — confirmed by the asset recipe: `"adapter":"procedural_preview"`, `"realModelInference":false`.

`resolve_candle_image_route`'s generic txt2img arm gates on `is_candle_engine(model)`. That list had `krea_2_turbo` but **not `krea_2_raw`**, so plain Raw t2i matched no route → `None` → the worker fell through to `generate_stub_stream`.

Router/worker skew: the scheduler **does** route `krea_2_raw` to candle (`IMAGE_MODEL_CAPS` `candle_routed=true`, mirroring Turbo), but the worker stubbed it. Classic *new-lane-misses-the-house-pattern*: epic 9992 / sc-9994 landed the candle `render_base` generator + the catalog/manifest entries but never added `krea_2_raw` to `is_candle_engine`. Turbo was unaffected; the Krea **edit** lane (checked first) hid the gap for edit jobs; and there was no `krea_2_raw` t2i routing test.

## Fix
- Add `krea_2_raw` to `is_candle_engine` → routes plain Raw t2i/img2img to `CandleTxt2Img` → `generate_candle_stream` → the real `candle-gen-krea` `render_base`.
- Add a `krea_2_raw` t2i + img2img routing test; extend the `is_candle_engine` coverage test; correct the stale "MLX-only for t2i" comment in the `KreaEdit` arm.

## Verification
- Routing tests pass: `candle_image_route_sends_krea_img2img_to_txt2img`, `candle_image_route_gates_on_flag_then_pose_reject_then_txt2img`, `is_candle_engine_covers_only_the_wired_txt2img_families` — **3 passed**.
- Engine GPU-verified independently to render a coherent 1024² image via `load_raw`/`render_base`: **resident + sequential** residency, q8 + bf16 code path, `CUDA_COMPUTE_CAP` 80 and 120 — all coherent (~245s), byte-identical stats.

Fixes sc-13831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)