### PR TITLE
feat(audio): provision acestep SFT Cover snapshot + adopt sft_cover seam [sc-13821]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,10 +424,9 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
- "hf-hub",
  "libc",
  "sceneworks-gen-core",
  "sha2",
@@ -437,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -452,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -472,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -488,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -497,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -509,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -525,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -538,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -553,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -566,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -579,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -630,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -648,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -659,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -672,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -685,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -723,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -737,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -750,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -760,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -770,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -787,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -801,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -815,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -828,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -837,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -852,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -867,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -881,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -893,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -906,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "image",
@@ -916,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -933,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -946,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -967,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -981,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1015,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1026,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1038,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1048,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1060,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1077,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "cudaforge",
 ]
@@ -1085,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1314,19 +1313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -1976,12 +1962,6 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2935,26 +2915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hf-hub"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
-dependencies = [
- "dirs",
- "http",
- "indicatif",
- "libc",
- "log",
- "rand 0.9.4",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "ureq 2.12.1",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,7 +3009,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3317,19 +3277,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
 ]
 
 [[package]]
@@ -3891,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3904,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3916,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3929,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3942,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3981,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3994,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4004,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4013,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4022,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4035,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4047,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4059,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4071,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4080,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4092,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4106,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4119,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4130,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4141,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4152,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4163,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4174,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4183,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4192,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4202,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4213,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4227,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4240,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4250,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4261,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4271,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4284,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4308,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "core-llm",
  "half",
@@ -4620,17 +4567,11 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2"
@@ -4940,7 +4881,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
@@ -4951,7 +4892,7 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
@@ -5728,7 +5669,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5856,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5866,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5877,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5990,7 +5931,6 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6156,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=f3483f936ff539eb4877999dc8b342a9ca8e76f5#f3483f936ff539eb4877999dc8b342a9ca8e76f5"
+source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -8050,12 +7990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8072,25 +8006,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.11",
-]
 
 [[package]]
 name = "ureq"
@@ -8478,15 +8393,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -8574,7 +8480,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d" }

