### PR TITLE
fix(training): resolve macOS Wan LoRA base weights from the MLX turnkey [sc-13878]

### DIFF
--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -93,6 +93,34 @@ impl Drop for HfCacheEnvGuard {
     }
 }
 
+/// Pin `HF_HUB_CACHE` to a REAL hub dir (not a tempdir) under [`HF_ENV_LOCK`] — the inverse of
+/// [`isolate_hf_cache`]. For `#[ignore]` real-weights tests that resolve the developer's actual
+/// installed turnkeys through `huggingface_repo_cache_path`. Clears the lower-priority `HUGGINGFACE_HUB_CACHE`
+/// / `HF_HOME` so `hub` wins unambiguously; restores all three on drop. macOS-only: its sole caller is the
+/// macOS Wan real-weights test, so gating it here keeps it from reading as dead code on the candle OSes.
+#[cfg(target_os = "macos")]
+pub(crate) fn pin_hf_hub_cache(hub: &std::path::Path) -> HfCacheEnvGuard {
+    let guard = HF_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let restore = ["HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME"]
+        .into_iter()
+        .map(|key| {
+            let previous = std::env::var(key).ok();
+            if key == "HF_HUB_CACHE" {
+                std::env::set_var(key, hub);
+            } else {
+                std::env::remove_var(key);
+            }
+            (key, previous)
+        })
+        .collect();
+    HfCacheEnvGuard {
+        restore,
+        _guard: guard,
+    }
+}
+
 pub(crate) fn readiness_worker(
     id: &str,
     status: WorkerStatus,

--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -2809,6 +2809,277 @@ fn training_base_status_distinguishes_missing_from_tier_missing() {
     );
 }
 
