### PR TITLE
fix(training): point re-hosted training targets at their installed turnkeys [sc-13860]

### DIFF
--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -9,6 +9,7 @@ pub(crate) use crate::events::{EventHub, EventMessage};
 
 pub(crate) use crate::training::{
     insufficient_disk_space, resolve_base_model_path, training_base_model_installed,
+    training_base_model_status, training_base_unavailable_message, TrainingBaseStatus,
 };
 
 pub(crate) use crate::workers::person_readiness_from_workers;
@@ -448,9 +449,14 @@ pub(crate) async fn drain_event_names(
 /// Seeds the Z-Image-Turbo base model as installed (a managed-download
 /// marker) so a real training run clears the missing-model guardrail.
 pub(crate) fn seed_installed_base_model(data_dir: &std::path::Path) {
+    // Seed the SceneWorks-managed install marker under the target's `base_model` id
+    // (`models/z_image_turbo`), which `training_base_model_installed` checks as its final fallback
+    // regardless of `base_model_repo`. Keying on the stable base_model (not the repo slug) keeps this
+    // helper from breaking whenever a target's `base_model_repo` is re-homed — as it just was when
+    // z_image_turbo moved off the flat `Tongyi-MAI/Z-Image-Turbo` upstream to its turnkey (sc-13860).
     let model_dir = data_dir
         .join("models")
-        .join(safe_download_dir("Tongyi-MAI/Z-Image-Turbo"));
+        .join(safe_download_dir("z_image_turbo"));
     std::fs::create_dir_all(&model_dir).expect("model dir creates");
     std::fs::write(model_dir.join(".sceneworks-download-complete.json"), "{}")
         .expect("model marker writes");

--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -1628,6 +1628,7 @@ async fn create_training_job_rejects_unknown_target_and_missing_dataset() {
 
 #[tokio::test]
 async fn create_training_job_queues_real_run_when_not_dry_run() {
+    let _env = isolate_hf_cache(); // hermetic: resolve the seeded base under the tempdir, never a dev's real HF cache (sc-13834/sc-13860)
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);
     let app = create_app(settings.clone()).expect("app creates");
@@ -1707,6 +1708,7 @@ async fn create_training_job_queues_real_run_when_not_dry_run() {
 
 #[tokio::test]
 async fn completed_training_job_registers_lora_with_provenance() {
+    let _env = isolate_hf_cache(); // hermetic: resolve the seeded base under the tempdir, never a dev's real HF cache (sc-13834/sc-13860)
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);
     let app = create_app(settings.clone()).expect("app creates");
@@ -1820,6 +1822,7 @@ async fn completed_training_job_registers_lora_with_provenance() {
 
 #[tokio::test]
 async fn failed_or_unwritten_training_job_registers_no_lora() {
+    let _env = isolate_hf_cache(); // hermetic: resolve the seeded base under the tempdir, never a dev's real HF cache (sc-13834/sc-13860)
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);
     let app = create_app(settings.clone()).expect("app creates");
@@ -1891,6 +1894,7 @@ async fn failed_or_unwritten_training_job_registers_no_lora() {
 /// ownership + terminal status are confirmed, not before.
 #[tokio::test]
 async fn terminal_training_job_completed_report_registers_no_lora_and_409s() {
+    let _env = isolate_hf_cache(); // hermetic: resolve the seeded base under the tempdir, never a dev's real HF cache (sc-13834/sc-13860)
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);
     let app = create_app(settings.clone()).expect("app creates");
@@ -1966,6 +1970,7 @@ async fn terminal_training_job_completed_report_registers_no_lora_and_409s() {
 /// the completion side-effects, not fire too late.
 #[tokio::test]
 async fn non_owner_completed_report_registers_no_lora_and_409s() {
+    let _env = isolate_hf_cache(); // hermetic: resolve the seeded base under the tempdir, never a dev's real HF cache (sc-13834/sc-13860)
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);
     let app = create_app(settings.clone()).expect("app creates");
@@ -2030,6 +2035,7 @@ async fn non_owner_completed_report_registers_no_lora_and_409s() {
 /// registers the trained LoRA into the catalog exactly as before.
 #[tokio::test]
 async fn winning_completed_report_still_registers_lora() {
+    let _env = isolate_hf_cache(); // hermetic: resolve the seeded base under the tempdir, never a dev's real HF cache (sc-13834/sc-13860)
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);
     let app = create_app(settings.clone()).expect("app creates");
@@ -2664,6 +2670,142 @@ fn stock_sdxl_target_points_at_installed_turnkey() {
     assert!(
         training_base_model_installed(&data_dir, &target),
         "a bf16 tier with a unet/ backbone is training-ready"
+    );
+}
+
+#[test]
+fn epic_8506_rehost_targets_point_at_their_installed_turnkeys() {
+    // sc-13860: the epic-8506 MLX re-host moved the catalog to `SceneWorks/*-mlx` turnkeys, but these
+    // four targets still named the flat UPSTREAM repos the app no longer downloads, so the pre-flight
+    // gate reported the installed base as missing and 400'd every real run (the SDXL #1694 class). Pin
+    // that each now names its turnkey AND resolves training to the dense `bf16/` tier the trainer needs,
+    // gating on that tier (a q4-only generation install must NOT read as training-ready). One case per
+    // backbone shape: DiT turnkeys pack `transformer/` (z-image, SD3.5), the SDXL-arch Kolors packs
+    // `unet/` — the same split `bf16_component_tree_present` probes.
+    for (base_model, expected_repo, backbone) in [
+        (
+            "z_image_turbo",
+            "SceneWorks/z-image-turbo-mlx",
+            "transformer",
+        ),
+        ("sd3_5_large", "SceneWorks/sd3.5-large-mlx", "transformer"),
+        ("sd3_5_medium", "SceneWorks/sd3.5-medium-mlx", "transformer"),
+        ("kolors", "SceneWorks/kolors-mlx", "unet"),
+    ] {
+        let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
+        let temp = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp.path().join("data");
+
+        let target = crate::builtin_training_targets()
+            .targets
+            .into_iter()
+            .find(|t| t.base_model == base_model)
+            .unwrap_or_else(|| panic!("{base_model} target present"));
+        assert_eq!(
+            target.base_model_repo.as_deref(),
+            Some(expected_repo),
+            "{base_model} trains off the installed SceneWorks turnkey, not the dead upstream repo"
+        );
+        let repo = target.base_model_repo.clone().expect("repo set");
+
+        let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");
+        let revision = "rev13860";
+        let snapshot = repo_root.join("snapshots").join(revision);
+        // Only the q4 GENERATION tier installed so far (no dense weights).
+        std::fs::create_dir_all(snapshot.join("q4").join(backbone)).expect("q4 tree");
+        std::fs::create_dir_all(repo_root.join("refs")).expect("create refs");
+        std::fs::write(repo_root.join("refs").join("main"), revision).expect("write refs/main");
+
+        assert_eq!(
+            resolve_base_model_path(&target, &data_dir),
+            snapshot.join("bf16").display().to_string(),
+            "{base_model}: a tiered turnkey resolves training to its dense bf16 tier"
+        );
+        assert!(
+            !training_base_model_installed(&data_dir, &target),
+            "{base_model}: a q4-only turnkey carries no dense weights → not training-ready"
+        );
+
+        std::fs::create_dir_all(snapshot.join("bf16").join(backbone)).expect("bf16 backbone");
+        std::fs::create_dir_all(snapshot.join("bf16").join("text_encoder")).expect("bf16 te");
+        std::fs::create_dir_all(snapshot.join("bf16").join("vae")).expect("bf16 vae");
+        assert!(
+            training_base_model_installed(&data_dir, &target),
+            "{base_model}: a bf16 tier with the backbone + TE + VAE is training-ready"
+        );
+    }
+}
+
+#[test]
+fn training_base_status_distinguishes_missing_from_tier_missing() {
+    // sc-13860 AC #4: a tiered turnkey installed for GENERATION (q4 only, no dense bf16) must gate as
+    // `TrainingTierMissing` — an actionable "install the training tier (bf16)" message — NOT the bare
+    // `Missing` "not installed", which sent #1694 reporters in circles trying to reinstall a base they
+    // already had. A repo with nothing on disk stays `Missing`; a full bf16 tree is `Ready`.
+    let _env = isolate_hf_cache(); // seed under the tempdir, never a developer's real HF cache (sc-13834)
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = crate::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "z_image_turbo")
+        .expect("z_image_turbo target");
+    let repo = target.base_model_repo.clone().expect("repo set");
+    let repo_root = huggingface_repo_cache_path(&data_dir, &repo).expect("repo cache path");
+
+    // Nothing on disk → Missing, with the original "not installed / install it from the catalog" text.
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::Missing
+    );
+    let missing =
+        training_base_unavailable_message(TrainingBaseStatus::Missing, &target.base_model)
+            .expect("Missing blocks a real run");
+    assert!(missing.contains("is not installed"), "{missing}");
+    assert!(
+        missing.contains("Install it from the model catalog"),
+        "{missing}"
+    );
+    assert!(
+        !missing.contains("training tier"),
+        "the Missing message must not claim a tier is installed: {missing}"
+    );
+
+    // The q4 GENERATION tier installed, no dense bf16 → TrainingTierMissing, with the tier-specific text.
+    let revision = "rev13860";
+    let snapshot = repo_root.join("snapshots").join(revision);
+    std::fs::create_dir_all(snapshot.join("q4").join("transformer")).expect("q4 tree");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("create refs");
+    std::fs::write(repo_root.join("refs").join("main"), revision).expect("write refs/main");
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::TrainingTierMissing
+    );
+    let tier = training_base_unavailable_message(
+        TrainingBaseStatus::TrainingTierMissing,
+        &target.base_model,
+    )
+    .expect("TrainingTierMissing blocks a real run");
+    assert!(tier.contains("training tier"), "{tier}");
+    assert!(tier.contains("bf16"), "{tier}");
+    assert!(
+        tier.contains("installed for generation"),
+        "the tier message tells the user their generation install is fine: {tier}"
+    );
+
+    // Dense bf16 component tree present → Ready, no error message.
+    std::fs::create_dir_all(snapshot.join("bf16").join("transformer")).expect("bf16 transformer");
+    std::fs::create_dir_all(snapshot.join("bf16").join("text_encoder")).expect("bf16 te");
+    std::fs::create_dir_all(snapshot.join("bf16").join("vae")).expect("bf16 vae");
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::Ready
+    );
+    assert_eq!(
+        training_base_unavailable_message(TrainingBaseStatus::Ready, &target.base_model),
+        None,
+        "a ready base does not block the run"
     );
 }
 

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -1284,11 +1284,11 @@ pub(crate) async fn create_training_job(
     // model installed and room on disk. A dry run only resolves the plan, so it
     // is exempt — that is how you preview a plan before installing the model.
     if !payload.dry_run {
-        if !training_base_model_installed(&data_dir, target) {
-            return Err(ApiError::bad_request(format!(
-                "Base model '{}' is not installed. Install it from the model catalog before starting a real training run (dry runs work without it).",
-                target.base_model
-            )));
+        if let Some(message) = training_base_unavailable_message(
+            training_base_model_status(&data_dir, target),
+            &target.base_model,
+        ) {
+            return Err(ApiError::bad_request(message));
         }
         if let Some(message) = training_disk_space_error(&output_dir) {
             return Err(ApiError::bad_request(message));
@@ -1708,11 +1708,29 @@ pub(crate) fn validate_lora_id_component(lora_id: &str) -> Result<(), ApiError> 
     Ok(())
 }
 
+/// Outcome of the pre-flight training-base check. Splitting "nothing on disk" from "the model is
+/// installed for generation but its dense training tier isn't" lets the run-gate give the second case
+/// an actionable "install the training tier" message instead of a bare "not installed" — the exact
+/// confusion the #1694 fix surfaced (sc-13860, AC #4). Both non-`Ready` states block a real run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrainingBaseStatus {
+    /// The dense training weights are present on disk — a real run can proceed.
+    Ready,
+    /// The base repo IS on disk (a tiered turnkey is installed — e.g. the q4 generation default) but
+    /// its dense `bf16/` training tier is absent. Training needs the full-precision tier specifically.
+    TrainingTierMissing,
+    /// Nothing for this base is on disk — the model was never installed.
+    Missing,
+}
+
 /// Whether the training target's base model weights are present on disk, using
 /// the same resolution `model_catalog` reports: the shared Hugging Face hub
 /// cache for the target's repo, or a SceneWorks-managed `data/models/<id>`
-/// install marker. A real run requires this; a dry run does not.
-pub(crate) fn training_base_model_installed(data_dir: &FsPath, target: &TrainingTarget) -> bool {
+/// install marker. A real run requires [`TrainingBaseStatus::Ready`]; a dry run does not.
+pub(crate) fn training_base_model_status(
+    data_dir: &FsPath,
+    target: &TrainingTarget,
+) -> TrainingBaseStatus {
     if let Some(repo) = target
         .base_model_repo
         .as_deref()
@@ -1721,27 +1739,69 @@ pub(crate) fn training_base_model_installed(data_dir: &FsPath, target: &Training
     {
         if let Some(cache_path) = huggingface_repo_cache_path(data_dir, repo) {
             // Tiered-turnkey re-host (epic 9992 Krea 2 Raw): training reads the DENSE `bf16/` tier, but
-            // generation may have installed only the q8 default. The repo-level completion marker does
+            // generation may have installed only the q4/q8 default. The repo-level completion marker does
             // NOT certify a tier (sc-9909), so require the bf16 component tree specifically — otherwise
-            // the run-gate would green-light training on a repo that has no dense weights to train.
+            // the run-gate would green-light training on a repo that has no dense weights to train. A
+            // turnkey on disk without that tier is `TrainingTierMissing`, not `Missing`.
             if let Some(snapshot) = huggingface_snapshot_dirs(&cache_path).into_iter().next() {
                 if snapshot_is_tiered_turnkey(&snapshot) {
-                    return bf16_component_tree_present(&snapshot.join("bf16"));
+                    return if bf16_component_tree_present(&snapshot.join("bf16")) {
+                        TrainingBaseStatus::Ready
+                    } else {
+                        TrainingBaseStatus::TrainingTierMissing
+                    };
                 }
             }
             if models::huggingface_cache_health(&cache_path, &[]).installed {
-                return true;
+                return TrainingBaseStatus::Ready;
             }
         }
         let managed = data_dir.join("models").join(safe_download_dir(repo));
         if model_is_installed(&managed) {
-            return true;
+            return TrainingBaseStatus::Ready;
         }
     }
     let managed = data_dir
         .join("models")
         .join(safe_download_dir(&target.base_model));
-    model_is_installed(&managed)
+    if model_is_installed(&managed) {
+        return TrainingBaseStatus::Ready;
+    }
+    TrainingBaseStatus::Missing
+}
+
+/// Thin boolean wrapper over [`training_base_model_status`]: `true` only when the dense training
+/// weights are ready. Test-only — production wants the richer status for its actionable messages
+/// (sc-13860); the readiness tests only care ready-or-not.
+#[cfg(test)]
+pub(crate) fn training_base_model_installed(data_dir: &FsPath, target: &TrainingTarget) -> bool {
+    matches!(
+        training_base_model_status(data_dir, target),
+        TrainingBaseStatus::Ready
+    )
+}
+
+/// The 400 detail to reject a real run whose base model isn't training-ready, or `None` when it is.
+/// The two blocking states get DISTINCT messages: `Missing` keeps the historical "not installed …
+/// install it from the model catalog" wording, while `TrainingTierMissing` says the model IS installed
+/// (for generation) but training needs the dense bf16 tier — the actionable message the flat #1694 error
+/// lacked (sc-13860, AC #4). Split out as a pure fn so the wording is unit-testable without the API.
+pub(crate) fn training_base_unavailable_message(
+    status: TrainingBaseStatus,
+    base_model: &str,
+) -> Option<String> {
+    match status {
+        TrainingBaseStatus::Ready => None,
+        TrainingBaseStatus::TrainingTierMissing => Some(format!(
+            "The training tier for base model '{base_model}' is not installed. It's installed for \
+             generation, but training needs the full-precision (bf16) tier — install that tier from \
+             the model catalog before starting a real training run (dry runs work without it)."
+        )),
+        TrainingBaseStatus::Missing => Some(format!(
+            "Base model '{base_model}' is not installed. Install it from the model catalog before \
+             starting a real training run (dry runs work without it)."
+        )),
+    }
 }
 
 /// Minimum free space we require at the output location before queuing a real

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1254,7 +1254,14 @@ fn z_image_turbo_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "z-image".to_owned(),
         base_model: "z_image_turbo".to_owned(),
-        base_model_repo: Some("Tongyi-MAI/Z-Image-Turbo".to_owned()),
+        // Point at the SceneWorks quant-matrix turnkey the catalog + engine actually install
+        // (`z_image_turbo` catalog entry / engines.rs `default_repo`), NOT the flat upstream
+        // `Tongyi-MAI/Z-Image-Turbo` — the epic-8506 re-host stopped downloading the latter, so the
+        // pre-flight install gate reported the installed base as missing and blocked every real run
+        // (sc-13860; same class as the SDXL #1694 fix). Z-Image-Turbo is the DEFAULT training base,
+        // so this was the highest-impact instance. Training resolves the dense `bf16/` tier via
+        // `tiered_turnkey_train_dir`.
+        base_model_repo: Some("SceneWorks/z-image-turbo-mlx".to_owned()),
         kernel: "z_image_lora".to_owned(),
         defaults: TrainingConfig {
             rank: 16,
@@ -1346,6 +1353,12 @@ fn lens_turbo_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "lens".to_owned(),
         base_model: "lens".to_owned(),
+        // sc-13860: intentionally the flat `SceneWorks/Lens` diffusers re-host, NOT the `SceneWorks/lens-mlx`
+        // inference turnkey. The catalog `lens` entry installs BOTH — `lens-mlx` (q4/q8/bf16 packed MLX
+        // subdirs) for generation AND `SceneWorks/Lens` as a `training` variant (builtin.models.jsonc). The
+        // flat-diffusers LoRA trainer cannot read the packed turnkey subdirs, and training on the distilled
+        // Lens-Turbo drifts (see the doc comment above), so this must stay `SceneWorks/Lens`. It IS
+        // catalog-installable, so this is not the false-"not installed" class the sibling targets hit.
         base_model_repo: Some("SceneWorks/Lens".to_owned()),
         kernel: "lens_lora".to_owned(),
         defaults: TrainingConfig {
@@ -1636,7 +1649,12 @@ fn sd3_large_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "sd3".to_owned(),
         base_model: "sd3_5_large".to_owned(),
-        base_model_repo: Some("stabilityai/stable-diffusion-3.5-large".to_owned()),
+        // Point at the SceneWorks turnkey the catalog + engine install (`sd3_5_large` catalog entry /
+        // engines.rs `default_repo`), NOT the flat upstream `stabilityai/stable-diffusion-3.5-large` —
+        // the epic-8506 re-host stopped downloading the latter, so the pre-flight install gate reported
+        // the installed base as missing and blocked every real run (sc-13860). The native-MLX `sd3_lora`
+        // trainer reads the dense `bf16/` tier (resolved via `tiered_turnkey_train_dir`), like LTX.
+        base_model_repo: Some("SceneWorks/sd3.5-large-mlx".to_owned()),
         kernel: "sd3_lora".to_owned(),
         defaults: TrainingConfig {
             rank: 16,
@@ -1729,7 +1747,12 @@ fn sd3_medium_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "sd3".to_owned(),
         base_model: "sd3_5_medium".to_owned(),
-        base_model_repo: Some("stabilityai/stable-diffusion-3.5-medium".to_owned()),
+        // Point at the SceneWorks turnkey the catalog + engine install (`sd3_5_medium` catalog entry /
+        // engines.rs `default_repo`), NOT the flat upstream `stabilityai/stable-diffusion-3.5-medium` —
+        // the epic-8506 re-host stopped downloading the latter, so the pre-flight install gate reported
+        // the installed base as missing and blocked every real run (sc-13860). Same native-MLX bf16-tier
+        // resolution as the Large target above.
+        base_model_repo: Some("SceneWorks/sd3.5-medium-mlx".to_owned()),
         kernel: "sd3_lora".to_owned(),
         defaults: TrainingConfig {
             rank: 16,
@@ -1895,6 +1918,15 @@ fn wan_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "wan-video".to_owned(),
         base_model: "wan_2_2".to_owned(),
+        // sc-13860: intentionally the `Wan-AI/Wan2.2-TI2V-5B-Diffusers` diffusers snapshot, NOT the
+        // `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey. The `wan_lora` kernel is torch/diffusers, so it needs
+        // DIFFUSERS weights — not the MLX-packed turnkey. On Windows/Linux the catalog installs exactly
+        // this repo as the `bf16` variant (builtin.models.jsonc), so the install gate finds it there
+        // (that torch/CUDA path is where #1694 was reported). This is NOT the epic-8506 mis-naming class
+        // the sibling targets hit — the repo is correct — so pointing at the MLX turnkey would only hand
+        // the torch trainer weights it can't load. NOTE the diffusers download is gated to Windows/Linux;
+        // whether macOS should run this trainer at all (and if so, get a Mac-installable diffusers base)
+        // is the SEPARATE gap tracked in sc-13878, not fixable by a repo rename here.
         base_model_repo: Some("Wan-AI/Wan2.2-TI2V-5B-Diffusers".to_owned()),
         kernel: "wan_lora".to_owned(),
         defaults: TrainingConfig {
@@ -2327,7 +2359,14 @@ fn kolors_lora_target() -> TrainingTarget {
         output_kind: TrainingOutputKind::Lora,
         family: "kolors".to_owned(),
         base_model: "kolors".to_owned(),
-        base_model_repo: Some("Kwai-Kolors/Kolors-diffusers".to_owned()),
+        // Point at the SceneWorks quant-matrix turnkey the catalog + engine install (`kolors` catalog
+        // entry / engines.rs `default_repo`), NOT the flat upstream `Kwai-Kolors/Kolors-diffusers` — the
+        // epic-8506 re-host stopped downloading the latter, so the pre-flight install gate reported the
+        // installed base as missing and blocked every real run (sc-13860). Structurally identical to the
+        // SDXL #1694 fix: SDXL-arch U-Net packed under `unet/`, dense `bf16/` tier resolved via
+        // `tiered_turnkey_train_dir`. (The ChatGLM3 tokenizer-materialization prereq, sc-4764, is a
+        // separate worker-side step, unaffected by the base repo name.)
+        base_model_repo: Some("SceneWorks/kolors-mlx".to_owned()),
         kernel: "kolors_lora".to_owned(),
         defaults: TrainingConfig {
             rank: 16,

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -238,6 +238,13 @@ fn builtin_registry_exposes_z_image_turbo_target() {
     assert_eq!(target.output_kind, TrainingOutputKind::Lora);
     assert_eq!(target.family, "z-image");
     assert_eq!(target.base_model, "z_image_turbo");
+    // sc-13860: the DEFAULT training base trains off the SceneWorks/z-image-turbo-mlx turnkey the
+    // catalog + engine install, NOT the flat upstream `Tongyi-MAI/Z-Image-Turbo` the epic-8506 re-host
+    // stopped downloading (false "not installed"); the trainer reads its dense `bf16/` tier.
+    assert_eq!(
+        target.base_model_repo.as_deref(),
+        Some("SceneWorks/z-image-turbo-mlx")
+    );
     assert_eq!(target.kernel, "z_image_lora");
     assert_eq!(target.defaults.rank, 16);
     assert_eq!(target.defaults.resolution, 1024);
@@ -283,11 +290,94 @@ fn builtin_registry_exposes_sdxl_target() {
     );
 }
 
+/// sc-13860 — registry↔catalog parity guard.
+///
+/// Every training target's `base_model_repo` must be a repo the target's own model CATALOG entry
+/// actually downloads. The pre-flight install gate (`training_base_model_installed`, rust-api) keys on
+/// `base_model_repo` in the HF cache; if a target names an UPSTREAM repo the app no longer downloads
+/// (the epic-8506 MLX re-host moved the catalog to `SceneWorks/*-mlx` turnkeys), the gate never finds
+/// it and 400s "not installed" on every real run — even when the model IS installed for generation.
+/// That was issue #1694 (SDXL) and this whole class (z-image / sd3.5 / kolors). Reading the SHIPPED
+/// `builtin.models.jsonc` and asserting the invariant here means the class can't silently drift again.
+///
+/// The join is per-target (target `base_model` == catalog `id`), so it catches "named the wrong repo",
+/// not merely "named a dead one". NOTE lens (`SceneWorks/Lens` flat-diffusers training variant) and wan
+/// (`Wan-AI/Wan2.2-TI2V-5B-Diffusers`, the Windows/Linux torch bf16 variant) INTENTIONALLY do not name
+/// their `*-mlx` inference turnkey — the guard still passes because the catalog installs those exact
+/// repos as separate download variants (verified sc-13860; do NOT "fix" them to the turnkey).
+#[test]
+fn every_training_base_repo_is_installed_by_its_catalog_entry() {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+    use std::collections::BTreeSet;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc embedded in BUILTIN_MANIFESTS");
+    let catalog: Value = serde_json::from_str(&strip_jsonc_comments(raw))
+        .expect("builtin.models.jsonc parses as JSON");
+    let models = catalog["models"]
+        .as_array()
+        .expect("catalog has a models array");
+    // Mutation-check on the parser itself: a silently-empty catalog would make every assertion below
+    // vacuously pass. The real catalog has dozens of models.
+    assert!(
+        models.len() > 20,
+        "catalog parsed to only {} models — the manifest parse likely broke, not a real result",
+        models.len()
+    );
+
+    // model id -> the set of every repo any of its download variants pulls.
+    let mut downloads_by_id: std::collections::BTreeMap<&str, BTreeSet<&str>> =
+        std::collections::BTreeMap::new();
+    for model in models {
+        let Some(id) = model["id"].as_str() else {
+            continue;
+        };
+        let repos = downloads_by_id.entry(id).or_default();
+        if let Some(downloads) = model["downloads"].as_array() {
+            for download in downloads {
+                if let Some(repo) = download["repo"].as_str() {
+                    repos.insert(repo);
+                }
+            }
+        }
+    }
+
+    for target in builtin_training_targets().targets {
+        let Some(repo) = target.base_model_repo.as_deref() else {
+            // A target with no explicit repo resolves via the app-managed models dir, not the HF-cache
+            // gate keyed on `base_model_repo`, so there is nothing to reconcile against the catalog.
+            continue;
+        };
+        let catalog_repos = downloads_by_id.get(target.base_model.as_str()).unwrap_or_else(|| {
+            panic!(
+                "training target `{}` trains base `{}`, but no model in builtin.models.jsonc has that \
+                 id — the training base has no catalog entry to install it from (sc-13860)",
+                target.id, target.base_model
+            )
+        });
+        assert!(
+            catalog_repos.contains(repo),
+            "training target `{}` names base_model_repo `{}`, which the `{}` catalog entry does NOT \
+             download (it installs: {:?}). The pre-flight install gate keys on this repo, so it would \
+             report the installed base as missing and 400 every real run (sc-13860). Point it at the \
+             repo the catalog installs.",
+            target.id,
+            repo,
+            target.base_model,
+            catalog_repos
+        );
+    }
+}
+
 #[test]
 fn builtin_registry_exposes_kolors_target() {
     // Kolors (epic 1929) is an SDXL-architecture U-Net target served by the
     // `kolors_lora` kernel; it reuses the SDXL attention modules + LoKr support
-    // (epic 2193 / sc-2217) and resolves the Kolors-diffusers base.
+    // (epic 2193 / sc-2217) and resolves the SceneWorks/kolors-mlx turnkey's dense bf16 tier.
     let registry = builtin_training_targets();
     let target = registry
         .targets
@@ -300,9 +390,12 @@ fn builtin_registry_exposes_kolors_target() {
     assert_eq!(target.family, "kolors");
     assert_eq!(target.base_model, "kolors");
     assert_eq!(target.kernel, "kolors_lora");
+    // sc-13860: trains off the SceneWorks/kolors-mlx turnkey the catalog + engine install, NOT the flat
+    // upstream `Kwai-Kolors/Kolors-diffusers` the epic-8506 re-host stopped downloading (false
+    // "not installed"); the trainer reads its dense `bf16/` tier.
     assert_eq!(
         target.base_model_repo.as_deref(),
-        Some("Kwai-Kolors/Kolors-diffusers")
+        Some("SceneWorks/kolors-mlx")
     );
     // SDXL-shared attention modules + LoKr advertised (sc-2217).
     assert_eq!(
@@ -377,16 +470,19 @@ fn builtin_registry_exposes_sd3_targets() {
         "to_add_out"
     ]);
 
+    // sc-13860: both train off the SceneWorks/sd3.5-*-mlx turnkeys the catalog + engine install, NOT
+    // the flat upstream `stabilityai/stable-diffusion-3.5-*` the epic-8506 re-host stopped downloading
+    // (false "not installed"); the native-MLX trainer reads each turnkey's dense `bf16/` tier.
     for (id, base_model, repo) in [
         (
             "sd3_5_large_lora",
             "sd3_5_large",
-            "stabilityai/stable-diffusion-3.5-large",
+            "SceneWorks/sd3.5-large-mlx",
         ),
         (
             "sd3_5_medium_lora",
             "sd3_5_medium",
-            "stabilityai/stable-diffusion-3.5-medium",
+            "SceneWorks/sd3.5-medium-mlx",
         ),
     ] {
         let target = registry

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -8,7 +8,7 @@
       "outputKind": "lora",
       "family": "z-image",
       "baseModel": "z_image_turbo",
-      "baseModelRepo": "Tongyi-MAI/Z-Image-Turbo",
+      "baseModelRepo": "SceneWorks/z-image-turbo-mlx",
       "kernel": "z_image_lora",
       "defaults": {
         "rank": 16,
@@ -382,7 +382,7 @@
       "outputKind": "lora",
       "family": "kolors",
       "baseModel": "kolors",
-      "baseModelRepo": "Kwai-Kolors/Kolors-diffusers",
+      "baseModelRepo": "SceneWorks/kolors-mlx",
       "kernel": "kolors_lora",
       "defaults": {
         "rank": 16,
@@ -759,7 +759,7 @@
       "outputKind": "lora",
       "family": "sd3",
       "baseModel": "sd3_5_large",
-      "baseModelRepo": "stabilityai/stable-diffusion-3.5-large",
+      "baseModelRepo": "SceneWorks/sd3.5-large-mlx",
       "kernel": "sd3_lora",
       "defaults": {
         "rank": 16,
@@ -865,7 +865,7 @@
       "outputKind": "lora",
       "family": "sd3",
       "baseModel": "sd3_5_medium",
-      "baseModelRepo": "stabilityai/stable-diffusion-3.5-medium",
+      "baseModelRepo": "SceneWorks/sd3.5-medium-mlx",
       "kernel": "sd3_lora",
       "defaults": {
         "rank": 16,


### PR DESCRIPTION
Fixes [sc-13860]. Continues the SDXL fix in #1694 / #1696 for the remaining training targets.

## Problem

The epic-8506 MLX re-host moved the model **catalog** to `SceneWorks/*-mlx` turnkeys, but several **training targets** in `crates/sceneworks-core/src/training.rs` still named the pre-migration **upstream** repos in `base_model_repo`. Nothing downloads those upstream repos anymore, so the pre-flight install gate `training_base_model_installed` (`apps/rust-api/src/training.rs`) keys on a repo that never lands on disk and 400s `Base model '<x>' is not installed…` on every real (non-dry-run) training run — even when the model is installed for generation. Reported for SDXL in #1694.

## Per-target validation (the story required this — NOT a blanket swap)

I mapped each target against what the catalog + engine actually install (`config/manifests/builtin.models.jsonc`, `crates/sceneworks-worker/src/engines.rs`) before changing anything:

| target | was | now | why |
|---|---|---|---|
| `z_image_turbo` | `Tongyi-MAI/Z-Image-Turbo` | **`SceneWorks/z-image-turbo-mlx`** | packed turnkey the catalog installs; trains off dense `bf16/` tier. The DEFAULT training base → highest-impact. |
| `sd3_5_large` | `stabilityai/stable-diffusion-3.5-large` | **`SceneWorks/sd3.5-large-mlx`** | native-MLX turnkey; trains off `bf16/`. |
| `sd3_5_medium` | `stabilityai/stable-diffusion-3.5-medium` | **`SceneWorks/sd3.5-medium-mlx`** | native-MLX turnkey; trains off `bf16/`. |
| `kolors` | `Kwai-Kolors/Kolors-diffusers` | **`SceneWorks/kolors-mlx`** | SDXL-arch turnkey (unet backbone); trains off `bf16/`. |
| `lens` | `SceneWorks/Lens` | **unchanged** | **story table was wrong.** The catalog `lens` entry installs `SceneWorks/Lens` as a `variant: "training"` download (a flat diffusers re-host). The flat-diffusers trainer can't read the packed `lens-mlx` turnkey subdirs, and training on the distilled Lens-Turbo drifts. `SceneWorks/Lens` is correct and IS catalog-installable. |
| `wan_2_2` | `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | **unchanged** | **story table was wrong.** The `wan_lora` kernel is torch/diffusers and needs diffusers weights; the catalog installs `Wan-AI/Wan2.2-TI2V-5B-Diffusers` as the Windows/Linux `bf16` variant — where the CUDA trainer runs and where #1694 was reported. Pointing at the MLX turnkey would hand the torch trainer weights it can't load. |

`anima_base` (`circlestone-labs/Anima`) was already correct — verified.

## Changes

- **`crates/sceneworks-core/src/training.rs`** — the 4 repo fixes, each with a comment explaining the class; plus explicit `sc-13860` notes on `lens`/`wan_2_2` so no one blanket-swaps them later.
- **`apps/rust-api/src/training.rs`** (AC #4) — split the gate into `training_base_model_status` → `{Ready, TrainingTierMissing, Missing}` and a pure `training_base_unavailable_message`. A tiered turnkey installed for **generation** (q4 only, no dense `bf16`) now gets an actionable *"install the training (bf16) tier"* message instead of the bare *"not installed"* that sent #1694 reporters in circles. The `Missing` message is byte-identical to before.
- **`crates/sceneworks-core/tests/training_contracts.rs`** (AC #2) — `every_training_base_repo_is_installed_by_its_catalog_entry`: parses the shipped `builtin.models.jsonc` and asserts every training target's `base_model_repo` is a repo its own catalog entry downloads (covers all 14 targets incl. the wan 14B MoE). Registry↔catalog drift can't recur silently. Updated the kolors/sd3/z-image per-target assertions.
- **`apps/rust-api/src/tests/training.rs`** — `epic_8506_rehost_targets_point_at_their_installed_turnkeys` (per-target resolve→`bf16` + gate for all 4 fixed, both backbone shapes) and `training_base_status_distinguishes_missing_from_tier_missing` (AC #4).
- **`tests/fixtures/.../target-registry.json`** — regenerated (4 baseModelRepo lines).

## Validation (AC #3)

Real-weights check against the installed `SceneWorks/z-image-turbo-mlx` turnkey in the OS HF cache: the actual `resolve_base_model_path` descends into the real `…/bb2bc…/bf16` tier and `training_base_model_status` returns `Ready` (gate passes) — a real z-image train click now clears the gate. Kolors is the same packed-turnkey mechanism (unet backbone, validated synthetically + covered by the real SDXL-family turnkeys); a real kolors install wasn't on the validation box.

`cargo fmt --all` clean; `clippy -D warnings` clean on both crates; `sceneworks-core` training contracts + `sceneworks-rust-api` training tests green.

## Stacking note

This branch **merges #1696** (the SDXL fix, commit `d9827b65`) as an ancestor so the parity guard can cover `sdxl` too. Until #1696 merges, this PR's diff shows #1696's changes as well; once #1696 lands, merging `main` collapses the diff to just the sc-13860 changes (no conflict — the commit is already in this history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
