### PR TITLE
fix(worker): heartbeat through post-download SHA-256 verify + copy so model imports aren't swept "interrupted" [sc-13856]

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -63,6 +63,15 @@ pub(crate) const DOWNLOAD_STALL_MIN_PROGRESS: u64 = 1024 * 1024;
 /// instead of looping forever.
 const MAX_STALL_RESUMES_WITHOUT_PROGRESS: u32 = 3;
 
+/// A file whose declared size is at least this large gets a visible "Verifying…" progress line
+/// while its post-download SHA-256 runs, because hashing it can approach or exceed the stale-worker
+/// timeout — the phase that would otherwise look like a frozen "Downloading" bar (sc-13856 / GitHub
+/// #1690). Smaller files (configs/tokenizers) hash in well under one heartbeat interval, so their
+/// verify never risks the sweep and needs no separate line; the heartbeat keepalive still wraps
+/// every hash regardless, and simply resolves before its first tick for those. 256 MiB is comfortably
+/// below any single weight shard yet above the small-file noise.
+const VERIFY_PROGRESS_MIN_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Resolve the stall-watchdog window: [`DOWNLOAD_STALL_TIMEOUT`] by default,
 /// overridable via `SCENEWORKS_DOWNLOAD_STALL_TIMEOUT_SECONDS`. An explicit `0`
 /// disables the watchdog (returns `None`), matching the "no total timeout" posture of
@@ -296,14 +305,30 @@ pub(crate) async fn ensure_cached_file_verified(
             // A cached file that already matches the expected length still gets its
             // digest checked so a size-colliding tampered artifact can't be reused.
             if let Some(expected) = expected_sha256 {
-                verify_file_sha256(target, expected, label).await?;
+                verify_file_sha256(
+                    context.api,
+                    context.settings,
+                    context.job_id,
+                    target,
+                    expected,
+                    label,
+                )
+                .await?;
             }
             return Ok(target.to_path_buf());
         }
     }
     if expected_size.is_none() && target.exists() {
         if let Some(expected) = expected_sha256 {
-            verify_file_sha256(target, expected, label).await?;
+            verify_file_sha256(
+                context.api,
+                context.settings,
+                context.job_id,
+                target,
+                expected,
+                label,
+            )
+            .await?;
         }
         return Ok(target.to_path_buf());
     }
@@ -576,7 +601,26 @@ async fn download_file(
 ) -> WorkerResult<()> {
     download_file_inner(context, url, dest, expected_size, label, progress).await?;
     if let Some(expected) = expected_sha256 {
-        verify_file_sha256(dest, expected, label).await?;
+        // Surface a "Verifying…" line for a large shard whose hash can outlast the stale-worker
+        // timeout, holding the bar at the transfer's current fraction so it doesn't regress
+        // (sc-13856). Best-effort — a failed progress POST must not fail the download.
+        if expected_size.is_some_and(|size| size >= VERIFY_PROGRESS_MIN_BYTES) {
+            let _ = update_job(
+                context.api,
+                context.job_id,
+                progress.verifying_payload(label),
+            )
+            .await;
+        }
+        verify_file_sha256(
+            context.api,
+            context.settings,
+            context.job_id,
+            dest,
+            expected,
+            label,
+        )
+        .await?;
     }
     Ok(())
 }
