### PR TITLE
chore(worker,api): isolate HF_HOME-honoring cache tests + fall back off an empty refs/main snapshot [sc-13834]

### DIFF
--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -39,6 +39,59 @@ pub(crate) use tower::ServiceExt;
 
 pub(crate) const PNG_32X32: &[u8] = include_bytes!("../../../desktop/icons/32x32.png");
 
+/// The single process-global lock every rust-api test that mutates HF-cache env serializes on.
+/// rust-api's `#[test]`s run as threads in ONE binary, so a `set_var`/`remove_var` in one is visible
+/// to all the others; mutual exclusion must therefore be crate-wide — a per-module lock serializes
+/// nothing against the rest (mirrors `sceneworks_worker::test_env::ENV_LOCK`, sc-12380). Do NOT add a
+/// second one.
+static HF_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// The HF-cache env vars neutralized (removed) for as long as this guard lives, restored on drop,
+/// under [`HF_ENV_LOCK`]. `huggingface_repo_cache_path` reads `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE`
+/// / `HF_HOME` BEFORE `data_dir`, so a test that seeds a snapshot under a tempdir `data_dir` writes
+/// into the developer's REAL cache unless these are cleared first — clobbering a real repo's
+/// `refs/main` (the krea-2-raw-mlx pollution, sc-13834). The runner strips `HF_HOME` for `cargo test`,
+/// but that does not cover ad-hoc / IDE runs; this makes the tempdir hermetic regardless. Restoring on
+/// `Drop` (not around a closure) keeps a panicking assertion from leaking a cleared cache var into
+/// every later test in the process.
+#[must_use = "bind to a named `_env` local; dropping it immediately restores the env and pins nothing"]
+pub(crate) struct HfCacheEnvGuard {
+    restore: Vec<(&'static str, Option<String>)>,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+/// Take [`HF_ENV_LOCK`] and clear the HF-cache env vars until the returned guard drops, so
+/// `huggingface_repo_cache_path` / `resolve_base_model_path` resolve under the test's own `data_dir`
+/// instead of the developer's real cache. See [`HfCacheEnvGuard`].
+pub(crate) fn isolate_hf_cache() -> HfCacheEnvGuard {
+    let guard = HF_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let restore = ["HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME"]
+        .into_iter()
+        .map(|key| {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            (key, previous)
+        })
+        .collect();
+    HfCacheEnvGuard {
+        restore,
+        _guard: guard,
+    }
+}
+
+impl Drop for HfCacheEnvGuard {
+    fn drop(&mut self) {
+        for (key, previous) in &self.restore {
+            match previous {
+                Some(prior) => std::env::set_var(key, prior),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
 pub(crate) fn readiness_worker(
     id: &str,
     status: WorkerStatus,

--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -2433,6 +2433,7 @@ fn resolve_base_model_path_descends_into_hf_snapshot() {
     // the HF snapshot dir, not the repo cache root. Resolving to the repo root made every
     // HF-cache base model fail at trainer load — z-image "tokenizer: No such file or directory",
     // sdxl "read vocab.json: No such file or directory", ltx "Path must point to a local file".
+    let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 
@@ -2474,6 +2475,7 @@ fn tiered_turnkey_base_trains_on_bf16_tier() {
     // epic 9992 Krea 2 Raw (Path 1): SceneWorks/krea-2-raw-mlx ships bf16/ q8/ q4/ tier subdirs with NO
     // component tree at the snapshot root. Training reads the DENSE bf16 tier; a repo with only the q8
     // GENERATION tier installed is NOT training-ready (no dense weights to LoRA-train on).
+    let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 
@@ -2526,6 +2528,7 @@ fn sdxl_family_tiered_turnkey_trains_on_its_bf16_unet_tier() {
     // gate tested `transformer/` only, so a fully-installed SDXL tiered turnkey (Illustrious) read as
     // un-installed forever and Training Studio blocked submit — while the resolver happily pointed at
     // the bf16 tier. Krea/LTX never caught this: they are DiTs and really do have `transformer/`.
+    let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 
@@ -2580,6 +2583,7 @@ fn flat_sdxl_snapshot_is_not_treated_as_a_tiered_turnkey() {
     // Backward-compat guard for sc-10613: `unet/` at the snapshot root marks a FLAT diffusers tree
     // (stabilityai/stable-diffusion-xl-base-1.0, Kwai-Kolors/Kolors-diffusers). It must resolve
     // unchanged, never descend into a `bf16/` subdir — even if a stray tier dir sits alongside it.
+    let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 
@@ -2617,6 +2621,7 @@ fn resolve_base_model_path_prefers_converted_mlx_dir_for_conversion_models() {
     // HF cache holds only the native *source* checkpoint the converter consumes. Resolving Wan
     // training to the HF source made the trainer fail ("wan umt5 tokenizer: No such file"); it
     // must read the converted dir, mirroring inference's local_mlx_dir.
+    let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1866,17 +1866,46 @@ pub(crate) fn huggingface_receipt_weights_dir(
 fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathBuf> {
     let repo_dir = huggingface_repo_cache_path(data_dir, repo)?;
     let snapshots = repo_dir.join("snapshots");
+    // Prefer `refs/main`, but ONLY when the snapshot it names actually holds files. A polluted
+    // `refs/main` — e.g. a test that clobbered it to an empty placeholder snapshot (sc-13834) —
+    // must not strand the model on an empty dir. This is best-effort defense in depth, not a
+    // substitute for a correct `refs/main`: it distinguishes a materialized snapshot from an
+    // empty/torn one, not dummy fixture weights from real ones.
     if let Ok(rev) = std::fs::read_to_string(repo_dir.join("refs").join("main")) {
         let candidate = snapshots.join(rev.trim());
-        if candidate.is_dir() {
+        if snapshot_file_count(&candidate) > 0 {
             return Some(candidate);
         }
     }
+    // Fallback: the cached snapshot with the most files, so an empty/partial one never wins over a
+    // fully materialized sibling (the old "first dir wins" scan happily returned an empty snapshot).
     std::fs::read_dir(&snapshots)
         .ok()?
         .flatten()
         .map(|entry| entry.path())
-        .find(|path| path.is_dir())
+        .filter(|path| path.is_dir())
+        .map(|path| (snapshot_file_count(&path), path))
+        .filter(|(count, _)| *count > 0)
+        .max_by_key(|(count, _)| *count)
+        .map(|(_, path)| path)
+}
+
+/// Recursively count regular files under `dir` (symlinks counted as files — HF snapshots link into
+/// `blobs/`), returning 0 when it is absent, unreadable, or holds only empty subdirectories. Lets
+/// [`resolve_huggingface_snapshot_dir`] tell a fully materialized snapshot from an empty placeholder.
+fn snapshot_file_count(dir: &Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut count = 0;
+    for entry in entries.flatten() {
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() => count += snapshot_file_count(&entry.path()),
+            Ok(_) => count += 1,
+            Err(_) => {}
+        }
+    }
+    count
 }
 
 /// Replace the relative `snapshots/<rev>/… -> ../blobs/<etag>` symlinks under a resolved
@@ -3566,6 +3595,51 @@ mod co_requisite_tests {
             ("HUGGINGFACE_HUB_CACHE", ""),
             ("HF_HOME", ""),
         ])
+    }
+
+    #[test]
+    fn snapshot_resolution_skips_an_empty_refs_main_and_falls_back_to_the_populated_snapshot() {
+        // A `refs/main` clobbered to an empty placeholder snapshot (the sc-13834 cache-pollution
+        // shape) must NOT strand the model on that empty dir; the resolver falls back to the
+        // most-populated cached sibling instead. Regression guard for the old "first dir wins" scan,
+        // which happily returned an empty snapshot the moment `refs/main` pointed at one.
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let repo = "SceneWorks/krea-2-raw-mlx";
+        let repo_dir =
+            huggingface_repo_cache_path(data_dir.path(), repo).expect("repo cache path resolves");
+        let snapshots = repo_dir.join("snapshots");
+
+        // The real, fully materialized snapshot …
+        let populated = snapshots.join("b88090c7");
+        std::fs::create_dir_all(populated.join("q8/transformer")).expect("populated tree");
+        std::fs::write(
+            populated.join("q8/transformer/diffusion_pytorch_model.safetensors"),
+            b"real",
+        )
+        .expect("write real weight");
+        // … alongside an EMPTY placeholder snapshot (tier dirs only, no files) …
+        std::fs::create_dir_all(snapshots.join("abc123/q8/transformer"))
+            .expect("empty placeholder");
+        // … with `refs/main` clobbered to point at the empty one.
+        std::fs::create_dir_all(repo_dir.join("refs")).expect("create refs");
+        std::fs::write(repo_dir.join("refs").join("main"), "abc123").expect("write refs/main");
+
+        let resolved = resolve_huggingface_snapshot_dir(data_dir.path(), repo)
+            .expect("a populated snapshot exists, so resolution must succeed");
+        assert_eq!(
+            resolved, populated,
+            "a refs/main pointing at an empty snapshot must fall back to the populated sibling"
+        );
+
+        // Sanity: a VALID `refs/main` (populated) is still honored on the fast path — the fallback
+        // only engages when `refs/main` names an empty/absent snapshot.
+        std::fs::write(repo_dir.join("refs").join("main"), "b88090c7").expect("repoint refs/main");
+        assert_eq!(
+            resolve_huggingface_snapshot_dir(data_dir.path(), repo).expect("still resolves"),
+            populated,
+            "a populated refs/main must resolve to exactly that snapshot"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -1164,11 +1164,26 @@ async fn spawn_tree_stub_with_files(
     (format!("http://{address}"), posts)
 }
 
+/// Neutralize the ambient HF-cache env so a download job's `ensure_hf_files_cached` writes under the
+/// test's tempdir `data_dir`, not a developer's real `HF_HOME` (sc-13834). `huggingface_hub_cache_dir`
+/// reads `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME` BEFORE `data_dir`, so `run_model_download_job`
+/// / `run_lora_download_job` (which fetch into `snapshots/main` via `ensure_hf_files_cached(…, "main", …)`)
+/// otherwise land in the real cache — this is what wrote the krea-2-raw-mlx `snapshots/main` dummy
+/// weights. Mirrors the model_jobs / audio_jobs co-requisite seam tests' `isolate_hf_cache`.
+fn isolate_hf_cache() -> crate::test_env::EnvVars {
+    crate::test_env::EnvVars::set(&[
+        ("HF_HUB_CACHE", ""),
+        ("HUGGINGFACE_HUB_CACHE", ""),
+        ("HF_HOME", ""),
+    ])
+}
+
 #[tokio::test]
 async fn model_download_fails_when_the_tier_resolves_no_files() {
     // sc-9909: installing a quant tier whose weights aren't published yet (sc-8513 rollout) resolves
     // ZERO files. That must FAIL with a clear message rather than silently "succeed" and leave an
     // empty cache + a stale completion marker.
+    let _env = isolate_hf_cache(); // keep the stubbed download in the tempdir, off the real cache (sc-13834)
     let temp = tempdir().expect("tempdir creates");
     let (base_url, posts) = spawn_empty_tree_stub().await;
     let mut settings = test_settings(base_url.clone(), None);
@@ -1215,6 +1230,7 @@ async fn model_download_fails_when_one_declared_pattern_matches_nothing() {
     // sc-12283: `allow_pattern_matches` ORs across the filter, so a tier whose transformer matched but
     // whose `tokenizer/*` matched NOTHING passed the aggregate zero-file check, downloaded, completed
     // and wrote an install marker — an "installed" tier that cannot load. This is the #850 shape.
+    let _env = isolate_hf_cache(); // keep the stubbed download in the tempdir, off the real cache (sc-13834)
     let temp = tempdir().expect("tempdir creates");
     // The repo satisfies q8/transformer/* and q8/vae/* but has NO q8/tokenizer/* at all. Sizes are
     // token — the stub serves them verbatim, and this test is about the filter, not the transfer.
@@ -1278,6 +1294,7 @@ async fn lora_download_fails_when_the_declared_adapter_is_absent() {
     // the repo (renamed upstream / typo'd entry / unpublished) resolved zero files, downloaded
     // nothing, and reported the job COMPLETED — while the catalog still read "not installed", because
     // the install probe finds an empty cache. A success post for a fetch of nothing is the bug.
+    let _env = isolate_hf_cache(); // keep the stubbed download in the tempdir, off the real cache (sc-13834)
     let temp = tempdir().expect("tempdir creates");
     // The repo exists but holds a DIFFERENT adapter than the one declared.
     let (base_url, posts) =
@@ -1322,6 +1339,7 @@ async fn lora_download_fails_when_one_of_several_declared_files_is_absent() {
     // sc-12288: `create_lora_download_job` accepts an explicit `files` LIST and the filter ORs across
     // it, so a multi-file adapter that landed one half and not the other passes the aggregate
     // zero-file check and completes as a torn install. Same gap as sc-12283, LoRA side.
+    let _env = isolate_hf_cache(); // keep the stubbed download in the tempdir, off the real cache (sc-13834)
     let temp = tempdir().expect("tempdir creates");
     let (base_url, posts) = spawn_tree_stub_with_files(vec![("high_noise.safetensors", 8)]).await;
     let mut settings = test_settings(base_url.clone(), None);


### PR DESCRIPTION
## Summary
Test-hygiene / hardening chore ([sc-13834](https://app.shortcut.com/trefry/story/13834)), found while debugging [sc-13831](https://app.shortcut.com/trefry/story/13831) but **separate** from it.

`huggingface_hub_cache_dir` / `huggingface_repo_cache_path` read ambient `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME` **before** `data_dir`. Tests that pass a tempdir `data_dir` and then WRITE into the resolved cache therefore leak into the developer's real HF cache when `HF_HOME` is set. Two such tests polluted `E:/huggingface/hub/models--SceneWorks--krea-2-raw-mlx`:

| Test | Wrote |
|---|---|
| `rust-api tests/training.rs::tiered_turnkey_base_trains_on_bf16_tier` | `refs/main`→`abc123` + empty `snapshots/abc123` (clobbered the real ref) |
| `worker tests/lora_and_downloads.rs::model_download_fails_when_one_declared_pattern_matches_nothing` | dummy weights into `snapshots/main` via `ensure_hf_files_cached(.., "main", ..)` |

Renders survived only because `resolve_weights_dir` tries the install receipt first (which file-matched the real `b88090c7` snapshot); nothing else caught it.

## Changes
- **Isolate the offender files' cache-resolving tests** to a temp cache (neutralize the three env vars under a serialized guard):
  - worker `lora_and_downloads.rs` — the 4 download/lora-job tests (reuse `test_env::EnvVars`).
  - rust-api `training.rs` — the 5 tiered-turnkey / `resolve_base_model_path` tests. rust-api had **no** env lock (it leaned entirely on the runner's `env -u HF_HOME`, which doesn't cover ad-hoc / IDE runs), so this adds a mirror `isolate_hf_cache` guard + crate-wide lock to `tests/support.rs`.
- **Harden `resolve_huggingface_snapshot_dir`** (`model_jobs.rs`): trust `refs/main` only when that snapshot actually holds files; otherwise fall back to the most-populated cached snapshot, so a polluted/empty `refs/main` can't strand a model on an empty dir. Adds `snapshot_file_count` + a regression test.

## Verification
- `cargo test -p sceneworks-worker` (resolver + 4 download tests) and `-p sceneworks-rust-api` (5 training tests) green.
- `cargo clippy -p sceneworks-worker -p sceneworks-rust-api --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- **Adversarial proof:** both offenders re-run with `HF_HOME=E:\huggingface` **set** now pass and leave the cache clean — no `snapshots/main`, no `snapshots/abc123`, `refs/main` intact.
- The real box's `krea-2-raw-mlx` cache was repointed to `b88090c7` and the placeholder snapshots removed; `krea-2-turbo-mlx` was already clean.

## Follow-up
[sc-13835](https://app.shortcut.com/trefry/story/13835): apply the same guard to the remaining ~22 install-state tests in `catalog.rs` / `models.rs` (runner-mitigated today; the resolver hardening here already prevents the stranding outcome for them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)