--- a/apps/desktop/licenses/acestep-v15-sft-cover/MIT.txt
+++ b/apps/desktop/licenses/acestep-v15-sft-cover/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ACE Studio and StepFun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -129,6 +129,18 @@
       ]
     },
     {
+      "id": "acestep-v15-sft-cover",
+      "name": "ACE-Step v1.5 XL SFT (Cover restyle)",
+      "publisher": "ACE Studio · StepFun",
+      "license": "MIT",
+      "homepage": "https://huggingface.co/ACE-Step/acestep-v15-xl-sft-diffusers",
+      "platforms": ["macos", "windows", "linux"],
+      "usage": "Cover-restyle checkpoint for the ACE-Step Music model (Audio Studio → Music → Cover). SceneWorks downloads the upstream MIT weights on first use as a co-requisite of ACE-Step v1.5 XL Turbo, from ACE-Step/acestep-v15-xl-sft-diffusers — the non-distilled reference cover DiT (transformer) plus the FSQ audio_tokenizer and audio_token_detokenizer conditioning modules — and runs them natively (Candle) on every platform. Used only for the Cover edit mode; text-to-music and the inpaint/repaint/extend edits use the Turbo weights above. Redistributed with attribution as permitted by MIT. Permissive — commercial use allowed.",
+      "documents": [
+        { "label": "MIT License", "key": "acestep-v15-sft-cover-mit" }
+      ]
+    },
+    {
       "id": "openvoice-v2",
       "name": "OpenVoice V2 (Voice Conversion)",
       "publisher": "MyShell.ai",

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -28,6 +28,9 @@ import ltxGemma from "../../../desktop/licenses/ltx-2.3/Gemma-Terms.txt?raw";
 import kokoroApache from "../../../desktop/licenses/kokoro-82m/Apache-2.0.txt?raw";
 import mossApache from "../../../desktop/licenses/moss-soundeffect-v2/Apache-2.0.txt?raw";
 import acestepMit from "../../../desktop/licenses/acestep-v15-turbo/MIT.txt?raw";
+// ACE-Step SFT Cover-restyle checkpoint (sc-13821, epic 13678): the Cover-only co-requisite of the
+// Turbo Music model (transformer cover DiT + FSQ audio_tokenizer/detokenizer), MIT, same ACE-Step org.
+import acestepSftCoverMit from "../../../desktop/licenses/acestep-v15-sft-cover/MIT.txt?raw";
 import openvoiceMit from "../../../desktop/licenses/openvoice-v2/MIT.txt?raw";
 // Chatterbox (Resemble AI, epic 13678): all three components are MIT (Copyright (c)
 // 2025 Resemble AI). chatterboxTtsMit covers the PRIMARY T3/s3gen weights
@@ -71,6 +74,7 @@ const DOCUMENT_TEXT = {
   "kokoro-82m-apache": kokoroApache,
   "moss-soundeffect-v2-apache": mossApache,
   "acestep-v15-turbo-mit": acestepMit,
+  "acestep-v15-sft-cover-mit": acestepSftCoverMit,
   "openvoice-v2-mit": openvoiceMit,
   "chatterbox-tts-mit": chatterboxTtsMit,
   "chatterbox-ve-mit": chatterboxMit,

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -636,7 +636,7 @@ export function AudioStudio() {
             // Extend: the appended tail's new TOTAL length is the Length field; the worker defaults the
             // region start to the source clip's own length (where generation begins).
             payload.editRegionEndSecs = clampedDuration;
-          } else {
+          } else if (editMode === "inpaint" || editMode === "repaint") {
             // Inpaint / repaint: a bounded interior window (seconds). Cleared bounds are omitted so the
             // worker/provider apply their own defaults (end unset ⇒ to the clip end).
             payload.editRegionStartSecs =
@@ -644,6 +644,8 @@ export function AudioStudio() {
             payload.editRegionEndSecs =
               editRegionEndSecs === "" ? undefined : Number(editRegionEndSecs);
           }
+          // Cover (sc-13821) is a whole-clip restyle — no region (the worker's audio_edit_region
+          // returns None for Cover); the source track + prompt are the whole input.
           payload.editStrength = editStrength === "" ? undefined : Number(editStrength);
         }
       } else if (mode === "voiceclone") {

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -51,7 +51,7 @@ const ACESTEP = {
     languages: ["en", "zh"],
     sampleRates: [48000],
     maxDurationSecs: 600,
-    editModes: ["inpaint", "repaint", "extend"],
+    editModes: ["inpaint", "repaint", "extend", "cover"],
     conditioning: ["AudioEdit"],
   },
   ui: { label: "ACE-Step v1.5 XL Turbo" },
@@ -243,7 +243,7 @@ describe("AudioStudio shell (sc-13407)", () => {
     const editChips = [...container.querySelectorAll(".settings-bar-styles .preset-chip")].map((b) =>
       b.textContent.trim(),
     );
-    expect(editChips).toEqual(["inpaint", "repaint", "extend"]);
+    expect(editChips).toEqual(["inpaint", "repaint", "extend", "cover"]);
     // Music has no voice bank, so the Speech-only voice field is absent.
     expect(fieldByLabelStart(container, "Voice")).toBeFalsy();
   });
@@ -788,7 +788,7 @@ describe("AudioStudio Music generation (sc-13410)", () => {
     expect(band).toBeTruthy();
     expect(band.textContent).toContain("Source track");
     const editChips = [...band.querySelectorAll(".preset-chip")].map((b) => b.textContent.trim());
-    expect(editChips).toEqual(["inpaint", "repaint", "extend"]);
+    expect(editChips).toEqual(["inpaint", "repaint", "extend", "cover"]);
   });
 
   it("hides the music fields + source band on Speech / Sound FX (no editModes advertised)", async () => {
@@ -945,6 +945,47 @@ describe("AudioStudio Music generation (sc-13410)", () => {
     expect(payload.editRegionStartSecs).toBe(2);
     expect(payload.editRegionEndSecs).toBe(5);
     expect(payload.editStrength).toBe(0.7);
+  });
+
+  it("rides a cover restyle through as a whole-clip AudioEdit: source + editMode=cover, no region (sc-13821)", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-audio-project_1",
+      JSON.stringify({ sourceAudioAssetId: "audio-src-1" }),
+    );
+    const sourceAsset = { id: "audio-src-1", type: "audio", displayName: "Base loop" };
+    const createAudioJob = vi.fn(async () => ({ id: "cover-1" }));
+    await render(
+      baseContext({
+        assets: [sourceAsset],
+        createAudioJob,
+        rememberLocalGenerationJob: vi.fn(),
+      }),
+    );
+    await click(modeTab(container, "Music"));
+    await setTextarea(container.querySelector(".prompt-input"), "a brass ensemble of trumpets");
+    // Default op is "inpaint", which reveals the region window: set a region FIRST, then switch to
+    // cover. This is the mutation guard — without cover's region-less payload branch the stale 2..5
+    // region would leak onto the whole-clip restyle.
+    await setNumber(container.querySelector(".settings-field-region-start input"), "2");
+    await setNumber(container.querySelector(".settings-field-region-end input"), "5");
+    // Pick the "cover" edit op — the whole-clip restyle backed by the sft_cover coRequisite.
+    const band = container.querySelector(".studio-source-band");
+    const coverChip = [...band.querySelectorAll(".preset-chip")].find(
+      (b) => b.textContent.trim() === "cover",
+    );
+    expect(coverChip).toBeTruthy();
+    await click(coverChip);
+    // Cover is whole-clip: the interior region window must NOT be shown (only inpaint/repaint reveal it).
+    expect(container.querySelector(".settings-field-region-start")).toBeNull();
+    expect(container.querySelector(".settings-field-region-end")).toBeNull();
+    await submitForm();
+
+    const payload = createAudioJob.mock.calls[0][0];
+    expect(payload.sourceAudioAssetId).toBe("audio-src-1");
+    expect(payload.editMode).toBe("cover");
+    // No region for a whole-clip restyle (the worker's audio_edit_region returns None for Cover).
+    expect(payload.editRegionStartSecs).toBeUndefined();
+    expect(payload.editRegionEndSecs).toBeUndefined();
   });
 });
 

--- a/apps/web/src/screens/LicensesScreen.test.jsx
+++ b/apps/web/src/screens/LicensesScreen.test.jsx
@@ -68,6 +68,21 @@ describe("LicensesScreen", () => {
     );
   });
 
