### PR TITLE
feat(krea): raise resolution ceiling to 2048² + memory-gate high-res buckets [sc-13959]

### DIFF
--- a/apps/web/src/resolutionMemory.js
+++ b/apps/web/src/resolutionMemory.js
@@ -1,0 +1,109 @@
+// Resolution memory-gating (sc-13959, epic 13879). Krea 2 renders up to 2048² (the pinned engine's
+// RES_MAX), and the manifest now advertises the full ÷16 ladder to that ceiling. 2048² is ~4× the
+// pixels of 1024², so its single-pass VAE-decode + attention transient is far larger than the ≤1536²
+// set the model's `minMemoryGb` visibility floor was calibrated for — a 48 GB Mac that runs 1536²
+// fine OOMs at 2048². This module is the pure, unit-testable gate the studios use to hide a high-res
+// bucket a host can't fit, MIRRORING the quant-tier gate (tierSuggestion.js): budget an estimated
+// PEAK against the host's unified/GPU memory with headroom, and NEVER withhold on missing data.
+//
+// SCOPE — three deliberate no-ops keep this from touching anything the story doesn't:
+//   1. Buckets at/below the historical 1536² ceiling are ALWAYS offered. They shipped before this
+//      change and the model's own `minMemoryGb` visibility floor already gates them, so ≤1536²
+//      behavior is byte-identical.
+//   2. Unknown host memory (`null`, the probe hasn't resolved / no signal) ⇒ everything fits. We never
+//      withhold a resolution on missing data — the worst case is offering a heavy one, which the
+//      worker's own load-time fit gate + runtime decode still backstop (mirrors tierFits).
+//   3. A model that declares NO memory floor (no `mlx.minMemoryGb` / `candle.minMemoryGb` — e.g.
+//      SenseNova, which already ships 2048² buckets) is left entirely unchanged: with no floor there
+//      is no basis to predict a peak, so the gate returns "fits". Only a model that BOTH declares a
+//      floor AND advertises >1536² buckets is affected — today that is exactly Krea 2 Raw / Turbo.
+
+import { MEMORY_HEADROOM_FRACTION } from "./tierSuggestion.js";
+
+// The historical resolution ceiling (pixels). Every bucket at/below this was shipped before sc-13959
+// and stays unconditionally offered (SCOPE note 1). 1536×1536 = 2,359,296 px ≈ 2.36 MP.
+export const BASELINE_PIXELS = 1536 * 1536;
+
+// Transient working-set (GB) a single generation needs PER MEGAPIXEL of output ABOVE the baseline, on
+// TOP of the model's `minMemoryGb` floor (which already covers the resident weights + the ≤1536²
+// transient for the default tier). Anchored on the app's measured single-pass VAE-decode + attention
+// transient: sc-8516 / mlx_fit_gate `HEADROOM_GB` measured ~14 GiB at 1024² (≈1.05 MP) ⇒ ~13 GB/MP.
+// The plain text-to-image GENERATE lane still decodes SINGLE-PASS in the pinned Krea engine (the
+// budget-gated tiled decode, sc-11747, is wired only on the control lane), so the gate budgets against
+// that single-pass peak — deliberately conservative: over-estimating hides a borderline size (safe),
+// under-estimating would offer one that OOMs. When generate-lane tiled decode lands upstream this
+// coefficient can be relaxed toward the ~7 GB/MP tiled figure (qwen-image's tiled-VAE transient).
+export const HIGHRES_TRANSIENT_GB_PER_MP = 13;
+
+// Parse a "WxH" bucket to its pixel count, or null when malformed.
+function pixelsOf(resolution) {
+  if (typeof resolution !== "string") {
+    return null;
+  }
+  const [width, height] = resolution.split("x").map((value) => Number(value));
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return width * height;
+}
+
+// The model's declared memory floor (GB) on the active backend, or null when it declares none. mlx =
+// unified-memory OS peak on a Mac; candle = discrete GPU VRAM. Both are the DEFAULT (lightest) tier's
+// ≤1536² peak — the value `useUnifiedMemoryGb` is budgeted against elsewhere for tier selection.
+function floorGb(model, backend) {
+  const block = backend === "candle" ? model?.candle : model?.mlx;
+  const gb = block?.minMemoryGb;
+  return typeof gb === "number" && Number.isFinite(gb) && gb > 0 ? gb : null;
+}
+
+// Predicted PEAK memory (GB) a generation at `resolution` needs for `model` on `backend`, or null when
+// it can't be predicted (malformed resolution, or the model declares no memory floor). At/below the
+// baseline this is just the floor (already the calibrated ≤1536² peak); above it, the floor plus the
+// per-megapixel transient for the extra pixels.
+export function predictedResolutionPeakGb(model, resolution, backend) {
+  const pixels = pixelsOf(resolution);
+  const floor = floorGb(model, backend);
+  if (pixels == null || floor == null) {
+    return null;
+  }
+  if (pixels <= BASELINE_PIXELS) {
+    return floor;
+  }
+  const extraMegapixels = (pixels - BASELINE_PIXELS) / 1_000_000;
+  return floor + HIGHRES_TRANSIENT_GB_PER_MP * extraMegapixels;
+}
+
+// Whether `resolution` should be OFFERED for `model` on a host with `unifiedMemoryGb` of unified/GPU
+// memory. See the SCOPE notes at the top for the three always-fit cases. Otherwise the predicted peak
+// must fit under the same headroom fraction the quant-tier gate uses (0.9), leaving the remainder for
+// the OS + other apps.
+export function resolutionFitsMemory(model, resolution, unifiedMemoryGb, options = {}) {
+  const { backend } = options;
+  const pixels = pixelsOf(resolution);
+  // (1) The historical ≤1536² set is always offered.
+  if (pixels == null || pixels <= BASELINE_PIXELS) {
+    return true;
+  }
+  // (2) Never withhold on missing data.
+  if (unifiedMemoryGb == null || !Number.isFinite(unifiedMemoryGb)) {
+    return true;
+  }
+  const required = predictedResolutionPeakGb(model, resolution, backend);
+  // (3) No declared floor ⇒ no prediction ⇒ leave the model's buckets unchanged.
+  if (required == null) {
+    return true;
+  }
+  return required <= unifiedMemoryGb * MEMORY_HEADROOM_FRACTION;
+}
+
+// Filter a list of "WxH" buckets to those that fit `unifiedMemoryGb`, preserving order. The studio's
+// effective resolution options: identical to the input for every ≤1536²-only model and for an unknown
+// memory reading; trims only the over-budget high-res buckets of a floored model on a known-small host.
+export function fitsResolutionOptions(model, resolutions, unifiedMemoryGb, options = {}) {
+  if (!Array.isArray(resolutions)) {
+    return [];
+  }
+  return resolutions.filter((resolution) =>
+    resolutionFitsMemory(model, resolution, unifiedMemoryGb, options),
+  );
+}

