### PR TITLE
feat(krea): register Krea 2 turbo LoRA as an accelerator-role builtin [sc-13882]

### DIFF
--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -96,6 +96,20 @@ describe("loraMatchesModel", () => {
   it("normalizes separators/underscores on both sides before comparing", () => {
     expect(loraMatchesModel({ id: "l", family: "Z_Image" }, { id: "z", loraCompatibility: { families: ["z-image"] } })).toBe(true);
   });
+
+  it("surfaces the Krea 2 turbo accelerator LoRA under Krea 2 Raw (sc-13882)", () => {
+    // The manifest-shaped accelerator (family krea_2, role accelerator) must be picker-compatible
+    // with the Raw model, whose loraCompatibility.families is ["krea_2"]. The `role` marker is inert
+    // to this gate (family is the only signal) — it exists for the S3 sampling-regime routing.
+    const turboAccel = {
+      id: "krea2_turbo_accel",
+      family: "krea_2",
+      role: "accelerator",
+      compatibility: { families: ["krea_2"] },
+    };
+    const kreaRaw = { id: "krea_2_raw", loraCompatibility: { families: ["krea_2"], types: ["character", "style", "acceleration"] } };
+    expect(loraMatchesModel(turboAccel, kreaRaw)).toBe(true);
+  });
 });
 
 describe("loraHasResolvableFamily", () => {

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -132,6 +132,36 @@
         "repo": "conradlocke/krea2-identity-edit",
         "file": "krea2_identity_edit_v1_2.safetensors"
       }
+    },
+    {
+      // Krea 2 Turbo accelerator LoRA (epic 13879 S2, sc-13882). The rank-64 bf16 step-distill
+      // ("turbo") adapter Krea ships in Comfy-Org/Krea-2 (`loras/krea2_turbo_lora_rank_64_bf16.
+      // safetensors`) — the low-rank residual that turns the full-fidelity Raw DiT into the fast,
+      // CFG-free Turbo regime. `role: accelerator` is the sampling-regime sibling of
+      // `conditioningRole`: it marks a LoRA that changes HOW the sampler runs (fewer steps, CFG off),
+      // not how the job is CONDITIONED (ic_lora / image_edit). This slice registers it WEIGHT-LOAD
+      // ONLY: family `krea_2` makes it surface in the Raw LoRA picker (family match, no base-model
+      // gating — lora_family.rs), and the additive-LoRA core reads the rank straight off the tensor
+      // shapes at load (mlx-gen `adapters/loader.rs::apply_lora_peft`, `factor_rank = a.shape()[1]`),
+      // so rank 64 is a drop-in on the frozen Raw DiT with no code change. Selecting it today only
+      // stacks the residual — Raw STILL runs its 52-step true-CFG regime; the auto-switch to the turbo
+      // sampling recipe (fewer steps, guidance off) is S3 (sc-13883), and candle is S6. Pinned to the
+      // current Comfy-Org/Krea-2 commit (an immutable snapshot; the file is confirmed present at this
+      // SHA). Krea 2 Community License — the SAME license we already ship Krea 2 Raw/Turbo under, so no
+      // new gating/consent beyond the base.
+      "id": "krea2_turbo_accel",
+      "name": "Krea 2 Turbo (accelerator)",
+      "family": "krea_2",
+      "triggerWords": [],
+      "compatibility": { "families": ["krea_2"] },
+      "role": "accelerator",
+      "defaultWeight": 1.0,
+      "source": {
+        "provider": "huggingface",
+        "repo": "Comfy-Org/Krea-2",
+        "file": "loras/krea2_turbo_lora_rank_64_bf16.safetensors",
+        "revision": "952f49d49653cb42e7d6cf7cbfad74738073ec7d"
+      }
     }
   ]
 }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3047,9 +3047,13 @@
       },
       "loraCompatibility": {
         // Krea LoRAs (family krea_2) apply at Raw inference too (family match, no base-model gating —
-        // lora_family.rs), and Raw's bf16 tier is their training base. `types` lists what trains here.
+        // lora_family.rs), and Raw's bf16 tier is their training base. `types` advertises what applies
+        // here: "character"/"style" are the trainable tiers; "acceleration" (sc-13882, epic 13879)
+        // advertises the shipped Krea 2 Turbo accelerator LoRA (`krea2_turbo_accel`, family krea_2) —
+        // a weight-load-only step-distill adapter, not a training tier. Its sampling-regime routing is
+        // S3 (sc-13883); registering the type here surfaces the accelerator as Raw-compatible.
         "families": ["krea_2"],
-        "types": ["character", "style"]
+        "types": ["character", "style", "acceleration"]
       },
       "mlx": {
         // Pre-quantized Q8 turnkey (`q8/` subdir) is the default. Raw runs TRUE CFG (two DiT forwards per

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -704,4 +704,83 @@ mod tests {
             "overwrite refreshes the builtin manifest to the embedded copy"
         );
     }
