### PR TITLE
fix(worker): evict-then-reclaim for the bespoke candle edit/control VRAM gates (sc-13960)

### DIFF
--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -446,6 +446,59 @@ where
     })?
 }
 
+/// Evict the resident cached generator (if any) from the single-slot cache, freeing its cudarc pool
+/// pages, and wait for the eviction to complete. Returns `true` if a generator was evicted, `false`
+/// when the slot was already empty (both are success). The evict-then-reclaim primitive for the
+/// bespoke candle edit/control lanes (sc-13960).
+///
+/// Those lanes load a bespoke `runtime_cuda` provider (`QwenEdit` / `KreaStrictControl`) off the cache
+/// thread through `start_gen_stream`, so — unlike the txt2img gate (base.rs, which loads THROUGH
+/// [`with_cached_generator`], evicting on a cold miss) or the video comfyui lane ([`with_uncached_generator`])
+/// — nothing frees the resident txt2img generator's pages before their load. That is why they budget
+/// against RAW free (sc-13588): a live co-resident generator's cudarc pool pages are NOT reclaimable,
+/// so crediting them would over-admit an OOM. This gives them the missing lever: evict FIRST — freeing
+/// the resident generator's VRAM back for the incoming load — then the caller may safely fold
+/// [`crate::vram_gate::with_reclaimable`]. (Whether the freed VRAM returns to the driver or stays in
+/// cudarc's in-process pool depends on device ownership; measured on the RTX PRO 6000, a full generator
+/// drop returns most of it to the driver — either way it is available to the next load, the same
+/// property the shipped video [`with_uncached_generator`] lane relies on.) The eviction is the exact
+/// `cache.evict()` + [`cache_thread::release_backend_cache_after_evict`] pair [`with_uncached_generator`]
+/// performs before its in-place load; on CUDA the release is a no-op (cudarc has no `empty_cache`).
+///
+/// **Concurrency.** The evict runs as a job on the single cache thread, so it serializes with every
+/// cache load/evict; there is no window where a load observes a half-evicted slot. The worker processes
+/// one generation at a time, so no concurrent job re-populates the cache between this evict and the
+/// bespoke lane's subsequent `start_gen_stream` load — the same single-in-flight assumption base.rs's
+/// reclaim already relies on. (Idle-timeout eviction only ever *evicts*, never loads, so it cannot
+/// re-occupy the pool either.)
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(crate) async fn evict_cached_generator() -> WorkerResult<bool> {
+    evict_cached_generator_on(generator_worker()).await
+}
+
+/// [`evict_cached_generator`] against a caller-supplied cache-worker sender — the seam a unit test drives
+/// its own seeded [`GeneratorCache`] worker through (the production entry point uses the process-global
+/// [`generator_worker`]).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn evict_cached_generator_on(worker: &mpsc::Sender<GeneratorJob>) -> WorkerResult<bool> {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel::<bool>();
+    let job: GeneratorJob = Box::new(move |cache: &mut GeneratorCache| {
+        let evicted = cache.evict().is_some();
+        if evicted {
+            // On CUDA a no-op (cudarc has no empty_cache); the evicted generator's drop already
+            // returned its allocation to the process pool for the incoming bespoke load to reuse.
+            cache_thread::release_backend_cache_after_evict();
+        }
+        let _ = reply_tx.send(evicted);
+    });
+    worker
+        .send(job)
+        .map_err(|_| crate::WorkerError::Engine("MLX generator cache worker stopped".to_owned()))?;
+    reply_rx.await.map_err(|_| {
+        crate::WorkerError::Engine("MLX generator cache worker dropped the job result".to_owned())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -878,6 +931,64 @@ mod tests {
                 .expect("cache state reply"),
             "expected disabled idle timeout to keep the resident generator"
         );
+        drop(tx);
+        worker.join().expect("cache worker exits");
+    }
+
+    // sc-13960: the evict-then-reclaim primitive frees the single resident slot on demand (the
+    // bespoke edit/control lanes call it before folding `with_reclaimable`). It must (1) evict a
+    // resident generator and report `true`, (2) leave the slot empty, and (3) no-op with `false` when
+    // the slot is already empty — so a lane that evicts on an already-cold worker neither errors nor
+    // lies about having freed pages. Drives a locally-seeded worker through the `_on` seam rather than
+    // the process-global cache. Candle-gated to match the primitive.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[tokio::test]
+    async fn evict_cached_generator_frees_the_resident_slot_and_no_ops_when_empty() {
+        let (tx, rx) = mpsc::channel::<GeneratorJob>();
+        let worker = thread::spawn(move || {
+            run_generator_cache_worker(rx, None);
+        });
+
+        // Seed a resident stub generator (the test replacement for a warm txt2img generator).
+        let (seed_tx, seed_rx) = mpsc::channel();
+        tx.send(Box::new(move |cache: &mut GeneratorCache| {
+            seed_stub_entry(cache);
+            seed_tx.send(()).expect("ack cache seed");
+        }))
+        .expect("seed cache entry");
+        seed_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("cache seed ack");
+
+        // First evict frees the resident slot and reports it evicted something.
+        assert!(
+            evict_cached_generator_on(&tx)
+                .await
+                .expect("evict succeeds"),
+            "evicting a resident generator must report true"
+        );
+
+        // The slot is now empty.
+        let (reply_tx, reply_rx) = mpsc::channel();
+        tx.send(Box::new(move |cache: &mut GeneratorCache| {
+            reply_tx.send(cache.is_empty()).expect("send cache state");
+        }))
+        .expect("check cache state");
+        assert!(
+            reply_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("cache state reply"),
+            "the resident generator must be gone after an evict"
+        );
+
+        // A second evict on the now-empty slot is a no-op that reports false (never an error).
+        assert!(
+            !evict_cached_generator_on(&tx)
+                .await
+                .expect("evict on empty succeeds"),
+            "evicting an empty slot must report false, not error"
+        );
+
         drop(tx);
         worker.join().expect("cache worker exits");
     }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4984,6 +4984,61 @@ fn tier_to_quant(tier: &str) -> (Option<Quant>, Option<i64>) {
     }
 }
 
