### PR TITLE
fix(desktop): tree-kill the Windows candle supervisor on worker restart [sc-13584]

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -879,6 +879,18 @@ pub fn restart_gpu_worker(app: &AppHandle) {
         .take();
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     if let Some(child) = child {
+        // macOS runs a single MLX worker process — CommandChild::kill() (TerminateProcess
+        // on Windows / a plain kill here) reaps it fully. Windows runs the candle `auto`
+        // supervisor, which spawns one child per GPU plus a CPU child, each inheriting
+        // SCENEWORKS_PARENT_PID = this desktop PID. Unlike a quit, a restart leaves the
+        // desktop alive, so plain-killing only the supervisor orphans those children:
+        // their parent-death watchdog still sees the live desktop and never fires, and the
+        // respawned supervisor spawns a duplicate set contending for the same GPUs and
+        // worker IDs. Tree-kill the whole group by PID instead (taskkill /T /F), mirroring
+        // `begin_shutdown` and `stop_sidecars_for_update`.
+        #[cfg(target_os = "windows")]
+        kill_pid(child.pid());
+        #[cfg(target_os = "macos")]
         let _ = child.kill();
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]


### PR DESCRIPTION
## Summary

`restart_gpu_worker` — the Settings **"Restart worker"** button and the remote REST restart (epic 4484) — plain-killed the Windows candle `auto` supervisor via `CommandChild::kill()` (TerminateProcess), which reaps **only** the supervisor and orphans its per-GPU + CPU children.

Unlike a quit, a **restart leaves the desktop process alive**, so the orphaned children's parent-death watchdog (`SCENEWORKS_PARENT_PID` = desktop PID) never fires. The respawned supervisor then spawns a **duplicate** set of per-GPU workers contending for the same GPUs and worker IDs.

This mirrors the fix already in `begin_shutdown` (setup.rs:1573-1578) and `stop_sidecars_for_update` (setup.rs:1665-1670): tree-kill the whole process group by PID (`taskkill /T /F`) for the Windows candle child. The macOS MLX worker is a single process and keeps its plain `child.kill()`.

## Change
- `apps/desktop/src/setup.rs` `restart_gpu_worker`: the Windows candle child now uses `kill_pid(child.pid())`; the macOS MLX child is byte-for-byte unchanged.

Both callers route through this one function — `settings.rs:941` (local "Restart worker") and `setup.rs:686` (`WORKER_RESTART_SENTINEL`, remote REST) — so there is no second plain-kill path to the candle supervisor.

## Testing
- `cargo fmt --all -- --check` — clean.
- `cargo check -p sceneworks-desktop` (macOS, on the merge commit) — clean; the macOS arm is the unchanged prior behavior.
- The Windows arm is a byte-identical mirror of the shipped, CI-green line in `begin_shutdown` / `stop_sidecars_for_update`; it will be validated by the Windows CI lane (cannot be exercised on this macOS host).
- Independent adversarial review: **SHIP** — complete scope, correct cfg gating, no remaining plain-kill path.

No unit test added: the teardown functions require a live Tauri `AppHandle` + real child process trees and Windows-only `taskkill` behavior, with no injectable seam — consistent with the two existing sibling paths, which are also untested.

Closes [sc-13584](https://app.shortcut.com/trefry/story/13584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)