+  it("records the ACE-Step SFT Cover-restyle co-requisite under MIT (sc-13821)", async () => {
+    await render();
+    const sftCover = [...container.querySelectorAll(".licenses-item")].find((b) =>
+      b.textContent.includes("ACE-Step v1.5 XL SFT"),
+    );
+    expect(sftCover).toBeTruthy();
+    await act(async () => sftCover.click());
+    // The usage copy names the Cover-only role and the three re-hosted modules.
+    expect(container.textContent).toContain("Cover");
+    expect(container.querySelector(".licenses-text").textContent).toContain("MIT License");
+    expect(container.querySelector(".licenses-text").textContent).toContain(
+      "ACE Studio and StepFun",
+    );
+  });
+
   it("surfaces both LTX-2 and Gemma notices for the LTX bundle", async () => {
     await render();
     const ltx = [...container.querySelectorAll(".licenses-item")].find((b) =>

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -8870,7 +8870,8 @@
         "editModes": [
           "inpaint",
           "repaint",
-          "extend"
+          "extend",
+          "cover"
         ],
         "conditioning": [
           "AudioEdit"
@@ -8903,6 +8904,56 @@
           "estimatedSizeBytes": 11100883579,
           "footprint": {
             "diskSizeBytes": 11100883579
+          }
+        },
+        {
+          // Cover restyle co-requisite (sc-13821, epic 13678) — the acestep SFT checkpoint, a SECOND,
+          // distinct snapshot from the turbo/text2music primary above. The turbo checkpoint ships no
+          // `audio_tokenizer` / `audio_token_detokenizer`; this sibling `-sft-diffusers` checkpoint (same
+          // MIT org, same 64-ch/25 Hz acoustic latent space) does, and it carries the non-distilled
+          // reference cover DiT (`transformer/`) the Cover restyle needs. The Cover path pulls the two
+          // FSQ component dirs AND the sft `transformer` (~8.76 GB total); everything else — text-to-music
+          // and the Inpaint/Repaint/Extend region edits — stays on the turbo DiT + its Oobleck VAE.
+          //
+          // This is an OPTIONAL, on-demand component the worker stages as the model's `sft_cover`
+          // component (`componentId` below) ONLY for a Cover edit request — mirroring LTX's
+          // `uncensored_enhancer` / sensenova's `distill_lora`, NOT the always-loaded chatterbox/MOSS
+          // codec pattern. Because it is Cover-only it is `required: "soft"` (never install-gating for
+          // base text2music) and it is deliberately NOT a `descriptor.required_components` id — so the
+          // generic `resolve_co_requisites` seam (required-components-only) does not stage it; the audio
+          // worker attaches it explicitly on a Cover request (audio_jobs.rs, `resolve_optional_component`
+          // → `LoadSpec::with_component("sft_cover", Dir)`, matched to `candle_audio_acestep`'s
+          // `COVER_COMPONENT_ID = "sft_cover"`). An unprovisioned Cover fails fast at load with an
+          // actionable error naming the component; inference never self-fetches (epic 13657).
+          //
+          // `revision` MUST be the full 40-hex SHA the runtime resolves (snapshots/<sha>/), so a
+          // main-branch fetch would populate the wrong snapshot and offline Cover would fail. Pinned to
+          // the exact commit candle-audio-acestep was ported against (SFT_HUB_REVISION). Provisioned
+          // alongside the turbo primary on install; the HF blob layout dedups for users who already have
+          // it (no surprise re-download). Cross-repo coupling: the adopted inference pin (sc-13756, PR
+          // #186) reads this snapshot ONLY from the `sft_cover` component seam — the earlier
+          // `ACESTEP_SFT_SNAPSHOT` env read + self-fetch were removed — so this coRequisite + the worker
+          // attach are what make Cover render offline. All three modules (cover DiT transformer + FSQ
+          // audio_tokenizer + audio_token_detokenizer) are MIT.
+          "provider": "huggingface",
+          "repo": "ACE-Step/acestep-v15-xl-sft-diffusers",
+          "revision": "4bf7b60a63b27144f539f980927eeb89f5f912b0",
+          "coRequisite": true,
+          "required": "soft",
+          "componentId": "sft_cover",
+          "files": [
+            "transformer/*",
+            "audio_tokenizer/*",
+            "audio_token_detokenizer/*"
+          ],
+          "platforms": [
+            "macos",
+            "windows",
+            "linux"
+          ],
+          "estimatedSizeBytes": 8758016981,
+          "footprint": {
+            "diskSizeBytes": 8758016981
           }
         }
       ],

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "f3483f936ff539eb4877999dc8b342a9ca8e76f5", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -671,12 +671,31 @@ async fn run_audio_synthesis_using(
     // co-requisite fails the JOB here with an actionable error rather than a mid-render hub fetch. The
     // resolved paths are staged in `LoadSpec::components` for the generator's load-time
     // `require_component` gate. Weights-free registry read; no-op when this build ships no audio lane.
-    let components = match crate::inference_runtime::audio_descriptor(&model_id) {
+    let mut components = match crate::inference_runtime::audio_descriptor(&model_id) {
         Some(descriptor) => {
             resolve_co_requisites(&descriptor, &request.model_manifest_entry, settings)?
         }
         None => BTreeMap::new(),
     };
+    // Optional, on-demand Cover component (sc-13821): acestep's ~8.76 GB `sft_cover` snapshot — the
+    // non-distilled reference cover DiT plus the FSQ audio_tokenizer/detokenizer — is staged ONLY for a
+    // Cover restyle request. It is deliberately NOT a `required_components` id (Cover-only, lazy,
+    // mirroring LTX `uncensored_enhancer`), so the generic `resolve_co_requisites` above never stages
+    // it; text2music and the Inpaint/Repaint/Extend region edits load without it. The id matches
+    // `candle_audio_acestep::COVER_COMPONENT_ID` ("sft_cover"); resolve it from the model's own soft
+    // `sft_cover` coRequisite in the manifest. At the adopted inference pin (sc-13756) the Cover path
+    // reads this snapshot ONLY from `LoadSpec::components["sft_cover"]` (the env-var/self-fetch read was
+    // removed), so this attach is the sole offline Cover source. An absent snapshot stages nothing; the
+    // engine then surfaces the actionable Cover-needs-`sft_cover` error on the request that needs it.
+    if request.edit_mode.as_deref() == Some("cover") {
+        if let Some(source) = crate::model_jobs::resolve_optional_component(
+            &request.model_manifest_entry,
+            "sft_cover",
+            settings,
+        ) {
+            components.insert("sft_cover".to_string(), source);
+        }
+    }
     let handle = {
         let cancel = cancel.clone();
         let chunk_tx = chunk_tx.clone();
@@ -2607,6 +2626,166 @@ mod tests {
         assert!(
             posts.iter().all(|p| p["status"] != "canceled"),
             "a clean completion posts no terminal Canceled, got {posts:?}"
+        );
+    }
+
+    // acestep's Cover snapshot pin (sc-13821), matching the `sft_cover` soft coRequisite in
+    // config/manifests/builtin.models.jsonc and candle-audio-acestep's SFT_HUB_REVISION.
+    const SFT_COVER_REPO: &str = "ACE-Step/acestep-v15-xl-sft-diffusers";
+    const SFT_COVER_REVISION: &str = "4bf7b60a63b27144f539f980927eeb89f5f912b0";
+
+    /// Stage acestep's `sft_cover` Cover snapshot (sc-13821) under an isolated HF cache with the three
+    /// component subdirs the provider joins (`transformer/`, `audio_tokenizer/`,
+    /// `audio_token_detokenizer/`), point `settings.data_dir` at it, and return the acestep
+    /// `modelManifestEntry` carrying the soft `sft_cover` coRequisite. Mirrors
+    /// [`stage_chatterbox_components`]; the staged bytes are never read (the loaded generator is a stub)
+    /// — the test asserts the RESOLVED PATH reaches the LoadSpec. Guard + tempdir must outlive the test.
+    struct StagedSftCover {
+        _env: crate::test_env::EnvVars,
+        _data_dir: tempfile::TempDir,
+        manifest_entry: Value,
+    }
+
+    fn stage_sft_cover(settings: &mut Settings) -> StagedSftCover {
+        let env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let snapshot =
+            sceneworks_core::hf_home::huggingface_repo_cache_path(data_dir.path(), SFT_COVER_REPO)
+                .expect("repo cache path resolves")
+                .join("snapshots")
+                .join(SFT_COVER_REVISION);
+        for (subdir, file) in [
+            (
+                "transformer",
+                "diffusion_pytorch_model.safetensors.index.json",
+            ),
+            ("audio_tokenizer", "config.json"),
+            ("audio_token_detokenizer", "config.json"),
+        ] {
+            let dir = snapshot.join(subdir);
+            std::fs::create_dir_all(&dir).expect("create component subdir");
+            std::fs::write(dir.join(file), b"weights").expect("write staged component file");
+        }
+        settings.data_dir = data_dir.path().to_path_buf();
+        let manifest_entry = json!({
+            "id": "acestep_v15_turbo",
+            "type": "audio",
+            "downloads": [
+                { "provider": "huggingface", "repo": "ACE-Step/acestep-v15-xl-turbo-diffusers",
+                  "revision": "200ba991ae448051e14b0183157e35c2d27c9fb0" },
+                { "provider": "huggingface", "repo": SFT_COVER_REPO, "revision": SFT_COVER_REVISION,
+                  "coRequisite": true, "required": "soft", "componentId": "sft_cover",
+                  "files": ["transformer/*", "audio_tokenizer/*", "audio_token_detokenizer/*"] }
+            ],
+        });
+        StagedSftCover {
+            _env: env,
+            _data_dir: data_dir,
+            manifest_entry,
+        }
+    }
+
+    /// A loader that records the `LoadSpec::components` it receives before returning a completing stub —
+    /// the audio twin of [`stub_load`], used to assert which components a request stages on the spec the
+    /// engine load actually sees (the seam the multi-entrypoint bug hid, sc-13686).
+    fn spec_capture_load(
+        captured: Arc<Mutex<Option<BTreeMap<String, gen_core::WeightsSource>>>>,
+    ) -> impl FnOnce(&str, &LoadSpec) -> gen_core::Result<Box<dyn Generator>> + Send + 'static {
+        move |_id: &str, spec: &LoadSpec| {
+            *captured.lock().expect("spec capture lock") = Some(spec.components.clone());
+            Ok(Box::new(StubGenerator {
+                descriptor: stub_descriptor(),
+                behavior: StubBehavior::CompleteOk,
+                observed_cancel: Arc::new(AtomicBool::new(false)),
+            }) as Box<dyn Generator>)
+        }
+    }
+
+    /// sc-13821: a Cover request stages the pinned `sft_cover` snapshot into the LoadSpec the loader
+    /// receives — the OPTIONAL, on-demand component the generic `resolve_co_requisites` seam does NOT
+    /// stage (sft_cover is deliberately not a `required_components` id). This drives the REAL
+    /// `run_audio_synthesis_using` entrypoint (not the resolver in isolation), matching
+    /// [[coreq_seam_has_multiple_loadspec_entrypoints]].
+    #[tokio::test]
+    async fn cover_request_stages_the_sft_cover_component_on_the_loadspec() {
+        let (base_url, _progress) = spawn_audio_cancel_stub(false).await;
+        let mut settings = cancel_test_settings(base_url);
+        let staged = stage_sft_cover(&mut settings);
+        let api = ApiClient::new(&settings);
+        let job = audio_test_job("audio-sft-cover");
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "acestep_v15_turbo",
+            "editMode": "cover",
+            "modelManifestEntry": staged.manifest_entry.clone(),
+        })));
+
+        let captured = Arc::new(Mutex::new(None));
+        run_audio_synthesis_using(
+            &api,
+            &settings,
+            &job,
+            &request,
+            PathBuf::from("unused"),
+            None,
+            spec_capture_load(captured.clone()),
+        )
+        .await
+        .expect("the stub Cover synthesis completes");
+
+        let comps = captured
+            .lock()
+            .expect("capture lock")
+            .take()
+            .expect("the loader captured a LoadSpec");
+        match comps.get("sft_cover") {
+            Some(gen_core::WeightsSource::Dir(dir)) => assert!(
+                dir.ends_with(SFT_COVER_REVISION),
+                "sft_cover must resolve to the PINNED snapshot dir (snapshots/<sha>/), got {dir:?}"
+            ),
+            other => panic!(
+                "a Cover request must stage sft_cover as a Dir on the LoadSpec, got {other:?}"
+            ),
+        }
+    }
+
+    /// Mutation guard for [`cover_request_stages_the_sft_cover_component_on_the_loadspec`]: with the SAME
+    /// model + manifest and the snapshot present, a NON-Cover (text-to-music) request must NOT stage
+    /// `sft_cover` — an unconditional attach (or one via the always-run required-components seam) would
+    /// false-green the positive test.
+    #[tokio::test]
+    async fn non_cover_request_does_not_stage_the_sft_cover_component() {
+        let (base_url, _progress) = spawn_audio_cancel_stub(false).await;
+        let mut settings = cancel_test_settings(base_url);
+        let staged = stage_sft_cover(&mut settings);
+        let api = ApiClient::new(&settings);
+        let job = audio_test_job("audio-sft-no-cover");
+        let request = AudioRequest::from_payload(&payload(json!({
+            "model": "acestep_v15_turbo",
+            "modelManifestEntry": staged.manifest_entry.clone(),
+        })));
+
+        let captured = Arc::new(Mutex::new(None));
+        run_audio_synthesis_using(
+            &api,
+            &settings,
+            &job,
+            &request,
+            PathBuf::from("unused"),
+            None,
+            spec_capture_load(captured.clone()),
+        )
+        .await
+        .expect("the stub text-to-music synthesis completes");
+
+        let comps = captured
+            .lock()
+            .expect("capture lock")
+            .take()
+            .expect("the loader captured a LoadSpec");
+        assert!(
+            !comps.contains_key("sft_cover"),
+            "a non-Cover request must NOT stage sft_cover, got {:?}",
+            comps.get("sft_cover")
         );
     }
 

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -78,7 +78,9 @@ use runtime_macos::providers::instantid::{
 // the exact type `InstantId::generate` consumes.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use runtime_cuda::providers::instantid::{
-    BodyPoint, InstantId, InstantIdPaths, InstantIdRequest, FACE_RESTORE_PROMPT,
+    BodyPoint, InstantId, InstantIdPaths, InstantIdRequest, SdxlComponents,
+    COMPONENT_TOKENIZER_CLIP_BIGG, COMPONENT_TOKENIZER_CLIP_L, COMPONENT_VAE_FP16_FIX,
+    FACE_RESTORE_PROMPT,
 };
 // SDXL IP-Adapter-Plus reference provider (sc-5488, epic 5480) — the candle (Windows/CUDA) reference-
 // conditioning sibling of the InstantID lane, living in `candle-gen-sdxl` (it composes that crate's

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -855,9 +855,24 @@ async fn generate_instantid_stream(
     // Resolved before the blocking closure (a missing one fails fast) and moved in. `InstantIdPaths`
     // carries these fields ONLY on the candle build — the macOS MLX InstantID lane is self-contained — so
     // both the resolve and the struct fields are candle-gated.
+    // sc-13739: the candle `InstantIdPaths` no longer takes the three SDXL components as flat fields —
+    // it takes an `SdxlComponents` built from a `LoadSpec` (the same load-time gate the SDXL engine
+    // runs). Resolve the three from the manifest coRequisites, stage them under their component ids, and
+    // build the gated `SdxlComponents` here; a missing/misconfigured one fails the job before the load.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-    let (tokenizer_clip_l, tokenizer_clip_bigg, vae_fp16_fix) =
-        resolve_sdxl_components(&request.model_manifest_entry, settings)?;
+    let sdxl = {
+        let (tokenizer_clip_l, tokenizer_clip_bigg, vae_fp16_fix) =
+            resolve_sdxl_components(&request.model_manifest_entry, settings)?;
+        SdxlComponents::from_spec(
+            &gen_core::LoadSpec::new(WeightsSource::Dir(std::path::PathBuf::new()))
+                .with_component(COMPONENT_TOKENIZER_CLIP_L, tokenizer_clip_l)
+                .with_component(COMPONENT_TOKENIZER_CLIP_BIGG, tokenizer_clip_bigg)
+                .with_component(COMPONENT_VAE_FP16_FIX, vae_fp16_fix),
+        )
+        .map_err(|error| {
+            WorkerError::InvalidPayload(format!("InstantID SDXL components: {error}"))
+        })?
+    };
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "instantid",
@@ -872,13 +887,9 @@ async fn generate_instantid_stream(
                 // pin now 19d5522, candle pin c98609f). Populated for BOTH backends — superseding the
                 // earlier candle-only `Vec::new()` stopgap from #730.
                 adapters,
-                // The three caller-staged SDXL components (candle only — see above).
+                // The caller-staged SDXL components as an `SdxlComponents` (candle only — see above).
                 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-                tokenizer_clip_l,
-                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-                tokenizer_clip_bigg,
-                #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-                vae_fp16_fix,
+                sdxl,
             };
             let model = InstantId::load(&paths)
                 .map_err(|error| WorkerError::Engine(format!("InstantID load failed: {error}")))?;

--- a/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/instantid_pid_gpu_smoke.rs
@@ -43,8 +43,11 @@
 use std::path::{Path, PathBuf};
 
 use gen_core::runtime::CancelFlag;
-use gen_core::{Image, PidWeights, WeightsSource};
-use runtime_cuda::providers::instantid::{BodyPoint, InstantId, InstantIdPaths, InstantIdRequest};
+use gen_core::{Image, LoadSpec, PidWeights, WeightsSource};
+use runtime_cuda::providers::instantid::{
+    BodyPoint, InstantId, InstantIdPaths, InstantIdRequest, SdxlComponents,
+    COMPONENT_TOKENIZER_CLIP_BIGG, COMPONENT_TOKENIZER_CLIP_L, COMPONENT_VAE_FP16_FIX,
+};
 
 /// The InstantID identity-preservation floor. InstantID's target envelope is ArcFace-cosine ~0.82
 /// @1024²; a conservative 0.35 floor proves the reference identity clearly transferred (an unrelated
@@ -262,9 +265,25 @@ fn instantid_pid_gpu_smoke() {
         identitynet: WeightsSource::Dir(identitynet.clone()),
         ip_adapter: ip_adapter.clone(),
         adapters: Vec::new(),
-        tokenizer_clip_l: WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_L_DIR")),
-        tokenizer_clip_bigg: WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_BIGG_DIR")),
-        vae_fp16_fix: WeightsSource::Dir(env_path("SDXL_VAE_FP16_FIX_DIR")),
+        // The three SDXL components (sc-13739) now flow through LoadSpec::components rather than flat
+        // InstantIdPaths fields: stage them from the same env dirs and let SdxlComponents::from_spec
+        // resolve + gate them (the load-time contract InstantID's own load runs).
+        sdxl: SdxlComponents::from_spec(
+            &LoadSpec::new(WeightsSource::Dir(base.clone()))
+                .with_component(
+                    COMPONENT_TOKENIZER_CLIP_L,
+                    WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_L_DIR")),
+                )
+                .with_component(
+                    COMPONENT_TOKENIZER_CLIP_BIGG,
+                    WeightsSource::Dir(env_path("SDXL_TOKENIZER_CLIP_BIGG_DIR")),
+                )
+                .with_component(
+                    COMPONENT_VAE_FP16_FIX,
+                    WeightsSource::Dir(env_path("SDXL_VAE_FP16_FIX_DIR")),
+                ),
+        )
+        .expect("stage SDXL components"),
     })
     .expect("load candle InstantId");
     // Attach OpenPose (pose mode) BEFORE the face stack — the engine's documented order. Harmless for

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1739,6 +1739,55 @@ pub(crate) fn resolve_co_requisites(
     Ok(components)
 }
 