+/// sc-13960 — the evict-then-reclaim gate driver the bespoke (non-cache-evicting) candle image lanes
+/// (`qwen_edit_candle` / `krea_control_candle`) share. Runs the lane's PURE `gate(budget)` against a
+/// **two-pass** budget and returns the plan to act on plus the budget it was resolved against:
+///
+///  1. **Raw pass.** Gate against raw live free VRAM (no reclaim). Correct as-is: a resident txt2img
+///     generator stays live and co-resident with the bespoke load, so its cudarc pool pages are NOT
+///     free — crediting them would over-admit an OOM (sc-13588's documented reason these lanes budget
+///     raw). If nothing is reclaimable (cold pool) — or the plan the raw budget yields already stands
+///     after folding the pool — return it here, and **the warm txt2img generator cache is preserved**
+///     (the deliberate tradeoff: we do NOT evict on every render, only when it changes the outcome).
+///  2. **Reclaim pass.** Otherwise gate again against `free + reclaimable_pool` and, when that yields a
+///     BETTER plan (`reclaim_improves` — the budget only ever grows, so a changed plan is always a
+///     higher residency / an admit-instead-of-reject), EVICT the single-slot generator cache so the
+///     resident generator's pages become genuinely free, making the reclaim credit honest, then act on
+///     the reclaimed plan. This is the missing half of sc-11023 for the bespoke lanes: a second
+///     edit/control render in the same worker no longer sees the first render's dropped-but-pooled
+///     pages as unavailable.
+///
+/// `reclaim_improves(&raw, &reclaimed)` returns whether the reclaimed plan is worth an evict — `false`
+/// when it is the same action as raw (including two rejects that differ only in their reported
+/// free-VRAM number, which must NOT trigger a pointless evict). Mirrors the candle video comfyui lane's
+/// `generator_cache::with_uncached_generator` precedent (evict, then reclaim) — see that function and
+/// `video_jobs::candle_video_vram_budget`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn gate_with_evict_reclaim<D>(
+    gpu_id: &str,
+    raw_budget: Option<crate::vram_gate::VramBudget>,
+    gate: impl Fn(Option<crate::vram_gate::VramBudget>) -> D,
+    reclaim_improves: impl Fn(&D, &D) -> bool,
+) -> WorkerResult<(D, Option<crate::vram_gate::VramBudget>)> {
+    let raw = gate(raw_budget);
+    let reclaimable = crate::vram_gate::reclaimable_pool_gb(gpu_id);
+    // Cold pool: nothing this process pooled to reclaim, hence nothing resident to evict — gate exactly
+    // as the pre-sc-13960 lanes did.
+    if reclaimable <= 0.0 {
+        return Ok((raw, raw_budget));
+    }
+    let reclaimed_budget =
+        raw_budget.map(|budget| crate::vram_gate::with_reclaimable(budget, reclaimable));
+    let reclaimed = gate(reclaimed_budget);
+    if !reclaim_improves(&raw, &reclaimed) {
+        // Reclaim would not change the plan — keep the warm txt2img cache rather than evict for nothing.
+        return Ok((raw, raw_budget));
+    }
+    let evicted = crate::generator_cache::evict_cached_generator().await?;
+    tracing::info!(
+        gpu_id,
+        evicted,
+        reclaimable_gb = reclaimable,
+        "candle bespoke-lane VRAM gate: evicted the resident generator to reclaim its cudarc pool so \
+         this render admits at a higher residency (sc-13960)"
+    );
+    Ok((reclaimed, reclaimed_budget))
+}
+
 /// Windows/CUDA candle execution path (sc-3675 SDXL, generalized in sc-5096). The macOS dispatch is
 /// MLX-bound; candle is a narrow **txt2img-only** lane, so this is a trimmed sibling of
 /// [`generate_stream`] that drives the SAME neutral streaming harness (`start_cached_gen_stream` →

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -445,9 +445,17 @@ async fn generate_candle_krea_control_stream(
     // quality penalty. On a constrained card (or one emulated via `SCENEWORKS_CUDA_VRAM_CAP_GB`) the ladder
     // first stages the text and heavy phases sequentially (sc-12176), then engages VAE-decode tiling
     // (sc-11744), activation chunking / res-cap (sc-11745), and finally the last-resort branch-quant rung
-    // (q8 near-lossless, then q4 pose-locked) until it fits, else rejects-before-OOM. NB: this lane uses
-    // the UNcached `start_gen_stream` (it doesn't evict the single-slot generator cache), so budget against
-    // raw live free VRAM — the cache's pages are NOT reclaimable by this load, unlike the base.rs gate.
+    // (q8 near-lossless, then q4 pose-locked) until it fits, else rejects-before-OOM.
+    //
+    // sc-13588 / sc-13960: this lane loads through the UNcached `start_gen_stream` (it never evicts the
+    // single-slot generator cache), so a resident txt2img generator stays co-resident and its cudarc pool
+    // pages are NOT free — the ladder gates against RAW live free first (crediting those pages against a
+    // raw gate would over-admit an OOM). `gate_with_evict_reclaim` (base.rs) adds the missing lever: only
+    // when reclaiming the pool would readmit this render at a higher residency does it EVICT that
+    // generator (making the credit honest, at the cost of the warm txt2img cache) and act on the reclaimed
+    // plan — fixing the repeated-control-render needless downtier / reject. Same treatment as
+    // `qwen_edit_candle.rs`; base.rs already gets it for free via the evicting cache. The admitted peak is
+    // recorded (`note_loaded_peak` below) so a repeated control render can reclaim these pooled pages.
     // sc-11042: `base` is the tier dir this lane resolved (`krea_model_subdir`'s output when the user has
     // the packed MLX turnkey; a dense diffusers snapshot root otherwise, which is never an `nvfp4/` dir),
     // so the NVFP4 tier is sized only when it is the tier that actually resolved.
@@ -456,23 +464,57 @@ async fn generate_candle_krea_control_stream(
         &request.model_manifest_entry,
         nvfp4_selected(request, nvfp4_host_eligible(), Some(&base)),
     );
-    let budget = crate::vram_gate::apply_vram_cap(
+    // Fit-ladder inputs are budget-independent; resolve them once, then run the two-pass gate below.
+    let peak = crate::krea_control_fit::predicted_control_peak_gb(&request.model_manifest_entry, tier);
+    let sequential_peak = crate::krea_control_fit::predicted_control_sequential_peak_gb(
+        &request.model_manifest_entry,
+        tier,
+    );
+    let decode_tile_save =
+        crate::krea_control_fit::decode_tile_save_gb(&request.model_manifest_entry, tier);
+    let chunk_attn_save = crate::krea_control_fit::chunk_attn_save_gb(&request.model_manifest_entry);
+    let q8_save = crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q8");
+    let q4_save = crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q4");
+    let raw_budget = crate::vram_gate::apply_vram_cap(
         crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
         crate::vram_gate::cuda_vram_cap_gb(),
     );
-    let (offload_policy, tile_vae_decode, chunk_attention, branch_quant) =
-        match crate::krea_control_fit::fit_ladder(
-        crate::krea_control_fit::predicted_control_peak_gb(&request.model_manifest_entry, tier),
-        crate::krea_control_fit::predicted_control_sequential_peak_gb(
-            &request.model_manifest_entry,
-            tier,
-        ),
-        budget,
-        crate::krea_control_fit::decode_tile_save_gb(&request.model_manifest_entry, tier),
-        crate::krea_control_fit::chunk_attn_save_gb(&request.model_manifest_entry),
-        crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q8"),
-        crate::krea_control_fit::branch_quant_save_gb(&request.model_manifest_entry, "q4"),
-    ) {
+    // sc-13960 two-pass: walk the ladder against raw free, then — only if reclaiming the cudarc pool
+    // would step it off a needless rung (a strict improvement; the reclaimed budget only grows) — evict
+    // the resident generator and act on the reclaimed walk.
+    let (fit, _budget) = gate_with_evict_reclaim(
+        &settings.gpu_id,
+        raw_budget,
+        |budget| {
+            crate::krea_control_fit::fit_ladder(
+                peak,
+                sequential_peak,
+                budget,
+                decode_tile_save,
+                chunk_attn_save,
+                q8_save,
+                q4_save,
+            )
+        },
+        // Two rejects differing only in their reported free number are the same non-outcome — a reclaim
+        // that still won't fit must NOT trigger a pointless evict. Any other change is a strict
+        // improvement, worth evicting the warm txt2img cache for.
+        |raw, reclaimed| {
+            !matches!(
+                (raw, reclaimed),
+                (
+                    crate::krea_control_fit::KreaControlFit::TooBig { .. },
+                    crate::krea_control_fit::KreaControlFit::TooBig { .. }
+                )
+            ) && raw != reclaimed
+        },
+    )
+    .await?;
+    // The peak this admitted load actually leaves in the cudarc pool (sc-13960) — recorded below as the
+    // reclaimable high-water. Computed before the by-value match consumes `fit`; `None` on a reject.
+    let incurred_peak =
+        crate::krea_control_fit::incurred_peak_gb(&fit, &request.model_manifest_entry, tier);
+    let (offload_policy, tile_vae_decode, chunk_attention, branch_quant) = match fit {
         // Big-card fast path (or no signal): monolithic full-speed decode, unchunked attention, bf16 branch.
         crate::krea_control_fit::KreaControlFit::Unknown
         | crate::krea_control_fit::KreaControlFit::Fits {
@@ -519,6 +561,13 @@ async fn generate_candle_krea_control_stream(
             )));
         }
     };
+    // sc-13960: record the admitted control peak so a repeated control render (or a following
+    // txt2img/edit gate) can reclaim these pooled pages — the control lane recorded nothing before this,
+    // which is why its own repeated renders could not reclaim. Dropped when `run_candle_strict_control`
+    // returns; `None` (unmeasured / rejected) ⇒ no-op.
+    if let Some(peak_gb) = incurred_peak {
+        crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
+    }
 
     let provider = KreaStrictControl {
         base,

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -465,23 +465,22 @@ async fn generate_candle_qwen_edit_stream(
     // measure-sibling of the qwen txt2img sc-10969 + flux2 sc-10920; before it, unmeasured tiers made this
     // Unknown → resident (inert).
     //
-    // sc-13588: this gate budgets against RAW live free VRAM and deliberately does NOT fold
-    // `with_reclaimable` the way the txt2img `generate_candle_stream` gate (base.rs, sc-11023) and the
-    // candle video gate do. Those lanes load THROUGH the single-slot generator cache
-    // (`with_cached_generator` / `with_uncached_generator`), which EVICTS its resident occupant before the
-    // incoming load — so that occupant's cudarc pool pages ARE reclaimable by the load being gated. This
-    // edit lane instead loads through the UNcached `start_gen_stream` below: it never touches the generator
-    // cache, so any resident txt2img generator stays live and CO-RESIDENT with the QwenEdit load. Its pages
-    // are NOT reclaimable here; crediting them would over-admit a load that then OOMs alongside the
-    // still-resident model. Raw free correctly reject-before-OOMs when the edit peak + the resident won't
-    // co-fit. Same reasoning — and the same deliberate omission — as `krea_control_candle.rs` (the other
-    // `start_gen_stream` lane); see its note. The reclaimable *high-water* is still recorded after an admit
-    // (see `note_loaded_peak` below), which is the half of sc-11023 that DOES apply cross-lane.
+    // sc-13588 / sc-13960: this gate budgets against RAW live free VRAM FIRST — deliberately not
+    // folding `with_reclaimable` up front, unlike the txt2img `generate_candle_stream` gate (base.rs,
+    // sc-11023) and the candle video gate. Those load THROUGH the single-slot generator cache
+    // (`with_cached_generator` / `with_uncached_generator`), which EVICTS its resident occupant before
+    // the incoming load — so the occupant's cudarc pool pages ARE reclaimable by the load being gated.
+    // This edit lane instead loads through the UNcached `start_gen_stream` below: it never touches the
+    // generator cache, so any resident txt2img generator stays live and CO-RESIDENT with the QwenEdit
+    // load, and crediting its pages against a raw gate would over-admit an OOM. sc-13960 adds the missing
+    // lever: `gate_with_evict_reclaim` re-gates against `free + reclaimable_pool` only when that would
+    // readmit this render at a higher residency, and — before it does — EVICTS the resident generator so
+    // its pages are genuinely free, making the credit honest (freeing a warm txt2img cache is the
+    // deliberate tradeoff, taken only when it changes the outcome). This fixes the repeated-edit
+    // warm-swap false-reject / needless sequential downtier; base.rs already gets it for free via the
+    // evicting cache. Same treatment as `krea_control_candle.rs` (the other `start_gen_stream` lane).
+    // The reclaimable high-water is still recorded after an admit (`note_loaded_peak` below).
     let use_sequential = {
-        let budget = crate::vram_gate::apply_vram_cap(
-            crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
-            crate::vram_gate::cuda_vram_cap_gb(),
-        );
         // sc-13534: key the budget off the tier `resolve_qwen_edit_candle_base` ACTUALLY landed on, not
         // the bits the request asked for — this lane now grows the tier layout the old `nvfp4 = false`
         // note said to wire when it did. `gate_tier_key` is the shared txt2img helper (sc-12090 /
@@ -506,21 +505,54 @@ async fn generate_candle_qwen_edit_stream(
             nvfp4_selected(request, nvfp4_host_eligible(), Some(&qwen_base)),
         );
         let needed = crate::vram_gate::predicted_peak_gb(&request.model_manifest_entry, tier);
-        match crate::vram_gate::resolve_offload(
-            crate::vram_gate::fit_decision(needed, budget),
-            /* sequential_capable */ true,
-        ) {
-            crate::vram_gate::FitDecision::Offload {
-                needed_gb,
-                available_gb,
-            } => {
-                // Second-stage gate (sc-10856): if this tier's MEASURED sequential peak is known and STILL
-                // exceeds the budget, reject before load instead of a reactive OOM. Absent the number
-                // (unmeasured edit tier) keep the best-effort sequential run.
-                let sequential_needed = crate::vram_gate::predicted_sequential_peak_gb(
-                    &request.model_manifest_entry,
+        // Second-stage gate input (sc-10856): the tier's MEASURED sequential peak (the largest single
+        // working set once the VL encoder is dropped). `None` for an unmeasured tier ⇒ best-effort stage.
+        let sequential_needed =
+            crate::vram_gate::predicted_sequential_peak_gb(&request.model_manifest_entry, tier);
+        let raw_budget = crate::vram_gate::apply_vram_cap(
+            crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
+            crate::vram_gate::cuda_vram_cap_gb(),
+        );
+        // sc-13960 two-pass: resolve the plan against raw free, then — only if reclaiming the pool would
+        // change (improve) it — evict the resident generator and act on the reclaimed plan. The edit lane
+        // is always sequential-capable (sc-10968 wired `QwenEdit::generate_sequential`).
+        let (plan, budget) = gate_with_evict_reclaim(
+            &settings.gpu_id,
+            raw_budget,
+            |budget| {
+                crate::vram_gate::load_plan(
+                    needed,
+                    sequential_needed,
+                    budget,
+                    /* sequential_capable */ true,
+                )
+            },
+            |raw, reclaimed| raw != reclaimed,
+        )
+        .await?;
+        let available_gb = budget.map_or(0.0, |b| b.free_gb);
+        match plan {
+            crate::vram_gate::LoadPlan::Sequential => {
+                tracing::info!(
+                    model = %request.model,
                     tier,
+                    available_gb = available_gb.round() as i64,
+                    "candle Qwen-Edit VRAM fit-gate: resident peak exceeds free VRAM — loading with \
+                     sequential component residency (VL encoder dropped before the DiT)"
                 );
+                // sc-13588: record the admitted SEQUENTIAL peak as the reclaimable high-water for the next
+                // gate — the QwenEdit this admits is dropped when `start_gen_stream`'s closure returns, so
+                // its pages return to cudarc's process pool; a later gate (base.rs / video, or a repeated
+                // edit via `gate_with_evict_reclaim`) that evicts + reclaims must credit this peak or it
+                // under-counts the pool and false-rejects a load that fits.
+                if let Some(peak_gb) = sequential_needed {
+                    crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
+                }
+                true
+            }
+            crate::vram_gate::LoadPlan::Reject => {
+                // For the always-sequential-capable edit lane a reject is the sc-10856 second-stage
+                // sequential overflow: even staged, the measured peak won't fit the (post-reclaim) budget.
                 if let Some(seq_gb) =
                     crate::vram_gate::sequential_overflow_gb(sequential_needed, budget)
                 {
@@ -535,35 +567,15 @@ async fn generate_candle_qwen_edit_stream(
                         gpu = settings.gpu_id,
                     )));
                 }
-                tracing::info!(
-                    model = %request.model,
-                    needed_gb = needed_gb.round() as i64,
-                    available_gb = available_gb.round() as i64,
-                    "candle Qwen-Edit VRAM fit-gate: resident peak exceeds free VRAM — loading with \
-                     sequential component residency (VL encoder dropped before the DiT)"
-                );
-                // sc-13588: record the admitted SEQUENTIAL peak as the reclaimable high-water for the next
-                // gate — the missing half of the sc-11023 backport (see the header note). The QwenEdit this
-                // admits is dropped when `start_gen_stream`'s closure returns, so its pages return to
-                // cudarc's process pool; a later CACHED gate (base.rs / video) that evicts + reclaims must
-                // credit this peak or it under-counts the pool and false-rejects a load that fits.
-                // `sequential_needed` is the measured sequential peak just checked above (`None` for an
-                // unmeasured tier ⇒ no-op).
-                if let Some(peak_gb) = sequential_needed {
-                    crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
-                }
-                true
-            }
-            crate::vram_gate::FitDecision::TooBig {
-                needed_gb,
-                available_gb,
-            } => {
+                // Defensive: a resident overflow with no staging — unreachable for this lane (it is always
+                // sequential-capable, so `load_plan` never reaches `Reject` via `TooBig`), but keep an
+                // honest message rather than an unwrap if that ever changes.
                 return Err(WorkerError::InvalidPayload(format!(
                     "{model} at the {tier} tier needs ~{needed} GB of VRAM (with headroom) but GPU \
                      {gpu} has ~{available} GB available. Pick a lower tier (Q4/Q8), lower the output \
                      resolution, or run on a card with more VRAM.",
                     model = request.model,
-                    needed = needed_gb.round() as i64,
+                    needed = needed.unwrap_or(0.0).round() as i64,
                     available = available_gb.round() as i64,
                     gpu = settings.gpu_id,
                 )));
@@ -571,7 +583,7 @@ async fn generate_candle_qwen_edit_stream(
             // Resident admit (`Fits`) — or `Unknown` when a tier is unmeasured. Record the RESIDENT peak
             // as the reclaimable high-water (sc-13588); `needed` is `None` for an unmeasured tier, so this
             // no-ops there exactly as the gate itself does.
-            _ => {
+            crate::vram_gate::LoadPlan::Resident => {
                 if let Some(peak_gb) = needed {
                     crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
                 }

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -278,6 +278,54 @@ pub(crate) fn fit_ladder(
     }
 }
 
+/// The VRAM peak (GB) a Krea control render actually incurs under `fit`, for the reclaimable high-water
+/// ([`crate::vram_gate::note_loaded_peak`], sc-13960 — the control lane, unlike the txt2img/edit lanes,
+/// recorded NO peak before this, so a repeated control render could not reclaim the first render's
+/// dropped-but-pooled pages). Mirrors [`fit_ladder`]'s own arithmetic: the resident or staged base
+/// peak, less each engaged speed/quality rung's measured saving.
+///
+/// Returns `None` for a non-admit (`Unknown` / `TooBig`) or an admitted-but-unmeasured peak — there is
+/// nothing honest to record, exactly as base.rs records nothing for an unmeasured tier. Never
+/// OVER-counts the pool the load leaves behind: an over-count would let a LATER gate credit more than is
+/// actually free and over-admit an OOM, so only the ENGAGED rungs' MEASURED savings are subtracted (a
+/// rung the ladder could not have engaged has an unmeasured, `None` saving and contributes no phantom
+/// reduction). The base peak carries [`HEADROOM_GB`] like the txt2img `predicted_peak_gb` this mirrors,
+/// so the small headroom over-count is the same one base.rs's reclaim already tolerates (bounded by the
+/// next load's own headroom).
+pub(crate) fn incurred_peak_gb(
+    fit: &KreaControlFit,
+    manifest_entry: &JsonObject,
+    tier_key: &str,
+) -> Option<f64> {
+    let KreaControlFit::Fits {
+        offload_policy,
+        tile_vae_decode,
+        chunk_attention,
+        branch_quant,
+    } = fit
+    else {
+        return None; // Unknown / TooBig — no admitted load to record.
+    };
+    // The base peak the ladder admitted at: the resident whole-model peak, or the staged working set.
+    let mut peak = if *offload_policy == OffloadPolicy::Resident {
+        predicted_control_peak_gb(manifest_entry, tier_key)?
+    } else {
+        predicted_control_sequential_peak_gb(manifest_entry, tier_key)?
+    };
+    if *tile_vae_decode {
+        peak -= decode_tile_save_gb(manifest_entry, tier_key).unwrap_or(0.0);
+    }
+    if *chunk_attention {
+        peak -= chunk_attn_save_gb(manifest_entry).unwrap_or(0.0);
+    }
+    match branch_quant {
+        Some(Quant::Q8) => peak -= branch_quant_save_gb(manifest_entry, "q8").unwrap_or(0.0),
+        Some(Quant::Q4) => peak -= branch_quant_save_gb(manifest_entry, "q4").unwrap_or(0.0),
+        _ => {}
+    }
+    Some(peak.max(0.0))
+}
+
 /// Parse a JSON float from either a number or a numeric string (mirrors [`crate::vram_gate`]'s helper).
 fn json_f64(value: &Value) -> Option<f64> {
     value
@@ -718,6 +766,132 @@ mod tests {
                 chunk_attention: true,
                 branch_quant: None,
             }
+        );
+    }
+
+    /// sc-13960: [`incurred_peak_gb`] records the peak a control render actually leaves in the cudarc
+    /// pool — the resident/staged base peak less every ENGAGED rung's measured saving — so a later gate's
+    /// reclaim credit is honest. It must mirror the ladder and never OVER-count (which would let a later
+    /// gate over-admit an OOM).
+    #[test]
+    fn incurred_peak_mirrors_the_ladder_and_never_over_counts() {
+        let m = krea_manifest_with_chunking();
+        let tier = "q4";
+
+        // Fast-path resident admit → exactly the resident control peak (with headroom).
+        let resident = KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Resident,
+            tile_vae_decode: false,
+            chunk_attention: false,
+            branch_quant: None,
+        };
+        assert_eq!(
+            incurred_peak_gb(&resident, &m, tier),
+            predicted_control_peak_gb(&m, tier) // 32.9
+        );
+
+        // Staged + tiled + chunked + q4: the sequential peak (27.0) less every engaged measured saving.
+        let laddered = KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
+            tile_vae_decode: true,
+            chunk_attention: true,
+            branch_quant: Some(Quant::Q4),
+        };
+        let expected = predicted_control_sequential_peak_gb(&m, tier).unwrap()
+            - decode_tile_save_gb(&m, tier).unwrap()
+            - chunk_attn_save_gb(&m).unwrap()
+            - branch_quant_save_gb(&m, "q4").unwrap(); // 27 − 6.9 − 2.43 − 10.2 = 7.47
+        assert!((incurred_peak_gb(&laddered, &m, tier).unwrap() - expected).abs() < 1e-6);
+
+        // Non-admits record nothing (no pooled pages to reclaim).
+        assert_eq!(incurred_peak_gb(&KreaControlFit::Unknown, &m, tier), None);
+        assert_eq!(
+            incurred_peak_gb(
+                &KreaControlFit::TooBig {
+                    needed_gb: 50.0,
+                    available_gb: 10.0
+                },
+                &m,
+                tier
+            ),
+            None
+        );
+
+        // An admitted-but-unmeasured staged peak → None, not a guess (mirrors base.rs's None ⇒ no-op).
+        let no_seq = obj(json!({ "candle": { "control": { "peakGbByTier": { "q4": 30.9 } } } }));
+        let staged = KreaControlFit::Fits {
+            offload_policy: OffloadPolicy::Sequential,
+            tile_vae_decode: false,
+            chunk_attention: false,
+            branch_quant: None,
+        };
+        assert_eq!(incurred_peak_gb(&staged, &no_seq, "q4"), None);
+
+        // Safety: whatever the ladder ADMITS, the peak recorded for it never exceeds the budget it was
+        // admitted against — so the pool the load leaves behind is never over-reported.
+        let b = budget(24.0);
+        let fit = super::fit_ladder(
+            predicted_control_peak_gb(&m, tier),
+            predicted_control_sequential_peak_gb(&m, tier),
+            Some(b),
+            decode_tile_save_gb(&m, tier),
+            chunk_attn_save_gb(&m),
+            branch_quant_save_gb(&m, "q8"),
+            branch_quant_save_gb(&m, "q4"),
+        );
+        if let Some(p) = incurred_peak_gb(&fit, &m, tier) {
+            assert!(
+                p <= b.free_gb + 1e-6,
+                "incurred peak {p} must not exceed the admitting budget {}",
+                b.free_gb
+            );
+        }
+    }
+
+    /// sc-13960: on a warm worker, crediting the cudarc pool the previous control render left behind
+    /// FLIPS the ladder off its needless rungs — the repeated-control-render scenario the story names.
+    /// Pins the arithmetic the two-pass evict-reclaim gate performs (`fit_ladder(raw)` vs
+    /// `fit_ladder(with_reclaimable(raw, pool))`).
+    #[test]
+    fn reclaim_flips_a_warm_control_gate_back_to_resident() {
+        let m = krea_manifest();
+        let tier = "bf16"; // control peak 48.2, sequential 42.0, no tiling rung for this tier
+        let peak = predicted_control_peak_gb(&m, tier);
+        let seq = predicted_control_sequential_peak_gb(&m, tier);
+        let tile = decode_tile_save_gb(&m, tier); // None
+        let chunk = chunk_attn_save_gb(&m); // None
+        let q8 = branch_quant_save_gb(&m, "q8");
+        let q4 = branch_quant_save_gb(&m, "q4");
+
+        // Second bf16 control render on a 96 GB card: the first (48.2 peak) dropped but its pages are
+        // pooled, so RAW free is ~47.8 GB — the resident peak no longer fits, so the ladder needlessly
+        // stages sequentially.
+        let raw = VramBudget {
+            free_gb: 47.8,
+            total_gb: 96.0,
+        };
+        assert_eq!(
+            super::fit_ladder(peak, seq, Some(raw), tile, chunk, q8, q4),
+            KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
+                tile_vae_decode: false,
+                chunk_attention: false,
+                branch_quant: None,
+            }
+        );
+        // Crediting the 48.2 GB the first render left in-pool readmits it at the big-card fast path.
+        let reclaimed = crate::vram_gate::with_reclaimable(raw, 48.2);
+        assert_eq!(
+            super::fit_ladder(peak, seq, Some(reclaimed), tile, chunk, q8, q4),
+            fits_untiled_bf16()
+        );
+
+        // A cold pool (reclaimable 0) is a no-op: the raw plan stands (a genuine first-load on a
+        // constrained card is gated exactly as before).
+        let reclaimed_cold = crate::vram_gate::with_reclaimable(raw, 0.0);
+        assert_eq!(
+            super::fit_ladder(peak, seq, Some(reclaimed_cold), tile, chunk, q8, q4),
+            super::fit_ladder(peak, seq, Some(raw), tile, chunk, q8, q4)
         );
     }
 }

--- a/crates/sceneworks-worker/src/qwen_edit_candle_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/qwen_edit_candle_gpu_smoke.rs
@@ -191,3 +191,248 @@ fn qwen_edit_worker_lane_gpu_smoke() {
         png.display()
     );
 }
+
+/// sc-13960 warm-2nd-run acceptance on real CUDA. The bespoke edit lane loads off the UNcached
+/// `start_gen_stream` and never touches the single-slot generator cache, so a co-resident generator's
+/// VRAM stays held while the bespoke gate reads RAW free — and a naive gate against that reduced free
+/// needlessly downtiers (or rejects) a render whose room the co-resident's imminent eviction frees.
+/// This smoke validates the fix end-to-end on the RTX PRO 6000, using LIVE `nvidia-smi` readings — the
+/// facts the unit tests cannot see: that a resident generator really occupies VRAM, and that
+/// evicting/dropping it really frees that VRAM back for the next load.
+///
+///   1. Load a real packed-q4 `QwenEdit`, render one edit; while it is RESIDENT, measure how much VRAM
+///      it occupies (this is what a bespoke gate's raw free is reduced by when a generator is cached).
+///   2. DROP it and confirm `nvidia-smi` free RISES back — evicting the resident frees its VRAM for the
+///      incoming render (on this hardware a full drop returns it to the driver; the shared-device
+///      sequential-offload path instead pools it — either way it becomes available, the same property
+///      the shipped video `with_uncached_generator` lane relies on). This is the fix's whole mechanism.
+///   3. Confirm the gate's reclaim credit PREDICTS that freed budget: crediting the resident's peak onto
+///      the RESIDENT (reduced) reading — [`vram_gate::with_reclaimable`] over `note_loaded_peak` — lands
+///      within a couple GB of the measured post-drop free. That is what lets the gate admit resident
+///      BEFORE the evict has happened.
+///   4. Assert the gate's plan FLIPS: on a budget whose raw free sits just below the resident peak, the
+///      plan is a non-resident downtier (the bug); crediting the peak the evict will free readmits it
+///      resident (the fix). Uses the REAL occupied peak, forced constrained so the flip shows on any card.
+///   5. Reload + render a WARM second edit into the reclaimed room — proving the reclaimed residency is
+///      safe (no OOM), the literal "warm 2nd-run" the acceptance names.
+///
+/// Run (needs the turnkey in the HF cache + a CUDA device via SCENEWORKS_GPU_ID, `--release` for a
+/// realistic peak):
+/// ```text
+/// $env:SCENEWORKS_GPU_ID="0"; $env:HF_HOME="E:\huggingface"
+/// $env:QWEN_EDIT_OUT_DIR="D:\sceneworks-qwen-edit-validate"
+/// cargo test -p sceneworks-worker --no-default-features --features backend-candle --release \
+///   qwen_edit_warm_reclaim_gpu_smoke -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "sc-13960 real-weight warm-reclaim GPU smoke; needs the SceneWorks/qwen-image-edit-2511-mlx \
+            turnkey in the HF cache + a CUDA device (cap=120)"]
+fn qwen_edit_warm_reclaim_gpu_smoke() {
+    use crate::image_jobs::resolve_qwen_edit_candle_base;
+    use crate::settings::Settings;
+    use crate::vram_gate::{
+        load_plan, note_loaded_peak, reclaimable_pool_gb, with_reclaimable, LoadPlan, VramBudget,
+    };
+    use sceneworks_core::image_request::ImageRequest;
+    use serde_json::json;
+
+    let out_dir = std::path::PathBuf::from(env_or("QWEN_EDIT_OUT_DIR", "/tmp/qwen_edit_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let settings = Settings::from_env();
+    let gpu_id = settings.gpu_id.clone();
+
+    // A live VRAM budget read (blocking, since this is a sync test); `None` means no NVIDIA GPU visible,
+    // which fails the smoke loudly rather than pretending it validated hardware it never touched.
+    let budget = |label: &str| -> VramBudget {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let b = rt
+            .block_on(crate::gpu::nvidia_vram_budget_gb(&gpu_id))
+            .unwrap_or_else(|| panic!("no live NVIDIA VRAM budget for gpu {gpu_id} at {label}"));
+        println!(
+            "[reclaim-smoke] {label}: free={:.2} GB / total={:.2} GB",
+            b.free_gb, b.total_gb
+        );
+        b
+    };
+
+    // Small + fast: this smoke measures VRAM mechanics, not image fidelity. The packed-q4 resident
+    // weights dominate the pool regardless of resolution, so 512² / 4 steps is plenty.
+    let (w, h): (u32, u32) = (512, 512);
+    let steps: usize = 4;
+    let guidance: f32 = 4.0;
+    let model = env_or("QWEN_EDIT_MODEL", "qwen_image_edit_2511");
+    let prompt = "turn the plain gray card into a lush watercolor of a mountain lake at sunrise";
+    let negative = "blurry, low quality, jpeg artifacts, deformed";
+
+    let payload = json!({
+        "model": model,
+        "mode": "edit_image",
+        "sourceAssetId": "smoke-src",
+        "prompt": prompt,
+        "width": w,
+        "height": h,
+        "advanced": { "mlxQuantize": 4 },
+    });
+    let request = ImageRequest::from_payload(payload.as_object().unwrap());
+    let dir = resolve_qwen_edit_candle_base(&request, &settings)
+        .expect("resolve_qwen_edit_candle_base")
+        .unwrap_or_else(|| {
+            panic!("{model}: SceneWorks/qwen-image-edit-2511-mlx turnkey not cached")
+        });
+
+    let render = |tag: &str| {
+        let engine = QwenEdit::load(&QwenEditPaths {
+            root: dir.clone(),
+            adapters: Vec::new(),
+            offload_policy: OffloadPolicy::Resident,
+        })
+        .unwrap_or_else(|e| panic!("QwenEdit::load ({tag}): {e}"));
+        let reference = Image {
+            width: w,
+            height: h,
+            pixels: vec![128u8; (w * h * 3) as usize],
+        };
+        let req = QwenEditRequest {
+            prompt: prompt.to_owned(),
+            negative: negative.to_owned(),
+            width: w,
+            height: h,
+            steps,
+            guidance,
+            seed: 42,
+            lightning: false,
+            cancel: CancelFlag::new(),
+        };
+        let out = engine
+            .generate(&req, std::slice::from_ref(&reference), &mut |_| {})
+            .unwrap_or_else(|e| panic!("{model} generate ({tag}): {e}"));
+        (out, engine) // caller controls the drop point
+    };
+
+    // ---- (1) baseline → load+render #1 → measure occupied → DROP ----
+    let baseline = budget("baseline");
+    let (out1, engine1) = render("render#1");
+    let loaded = budget("after load+render #1 (engine still resident)");
+    let occupied = (baseline.free_gb - loaded.free_gb).max(0.0);
+    println!("[reclaim-smoke] render #1 occupied ~{occupied:.2} GB of VRAM");
+    assert!(
+        occupied > 4.0,
+        "render #1 must occupy real VRAM (got {occupied:.2} GB) — the pool premise is untestable otherwise"
+    );
+    let std1 = image_std(&out1);
+    assert!(
+        std1 >= DEGENERATE_STD_FLOOR_DEFAULT,
+        "render #1 degenerate (std {std1:.3})"
+    );
+    drop(engine1); // evict: free the resident generator's VRAM back for the next load
+
+    // ---- (2) the crux: evicting/dropping the resident FREES its VRAM back (nvidia-smi free RISES) ----
+    // This is the mechanism the fix depends on. The bespoke gate reads raw free WHILE a generator is
+    // resident (reduced by `occupied`); admitting the render requires that evicting the resident will
+    // free that VRAM. Confirm it does — most of `occupied` comes back.
+    let after_drop = budget("after DROP of engine #1");
+    let freed = after_drop.free_gb - loaded.free_gb; // VRAM the evict returned
+    println!(
+        "[reclaim-smoke] evicting engine #1 freed {freed:.2} GB back (of {occupied:.2} occupied)"
+    );
+    assert!(
+        freed > occupied * 0.5,
+        "evicting the resident generator must free most of its {occupied:.2} GB back for the incoming \
+         render (only {freed:.2} GB came back) — the reclaim credit would be dishonest otherwise"
+    );
+
+    // ---- (3) the gate's reclaim credit PREDICTS that freed budget from the RESIDENT (reduced) reading.
+    // While the generator is resident the bespoke gate sees `loaded` (free = total − occupied). Crediting
+    // the resident's peak (recorded via note_loaded_peak — what the imminent evict frees) must land near
+    // the ACTUAL post-evict free, so the gate can admit resident before the evict has run.
+    note_loaded_peak(&gpu_id, occupied);
+    let pool = reclaimable_pool_gb(&gpu_id);
+    assert!(
+        pool >= occupied - 1e-6,
+        "note_loaded_peak/reclaimable_pool must record the occupied peak"
+    );
+    let predicted = with_reclaimable(loaded, pool); // the gate's view: reduced reading + reclaim credit
+    println!(
+        "[reclaim-smoke] gate credit: resident free {:.2} + peak {:.2} -> predicted {:.2} GB \
+         (measured post-evict {:.2})",
+        loaded.free_gb, pool, predicted.free_gb, after_drop.free_gb
+    );
+    assert!(
+        (predicted.free_gb - after_drop.free_gb).abs() < 3.0,
+        "the reclaim credit must predict the post-evict free within a few GB (predicted {:.2} vs \
+         measured {:.2}) — otherwise the gate admits against a budget the evict never delivers",
+        predicted.free_gb,
+        after_drop.free_gb
+    );
+    // For the flip below, budget the render against the actual reclaimed free (measured post-evict).
+    let reclaimed = after_drop;
+
+    // ---- (4) the gate plan FLIPS: raw free below the resident peak downtiers; crediting the pooled
+    // pages readmits it resident. Uses the REAL occupied value as the resident peak. The "warm 2nd
+    // render" budget is forced deterministically (raw free just below the peak — what the retained pool
+    // does on a card sized ~2x the model — pooling `occupied` GB) so the flip is demonstrated regardless
+    // of how roomy THIS particular card is; the untouched post-drop nvidia budget is also checked when
+    // the card is constrained enough to exhibit the flip on its own reading.
+    let peak = Some(occupied);
+    let seq = Some(occupied * 0.6); // a plausible staged peak, safely below the resident peak
+    let constrained = VramBudget {
+        free_gb: occupied - 1.0,
+        total_gb: baseline.total_gb,
+    };
+    let raw_plan = load_plan(peak, seq, Some(constrained), true);
+    let fixed_plan = load_plan(
+        peak,
+        seq,
+        Some(with_reclaimable(constrained, occupied)),
+        true,
+    );
+    println!(
+        "[reclaim-smoke] deterministic flip (real peak {occupied:.2} GB, free {:.2}): raw={raw_plan:?} \
+         -> reclaimed={fixed_plan:?}",
+        constrained.free_gb
+    );
+    assert_ne!(
+        raw_plan,
+        LoadPlan::Resident,
+        "raw free below the resident peak must NOT admit resident — that is the needless downtier \
+         sc-13960 fixes"
+    );
+    assert_eq!(
+        fixed_plan,
+        LoadPlan::Resident,
+        "reclaiming the pool must readmit the warm render at full residency"
+    );
+
+    // If this card's real post-drop free is already below the peak, the same flip holds on the
+    // untouched nvidia-smi reading — the fully-natural warm-2nd-run condition.
+    if after_drop.free_gb < occupied {
+        assert_ne!(
+            load_plan(peak, seq, Some(after_drop), true),
+            LoadPlan::Resident
+        );
+        assert_eq!(
+            load_plan(peak, seq, Some(reclaimed), true),
+            LoadPlan::Resident
+        );
+        println!("[reclaim-smoke] natural flip on the real post-drop budget ALSO verified");
+    } else {
+        println!(
+            "[reclaim-smoke] (card too roomy — post-drop free {:.2} >= peak {occupied:.2} — for a \
+             fully-natural downtier; the deterministic flip above used the real occupied peak)",
+            after_drop.free_gb
+        );
+    }
+
+    // ---- (5) warm 2nd run: reload (reusing the pooled pages) + render resident, no OOM ----
+    let (out2, engine2) = render("render#2 (warm)");
+    let std2 = image_std(&out2);
+    assert!(
+        std2 >= DEGENERATE_STD_FLOOR_DEFAULT,
+        "warm render #2 degenerate (std {std2:.3})"
+    );
+    drop(engine2);
+    save_png(&out2, &out_dir.join(format!("{model}_warm2nd_{w}x{h}.png")));
+    println!(
+        "[reclaim-smoke] warm 2nd-run rendered resident OK (std {std2:.2}) — sc-13960 validated"
+    );
+}

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -251,6 +251,55 @@ pub(crate) fn sequential_overflow_gb(
     (budget.free_gb + f64::EPSILON < needed_gb).then_some(needed_gb)
 }
 
+/// The resolved residency PLAN for a sequential-capable candle image lane: the pure composition of
+/// [`fit_decision`] → [`resolve_offload`] → [`sequential_overflow_gb`] that base.rs's txt2img gate and
+/// the bespoke Qwen-Edit gate share. Carries only the ACTION — never a budget-derived number — so two
+/// plans computed against different budgets compare equal **iff they take the same action**. That is
+/// the invariant the sc-13960 evict-then-reclaim two-pass leans on: gate once against raw free and once
+/// against `free + reclaimable_pool`, and evict only when the plan actually improves (never for two
+/// rejects that differ only in their reported free-VRAM number).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LoadPlan {
+    /// Load at full residency — the whole-model resident peak fits (or the tier is unmeasured, so the
+    /// gate never blocks).
+    Resident,
+    /// Load with sequential component residency — the resident peak overflows but the staged working
+    /// set fits (or its peak is unmeasured, so best-effort staging).
+    Sequential,
+    /// Reject before OOM — the resident peak overflows AND either the measured sequential peak also
+    /// overflows or the engine cannot stage.
+    Reject,
+}
+
+/// Resolve the [`LoadPlan`] for `needed` (resident peak) and `sequential_needed` (measured staged peak,
+/// [`predicted_sequential_peak_gb`]) against `budget`. `None` peaks are unmeasured ⇒ never block (admit
+/// resident, or stage best-effort). `sequential_capable` is the provider's staging capability: a lane
+/// that cannot stage turns a resident overflow straight into [`LoadPlan::Reject`].
+///
+/// Monotonic in the budget: a larger `free_gb` can only move the plan `Reject → Sequential → Resident`,
+/// never the other way — which is what makes "plan changed after reclaim ⇒ plan improved" sound.
+pub(crate) fn load_plan(
+    needed: Option<f64>,
+    sequential_needed: Option<f64>,
+    budget: Option<VramBudget>,
+    sequential_capable: bool,
+) -> LoadPlan {
+    match resolve_offload(fit_decision(needed, budget), sequential_capable) {
+        FitDecision::Offload { .. } => {
+            if sequential_overflow_gb(sequential_needed, budget).is_some() {
+                LoadPlan::Reject
+            } else {
+                LoadPlan::Sequential
+            }
+        }
+        // Reached only when the engine cannot stage (resolve_offload leaves TooBig intact); a
+        // sequential-capable lane rewrites TooBig → Offload above.
+        FitDecision::TooBig { .. } => LoadPlan::Reject,
+        // Fits (resident) or Unknown (unmeasured / no budget) — admit resident, never block.
+        _ => LoadPlan::Resident,
+    }
+}
+
 // ---------------------------------------------------------------------------------------------
 // Mochi 1: the FRAME-DEPENDENT decode fit gate, candle/CUDA half (epic 1788 / sc-12306)
 // ---------------------------------------------------------------------------------------------
@@ -1069,6 +1118,97 @@ mod tests {
                 free_gb: 96.0,
                 total_gb: 96.0,
             }
+        );
+    }
+
+    /// [`load_plan`] resolves the residency ACTION for a sequential-capable lane and ignores the
+    /// budget's reported numbers in its identity — the invariant the sc-13960 two-pass relies on.
+    #[test]
+    fn load_plan_resolves_resident_sequential_and_reject() {
+        let needed = Some(56.7); // resident peak
+        let seq = Some(30.0); // measured staged peak
+        let big = Some(VramBudget {
+            free_gb: 90.0,
+            total_gb: 96.0,
+        });
+        let mid = Some(VramBudget {
+            free_gb: 40.0,
+            total_gb: 96.0,
+        });
+        let tiny = Some(VramBudget {
+            free_gb: 10.0,
+            total_gb: 96.0,
+        });
+        // Resident peak fits ⇒ Resident.
+        assert_eq!(load_plan(needed, seq, big, true), LoadPlan::Resident);
+        // Resident overflows but the staged peak fits ⇒ Sequential.
+        assert_eq!(load_plan(needed, seq, mid, true), LoadPlan::Sequential);
+        // Even the staged peak overflows ⇒ Reject.
+        assert_eq!(load_plan(needed, seq, tiny, true), LoadPlan::Reject);
+        // A NON-sequential-capable lane rejects a resident overflow outright (no staging).
+        assert_eq!(load_plan(needed, seq, mid, false), LoadPlan::Reject);
+        // Unmeasured peak or no budget ⇒ never block (Resident).
+        assert_eq!(load_plan(None, seq, mid, true), LoadPlan::Resident);
+        assert_eq!(load_plan(needed, seq, None, true), LoadPlan::Resident);
+        // Two Rejects against different budgets are the SAME plan (no budget number in the identity),
+        // so the two-pass never evicts for a reclaim that still can't fit.
+        assert_eq!(
+            load_plan(needed, seq, tiny, true),
+            load_plan(needed, seq, mid, false)
+        );
+    }
+
+    /// sc-13960: on a warm worker, folding the reclaimable pool FLIPS a bespoke edit lane's plan from a
+    /// needless sequential downtier (and from an outright reject) back to a full-residency admit — the
+    /// exact repeated-render scenarios the story names. Pins the arithmetic the two-pass evict-reclaim
+    /// gate performs (`load_plan(raw)` vs `load_plan(with_reclaimable(raw, pool))`).
+    #[test]
+    fn reclaim_flips_a_warm_edit_gate_back_to_resident() {
+        // Two q4 Qwen-Edits (peak 56.7) back-to-back on a 96 GB card: after edit #1 drops, cudarc holds
+        // ~56.7 GB in-pool, so edit #2's RAW free is ~39.3 GB.
+        let q4_needed = Some(56.7);
+        let q4_seq = Some(30.0);
+        let raw = Some(VramBudget {
+            free_gb: 39.3,
+            total_gb: 96.0,
+        });
+        // RAW free needlessly downtiers to sequential…
+        assert_eq!(
+            load_plan(q4_needed, q4_seq, raw, true),
+            LoadPlan::Sequential
+        );
+        // …but crediting the 56.7 GB pool the first edit left behind readmits it RESIDENT.
+        let reclaimed = raw.map(|b| with_reclaimable(b, 56.7));
+        assert_eq!(
+            load_plan(q4_needed, q4_seq, reclaimed, true),
+            LoadPlan::Resident
+        );
+
+        // A repeated bf16 edit (81.7 resident / 52.2 sequential): after edit #1 drops, RAW free ~14.3 GB
+        // — the staged 52.2 overflows, so RAW REJECTS the second render.
+        let bf16_needed = Some(81.7);
+        let bf16_seq = Some(52.2);
+        let raw = Some(VramBudget {
+            free_gb: 14.3,
+            total_gb: 96.0,
+        });
+        assert_eq!(
+            load_plan(bf16_needed, bf16_seq, raw, true),
+            LoadPlan::Reject
+        );
+        // Reclaiming the 81.7 GB pool the first edit left behind readmits it RESIDENT.
+        let reclaimed = raw.map(|b| with_reclaimable(b, 81.7));
+        assert_eq!(
+            load_plan(bf16_needed, bf16_seq, reclaimed, true),
+            LoadPlan::Resident
+        );
+
+        // A cold pool (reclaimable 0) is a no-op: the raw plan stands, so a genuine first-load on a
+        // constrained card is gated exactly as before.
+        let reclaimed_cold = raw.map(|b| with_reclaimable(b, 0.0));
+        assert_eq!(
+            load_plan(bf16_needed, bf16_seq, reclaimed_cold, true),
+            load_plan(bf16_needed, bf16_seq, raw, true)
         );
     }
 


### PR DESCRIPTION
Fixes [sc-13960](https://app.shortcut.com/trefry/story/13960) — the evict-then-reclaim follow-up flagged by the sc-13588 review (#1708).

## Problem

candle's CUDA backend uses cudarc's caching allocator, so the txt2img gate (`base.rs generate_candle_stream`) folds `with_reclaimable(reclaimable_pool_gb(..))` into its VRAM budget — it loads **through** the single-slot generator cache (`with_cached_generator`), which **evicts** its resident occupant first, so that occupant's VRAM is genuinely reclaimable by the incoming load (sc-11023).

The bespoke candle **edit / control** lanes (`QwenEdit`, `KreaStrictControl`) do **not**: they load via the UNcached `start_gen_stream`, never touching the generator cache. sc-13588 documented that they therefore budget **RAW free** — a live co-resident txt2img generator's pages are *not* free, so crediting them against a raw gate would over-admit an OOM. That left the warm-swap false-reject / needless sequential downtier **unfixed** for these lanes: a bespoke edit/control render gated while a warm txt2img generator sits in the cache sees the reduced free and needlessly downtiers (or rejects) — even though evicting that generator would free exactly the room it needs.

## Fix

Give these lanes the missing lever, mirroring the shipped video `with_uncached_generator` (evict-then-reclaim) precedent:

- **`evict_cached_generator`** (`generator_cache.rs`) — an evict-only generator-cache-thread primitive callable from the bespoke `spawn_blocking` load path (the bespoke providers can't ride the cache's `Box<dyn Generator>` job type). Runs the exact `cache.evict()` + `release_backend_cache_after_evict()` pair as `with_uncached_generator`.
- **`gate_with_evict_reclaim`** (`base.rs`) — a **two-pass** gate driver shared by both lanes. It budgets **raw free first**, and only when crediting the reclaimable pool would admit the render at a **higher residency** does it evict the resident generator (making the credit honest) and act on the reclaimed plan.
- **`LoadPlan` / `load_plan`** (`vram_gate.rs`) — a pure, *action-only* residency decision (`Resident`/`Sequential`/`Reject`, no budget number in its identity) so the two-pass can compare "did reclaim change the outcome" without a stale-number false trigger.
- **Krea control now records its admitted peak** (`incurred_peak_gb` → `note_loaded_peak`). It recorded **none** before, so a repeated control render couldn't reclaim the prior render's pooled pages. `incurred_peak_gb` mirrors the fit-ladder arithmetic (resident/staged base peak minus each *engaged* rung's measured saving) and is proven never to over-count.

### The warm-cache tradeoff (decided)

Evicting sacrifices the warm txt2img generator cache (the next txt2img reloads cold). The story left this a per-lane decision. **Decision: evict only when it changes the outcome** — the two-pass keeps the warm cache on a clear big card (raw already admits resident → no evict) and evicts only when reclaiming actually flips a downtier/reject to a resident admit. Applied identically to both lanes.

### Scope

`base.rs`, `qwen_edit_candle.rs`, and `krea_control_candle.rs` are the **complete set** of reclaim-aware bespoke gates. Every other `start_gen_stream` lane (`sdxl`/`flux2`/`zimage` edit, the `flux1`/`flux2`/`kolors`/`zimage` control + the ipadapter/pulid lanes) has **no VRAM fit-gate at all**, so none can exhibit this downtier. Safety rests on `with_reclaimable`'s clamp-to-total, which bounds the credit even against a stale monotonic high-water.

## Testing

- **Unit (run on the RTX PRO 6000 box, `--features backend-candle`):** `load_plan` resolution; **reclaim-flip** for BOTH lanes (`load_plan(raw)=Sequential`/`Reject` → `load_plan(reclaimed)=Resident`; `fit_ladder` off its rungs); the evict primitive (frees the slot / no-ops when empty); an `incurred_peak_gb` non-over-count safety invariant. All 7 pass.
- **GPU validation (`qwen_edit_warm_reclaim_gpu_smoke`, RTX PRO 6000):** a resident QwenEdit occupies **45.7 GB**; evicting it frees **45.1 GB back**; the gate's reclaim credit predicts the post-evict free within **0.6 GB** (48.84 + 45.72 = 94.56 vs 93.97 measured); the plan flips **Sequential → Resident**; a warm 2nd render admits resident (no OOM). `fmt` + `clippy --features backend-candle --all-targets -D warnings` clean on the merged tree.

> **Note on the reclaim premise:** the GPU run showed that on this hardware a *full* generator drop returns most VRAM to the **driver** (`nvidia-smi` free rises), not a retained in-process pool as some existing docs frame it. Either way the evict frees the room the credit predicts — the same property the shipped video `with_uncached_generator` lane relies on — so the fix is correct regardless. The smoke asserts this honestly (evict *recovers* the VRAM; the credit *predicts* it) rather than the pool-retention framing.

## Review notes (from the adversarial pass — verdict SHIP)

- **New coupling (L1):** on the reclaim-improves path these lanes now depend on the generator-cache thread being alive (`evict_cached_generator().await?`); a dead cache worker (already an all-generation-failing state) now also fails an edit/control render there. Defensible; recorded here.
- **Krea GPU coverage (L2):** the GPU smoke is qwen-only. The load-bearing hardware fact (a resident generator occupies VRAM; evicting frees it; the credit predicts it) is **candle-device-level and model-agnostic**, so krea deliberately rides the qwen-validated shared premise; its lane-specific new code (`incurred_peak_gb`, the two-pass wiring) is pure arithmetic covered by mutation-resistant units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