+// ---- macOS Wan training-base resolution (sc-13878) ----
+//
+// On macOS the Wan targets' diffusers `base_model_repo` is never installed; the native MLX trainer
+// loads the `SceneWorks/wan2.2-*-mlx` turnkey instead, so the gate + resolver must key off THAT repo.
+// These pin the macOS behavior; the platform-blind manifest side is guarded in sceneworks-core's
+// `macos_wan_targets_have_a_macos_installable_mlx_turnkey_base`. macOS-only: off-Mac the overrides are
+// inert (`None`) and the shared diffusers-turnkey path — covered above — runs unchanged.
+
+/// Seed a flat MLX Wan tier (the layout the native trainer reads) at `dir`.
+#[cfg(target_os = "macos")]
+fn seed_wan_mlx_tier(dir: &std::path::Path, dual_expert: bool) {
+    std::fs::create_dir_all(dir).expect("tier dir");
+    for file in [
+        "config.json",
+        "t5_encoder.safetensors",
+        "vae.safetensors",
+        "tokenizer.json",
+    ] {
+        std::fs::write(dir.join(file), "{}").expect("seed shared component");
+    }
+    if dual_expert {
+        std::fs::write(dir.join("low_noise_model.safetensors"), "x").expect("low expert");
+        std::fs::write(dir.join("high_noise_model.safetensors"), "x").expect("high expert");
+    } else {
+        std::fs::write(dir.join("model.safetensors"), "x").expect("dense expert");
+    }
+}
+
+/// Materialize an HF-cache snapshot for `repo` under `data_dir` and return the snapshot dir.
+#[cfg(target_os = "macos")]
+fn materialize_snapshot(
+    data_dir: &std::path::Path,
+    repo: &str,
+    revision: &str,
+) -> std::path::PathBuf {
+    let repo_root = huggingface_repo_cache_path(data_dir, repo).expect("repo cache path");
+    let snapshot = repo_root.join("snapshots").join(revision);
+    std::fs::create_dir_all(&snapshot).expect("snapshot dir");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("refs dir");
+    std::fs::write(repo_root.join("refs").join("main"), revision).expect("refs/main");
+    snapshot
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_wan_5b_dense_flat_root_is_ready_and_resolves_to_root() {
+    // The installed 5B turnkey ships its dense (bf16) weights as flat MLX files at the snapshot ROOT
+    // (legacy layout, `quantization: None`), with q4 as a generation subdir. The gate must read Ready
+    // and the resolver must hand the trainer the ROOT (its flat files), NOT the diffusers repo.
+    let _env = isolate_hf_cache();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = crate::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "wan_2_2")
+        .expect("wan_lora target");
+    // Independently pin the turnkey repo (not read from the map) so a map typo is caught: the gate
+    // resolves via `macos_wan_mlx_repo`, and if that drifts from this seed location it finds nothing.
+    let snapshot = materialize_snapshot(&data_dir, "SceneWorks/wan2.2-ti2v-5b-mlx", "revwan5b");
+    seed_wan_mlx_tier(&snapshot, false); // dense flat root
+    seed_wan_mlx_tier(&snapshot.join("q4"), false); // a generation tier that must NOT be selected
+
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::Ready,
+        "the dense flat-root turnkey is training-ready on macOS"
+    );
+    assert_eq!(
+        resolve_base_model_path(&target, &data_dir),
+        snapshot.display().to_string(),
+        "the trainer loads the dense flat root, not the q4 tier or the diffusers repo"
+    );
+
+    // Mutation check: tear one dense component from the root → the dense tier is gone, and with only the
+    // q4 generation tier left the gate is TrainingTierMissing (proves `wan_tier_complete` is load-bearing).
+    std::fs::remove_file(snapshot.join("model.safetensors")).expect("remove dense DiT");
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::TrainingTierMissing,
+        "a torn dense tier with only q4 present is not training-ready"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_wan_5b_q4_only_is_training_tier_missing() {
+    // A macOS Wan install for GENERATION is q4 by default (no dense bf16). Training needs full precision,
+    // so a q4-only turnkey gates as TrainingTierMissing with the actionable "install the bf16 tier" text —
+    // NOT the bare Missing that would send the user to reinstall a base they already have.
+    let _env = isolate_hf_cache();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = crate::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "wan_2_2")
+        .expect("wan_lora target");
+    let snapshot = materialize_snapshot(&data_dir, "SceneWorks/wan2.2-ti2v-5b-mlx", "revwan5bq4");
+    seed_wan_mlx_tier(&snapshot.join("q4"), false); // only the generation tier
+
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::TrainingTierMissing
+    );
+    let message = training_base_unavailable_message(
+        TrainingBaseStatus::TrainingTierMissing,
+        &target.base_model,
+    )
+    .expect("TrainingTierMissing blocks a real run");
+    assert!(message.contains("bf16"), "{message}");
+    assert!(message.contains("installed for generation"), "{message}");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_wan_5b_uninstalled_turnkey_is_missing() {
+    // No turnkey on disk → Missing (the base was never installed), NOT a resolve against the diffusers
+    // repo that can't exist on macOS.
+    let _env = isolate_hf_cache();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    let target = crate::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "wan_2_2")
+        .expect("wan_lora target");
+
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::Missing
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_wan_a14b_bf16_subdir_dual_expert_is_ready() {
+    // The A14B MoE turnkeys ship their dense tier as a `bf16/` SUBDIR of dual-expert files
+    // (low_noise + high_noise). The resolver descends into `bf16/`; the gate reads Ready. Covers BOTH
+    // A14B siblings (T2V + I2V) — the story is titled "5B" but the fix must cover all three Wan targets.
+    let _env = isolate_hf_cache();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+
+    for (base_model, repo, revision) in [
+        (
+            "wan_2_2_t2v_14b",
+            "SceneWorks/wan2.2-t2v-a14b-mlx",
+            "revt2v14b",
+        ),
+        (
+            "wan_2_2_i2v_14b",
+            "SceneWorks/wan2.2-i2v-a14b-mlx",
+            "revi2v14b",
+        ),
+    ] {
+        let target = crate::builtin_training_targets()
+            .targets
+            .into_iter()
+            .find(|t| t.base_model == base_model)
+            .unwrap_or_else(|| panic!("{base_model} training target present"));
+        let snapshot = materialize_snapshot(&data_dir, repo, revision);
+        seed_wan_mlx_tier(&snapshot.join("q4"), true); // generation tier (not selected)
+        seed_wan_mlx_tier(&snapshot.join("bf16"), true); // dense training tier
+
+        assert_eq!(
+            training_base_model_status(&data_dir, &target),
+            TrainingBaseStatus::Ready,
+            "{base_model}: dense bf16 dual-expert tier is training-ready"
+        );
+        assert_eq!(
+            resolve_base_model_path(&target, &data_dir),
+            snapshot.join("bf16").display().to_string(),
+            "{base_model}: the dual-expert trainer loads the dense bf16 subdir"
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "real weights: needs the SceneWorks/wan2.2-ti2v-5b-mlx turnkey (dense/bf16 tier) in the HF cache"]
+fn macos_wan_5b_real_turnkey_is_training_ready() {
+    // Walking-skeleton proof against REAL installed weights: run the production gate + resolver against
+    // the developer's actual HF hub cache and confirm the installed Wan 5B turnkey is training-ready and
+    // the resolved dir holds the flat MLX files the native trainer loads. Run with:
+    //   cargo test -p sceneworks-rust-api --lib macos_wan_5b_real_turnkey_is_training_ready -- --ignored
+    // (In production the app defaults HF_HOME to ~/.cache/huggingface at startup, server.rs; the test
+    // runner strips it, so pin the real hub explicitly.)
+    let home = std::path::PathBuf::from(std::env::var("HOME").expect("HOME"));
+    let _env = pin_hf_hub_cache(&home.join(".cache").join("huggingface").join("hub"));
+    let data_dir = home.join("SceneWorks").join("data");
+    let target = crate::builtin_training_targets()
+        .targets
+        .into_iter()
+        .find(|t| t.base_model == "wan_2_2")
+        .expect("wan_lora target");
+
+    assert_eq!(
+        training_base_model_status(&data_dir, &target),
+        TrainingBaseStatus::Ready,
+        "the installed Wan 5B turnkey must be training-ready (install its dense bf16 tier if this fails)"
+    );
+
+    let resolved = resolve_base_model_path(&target, &data_dir);
+    let dir = std::path::Path::new(&resolved);
+    for file in [
+        "model.safetensors",
+        "config.json",
+        "t5_encoder.safetensors",
+        "vae.safetensors",
+        "tokenizer.json",
+    ] {
+        assert!(
+            dir.join(file).exists(),
+            "resolved training dir {resolved} must hold the flat MLX file `{file}` the trainer reads"
+        );
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_wan_repos_match_manifest_macos_downloads() {
+    // Pin the rust-api `macos_wan_mlx_repo` map to the manifest's macOS download repo for each Wan base,
+    // so the two cannot drift (the gate/resolver only work if they resolve the repo macOS actually
+    // installs). Complements the platform-blind sceneworks-core guard.
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+    use std::collections::BTreeSet;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc embedded");
+    let catalog: Value = serde_json::from_str(&strip_jsonc_comments(raw)).expect("manifest parses");
+    let models = catalog["models"].as_array().expect("models array");
+
+    // The BASE download repos macOS installs, excluding co-requisites — the A14B entries carry a
+    // `lightx2v/Wan2.2-Lightning` co-requisite (sc-10030) that installs ALONGSIDE the base, not AS it,
+    // so it is not the training base the map resolves.
+    let macos_base_download_repos = |base_model: &str| -> BTreeSet<String> {
+        models
+            .iter()
+            .find(|m| m["id"].as_str() == Some(base_model))
+            .and_then(|m| m["downloads"].as_array())
+            .expect("base model entry with downloads")
+            .iter()
+            .filter(|d| !crate::models::is_co_requisite_download(d))
+            .filter(|d| match d.get("platforms").and_then(Value::as_array) {
+                None => true,
+                Some(platforms) => platforms.iter().any(|p| p.as_str() == Some("macos")),
+            })
+            .filter_map(|d| d["repo"].as_str().map(str::to_owned))
+            .collect()
+    };
+
+    for base_model in ["wan_2_2", "wan_2_2_t2v_14b", "wan_2_2_i2v_14b"] {
+        let mapped = crate::training::macos_wan_mlx_repo(base_model)
+            .unwrap_or_else(|| panic!("{base_model} is mapped to a macOS turnkey"));
+        assert_eq!(
+            macos_base_download_repos(base_model),
+            BTreeSet::from([mapped.to_owned()]),
+            "{base_model}: the rust-api macOS turnkey map ({mapped}) must equal the manifest's macOS \
+             base download repo(s) — they drifted"
+        );
+    }
+}
+
 #[test]
 fn resolve_base_model_path_prefers_converted_mlx_dir_for_conversion_models() {
     // `requiresConversion` models (Wan) keep usable weights in <data>/models/mlx/<id>, while the

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -1497,6 +1497,11 @@ pub(crate) fn resolve_base_model_path(target: &TrainingTarget, data_dir: &FsPath
     if converted.join("config.json").is_file() {
         return converted.display().to_string();
     }
+    // macOS Wan: the trainer loads the installed MLX turnkey's dense tier, NOT the Windows/Linux
+    // diffusers `base_model_repo` below (never installed on macOS) — sc-13878. Inert off-Mac / non-Wan.
+    if let Some(path) = macos_wan_base_path(data_dir, target) {
+        return path;
+    }
     if let Some(repo) = target
         .base_model_repo
         .as_deref()
@@ -1560,6 +1565,113 @@ fn tiered_turnkey_train_dir(snapshot: std::path::PathBuf) -> std::path::PathBuf 
         return snapshot.join("bf16");
     }
     snapshot
+}
+
+// ---- macOS Wan training-base resolution (sc-13878) ----
+//
+// The three Wan targets (`wan_lora` 5B + the two A14B MoE) name a Windows/Linux torch/diffusers
+// `base_model_repo` (`Wan-AI/Wan2.2-*-Diffusers`). That repo is gated to `platforms:[windows,linux]`
+// in the manifest, so macOS NEVER installs it — macOS installs the pre-converted MLX turnkey
+// (`SceneWorks/wan2.2-*-mlx`, `platforms:[macos]`) and routes the job to the in-process native MLX
+// trainer (`MLX_ROUTED_TRAINING_KERNELS` → mlx-gen-wan). So on macOS the pre-flight gate and the
+// base-path resolver must key off the MLX turnkey, not the diffusers repo, or every real Wan train
+// click 400s "not installed" against a repo that cannot exist there while the weights the trainer
+// actually loads sit installed. Off-Mac and for non-Wan targets these overrides are inert (`None`),
+// so the shared diffusers-turnkey logic below is unchanged.
+
+/// The macOS MLX turnkey repo the native Wan trainer loads for a Wan `base_model`, or `None` for a
+/// non-Wan base. The per-platform counterpart to the target's diffusers `base_model_repo`. Mirrors the
+/// worker's generation-side `resolve_wan_model_dir` (video_jobs.rs) 1:1; a manifest-parity test
+/// (`macos_wan_repos_match_manifest_macos_downloads`) pins each pair so the two cannot drift.
+#[cfg(target_os = "macos")]
+pub(crate) fn macos_wan_mlx_repo(base_model: &str) -> Option<&'static str> {
+    match base_model {
+        "wan_2_2" => Some("SceneWorks/wan2.2-ti2v-5b-mlx"),
+        "wan_2_2_t2v_14b" => Some("SceneWorks/wan2.2-t2v-a14b-mlx"),
+        "wan_2_2_i2v_14b" => Some("SceneWorks/wan2.2-i2v-a14b-mlx"),
+        _ => None,
+    }
+}
+
+/// The resolved MLX turnkey snapshot dir for a Wan `base_model` on macOS, or `None` when the turnkey
+/// is not materialized (nor a Wan base). Same HF-cache resolution the shared logic uses.
+#[cfg(target_os = "macos")]
+fn macos_wan_turnkey_snapshot(data_dir: &FsPath, base_model: &str) -> Option<PathBuf> {
+    let repo = macos_wan_mlx_repo(base_model)?;
+    huggingface_repo_cache_path(data_dir, repo)
+        .and_then(|cache| huggingface_snapshot_dirs(&cache).into_iter().next())
+}
+
+/// The dense (bf16) MLX Wan training weights inside a resolved turnkey `snapshot`, or `None` when only
+/// a quantized generation tier (q4/q8) is present. Training needs full precision — the trainer freezes
+/// the bf16 DiT and learns f32 adapter factors, so a q4/q8-only install is present-but-not-trainable.
+/// The turnkey ships the dense tier either as a `bf16/` subdir (the quant-matrix layout) or, on legacy
+/// installs, as the flat snapshot root itself; both are the flat MLX layout the trainer reads directly,
+/// so prefer the `bf16/` subdir and fall back to the root. The `q4/`/`q8/` subdirs are never selected.
+#[cfg(target_os = "macos")]
+fn wan_mlx_dense_train_dir(snapshot: &FsPath) -> Option<PathBuf> {
+    use sceneworks_core::mlx_tier_completeness::wan_tier_complete;
+    let bf16 = snapshot.join("bf16");
+    if wan_tier_complete(&bf16) {
+        return Some(bf16);
+    }
+    if wan_tier_complete(snapshot) {
+        return Some(snapshot.to_path_buf());
+    }
+    None
+}
+
+/// macOS Wan override for the pre-flight training-base status, or `None` (fall through to the shared
+/// diffusers-turnkey logic) off-Mac or for a non-Wan target. `Ready` when the turnkey's dense tier is
+/// present; `TrainingTierMissing` when the turnkey is installed for generation (e.g. only q4) but has no
+/// dense tier; `Missing` when the turnkey is not installed at all.
+fn macos_wan_base_status(data_dir: &FsPath, target: &TrainingTarget) -> Option<TrainingBaseStatus> {
+    #[cfg(target_os = "macos")]
+    {
+        if macos_wan_mlx_repo(&target.base_model).is_some() {
+            // A locally-converted dir (`<data>/models/mlx/<id>`, keyed on config.json) is what
+            // `resolve_base_model_path` returns FIRST, so honor it here too or the gate and resolver
+            // disagree. This is the legacy local-conversion tree; the turnkey is the standard install.
+            let converted = data_dir.join("models").join("mlx").join(&target.base_model);
+            if converted.join("config.json").is_file() {
+                return Some(TrainingBaseStatus::Ready);
+            }
+            return Some(
+                match macos_wan_turnkey_snapshot(data_dir, &target.base_model) {
+                    Some(snapshot) if wan_mlx_dense_train_dir(&snapshot).is_some() => {
+                        TrainingBaseStatus::Ready
+                    }
+                    Some(_) => TrainingBaseStatus::TrainingTierMissing,
+                    None => TrainingBaseStatus::Missing,
+                },
+            );
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (data_dir, target);
+    }
+    None
+}
+
+/// macOS Wan override for the base-model path the trainer loads, or `None` (fall through) off-Mac or
+/// for a non-Wan target. Prefers the dense tier; when only a quant tier is present (a real run is gated
+/// `TrainingTierMissing` anyway) falls back to the snapshot root so a dry run still resolves a real path.
+fn macos_wan_base_path(data_dir: &FsPath, target: &TrainingTarget) -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        if macos_wan_mlx_repo(&target.base_model).is_some() {
+            if let Some(snapshot) = macos_wan_turnkey_snapshot(data_dir, &target.base_model) {
+                let dir = wan_mlx_dense_train_dir(&snapshot).unwrap_or(snapshot);
+                return Some(dir.display().to_string());
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (data_dir, target);
+    }
+    None
 }
 
 /// GPU selection for a training job, read from the config's advanced bag (the
@@ -1731,6 +1843,11 @@ pub(crate) fn training_base_model_status(
     data_dir: &FsPath,
     target: &TrainingTarget,
 ) -> TrainingBaseStatus {
+    // macOS Wan: certify the installed MLX turnkey the native trainer loads, NOT the Windows/Linux
+    // diffusers `base_model_repo` below (never installed on macOS) — sc-13878. Inert off-Mac / non-Wan.
+    if let Some(status) = macos_wan_base_status(data_dir, target) {
+        return status;
+    }
     if let Some(repo) = target
         .base_model_repo
         .as_deref()

--- a/crates/sceneworks-core/src/mlx_tier_completeness.rs
+++ b/crates/sceneworks-core/src/mlx_tier_completeness.rs
@@ -72,6 +72,29 @@ pub fn sana_tier_complete(dir: &Path) -> bool {
         && dir.join("text_encoder/tokenizer.json").is_file()
 }
 
+/// Whether a Wan2.2 MLX turnkey tier `dir` is COMPLETE and loadable by the native MLX Wan trainer
+/// (sc-13878). The `SceneWorks/wan2.2-{ti2v-5b,t2v-a14b,i2v-a14b}-mlx` turnkeys ship a FLAT MLX layout
+/// (a `config.json` + top-level `*.safetensors`, NOT a diffusers `model_index.json` / `transformer/`
+/// component tree), so both the shared `model_index.json` guard and rust-api's diffusers-shaped
+/// training-base checks (`bf16_component_tree_present`, which probes `transformer/`|`unet/` dirs) are a
+/// no-op for them: a torn tier clears the coarse `<tier>/*` glob yet the trainer
+/// (mlx-gen-wan `build_trainer_concrete`) dies on the first absent flat file. A tier is complete when the
+/// UMT5 T5 encoder, the Wan VAE, the tokenizer, the `config.json`, and the DiT are all present — the DiT
+/// being either the single-expert `model.safetensors` (dense TI2V-5B) OR both MoE experts
+/// `low_noise_model.safetensors` + `high_noise_model.safetensors` (A14B T2V/I2V). Exact-path `.is_file()`
+/// checks are AppleDouble-safe by construction — a hidden `._name` sidecar has a different name
+/// (SceneWorks#1333) — and pin the exact filenames the trainer's `LoadSpec` dir must contain.
+pub fn wan_tier_complete(dir: &Path) -> bool {
+    let shared = dir.join("config.json").is_file()
+        && dir.join("t5_encoder.safetensors").is_file()
+        && dir.join("vae.safetensors").is_file()
+        && dir.join("tokenizer.json").is_file();
+    let dense_expert = dir.join("model.safetensors").is_file();
+    let dual_expert = dir.join("low_noise_model.safetensors").is_file()
+        && dir.join("high_noise_model.safetensors").is_file();
+    shared && (dense_expert || dual_expert)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,6 +127,25 @@ mod tests {
         touch(&dir.join("vae/diffusion_pytorch_model.safetensors"));
         touch(&dir.join("text_encoder/gemma-2-2b-it.safetensors"));
         touch(&dir.join("text_encoder/tokenizer.json"));
+    }
+
+    /// Write a COMPLETE dense (single-expert, TI2V-5B) Wan MLX tier tree.
+    fn seed_wan_dense(dir: &Path) {
+        touch(&dir.join("config.json"));
+        touch(&dir.join("t5_encoder.safetensors"));
+        touch(&dir.join("vae.safetensors"));
+        touch(&dir.join("tokenizer.json"));
+        touch(&dir.join("model.safetensors"));
+    }
+
+    /// Write a COMPLETE dual-expert (A14B MoE) Wan MLX tier tree.
+    fn seed_wan_moe(dir: &Path) {
+        touch(&dir.join("config.json"));
+        touch(&dir.join("t5_encoder.safetensors"));
+        touch(&dir.join("vae.safetensors"));
+        touch(&dir.join("tokenizer.json"));
+        touch(&dir.join("low_noise_model.safetensors"));
+        touch(&dir.join("high_noise_model.safetensors"));
     }
 
     #[test]
@@ -214,6 +256,74 @@ mod tests {
     }
 
     #[test]
+    fn wan_dense_complete_true_each_component_load_bearing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("bf16");
+        seed_wan_dense(&dir);
+        assert!(
+            wan_tier_complete(&dir),
+            "fully-seeded dense tier is complete"
+        );
+
+        // Mutation check: removing ANY single component must flip the verdict to incomplete.
+        for component in [
+            "config.json",
+            "t5_encoder.safetensors",
+            "vae.safetensors",
+            "tokenizer.json",
+            "model.safetensors",
+        ] {
+            let torn = tmp.path().join("torn");
+            seed_wan_dense(&torn);
+            fs::remove_file(torn.join(component)).unwrap();
+            assert!(
+                !wan_tier_complete(&torn),
+                "removing {component} must read incomplete"
+            );
+            fs::remove_dir_all(&torn).ok();
+        }
+    }
+
+    #[test]
+    fn wan_moe_complete_true_each_component_load_bearing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("bf16");
+        seed_wan_moe(&dir);
+        assert!(wan_tier_complete(&dir), "fully-seeded MoE tier is complete");
+
+        // Mutation check: BOTH experts are load-bearing (a single-expert dir is not a valid A14B tier)
+        // alongside every shared component.
+        for component in [
+            "config.json",
+            "t5_encoder.safetensors",
+            "vae.safetensors",
+            "tokenizer.json",
+            "low_noise_model.safetensors",
+            "high_noise_model.safetensors",
+        ] {
+            let torn = tmp.path().join("torn");
+            seed_wan_moe(&torn);
+            fs::remove_file(torn.join(component)).unwrap();
+            assert!(
+                !wan_tier_complete(&torn),
+                "removing {component} must read incomplete"
+            );
+            fs::remove_dir_all(&torn).ok();
+        }
+    }
+
+    #[test]
+    fn wan_ignores_appledouble_expert_sidecar() {
+        // A hidden `._` DiT sidecar is not a real weight (SceneWorks#1333); exact-path checks reject it.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("bf16");
+        seed_wan_dense(&dir);
+        fs::remove_file(dir.join("model.safetensors")).unwrap();
+        touch(&dir.join("._model.safetensors"));
+        assert!(!wan_tier_complete(&dir));
+    }
+
+    #[test]
     fn missing_tier_dir_is_incomplete_for_every_family() {
         // A tier subdir that does not exist at all (never converted / never downloaded) is incomplete,
         // not a panic — the catalog treats it as a clean "missing".
@@ -222,5 +332,6 @@ mod tests {
         assert!(!anima_tier_complete(&absent));
         assert!(!boogu_tier_complete(&absent));
         assert!(!sana_tier_complete(&absent));
+        assert!(!wan_tier_complete(&absent));
     }
 }

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1902,14 +1902,15 @@ fn ltx_video_lora_target() -> TrainingTarget {
 /// models.
 ///
 /// Like the LTX video LoRA it trains from a still-image dataset (each item
-/// encodes to a single Wan-VAE latent frame, `numFrames: 1`), but the `wan_lora`
-/// kernel is torch/diffusers — CUDA *and* Apple-Silicon MPS — not MLX: a
-/// flow-matching velocity loop on the `WanTransformer3DModel` attention
-/// projections (`to_q`/`to_k`/`to_v`/`to_out.0`). On MPS it runs in fp32 (Wan's
-/// Conv3d patch embedding has no bf16 Metal kernel; the kernel forces it). The
-/// output registers as a `wan-video` family LoRA the Wan video adapter loads at
-/// generation. This dense 5B target is the base the 14B (A14B MoE) trainer
-/// extends for the two-expert (high/low-noise) case.
+/// encodes to a single Wan-VAE latent frame, `numFrames: 1`) with a flow-matching
+/// velocity loop on the `WanTransformer3DModel` attention projections
+/// (`to_q`/`to_k`/`to_v`/`to_out.0`). The trainer is per-platform: off-Mac the
+/// `wan_lora` kernel is torch/diffusers (CUDA), while on macOS the job routes to
+/// the native in-process MLX trainer (`mlx-gen-wan`'s `wan2_2_ti2v_5b`), which
+/// loads the installed `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey's dense bf16 tier —
+/// NOT torch/MPS (sc-13878). The output registers as a `wan-video` family LoRA the
+/// Wan video adapter loads at generation. This dense 5B target is the base the 14B
+/// (A14B MoE) trainer extends for the two-expert (high/low-noise) case.
 fn wan_lora_target() -> TrainingTarget {
     TrainingTarget {
         id: "wan_lora".to_owned(),
@@ -1919,14 +1920,16 @@ fn wan_lora_target() -> TrainingTarget {
         family: "wan-video".to_owned(),
         base_model: "wan_2_2".to_owned(),
         // sc-13860: intentionally the `Wan-AI/Wan2.2-TI2V-5B-Diffusers` diffusers snapshot, NOT the
-        // `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey. The `wan_lora` kernel is torch/diffusers, so it needs
-        // DIFFUSERS weights — not the MLX-packed turnkey. On Windows/Linux the catalog installs exactly
-        // this repo as the `bf16` variant (builtin.models.jsonc), so the install gate finds it there
-        // (that torch/CUDA path is where #1694 was reported). This is NOT the epic-8506 mis-naming class
-        // the sibling targets hit — the repo is correct — so pointing at the MLX turnkey would only hand
-        // the torch trainer weights it can't load. NOTE the diffusers download is gated to Windows/Linux;
-        // whether macOS should run this trainer at all (and if so, get a Mac-installable diffusers base)
-        // is the SEPARATE gap tracked in sc-13878, not fixable by a repo rename here.
+        // `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey. The off-Mac `wan_lora` kernel is torch/diffusers, so it
+        // needs DIFFUSERS weights — not the MLX-packed turnkey. On Windows/Linux the catalog installs
+        // exactly this repo as the `bf16` variant (builtin.models.jsonc), so the install gate finds it
+        // there (that torch/CUDA path is where #1694 was reported). This is NOT the epic-8506 mis-naming
+        // class the sibling targets hit — the repo is correct — so pointing at the MLX turnkey would only
+        // hand the off-Mac torch trainer weights it can't load. The diffusers download is gated to
+        // Windows/Linux; on macOS the job runs the native MLX trainer against the installed
+        // `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey instead, which the platform-aware training gate +
+        // base-path resolver select (apps/rust-api/src/training.rs `macos_wan_*`, sc-13878) — so
+        // `base_model_repo` stays the diffusers repo and is simply not consulted on macOS.
         base_model_repo: Some("Wan-AI/Wan2.2-TI2V-5B-Diffusers".to_owned()),
         kernel: "wan_lora".to_owned(),
         defaults: TrainingConfig {
@@ -1991,7 +1994,7 @@ fn wan_lora_target() -> TrainingTarget {
         })),
         ui: object(json!({
             "label": "Wan2.2 Video LoRA",
-            "description": "Train a Wan2.2 video LoRA from still images (Wan2.2-TI2V-5B). Runs on CUDA and Apple Silicon (MPS).",
+            "description": "Train a Wan2.2 video LoRA from still images (Wan2.2-TI2V-5B). Runs on CUDA and Apple Silicon.",
             "recommendedFor": ["character", "style"],
             "datasetModality": "image"
         })),
@@ -2004,10 +2007,12 @@ fn wan_lora_target() -> TrainingTarget {
 /// A14B is a two-expert mixture: a high-noise expert (`transformer`) and a
 /// low-noise expert (`transformer_2`), so the `wan_moe_lora` kernel trains a
 /// separate LoRA on each, split at the pipeline `boundary_ratio` (0.875), and
-/// saves two `wan-video` family files. Same diffusers flow-matching recipe as the
-/// dense 5B `wan_lora` target (still-image dataset, fp32 on MPS), but the A14B
-/// bf16 base is GPU-only (~56GB of transformers); the Q8_0 GGUF base path fits
-/// memory-bound hosts. `base_model` records the specific A14B variant so the
+/// saves two `wan-video` family files. Same flow-matching recipe as the dense 5B
+/// `wan_lora` target (still-image dataset), and the same per-platform backend split —
+/// off-Mac torch/diffusers (CUDA), on macOS the native MLX trainer against the
+/// installed `SceneWorks/wan2.2-{t2v,i2v}-a14b-mlx` turnkey's dense tier (sc-13878).
+/// The A14B bf16 base is GPU-only (~56GB of transformers); the Q8_0 GGUF base path
+/// fits memory-bound hosts. `base_model` records the specific A14B variant so the
 /// inference loader gates the LoRA to the matching model (not the 5B).
 fn wan_moe_lora_target(
     id: &str,
@@ -2086,7 +2091,7 @@ fn wan_t2v_14b_lora_target() -> TrainingTarget {
         "Wan2.2 14B T2V Video LoRA",
         "wan_2_2_t2v_14b",
         "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
-        "Train a Wan2.2 14B (A14B MoE, text-to-video) LoRA from still images. Trains both noise experts; GPU-only at bf16 (Q8_0 GGUF base fits smaller hosts).",
+        "Train a Wan2.2 14B (A14B MoE, text-to-video) LoRA from still images. Trains both noise experts against the full-size bf16 base (large; on Windows/Linux a Q8_0 GGUF base fits smaller hosts).",
     )
 }
 
@@ -2096,7 +2101,7 @@ fn wan_i2v_14b_lora_target() -> TrainingTarget {
         "Wan2.2 14B I2V Video LoRA",
         "wan_2_2_i2v_14b",
         "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
-        "Train a Wan2.2 14B (A14B MoE, image-to-video) LoRA from still images. Trains both noise experts; GPU-only at bf16 (Q8_0 GGUF base fits smaller hosts).",
+        "Train a Wan2.2 14B (A14B MoE, image-to-video) LoRA from still images. Trains both noise experts against the full-size bf16 base (large; on Windows/Linux a Q8_0 GGUF base fits smaller hosts).",
     )
 }
 

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -373,6 +373,122 @@ fn every_training_base_repo_is_installed_by_its_catalog_entry() {
     }
 }
 
+/// sc-13878 — platform-aware training-base guard (the sc-13860 guard above is platform-BLIND).
+///
+/// The three Wan video targets name a Windows/Linux torch/diffusers `base_model_repo`
+/// (`Wan-AI/Wan2.2-*-Diffusers`) the manifest gates to `platforms:[windows,linux]`. macOS installs a
+/// DIFFERENT repo — the pre-converted MLX turnkey (`SceneWorks/wan2.2-*-mlx`, `platforms:[macos]`) — and
+/// runs the native MLX trainer against it. The sc-13860 guard only checks `base_model_repo ∈ downloads`
+/// (which PASSES here — the diffusers repo IS a win/linux download), so it structurally cannot catch that
+/// on macOS the gate/resolver must key off a DIFFERENT repo; that mismatch was this bug. This guard
+/// asserts, per Wan target, that the manifest offers a macOS-installable MLX turnkey for the base AND that
+/// the diffusers repo is win/linux-only — the platform split the rust-api `macos_wan_*` gate/resolver
+/// depend on. A dropped macOS turnkey download, or the diffusers repo (wrongly) tagged for macOS, fails
+/// here regardless of which OS runs CI.
+#[test]
+fn macos_wan_targets_have_a_macos_installable_mlx_turnkey_base() {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc embedded in BUILTIN_MANIFESTS");
+    let catalog: Value = serde_json::from_str(&strip_jsonc_comments(raw))
+        .expect("builtin.models.jsonc parses as JSON");
+    let models = catalog["models"]
+        .as_array()
+        .expect("catalog has a models array");
+    assert!(
+        models.len() > 20,
+        "catalog parsed to only {} models — the manifest parse likely broke",
+        models.len()
+    );
+
+    // A download applies to an OS when it has no `platforms` key (all OSes) or lists that OS.
+    fn download_targets_os(download: &Value, os: &str) -> bool {
+        match download.get("platforms").and_then(Value::as_array) {
+            None => true,
+            Some(platforms) => platforms.iter().any(|p| p.as_str() == Some(os)),
+        }
+    }
+    let model_entry = |id: &str| -> Value {
+        models
+            .iter()
+            .find(|m| m["id"].as_str() == Some(id))
+            .unwrap_or_else(|| panic!("builtin.models.jsonc has a `{id}` entry"))
+            .clone()
+    };
+
+    // The macOS MLX turnkey each Wan base installs — the per-platform counterpart the rust-api
+    // `macos_wan_mlx_repo` map returns. Kept in lockstep with that map (a typo here or there fails).
+    let expected_macos_turnkey = |base_model: &str| -> &'static str {
+        match base_model {
+            "wan_2_2" => "SceneWorks/wan2.2-ti2v-5b-mlx",
+            "wan_2_2_t2v_14b" => "SceneWorks/wan2.2-t2v-a14b-mlx",
+            "wan_2_2_i2v_14b" => "SceneWorks/wan2.2-i2v-a14b-mlx",
+            other => panic!("unexpected Wan base_model `{other}` — extend the macOS turnkey map"),
+        }
+    };
+
+    let wan_targets: Vec<_> = builtin_training_targets()
+        .targets
+        .into_iter()
+        .filter(|t| t.family == "wan-video")
+        .collect();
+    // Anti-vacuous: the dense 5B + both A14B MoE targets. A silently-empty filter must not pass.
+    assert_eq!(
+        wan_targets.len(),
+        3,
+        "expected the 3 wan-video training targets (5B + T2V/I2V A14B), got {}",
+        wan_targets.len()
+    );
+
+    for target in wan_targets {
+        let entry = model_entry(&target.base_model);
+        let downloads = entry["downloads"]
+            .as_array()
+            .unwrap_or_else(|| panic!("`{}` has a downloads array", target.base_model));
+
+        // 1) macOS installs the MLX turnkey the native trainer loads.
+        let turnkey = expected_macos_turnkey(&target.base_model);
+        assert!(
+            downloads.iter().any(|d| d["repo"].as_str() == Some(turnkey)
+                && download_targets_os(d, "macos")),
+            "training target `{}` (base `{}`) has no macOS-installable `{}` download — macOS Wan LoRA \
+             training has no base to run against (sc-13878)",
+            target.id,
+            target.base_model,
+            turnkey
+        );
+
+        // 2) The diffusers `base_model_repo` is the Windows/Linux torch base — NOT installed on macOS.
+        //    This is exactly why keying the gate on `base_model_repo` (sc-13860) breaks on macOS.
+        let diffusers = target
+            .base_model_repo
+            .as_deref()
+            .expect("wan target names a diffusers base_model_repo");
+        let diffusers_downloads: Vec<_> = downloads
+            .iter()
+            .filter(|d| d["repo"].as_str() == Some(diffusers))
+            .collect();
+        assert!(
+            !diffusers_downloads.is_empty(),
+            "`{}` diffusers base `{diffusers}` must still be a catalog download (the off-Mac torch base)",
+            target.base_model
+        );
+        assert!(
+            diffusers_downloads
+                .iter()
+                .all(|d| !download_targets_os(d, "macos")),
+            "`{}` diffusers base `{diffusers}` is tagged for macOS — it must be Windows/Linux only, or the \
+             sc-13860 gate would (wrongly) look for it on macOS (sc-13878)",
+            target.base_model
+        );
+    }
+}
+
 #[test]
 fn builtin_registry_exposes_kolors_target() {
     // Kolors (epic 1929) is an SDXL-architecture U-Net target served by the
@@ -626,8 +742,8 @@ fn builtin_registry_exposes_wan_target() {
     assert_eq!(target.kernel, "wan_lora");
     assert_eq!(target.defaults.rank, 32);
     assert_eq!(target.defaults.resolution, 512);
-    // Cross-platform torch trainer: plain AdamW (adamw8bit is CUDA-only and falls
-    // back), unlike the MLX LTX target which is also adamw but MPS-only.
+    // Cross-platform default: plain AdamW (adamw8bit is CUDA-only and falls back off it). The
+    // backend is per-platform — off-Mac torch/CUDA, on macOS the native MLX trainer (sc-13878).
     assert_eq!(target.defaults.optimizer, "adamw");
     // Wan transformer attention projections drive the LoRA injection.
     assert_eq!(
@@ -639,7 +755,10 @@ fn builtin_registry_exposes_wan_target() {
         target.defaults.advanced.get("numFrames"),
         Some(&serde_json::json!(1))
     );
-    // Not MLX/Apple-Silicon-gated — runs on CUDA and MPS.
+    // Not Apple-Silicon-gated: it runs off-Mac (torch/CUDA) AND on macOS (the native MLX trainer
+    // against the installed MLX turnkey, sc-13878), so it carries no `appleSiliconOnly` marker —
+    // unlike the MLX-only LTX target. The macOS base-weight resolution lives in the rust-api
+    // `macos_wan_*` gate/resolver, guarded by `macos_wan_targets_have_a_macos_installable_mlx_turnkey_base`.
     assert_eq!(target.limits.get("appleSiliconOnly"), None);
 }
 

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -1231,7 +1231,7 @@
       },
       "ui": {
         "datasetModality": "image",
-        "description": "Train a Wan2.2 video LoRA from still images (Wan2.2-TI2V-5B). Runs on CUDA and Apple Silicon (MPS).",
+        "description": "Train a Wan2.2 video LoRA from still images (Wan2.2-TI2V-5B). Runs on CUDA and Apple Silicon.",
         "label": "Wan2.2 Video LoRA",
         "recommendedFor": [
           "character",
@@ -1326,7 +1326,7 @@
       },
       "ui": {
         "datasetModality": "image",
-        "description": "Train a Wan2.2 14B (A14B MoE, text-to-video) LoRA from still images. Trains both noise experts; GPU-only at bf16 (Q8_0 GGUF base fits smaller hosts).",
+        "description": "Train a Wan2.2 14B (A14B MoE, text-to-video) LoRA from still images. Trains both noise experts against the full-size bf16 base (large; on Windows/Linux a Q8_0 GGUF base fits smaller hosts).",
         "label": "Wan2.2 14B T2V Video LoRA",
         "recommendedFor": [
           "character",
@@ -1421,7 +1421,7 @@
       },
       "ui": {
         "datasetModality": "image",
-        "description": "Train a Wan2.2 14B (A14B MoE, image-to-video) LoRA from still images. Trains both noise experts; GPU-only at bf16 (Q8_0 GGUF base fits smaller hosts).",
+        "description": "Train a Wan2.2 14B (A14B MoE, image-to-video) LoRA from still images. Trains both noise experts against the full-size bf16 base (large; on Windows/Linux a Q8_0 GGUF base fits smaller hosts).",
         "label": "Wan2.2 14B I2V Video LoRA",
         "recommendedFor": [
           "character",


### PR DESCRIPTION
Fixes [sc-13878](https://app.shortcut.com/trefry/story/13878). Follow-up to sc-13860 (which was Windows/Linux-only).

## The bug

On **macOS**, a real Wan2.2 video-LoRA train click 400s **"Base model 'wan_2_2' is not installed"** with no catalog path to fix it. The pre-flight gate (`training_base_model_status`) and base-path resolver (`resolve_base_model_path`, `apps/rust-api/src/training.rs`) both key off the target's `base_model_repo` = `Wan-AI/Wan2.2-TI2V-5B-Diffusers` — the **Windows/Linux** torch/diffusers snapshot, gated to `platforms:[windows,linux]` in the manifest and **never installed on macOS**.

But macOS routes Wan training to the **native in-process MLX trainer** (`wan_lora`/`wan_moe_lora` ∈ `MLX_ROUTED_TRAINING_KERNELS` → `mlx-gen-wan`), which loads the pre-converted MLX turnkey `SceneWorks/wan2.2-*-mlx` — installed for generation. So the gate/resolver were keying off a repo that **cannot exist on macOS** while the weights the trainer actually loads sat installed.

Resolving the story's open questions: there is **no torch/MPS Wan trainer** anywhere in either repo — macOS runs the native MLX trainer, so the base is already installable (the MLX turnkey); no new download is needed. The "Runs on CUDA and Apple Silicon (MPS)" copy was aspirational and is corrected.

## The fix

Make the gate + resolver **platform-aware** on macOS for the Wan base models (inert off-Mac / for non-Wan targets — the shared diffusers-turnkey path is unchanged):

- Resolve the installed MLX turnkey and require its **dense (bf16) tier** — training needs full precision (the trainer freezes the bf16 DiT and learns f32 adapter factors); `q4`/`q8` are generation tiers. The dense tier is the `bf16/` subdir (A14B quant-matrix layout) or the flat snapshot root (legacy 5B layout).
- `Ready` when the dense tier is present; `TrainingTierMissing` (actionable "install the bf16 tier") when only a generation tier (e.g. q4) is installed; `Missing` when the turnkey is absent.
- Covers **all three** Wan targets (dense 5B + both A14B MoE) — they share the gap.

## Structural guards & tests

- Shared `sceneworks_core::mlx_tier_completeness::wan_tier_complete` (flat MLX layout, single- or dual-expert), mutation-checked.
- **Platform-aware parity guard** (`macos_wan_targets_have_a_macos_installable_mlx_turnkey_base`) — the sc-13860 guard is platform-blind and structurally cannot catch this class; the new one asserts each Wan base has a macOS-installable MLX turnkey and that its diffusers repo is Windows/Linux-only. Runs on every CI lane.
- macOS map↔manifest pin (`macos_wan_repos_match_manifest_macos_downloads`) so the turnkey map can't drift.
- Gate/resolver unit tests: dense flat root → Ready+resolve-to-root, dense bf16 subdir dual-expert (T2V **and** I2V) → Ready+resolve-to-bf16, q4-only → TrainingTierMissing, absent → Missing.
- An `#[ignore]` real-weights test that runs the production gate/resolver against the actually-installed turnkey (verified passing locally on an M5 Max).
- Corrected the Wan target UI/doc copy (native MLX on macOS, not torch/MPS; A14B copy no longer advertises the win/linux-only GGUF base as universal).

## Validation

`cargo fmt --all --check`, `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets -- -D warnings`, and the sceneworks-core + rust-api training suites all green on the merge commit (macOS/MLX box). The Linux/candle lanes compile the platform overrides as inert `None` (verified by cfg analysis + a fresh adversarial review); CI covers them.

## Follow-up filed

[sc-13915](https://app.shortcut.com/trefry/story/13915) — the rust-api training snapshot resolver reuses `huggingface_snapshot_dirs().next()`, which lacks the sc-13834 file-count guard the worker's generation resolver has (pre-existing, platform-blind, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)