+/// Resolve an OPTIONAL, on-demand model component the caller stages only for specific requests — the
+/// counterpart to [`resolve_co_requisites`] for a component deliberately kept OUT of the descriptor's
+/// `required_components` so the generic seam never stages it. The motivating case is acestep's
+/// `sft_cover` Cover snapshot (sc-13821): a ~8.76 GB checkpoint read only for a Cover restyle, Cover-only
+/// and lazy, mirroring LTX's `uncensored_enhancer` / sensenova's `distill_lora`.
+///
+/// Returns `Some(source)` when the manifest declares a `coRequisite` download tagged
+/// `componentId: <component_id>` AND its pinned snapshot is installed on disk; `None` when the manifest
+/// declares no such component (an older inference pin, or a different model) OR its snapshot is not
+/// installed. `None` is a deliberate no-op: an optional component is never install-gating (a `soft`
+/// co-requisite leaves text2music + the region edit modes usable), and the engine surfaces its own
+/// actionable "component not staged" error on the one request that actually needs the component — so
+/// the worker does not pre-empt that with a hard error here (which on the pre-adoption inference pin,
+/// whose Cover path still self-fetches, would be a regression). Snapshot resolution mirrors
+/// [`resolve_co_requisites`]: a pinned `revision` reads the exact `snapshots/<sha>/` (never `refs/main`).
+pub(crate) fn resolve_optional_component(
+    manifest_entry: &Value,
+    component_id: &str,
+    settings: &Settings,
+) -> Option<gen_core::WeightsSource> {
+    let downloads = manifest_entry.get("downloads").and_then(Value::as_array)?;
+    let download = downloads.iter().find(|download| {
+        download.get("coRequisite").and_then(Value::as_bool) == Some(true)
+            && download.get("componentId").and_then(Value::as_str) == Some(component_id)
+    })?;
+    let repo = download.get("repo").and_then(Value::as_str)?;
+    let snapshot = match download.get("revision").and_then(Value::as_str) {
+        Some(revision) => huggingface_pinned_snapshot_dir(&settings.data_dir, repo, revision),
+        None => huggingface_snapshot_dir(&settings.data_dir, repo),
+    }?;
+    let files: Vec<&str> = download
+        .get("files")
+        .and_then(Value::as_array)
+        .map(|files| files.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    // A single concrete file resolves to that file; a multi-file / glob component (sft_cover's
+    // `transformer/*` + the two FSQ dirs) resolves to the snapshot ROOT — the provider joins its own
+    // internal subpaths (candle-audio-acestep reads `transformer/`, `audio_tokenizer/`,
+    // `audio_token_detokenizer/` under the staged dir).
+    match files.as_slice() {
+        [file] if !file.contains('*') => {
+            let path = snapshot.join(file);
+            path.is_file()
+                .then_some(gen_core::WeightsSource::File(path))
+        }
+        _ => Some(gen_core::WeightsSource::Dir(snapshot)),
+    }
+}
+
 /// Resolve the exact snapshot/tier recorded by a completed model-download receipt.
 ///
 /// A manifest may rename files after an install.  In that case the catalog deliberately keeps the
@@ -3566,6 +3615,57 @@ mod co_requisite_tests {
             ("HUGGINGFACE_HUB_CACHE", ""),
             ("HF_HOME", ""),
         ])