@@ -585,6 +629,9 @@ async fn download_file(
 /// an actionable error. A malformed/absent `expected` (not 64 hex) is treated as "no
 /// digest available" and skipped — only a real content digest is enforced.
 pub(crate) async fn verify_file_sha256(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
     path: &Path,
     expected: &str,
     label: &str,
@@ -592,7 +639,7 @@ pub(crate) async fn verify_file_sha256(
     let Some(expected) = normalize_sha256(expected) else {
         return Ok(());
     };
-    let actual = sha256_file(path).await?;
+    let actual = sha256_file(api, settings, job_id, path).await?;
     if actual != expected {
         let _ = tokio::fs::remove_file(path).await;
         return Err(WorkerError::InvalidPayload(format!(
@@ -603,31 +650,35 @@ pub(crate) async fn verify_file_sha256(
     Ok(())
 }
 
-/// Stream `path` through SHA-256 on the blocking pool (weights are multi-GB; hashing
-/// on the async runtime would stall heartbeats/cancel checks).
-async fn sha256_file(path: &Path) -> WorkerResult<String> {
+/// Stream `path` through SHA-256 on the blocking pool (weights are multi-GB; hashing on the async
+/// runtime would stall heartbeats/cancel checks) AND keep the worker heartbeating while it runs.
+/// Hashing a multi-GB weight routinely takes longer than the 90s stale-worker timeout, so without
+/// the [`heartbeat_while_blocking`] keepalive the sweep would mark the still-healthy import
+/// `interrupted` the moment the byte-streaming loop's own heartbeats stop — the exact "No heartbeat
+/// from the worker for 90s" freeze the transfer-only sc-11939 watchdog left uncovered (sc-13856 /
+/// GitHub #1690).
+async fn sha256_file(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
+    path: &Path,
+) -> WorkerResult<String> {
     let path = path.to_path_buf();
-    tokio::task::spawn_blocking(move || -> std::io::Result<String> {
+    let handle = tokio::task::spawn_blocking(move || -> WorkerResult<String> {
         use std::io::Read;
-        let mut file = std::fs::File::open(&path)?;
+        let mut file = std::fs::File::open(&path).map_err(WorkerError::Io)?;
         let mut hasher = Sha256::new();
         let mut buffer = vec![0_u8; 1024 * 1024];
         loop {
-            let read = file.read(&mut buffer)?;
+            let read = file.read(&mut buffer).map_err(WorkerError::Io)?;
             if read == 0 {
                 break;
             }
             hasher.update(&buffer[..read]);
         }
         Ok(format!("{:x}", hasher.finalize()))
-    })
-    .await
-    .map_err(|error| {
-        WorkerError::Io(std::io::Error::other(format!(
-            "sha256 task failed: {error}"
-        )))
-    })?
-    .map_err(WorkerError::Io)
+    });
+    heartbeat_while_blocking(api, settings, job_id, "sha256 verify", handle).await
 }
 
 /// Download a single file to `dest` (resumable via HTTP Range), reporting transfer
@@ -946,7 +997,25 @@ pub(crate) async fn download_snapshot_into_cache(
         rel_target.push("blobs");
         rel_target.push(etag);
         if !link_blob(&blobs_dir.join(etag), &rel_target, &link).await {
-            tokio::fs::copy(blobs_dir.join(etag), &link).await?;
+            // Copy fallback (a Windows hardlink failure across the blob/snapshot pair): a multi-GB
+            // blob copy can outlast the stale-worker timeout just like the hash above, so keep the
+            // worker heartbeating through it rather than letting the finalize phase get swept
+            // (sc-13856 / GitHub #1690).
+            let blob = blobs_dir.join(etag);
+            let dest = link.clone();
+            let handle = tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+                std::fs::copy(&blob, &dest)
+                    .map(|_| ())
+                    .map_err(WorkerError::Io)
+            });
+            heartbeat_while_blocking(
+                context.api,
+                context.settings,
+                context.job_id,
+                "blob copy",
+                handle,
+            )
+            .await?;
         }
     }
     Ok(commit)
@@ -1484,6 +1553,32 @@ impl<'a> DownloadProgress<'a> {
             self.total_bytes,
             self.started_bytes,
             self.started_at.elapsed(),
+        )
+    }
+
+    /// Progress payload for the post-download integrity check of one shard: the SAME transfer
+    /// fraction [`Self::payload`] would report (so the bar holds where the download left it, never
+    /// regressing) but with a "Verifying…" message, so a multi-GB SHA-256 that outlasts the
+    /// stale-worker timeout reads as an active phase rather than a frozen "Downloading" bar
+    /// (sc-13856 / GitHub #1690). Mirrors the fraction formula in [`download_progress_payload`].
+    fn verifying_payload(&self, label: &str) -> ProgressRequest {
+        let fraction = match self.total_bytes {
+            Some(total) if total > 0 => {
+                0.1 + (self.downloaded_bytes() as f64 / total as f64).clamp(0.0, 1.0) * 0.85
+            }
+            // No known total (or a zero-byte total): the transfer bar sits at its floor/complete
+            // marker; keep verify near the top rather than snapping it around.
+            Some(_) => 0.95,
+            None => 0.1,
+        };
+        progress_payload(
+            JobStatus::Downloading,
+            ProgressStage::Downloading,
+            fraction,
+            &format!("Verifying {label} integrity."),
+            None,
+            None,
+            None,
         )
     }
 }

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -2405,7 +2405,16 @@ pub(crate) async fn run_lora_import_job(
     // mismatch, so a corrupt artifact is never left behind.
     if let Some(expected_sha256) = optional_payload_string(&job.payload, "expectedSha256") {
         if let Some(file) = first_safetensors_path(&target_dir) {
-            if let Err(error) = verify_file_sha256(&file, expected_sha256, "Imported LoRA").await {
+            if let Err(error) = verify_file_sha256(
+                api,
+                settings,
+                &job.id,
+                &file,
+                expected_sha256,
+                "Imported LoRA",
+            )
+            .await
+            {
                 return fail_job(api, &job.id, "LoRA import failed.", Some(error.to_string()))
                     .await;
             }
@@ -2735,7 +2744,16 @@ pub(crate) async fn run_model_import_job(
     // file is removed and the job fails with an actionable message.
     if let Some(expected_sha256) = optional_payload_string(&job.payload, "expectedSha256") {
         if let Some(file) = first_safetensors_path(&target_dir) {
-            if let Err(error) = verify_file_sha256(&file, expected_sha256, "Imported model").await {
+            if let Err(error) = verify_file_sha256(
+                api,
+                settings,
+                &job.id,
+                &file,
+                expected_sha256,
+                "Imported model",
+            )
+            .await
+            {
                 return fail_job(
                     api,
                     &job.id,

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -887,7 +887,15 @@ async fn ensure_one(
     // transfer length, so verify the fetched bundle against the pinned SHA-256 before
     // extracting the weights it contains (sc-8879). A mismatch removes the file and
     // fails the job with the integrity-check error.
-    verify_file_sha256(&zip_path, zip_sha256, &format!("DWPose {file} bundle")).await?;
+    verify_file_sha256(
+        context.api,
+        context.settings,
+        context.job_id,
+        &zip_path,
+        zip_sha256,
+        &format!("DWPose {file} bundle"),
+    )
+    .await?;
     // The openmmlab bundle is a .zip containing a single .onnx; extract it.
     let target_clone = target.clone();
     let zip_for_extract = zip_path.clone();

--- a/crates/sceneworks-worker/src/progress.rs
+++ b/crates/sceneworks-worker/src/progress.rs
@@ -388,6 +388,48 @@ pub(crate) fn no_cancel_ack() -> Option<fn() -> std::future::Ready<WorkerResult<
     None
 }
 
+/// Await a bounded blocking task while keeping the worker's heartbeat alive on the progress
+/// interval. Cross-platform, cancel-free sibling of [`run_blocking_with_heartbeat`]: use it for a
+/// SINGLE bounded pass with nothing to interrupt — the post-download SHA-256 of one file, or one
+/// blob copy — where the only hazard is that the pass can outlast the stale-worker timeout
+/// (`jobs_store::mark_stale_workers_interrupted`) and get the still-healthy worker swept to
+/// `interrupted` mid-op. A multi-GB weight hash routinely exceeds that 90s window, which is exactly
+/// how a model import froze with "No heartbeat from the worker for 90s" even though the worker was
+/// alive and hashing (sc-13856 / GitHub #1690, the verify/finalize half the sc-11939 transfer
+/// watchdog didn't cover).
+///
+/// It carries NO [`gen_core::CancelFlag`]/teardown machinery precisely because there is no per-step
+/// loop to trip: the task runs to its natural end either way (same posture as the `None`-cancel
+/// bounded callers of [`run_blocking_with_heartbeat`]). Unlike a long GPU/training run, a read-only
+/// hash or a file copy holds no GPU/unified-memory contention, so on the early-return path (a
+/// heartbeat POST transport failure, or a 409 from the stale sweep having already reclaimed the job)
+/// the bounded task is simply left to finish on the blocking pool rather than force-joined. For work
+/// that MUST wind down on cancel, use [`run_blocking_with_heartbeat`] instead.
+pub(crate) async fn heartbeat_while_blocking<R: Send + 'static>(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
+    task_label: &'static str,
+    task: tokio::task::JoinHandle<WorkerResult<R>>,
+) -> WorkerResult<R> {
+    let mut task = task;
+    let mut interval = tokio::time::interval(progress_report_interval(settings));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // A tokio interval's first tick is immediate; consume it so a sub-interval task (a small
+    // file's fast hash) resolves without firing a redundant heartbeat POST.
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            result = &mut task => {
+                return result.map_err(|error| task_join_error(task_label, error))?;
+            }
+            _ = interval.tick() => {
+                heartbeat(api, settings, WorkerStatus::Busy, Some(job_id)).await?;
+            }
+        }
+    }
+}
+
 /// Check-only cancel poll (sc-5515): returns `true` when the user requested
 /// cancellation, WITHOUT posting any status. Unlike [`check_cancel`] this never
 /// writes the terminal `Canceled`. In-loop generation/training pollers that sit in

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -75,8 +75,8 @@ use super::supervisor::{
 };
 use super::{
     allow_pattern_matches, bounded_tail, cancel_requested_peek, cleanup_uploaded_import_source,
-    copy_lora_source, fresh_asset_id, import_lora_source_file_as, import_lora_source_path,
-    normalize_app_managed_cache_path, now_rfc3339, parse_credentials_env,
+    copy_lora_source, fresh_asset_id, heartbeat_while_blocking, import_lora_source_file_as,
+    import_lora_source_path, normalize_app_managed_cache_path, now_rfc3339, parse_credentials_env,
     resolve_model_convert_output, resolve_model_import_target, safe_download_dir,
     safe_project_path, value_f64, wan_moe_pair_filenames, write_model_download_receipt,
     write_model_install_marker, CredentialScheme, IdleHeartbeat, JsonObject,

--- a/crates/sceneworks-worker/src/tests/cancel_and_heartbeat.rs
+++ b/crates/sceneworks-worker/src/tests/cancel_and_heartbeat.rs
@@ -1022,3 +1022,44 @@ async fn stdin_close_latch_retained_across_zero_receiver_window() {
     );
 }
 
+/// sc-13856 / GitHub #1690 — a post-download verify/finalize pass that outlasts the heartbeat
+/// interval (in production a multi-GB SHA-256 or blob copy that runs past the 90s stale-worker
+/// timeout) must keep the worker heartbeating for its whole duration, so the stale sweep does NOT
+/// mark the still-healthy import `interrupted`. Before the `heartbeat_while_blocking` keepalive,
+/// the hash ran with no heartbeat between the download loop's last tick and the next file, and a
+/// slow hash tripped the sweep — the "No heartbeat from the worker for 90s" freeze in the issue.
+/// The heartbeat interval floors at 5s (`progress_report_interval`), so a task that runs just past
+/// it must produce at least one heartbeat; a discriminator that a no-op await could not satisfy.
+#[tokio::test]
+async fn heartbeat_while_blocking_keeps_worker_live_through_a_long_pass() {
+    let (base_url, beats) = spawn_heartbeat_counting_stub().await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url;
+    settings.heartbeat_seconds = 5; // progress_report_interval floor
+
+    let api = ApiClient::new(&settings);
+
+    // A bounded blocking pass that runs past one heartbeat interval (~5s), standing in for a
+    // multi-GB hash/copy. `std::thread::sleep` on the blocking pool keeps it off the runtime,
+    // exactly like the real hash loop.
+    let task = tokio::task::spawn_blocking(|| {
+        std::thread::sleep(Duration::from_millis(5_400));
+        Ok::<(), WorkerError>(())
+    });
+
+    let started = std::time::Instant::now();
+    heartbeat_while_blocking(&api, &settings, "job-1", "test blocking pass", task)
+        .await
+        .expect("the bounded task's Ok result is returned once it finishes");
+
+    assert!(
+        started.elapsed() >= Duration::from_millis(5_300),
+        "the wrapper must await the WHOLE blocking pass, not return early"
+    );
+    assert!(
+        beats.load(Ordering::SeqCst) >= 1,
+        "at least one heartbeat must fire while a >interval pass runs (got {})",
+        beats.load(Ordering::SeqCst)
+    );
+}
+

--- a/crates/sceneworks-worker/src/tests/support_stubs.rs
+++ b/crates/sceneworks-worker/src/tests/support_stubs.rs
@@ -575,6 +575,38 @@ async fn spawn_no_user_cancel_capture_stub(
     (format!("http://{address}"), posts)
 }
 
+/// sc-13856 — stub that counts worker heartbeat POSTs (and answers them), used to prove the
+/// post-download verify/finalize keepalive (`heartbeat_while_blocking`) actually pumps heartbeats
+/// while a bounded blocking pass runs.
+async fn spawn_heartbeat_counting_stub() -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>)
+{
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+    type Beats = Arc<AtomicUsize>;
+    async fn heartbeat_route(
+        State(beats): State<Beats>,
+        axum::extract::Path(worker_id): axum::extract::Path<String>,
+    ) -> Response {
+        beats.fetch_add(1, Ordering::SeqCst);
+        Json(worker_snapshot_json(&worker_id)).into_response()
+    }
+    let beats: Beats = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route(
+            "/api/v1/workers/:worker_id/heartbeat",
+            post(heartbeat_route),
+        )
+        .with_state(beats.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+    (format!("http://{address}"), beats)
+}
+
 fn placeholder_job_snapshot() -> JobSnapshot {
     serde_json::from_value(json!({
         "id": "job-1",


### PR DESCRIPTION
Fixes the recurring **"Downloads still not completing — No heartbeat from the worker for 90s"** model-import freeze reported in [#1690](https://github.com/SceneWorks/SceneWorks/issues/1690) (macOS/MLX, v0.8.0; a recurrence of #1613 closed "fixed in 0.8.0"). Story: [sc-13856](https://app.shortcut.com/trefry/story/13856).

## Symptom
Model imports (e.g. "Krea 2 Turbo") repeatedly land as **Interrupted** with *"No heartbeat from the worker for 90s."* on the CPU utility worker, retry up to 5x, and never complete — the progress bar frozen at varying levels (some partial, one near-full at 229m elapsed). The worker is alive the whole time.

## Root cause
The worker heartbeats only from *inside* a job's progress ticks — there is no background heartbeat during a job. The download's byte-streaming loop heartbeats on each progress interval (sc-11939), but the **post-download SHA-256 integrity check** (`verify_file_sha256` → `sha256_file`) ran the hash on `spawn_blocking` with **no heartbeat**. Hashing a multi-GB weight routinely exceeds the 90s stale-worker timeout, so the sweep (`mark_stale_workers_interrupted`) flipped the still-healthy job to `interrupted` mid-import. Verification runs after *each* file in the per-file loop, so the stall trips at any progress level; the finalization `std::fs::copy` blob-fallback (Windows hardlink-failure path) had the same gap. 0.8.0's #1613 fix hardened the *transfer* phase but left *verify/finalize* uncovered.

## Fix
- Add `heartbeat_while_blocking` — a cross-platform, cancel-free sibling of `run_blocking_with_heartbeat` for a bounded blocking pass with nothing to interrupt (a hash / a file copy). It pumps a `Busy` heartbeat on the progress interval for the whole pass.
- Route the SHA-256 hash and the copy fallback through it, so the worker stays live during verify/finalize.
- Surface a **"Verifying… integrity"** progress line for large shards (≥256 MiB), held at the transfer's current fraction so the bar doesn't regress.
- Thread `(api, settings, job_id)` through `verify_file_sha256`; all five callers updated (HF download, cache warm-up, LoRA import, model import, DWPose bundle).

## Tests
- New regression test: a bounded pass that outlasts the heartbeat interval keeps the worker heartbeating (≥1 heartbeat observed) — a discriminator a no-op await could not satisfy.
- Existing digest-verify / snapshot tests still pass.
- Parity clippy (`-p sceneworks-worker --all-targets -- -D warnings`) clean; `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)