+
+    #[test]
+    fn krea_turbo_accelerator_lora_is_registered_and_sha_pinned() {
+        // sc-13882 (epic 13879 S2): the Krea 2 turbo LoRA registers as a weight-load-only builtin
+        // accelerator. Pin every NON-default field so this discriminates a real registration from an
+        // empty/renamed one: repo + exact file, a FULL 40-hex commit SHA revision (a floating `main`
+        // would silently drift the accelerator weights under the frozen Raw DiT), family `krea_2`
+        // (what surfaces it in the Raw picker), and `role: accelerator` (the sampling-regime marker
+        // S3 routes on).
+        let stripped = crate::jsonc::strip_jsonc_comments(embedded("builtin.loras.jsonc"));
+        let manifest: serde_json::Value =
+            serde_json::from_str(&stripped).expect("builtin.loras.jsonc parses as JSON");
+        let loras = manifest["loras"]
+            .as_array()
+            .expect("builtin.loras.jsonc has a loras array");
+        let lora = loras
+            .iter()
+            .find(|l| l["id"] == serde_json::json!("krea2_turbo_accel"))
+            .expect("krea2_turbo_accel is registered in builtin.loras.jsonc");
+
+        assert_eq!(lora["family"], serde_json::json!("krea_2"));
+        assert_eq!(lora["role"], serde_json::json!("accelerator"));
+        assert_eq!(
+            lora["compatibility"]["families"],
+            serde_json::json!(["krea_2"])
+        );
+        assert_eq!(lora["source"]["provider"], serde_json::json!("huggingface"));
+        assert_eq!(
+            lora["source"]["repo"],
+            serde_json::json!("Comfy-Org/Krea-2")
+        );
+        assert_eq!(
+            lora["source"]["file"],
+            serde_json::json!("loras/krea2_turbo_lora_rank_64_bf16.safetensors")
+        );
+        let revision = lora["source"]["revision"]
+            .as_str()
+            .expect("the accelerator LoRA pins a source.revision");
+        assert!(
+            is_full_sha_revision(revision),
+            "the accelerator LoRA must pin a full 40-hex commit SHA (not a floating branch); got \
+             {revision:?}"
+        );
+        assert_eq!(revision, "952f49d49653cb42e7d6cf7cbfad74738073ec7d");
+    }
+
+    #[test]
+    fn krea_2_raw_advertises_the_acceleration_lora_compat_type() {
+        // sc-13882: Raw must advertise "acceleration" as a compatible LoRA type so the turbo adapter
+        // is offered under Raw. Assert the NEW value is present AND the pre-existing trainable tiers
+        // survive the edit (a replacement, not an addition, would be the likely regression).
+        let stripped = crate::jsonc::strip_jsonc_comments(embedded("builtin.models.jsonc"));
+        let manifest: serde_json::Value =
+            serde_json::from_str(&stripped).expect("builtin.models.jsonc parses as JSON");
+        let models = manifest["models"]
+            .as_array()
+            .expect("builtin.models.jsonc has a models array");
+        let raw = models
+            .iter()
+            .find(|m| m["id"] == serde_json::json!("krea_2_raw"))
+            .expect("krea_2_raw is present");
+        let types = raw["loraCompatibility"]["types"]
+            .as_array()
+            .expect("krea_2_raw declares loraCompatibility.types");
+        assert!(
+            types.contains(&serde_json::json!("acceleration")),
+            "krea_2_raw must advertise the acceleration compat type (sc-13882); got {types:?}"
+        );
+        assert!(
+            types.contains(&serde_json::json!("character"))
+                && types.contains(&serde_json::json!("style")),
+            "the trainable character/style tiers must survive the edit; got {types:?}"
+        );
+        // The family match that actually surfaces the LoRA in the Raw picker is unchanged.
+        assert_eq!(
+            raw["loraCompatibility"]["families"],
+            serde_json::json!(["krea_2"])
+        );
+    }
 }

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -348,9 +348,10 @@ pub(crate) async fn run_lora_download_job(
     // repo" (apps/rust-api `create_lora_download_job`) — but that only widens the filter, so resolving
     // zero files still means there was nothing to fetch.
     //
-    // Safe to hard-fail: swept every entry in builtin.loras.jsonc against its repo — 7 entries, all
-    // declaring an explicit `source.file`, all 7 present, no whole-repo entries. Nothing shipping
-    // relies on this silently passing.
+    // Safe to hard-fail: swept every entry in builtin.loras.jsonc against its repo — 8 entries, all
+    // declaring an explicit `source.file`, all 8 present, no whole-repo entries. Nothing shipping
+    // relies on this silently passing. (The 8th, `krea2_turbo_accel` sc-13882, pins a SHA revision;
+    // its file was confirmed present at that snapshot.)
     if snapshot.files.is_empty() {
         let scope = if files.is_empty() {
             String::new()

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -25,6 +25,11 @@
             "type": "string",
             "description": "How the worker must condition a job for this LoRA to function. 'ic_lora' = LTX in-context video conditioning (source clip). 'image_edit' = Kontext-style image edit (source image as in-context VAE tokens + vision-tower grounding); selecting such a LoRA auto-activates the model's edit recipe. A base without the matching conditioning leaves these weights inert.",
             "enum": ["ic_lora", "image_edit"]
+          },
+          "role": {
+            "type": "string",
+            "description": "Sampling-regime role marker (the sibling of 'conditioningRole', which is about how a job is CONDITIONED). 'accelerator' = a step-distill / turbo LoRA (e.g. the Krea 2 turbo adapter, sc-13882) whose weights load additively like any other LoRA but whose intent is to change the sampler regime — fewer steps, CFG off. Selecting one auto-switching the model to that regime is separately wired per model; absent that wiring the weights still stack as a plain residual.",
+            "enum": ["accelerator"]
           }
         },
         "additionalProperties": true


### PR DESCRIPTION
## What & why

Epic 13879 **S2 (sc-13882)**. Registers the rank-64 bf16 **Krea 2 turbo** step-distill LoRA (`Comfy-Org/Krea-2` → `loras/krea2_turbo_lora_rank_64_bf16.safetensors`) as a **weight-load-only** builtin accelerator adapter for Krea 2. This is registration + compatibility only — the sampling-regime routing (auto-switch to fewer steps / CFG off when selected) is **S3 (sc-13883)**, and candle is **S6**. Selecting it today just stacks the low-rank residual; Raw still runs its 52-step true-CFG regime.

## Changes

- **`config/manifests/builtin.loras.jsonc`** — new `krea2_turbo_accel` entry: `family: krea_2`, `compatibility.families: ["krea_2"]`, `role: accelerator`, `source` = `Comfy-Org/Krea-2` + the file, **pinned to commit `952f49d49653cb42e7d6cf7cbfad74738073ec7d`**. Krea 2 Community License — the same license we already ship Krea 2 Raw/Turbo under, so **no new gating/consent**.
- **New `role: accelerator` marker** — the sampling-regime sibling of `conditioningRole` (which is about how a job is *conditioned*). Documented in **`packages/schemas/lora-manifest.schema.json`** with an enum + description, mirroring `conditioningRole`.
- **`config/manifests/builtin.models.jsonc`** — `krea_2_raw.loraCompatibility.types` gains `"acceleration"`. (`types` has no schema enum — open string array — so no schema change was needed there.) sc-13881's `ui.defaultNegativePrompt`/`ui.promptGuide` and sc-13959's resolution ceiling are untouched.
- **`crates/sceneworks-worker/src/model_jobs.rs`** — kept the "swept every entry in builtin.loras.jsonc" sweep comment accurate (7 → 8 entries).

## Scope vs acceptance

- **LoRA downloads + resolves** — `source.repo` + `source.file` + pinned `source.revision` are read by `apps/rust-api/src/loras.rs::lora_huggingface_source` (defaults to `main` when absent; here pinned to the SHA). File confirmed present at the pinned SHA via the HF resolve API (`HTTP 302` to CDN, `x-linked-size: 469423778` ≈ 469 MB, consistent with rank-64 bf16).
- **Appears in the Raw LoRA picker** — picker compatibility is **family-based** (`presetUtils.js::loraMatchesModel` / rust-api `model_lora_families`): `family: krea_2` vs Raw's `loraCompatibility.families: ["krea_2"]` matches. `role` is inert to this gate (it exists for S3). Covered by a new `presetUtils.test.jsx` case.
- **Weights load additively without error / rank-64 drop-in** — verified by code inspection: the additive-LoRA core reads rank dynamically from tensor shapes, **not** a hardcoded rank — `mlx-gen/src/adapters/loader.rs::apply_lora_peft` (inference rev `cd46a91`): `let factor_rank = a.shape()[1] as f32;` (line 917) then `let rank = cfg_rank.unwrap_or(factor_rank);` (line 926). This is the same seam the `krea2_identity_edit` comment already relies on for its full-rank drop-in. **Live weight-load on the frozen Raw DiT on a real GPU was not run here** (large download + hardware) — see limitation below.
- **No sampling change yet** — no worker/recipe routing added; `role` is not round-tripped through `serializeLora` (that's S3). Raw's 52-step CFG regime is unchanged.

## Tests

- `crates/sceneworks-core/src/builtin_manifests.rs`:
  - `krea_turbo_accelerator_lora_is_registered_and_sha_pinned` — pins repo, exact file, a full 40-hex SHA revision (via the existing `is_full_sha_revision` audit helper) equal to the pinned SHA, `family: krea_2`, `role: accelerator`, `compatibility.families`.
  - `krea_2_raw_advertises_the_acceleration_lora_compat_type` — asserts `"acceleration"` is present **and** the `character`/`style` tiers survive.
  - Existing `no_builtin_manifest_has_a_duplicate_key` and the sc-13881 negative/guide test still pass (no disturbance).
- `apps/web/src/presetUtils.test.jsx` — `loraMatchesModel(turboAccel, krea_2_raw)` is `true`.

**Ran locally:** `cargo fmt --all -- --check` (clean, exit 0) · `cargo clippy -p sceneworks-core --all-targets -- -D warnings` (clean) · `cargo test -p sceneworks-core --lib builtin_manifests` (14 passed) · `cargo check -p sceneworks-worker` (compiles) · `npx vitest run src/presetUtils.test.jsx` (51 passed).

## Limitation (needs hardware validation)

The acceptance clause "weights load additively without error" was verified by **code inspection** of the rank-dynamic apply path, not by a live download + load on the frozen Raw DiT GPU path. That end-to-end load (fetch ~469 MB, apply on MLX) should be spot-checked by Michael on Apple Silicon. This is a stated validation limit, not a scope cut.

## Follow-ups

- **S3 (sc-13883)** — wire `role: accelerator` selection to auto-activate the turbo sampling recipe (fewer steps, CFG off); this will also need `role` round-tripped through `serializeLora` and read worker-side.
- **S6** — candle/CUDA parity for the accelerator load path.

sc-13882