--- a/apps/web/src/resolutionMemory.test.js
+++ b/apps/web/src/resolutionMemory.test.js
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  BASELINE_PIXELS,
+  HIGHRES_TRANSIENT_GB_PER_MP,
+  fitsResolutionOptions,
+  predictedResolutionPeakGb,
+  resolutionFitsMemory,
+} from "./resolutionMemory.js";
+import { MEMORY_HEADROOM_FRACTION } from "./tierSuggestion.js";
+
+// A Krea-shaped model: a real mlx/candle memory floor + the sc-13959 high-res ladder.
+function kreaModel(overrides = {}) {
+  return {
+    id: "krea_2_raw",
+    family: "krea_2",
+    mlx: { minMemoryGb: 48 },
+    candle: { minMemoryGb: 32 },
+    limits: {
+      resolutions: [
+        "1024x1024",
+        "1216x832",
+        "1152x896",
+        "1536x1536",
+        "2048x1152",
+        "2048x1408",
+        "2048x2048",
+      ],
+    },
+    ...overrides,
+  };
+}
+
+const KREA_RES = kreaModel().limits.resolutions;
+
+describe("resolutionFitsMemory", () => {
+  it("always offers the historical <=1536^2 set, regardless of memory or backend", () => {
+    for (const res of ["1024x1024", "1216x832", "1152x896", "1536x1536"]) {
+      // Even an absurdly tiny budget cannot hide a <=baseline bucket.
+      expect(resolutionFitsMemory(kreaModel(), res, 1, { backend: "mlx" })).toBe(true);
+      expect(resolutionFitsMemory(kreaModel(), res, 1, { backend: "candle" })).toBe(true);
+    }
+    // 1536x1536 is exactly the baseline (not strictly above it) and stays offered.
+    expect(1536 * 1536).toBe(BASELINE_PIXELS);
+  });
+
+  it("never withholds when the host memory reading is unknown", () => {
+    for (const res of KREA_RES) {
+      expect(resolutionFitsMemory(kreaModel(), res, null, { backend: "mlx" })).toBe(true);
+      expect(resolutionFitsMemory(kreaModel(), res, undefined, { backend: "mlx" })).toBe(true);
+      expect(resolutionFitsMemory(kreaModel(), res, NaN, { backend: "mlx" })).toBe(true);
+    }
+  });
+
+  it("hides 2048^2 on a 48 GB Mac but offers it on a 128 GB Mac (mlx)", () => {
+    // Discriminating boundary: a low budget must EXCLUDE the top bucket a high budget INCLUDES.
+    expect(resolutionFitsMemory(kreaModel(), "2048x2048", 48, { backend: "mlx" })).toBe(false);
+    expect(resolutionFitsMemory(kreaModel(), "2048x2048", 128, { backend: "mlx" })).toBe(true);
+  });
+
+  it("hides 2048^2 on a 48 GB CUDA card but offers it on an 80 GB card (candle)", () => {
+    expect(resolutionFitsMemory(kreaModel(), "2048x2048", 48, { backend: "candle" })).toBe(false);
+    expect(resolutionFitsMemory(kreaModel(), "2048x2048", 80, { backend: "candle" })).toBe(true);
+  });
+
+  it("gates a mid-high bucket independently of the top bucket", () => {
+    // 2048x1152 (2.36 MP, just above baseline) fits a 64 GB Mac that still can't fit 2048^2 (4.19 MP).
+    expect(resolutionFitsMemory(kreaModel(), "2048x1152", 64, { backend: "mlx" })).toBe(true);
+    expect(resolutionFitsMemory(kreaModel(), "2048x2048", 64, { backend: "mlx" })).toBe(false);
+  });
+
+  it("leaves a model with no declared memory floor unchanged (e.g. SenseNova)", () => {
+    // SenseNova ships 2048^2 today with no minMemoryGb — the gate must not start hiding its buckets,
+    // even on a tiny host with a known memory reading.
+    const sensenova = {
+      id: "sensenova_u1_8b",
+      limits: { resolutions: ["2048x2048", "1888x1248"] },
+    };
+    expect(resolutionFitsMemory(sensenova, "2048x2048", 16, { backend: "mlx" })).toBe(true);
+    expect(resolutionFitsMemory(sensenova, "1888x1248", 16, { backend: "mlx" })).toBe(true);
+  });
+
+  it("budgets exactly at the shared 0.9 headroom fraction boundary", () => {
+    // Pin a NON-default boundary so the test discriminates the actual comparison, not a constant.
+    const model = kreaModel({ mlx: { minMemoryGb: 40 }, candle: undefined });
+    const pixels = 2048 * 2048;
+    const required =
+      40 + HIGHRES_TRANSIENT_GB_PER_MP * ((pixels - BASELINE_PIXELS) / 1_000_000);
+    const exactBudgetGb = required / MEMORY_HEADROOM_FRACTION;
+    // At exactly the budget it fits; a hair under it does not.
+    expect(resolutionFitsMemory(model, "2048x2048", exactBudgetGb, { backend: "mlx" })).toBe(true);
+    expect(
+      resolutionFitsMemory(model, "2048x2048", exactBudgetGb - 0.001, { backend: "mlx" }),
+    ).toBe(false);
+  });
+});
+
+describe("predictedResolutionPeakGb", () => {
+  it("returns the bare floor at/below baseline and floor+transient above it", () => {
+    expect(predictedResolutionPeakGb(kreaModel(), "1024x1024", "mlx")).toBe(48);
+    expect(predictedResolutionPeakGb(kreaModel(), "1536x1536", "mlx")).toBe(48);
+    const above = predictedResolutionPeakGb(kreaModel(), "2048x2048", "mlx");
+    expect(above).toBeGreaterThan(48);
+    const extraMp = (2048 * 2048 - BASELINE_PIXELS) / 1_000_000;
+    expect(above).toBeCloseTo(48 + HIGHRES_TRANSIENT_GB_PER_MP * extraMp, 6);
+  });
+
+  it("reads the backend-specific floor", () => {
+    expect(predictedResolutionPeakGb(kreaModel(), "1024x1024", "mlx")).toBe(48);
+    expect(predictedResolutionPeakGb(kreaModel(), "1024x1024", "candle")).toBe(32);
+  });
+
+  it("is null when the model declares no floor or the resolution is malformed", () => {
+    expect(predictedResolutionPeakGb({ id: "x" }, "2048x2048", "mlx")).toBeNull();
+    expect(predictedResolutionPeakGb(kreaModel(), "not-a-size", "mlx")).toBeNull();
+  });
+});
+
+describe("fitsResolutionOptions", () => {
+  it("trims only the over-budget high-res buckets, preserving order", () => {
+    const filtered = fitsResolutionOptions(kreaModel(), KREA_RES, 48, { backend: "mlx" });
+    // The <=1536^2 set survives; 2048^2 is dropped on a 48 GB Mac.
+    expect(filtered).toContain("1024x1024");
+    expect(filtered).toContain("1536x1536");
+    expect(filtered).not.toContain("2048x2048");
+    // Order of the survivors matches the input order.
+    expect(filtered).toEqual(KREA_RES.filter((r) => filtered.includes(r)));
+  });
+
+  it("returns the full list on a large host and on an unknown reading", () => {
+    expect(fitsResolutionOptions(kreaModel(), KREA_RES, 256, { backend: "mlx" })).toEqual(KREA_RES);
+    expect(fitsResolutionOptions(kreaModel(), KREA_RES, null, { backend: "mlx" })).toEqual(KREA_RES);
+  });
+
+  it("tolerates a non-array input", () => {
+    expect(fitsResolutionOptions(kreaModel(), undefined, 48, { backend: "mlx" })).toEqual([]);
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -152,6 +152,7 @@ import { readLastTier, writeLastTier } from "../lastTierStore.js";
 import { readDefaultGenerationQuality } from "../generationQuality.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { parseResolution, pickClosestResolution } from "../resolutionMatch.js";
+import { fitsResolutionOptions } from "../resolutionMemory.js";
 import { finiteRecipeNumber, recipeLoraSelection, recipeResolution } from "../recipeFields.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
@@ -1202,13 +1203,22 @@ export function ImageStudio() {
     setPrompt(promptSeedFor(ui));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, model]);
-  const resolutionOptions = useMemo(
-    () =>
-      selectedModel?.limits?.resolutions?.length
-        ? selectedModel.limits.resolutions
-        : DEFAULT_RESOLUTION_OPTIONS,
-    [selectedModel],
-  );
+  // The model's advertised buckets, MEMORY-GATED for this host (sc-13959): a resolution above the
+  // historical 1536² ceiling is hidden when its predicted peak won't fit `unifiedMemoryGb` (unified
+  // memory on a Mac / GPU VRAM off Mac) on the active backend — so a 48 GB Mac isn't offered a 2048²
+  // that OOMs while a 128 GB Mac gets the full range. A no-op for ≤1536²-only models, an unknown
+  // memory reading, and models with no declared memory floor (see resolutionMemory.js). The
+  // downstream snap/default effects keep the selection valid within the gated list.
+  const resolutionOptions = useMemo(() => {
+    const declared = selectedModel?.limits?.resolutions?.length
+      ? selectedModel.limits.resolutions
+      : DEFAULT_RESOLUTION_OPTIONS;
+    const backend = macCapabilities?.macGatingActive ? "mlx" : "candle";
+    const gated = fitsResolutionOptions(selectedModel, declared, unifiedMemoryGb, { backend });
+    // Never collapse to an empty picker: if the gate somehow trims everything (it never trims
+    // ≤1536², so this is defensive), fall back to the declared list.
+    return gated.length > 0 ? gated : declared;
+  }, [selectedModel, unifiedMemoryGb, macCapabilities]);
   // Reference-image auto-preset (sc-8109, epic 8102): when a captioning reference
   // image's natural dimensions become known, snap the resolution picker to whichever
   // option best matches its aspect ratio. The caption's bboxes are normalized 0–1000

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -2733,7 +2733,19 @@
         "scheduler": "default"
       },
       "limits": {
-        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280", "1536x1536"],
+        // sc-13959 (epic 13879): raised to Krea's real 2048² ceiling (model card + guide: any ÷16
+        // multiple up to 2048²), adding the aspect ratios Krea itself ships (3:2 1216×832 / 832×1216,
+        // ~9:7 1152×896 / 896×1152) plus their 2048-scale variants (16:9 2048×1152 / 1152×2048, ~3:2
+        // 2048×1408 / 1408×2048, square 2048×2048). Every bucket is ÷16-aligned and ≤2048², i.e. inside
+        // the PINNED Krea engine envelope (RES_MIN 256 / RES_MAX 2048 / ÷16) — asserted by
+        // `engines.rs::shipped_image_geometry_is_within_the_pinned_engine_envelope`. The buckets ABOVE
+        // the old 1536² cap are MEMORY-GATED client-side (apps/web/src/resolutionMemory.js) against the
+        // host's unified/GPU memory so a 48 GB Mac is never offered a size that OOMs while a 128 GB Mac
+        // gets the full range; ≤1536² is unchanged. `minMemoryGb` below stays the DEFAULT-tier /
+        // ≤1536² VISIBILITY floor — the extra single-pass VAE-decode spike at 2048² is what the
+        // client gate covers, not this floor (raising it would wrongly hide the model on 48 GB Macs
+        // that run ≤1536² fine).
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280", "1216x832", "832x1216", "1152x896", "896x1152", "1536x1536", "2048x1152", "1152x2048", "2048x1408", "1408x2048", "2048x2048"],
         "count": [1, 2, 4],
         // Krea Turbo routes the per-generation sampler/scheduler knobs through the unified framework
         // (run_flow_sampler / resolve_flow_schedule), exactly like z_image_turbo — so it advertises the
@@ -3013,7 +3025,19 @@
         "scheduler": "default"
       },
       "limits": {
-        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280", "1536x1536"],
+        // sc-13959 (epic 13879): raised to Krea's real 2048² ceiling (model card + guide: any ÷16
+        // multiple up to 2048²), adding the aspect ratios Krea itself ships (3:2 1216×832 / 832×1216,
+        // ~9:7 1152×896 / 896×1152) plus their 2048-scale variants (16:9 2048×1152 / 1152×2048, ~3:2
+        // 2048×1408 / 1408×2048, square 2048×2048). Every bucket is ÷16-aligned and ≤2048², i.e. inside
+        // the PINNED Krea engine envelope (RES_MIN 256 / RES_MAX 2048 / ÷16) — asserted by
+        // `engines.rs::shipped_image_geometry_is_within_the_pinned_engine_envelope`. The buckets ABOVE
+        // the old 1536² cap are MEMORY-GATED client-side (apps/web/src/resolutionMemory.js) against the
+        // host's unified/GPU memory so a 48 GB Mac is never offered a size that OOMs while a 128 GB Mac
+        // gets the full range; ≤1536² is unchanged. `minMemoryGb` below stays the DEFAULT-tier /
+        // ≤1536² VISIBILITY floor — the extra single-pass VAE-decode spike at 2048² is what the
+        // client gate covers, not this floor (raising it would wrongly hide the model on 48 GB Macs
+        // that run ≤1536² fine).
+        "resolutions": ["1024x1024", "768x1024", "1024x768", "1280x720", "720x1280", "1216x832", "832x1216", "1152x896", "896x1152", "1536x1536", "2048x1152", "1152x2048", "2048x1408", "1408x2048", "2048x2048"],
         "count": [1, 2, 4],
         // Raw routes the per-generation sampler/scheduler knobs through the unified framework, exactly
         // like Turbo — the `krea_2_raw` descriptor advertises curated_sampler_names()/


### PR DESCRIPTION
## sc-13959 — Raise Krea 2 resolution ceiling to 2048² (memory-gated) + add real aspect ratios

Krea 2 Raw/Turbo render at up to **2048²** (the pinned engine's `RES_MAX`, any ÷16 multiple), but the manifest capped `limits.resolutions` at **1536×1536** — a conservative memory-safety floor for 48 GB-class Macs, **not** a model limit. This raises the ceiling and memory-gates the new high-res options so a 128 GB Mac / high-VRAM CUDA gets the full range and a 48 GB Mac is never offered a size that OOMs.

### What changed & why

**Manifest** — `config/manifests/builtin.models.jsonc`
- Extended `krea_2_raw` + `krea_2_turbo` `limits.resolutions` to the full ÷16 ladder up to 2048², adding the aspect ratios Krea itself ships (3:2 `1216×832`/`832×1216`, ~9:7 `1152×896`/`896×1152`) plus their 2048-scale variants (16:9 `2048×1152`/`1152×2048`, ~3:2 `2048×1408`/`1408×2048`, square `2048×2048`). Every bucket is ÷16-aligned and ≤2048² — inside the **pinned Krea engine envelope** (`RES_MIN 256` / `RES_MAX 2048` / ÷16), asserted by `engines.rs::shipped_image_geometry_is_within_the_pinned_engine_envelope`.
- `minMemoryGb` is deliberately **unchanged**: it stays the DEFAULT-tier / ≤1536² *visibility* floor. Raising it would wrongly hide the model on 48 GB Macs that run ≤1536² fine. The extra single-pass VAE-decode spike at 2048² is covered by the client gate instead.

**Memory-gate** — new `apps/web/src/resolutionMemory.js` + `ImageStudio.jsx` wiring
- Pure, unit-tested gate **mirroring the quant-tier gate** (`tierSuggestion.js`): budgets a resolution's predicted peak (model floor + a per-megapixel single-pass transient, anchored on the sc-8516 / `mlx_fit_gate` ~14 GiB @1024² figure) against the host's unified/GPU memory (`useUnifiedMemoryGb`) with the shared `MEMORY_HEADROOM_FRACTION` (0.9).
- Three deliberate no-ops keep it scoped so **only Krea is affected**: (1) ≤1536² is always offered (byte-identical), (2) an unknown memory reading never withholds, (3) a model that declares **no** memory floor — e.g. SenseNova, which already ships 2048² — is left entirely unchanged (no floor ⇒ no prediction ⇒ fits).
- `ImageStudio` filters `resolutionOptions` through the gate on the **active backend** (`mlx`/`candle`). Because `2048×1152` (16:9) has exactly baseline pixels, it stays offered on a 48 GB Mac while `2048×1408`/`2048×2048` are hidden — the gate is pixel-count-correct, not a flat >1536² cutoff.

### Scope vs acceptance
| Acceptance item | Status |
|---|---|
| Manifest resolutions raised to 2048² + real aspect ratios (÷16, ≤2048) | ✅ both models |
| Picker exposes the added aspect ratios | ✅ (`limits.resolutions` → picker; ≤1536² ratios always shown) |
| Memory-gate: 48 GB sees only what fits, 128 GB gets full range | ✅ both backends (`resolutionMemory.js`) |
| Existing ≤1536² unaffected | ✅ (gate is a hard no-op ≤ baseline) |
| Pinned-engine geometry guard respected (÷16, ≤2048²) | ✅ (guard test green) |
| **2048² renders coherent, no OOM on 128 GB Mac** | ⚠️ requires hardware validation (needs app + weights + 128 GB Mac) |
| Generate-lane engages tiled decode at 2048² | ⛔ see below — plain t2i decode is single-pass in the pinned engine; wiring is upstream (inference repo) |
| Sidecar records actual overridden dims | ✅ already handled (see below) |

### Generate-lane tiled decode (Part C) — upstream inference work
Investigated the pinned inference dep (`SceneWorks/inference` @ `cd46a91`). The **plain t2i generate lane does NOT thread `decode_tiling`** — both backends decode single-pass:
- MLX: `render_base_from`/`render_turbo_from` call `decode_latents` (single-pass); only `render_control_from` threads `decode_latents_native_tiled` (`Some(cfg)`). (`crates/media/mlx-gen/mlx-gen-krea/src/pipeline.rs:749/758` → `decode_latents`; tiled seam at `:869`.)
- candle: `candle-gen-krea/src/pipeline.rs` non-PiD path uses `comps.vae.decode(&lat)` (single-pass); only the control lane has `tile_vae_decode`.

Wiring the budget-gated tiled decode into the plain t2i lane requires an **upstream inference change** (add `decode_tiling` to `render_*_from` + the Generator seam budget-gate) **plus a Cargo `rev` bump** in this repo — it can't land in a SceneWorks-repo-only PR. **This PR's memory gate is conservative for exactly this reason:** it budgets against the *single-pass* peak (current reality), so "never a resolution that OOMs" holds today, before the tiling wiring lands. Filed as a follow-up.

### Sidecar dims (Part D) — verified already correct, no change needed
The image sidecar already records the **actual (override-applied) dims**: worker sets `normalizedWidth/Height = request.width/height` (the effective override dims from the top-level payload, `imageJobRequest.js:148`), the sidecar's `normalizedSettings.width/height` reads those (`project_store.rs:3820`), and image replay's `recipeResolution` **prefers `normalizedSettings.width/height`** over the base `advanced.resolution` string by design (`recipeFields.js:18`). So an overridden render reproduces its actual output. (`rawAdapterSettings.resolution` still records the base preset, but it's not what image replay uses.) The story's concern is not a live bug on the image path — bonus: adding `2048×2048` as a real bucket also fixes replay-snap for width/height-overridden 2048² renders.

### Tests / verification
- **New**: `apps/web/src/resolutionMemory.test.js` — 13 discriminating cases incl. the 48 GB-excludes / 128 GB-includes boundary pinned at the exact `required / 0.9` budget, backend-specific floors, and the SenseNova (no-floor) no-op.
- Full web suite: **2236 passed** (154 files) incl. `ImageStudio`/`App.imageGeneration`/`studioRestore`.
- Rust MLX lane: `shipped_image_geometry_is_within_the_pinned_engine_envelope` ✅, all `engines::` tests (17) ✅, `sceneworks-core` (737) ✅.
- `apps/web` lint ✅ (0 errors), production build ✅, `cargo fmt --all --check` clean.

### Follow-ups
- **Thread budget-gated tiled VAE decode into the Krea plain t2i generate lane** (both backends) in `SceneWorks/inference`, then bump the `rev` here — relaxes the gate coefficient toward the ~7 GB/MP tiled figure and lets smaller machines fit higher resolutions.
- 2048² coherent-render / no-OOM validation on a 128 GB Mac (hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)