### PR TITLE
chore(api): self-isolate remaining HF-cache install-state tests [sc-13835]

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1426,6 +1426,10 @@ fn backfill_current_receipt(
 #[cfg(test)]
 mod download_receipt_tests {
     use super::*;
+    // Reuse the ONE crate-wide HF-cache guard (sc-13834): tests here seed/resolve the cache via the
+    // env-first `huggingface_repo_cache_path`, so without this they would resolve into a developer's
+    // real HF cache when HF_HOME is set. Serialize on the same `HF_ENV_LOCK`; never add a second lock.
+    use crate::tests::support::isolate_hf_cache;
 
     #[test]
     fn multi_repo_marker_filters_nested_receipts_by_requested_repo() {
@@ -1460,6 +1464,7 @@ mod download_receipt_tests {
 
     #[test]
     fn complete_pre_receipt_install_is_backfilled_and_protected_after_rename() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let temp = tempfile::tempdir().unwrap();
         let data_dir = temp.path();
         let repo = "owner/backfill";
@@ -1499,6 +1504,7 @@ mod download_receipt_tests {
 
     #[test]
     fn receipt_remains_usable_when_current_manifest_file_changes() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let temp = tempfile::tempdir().unwrap();
         let data_dir = temp.path();
         let repo = "owner/model";
@@ -1541,6 +1547,7 @@ mod download_receipt_tests {
 
     #[test]
     fn catalog_distinguishes_usable_stale_from_torn_and_points_at_cache() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let temp = tempfile::tempdir().unwrap();
         let data_dir = temp.path();
         let repo = "owner/model";
@@ -1578,6 +1585,7 @@ mod download_receipt_tests {
 
     #[test]
     fn breaking_and_corequisite_softness_matrix() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         for breaking in [false, true] {
             for soft in [false, true] {
                 let temp = tempfile::tempdir().unwrap();
@@ -1657,6 +1665,7 @@ mod download_receipt_tests {
     /// installed — proving the perth+VE rehoming is enforced end to end.
     #[test]
     fn chatterbox_tts_install_state_gates_on_the_perth_and_ve_co_requisites() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let temp = tempfile::tempdir().unwrap();
         let data_dir = temp.path();
         // The primary chatterbox snapshot (T3 + S3Gen + tokenizer) is present…
@@ -1741,6 +1750,7 @@ mod download_receipt_tests {
     /// builtin manifest so a dropped/renamed component coRequisite (or a lost pinned revision) fails here.
     #[test]
     fn mmaudio_install_state_gates_on_all_five_component_co_requisites() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         fn builtin_models_entry(model_id: &str) -> Value {
             let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
                 .iter()
@@ -1837,6 +1847,7 @@ mod download_receipt_tests {
     /// then fails at load with the actionable error; this proves the catalog never advertises it ready.
     #[test]
     fn moss_tts_install_state_gates_on_the_codec_co_requisite() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         fn builtin_models_entry(model_id: &str) -> Value {
             let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
                 .iter()
@@ -3803,6 +3814,10 @@ mod gated_credential_tests {
 mod variant_install_tests {
     use super::*;
     use serde_json::json;
+    // Reuse the ONE crate-wide HF-cache guard (sc-13834) so these tests resolve the cache under
+    // their tempdir `data_dir`, never a developer's real HF cache — and serialize on the same
+    // `HF_ENV_LOCK` as the `crate::tests` suite (a second lock would defeat the mutual exclusion).
+    use crate::tests::support::isolate_hf_cache;
 
     /// Seed a HuggingFace repo cache snapshot under `data_dir` containing `files` (repo-relative
     /// paths). Mirrors the on-disk layout `model_variant_states` probes.
@@ -3886,6 +3901,7 @@ mod variant_install_tests {
         // Two unlabeled download entries (alternate sources / co-requisite TE repo) must NOT be
         // treated as a quant matrix: both would otherwise collapse to a duplicate "default" key.
         // The dedup guard emits exactly one "default" variant, matching the single-variant contract.
+        let _env = isolate_hf_cache(); // resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let model = json!({
@@ -3906,6 +3922,7 @@ mod variant_install_tests {
         // Every emitted variant key must be unique. A manifest that duplicates a variant (or maps
         // two entries to the same key) keeps only the first; downstream tracking never emits two
         // same-keyed states (sc-8508).
+        let _env = isolate_hf_cache(); // resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
 
@@ -3932,6 +3949,7 @@ mod variant_install_tests {
 
     #[test]
     fn single_variant_model_yields_one_default_variant() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let model = json!({
@@ -3963,6 +3981,7 @@ mod variant_install_tests {
     /// so the cache is the proxy). Generic: keys only off the manifest fields.
     #[test]
     fn mlx_update_available_tracks_source_file_in_cache() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "TenStrip/LTX2.3-10Eros";
@@ -4008,6 +4027,7 @@ mod variant_install_tests {
     /// degrades to a no-op rather than misfiring, so it's safe to leave enabled for all models.
     #[test]
     fn mlx_update_unavailable_without_convert_source_file() {
+        let _env = isolate_hf_cache(); // resolve the convert-source cache under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let model = json!({
@@ -4032,6 +4052,7 @@ mod variant_install_tests {
 
     #[test]
     fn per_variant_tracking_reports_which_tiers_are_on_disk() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "SceneWorks/matrix";
@@ -4102,6 +4123,7 @@ mod variant_install_tests {
     /// weights; an absent tier stays a clean "missing", not a repairable "incomplete".
     #[test]
     fn torn_diffusers_tier_reads_incomplete_not_installed() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "SceneWorks/matrix";
@@ -4177,6 +4199,7 @@ mod variant_install_tests {
     /// stays a clean `missing`.
     #[test]
     fn torn_sana_tier_reads_incomplete_not_installed() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "SceneWorks/Sana_Sprint_1.6B_1024px_mlx";
@@ -4247,6 +4270,7 @@ mod variant_install_tests {
 
     #[test]
     fn torn_boogu_default_reads_incomplete_not_installed() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "SceneWorks/boogu-image-mlx";
@@ -4281,6 +4305,7 @@ mod variant_install_tests {
     /// torn install. The shared predicate must downgrade it there too.
     #[test]
     fn torn_boogu_top_level_badge_reads_incomplete_not_installed() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "SceneWorks/boogu-image-mlx";
@@ -4312,6 +4337,7 @@ mod variant_install_tests {
     /// check folds across snapshots with `any`, not `all` (guards the epic-13075 multi-snapshot trap).
     #[test]
     fn sana_tier_complete_in_one_of_two_snapshots_reads_installed() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "SceneWorks/Sana_1600M_1024px_mlx";
@@ -4348,6 +4374,7 @@ mod variant_install_tests {
     /// pinned filenames surfaces as a RED test, not a silent false-incomplete on the Anima source badge.
     #[test]
     fn anima_source_download_variant_stays_installed_predicate_is_noop() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "circlestone-labs/Anima";
@@ -4386,6 +4413,7 @@ mod variant_install_tests {
     /// so a metadata-only tier produced a receipt whose files all exist yet cannot load).
     #[test]
     fn model_with_only_a_torn_tier_is_not_installed() {
+        let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
         let repo = "SceneWorks/matrix";

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -95,6 +95,7 @@ fn repo_slug_functions_match_cross_language_contract() {
 
 #[test]
 fn mlx_catalog_status_reports_turnkey_and_conversion_states() {
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     let temp = tempfile::tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
 
@@ -1348,6 +1349,7 @@ async fn imported_model_catalog_uses_paths_model_install_marker() {
 
 #[tokio::test]
 async fn downloadable_model_catalog_uses_huggingface_cache_install_state() {
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -1445,6 +1447,7 @@ async fn downloadable_model_catalog_uses_huggingface_cache_install_state() {
 
 #[tokio::test]
 async fn downloadable_model_catalog_flags_incomplete_huggingface_snapshots() {
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -1537,6 +1540,7 @@ async fn downloadable_model_catalog_ignores_absent_optional_diffusers_components
     // doesn't use, which have no files on disk by design. The health check must
     // not report them as missing, otherwise a fully-installed model is flagged
     // incomplete on every platform.
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -1635,6 +1639,7 @@ async fn downloadable_model_catalog_treats_processor_components_as_weightless() 
     // The health check must not demand `processor/config.json` + `processor/<weights>`
     // (which the repo never contains), otherwise a fully-installed model is flagged
     // incomplete forever and the "Fix" download can never satisfy it.
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -1732,6 +1737,7 @@ async fn downloadable_model_catalog_reports_incomplete_cache_for_installed_manag
     // A model can have SceneWorks' managed completion marker while its Hugging
     // Face cache snapshot is partial. Keep those states independent so the UI
     // can offer "Fix" instead of disabling the primary action as "Ready".
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let repo = "owner/mixed";
@@ -1920,6 +1926,7 @@ async fn quant_matrix_model_with_single_tier_reads_installed_not_incomplete() {
     // valid tier (here q8, NOT the default q4) previously tripped the top-level default-tier check
     // and surfaced a false "Cached files are incomplete" + Fix button. The card must read installed,
     // never incomplete/repairable, and the per-tier states must show q8 installed / q4+bf16 missing.
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -2020,6 +2027,7 @@ async fn quant_matrix_empty_cache_skeleton_reads_missing_not_incomplete() {
     // skeleton (bare blobs/, no snapshots) PLUS a stale repo-level completion marker. That must read
     // as a clean not-installed model — NOT a false "installed" (from the marker) and NOT the confusing
     // "Cached files are incomplete: snapshots/<revision>" repair banner.
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -2109,6 +2117,7 @@ async fn downloadable_model_catalog_accepts_weightless_component_with_nonstandar
     // "the directory exists and holds a file", not a hard-coded config filename.
     // A processor that ships an unexpected config name must still read complete,
     // so future class variants can't re-trigger a permanent false "incomplete".
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     single_model_manifest(
@@ -2150,6 +2159,7 @@ async fn downloadable_model_catalog_accepts_weightless_component_with_nonstandar
 async fn downloadable_model_catalog_flags_empty_weightless_component_dir() {
     // The hardening must not silently pass everything: a genuinely absent/empty
     // weightless component directory still reports incomplete (partial download).
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     single_model_manifest(
@@ -2445,6 +2455,7 @@ async fn model_catalog_gates_install_state_on_co_requisite() {
     // sc-9696: the entry is "installed" only when the primary AND every co-requisite are cached.
     // Primary present but the gemma-2-2b-it caption encoder missing → not-installed + repairable, so
     // the web PiD toggle stays hidden and the user still has a path to fetch the missing dependency.
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -2531,6 +2542,7 @@ async fn model_catalog_gates_install_state_on_co_requisite() {
 
 #[tokio::test]
 async fn lora_catalog_uses_huggingface_cache_install_state() {
+    let _env = isolate_hf_cache(); // resolve the HF cache under the tempdir, never a dev's real cache (sc-13835)
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/rust-api/src/tests/mod.rs
+++ b/apps/rust-api/src/tests/mod.rs
@@ -10,6 +10,9 @@ mod projects;
 mod prompt_batches;
 mod recipe_presets;
 mod server;
-mod support;
+// `pub(crate)` so the inline `#[cfg(test)]` test modules that live OUTSIDE this `tests`
+// tree (e.g. `crate::models::variant_install_tests`) can reuse the ONE crate-wide
+// `isolate_hf_cache` / `HF_ENV_LOCK` guard rather than adding a second lock (sc-13835).
+pub(crate) mod support;
 mod training;
 mod uploads;


### PR DESCRIPTION
## Summary

Follow-up to sc-13834. `huggingface_repo_cache_path(&data_dir, repo)` reads `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME` **before** `data_dir`, so a test that passes a tempdir `data_dir` and then **writes** into the resolved cache both pollutes and reads from a developer's **real** HF cache whenever `HF_HOME` is set. sc-13834 fixed `training.rs` + `lora_and_downloads.rs` and added the reusable `support::isolate_hf_cache()` guard (takes one crate-wide `HF_ENV_LOCK`, clears the three env vars for its lifetime). This PR applies that same guard to the **remaining** cache-resolving install-state tests so the whole rust-api suite is hermetic on dev boxes too — and the runner can drop its `env -u HF_HOME` workaround.

Story: [sc-13835](https://app.shortcut.com/trefry/story/13835)

## Changes

- **`tests/mod.rs`**: `mod support;` → `pub(crate) mod support;` so the inline `#[cfg(test)]` test modules that live in `crate::models` (outside the `tests` tree) can reuse the **one** crate-wide `HF_ENV_LOCK` / `isolate_hf_cache` rather than adding a second lock (a second lock would defeat the mutual exclusion the guard relies on).
- **`tests/catalog.rs`** — guard the **12** tests that seed the HF hub cache and assert the resolved install-state.
- **`models.rs`** — guard the **13** cache-resolving `variant_install_tests` and the **7** cache-resolving `download_receipt_tests` (the latter seed real repos such as `ResembleAI/chatterbox` + `SceneWorks/perth-implicit`), importing the shared guard into each module.

**32 tests guarded total.**

### Deliberately left unguarded (verified env-independent)
- `catalog.rs`: the four `*_cache_health_*` tests (pass an explicit `repo_root`, no env resolution); the managed-marker / imported / external-root install-state tests (install-state derives from local `data/models` markers or filesystem paths, not the HF cache); the pure `lora_artifact_paths` test.
- `models.rs`: the pure-JSON tests in `variant_install_tests`; `download_receipt_tests::multi_repo_marker_filters_nested_receipts_by_requested_repo` (reads a managed marker) and `…sdxl_shared_components…` (pure manifest logic); the whole `gated_credential_tests` / `variant_delete_tests` modules (zero cache resolution); `mlx_tier_probe_tests` (bare explicit root).

## Behavior / risk

No behavior change under CI — the runner already strips `HF_HOME`, so resolution was already hermetic there. This makes it hermetic for ad-hoc / IDE runs too.

## Verification

- `cargo fmt --all -- --check` → exit 0
- `cargo clippy -p sceneworks-rust-api --lib --tests -- -D warnings` → exit 0
- All **75** affected tests pass under a set throwaway `HF_HOME` and leave it **empty** (0 entries) — direct evidence the previously-unguarded writers no longer pollute the real cache and resolution is hermetic.
- **Mutation check**: temporarily removing one guard reproduces `models--owner--single/snapshots/abc123/model.safetensors` in the throwaway `HF_HOME` (test still passes — exactly why the leak went unnoticed), confirming the guard is load-bearing.
- Verified on the `main` merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)