### PR TITLE
chore(worker): route leaking HF_HOME test writers through the ENV_LOCK seam [sc-13909]

### DIFF
--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -3293,7 +3293,9 @@ mod tests {
         );
 
         // ── Step 4: DISABLE NETWORK for the render — offline flags PLUS a black-hole proxy that fails
-        //    any residual hub agent (belt and suspenders; at this pin a cache HIT never builds one). ──
+        //    any residual hub agent (belt and suspenders; at this pin a cache HIT never builds one).
+        //    All five keys are pre-registered by the `_env` guard above, so they restore on drop —
+        //    no leak (sc-13909). ──
         std::env::set_var("HF_HUB_OFFLINE", "1");
         std::env::set_var("TRANSFORMERS_OFFLINE", "1");
         std::env::set_var("ALL_PROXY", "http://127.0.0.1:1");

--- a/crates/sceneworks-worker/src/voiceclone_smoke.rs
+++ b/crates/sceneworks-worker/src/voiceclone_smoke.rs
@@ -462,12 +462,17 @@ fn saved_voice_register_render_dod() {
         SavedVoiceCreateInput, SavedVoiceStore, DEFAULT_VOICE_DEDUP_THRESHOLD,
     };
 
-    // The register embed path resolves ve.safetensors from the HF cache; point it at the OS hub cache.
-    if std::env::var_os("HF_HOME").is_none() {
-        if let Some(home) = sceneworks_core::hf_home::os_huggingface_home() {
-            std::env::set_var("HF_HOME", home);
-        }
-    }
+    // The register embed path resolves ve.safetensors from the HF cache; point it at the OS hub cache
+    // when the caller hasn't pinned HF_HOME. Via the `test_env` seam so it is restored on drop (and
+    // lock-serialized) instead of leaking to sibling tests in the shared process (sc-13909); `None`
+    // (a no-op, matching the old guard) when HF_HOME is already set or no home dir resolves.
+    let _hf_home = std::env::var_os("HF_HOME")
+        .is_none()
+        .then(sceneworks_core::hf_home::os_huggingface_home)
+        .flatten()
+        .map(|home| {
+            crate::test_env::EnvVars::set(&[("HF_HOME", home.to_str().expect("utf-8 OS HF home"))])
+        });
     let data_dir = std::env::temp_dir();
     let chatterbox_dir = resolve_dir("VOICECLONE_CHATTERBOX_DIR", "ResembleAI/chatterbox", None);
     // The generator requires ve + perth staged as named components at this pin (no self-fetch).
