### PR TITLE
fix(worker): validate HF repo/revision/pattern on user-facing download & import jobs [sc-13583]

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -922,10 +922,17 @@ pub(crate) async fn download_snapshot_into_cache(
     // Materialize the snapshot once every blob is present: refs/<rev> -> commit and
     // snapshots/<commit>/<path> -> ../../blobs/<etag>.
     let commit = commit.unwrap_or_else(|| revision.to_owned());
+    // Confine both the `refs/<rev>` pointer and the `snapshots/<commit>` root to the repo cache dir
+    // before writing anything: `revision` is payload-supplied over the LAN jobs API (epic 4484), and
+    // `commit` falls back to it when the upstream omits `X-Repo-Commit`, so a `..`/absolute value
+    // would otherwise write the receipt pointer and materialize the snapshot tree OUTSIDE the cache
+    // (sc-13583). Real revisions are `main` or a 40-hex commit — a single, traversal-free component —
+    // so `safe_join` (which rejects any non-`Normal` component, exactly like the per-file join below)
+    // is a no-op for every legitimate download.
     let refs_dir = repo_dir.join("refs");
     tokio::fs::create_dir_all(&refs_dir).await?;
-    tokio::fs::write(refs_dir.join(revision), commit.as_bytes()).await?;
-    let snapshot_dir = repo_dir.join("snapshots").join(&commit);
+    tokio::fs::write(safe_join(&refs_dir, revision)?, commit.as_bytes()).await?;
+    let snapshot_dir = safe_join(&repo_dir.join("snapshots"), &commit)?;
     for (relpath, etag) in &placements {
         let link = safe_join(&snapshot_dir, relpath)?;
         if let Some(parent) = link.parent() {

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -66,6 +66,12 @@ pub(crate) async fn run_model_download_job(
     let files = payload_string_array(&job.payload, "files");
     let revision = optional_payload_string(&job.payload, "revision").unwrap_or("main");
     let fresh_download = optional_payload_string(&job.payload, "downloadAction") == Some("fresh");
+    // The jobs API is the worker's trust boundary (unauthenticated for local use, LAN-exposed via
+    // epic 4484), so reject any repo / revision / include-pattern that could escape the intended
+    // Hugging Face path before it reaches `HuggingFaceSnapshot::resolve`'s URL builder or the
+    // `download_snapshot_into_cache` refs/snapshot joins below — the on-demand tier fetches already
+    // gate this in `ensure_hf_files_cached`, but this user-facing entry point did not (sc-13583).
+    validate_hf_download_inputs(repo, revision, &files)?;
     // The worker is the trust boundary (jobs API is unauthenticated for local use), so a
     // client-supplied targetDir must be constrained to app-managed data/models the same way
     // import jobs are, not used verbatim.
@@ -296,6 +302,10 @@ pub(crate) async fn run_lora_download_job(
     };
     let files = payload_string_array(&job.payload, "files");
     let revision = optional_payload_string(&job.payload, "revision").unwrap_or("main");
+    // Trust-boundary validation for the LAN-exposed jobs API (epic 4484), mirroring
+    // `run_model_download_job`: reject a path-escaping repo/revision/pattern before the URL builder
+    // and the `download_snapshot_into_cache` refs/snapshot joins downstream (sc-13583).
+    validate_hf_download_inputs(repo, revision, &files)?;
 
     heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
     update_job(
@@ -426,7 +436,12 @@ pub(crate) async fn run_lora_download_job(
         &mut progress,
     )
     .await?;
-    let resolved_revision = tokio::fs::read_to_string(repo_dir.join("refs").join(revision))
+    // Symmetric with the `refs/<rev>` write in `download_snapshot_into_cache`: confine the read path
+    // so this receipt-facing lookup can't be turned into an arbitrary-file read by a `..`/absolute
+    // revision (sc-13583). `revision` is already validated at the entry point above; this is the
+    // defense-in-depth twin of the write-side `safe_join`.
+    let refs_path = safe_join(&repo_dir.join("refs"), revision)?;
+    let resolved_revision = tokio::fs::read_to_string(refs_path)
         .await
         .ok()
         .map(|value| value.trim().to_owned())
@@ -1625,9 +1640,17 @@ pub(crate) fn huggingface_pinned_snapshot_dir(
     repo: &str,
     revision: &str,
 ) -> Option<PathBuf> {
-    let dir = huggingface_repo_cache_path(data_dir, repo)?
-        .join("snapshots")
-        .join(revision);
+    // `revision` reaches here straight from the job payload's `modelManifestEntry` (the co-requisite
+    // seam, `resolve_co_requisites` / `resolve_optional_component`), which is unvalidated over the LAN
+    // jobs API (epic 4484). A `..`/absolute revision would otherwise join OUTSIDE `snapshots/` — a dir
+    // that passes `is_dir()` and, on Windows, gets its symlinks rewritten to hardlinks by
+    // `materialize_snapshot_hardlinks`. A pinned revision is a single 40-hex commit component, so
+    // confine it with `safe_join`; a traversal value yields `None` ("not installed") (sc-13583).
+    let dir = safe_join(
+        &huggingface_repo_cache_path(data_dir, repo)?.join("snapshots"),
+        revision,
+    )
+    .ok()?;
     if !dir.is_dir() {
         return None;
     }
@@ -1723,7 +1746,10 @@ pub(crate) fn resolve_co_requisites(
             .unwrap_or_default();
         let source = match files.as_slice() {
             [file] => {
-                let path = snapshot.join(file);
+                // `file` comes from the payload `modelManifestEntry`; confine it under the snapshot so
+                // a `..`/absolute entry can't stage an arbitrary host file as this component's weights
+                // (on Windows `join` with an absolute path replaces the base entirely) (sc-13583).
+                let path = safe_join(&snapshot, file)?;
                 if !path.is_file() {
                     return Err(WorkerError::InvalidPayload(format!(
                         "{model_id}: the '{component_id}' component file {repo}/{file} is missing \
@@ -1780,7 +1806,10 @@ pub(crate) fn resolve_optional_component(
     // `audio_token_detokenizer/` under the staged dir).
     match files.as_slice() {
         [file] if !file.contains('*') => {
-            let path = snapshot.join(file);
+            // Confine the payload-supplied file under the snapshot (sc-13583) — the optional-component
+            // twin of the `resolve_co_requisites` guard above; a `..`/absolute entry yields `None`
+            // (component simply not staged), never an out-of-snapshot host file.
+            let path = safe_join(&snapshot, file).ok()?;
             path.is_file()
                 .then_some(gen_core::WeightsSource::File(path))
         }
@@ -2368,6 +2397,10 @@ pub(crate) async fn run_lora_import_job(
     if let Some(repo) = repo {
         let files = payload_string_array(&job.payload, "files");
         let revision = optional_payload_string(&job.payload, "revision").unwrap_or("main");
+        // Trust-boundary validation for the LAN-exposed jobs API (epic 4484): a LoRA HF import takes a
+        // caller-supplied repo/revision/files and resolves them into download URLs and on-disk paths,
+        // so reject anything that could escape the intended Hugging Face path (sc-13583).
+        validate_hf_download_inputs(repo, revision, &files)?;
         let snapshot =
             HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
         let mut progress = DownloadProgress::new(
@@ -2716,6 +2749,10 @@ pub(crate) async fn run_model_import_job(
     if let Some(repo) = repo {
         let files = payload_string_array(&job.payload, "files");
         let revision = optional_payload_string(&job.payload, "revision").unwrap_or("main");
+        // Trust-boundary validation for the LAN-exposed jobs API (epic 4484): a model HF import takes a
+        // caller-supplied repo/revision/files and resolves them into download URLs and on-disk paths,
+        // so reject anything that could escape the intended Hugging Face path (sc-13583).
+        validate_hf_download_inputs(repo, revision, &files)?;
         let snapshot =
             HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
         let mut progress = DownloadProgress::new(
@@ -3695,6 +3732,111 @@ mod co_requisite_tests {
             ),
             other => panic!("an installed sft_cover resolves to a Dir, got {other:?}"),
         }
+    }
+
+    /// sc-13583 / F-002 (co-requisite seam, 5th site): `revision` reaches
+    /// [`huggingface_pinned_snapshot_dir`] straight from the payload `modelManifestEntry`. A `..`
+    /// revision must NOT resolve to a directory OUTSIDE `snapshots/`, even when that directory exists
+    /// on disk (it would pass `is_dir()` and, on Windows, get its symlinks rewritten to hardlinks).
+    #[test]
+    fn huggingface_pinned_snapshot_dir_confines_a_traversal_revision() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let repo = "ResembleAI/chatterbox";
+
+        // A real pinned snapshot still resolves — proving the guard is a confinement, not a blanket
+        // reject of every non-`main` revision.
+        let revision = "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18";
+        stage_snapshot_file(data_dir.path(), repo, revision, "ve.safetensors");
+        assert!(
+            huggingface_pinned_snapshot_dir(data_dir.path(), repo, revision).is_some(),
+            "a real pinned snapshot must still resolve"
+        );
+
+        // Plant a real directory a level ABOVE snapshots/ that a `../` revision would land on …
+        let escaped = huggingface_repo_cache_path(data_dir.path(), repo)
+            .expect("repo cache path resolves")
+            .join("escaped");
+        std::fs::create_dir_all(&escaped).expect("escaped dir");
+        // … and confirm the traversal revision does not resolve to it.
+        assert_eq!(
+            huggingface_pinned_snapshot_dir(data_dir.path(), repo, "../escaped"),
+            None,
+            "a `..` revision must not resolve to a dir outside snapshots/"
+        );
+    }
+
+    /// sc-13583 (co-requisite seam): a single-entry `files: ["<../.. path>"]` in the payload
+    /// `modelManifestEntry` must not be joined onto the snapshot to stage an arbitrary host file as a
+    /// required component's weights — `resolve_co_requisites` must reject it via `safe_join`.
+    #[test]
+    fn resolve_co_requisites_confines_a_traversal_component_file() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let repo = "ResembleAI/chatterbox";
+        let revision = "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18";
+        // Snapshot present, plus a target file one level ABOVE the snapshot that a `../` entry hits.
+        stage_snapshot_file(data_dir.path(), repo, revision, "placeholder.bin");
+        let outside = huggingface_repo_cache_path(data_dir.path(), repo)
+            .expect("repo cache path resolves")
+            .join("snapshots")
+            .join("outside.bin");
+        std::fs::write(&outside, b"secret").expect("plant outside file");
+
+        let descriptor = gen_core::ModelDescriptor {
+            id: "trav_probe",
+            family: "chatterbox",
+            backend: "candle",
+            modality: gen_core::Modality::Audio,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &["voice_embedding"],
+        };
+        let manifest = json!({
+            "id": "trav_probe",
+            "downloads": [
+                { "provider": "huggingface", "repo": repo, "revision": revision, "coRequisite": true,
+                  "componentId": "voice_embedding", "files": ["../outside.bin"] }
+            ]
+        });
+        let settings = settings_at(data_dir.path().to_path_buf());
+        // The outside file EXISTS, so without the guard the join would resolve it to a real File
+        // (Ok), not the missing-file error — `expect_err` therefore discriminates the guard itself.
+        let error = resolve_co_requisites(&descriptor, &manifest, &settings)
+            .expect_err("a `..` component file entry is rejected");
+        assert!(
+            matches!(&error, WorkerError::InvalidPayload(message) if message.contains("Unsafe snapshot path")),
+            "expected a safe_join rejection, got {error:?}"
+        );
+    }
+
+    /// sc-13583 (co-requisite seam): the optional-component twin of the guard above — a `..` file
+    /// entry resolves to `None` (component simply not staged), never an out-of-snapshot host file.
+    #[test]
+    fn resolve_optional_component_confines_a_traversal_component_file() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let repo = "ACE-Step/acestep-v15-xl-sft-diffusers";
+        let revision = "4bf7b60a63b27144f539f980927eeb89f5f912b0";
+        stage_snapshot_file(data_dir.path(), repo, revision, "placeholder.bin");
+        let outside = huggingface_repo_cache_path(data_dir.path(), repo)
+            .expect("repo cache path resolves")
+            .join("snapshots")
+            .join("outside.bin");
+        std::fs::write(&outside, b"secret").expect("plant outside file");
+
+        let manifest = json!({
+            "id": "acestep_v15_turbo",
+            "downloads": [
+                { "provider": "huggingface", "repo": repo, "revision": revision,
+                  "coRequisite": true, "required": "soft", "componentId": "sft_cover",
+                  "files": ["../outside.bin"] }
+            ]
+        });
+        let settings = settings_at(data_dir.path().to_path_buf());
+        assert!(
+            resolve_optional_component(&manifest, "sft_cover", &settings).is_none(),
+            "a `..` file entry must not stage a host file outside the snapshot"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -1382,6 +1382,207 @@ async fn lora_download_fails_when_one_of_several_declared_files_is_absent() {
     assert!(!blames_present, "only the absent file should be named");
 }
 
+// ---------------------------------------------------------------------------
+// sc-13583 / F-002: HF repo/revision/pattern validation on the user-facing jobs
+// ---------------------------------------------------------------------------
+//
+// `validate_hf_download_inputs` was called from ONLY `ensure_hf_files_cached` (the on-demand tier
+// fetch). The four user-facing entry points — model/LoRA download and model/LoRA import — passed a
+// payload `repo`/`revision`/`files` straight to the HF URL builder and, for the downloads, to the
+// `refs/<rev>` / `snapshots/<rev>` cache joins with no validation, giving a LAN-API caller (epic
+// 4484) an arbitrary-path write/read primitive. Each entry point must now reject a path-escaping
+// revision UP FRONT. Every assertion below pins the validator's own "traversal components are not
+// allowed" message, so a test stays RED if ONLY the entry-point call is removed — the downstream
+// `safe_join` join-guard would otherwise still error, but with a distinct "Unsafe snapshot path"
+// message, masking the entry-point regression (the false-green trap).
+
+#[tokio::test]
+async fn model_download_rejects_a_path_escaping_revision_before_any_network() {
+    let _env = isolate_hf_cache();
+    let temp = tempdir().expect("tempdir creates");
+    // An unreachable API proves validation fires BEFORE any heartbeat / tree-resolve I/O: with the
+    // guard the job errors on the revision; without it, the first thing that happens is a heartbeat
+    // that can't connect — never the traversal message.
+    let mut settings = test_settings("http://127.0.0.1:1".to_owned(), None);
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("model_download");
+    job_json["payload"] = json!({
+        "modelId": "sdxl",
+        "repo": "SceneWorks/sdxl-base-mlx",
+        "revision": "../../evil",
+        "files": ["*.safetensors"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    let error = super::model_jobs::run_model_download_job(&api, &settings, &client, &job)
+        .await
+        .expect_err("a path-escaping revision is rejected at the entry point");
+    assert!(
+        error
+            .to_string()
+            .contains("traversal components are not allowed"),
+        "expected the revision validator to fire, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn lora_download_rejects_a_path_escaping_revision_before_any_network() {
+    let _env = isolate_hf_cache();
+    let temp = tempdir().expect("tempdir creates");
+    let mut settings = test_settings("http://127.0.0.1:1".to_owned(), None);
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("lora_download");
+    job_json["payload"] = json!({
+        "loraId": "probe",
+        "repo": "owner/adapter",
+        "revision": "../../evil",
+        "files": ["*.safetensors"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    let error = super::model_jobs::run_lora_download_job(&api, &settings, &client, &job)
+        .await
+        .expect_err("a path-escaping revision is rejected at the entry point");
+    assert!(
+        error
+            .to_string()
+            .contains("traversal components are not allowed"),
+        "expected the revision validator to fire, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn lora_import_rejects_a_path_escaping_revision() {
+    let _env = isolate_hf_cache();
+    let temp = tempdir().expect("tempdir creates");
+    // Imports heartbeat / post progress BEFORE the HF branch validates, so give them a live stub; the
+    // rejection must still come from the revision validator, not a transport error.
+    let (base_url, _posts) = spawn_tree_stub_with_files(vec![("model.safetensors", 8)]).await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url.clone();
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("lora_import");
+    job_json["payload"] = json!({
+        "loraId": "probe",
+        "repo": "owner/adapter",
+        "revision": "../../evil",
+        "files": ["*.safetensors"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    let error = super::model_jobs::run_lora_import_job(&api, &settings, &client, &job)
+        .await
+        .expect_err("a path-escaping revision is rejected in the HF import branch");
+    assert!(
+        error
+            .to_string()
+            .contains("traversal components are not allowed"),
+        "expected the revision validator to fire, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn model_import_rejects_a_path_escaping_revision() {
+    let _env = isolate_hf_cache();
+    let temp = tempdir().expect("tempdir creates");
+    let (base_url, _posts) = spawn_tree_stub_with_files(vec![("model.safetensors", 8)]).await;
+    let mut settings = test_settings(base_url.clone(), None);
+    settings.api_url = base_url.clone();
+    settings.data_dir = temp.path().to_path_buf();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("model_import");
+    job_json["payload"] = json!({
+        "modelId": "probe",
+        "repo": "owner/model",
+        "revision": "../../evil",
+        "files": ["*.safetensors"],
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+
+    let error = super::model_jobs::run_model_import_job(&api, &settings, &client, &job)
+        .await
+        .expect_err("a path-escaping revision is rejected in the HF import branch");
+    assert!(
+        error
+            .to_string()
+            .contains("traversal components are not allowed"),
+        "expected the revision validator to fire, got {error:?}"
+    );
+}
+
+/// The join-level twin of the entry-point guards: `download_snapshot_into_cache` joins `revision`
+/// into `refs/<rev>` (and, via the `commit` fallback, `snapshots/<rev>`). A `..` revision must be
+/// confined by `safe_join`, so the receipt pointer can never be written ABOVE the repo cache dir —
+/// defense in depth for any caller that reaches this without the entry validator.
+#[tokio::test]
+async fn download_snapshot_into_cache_confines_a_path_escaping_revision() {
+    let temp = tempdir().expect("tempdir creates");
+    let base_url = spawn_binary_stub(b"weights!!".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = base_url.clone();
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    // Nest the repo dir two levels deep so an un-guarded `../../` revision would land at
+    // `temp/cache/pwned` — outside the repo cache dir.
+    let repo_dir = temp.path().join("cache").join("models--owner--model");
+
+    let snapshot = HuggingFaceSnapshot {
+        files: vec![SnapshotFile {
+            path: "model.safetensors".to_owned(),
+            size: Some(9),
+            download_url: format!("{base_url}/owner/model/resolve/main/model.safetensors"),
+            sha256: None,
+        }],
+    };
+    let mut progress = DownloadProgress::new(
+        "owner/model",
+        0,
+        snapshot.total_bytes(),
+        Duration::from_secs(3600),
+    );
+
+    let error = download_snapshot_into_cache(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        },
+        &repo_dir,
+        "../../pwned",
+        &snapshot,
+        &mut progress,
+    )
+    .await
+    .expect_err("a path-escaping revision is rejected");
+    assert!(
+        error.to_string().contains("Unsafe snapshot path"),
+        "expected a safe_join rejection, got {error:?}"
+    );
+    // The escaped `refs/<rev>` pointer must never have been written above the cache dir.
+    assert!(
+        !temp.path().join("cache").join("pwned").exists(),
+        "the refs/<rev> write must stay confined to the repo cache dir"
+    );
+}
+
 /// A tree stub that paginates: page 1 (no cursor) returns bf16/q4 files plus a `Link: rel="next"`
 /// header pointing at page 2; page 2 (cursor=next) returns the q8 file and no further link.
 async fn spawn_paginated_tree_stub() -> String {


### PR DESCRIPTION
## Summary

Fixes [sc-13583](https://app.shortcut.com/trefry/story/13583) (**HIGH**, security — path traversal, code-review finding F-002).

`validate_hf_download_inputs` was wired into only `ensure_hf_files_cached` (the on-demand tier fetch). The four **user-facing** job entry points passed a payload-supplied `repo`/`revision`/`files` straight to `HuggingFaceSnapshot::resolve` and the cache-materialization joins with no validation. Over the LAN/loopback jobs API (epic 4484) a crafted `revision` was:

- an **arbitrary-path file-write** — the `refs/<rev>` receipt pointer written via `fs::write(refs_dir.join(revision), commit)` (and `snapshots/<commit>`, where `commit` falls back to the payload revision), and
- an **arbitrary-path read** reflected into the download receipt — `read_to_string(repo_dir.join("refs").join(revision))`.

A later model-resolution refactor added a **fifth** site of the same class: the co-requisite seam (`resolve_co_requisites` / `resolve_optional_component`) trusts the job payload's `modelManifestEntry` verbatim, joining its `revision` into `snapshots/<revision>` (via `huggingface_pinned_snapshot_dir`) and a single `files: ["…"]` entry into `snapshot.join(file)` → `WeightsSource::File`.

## Changes

- **Entry-point validation** — `validate_hf_download_inputs(repo, revision, &files)?` at the top of `run_model_download_job`, `run_lora_download_job`, and the HF branch of `run_lora_import_job` / `run_model_import_job`, before the URL builder and cache joins.
- **Cache-materialization joins** — `safe_join` confines the `refs/<rev>` write and the `snapshots/<commit>` root in `download_snapshot_into_cache` (the latter also closes the server-supplied `X-Repo-Commit` header vector), and the symmetric refs read in `run_lora_download_job`.
- **Co-requisite seam** — `safe_join` confines the `revision` join in `huggingface_pinned_snapshot_dir` and the `files` joins in `resolve_co_requisites` / `resolve_optional_component`, since `modelManifestEntry` is untrusted payload.
- **8 regression tests**, each pinned to the guard-specific message (`"traversal components are not allowed"` for the entry guard vs `"Unsafe snapshot path"` for `safe_join`) and planting a real escape target, so each stays RED if its guard is removed (mutation-verified).

## Design note

The finding suggested "reject any revision that is not a single normal path component," but the existing test `hf_download_inputs_accept_catalog_values` proves `refs/pr/N` is an *accepted* catalog revision. I used `safe_join` (confine — reject `..`/absolute/Windows-drive, permit benign nested refs) instead: it is byte-identical to the raw `.join()` for every real revision (`main` / 40-hex / `refs/pr/N`) and consistent with the `safe_join` already used for per-file placement two lines below. Confirmed no Rust builtin manifest ships a slash revision. Because the confinement lives at the join sites, **every** caller of these functions is protected — not only the four enumerated entry points.

## Testing

- `npm run rust:check` (fmt + clippy + test + build) green on the merge commit.
- 8 new tests pass; 26 existing download / co-requisite / validator tests pass with no regression.
- **Mutation-checked**: removing the `run_model_download_job` entry guard turns its test RED (a connection error instead of the validator message), proving the guard is discriminating, not a false green.
- Independent adversarial review verdict: **SHIP** — all 4 entry points + 5 sinks confined, no traversal slips through (Unix-backslash contained on both platforms), no legitimate-path regression.

Closes sc-13583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
