### PR TITLE
fix(worker-tests): stage co-req components in MLX offline-render smokes broken by self-fetch-free pin [sc-13818]

### DIFF
--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -3695,6 +3695,8 @@ mod tests {
     /// ```text
     /// SCENEWORKS_MOSS_TTS_AR_DIR=~/.cache/huggingface/hub/models--OpenMOSS-Team--MOSS-TTS-Realtime/\
     ///   snapshots/6acbc7f161a0db71c291f2d0aaa9eee59334cab2 \
+    /// SCENEWORKS_MOSS_TTS_CODEC_DIR=~/.cache/huggingface/hub/models--OpenMOSS-Team--MOSS-Audio-Tokenizer/\
+    ///   snapshots/3cd226ba2947efa357ef453bcad111b6eafba782 \
     /// HF_HUB_OFFLINE=1 \
     /// cargo test --release -p sceneworks-worker -- --ignored --nocapture \
     ///   moss_tts_realtime_streams_a_real_clip
@@ -3710,11 +3712,23 @@ mod tests {
         let ar_dir = std::env::var("SCENEWORKS_MOSS_TTS_AR_DIR").expect(
             "set SCENEWORKS_MOSS_TTS_AR_DIR to the cached MOSS-TTS-Realtime snapshot directory",
         );
+        // moss_tts_realtime advertises `required_components: ["codec"]` (sc-13681); on the self-fetch-free
+        // inference pin (sc-13818) the loader HARD-FAILS unless the MOSS-Audio-Tokenizer codec is staged in
+        // the LoadSpec — it no longer self-fetches it. The codec is a multi-file component, so it resolves
+        // to `WeightsSource::Dir` (the whole snapshot dir), matching production `resolve_co_requisites`
+        // (model_jobs.rs:1685). Silently broken by the pin bump because the smoke is `#[ignore]`d.
+        let codec_dir = std::env::var("SCENEWORKS_MOSS_TTS_CODEC_DIR").expect(
+            "set SCENEWORKS_MOSS_TTS_CODEC_DIR to the cached MOSS-Audio-Tokenizer snapshot directory \
+             (moss_tts_realtime's required `codec` component)",
+        );
         let generator = crate::inference_runtime::load_audio(
             "moss_tts_realtime",
-            &LoadSpec::new(WeightsSource::Dir(PathBuf::from(&ar_dir))),
+            &LoadSpec::new(WeightsSource::Dir(PathBuf::from(&ar_dir)))
+                .with_component("codec", WeightsSource::Dir(PathBuf::from(&codec_dir))),
         )
-        .expect("load the real moss_tts_realtime generator from the cached snapshot");
+        .expect(
+            "load the real moss_tts_realtime generator from the cached snapshot + staged codec",
+        );
         assert!(
             generator.descriptor().capabilities.supports_streaming,
             "moss_tts_realtime must advertise supports_streaming"
@@ -3843,6 +3857,8 @@ mod tests {
     ///   snapshots/8527b9136b6afefe2252ae597cecea2e80e7ebeb \
     /// SCENEWORKS_CHATTERBOX_VE_FILE=~/.cache/huggingface/hub/models--ResembleAI--chatterbox/\
     ///   snapshots/5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18/ve.safetensors \
+    /// SCENEWORKS_MOSS_TTSD_CODEC_FILE=~/.cache/huggingface/hub/models--OpenMOSS-Team--XY_Tokenizer_TTSD_V0/\
+    ///   snapshots/c83433728e698ed0698e88cb5096bc221fb8f8c5/xy_tokenizer.ckpt \
     /// HF_HUB_OFFLINE=1 \
     /// cargo test --release -p sceneworks-worker -- --ignored --nocapture \
     ///   moss_ttsd_renders_a_multi_speaker_dialogue
@@ -3864,12 +3880,22 @@ mod tests {
         let ve_file = std::env::var("SCENEWORKS_CHATTERBOX_VE_FILE").expect(
             "set SCENEWORKS_CHATTERBOX_VE_FILE to the cached chatterbox ve.safetensors path",
         );
+        // moss_ttsd_v05 advertises `required_components: ["codec"]` (sc-13681); on the self-fetch-free
+        // inference pin (sc-13818) the loader HARD-FAILS unless the XY_Tokenizer codec is staged in the
+        // LoadSpec — it no longer self-fetches it. Stage it exactly as production `resolve_co_requisites`
+        // does: a single-file co-requisite (`xy_tokenizer.ckpt`) resolves to `WeightsSource::File`
+        // (model_jobs.rs:1684). This was silently broken by the pin bump because the smoke is `#[ignore]`d.
+        let codec_file = std::env::var("SCENEWORKS_MOSS_TTSD_CODEC_FILE").expect(
+            "set SCENEWORKS_MOSS_TTSD_CODEC_FILE to the cached XY_Tokenizer_TTSD_V0 xy_tokenizer.ckpt path \
+             (moss_ttsd_v05's required `codec` component)",
+        );
 
         let generator = crate::inference_runtime::load_audio(
             "moss_ttsd_v05",
-            &LoadSpec::new(WeightsSource::Dir(PathBuf::from(&ar_dir))),
+            &LoadSpec::new(WeightsSource::Dir(PathBuf::from(&ar_dir)))
+                .with_component("codec", WeightsSource::File(PathBuf::from(&codec_file))),
         )
-        .expect("load the real moss_ttsd_v05 generator from the cached snapshot");
+        .expect("load the real moss_ttsd_v05 generator from the cached snapshot + staged codec");
         assert!(
             generator.descriptor().capabilities.supports_multi_speaker,
             "moss_ttsd_v05 must advertise supports_multi_speaker"

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1587,21 +1587,11 @@ fn pulid_flux_real_weights_holds_identity() {
     for p in [&pulid_adapter, &eva, &scrfd, &arcface, &bisenet] {
         assert!(p.exists(), "missing PuLID weight: {}", p.display());
     }
-    // Fill the engine's env-var weight seam from the local caches (exactly what
-    // `generate_pulid_flux_stream` does before the cached load). Through the crate-wide seam so the
-    // three vars are RESTORED on drop — the bare `set_var`s this replaces leaked them into every
-    // later test in the process, and took no lock while doing it (sc-12380).
-    let _env = EnvVars::set(&[
-        (
-            "PULID_FLUX_WEIGHTS",
-            pulid_adapter.to_str().expect("utf-8 pulid adapter path"),
-        ),
-        ("PULID_EVA_WEIGHTS", eva.to_str().expect("utf-8 eva path")),
-        (
-            "PULID_FACE_WEIGHTS_DIR",
-            bundle.to_str().expect("utf-8 face bundle dir"),
-        ),
-    ]);
+    // The self-fetch-free `pulid_flux` loader (sc-13818 pin) reads the PuLID adapter + EVA tower +
+    // native face stack from the typed `LoadSpec::identity` sub-slots — the process-global `PULID_*`
+    // env / HF-cache fallback was REMOVED (the loader now errors "no PULID_* env or HF-cache fallback"
+    // if identity is unset). Stage them on the spec below, mirroring `generate_pulid_flux_stream`
+    // (pulid.rs); nothing here mutates env.
 
     // Reference face: a portrait PNG (`SCENEWORKS_TEST_FACE`) if present, else the real face image
     // embedded in the face-align golden (`<bundle>/face_align_goldens.safetensors`, the same
@@ -1661,14 +1651,16 @@ fn pulid_flux_real_weights_holds_identity() {
     // Load via the worker's registry seam at the production default quant (Q8 — near-lossless for
     // PuLID identity per engine sc-3076, the manifest `mlx.quantize`) + generate with the worker's
     // request mapping. The PuLID conditioning (EVA/IDFormer/CA) stays f32 regardless of quant.
-    let generator = load_engine(
-        "pulid_flux",
-        flux_base,
-        Some(gen_core::Quant::Q8),
-        Vec::new(),
-        None,
-    )
-    .unwrap();
+    // Stage the three identity sub-slots exactly as production does (pulid.rs:184): encoder =
+    // File(PuLID adapter), eva = File(EVA tower), face_dir = Dir(the native face stack — scrfd +
+    // arcface + bisenet). They ride the LoadSpec into the load; no env involved.
+    let mut spec = load_spec(flux_base, Some(gen_core::Quant::Q8), Vec::new(), None);
+    spec.identity = Some(IdentityWeights {
+        encoder: Some(WeightsSource::File(pulid_adapter.clone())),
+        eva: Some(WeightsSource::File(eva.clone())),
+        face_dir: Some(WeightsSource::Dir(bundle.clone())),
+    });
+    let generator = load_control_engine("pulid_flux", &spec).unwrap();
     let cancel = gen_core::CancelFlag::new();
     let req = gen_core::GenerationRequest {
         prompt: "a portrait photo of a person, headshot, looking at the camera".to_owned(),


### PR DESCRIPTION
## sc-13818 — capstone of epic 13678 (rehome inference auto-downloads)

sc-13818's DoD (1) counterpart-completeness, (2) pin bump `f3483f93 → cd46a910`, and (4) green CI already landed via **sc-13821 / #1693** (merge `6cec1dc0`). This PR completes the remaining **DoD (3): re-run the offline-render matrix at the self-fetch-free pin `cd46a910` and prove no MLX model self-fetches at load** — and fixes the test-coverage gaps that verification surfaced.

### The finding

At the self-fetch-free pin, any component an inference loader needs that isn't staged in the `LoadSpec` is now a **hard load failure** (it previously self-fetched silently). Re-running the MLX offline-render matrix surfaced **three `#[ignore]`d real-weight smokes the pin bump silently broke** — they leaned on the old self-fetch fallback to materialize their passed-in components. CI can't catch them (they're `#[ignore]`d), so they only fail on a by-hand re-run.

### The fixes (test-only, 2 files)

| Smoke | Was | Now (mirrors the production seam) |
|---|---|---|
| `moss_ttsd_renders_a_multi_speaker_dialogue_in_distinct_voices` | bare `LoadSpec::new(Dir)` → loader hard-fails: "requires the XY_Tokenizer codec component 'codec'" | stage `codec` (single-file `xy_tokenizer.ckpt` → `WeightsSource::File`) — `resolve_co_requisites` (model_jobs.rs:1684) |
| `moss_tts_realtime_streams_a_real_clip_through_the_generator_seam` | bare `LoadSpec::new(Dir)` | stage `codec` (multi-file MOSS-Audio-Tokenizer → `WeightsSource::Dir`) |
| `pulid_flux_real_weights_holds_identity` | removed `PULID_*` env-var seam → loader errors "no PULID_* env or HF-cache fallback" | stage identity via `LoadSpec::identity {encoder, eva, face_dir}` — `generate_pulid_flux_stream` (image_jobs/pulid.rs:184) |

New env knobs: `SCENEWORKS_MOSS_TTSD_CODEC_FILE`, `SCENEWORKS_MOSS_TTS_CODEC_DIR`.

### Verification — full DoD (3) matrix, all offline at `cd46a910`

Each cell run as a **real render** with `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1` + a black-hole proxy (`ALL_PROXY/HTTPS_PROXY/HTTP_PROXY=http://127.0.0.1:1`). Any residual network fetch → hard fail, so a green render proves **zero self-fetch**.

| Cell | Result | Proof |
|---|---|---|
| chatterbox voice-clone | ✅ | staged `[perth, voice_embedding]`; 4.44 s/24 kHz, sha256 `830bc92e…` — **bit-identical to the sc-13794 old-pin render** ⇒ no regression |
| MOSS batch (moss_ttsd_v05) | ✅ | `codec` File staged; distinct voices, cross 0.5093 < self 0.7011 |
| MOSS realtime (moss_tts_realtime) | ✅ | `codec` Dir staged; 3 chunks, first-before-full, reassembly == one-shot |
| kokoro (control) | ✅ | 2 distinct kokoro voices + native chatterbox clone (margin 0.3013) — 2nd chatterbox seam |
| LTX | ✅ | `ltx_2_3_base_q8` + bundled gemma; 9 frames + audio track (real render, no skip) |
| PuLID | ✅ | identity via `LoadSpec::identity`; ArcFace cosine(gen, ref) = 0.8777 |
| sensenova_fast | ✅ | packed q8 tier load + non-degenerate 512² render (std > 10) |

**candle/CUDA cells (mmaudio, candle-SDXL) remain hardware-blocked (sc-13796)** — not runnable on Apple Silicon; unchanged by this PR.

Adversarially reviewed by a fresh subagent (**SHIP** verdict): each fix matches the production seam + manifest, all three CI lanes (macOS / candle-worker / parity) compile the edits, and no other in-scope pin-broken smoke exists.

Story: [sc-13818](https://app.shortcut.com/trefry/story/13818)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
