### PR TITLE
fix(worker): Qwen-Edit candle gate — record reclaimable peak + document raw-free budget (sc-13588)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -460,9 +460,23 @@ async fn generate_candle_qwen_edit_stream(
     // resident peak won't fit the card, load with sequential component residency (`QwenEdit` loads the
     // VL encoder + VAE encoder → encodes + VAE-encodes the references → DROPS them before the DiT loads)
     // instead of OOMing; and if even the MEASURED sequential peak won't fit, reject-before-OOM. The edit
-    // lane IS sequential-capable (sc-10968 wired `QwenEdit::generate_sequential`). Inert (Unknown →
-    // resident) until the edit manifest tiers carry a `candle` block with measured peaks (the sc-10969 /
-    // sc-10920 measure sibling for edit) — mirroring flux2 / qwen txt2img before their measure stories.
+    // lane IS sequential-capable (sc-10968 wired `QwenEdit::generate_sequential`). LIVE since sc-11019
+    // measured the edit tiers' `candle` block (`vramGbByTier` / `sequentialPeakGb`) — the edit
+    // measure-sibling of the qwen txt2img sc-10969 + flux2 sc-10920; before it, unmeasured tiers made this
+    // Unknown → resident (inert).
+    //
+    // sc-13588: this gate budgets against RAW live free VRAM and deliberately does NOT fold
+    // `with_reclaimable` the way the txt2img `generate_candle_stream` gate (base.rs, sc-11023) and the
+    // candle video gate do. Those lanes load THROUGH the single-slot generator cache
+    // (`with_cached_generator` / `with_uncached_generator`), which EVICTS its resident occupant before the
+    // incoming load — so that occupant's cudarc pool pages ARE reclaimable by the load being gated. This
+    // edit lane instead loads through the UNcached `start_gen_stream` below: it never touches the generator
+    // cache, so any resident txt2img generator stays live and CO-RESIDENT with the QwenEdit load. Its pages
+    // are NOT reclaimable here; crediting them would over-admit a load that then OOMs alongside the
+    // still-resident model. Raw free correctly reject-before-OOMs when the edit peak + the resident won't
+    // co-fit. Same reasoning — and the same deliberate omission — as `krea_control_candle.rs` (the other
+    // `start_gen_stream` lane); see its note. The reclaimable *high-water* is still recorded after an admit
+    // (see `note_loaded_peak` below), which is the half of sc-11023 that DOES apply cross-lane.
     let use_sequential = {
         let budget = crate::vram_gate::apply_vram_cap(
             crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
@@ -528,6 +542,16 @@ async fn generate_candle_qwen_edit_stream(
                     "candle Qwen-Edit VRAM fit-gate: resident peak exceeds free VRAM — loading with \
                      sequential component residency (VL encoder dropped before the DiT)"
                 );
+                // sc-13588: record the admitted SEQUENTIAL peak as the reclaimable high-water for the next
+                // gate — the missing half of the sc-11023 backport (see the header note). The QwenEdit this
+                // admits is dropped when `start_gen_stream`'s closure returns, so its pages return to
+                // cudarc's process pool; a later CACHED gate (base.rs / video) that evicts + reclaims must
+                // credit this peak or it under-counts the pool and false-rejects a load that fits.
+                // `sequential_needed` is the measured sequential peak just checked above (`None` for an
+                // unmeasured tier ⇒ no-op).
+                if let Some(peak_gb) = sequential_needed {
+                    crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
+                }
                 true
             }
             crate::vram_gate::FitDecision::TooBig {
@@ -544,7 +568,15 @@ async fn generate_candle_qwen_edit_stream(
                     gpu = settings.gpu_id,
                 )));
             }
-            _ => false,
+            // Resident admit (`Fits`) — or `Unknown` when a tier is unmeasured. Record the RESIDENT peak
+            // as the reclaimable high-water (sc-13588); `needed` is `None` for an unmeasured tier, so this
+            // no-ops there exactly as the gate itself does.
+            _ => {
+                if let Some(peak_gb) = needed {
+                    crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
+                }
+                false
+            }
         }
     };
 