+    }
+
+    /// The optional, on-demand `sft_cover` component seam (sc-13821): acestep's Cover snapshot is a
+    /// `coRequisite` deliberately kept OUT of `required_components`, so [`resolve_co_requisites`] never
+    /// stages it. [`resolve_optional_component`] resolves it on demand — `Some(Dir)` when installed,
+    /// `None` (never an error) when undeclared or absent, so an optional component is never
+    /// install-gating (a `soft` co-requisite keeps text2music + the region edits usable).
+    #[test]
+    fn resolve_optional_component_resolves_sft_cover_only_when_declared_and_installed() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let repo = "ACE-Step/acestep-v15-xl-sft-diffusers";
+        let revision = "4bf7b60a63b27144f539f980927eeb89f5f912b0";
+        let manifest = json!({
+            "id": "acestep_v15_turbo",
+            "downloads": [
+                { "provider": "huggingface", "repo": "ACE-Step/acestep-v15-xl-turbo-diffusers",
+                  "revision": "200ba991ae448051e14b0183157e35c2d27c9fb0" },
+                { "provider": "huggingface", "repo": repo, "revision": revision,
+                  "coRequisite": true, "required": "soft", "componentId": "sft_cover",
+                  "files": ["transformer/*", "audio_tokenizer/*", "audio_token_detokenizer/*"] }
+            ]
+        });
+        let settings = settings_at(data_dir.path().to_path_buf());
+
+        // Declared but NOT installed → None (the caller no-ops; never a hard error that would pre-empt
+        // the engine's own on-demand Cover error and, on the pre-adoption pin, its self-fetch).
+        assert!(
+            resolve_optional_component(&manifest, "sft_cover", &settings).is_none(),
+            "an absent optional component resolves to None, not an error"
+        );
+        // A component the manifest does not declare → None.
+        assert!(
+            resolve_optional_component(&manifest, "not_a_component", &settings).is_none(),
+            "an undeclared component resolves to None"
+        );
+
+        // Install it → resolves to the PINNED snapshot dir (a multi-file/glob component ⇒ Dir root).
+        stage_snapshot_file(
+            data_dir.path(),
+            repo,
+            revision,
+            "transformer/diffusion_pytorch_model.safetensors.index.json",
+        );
+        match resolve_optional_component(&manifest, "sft_cover", &settings) {
+            Some(gen_core::WeightsSource::Dir(dir)) => assert!(
+                dir.ends_with(revision),
+                "an installed sft_cover resolves to the pinned snapshots/<sha>/ dir, got {dir:?}"
+            ),
+            other => panic!("an installed sft_cover resolves to a Dir, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -265,11 +265,14 @@ def test_builtin_manifest_ships_the_seeded_audio_models():
     assert all(isinstance(v, dict) and v.get("id") for v in kokoro_voices)
     assert by_id["kokoro_82m"].get("recommended") is True, "Kokoro is the recommended Speech model"
 
-    # ACE-Step's real edit surface (Conditioning::AudioEdit → repaint task modes).
+    # ACE-Step's real edit surface (Conditioning::AudioEdit → repaint task modes). `cover` (sc-13821)
+    # is the whole-clip restyle backed by the `sft_cover` coRequisite — advertised here so the Music
+    # studio surfaces it, matching the backend descriptor's audio_edit_modes (Inpaint/Repaint/Extend/Cover).
     assert set(by_id["acestep_v15_turbo"]["audio"]["editModes"]) == {
         "inpaint",
         "repaint",
         "extend",
+        "cover",
     }
     assert "AudioEdit" in by_id["acestep_v15_turbo"]["audio"]["conditioning"]
 


### PR DESCRIPTION
## sc-13821 — provision acestep SFT Cover snapshot + adopt the `sft_cover` seam

The SceneWorks half of the acestep-Cover self-fetch fix (epic 13678). ACE-Step's **Cover** restyle needs a second snapshot — the non-distilled sft cover DiT (`transformer/`) + FSQ `audio_tokenizer/` + `audio_token_detokenizer/` — distinct from the turbo/text2music primary. This provisions it, wires the worker to stage it as the optional `sft_cover` component, records its license, and **bumps the inference pin to adopt the now-merged sc-13756 component seam** so Cover renders offline instead of self-fetching.

### Changes
- **Manifest** (`config/manifests/builtin.models.jsonc`): a soft (`required:"soft"`) `sft_cover` coRequisite on `acestep_v15_turbo` — repo `ACE-Step/acestep-v15-xl-sft-diffusers@4bf7b60a…`, `componentId:"sft_cover"`, 8.76 GB, `transformer/* audio_tokenizer/* audio_token_detokenizer/*`. Cover-only, never install-gating for base text2music.
- **Worker** (`audio_jobs.rs` + `model_jobs.rs`): new `resolve_optional_component` helper + a Cover-gated `LoadSpec::with_component("sft_cover", Dir)` attach. `sft_cover` is deliberately **not** a `required_component` (Cover-only, lazy, mirroring LTX `uncensored_enhancer`), so the generic `resolve_co_requisites` seam correctly ignores it and the worker attaches it on demand.
- **UI surfacing** (`AudioStudio.jsx` + audit): added `"cover"` to `acestep_v15_turbo.audio.editModes` (matching the backend descriptor's `audio_edit_modes`) so the Music studio actually offers the Cover chip — without this the feature is unreachable in the product. Cover rides through as a whole-clip `AudioEdit` (no region); a payload guard keeps a stale inpaint/repaint region off the request.
- **Licenses**: one `acestep-v15-sft-cover` MIT entry on About→Licenses (text + manifest + `bundledLicenses.js` + test).
- **Inference pin**: `f3483f93…` → `cd46a91079e993b3cb3b9e4438b8dd819944255d` (main tip; ≥ `d7c6d41f`). This adopts PR #186 (sc-13756: acestep Cover reads `spec.components["sft_cover"]`, env-var read removed) and the rest of the epic-13678 self-fetch purge. gen-core/candle-kernels skew checks pass; the purge drops `hf-hub`/`ureq`/`webpki-roots` from the lock.
- **Candle counterpart-completeness** (`image_jobs/instantid.rs`, `image_jobs.rs`, `instantid_pid_gpu_smoke.rs`): the bump also adopts sc-13739, which reshaped candle `InstantIdPaths` — its three SDXL components moved from flat fields into a single `sdxl: SdxlComponents` (built via `from_spec(&LoadSpec)`). Updated the two candle-only consumers to the new shape (macOS uses the unchanged mlx struct; the break was invisible to macOS `rust:check`/parity). Verified with the stubbed-nvcc linux cross-build (`--features backend-candle` check + clippy `-D warnings`).

### Validation
- **Offline Cover render** (`HF_HUB_OFFLINE=1`, pinned snapshot, sc-13756 conformance): **passed** — matched-chroma 0.7326 > mismatched 0.6515, per-direction floors cleared, restyle proven; 4 WAVs written. This is the DoD render through the exact `sft_cover` seam the worker stages.
- **`npm run rust:check`**: green at the new pin (fmt + clippy + test + build; counterpart-completeness holds).
- **Worker tests**: `cover_request_stages_the_sft_cover_component_on_the_loadspec` (drives the real `run_audio_synthesis_using` entrypoint; mutation-checked — goes RED with the attach disabled), a non-Cover guard, and a `resolve_optional_component` unit test.
- **Web**: a Cover-payload test (mutation-checked — the region guard goes RED if reverted) + updated edit-chip assertions; full vitest suite (2223 tests) green.
- **Manifest audit** (python) + Rust `builtin_manifests` backstop + `LicensesScreen` vitest + eslint: green. Gate re-run green on the `origin/main` merge commit.

### Notes / limitations
- This bump also adopts the self-fetch purge for **all** models. Compile+test counterpart-completeness is green; the audio/Metal offline-render cell (acestep Cover) is validated here, but the **mmaudio / candle-SDXL** offline-render cells need a CUDA runner (known gap, sc-13796) and are not exercisable on this Mac.
- Closes the capstone pin-adoption for the acestep half; relates to sc-13756 (inference), sc-13818 (pin adoption), sc-13251 (Cover feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