@@ -821,12 +826,16 @@ fn distinct_reference() -> gen_core::AudioTrack {
 #[ignore = "real-weight audio smoke: needs the cached ResembleAI/chatterbox ve.safetensors"]
 fn voice_register_embed_path_smoke() {
     // Point HF cache resolution at the OS hub cache so embed_reference_clip's data_dir-based
-    // resolution finds the installed snapshot regardless of the (unused) data dir passed below.
-    if std::env::var_os("HF_HOME").is_none() {
-        if let Some(home) = sceneworks_core::hf_home::os_huggingface_home() {
-            std::env::set_var("HF_HOME", home);
-        }
-    }
+    // resolution finds the installed snapshot regardless of the (unused) data dir passed below — when
+    // the caller hasn't pinned HF_HOME. Via the `test_env` seam so it is restored on drop instead of
+    // leaking to sibling tests (sc-13909); `None` (a no-op) when HF_HOME is set or no home dir resolves.
+    let _hf_home = std::env::var_os("HF_HOME")
+        .is_none()
+        .then(sceneworks_core::hf_home::os_huggingface_home)
+        .flatten()
+        .map(|home| {
+            crate::test_env::EnvVars::set(&[("HF_HOME", home.to_str().expect("utf-8 OS HF home"))])
+        });
     let data_dir = std::env::temp_dir();
 
     let tmp = std::env::temp_dir().join(format!("sw-voice-register-{}", std::process::id()));
@@ -1062,7 +1071,8 @@ fn chatterbox_offline_install_parity_smoke() {
     // ── Step 3: go offline, HARD — a black-hole proxy fails EVERY resolver download() (both hf-hub
     //    agents are built with ureq try_proxy_from_env), while a cache HIT never constructs the agent.
     //    Set AFTER install (which needed the real hub). Api::new() ignores HF_ENDPOINT, so the proxy —
-    //    not an endpoint — is the lever that actually blocks the resolver. ────────────────────────
+    //    not an endpoint — is the lever that actually blocks the resolver. These three keys are
+    //    pre-registered by the `_env` guard above, so they restore on drop — no leak (sc-13909). ─────
     std::env::set_var("ALL_PROXY", "http://127.0.0.1:1");
     std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:1");
     std::env::set_var("HTTP_PROXY", "http://127.0.0.1:1");


### PR DESCRIPTION
## What & why

Fixes [sc-13909](https://app.shortcut.com/trefry/story/13909) — the writer-half follow-up to the sc-13898 reader race.

Two `#[ignore]`d real-weight voiceclone smokes set `HF_HOME` with a bare `std::env::set_var` that **neither took the crate-wide `ENV_LOCK` nor restored the prior value**, so the write leaked to every later test in the shared `sceneworks-worker --lib` process:

- `voiceclone_smoke.rs:468` — `saved_voice_register_render_dod`
- `voiceclone_smoke.rs:827` — `voice_register_embed_path_smoke`

This is the mirror of sc-13898: "env locks protect **writers**, not readers" — here a writer sitting *outside* the lock.

## The fix

Route both through the `test_env` seam:

```rust
let _hf_home = std::env::var_os("HF_HOME")
    .is_none()
    .then(sceneworks_core::hf_home::os_huggingface_home)
    .flatten()
    .map(|home| EnvVars::set(&[("HF_HOME", home.to_str().expect("utf-8 OS HF home"))]));
```

Behavior-preserving in all three branches (HF_HOME already set → no-op, no lock taken; unset + OS home resolves → pins it; unset + no home dir → no-op), but the guard now holds `ENV_LOCK` for the test body and **restores `HF_HOME` on drop** (even on a panicking assertion).

## Scope — the class is fully closed

A crate-wide sweep for bare `std::env::set_var`/`remove_var` shows these two were the **only** genuine leaks. Every other bare write is already inside an enclosing `EnvVars::set` guard that pre-registers the key and restores it on drop:

- `audio_jobs.rs:3299-3303` (render offline flags) — guard at `:3219`
- `voiceclone_smoke.rs:1076-1078` (proxy black-hole) — guard at `:961`
- `person_segment.rs`, `person_segment_sam3_common.rs`, `person_jobs/tests.rs`, `footprint_measure.rs` — each under a `key`-registered guard (already documented)
- `ort_cuda.rs:140` — production Windows `PATH` prepend in a `OnceLock` init (not a test)

I added a one-line clarifier to the two covered-but-undocumented sites (`audio_jobs` render step, `voiceclone` proxy step) so they aren't re-flagged as leaks — matching the doc convention the `person_*`/`footprint` sites already carry. (My original story flagged `audio_jobs:3299` as a leak; that was inaccurate — it's guard-covered. Corrected on the story.)

## Verification

- `cargo fmt --all -- --check` clean · `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean.
- Full `cargo test -p sceneworks-worker --lib`: **946 passed, 0 failed, 175 ignored**.
- **Real-weight end-to-end:** ran the ignored `voice_register_embed_path_smoke` (which exercises the changed HF_HOME pin against the cached Chatterbox VE weights) — passes: `self=1.0000 cross=0.7423`. This proves the pin engages (HF_HOME was unset → set to the OS hub → cached `ve.safetensors` resolves) and the guard construction is correct, not just compiling.
- Independent adversarial review: **APPROVE** (traced behavior-preservation, reentrancy, and ran its own completeness sweep).

Test-only change; no production code touched.