### PR DESCRIPTION
## What & why

Backports the sc-11023 reclaimable-VRAM treatment to the candle **Qwen-Image-Edit** fit-gate (`crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs`). Review finding **F-007** (High), commit 6356a7de. Story: [sc-13588](https://app.shortcut.com/trefry/story/13588).

The finding asked for two things: fold `with_reclaimable(..)` into the budget, and call `note_loaded_peak(..)` after an admit — *or* "document why cache-pages-not-reclaimable applies as `krea_control_candle.rs` does." **This PR takes the documented-omission branch for the reclaim half, and adds `note_loaded_peak`** — because the reclaim half, mirrored verbatim, would be an OOM bug on this lane:

- The txt2img gate (base.rs, sc-11023) and the candle video gate reclaim **because they load through the single-slot generator cache** (`with_cached_generator` / `with_uncached_generator`), which **evicts** its resident occupant before the incoming load — so the evicted pages are genuinely reclaimable.
- The edit lane loads through the **UNcached** `start_gen_stream` (`stream.rs:174`) — it never touches the generator cache. `QwenEdit` is a bespoke `runtime_cuda` provider, not a `Box<dyn Generator>`, so `with_uncached_generator` can't wrap it. A resident txt2img generator therefore stays **live and co-resident** with the QwenEdit load. Folding `with_reclaimable` would credit that live model's pages as free → over-admit a load that OOMs alongside it. Budgeting on **raw free** correctly reject-before-OOMs when `edit_peak + resident` won't co-fit. This is exactly why `krea_control_candle.rs` (the other `start_gen_stream` lane) omits reclaim.

### The half that *does* apply cross-lane
`note_loaded_peak` after an admitted load. The `QwenEdit` is dropped when the stream closure returns, so its peak enters cudarc's process pool; a later **cached** gate (base.rs/video) that evicts + reclaims must credit it or it under-counts the pool and false-rejects a fitting txt2img load. Records the **sequential** peak on sequential-offload, the **resident** peak otherwise (`None` for an unmeasured tier ⇒ no-op) — exactly mirroring base.rs:5484-5490. Safe: `note_loaded_peak` is a monotonic max and `with_reclaimable` clamps to total, so a later gate can only *under*-credit, never over-admit.

### Drive-by
De-stales the gate's header comment — it claimed "Inert until the edit tiers carry a candle block," but sc-11019 added that measured block (`builtin.models.jsonc`: `vramGbByTier` q4=56.7/q8=69.0/bf16=81.7 + `sequentialPeakGb`), so the gate is **LIVE**.

## Not closed here → follow-up [sc-13960](https://app.shortcut.com/trefry/story/13960)
The finding's Impact (a) — a *second* edit render in the same process false-rejecting / needlessly downtiering to sequential because the first render's dropped pages sit uncredited in the pool — is **not** fixed by this PR. Closing it needs an evict-then-reclaim path (the video `with_uncached_generator` precedent) plus a deliberate warm-cache tradeoff, and applies equally to `krea_control`. Filed as sc-13960 (relates to sc-13588). Flagged by the adversarial review as a scope callout, not a code defect.

## Validation
- `cargo fmt` clean.
- Candle CI gate green on the RTX PRO 6000 box (MSVC 14.44.35207, CUDA 12.9, `CUDA_COMPUTE_CAP=120`):
  - `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings`
  - `cargo check -p sceneworks-worker --features backend-candle`
- Pure `vram_gate` primitives (`note_loaded_peak` / `with_reclaimable` / `reclaimable_pool_gb`) are already unit-tested. The gate wiring lives in a CUDA-gated async fn; like base.rs's identical sc-11023 wiring, it's held by compilation + review (no new unit test is feasible without driving the GPU gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
