### PR TITLE
fix(training): sc-13878 follow-ups — Kolors MPS copy + HF snapshot-resolver hardening [sc-13919][sc-13915]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2284,26 +2284,52 @@ fn huggingface_repo_cache_exists(path: &FsPath) -> bool {
 
 fn huggingface_snapshot_dirs(repo_root: &FsPath) -> Vec<PathBuf> {
     let snapshots = repo_root.join("snapshots");
-    let mut snapshot_dirs = std::fs::read_dir(&snapshots)
+    // Rank by materialization (most files first) so the `.into_iter().next()` / `.find()` callers — the
+    // training gate/resolver, `model_catalog`, download-state scans — get the FULLEST snapshot and never
+    // an empty/torn one; a partial download or a test that clobbered `refs/main` must not win over a
+    // fully-materialized sibling (sc-13915, porting the worker's sc-13834 `resolve_huggingface_snapshot_dir`
+    // hardening to the rust-api side). Empty dirs are deprioritized, NOT dropped, so iterate-all callers
+    // (dir scans) still see every snapshot; their order is irrelevant to them. Deterministic path tiebreak.
+    let mut counted: Vec<(usize, PathBuf)> = std::fs::read_dir(&snapshots)
         .map(|entries| {
             entries
                 .flatten()
                 .map(|entry| entry.path())
                 .filter(|path| path.is_dir())
+                .map(|path| (snapshot_file_count(&path), path))
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    snapshot_dirs.sort();
+    counted.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    let mut snapshot_dirs: Vec<PathBuf> = counted.into_iter().map(|(_, path)| path).collect();
+    // `refs/main` fronts the list ONLY when the snapshot it names is materialized (holds files); a
+    // polluted/empty `refs/main` must not front an empty dir over a full one.
     if let Some(main_snapshot) = huggingface_main_snapshot_dir(repo_root) {
-        let mut ordered = vec![main_snapshot.clone()];
-        ordered.extend(
-            snapshot_dirs
-                .into_iter()
-                .filter(|path| path != &main_snapshot),
-        );
-        return ordered;
+        if snapshot_file_count(&main_snapshot) > 0 {
+            snapshot_dirs.retain(|path| path != &main_snapshot);
+            snapshot_dirs.insert(0, main_snapshot);
+        }
     }
     snapshot_dirs
+}
+
+/// Recursively count regular files under `dir` (symlinks counted — HF snapshots symlink into `blobs/`);
+/// `0` when the dir is absent, unreadable, or holds only empty subdirectories. Lets
+/// [`huggingface_snapshot_dirs`] rank a fully materialized snapshot above an empty/torn placeholder
+/// (sc-13915; mirrors the worker's `snapshot_file_count`, sc-13834).
+fn snapshot_file_count(dir: &FsPath) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut count = 0;
+    for entry in entries.flatten() {
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() => count += snapshot_file_count(&entry.path()),
+            Ok(_) => count += 1,
+            Err(_) => {}
+        }
+    }
+    count
 }
 
 fn huggingface_main_snapshot_dir(repo_root: &FsPath) -> Option<PathBuf> {

--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -2477,6 +2477,48 @@ fn resolve_base_model_path_descends_into_hf_snapshot() {
 }
 
 #[test]
+fn huggingface_snapshot_dirs_ranks_materialized_over_torn_refs_main() {
+    // sc-13915: a torn/empty `refs/main` (or a partial download) must not front an empty snapshot over a
+    // fully-materialized sibling — the `.into_iter().next()` callers (training gate/resolver, model
+    // catalog) would otherwise report an installed base as missing. Ports the worker's sc-13834 file-count
+    // hardening to the rust-api resolver. No HF-cache env here: this drives the helper on an explicit root.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo_root = temp.path().join("models--Foo--bar");
+    let snapshots = repo_root.join("snapshots");
+
+    let full = snapshots.join("full_rev");
+    let empty = snapshots.join("empty_rev");
+    std::fs::create_dir_all(&empty).expect("empty snapshot dir");
+    std::fs::create_dir_all(full.join("transformer")).expect("full snapshot tree");
+    std::fs::write(full.join("config.json"), "{}").expect("config");
+    std::fs::write(full.join("transformer").join("model.safetensors"), "x").expect("weight");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("refs dir");
+
+    // `refs/main` points at the EMPTY (torn) snapshot → the materialized one must still be first.
+    std::fs::write(repo_root.join("refs").join("main"), "empty_rev").expect("refs/main");
+    let ordered = crate::huggingface_snapshot_dirs(&repo_root);
+    assert_eq!(
+        ordered.first(),
+        Some(&full),
+        "a materialized snapshot must outrank an empty one a torn refs/main points to"
+    );
+
+    // A `refs/main` that names a materialized snapshot is authoritative (stays first); the empty sibling
+    // is deprioritized, NOT dropped, so iterate-all scans still see it.
+    std::fs::write(repo_root.join("refs").join("main"), "full_rev").expect("refs/main");
+    let ordered = crate::huggingface_snapshot_dirs(&repo_root);
+    assert_eq!(
+        ordered.first(),
+        Some(&full),
+        "a materialized refs/main is authoritative"
+    );
+    assert!(
+        ordered.contains(&empty),
+        "empty snapshots are deprioritized, not removed from the list"
+    );
+}
+
+#[test]
 fn tiered_turnkey_base_trains_on_bf16_tier() {
     // epic 9992 Krea 2 Raw (Path 1): SceneWorks/krea-2-raw-mlx ships bf16/ q8/ q4/ tier subdirs with NO
     // component tree at the snapshot root. Training reads the DENSE bf16 tier; a repo with only the q8

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -2421,7 +2421,7 @@ fn kolors_lora_target() -> TrainingTarget {
         })),
         ui: object(json!({
             "label": "Kolors LoRA",
-            "description": "Train an image LoRA for Kolors (Kwai-Kolors). Runs the SDXL-UNet trainer with the Kolors pipeline + ChatGLM3 text encoder, on CUDA and Apple Silicon (MPS).",
+            "description": "Train an image LoRA for Kolors (Kwai-Kolors). Runs the SDXL-UNet trainer with the Kolors pipeline + ChatGLM3 text encoder, on CUDA and Apple Silicon.",
             "recommendedFor": ["character", "style"]
         })),
         extra: ExtraFields::new(),

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -461,7 +461,7 @@
         ]
       },
       "ui": {
-        "description": "Train an image LoRA for Kolors (Kwai-Kolors). Runs the SDXL-UNet trainer with the Kolors pipeline + ChatGLM3 text encoder, on CUDA and Apple Silicon (MPS).",
+        "description": "Train an image LoRA for Kolors (Kwai-Kolors). Runs the SDXL-UNet trainer with the Kolors pipeline + ChatGLM3 text encoder, on CUDA and Apple Silicon.",
         "label": "Kolors LoRA",
         "recommendedFor": [
           "character",


### PR DESCRIPTION
Two small follow-ups surfaced during [sc-13878](https://app.shortcut.com/trefry/story/13878) (merged, [#1703](https://github.com/SceneWorks/SceneWorks/pull/1703)). One commit per story.

## [sc-13919](https://app.shortcut.com/trefry/story/13919) — Kolors target copy no longer claims torch "(MPS)"
The `kolors_lora` target's user-facing description said it runs "on CUDA and Apple Silicon (MPS)", but on macOS the job routes to the native in-process MLX trainer (engine id `kolors`, `mlx-gen`), not torch/Metal-Performance-Shaders — the same mischaracterization sc-13878 corrected for the Wan targets. Dropped the misleading "(MPS)" label; regenerated the target-registry snapshot fixture.

## [sc-13915](https://app.shortcut.com/trefry/story/13915) — rank HF snapshots by materialization in the rust-api resolver
`huggingface_snapshot_dirs` (apps/rust-api/src/lib.rs) fronted the `refs/main` snapshot whenever it was a dir (else the alphabetically-first), with **no check that the chosen snapshot holds files**. The training gate/resolver, model catalog, and install-state scans all take `.into_iter().next()`, so a torn/empty `refs/main` — or a partial download — could strand them on an empty snapshot and report an installed base as **missing** (a false-negative that blocks a real run).

The worker's generation resolver was hardened for exactly this in **sc-13834** (`resolve_huggingface_snapshot_dir` + `snapshot_file_count`); that never propagated to the rust-api side. Ported it: rank snapshots by recursive file count (most-materialized first, deterministic path tiebreak), and front `refs/main` only when the snapshot it names is materialized. **Empty dirs are deprioritized, not dropped**, so iterate-all callers (dir scans) still see every snapshot — order is irrelevant to them. Pre-existing and platform-blind: fixes all training bases keyed on `base_model_repo`, not just the Wan macOS turnkeys.

New test `huggingface_snapshot_dirs_ranks_materialized_over_torn_refs_main` covers both the torn-refs/main fallback and the authoritative-materialized-refs/main case.

## Validation
`cargo fmt --all --check`, `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets -- -D warnings`, the `training_contracts` suite (Kolors fixture), and the rust-api training + **model install-state/catalog** tests (the broad `huggingface_snapshot_dirs` consumers — no regression from the reorder) all green. The sc-13878 real-weights `#[ignore]` skeleton still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)