### PR TITLE
fix(training): point SDXL LoRA trainer at the installed turnkey repo (#1694)

### DIFF
--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -2579,24 +2579,25 @@ fn sdxl_family_tiered_turnkey_trains_on_its_bf16_unet_tier() {
 }
 
 #[test]
-fn flat_sdxl_snapshot_is_not_treated_as_a_tiered_turnkey() {
-    // Backward-compat guard for sc-10613: `unet/` at the snapshot root marks a FLAT diffusers tree
-    // (stabilityai/stable-diffusion-xl-base-1.0, Kwai-Kolors/Kolors-diffusers). It must resolve
-    // unchanged, never descend into a `bf16/` subdir — even if a stray tier dir sits alongside it.
+fn flat_diffusers_snapshot_is_not_treated_as_a_tiered_turnkey() {
+    // Backward-compat guard for sc-10613: `unet/` at the snapshot root marks a FLAT diffusers tree.
+    // It must resolve unchanged, never descend into a `bf16/` subdir — even if a stray tier dir sits
+    // alongside it. Driven off a synthetic flat repo rather than a shipped target's `base_model_repo`
+    // so it exercises the resolution branch itself, independent of which targets ship a flat repo
+    // (the stock `sdxl` target moved to its tiered turnkey in issue #1694 — see
+    // `stock_sdxl_target_points_at_installed_turnkey`).
     let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 
-    let target = crate::builtin_training_targets()
+    // A real SDXL-family target struct with its repo overridden to a flat upstream diffusers repo,
+    // so only the resolution branch under test — not the shipped repo string — drives the assertion.
+    let mut target = crate::builtin_training_targets()
         .targets
         .into_iter()
         .find(|t| t.base_model == "sdxl")
         .expect("sdxl target");
-    assert_eq!(
-        target.base_model_repo.as_deref(),
-        Some("stabilityai/stable-diffusion-xl-base-1.0"),
-        "the stock SDXL target still trains off the flat upstream diffusers repo"
-    );
+    target.base_model_repo = Some("stabilityai/stable-diffusion-xl-base-1.0".to_owned());
     let repo = target.base_model_repo.clone().expect("repo set");
 
     let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");
@@ -2611,7 +2612,58 @@ fn flat_sdxl_snapshot_is_not_treated_as_a_tiered_turnkey() {
     assert_eq!(
         resolve_base_model_path(&target, &data_dir),
         snapshot.display().to_string(),
-        "a flat SDXL snapshot resolves to the snapshot root, not a bf16 tier"
+        "a flat diffusers snapshot resolves to the snapshot root, not a bf16 tier"
+    );
+}
+
+#[test]
+fn stock_sdxl_target_points_at_installed_turnkey() {
+    // Regression guard for issue #1694: the stock `sdxl` training target must name the same
+    // `SceneWorks/sdxl-base-mlx` turnkey the catalog + engine install — pointing at the flat
+    // upstream `stabilityai/stable-diffusion-xl-base-1.0` (which nothing downloads) made the
+    // pre-flight gate report the installed base as missing and block every real SDXL run.
+    // A dense `bf16/` tier resolves for training and passes the install gate; a q4-only install
+    // (the generation default) carries no dense weights and must NOT be reported training-ready.
+    let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = crate::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "sdxl")
+        .expect("sdxl target");
+    assert_eq!(
+        target.base_model_repo.as_deref(),
+        Some("SceneWorks/sdxl-base-mlx"),
+        "the stock SDXL target trains off the installed SceneWorks turnkey"
+    );
+    let repo = target.base_model_repo.clone().expect("repo set");
+
+    let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");
+    let revision = "def456";
+    let snapshot = repo_root.join("snapshots").join(revision);
+    // Only the q4 GENERATION tier installed so far (no dense weights).
+    std::fs::create_dir_all(snapshot.join("q4").join("unet")).expect("q4 tree");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("create refs");
+    std::fs::write(repo_root.join("refs").join("main"), revision).expect("write refs/main");
+
+    assert_eq!(
+        resolve_base_model_path(&target, &data_dir),
+        snapshot.join("bf16").display().to_string(),
+        "the SDXL tiered turnkey resolves training to its dense bf16 tier"
+    );
+    assert!(
+        !training_base_model_installed(&data_dir, &target),
+        "a q4-only SDXL turnkey carries no dense weights → not training-ready"
+    );
+
+    std::fs::create_dir_all(snapshot.join("bf16").join("unet")).expect("bf16 unet");
+    std::fs::create_dir_all(snapshot.join("bf16").join("text_encoder")).expect("bf16 te");
+    std::fs::create_dir_all(snapshot.join("bf16").join("vae")).expect("bf16 vae");
+    assert!(
+        training_base_model_installed(&data_dir, &target),
+        "a bf16 tier with a unet/ backbone is training-ready"
     );
 }
 

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -2078,6 +2078,9 @@ fn wan_i2v_14b_lora_target() -> TrainingTarget {
 /// separate `to_q`/`to_k`/`to_v` attention projections plus the `to_out.0`
 /// output projection; the output registers as an `sdxl` family LoRA the SDXL
 /// adapter loads at generation time.
+///
+/// The base weights come from the same `SceneWorks/sdxl-base-mlx` turnkey the
+/// catalog installs; training reads its dense `bf16/` tier.
 fn sdxl_lora_target() -> TrainingTarget {
     TrainingTarget {
         id: "sdxl_lora".to_owned(),
@@ -2086,7 +2089,14 @@ fn sdxl_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "sdxl".to_owned(),
         base_model: "sdxl".to_owned(),
-        base_model_repo: Some("stabilityai/stable-diffusion-xl-base-1.0".to_owned()),
+        // Point at the SceneWorks quant-matrix turnkey the catalog + engine actually install
+        // (`sdxl` catalog entry / engines.rs `default_repo`), NOT the flat upstream
+        // `stabilityai/stable-diffusion-xl-base-1.0` — nothing downloads the latter, so the
+        // pre-flight install gate reported the installed base as missing and blocked every real
+        // SDXL run (issue #1694). Mirrors the Illustrious/RealVisXL SDXL-family targets, which
+        // already name their turnkey. Training resolves the dense `bf16/` tier via
+        // `tiered_turnkey_train_dir`.
+        base_model_repo: Some("SceneWorks/sdxl-base-mlx".to_owned()),
         kernel: "sdxl_lora".to_owned(),
         defaults: TrainingConfig {
             rank: 16,

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -261,6 +261,13 @@ fn builtin_registry_exposes_sdxl_target() {
     assert_eq!(target.output_kind, TrainingOutputKind::Lora);
     assert_eq!(target.family, "sdxl");
     assert_eq!(target.base_model, "sdxl");
+    // Trains off the SceneWorks turnkey the catalog + engine install, NOT the flat upstream
+    // `stabilityai/stable-diffusion-xl-base-1.0` nothing downloads (issue #1694); the trainer
+    // reads its dense `bf16/` tier (rust-api resolve_base_model_path descends into it).
+    assert_eq!(
+        target.base_model_repo.as_deref(),
+        Some("SceneWorks/sdxl-base-mlx")
+    );
     assert_eq!(target.kernel, "sdxl_lora");
     assert_eq!(target.defaults.rank, 16);
     assert_eq!(target.defaults.resolution, 1024);

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -99,7 +99,7 @@
       "outputKind": "lora",
       "family": "sdxl",
       "baseModel": "sdxl",
-      "baseModelRepo": "stabilityai/stable-diffusion-xl-base-1.0",
+      "baseModelRepo": "SceneWorks/sdxl-base-mlx",
       "kernel": "sdxl_lora",
       "defaults": {
         "rank": 16,


### PR DESCRIPTION
Fixes #1694.

## Problem

Selecting **SDXL** in the Training Studio and clicking **Train** fails with:

> `Base model 'sdxl' is not installed. Install it from the model catalog before starting a real training run (dry runs work without it).`

…even when SDXL *is* installed.

## Root cause

The stock `sdxl` training target named its base as the flat upstream repo `stabilityai/stable-diffusion-xl-base-1.0`, but **nothing in the app downloads that repo**. The catalog `sdxl` entry and the worker engine both install the SceneWorks quant-matrix turnkey `SceneWorks/sdxl-base-mlx` (`config/manifests/builtin.models.jsonc`, `crates/sceneworks-worker/src/engines.rs`).

The pre-flight gate `training_base_model_installed` checks the HF cache for the target's `base_model_repo`, finds the never-downloaded `stabilityai/...` repo missing, and 400s — even though the real base is on disk. A dry run skips the gate, which is why only a real "train" click trips it.

## Fix

Point the SDXL target's `base_model_repo` at `SceneWorks/sdxl-base-mlx`, matching the catalog + engine and the Illustrious pattern. Training resolves the dense `bf16/` tier through the existing `tiered_turnkey_train_dir` path — no resolver changes needed.

## Tests

- `stock_sdxl_target_points_at_installed_turnkey` (new): pins that the SDXL target names the turnkey, resolves training to its `bf16/` tier, and passes the install gate only once the dense tier is present.
- `flat_diffusers_snapshot_is_not_treated_as_a_tiered_turnkey`: the flat-resolution guard's former SDXL exemplar is now a turnkey, so it's rebased onto a synthetic flat repo — it exercises the resolution branch itself, independent of registry drift.
- Core contract test asserts the new repo; registry snapshot fixture regenerated (one line).

All `sceneworks-core` training-contract and `sceneworks-rust-api` training tests pass; fmt clean.

## This is one instance of a broader drift

The epic 8506 MLX re-host migration moved the **catalog** to `SceneWorks/*-mlx` turnkeys but left several older **training targets** pointing at upstream repos the app no longer downloads. Illustrious/Krea/LTX/Anima were updated (e.g. sc-10617 for Illustrious); these were not:

| training target | points at (upstream) | catalog installs |
|---|---|---|
| `z_image_turbo` | `Tongyi-MAI/Z-Image-Turbo` | `SceneWorks/z-image-turbo-mlx` |
| `lens` | `SceneWorks/Lens` | `SceneWorks/lens-mlx` |
| `sd3_5_large` | `stabilityai/stable-diffusion-3.5-large` | `SceneWorks/sd3.5-large-mlx` |
| `sd3_5_medium` | `stabilityai/stable-diffusion-3.5-medium` | `SceneWorks/sd3.5-medium-mlx` |
| `wan_2_2` | `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | `SceneWorks/wan2.2-ti2v-5b-mlx` |
| `kolors` | `Kwai-Kolors/Kolors-diffusers` | `SceneWorks/kolors-mlx` |

Each likely trips the same false "not installed" (Kolors is structurally identical to SDXL). They need **per-target install-path validation** before the same change is applied blindly — Wan is a `requiresConversion` model and SD3.5 is native-MLX/Apple-only, so their install + resolve paths differ from the packed-turnkey SDXL/Kolors case. Tracked separately so this fix (the reported issue) isn't blocked on that audit.

## Note (not part of this fix)

Training requires the **`bf16/`** tier specifically. Image *generation* installs the **q4** tier by default, so a user who only installed SDXL for generation may — correctly, after this fix — still be told to install the training tier. That's expected, distinct from the false "not installed" this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)