### PR TITLE
fix(worker): pin HF_HUB_CACHE in wan/ltx adapter tests to close the env-reader race [sc-13898]

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -13684,7 +13684,8 @@ mod tests {
     ))]
     use crate::test_env::{offline_settings, temp_env_var, temp_env_vars};
 
-    // Only the macOS-gated eros fixture pins a var for a whole test body — see the cfg note above.
+    // The macOS-gated adapter fixtures (wan Lightning + ltx distill) pin a var for a whole test body —
+    // see the cfg note above.
     #[cfg(target_os = "macos")]
     use crate::test_env::EnvVars;
 
@@ -16134,20 +16135,24 @@ mod tests {
     /// toggle. Toggle on (default) → the high/low Lightning pair is prepended (per-expert tagged),
     /// then user LoRAs. Toggle off → NO Lightning adapters, but user LoRAs are still honored. Only an
     /// explicit `lightning:false` opts out; absent defaults to on (backward compatible). This test is
-    /// hermetic: env vars pointing HF cache elsewhere would break the fixture, so skip when set.
+    /// hermetic: it pins `HF_HUB_CACHE` at its own fixture hub for the whole body (sc-13898), so the
+    /// fake snapshot resolves regardless of the ambient HF cache env.
     #[cfg(target_os = "macos")]
     #[test]
     fn wan_adapters_gate_lightning_on_toggle() {
-        // The fake HF snapshot only resolves when the cache-dir env overrides are unset (else the
-        // real cache is consulted). Skip rather than assert-false in that unusual local config.
-        if std::env::var_os("HF_HUB_CACHE").is_some()
-            || std::env::var_os("HUGGINGFACE_HUB_CACHE").is_some()
-            || std::env::var_os("HF_HOME").is_some()
-        {
-            return;
-        }
         let dir = std::env::temp_dir().join(format!("sw_wan_light_{}", Uuid::new_v4().simple()));
         std::fs::create_dir_all(&dir).unwrap();
+        // PIN the hub cache at this fixture's own dir for the whole test. `huggingface_hub_cache_dir`
+        // reads `HF_HUB_CACHE` (then `HUGGINGFACE_HUB_CACHE` / `HF_HOME`) BEFORE `data_dir`, so the old
+        // "skip if any HF var is set" guard raced a concurrent test's `EnvVars::set` writer: a real HF
+        // path landing between the guard and the resolve pointed the cache elsewhere and the fake
+        // Lightning snapshot went missing (sc-13898, the "env locks protect writers, not readers"
+        // class). `EnvVars` holds the crate-wide env lock until it drops at end of test, closing the
+        // window; pinning the value also means this never silently no-ops on a box with an HF var set.
+        let _env = EnvVars::set(&[(
+            "HF_HUB_CACHE",
+            fake_hf_hub_dir(&dir).to_str().expect("utf-8 fixture hub"),
+        )]);
         let (high, low) = write_fake_wan_lightning(&dir, "wan2_2_t2v_14b");
         // A user LoRA lives under data_dir so the confinement check passes.
         let user_lora = dir.join("style.safetensors");
@@ -18414,14 +18419,18 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn ltx_distill_lora_missing_errors_and_base_model_is_noop() {
-        if std::env::var_os("HF_HUB_CACHE").is_some()
-            || std::env::var_os("HUGGINGFACE_HUB_CACHE").is_some()
-            || std::env::var_os("HF_HOME").is_some()
-        {
-            return;
-        }
         let dir = std::env::temp_dir().join(format!("sw_eros_missing_{}", Uuid::new_v4().simple()));
         std::fs::create_dir_all(&dir).unwrap();
+        // PIN the hub cache at this fixture's own (empty) dir for the whole test, the hermetic pattern
+        // of `ltx_eros_auto_injects_distill_lora_per_pass`. Nothing is staged under it, so the distill
+        // LoRA is genuinely missing → the resolver must error. The old "skip if any HF var is set"
+        // guard both raced a concurrent `EnvVars::set` writer (sc-13898) and was a silent PASS on any
+        // box with an ambient HF cache set; pinning removes both. `EnvVars` holds the crate-wide env
+        // lock until it drops, so no concurrent writer can retarget the resolver mid-test.
+        let _env = EnvVars::set(&[(
+            "HF_HUB_CACHE",
+            fake_hf_hub_dir(&dir).to_str().expect("utf-8 fixture hub"),
+        )]);
         let settings = Settings {
             data_dir: dir.clone(),
             ..Settings::from_env()


### PR DESCRIPTION
## What & why

Fixes [sc-13898](https://app.shortcut.com/trefry/story/13898) — the flaky `video_jobs::tests::wan_adapters_gate_lightning_on_toggle`, discovered during sc-13583.

`wan_adapters_gate_lightning_on_toggle` guarded **only at entry**:

```rust
if var_os("HF_HUB_CACHE"|"HUGGINGFACE_HUB_CACHE"|"HF_HOME").is_some() { return; }
```

then resolved adapters through `resolve_wan_adapters` → `resolve_lightning_loras` → `huggingface_snapshot_dir` → … → **`huggingface_hub_cache_dir(data_dir)`** (`crates/sceneworks-core/src/hf_home.rs:70`), which **re-reads those same process-global vars** and returns them *before* the `<data_dir>/cache/huggingface/hub` fallback.

Worker `--lib` tests run as concurrent threads in **one process**, and many set `HF_HUB_CACHE`/`HF_HOME` to real temp paths via `EnvVars::set`. A concurrent writer landing in the window **between this test's entry guard and its cache-dir read** retargeted the resolver to a foreign path → the fixture's fake Lightning snapshot was missing → the resolve failed:

```
InvalidPayload("wan2_2_t2v_14b: the Lightning distill LoRA (lightx2v/Wan2.2-Lightning) is not downloaded — fetch it via the model manager")
```

This is the documented **"env locks protect writers, not readers"** class: `EnvVars::set` serializes writers, but the reader here held no lock. (Observed: nax-worker RED once, GREEN on rerun of the same commit.)

## The fix

Replace the guard-and-skip with the `test_env` module's prescribed pattern (its docs explicitly condemn `if var_os(..).is_some() { return }` as "a silent PASS that asserts nothing"):

- **Pin `HF_HUB_CACHE`** at the fixture's own hub dir (`fake_hf_hub_dir(&dir)`) via `EnvVars::set` for the **whole test body**. `EnvVars` holds the crate-wide `ENV_LOCK` `MutexGuard` until it drops, so **no concurrent writer can retarget the resolver mid-test**, and the pinned value points the resolver at the exact dir where the fixture lays its snapshot.
- Pinning a concrete value also removes the old **silent no-op** on any box (dev or CI) that happens to have an HF cache var set.

The **identical** guard-and-skip existed a second time in the same file — `ltx_distill_lora_missing_errors_and_base_model_is_noop` — whose sibling `ltx_eros_auto_injects_distill_lora_per_pass` was *already* converted to this pin pattern. Both are fixed here so the class is closed consistently; a crate-wide sweep confirms **zero** remaining guard-and-skip HF sites.

## Verification

- `cargo fmt --all -- --check`: clean · `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`: clean.
- Full `cargo test -p sceneworks-worker --lib` (the concurrent condition the flake appeared under): **946 passed, 0 failed, 175 ignored** — on the **merge commit** with latest `main`.
- **Hermeticity proof (mutation-style):** both tests still run their assertions and PASS when invoked with a foreign ambient `HF_HUB_CACHE=/tmp/bogus…` and, separately, `HF_HOME=/tmp/bogus…` — exactly the payload the race delivers. The old guard-and-skip would have `return`ed early (silent pass) in both cases.
- Assertions are load-bearing: breaking the pin reproduces the sc-13898 symptom; staging the LoRA into test #2's pinned hub correctly turns its "missing → error" assertion RED.
- Independent adversarial review: **APPROVE** (traced the resolver chain in source, mutation-proved both directions, confirmed scope complete).

## Scope note

An adversarial review surfaced a **separate** class — un-restored bare `std::env::set_var` **writers** that bypass `ENV_LOCK` in `#[ignore]`d real-weight E2E smokes (`voiceclone_smoke.rs`, `audio_jobs.rs`). Those don't run in the PR `--lib` lane and can't cause this flake, so they're tracked as follow-up **sc-13909** rather than folded into this PR.

Test-only change; no production code touched.