### PR TITLE
fix(worker): preload CUDA/cuDNN DLLs before the Real-ESRGAN ort session [sc-13587]

### DIFF
--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -246,6 +246,16 @@ fn build_session(path: &Path, accel: bool) -> WorkerResult<Session> {
         }
         #[cfg(not(target_os = "macos"))]
         {
+            // Preload the CUDA-12 runtime + cuDNN-9 DLLs the loaded onnxruntime-gpu's CUDA
+            // provider depends on, before registering the EP — with the Python/torch stack
+            // retired off-Mac nothing else puts them on the loader path. Without this, an
+            // upscale that is the process's *first* `ort` CUDA surface (no prior pose/person
+            // job to preload) fails to initialise the CUDA EP and silently caches a CPU
+            // session in `UPSCALERS` for the process lifetime — ~9× slower and stuck on CPU
+            // even after a later pose job preloads the DLLs (sc-5499). Shared helper (runs
+            // once per process, also used by `pose_jobs`/`person_jobs`); best-effort, see
+            // `ort_cuda`.
+            crate::ort_cuda::preload_cuda_dylibs();
             // `error_on_failure` so a CUDA provider that can't initialise (no GPU, or a
             // cuDNN/CUDA mismatch in the loaded onnxruntime) surfaces as an error here —
             // `Upscaler::load` then falls back to a CPU session and reports `device = "cpu"`


### PR DESCRIPTION
## Story
[sc-13587](https://app.shortcut.com/trefry/story/13587) — [review][High] Preload CUDA/cuDNN DLLs before building the Real-ESRGAN session (epic 13900, Code review 2026-07-20 High findings; finding F-006).

## Problem
The off-Mac Real-ESRGAN `upscale_jobs::build_session` registered the CUDA execution provider with `.error_on_failure()` but never called `crate::ort_cuda::preload_cuda_dylibs()` first — unlike its siblings `pose_jobs::build_session` (pose_jobs.rs:505) and `person_jobs::build_session` (person_jobs.rs:865). With the Python/torch stack retired off-Mac, nothing else puts the CUDA-12 runtime + cuDNN-9 DLLs on the loader path.

Consequence: in a process where an image/dataset **upscale is the first `ort` CUDA surface** (no prior pose/person job to preload), the CUDA EP fails to initialise and the upscaler silently builds a **CPU** session — ~9× slower per the sc-3489 spike — and because `UPSCALERS` caches the session for the process lifetime, it stays on CPU even after a later pose job preloads the DLLs. Only the `device: "cpu"` result field hinted at it.

`ort_cuda`'s module doc already names Real-ESRGAN upscale (sc-5499) as a surface the shared, once-per-process, best-effort helper serves — this call site was simply missing.

## Fix
Add `crate::ort_cuda::preload_cuda_dylibs();` at the top of the `#[cfg(not(target_os = "macos"))]` accel branch of `upscale_jobs::build_session`, before the CUDA EP registration — mirroring the two siblings exactly. This closes the last of the three `ort` CUDA surfaces (pose / person / upscale) that lacked the preload.

The helper is idempotent (process-wide `OnceLock`), so a third call site adds no cost. It is correctly **not** invoked on the CPU-fallback path (`accel == false`) or on macOS (CoreML has no such dependency).

## Scope
Single call + comment in `crates/sceneworks-worker/src/upscale_jobs.rs`. Enumerated every `CUDAExecutionProvider` in the crate: exactly pose/person/upscale — all three now preload. `kps_jobs` (SCRFD) and `depth` are native-candle and register no CUDA EP, so no gap remains.

## Validation
- `npm run rust:check:candle` (the CI `windows-candle` lane: `clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` + rust-api sidecar `check`) — **green**, on both the fix commit and the `origin/main` merge commit. This is the only build config that compiles this cfg-gated code.
- `cargo fmt` clean.
- Independent adversarial review — VERDICT: SHIP, no issues (correctness, scope completeness, idempotency, convention, tests, scope-creep all pass).
- The gated real-weight GPU smoke `real_esrgan_candle_real_weights_upscales` exercises this exact seam (`Upscaler::load` → CUDA EP → device) but requires `ORT_DYLIB_PATH` (an onnxruntime-gpu build) + an exported `real_esrgan_x{factor}.onnx`, neither provisioned on this box, so it was not run here. The siblings have no unit test for their preload call either — it is a best-effort process-global side effect unobservable without a real GPU + DLLs; compile + the gated smoke is the house pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)