### PR TITLE
fix(core): guard generation-set id against path traversal [sc-13582]

### DIFF
--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -6,7 +6,9 @@ use rusqlite::{params, Connection, OptionalExtension, Row};
 use serde_json::Value;
 
 use crate::project_store::{ProjectStoreError, ProjectStoreResult};
-use crate::store_util::{optional_bool, optional_str, optional_u64, read_json, relative_string};
+use crate::store_util::{
+    is_safe_id, optional_bool, optional_str, optional_u64, read_json, relative_string,
+};
 
 pub(crate) const ASSET_SIDECAR_PATTERN: &str = "*.sceneworks.json";
 
@@ -240,7 +242,15 @@ pub(crate) fn normalize_asset_cached(
             }
         }
     }
-    if let Some(generation_set_id) = asset.get("generationSetId").and_then(Value::as_str) {
+    // The id comes from the on-disk sidecar and is joined into the
+    // generation-sets read path below; skip anything that isn't a plain id so a
+    // tampered sidecar can't pull JSON from outside the project into API
+    // responses (sc-13582).
+    if let Some(generation_set_id) = asset
+        .get("generationSetId")
+        .and_then(Value::as_str)
+        .filter(|id| is_safe_id(id))
+    {
         let cached = generation_sets
             .entries
             .entry(generation_set_id.to_owned())

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -2216,6 +2216,15 @@ impl ProjectStore {
             .ok_or_else(|| {
                 ProjectStoreError::BadRequest("generation set fact missing id".to_owned())
             })?;
+        // The id comes from the worker-reported fact and is joined into the
+        // generation-sets path below, so charset-check it before path use — the
+        // worker->API boundary must not write outside the project root
+        // (sc-13582; mirrors the persist_generated_asset guards, sc-5721/sc-4211).
+        if !is_safe_id(id) {
+            return Err(ProjectStoreError::BadRequest(
+                "Invalid generation set id".to_owned(),
+            ));
+        }
         let get = |key: &str| generation_set.get(key).cloned().unwrap_or(Value::Null);
         let record = json!({
             "schemaVersion": 1,
@@ -5255,6 +5264,90 @@ mod tests {
             json!(1024)
         );
         assert_eq!(written["recipe"]["rawAdapterSettings"]["steps"], json!(8));
+    }
+
+    /// sc-13582 / F-001: the generation-set id is worker-reported and joined
+    /// into the generation-sets write path; a traversal id must be rejected
+    /// before any directory/file is created, mirroring the
+    /// persist_generated_asset guards (sc-5721/sc-4211).
+    #[test]
+    fn write_generation_set_rejects_traversal_id() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Fixture").expect("project creates");
+        let generation_set = json!({
+            "id": "../../escaped",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "city",
+            "count": 1,
+            "createdAt": "2026-05-25T00:00:00Z",
+        });
+
+        let error = store
+            .write_generation_set(&project.id, "job-1", &generation_set, None)
+            .expect_err("traversal id is rejected");
+        assert!(
+            matches!(&error, ProjectStoreError::BadRequest(message) if message.contains("generation set id")),
+            "expected invalid-id BadRequest, got {error:?}"
+        );
+        // The atomic-rename writer must never have produced the escaped file
+        // (generation-sets/../../escaped.json resolves above the project root).
+        let project_path = std::path::Path::new(&project.path);
+        assert!(!project_path
+            .join("generation-sets/../../escaped.json")
+            .exists());
+    }
+
+    /// sc-13582 / F-001 (read half): a sidecar-supplied `generationSetId` is
+    /// joined into the generation-sets read path at list time; a tampered
+    /// traversal id must be skipped, not resolved to a file outside the
+    /// project and embedded into the API response.
+    #[test]
+    fn list_assets_skips_traversal_generation_set_id() {
+        use crate::store_util::{read_json, write_json};
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Gallery").expect("project creates");
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "genset_ok",
+                &json!({
+                    "assetId": "asset_one",
+                    "mediaPath": "assets/images/genset_ok/asset_one.png",
+                    "mimeType": "image/png",
+                    "displayName": "city #1",
+                    "createdAt": "2026-05-25T00:00:00Z",
+                    "mode": "text_to_image",
+                    "model": "z_image_turbo",
+                    "adapter": "z_image_diffusers",
+                    "prompt": "city",
+                }),
+            )
+            .expect("asset persists");
+
+        // Tamper the on-disk sidecar the way a compromised worker/file could,
+        // and plant the traversal target outside the project root.
+        let project_path = std::path::Path::new(&project.path);
+        let sidecar_path = project_path.join("assets/images/genset_ok/asset_one.sceneworks.json");
+        let mut sidecar = read_json(&sidecar_path).expect("sidecar reads");
+        sidecar["generationSetId"] = json!("../../leak");
+        write_json(&sidecar_path, &sidecar).expect("tampered sidecar writes");
+        let leak_path = project_path.join("generation-sets/../../leak.json");
+        std::fs::create_dir_all(project_path.join("generation-sets")).expect("sets dir");
+        write_json(&leak_path, &json!({"secret": "outside-project"})).expect("leak plant writes");
+
+        let assets = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .expect("list");
+        assert_eq!(assets.len(), 1);
+        assert!(
+            assets[0].get("generationSet").is_none(),
+            "traversal generationSetId must not resolve/embed a file from outside the project: {:?}",
+            assets[0].get("generationSet")
+        );
     }
 
     /// sc-4270 / F-CORE-10: list_assets resolves the embedded `generationSet`


### PR DESCRIPTION
## Summary

Closes the write-side path-traversal hole flagged as **F-001 (High, security)** in `CODE_REVIEW_2026-07-20.md` ([sc-13582](https://app.shortcut.com/trefry/story/13582)).

`write_generation_set` took the generation-set `id` straight from the worker-reported fact and wrote `project_path/generation-sets/{id}.json` with **no** `is_safe_id` check. A malicious or compromised worker — the LAN-exposed jobs API (epic 4484) is the documented threat model behind sc-5721 — could pass `id = "../../<anything>"` and write an attacker-shaped JSON file anywhere the API process can reach, clobbering existing files via the atomic-rename writer. The sibling on the same worker→API boundary, `persist_generated_asset`, was explicitly hardened for exactly this (sc-5721 / sc-4211); this method was missed.

## Changes

- **Write guard** (`project_store.rs`): reject `!is_safe_id(id)` with `BadRequest` *before* any path is derived or directory created, mirroring the `assetId` guard in `persist_generated_asset`.
- **Read guard** (`asset_index.rs`): skip a non-safe sidecar-supplied `generationSetId` in `normalize_asset` so a tampered sidecar can't pull JSON from *outside* the project into a `list_assets` response (the story's second requirement — the read path at `asset_index.rs:243-252`).
- **Regression tests** (both halves):
  - `write_generation_set_rejects_traversal_id` — `../../escaped` id → `BadRequest`, and no escaped file is written.
  - `list_assets_skips_traversal_generation_set_id` — plants a leak file outside the project root, tampers a sidecar's `generationSetId` to `../../leak`, asserts the traversal set is **not** embedded.

Real generation-set ids are `genset_<32 hex>` (every worker producer), fully inside `is_safe_id`'s `[A-Za-z0-9_-]` charset, so the read-side filter never drops a legitimate set.

## Validation

- `cargo fmt -p sceneworks-core -- --check` — clean
- `cargo clippy -p sceneworks-core --all-targets -- -D warnings` — clean
- `cargo test -p sceneworks-core --lib` — 525 passed
- Both new tests verified as mutation-killers: they go RED when the respective guard is removed (confirmed by an independent adversarial review pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)