### PR TITLE
fix(krea): Krea 2 Raw defaults + Raw guide + spec-preserving refiner [sc-13881]

### DIFF
--- a/apps/web/public/prompt-guides/krea-2-raw.md
+++ b/apps/web/public/prompt-guides/krea-2-raw.md
@@ -1,0 +1,113 @@
+# Krea 2 Raw Prompt Guide
+
+## Best For
+
+Highest-fidelity, most-controllable **still images** from natural-language prompts. Krea 2 Raw is Krea
+AI's **undistilled** foundation image model — a 12B single-stream rectified-flow DiT paired with a
+Qwen3-VL-4B text encoder, so it reads your prompt as plain language. Describe the image the way you'd
+describe it to a person; it is especially strong on **photographic realism, lighting, and coherent
+composition**.
+
+> **Krea 2 Raw** is the full-fidelity base — it runs **TRUE classifier-free guidance**: a real guidance
+> scale, an optional **negative prompt**, and ~52 steps. That extra control is exactly what makes it the
+> sharpest, most faithful Krea variant. (The distilled **Krea 2 Turbo** is the opposite regime —
+> few-step and CFG-free, with no guidance slider and no negative prompt.)
+
+## Prompt Shape
+
+`subject + scene + lighting + composition + camera/framing + aesthetic/style`
+
+Krea reads the whole prompt as intent, so natural descriptive language works better than a pile of
+disconnected tags. **Always name the lighting** — it is the strongest single lever on Raw's realism.
+
+## How Krea Reads A Prompt (keep it faithful and concise)
+
+The goal is a clear prompt, not a long one:
+
+- **Already clear → barely change it.** A short, well-defined prompt ("a cup of coffee on a windowsill")
+  needs little more than one lighting or style word. Don't invent scenes, props, or mood the prompt
+  didn't mention.
+- **Be concise, but keep the concrete specifications.** Drop only *empty praise* — subjective filler
+  like `masterpiece`, `stunning`, `premium`, `gorgeous`, `award-winning`, `8k`, `ultra-detailed` — which
+  adds no visual information. **Keep the concrete photographic specifications:** camera body
+  (`Canon EOS R5`), lens and focal length (`50mm`, `85mm f/1.4`), film stock (`Kodak Portra 400`), and
+  aperture. Krea understands and honors these — dropping them makes a photographic prompt *worse*, not
+  cleaner.
+- **Specify the light.** "soft overcast light", "golden-hour backlight", "hard noon sun", "warm
+  tungsten interior" — Krea is highly lighting-responsive, and its own showcase prompts all name the
+  lighting. This is the single highest-value detail you can add.
+- **Use the negative prompt.** Because Raw runs true CFG, a concise **quality negative** measurably
+  sharpens the result. The Studio seeds a mild default (`blurry, soft focus, low detail, low quality`)
+  into the negative box; you can edit or clear it. Keep it *mild* — an aggressive skin/texture negative
+  (e.g. `plastic skin, waxy skin`) over-corrects into an artificial plastic look. State what you want in
+  the prompt; use the negative only to push away genuine quality faults.
+
+## Build The Prompt
+
+### Subject
+
+Name the main subject and its visible traits (color, material, clothing, expression). One or two clear
+subjects render more coherently than a crowded frame.
+
+### Scene & Lighting
+
+Describe background, foreground, weather, time of day, and — above all — the **lighting**. Naming the
+light source, direction, and quality ("soft window light from the left", "golden-hour backlight", "hard
+noon sun") drives much of Raw's photorealism.
+
+### Composition & Framing
+
+Direct framing language works: `low angle`, `wide shot`, `medium close-up`, `centered subject`,
+`rule of thirds`, `shallow depth of field`.
+
+### Camera & Style
+
+Concrete camera specs are meaningful to Krea — name the body, lens/focal length, film stock, and
+aperture when you want a specific photographic look (`shot on a 50mm lens`, `Kodak Portra 400`,
+`f/1.8, shallow depth of field`). Concise style labels also work well: `photorealistic`, `cinematic`,
+`editorial photography`, `studio portrait`, `film noir`. Name a known style by its name only (e.g.
+`Kodak Portra`, `ukiyo-e`, `cyberpunk`) — you don't need to describe what it looks like. For everyday
+realistic subjects you don't need to say "photorealistic"; that's already the default.
+
+## Quality & Speed Notes
+
+- **Resolution:** use a native bucket (1024² / 768×1024 / 1024×768 / 1280×720 / 720×1280 / 1536²); width
+  and height must be multiples of 16. 1024² is the default.
+- **Steps:** ~52 (Raw is undistilled — it needs the full step budget, unlike few-step Turbo).
+- **Guidance:** a real classifier-free-guidance scale; **~3.5** is the reference default. Raise it a
+  little for stronger prompt adherence, lower it for a softer, more natural look.
+- **Negative prompt:** supported and recommended (see above). A concise quality negative is the biggest
+  lever on sharpness.
+- **Sampler / scheduler:** `default` is the native rectified-flow loop and the best starting point; the
+  curated samplers/schedulers are exposed for experimentation.
+- **Quantization:** Q8 is the default (near-lossless, ~20.5 GB download — needs a 48 GB-class Mac or a
+  ~32 GB-class CUDA GPU); Q4 is a lighter option; the dense bf16 tier doubles as the LoRA training base.
+
+## Using LoRAs
+
+Krea LoRAs train on the full **Krea 2 Raw** base and apply at inference here on that same base, so their
+effect reads at full strength (more directly than on the distilled Turbo). Krea LoRAs start at a higher
+default apply weight (1.5) than other families:
+
+- If a LoRA's style or subject isn't coming through on a strongly-described scene, raise the weight
+  toward **2.0** and leave the prompt a little room rather than over-specifying every detail.
+- If a LoRA over-dominates, lower it. The weight slider is the main lever; the default is just a
+  starting point.
+
+## Example Prompts
+
+`A weathered lighthouse on a rocky cliff at golden hour, waves breaking below, gulls in the distance.
+Wide shot, low angle, warm directional light. Shot on a 35mm lens. Photorealistic, cinematic.`
+
+`Portrait of an elderly fisherman, deep wrinkles, soft overcast window light from the left, shallow
+depth of field. 85mm f/1.4, Kodak Portra 400. Editorial photography.`
+
+`A quiet Kyoto side street after rain at dusk, wet stone reflecting paper-lantern light, a lone cyclist.
+Medium shot, centered, cool tungsten glow. Cinematic, photorealistic.`
+
+## Sources
+
+- [Krea 2 (Hugging Face)](https://huggingface.co/krea)
+- [Krea 2 Raw model card](https://huggingface.co/krea/Krea-2-Raw)
+- [Krea 2 Technical Report](https://www.krea.ai/blog/krea-2-technical-report)
+- [Krea 2 Community License](https://www.krea.ai/krea-2-licensing)

--- a/apps/web/public/prompt-guides/krea-2.md
+++ b/apps/web/public/prompt-guides/krea-2.md
@@ -25,9 +25,13 @@ The goal is a clear prompt, not a long one:
 - **Already clear → barely change it.** A short, well-defined prompt ("a cup of coffee on a windowsill")
   needs little more than maybe one style or lighting word. Don't invent scenes, props, or mood the
   prompt didn't mention.
-- **Be concise.** Short sentences; don't repeat ideas, pile up synonyms ("realistic, photographic,
-  ultra-real"), or add empty praise ("stunning", "premium", "masterpiece"). Concrete quality words like
-  `cinematic` or `soft window light` are fine.
+- **Be concise, but keep the concrete specifications.** Short sentences; don't repeat ideas or pile up
+  synonyms ("realistic, photographic, ultra-real"). Drop only *empty praise* — subjective filler like
+  "stunning", "premium", "masterpiece", "gorgeous", "award-winning" — which adds no visual information.
+  **Keep the concrete photographic specifications:** camera body, lens and focal length (`50mm`,
+  `85mm f/1.4`), film stock (`Kodak Portra 400`), and aperture. Krea understands and honors these, so
+  dropping them makes a photographic prompt worse. Concrete quality words like `cinematic` or `soft
+  window light` are fine.
 - **Describe what you want, not what you don't.** Krea Turbo is CFG-free and takes **no negative
   prompt**, so avoid negations ("no people", "without text") — state the positive scene instead; a thing
   you don't name simply won't appear.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3077,15 +3077,30 @@
           "secondaryLabel": "Image 2 (optional)",
           "secondaryHint": "Optional — a second image combined with Image 1 in a fixed order (Image 1, then Image 2). In your instruction, refer to each subject by position (\"the person in image 1 / image 2\") or by description (\"the woman in the green jacket\") — either works."
         },
+        // sc-13881 (epic 13879): curated default negative prompt. UNLIKE the CFG-free Turbo (no negative),
+        // Raw runs TRUE classifier-free guidance and USES a negative — a concise quality negative is the
+        // single biggest lever on Raw's "soft/over-warm" look (S0 sc-13880 proved the pipeline is faithful;
+        // the softness was prompting/defaults, not an engine bug). Image Studio seeds this into an EMPTY
+        // negative box on text-to-image / character mode (promptSeed.seedsNegativeInMode + the seeding
+        // effect in ImageStudio.jsx), so it rides the SAME `negativePrompt` path Raw already forwards to
+        // the TRUE-CFG denoise — no new manifest key, no Rust wiring. User-overridable and clearable (a
+        // cleared box stays cleared; an empty override yields no negative). Deliberately MILD: the
+        // aggressive "smooth waxy skin, plastic skin" variant over-corrected into plastic. Cross-platform.
+        "defaultNegativePrompt": "blurry, soft focus, low detail, low quality",
         "label": "Krea 2 Raw",
         "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~3.5) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Runs on Apple Silicon (MLX) and Windows/Linux NVIDIA GPUs (candle/CUDA, sc-9994); needs a 48 GB-class Mac or a ~32 GB-class CUDA GPU.",
         "recommendedFor": ["text_to_image"],
         // PiD decoder (epic 7840, qwenimage latent space — Krea 2 Raw reuses the Qwen VAE, like Turbo) —
         // optional per-generation VAE replacement, decode + 2K/4K SR; NC output. See `qwen_image`.
         "pid": { "checkpointId": "pid_qwenimage" },
+        // sc-13881 (epic 13879): Raw gets its OWN guide. The shared krea-2.md is TURBO-specific — it says
+        // "no negative prompt", "~8 steps", "guidance none/CFG-off", all WRONG for Raw and steering users
+        // (and the Refine feature, which fetches this path) away from the negative + true-CFG regime that
+        // fixes Raw. krea-2-raw.md documents the real Raw regime: TRUE-CFG, ~52 steps, guidance ~3.5, USE a
+        // concise quality negative, SPECIFY lighting. Turbo (krea_2_turbo) still points at krea-2.md.
         "promptGuide": {
-          "title": "Krea 2 Prompt Guide",
-          "path": "/prompt-guides/krea-2.md",
+          "title": "Krea 2 Raw Prompt Guide",
+          "path": "/prompt-guides/krea-2-raw.md",
           "sources": [
             { "label": "Krea 2 (Hugging Face)", "url": "https://huggingface.co/krea" },
             { "label": "Krea 2 Raw model card", "url": "https://huggingface.co/krea/Krea-2-Raw" }

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -184,6 +184,53 @@ mod tests {
     }
 
     #[test]
+    fn krea_2_raw_declares_the_sc13881_default_negative_and_raw_guide() {
+        // sc-13881 (epic 13879): Raw's UX/defaults fix set (NOT a pipeline fix — S0 sc-13880 proved the
+        // pipeline is faithful). Two source-of-truth manifest facts:
+        //   1. Raw seeds a MILD quality negative (biggest lever: Raw is TRUE-CFG and uses a negative,
+        //      unlike CFG-free Turbo). The aggressive "plastic skin" variant over-corrected, so the
+        //      shipped default is deliberately the conservative string.
+        //   2. Raw points at its OWN guide krea-2-raw.md (the shared krea-2.md is Turbo-specific — "no
+        //      negative", "~8 steps", "CFG-off" — all wrong for Raw); Turbo keeps krea-2.md.
+        let stripped = crate::jsonc::strip_jsonc_comments(embedded("builtin.models.jsonc"));
+        let manifest: serde_json::Value =
+            serde_json::from_str(&stripped).expect("builtin.models.jsonc parses as JSON");
+        let models = manifest["models"]
+            .as_array()
+            .expect("builtin.models.jsonc has a models array");
+        let find = |id: &str| {
+            models
+                .iter()
+                .find(|model| model["id"].as_str() == Some(id))
+                .unwrap_or_else(|| panic!("{id} present in the builtin models catalog"))
+        };
+
+        let raw = find("krea_2_raw");
+        assert_eq!(
+            raw["ui"]["defaultNegativePrompt"].as_str(),
+            Some("blurry, soft focus, low detail, low quality"),
+            "krea_2_raw seeds the sc-13881 mild quality negative"
+        );
+        assert_eq!(
+            raw["ui"]["promptGuide"]["path"].as_str(),
+            Some("/prompt-guides/krea-2-raw.md"),
+            "krea_2_raw points at the Raw-specific prompt guide"
+        );
+
+        // Turbo is CFG-free — it must NOT carry a default negative, and it keeps the Turbo guide.
+        let turbo = find("krea_2_turbo");
+        assert!(
+            turbo["ui"]["defaultNegativePrompt"].is_null(),
+            "krea_2_turbo (CFG-free) declares no default negative"
+        );
+        assert_eq!(
+            turbo["ui"]["promptGuide"]["path"].as_str(),
+            Some("/prompt-guides/krea-2.md"),
+            "krea_2_turbo keeps the shared Turbo prompt guide"
+        );
+    }
+
+    #[test]
     fn ships_the_seeded_audio_models_with_populated_capability_blocks() {
         // sc-13402 (epic 13400) + sc-13412 + sc-13675 + sc-13676: the shipped catalog the API serves
         // carries the live audio providers as first-class `type: "audio"` entries, each with a populated

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -223,6 +223,19 @@ fn base_rules(medium: &str) -> String {
             .to_owned(),
         "- Follow the guide's recommended structure, phrasing, and what-to-avoid guidance."
             .to_owned(),
+        // sc-13881 (epic 13879): a refined PHOTOGRAPHIC prompt must keep the concrete camera/lens/
+        // film-stock specifications the user wrote — they carry real visual meaning to modern image
+        // models (Krea, for one, honors "Kodak Portra"). The refiner used to strip the whole trailing
+        // comma-list when trimming for concision, taking the camera/lens specs with the empty praise —
+        // a net-negative edit. Trim ONLY the empty praise; preserve the specifications.
+        "- Keep concrete photographic specifications the user wrote — camera body, lens and focal \
+         length, film stock, and aperture (e.g. \"85mm f/1.4\", \"Kodak Portra 400\", \"shot on a \
+         50mm lens\"). These carry real visual meaning; do not drop them when trimming."
+            .to_owned(),
+        "- When trimming for concision, remove ONLY empty praise that adds no visual information \
+         (\"masterpiece\", \"stunning\", \"premium\", \"gorgeous\", \"award-winning\", \
+         \"ultra-detailed\"), never the concrete camera, lens, film-stock, or lighting details."
+            .to_owned(),
         "- Match the user's language: if their prompt is not in English, respond in the same \
          language."
             .to_owned(),
@@ -1486,6 +1499,40 @@ mod tests {
         assert!(
             build_refine_system_prompt(None, Some(" VIDEO ")).contains("generative video model")
         );
+    }
+
+    #[test]
+    fn refine_rules_preserve_photographic_specs_and_strip_only_empty_praise() {
+        // sc-13881 (epic 13879): the refiner used to trim the whole trailing comma-list for concision,
+        // taking camera/lens/film-stock specs (meaningful to Krea) along with the empty praise — a
+        // net-negative edit on a photographic prompt. The rewrite itself is LLM-driven, so the
+        // deterministic contract is that the system prompt INSTRUCTS both halves: keep the concrete
+        // specifications, strip ONLY empty praise. This guards against a future edit dropping either.
+        let system = build_refine_system_prompt(None, Some("image"));
+        // Keep the concrete photographic specifications.
+        assert!(system.contains("camera body"), "keeps camera body spec");
+        assert!(system.contains("focal"), "keeps focal length spec");
+        assert!(system.contains("film stock"), "keeps film-stock spec");
+        assert!(
+            system.contains("Kodak Portra"),
+            "the film-stock example is named as something to keep, not strip"
+        );
+        assert!(
+            system.contains("do not drop them when trimming"),
+            "explicitly forbids dropping the specs"
+        );
+        // Strip ONLY empty praise, with the removable words named so the model knows what to cut.
+        assert!(system.contains("empty praise"), "names the trim target");
+        for praise in ["masterpiece", "stunning", "premium", "award-winning"] {
+            assert!(
+                system.contains(praise),
+                "empty-praise example {praise} is listed as removable"
+            );
+        }
+        // The rules apply model-agnostically, whether or not a per-model guide is attached.
+        let bare = base_rules("image");
+        assert!(bare.contains("camera body"));
+        assert!(bare.contains("empty praise"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**sc-13881 (epic 13879) — S1 Krea 2 Raw defaults + guide + refiner.** This is a **UX/defaults fix, NOT a pipeline/engine fix.** S0 (sc-13880) proved the Krea 2 Raw pipeline is faithful/not broken; the "soft/over-warm" symptom is prompting + Turbo-centric guide/defaults. Three items, all cross-platform:

### 1. Default negative for `krea_2_raw` (biggest lever)
Raw runs **TRUE CFG** and uses a negative (unlike CFG-free Turbo), so a concise quality negative measurably sharpens it. Declared via the **existing, already-wired** `ui.defaultNegativePrompt` mechanism (schema line 290; read + seeded in `ImageStudio.jsx`, same pattern InstantID/RealVisXL/booru models already use):

```
"defaultNegativePrompt": "blurry, soft focus, low detail, low quality"
```

Deliberately **mild** — the aggressive `plastic skin` variant over-corrects into plastic (per the story). It seeds an **empty** negative box in text-to-image mode and rides the **same `negativePrompt` path Raw already forwards to the TRUE-CFG denoise** — so it provably reaches the render with **no new manifest key, no schema change, and no new Rust wiring** (avoids the "declared-but-unread" hazard). User-overridable and clearable (a cleared box stays cleared; an empty override yields no negative).

> Chose the established `ui.defaultNegativePrompt` over inventing `defaults.negativePrompt` (which the `defaults` block — `additionalProperties:false` — does not allow, and which nothing reads). This is the minimal, standard-pattern wiring and keeps the `parity` schema lane green.

### 2. Authored `krea-2-raw.md`; repointed `krea_2_raw.ui.promptGuide`
The shared `krea-2.md` is **Turbo-specific** — "no negative prompt", "~8 steps", "guidance none/CFG-off" — all **wrong for Raw**, and was steering Raw users + the Refine feature (which fetches this guide path) away from the negative/true-CFG regime that fixes Raw. The new Raw guide documents the true regime: **TRUE-CFG, ~52 steps, guidance ~3.5, USE a concise quality negative, and SPECIFY lighting** (Krea is highly lighting-responsive). Turbo (`krea_2_turbo`) still points at `krea-2.md`.

### 3. Refiner + guide preserve photographic specs
`crates/sceneworks-worker/src/prompt_refine_jobs.rs` `base_rules` and `krea-2.md` now instruct the rewriter to **KEEP concrete camera body / lens / focal-length / film-stock / aperture specs** (meaningful to Krea — it honors Kodak Portra) and **strip ONLY empty praise** (masterpiece/stunning/premium/…). Previously Refine trimmed the whole trailing comma-list, taking the camera/lens specs with the praise — a net-negative edit on a photographic prompt.

## Scope vs acceptance
- **Raw render sharper at defaults** — default negative wired through the existing seed→negativePrompt→TRUE-CFG path. ✅
- **Refine on Raw keeps camera/lens specs** — explicit keep-rule in `base_rules` + guide. ✅
- **Raw guide reflects the true regime** — `krea-2-raw.md` authored (TRUE-CFG / 52 steps / guidance 3.5 / negative / lighting). ✅
- **builtin-manifest prompt-guide-exists test passes for `krea-2-raw.md`** — verified green. ✅
- **Default negative is cross-platform** — web/manifest concept, `text_to_image` on all platforms. ✅

## Tests
- **New** `sceneworks-core` `krea_2_raw_declares_the_sc13881_default_negative_and_raw_guide` — asserts the default negative string, the Raw guide path, and that Turbo is unchanged (no default negative, keeps `krea-2.md`). Source-of-truth manifest test.
- **New** `sceneworks-worker` `refine_rules_preserve_photographic_specs_and_strip_only_empty_praise` — asserts the built refine system prompt keeps camera/lens/film-stock (incl. the Kodak Portra example) and names the empty-praise words as removable.
- Existing `every_builtin_model_prompt_guide_exists_in_the_web_app` now covers `krea-2-raw.md`.

## Verification
- `cargo fmt` (touched crates) — clean
- `cargo clippy -p sceneworks-core -p sceneworks-worker --all-targets -D warnings` — clean
- `cargo test -p sceneworks-core --lib builtin_manifests` — 12 passed
- `cargo test -p sceneworks-worker --lib prompt_refine_jobs::tests` — 35 passed (4 real-weight ignored)
- `npm run check` (scaffold) — passed
- `npm test` (full web suite) — **2223 passed / 153 files**

## Follow-ups
None discovered. (The refiner behavior is LLM-driven; the deterministic contract tested here is that the rules instruct keep-specs/strip-praise — real-model refine quality is out of scope for a unit test.)

sc-13881