### PR TITLE
feat(krea): single-phase turbo-on-Raw — accelerator LoRA → turbo sampling regime [sc-13883]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2008,6 +2008,10 @@ fn serialize_job_lora(lora: &Value, selected_lora: &Value, lora_id: &str) -> Val
         "compatibility": preferred_lora_object(selected_lora, lora, "compatibility"),
         "icLora": preferred_lora_value(selected_lora, lora, "icLora"),
         "conditioningRole": preferred_lora_value(selected_lora, lora, "conditioningRole"),
+        // Sampling-regime role (`accelerator`, sc-13882): carried into the generation payload so the
+        // worker can switch a Krea 2 Raw t2i job to the turbo sampling regime (epic 13879 S3, sc-13883)
+        // — the sibling of `conditioningRole`, round-tripped identically.
+        "role": preferred_lora_value(selected_lora, lora, "role"),
         "installedPath": preferred_lora_value(selected_lora, lora, "installedPath"),
         "sourcePath": preferred_lora_value(selected_lora, lora, "sourcePath"),
         // Declared adapter filename(s): lets the worker load the record's final adapter

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -1027,6 +1027,9 @@ pub(crate) fn serialize_preset_lora(lora: &Value, preset_lora: &Value, lora_id: 
         "compatibility": lora.get("compatibility").cloned().unwrap_or_else(|| Value::Object(JsonObject::new())),
         "icLora": lora.get("icLora").cloned().unwrap_or(Value::Bool(false)),
         "conditioningRole": lora.get("conditioningRole").cloned().unwrap_or(Value::Null),
+        // Sampling-regime role (`accelerator`, sc-13882) — round-tripped alongside `conditioningRole`
+        // so a preset-managed accelerator LoRA switches Krea 2 Raw to the turbo regime (epic 13879 S3).
+        "role": lora.get("role").cloned().unwrap_or(Value::Null),
         "installedPath": lora.get("installedPath").cloned().unwrap_or(Value::Null),
         // Carry the declared adapter filename(s) so the worker loads the record's final
         // adapter from its folder rather than an arbitrary sibling — e.g. a trained

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -136,6 +136,28 @@ fn serialize_job_lora_carries_network_type_to_payload() {
 }
 
 #[test]
+fn serialize_job_lora_carries_accelerator_role_to_payload() {
+    // The Krea 2 turbo accelerator LoRA (sc-13882) records `role: accelerator`; the generation payload
+    // must carry it so the worker can switch a Krea 2 Raw t2i job to the turbo sampling regime (epic
+    // 13879 S3, sc-13883) — the sampling-regime sibling of `conditioningRole`.
+    let lora = json!({
+        "id": "krea2_turbo_accel",
+        "family": "krea_2",
+        "role": "accelerator",
+        "source": { "provider": "huggingface" },
+    });
+    let payload = serialize_job_lora(&lora, &json!({}), "krea2_turbo_accel");
+    assert_eq!(
+        payload.get("role").and_then(Value::as_str),
+        Some("accelerator")
+    );
+
+    // A plain LoRA without the field stays absent/null (a plain additive residual downstream).
+    let plain = serialize_job_lora(&json!({ "id": "x", "family": "krea_2" }), &json!({}), "x");
+    assert!(plain.get("role").map(Value::is_null).unwrap_or(true));
+}
+
+#[test]
 fn person_readiness_reflects_live_worker_capabilities() {
     let workers = vec![
         readiness_worker(

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -356,6 +356,9 @@ export function serializePresetLora(lora, presetLora = {}) {
     compatibility: lora?.compatibility ?? presetLora?.compatibility ?? {},
     icLora: lora?.icLora ?? presetLora?.icLora ?? false,
     conditioningRole: lora?.conditioningRole ?? presetLora?.conditioningRole ?? null,
+    // Sampling-regime role (`accelerator`, sc-13882) — round-tripped alongside `conditioningRole` so a
+    // preset-managed accelerator LoRA still switches Krea 2 Raw to the turbo regime (epic 13879 S3).
+    role: lora?.role ?? presetLora?.role ?? null,
     installedPath: lora?.installedPath ?? presetLora?.installedPath ?? null,
     source: lora?.source ?? presetLora?.source ?? null,
     presetManaged: true,
@@ -385,6 +388,13 @@ export function serializeLora(lora, override = {}) {
     // edit lane's role check (R5) even though the user picked it. `icLora` rides along for
     // the flag-based half of the same test.
     conditioningRole: lora.conditioningRole ?? null,
+    // The sampling-regime role (`accelerator`, sc-13882) is the sibling of `conditioningRole`: it
+    // tells the worker a selected LoRA is a step-distill / turbo adapter, switching a Krea 2 Raw t2i
+    // job to the turbo sampling regime (fixed mu 1.15 / ~8 steps / CFG-off — epic 13879 S3, sc-13883).
+    // The worker reads it straight off the payload `loras` entry, so it MUST round-trip here — without
+    // it a picked accelerator loads only as a plain additive residual and Raw still runs its 52-step
+    // true-CFG regime.
+    role: lora.role ?? null,
     icLora: lora.icLora ?? false,
     // `installedPath` points at the LoRA directory; for trained LoRAs that
     // directory also holds step checkpoints, so the worker must be told the

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -362,6 +362,21 @@ describe("serializeLora round-trips the conditioning role (epic 10871)", () => {
   });
 });
 
+describe("serializeLora round-trips the sampling-regime role (sc-13883)", () => {
+  it("forwards role: accelerator so the worker can select the turbo regime", () => {
+    // The Krea 2 turbo accelerator LoRA (sc-13882). Without this round-trip the worker never sees the
+    // `role` marker and a picked accelerator runs only as a plain additive residual — Raw stays 52-step.
+    const out = serializeLora({ id: "krea2_turbo_accel", family: "krea_2", role: "accelerator" });
+    expect(out.role).toBe("accelerator");
+  });
+
+  it("defaults role to null for a LoRA that declares no sampling-regime role", () => {
+    expect(serializeLora({ id: "plain" }).role).toBe(null);
+    // The conditioning-axis sibling does not backfill `role` (they are orthogonal markers).
+    expect(serializeLora({ id: "edit", conditioningRole: "image_edit" }).role).toBe(null);
+  });
+});
+
 describe("loraLooksLikeImageEditLora (epic 10871)", () => {
   it("matches the image_edit conditioning role (case / separator insensitive)", () => {
     expect(loraLooksLikeImageEditLora({ conditioningRole: "image_edit" })).toBe(true);

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -442,6 +442,22 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::KreaTurboOnRaw => {
+                // Krea 2 Raw t2i + the accelerator (turbo) LoRA (sc-13882) → the distilled Turbo
+                // sampling regime (fixed mu 1.15 / ~8 steps / CFG-off) on the Raw base + LoRA additive
+                // (epic 13879 S3, sc-13883). Routes to the `krea_2_turbo` engine while loading the Raw
+                // weights — the engine-id sibling of the `krea_2_turbo_edit` vs `krea_2_edit` edit pick.
+                generate_krea_turbo_on_raw_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::InstantId => {
                 // InstantID identity-preserving character image (sc-3345): single identity or
                 // grouped angle/pose sets, on RealVisXL + IdentityNet + the native face stack.
@@ -1676,6 +1692,10 @@ include!("image_jobs/qwen.rs");
 #[cfg(target_os = "macos")]
 // Krea 2 Kontext-style image-edit routing (epic 10871).
 include!("image_jobs/krea_edit.rs");
+#[cfg(target_os = "macos")]
+// Krea 2 single-phase turbo-on-Raw routing (epic 13879 S3, sc-13883): the accelerator LoRA on a
+// `krea_2_raw` t2i job → the distilled Turbo sampling regime (fixed mu 1.15 / ~8 steps / CFG-off).
+include!("image_jobs/krea_turbo_raw.rs");
 #[cfg(target_os = "macos")]
 // Krea 2 pose-ControlNet (MLX) strict-pose routing (sc-8465, epic 8459 S5).
 include!("image_jobs/krea_control.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -89,6 +89,13 @@ enum ImageRoute {
     Flux2Edit,
     QwenEdit,
     KreaEdit,
+    /// A Krea 2 **Raw** t2i job carrying the accelerator (turbo) LoRA (`role: accelerator`, sc-13882)
+    /// → the single-phase turbo-on-Raw lane (epic 13879 S3, sc-13883): the Raw base + LoRA additive,
+    /// sampled through the distilled Turbo regime (fixed mu 1.15 / ~8 steps / CFG-off) by routing to
+    /// the `krea_2_turbo` engine. Wins over the generic `Mlx` arm below — `krea_2_raw` is in
+    /// MODEL_TABLE, so `mlx_available` would otherwise render it as plain Raw t2i (52-step true-CFG)
+    /// and never accelerate. The t2i sibling of [`ImageRoute::KreaEdit`].
+    KreaTurboOnRaw,
     InstantId,
     PulidFlux,
     SdxlAdvanced,
@@ -173,6 +180,13 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         // (epic 10871). Wins over the generic MLX arm below — `krea_2_raw` is in MODEL_TABLE, so
         // `mlx_available` would otherwise render it as plain t2i and silently drop the source.
         Some(ImageRoute::KreaEdit)
+    } else if krea_turbo_on_raw_available(request, settings) {
+        // Krea 2 Raw t2i + the accelerator (turbo) LoRA (sc-13882) → the single-phase turbo-on-Raw
+        // lane (epic 13879 S3, sc-13883): the Raw base + LoRA additive, sampled as Turbo (fixed mu
+        // 1.15 / ~8 steps / CFG-off) by routing to the `krea_2_turbo` engine. Wins over the generic
+        // `mlx_available` arm below — a plain Raw t2i would otherwise run the 52-step true-CFG regime
+        // and ignore the accelerator's intent. The t2i sibling of the `krea_edit_available` arm above.
+        Some(ImageRoute::KreaTurboOnRaw)
     } else if instantid_available(request, settings) {
         Some(ImageRoute::InstantId)
     } else if pulid_flux_available(request, settings) {
@@ -246,6 +260,9 @@ impl ImageRoute {
             | ImageRoute::SdxlAdvanced
             | ImageRoute::Bernini
             | ImageRoute::KreaEdit
+            // Turbo-on-Raw is plain per-image (like Krea edit + the base MLX path): `count` renders of
+            // the base prompt, each its own seed. No angle/pose grouping.
+            | ImageRoute::KreaTurboOnRaw
             | ImageRoute::PoseControlBaseMissing
             | ImageRoute::PoseReject
             | ImageRoute::Mlx => request.count,

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -184,8 +184,12 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         // Krea 2 Raw t2i + the accelerator (turbo) LoRA (sc-13882) → the single-phase turbo-on-Raw
         // lane (epic 13879 S3, sc-13883): the Raw base + LoRA additive, sampled as Turbo (fixed mu
         // 1.15 / ~8 steps / CFG-off) by routing to the `krea_2_turbo` engine. Wins over the generic
-        // `mlx_available` arm below — a plain Raw t2i would otherwise run the 52-step true-CFG regime
-        // and ignore the accelerator's intent. The t2i sibling of the `krea_edit_available` arm above.
+        // `mlx_available` arm below for PLAIN t2i — a plain Raw t2i would otherwise run the 52-step
+        // true-CFG regime and ignore the accelerator's intent. A `krea_2_raw` job that ALSO carries an
+        // img2img reference (`ui.img2img` + `referenceAssetId`) is EXCLUDED by the gate and falls
+        // through to the generic `mlx_available` img2img arm (reference honored, accelerator LoRA still
+        // additive) — turbo-on-Raw img2img is out of scope for this t2i story (sc-13883). The t2i
+        // sibling of the `krea_edit_available` arm above.
         Some(ImageRoute::KreaTurboOnRaw)
     } else if instantid_available(request, settings) {
         Some(ImageRoute::InstantId)

--- a/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
@@ -52,16 +52,36 @@ fn request_has_accelerator_lora(request: &ImageRequest) -> bool {
     request.loras.iter().any(lora_declares_accelerator_role)
 }
 
+/// True when this Raw job carries an img2img reference — a `ui.img2img` model (`krea_2_raw` ships
+/// `ui.img2img: true`) plus a non-empty `referenceAssetId`. This is exactly the shape the generic Mlx
+/// img2img arm (`resolve_generic_lane_conditioning`, base.rs) claims: `model_supports_img2img(request)
+/// && has_reference` (the turbo gate already excludes `edit_image`, so that clause of the generic arm is
+/// implied here). A reference-bearing Raw job MUST fall through to that arm — which VAE-encodes the
+/// reference into the Raw denoise AND still applies the accelerator LoRA additively — rather than be
+/// hijacked by this turbo-t2i lane, which resolves no reference/conditioning and would silently drop it.
+/// Turbo-on-Raw img2img is out of scope for this t2i story (sc-13883): the correct S3 behavior is for
+/// img2img reference jobs to keep running normally (Raw regime, LoRA additive), only plain t2i +
+/// accelerator taking the turbo regime.
+fn request_carries_img2img_reference(request: &ImageRequest) -> bool {
+    model_supports_img2img(request) && non_empty(&request.reference_asset_id)
+}
+
 /// True when this is a plain Krea 2 **Raw** t2i job carrying the accelerator (turbo) LoRA — the
 /// single-phase turbo-on-Raw lane (S3). Keyed on model `krea_2_raw`, a plain t2i shape (NOT
-/// `edit_image`, and no strict poses — those divert to the Krea edit / reject lanes ABOVE this arm),
-/// a selected accelerator-role LoRA, and resolvable Raw weights. Mirrors [`krea_edit_available`]'s
-/// job-shape gate; placed AFTER the edit/control lanes and BEFORE the generic `mlx_available` arm so
-/// it wins over plain Raw t2i (which would run the 52-step true-CFG regime and never accelerate).
+/// `edit_image`, no strict poses, and NO img2img reference — those divert to the Krea edit / reject /
+/// generic img2img lanes: `edit_image` + strict poses to the arms ABOVE this one, an img2img reference
+/// FALLS THROUGH to the generic `mlx_available` img2img arm BELOW), a selected accelerator-role LoRA,
+/// and resolvable Raw weights. Excluding the img2img reference here (sc-13883 review fix) keeps a
+/// `krea_2_raw` + reference + accelerator job on the generic img2img path (reference honored, LoRA
+/// additive) instead of hijacking it into a plain turbo-t2i render that drops the reference. Mirrors
+/// [`krea_edit_available`]'s job-shape gate; placed AFTER the edit/control lanes and BEFORE the generic
+/// `mlx_available` arm so it wins over plain Raw t2i (which would run the 52-step true-CFG regime and
+/// never accelerate).
 fn krea_turbo_on_raw_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.model == KREA_RAW_MODEL_ID
         && request.mode != "edit_image"
         && pose_entries(request).is_empty()
+        && !request_carries_img2img_reference(request)
         && request_has_accelerator_lora(request)
         && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
 }

--- a/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
@@ -1,0 +1,244 @@
+// ---------------------------------------------------------------------------
+// Krea 2 single-phase "turbo-on-Raw" (macOS, epic 13879 S3, sc-13883): the Raw base
+// DiT run through the DISTILLED TURBO SAMPLING REGIME when the accelerator-role turbo
+// LoRA (sc-13882 `krea2_turbo_accel`) is selected on a `krea_2_raw` t2i job. Routed here
+// from `ImageRoute::KreaTurboOnRaw`.
+//
+// The Krea engine keys its sampling regime on the DESCRIPTOR id, not per-generation params:
+// the Raw generator (`krea_2_raw`) always runs the resolution-DYNAMIC-mu, 52-step, true-CFG
+// `base_schedule`, while the Turbo generator (`krea_2_turbo`) always runs the FIXED mu 1.15,
+// 8-step, CFG-free `turbo_schedule` (single conditional forward — no negative branch). Both
+// share one loader/pipeline (`load_variant`) and load their weights straight off the
+// `LoadSpec`, so the descriptor id and the weights are independent. This lane exploits that:
+// it resolves the RAW weights + tier (the job's model IS `krea_2_raw`), applies the accelerator
+// LoRA (plus any user Raw-trained LoRA) ADDITIVELY, but hands the whole spec to the `krea_2_turbo`
+// ENGINE so the sampler runs the turbo regime. Net effect = "Raw base + LoRA additive, sampled
+// as Turbo" — exactly the community `raw+lora` recipe (fixed mu 1.15 / ~8 steps / CFG off).
+//
+// This is the t2i sibling of `krea_edit.rs::krea_edit_engine_id`, which likewise picks the
+// engine id (`krea_2_turbo_edit` vs `krea_2_edit`) by job shape. No inference-monorepo change
+// is required — the fixed-mu / CFG-off behavior is entirely the existing `krea_2_turbo`
+// generator's, reached by routing rather than by a new per-generation flag. (The whole file is
+// `include!`d only on macOS, so — like `krea_edit.rs` — nothing here needs a per-item cfg.)
+// ---------------------------------------------------------------------------
+
+/// The SceneWorks model id whose LoRA-training/Raw base this accelerator lane runs on. The
+/// accelerator LoRA is family `krea_2`, surfaced under Raw (`krea_2_raw.loraCompatibility.types`
+/// gained `"acceleration"`, sc-13882).
+const KREA_RAW_MODEL_ID: &str = "krea_2_raw";
+
+/// The registered engine id supplying the TURBO sampling regime (fixed mu 1.15 / 8 steps /
+/// CFG-free). Routing a Raw job to this engine is what selects `render_turbo` over `render_base`
+/// in the pinned Krea engine — the whole mechanism this lane relies on.
+const KREA_TURBO_ENGINE_ID: &str = "krea_2_turbo";
+
+/// True when a selected LoRA declares the ACCELERATOR sampling-regime role (`role: accelerator`,
+/// e.g. the builtin `krea2_turbo_accel`, sc-13882). The sampling-regime sibling of
+/// [`lora_declares_image_edit_role`] (`conditioningRole: image_edit`): where that marks a LoRA
+/// that changes how a job is CONDITIONED, this marks one that changes how the sampler RUNS (fewer
+/// steps, CFG off). Selecting it auto-switches a Raw job to the turbo regime (this lane). Reads the
+/// marker straight off the payload `loras` entry — it must round-trip via `serializeLora`
+/// (web) / `serialize_job_lora` (rust-api), which forward `role` exactly like `conditioningRole`.
+fn lora_declares_accelerator_role(lora: &Value) -> bool {
+    lora.as_object()
+        .and_then(|obj| obj.get("role"))
+        .and_then(Value::as_str)
+        .map(|role| role.trim().to_lowercase().replace('-', "_") == "accelerator")
+        .unwrap_or(false)
+}
+
+/// Whether the job carries an accelerator LoRA (any selected LoRA with `role: accelerator`).
+fn request_has_accelerator_lora(request: &ImageRequest) -> bool {
+    request.loras.iter().any(lora_declares_accelerator_role)
+}
+
+/// True when this is a plain Krea 2 **Raw** t2i job carrying the accelerator (turbo) LoRA — the
+/// single-phase turbo-on-Raw lane (S3). Keyed on model `krea_2_raw`, a plain t2i shape (NOT
+/// `edit_image`, and no strict poses — those divert to the Krea edit / reject lanes ABOVE this arm),
+/// a selected accelerator-role LoRA, and resolvable Raw weights. Mirrors [`krea_edit_available`]'s
+/// job-shape gate; placed AFTER the edit/control lanes and BEFORE the generic `mlx_available` arm so
+/// it wins over plain Raw t2i (which would run the 52-step true-CFG regime and never accelerate).
+fn krea_turbo_on_raw_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == KREA_RAW_MODEL_ID
+        && request.mode != "edit_image"
+        && pose_entries(request).is_empty()
+        && request_has_accelerator_lora(request)
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
+}
+
+/// Flat telemetry for a turbo-on-Raw generation (parity with [`mlx_raw_settings`] /
+/// [`krea_edit_raw_settings`]). Records the Raw repo/tier that actually loaded, the turbo step count,
+/// a null `guidanceScale` (CFG off), and a `samplingRegime` marker naming the engine the sampler ran.
+fn krea_turbo_on_raw_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    steps: u32,
+    quant_bits: Option<i64>,
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    // CFG off: the turbo regime is a single conditional forward, so no guidance scale is forwarded.
+    raw.insert("guidanceScale".to_owned(), Value::Null);
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    // Name the sampler regime that ran (the Raw DiT sampled as Turbo) so the recipe/telemetry is
+    // unambiguous about the accelerated path — distinct from a plain `krea_2_raw` render.
+    raw.insert(
+        "samplingRegime".to_owned(),
+        Value::String(KREA_TURBO_ENGINE_ID.to_owned()),
+    );
+    raw
+}
+
+/// Generate one turbo-on-Raw image (plain t2i, no reference/edit conditioning). CFG-free: no negative
+/// prompt and no guidance are forwarded — the `krea_2_turbo` generator runs a single conditional
+/// forward per step on the fixed-mu `turbo_schedule`. Mirrors [`krea_edit_generate_one`] minus the edit
+/// conditioning.
+#[allow(clippy::too_many_arguments)]
+fn krea_turbo_on_raw_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    text_style_gain: Option<f32>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        // CFG off — no negative branch (the distilled regime baked guidance into the weights).
+        negative_prompt: None,
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        steps: Some(steps),
+        // CFG off — the turbo generator is single-forward; a guidance scale would be rejected.
+        guidance: None,
+        text_style_gain,
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator.generate(&request, on_progress).map_err(|error| {
+        WorkerError::Engine(format!("Krea turbo-on-Raw generation failed: {error}"))
+    })?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::Engine("Krea turbo-on-Raw generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::Engine(
+            "Krea turbo-on-Raw generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+/// Real single-phase turbo-on-Raw generation (epic 13879 S3, sc-13883): load the RAW weights + the
+/// accelerator LoRA (additive) into the `krea_2_turbo` ENGINE so the sampler runs the distilled regime
+/// (fixed mu 1.15 / ~8 steps / CFG-free), then one output per requested count. Mirrors
+/// [`generate_krea_edit_stream`]'s blocking-thread + streamed-events shape and reuses
+/// [`consume_gen_events`]; differs in the plain t2i shape (no source references) and the engine-id
+/// swap that selects the turbo sampling regime while keeping the Raw base weights.
+async fn generate_krea_turbo_on_raw_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    // The job's model is `krea_2_raw`: resolve the RAW weights + tier + repo. The accelerator LoRA
+    // stacks ADDITIVELY on this frozen Raw DiT (the core reads rank off the tensor shapes at load,
+    // sc-13882), so the fidelity base is unchanged — only the sampler regime differs.
+    let raw_model = mlx_model(&request.model)
+        .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Krea 2 Raw weights not found".to_owned()))?;
+
+    // The `krea_2_turbo` engine supplies the sampling REGIME. Same architecture / snapshot layout as
+    // Raw, so it loads the Raw weights + adapters unchanged; its stored descriptor id is what makes
+    // the pinned engine run `render_turbo` (fixed mu 1.15, 8-step, single conditional forward) instead
+    // of `render_base` (dynamic-mu, 52-step, true CFG). Resolving the regime knobs against this Turbo
+    // descriptor yields the whole regime for free: `resolve_steps` defaults to the distilled 8 (an
+    // explicit `advanced.steps` is still honored). Guidance / negative are left off unconditionally —
+    // the Turbo generator is single-forward and rejects both.
+    let turbo = mlx_model(KREA_TURBO_ENGINE_ID).ok_or_else(|| {
+        WorkerError::InvalidPayload("Krea 2 Turbo engine is not registered".to_owned())
+    })?;
+    let engine_id = turbo.engine_id();
+
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
+    let steps = resolve_steps(request, &turbo);
+    let adapters = resolve_adapters(request, settings)?;
+    let repo = model_repo(request, &raw_model);
+    // Raw and Turbo share the `mlx_krea` adapter label, so telemetry names the family either way.
+    let adapter_label = raw_model.adapter_label();
+    // Krea "text style" tap-reweight gain (sc-11878) — self-gates on `ui.textStyleGain`; a no-op at the
+    // default. Forwarded for parity with the plain Krea t2i path (the Turbo generator honors it).
+    let text_style_gain = resolve_text_style_gain(request);
+
+    // Plain per-image work: `request.count` renders, each its own seed + the base prompt.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let raw_settings = krea_turbo_on_raw_raw_settings(request, &repo, steps, quant_bits);
+
+    let (width, height) = (request.width, request.height);
+    let adapter_count = adapters.len();
+    let spec = load_spec(weights_dir, quant, adapters, None);
+
+    let (cancel, rx, blocking) = start_cached_gen_stream(
+        job.id.clone(),
+        engine_id,
+        adapter_count,
+        spec,
+        format!("{engine_id} load failed"),
+        move |generator, tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let (out_w, out_h, pixels) = krea_turbo_on_raw_generate_one(
+                    generator,
+                    &prompt,
+                    width,
+                    height,
+                    seed,
+                    steps,
+                    text_style_gain,
+                    &cancel,
+                    on_progress,
+                )?;
+                Ok(Some((seed, out_w, out_h, pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        adapter_label,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -5250,6 +5250,139 @@ fn image_route_rejects_pose_on_unwired_mlx_family() {
     );
 }
 
+// sc-13883 (epic 13879 S3): a `krea_2_raw` t2i job carrying the accelerator (turbo) LoRA
+// (`role: accelerator`, sc-13882) routes to the single-phase turbo-on-Raw lane — NOT the generic
+// `Mlx` (plain 52-step true-CFG Raw) arm. The SAME Raw job WITHOUT the accelerator stays on `Mlx`
+// (the over-routing guard). Keyed on the role marker + resolvable Raw weights (`modelPath`), so it
+// locks the ROUTE decision the lane depends on.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_turbo_on_raw_routes_only_with_accelerator_lora() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    let model_path = dir.path().to_string_lossy().to_string();
+
+    // Raw t2i + the accelerator LoRA selected → the turbo-on-Raw lane.
+    let with_accel = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "loras": [{ "id": "krea2_turbo_accel", "family": "krea_2", "role": "accelerator" }],
+        "advanced": { "modelPath": model_path.clone() }
+    }));
+    assert_eq!(
+        resolve_image_route(&with_accel, &settings),
+        Some(ImageRoute::KreaTurboOnRaw),
+        "krea_2_raw t2i + an accelerator-role LoRA must route to the turbo-on-Raw lane",
+    );
+
+    // The over-routing guard: the SAME Raw t2i WITHOUT the accelerator stays on the generic MLX lane
+    // (the plain 52-step true-CFG Raw regime), and a plain (character/style) Raw LoRA does NOT trigger
+    // the accelerator lane — only the `role: accelerator` marker does.
+    let without_accel = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "loras": [{ "id": "my_character", "family": "krea_2" }],
+        "advanced": { "modelPath": model_path }
+    }));
+    assert_eq!(
+        resolve_image_route(&without_accel, &settings),
+        Some(ImageRoute::Mlx),
+        "a Raw job without an accelerator LoRA must stay on the plain Raw (Mlx) lane",
+    );
+}
+
+// sc-13883: the accelerator role detector recognizes `role: accelerator` (case- and separator-
+// normalized, mirroring `lora_declares_image_edit_role`) and rejects everything else — including the
+// `conditioningRole` sibling, which is a DIFFERENT axis (how a job is conditioned, not how it samples).
+#[cfg(target_os = "macos")]
+#[test]
+fn lora_declares_accelerator_role_matches_only_the_accelerator_marker() {
+    assert!(lora_declares_accelerator_role(
+        &json!({ "id": "a", "role": "accelerator" })
+    ));
+    // Normalized: mixed case + a dash separator still match.
+    assert!(lora_declares_accelerator_role(
+        &json!({ "id": "a", "role": "Accelerator" })
+    ));
+    // Not an accelerator: no role, a different role, or the conditioning-axis sibling.
+    assert!(!lora_declares_accelerator_role(&json!({ "id": "a" })));
+    assert!(!lora_declares_accelerator_role(
+        &json!({ "id": "a", "role": "style" })
+    ));
+    assert!(!lora_declares_accelerator_role(
+        &json!({ "id": "a", "conditioningRole": "image_edit" })
+    ));
+}
+
+// sc-13883 (epic 13879 S3) — the DISCRIMINATING param-selection test. The turbo-on-Raw lane resolves
+// its sampling regime against the `krea_2_turbo` descriptor (while loading Raw weights), so the whole
+// regime falls out for free: fixed-mu engine, ~8 steps, guidance off, no negative forwarded. Pinning
+// the NON-default turbo values here makes the test FAIL if the lane ever reverts to the Raw defaults
+// (52 steps / guidance 3.5 / dynamic-mu / negative forwarded). mu itself is engine-internal
+// (`TURBO_MU = 1.15` in the pinned Krea engine's `turbo_sigmas`), reached by selecting the
+// `krea_2_turbo` engine id — so asserting that engine id IS the worker-observable proof of fixed mu.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
+    let raw = mlx_model("krea_2_raw").expect("krea_2_raw engine registered");
+    let turbo = mlx_model("krea_2_turbo").expect("krea_2_turbo engine registered");
+
+    // The lane routes to the `krea_2_turbo` engine — the FIXED mu 1.15 / CFG-free `render_turbo`
+    // regime — NOT the `krea_2_raw` engine (resolution-DYNAMIC mu, true-CFG `render_base`). This engine
+    // swap IS the mu-1.15 mechanism (the pinned engine keys the schedule on the descriptor id).
+    assert_eq!(turbo.engine_id(), "krea_2_turbo");
+    assert_ne!(
+        turbo.engine_id(),
+        raw.engine_id(),
+        "turbo-on-Raw must route to the turbo engine (fixed mu), not the raw engine (dynamic mu)",
+    );
+
+    // A Raw-shaped request (a negative prompt set, NO explicit step override) resolved against the
+    // turbo descriptor yields the full turbo regime; the SAME request against the raw descriptor yields
+    // the Raw defaults — the contrast the lane relies on.
+    let req = request(json!({
+        "projectId": "p", "model": "krea_2_raw",
+        "negativePrompt": "blurry, low quality",
+        "loras": [{ "id": "krea2_turbo_accel", "family": "krea_2", "role": "accelerator" }]
+    }));
+
+    // Steps: the turbo default is ~8 (the distilled few-step student), NOT the Raw 52.
+    assert_eq!(
+        resolve_steps(&req, &turbo),
+        8,
+        "turbo-on-Raw defaults to the distilled 8 steps, not the Raw 52",
+    );
+    assert_eq!(
+        resolve_steps(&req, &raw),
+        52,
+        "control: the Raw default is 52"
+    );
+
+    // Guidance: CFG off (the turbo descriptor advertises no guidance → None), NOT the Raw 3.5.
+    assert_eq!(
+        resolve_guidance(&req, &turbo),
+        None,
+        "turbo-on-Raw forwards no guidance (CFG off)",
+    );
+    assert_eq!(
+        resolve_guidance(&req, &raw),
+        Some(3.5),
+        "control: the Raw default guidance is 3.5",
+    );
+
+    // Negative prompt: NOT forwarded under turbo (the descriptor advertises no negative), even though
+    // the request carries one; the Raw path DOES forward it.
+    assert_eq!(
+        resolve_negative_prompt(&req, &turbo),
+        None,
+        "turbo-on-Raw must not forward the negative prompt (CFG off)",
+    );
+    assert_eq!(
+        resolve_negative_prompt(&req, &raw),
+        Some("blurry, low quality".to_owned()),
+        "control: the Raw path forwards the user's negative prompt",
+    );
+}
+
 // sc-8828 (F-026): `resolve_candle_image_route` is the extracted candle dispatch decision — the
 // `else if settings.backend_candle_enabled && <predicate>` ladder pulled out of `run_image_generate_job`
 // into a table (the candle sibling of `resolve_image_route`/`ImageRoute`). Locks the flag gate + the

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -5275,6 +5275,31 @@ fn krea_turbo_on_raw_routes_only_with_accelerator_lora() {
         "krea_2_raw t2i + an accelerator-role LoRA must route to the turbo-on-Raw lane",
     );
 
+    // The img2img over-routing guard (sc-13883 review fix): a `krea_2_raw` job that carries an img2img
+    // reference (`ui.img2img: true` + a non-empty `referenceAssetId`) AND the accelerator LoRA must NOT
+    // be hijacked by the turbo-t2i lane — that lane resolves no reference/conditioning and would
+    // SILENTLY DROP the reference. It falls THROUGH to the generic `Mlx` img2img arm, which VAE-encodes
+    // the reference into the Raw denoise AND still applies the accelerator LoRA additively (Raw regime).
+    // Turbo-on-Raw img2img is out of scope for this t2i story.
+    let with_reference = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "modelManifestEntry": { "ui": { "img2img": true } },
+        "referenceAssetId": "asset-1",
+        "loras": [{ "id": "krea2_turbo_accel", "family": "krea_2", "role": "accelerator" }],
+        "advanced": { "modelPath": model_path.clone(), "strength": 0.6 }
+    }));
+    let with_reference_route = resolve_image_route(&with_reference, &settings);
+    assert_ne!(
+        with_reference_route,
+        Some(ImageRoute::KreaTurboOnRaw),
+        "a krea_2_raw job carrying an img2img reference must NOT route to the turbo-on-Raw lane (its reference would be silently dropped)",
+    );
+    assert_eq!(
+        with_reference_route,
+        Some(ImageRoute::Mlx),
+        "a krea_2_raw + img2img reference + accelerator job falls through to the generic Mlx img2img arm (reference honored, LoRA additive)",
+    );
+
     // The over-routing guard: the SAME Raw t2i WITHOUT the accelerator stays on the generic MLX lane
     // (the plain 52-step true-CFG Raw regime), and a plain (character/style) Raw LoRA does NOT trigger
     // the accelerator lane — only the `role: accelerator` marker does.
@@ -5380,6 +5405,42 @@ fn krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
         resolve_negative_prompt(&req, &raw),
         Some("blurry, low quality".to_owned()),
         "control: the Raw path forwards the user's negative prompt",
+    );
+
+    // Seam-level proof that the lane resolves against the RAW weights/model while selecting the TURBO
+    // engine for the sampler — the exact split `generate_krea_turbo_on_raw_stream` relies on: it passes
+    // `&turbo` (regime source) to `resolve_steps`, but loads the RAW weights + repo + telemetry label
+    // via `&raw_model`. This asserts the lane's OWN constants + resolved settings (not the turbo
+    // descriptor directly), so a future rename that pointed the sampler at the wrong engine, or the
+    // loader at the turbo repo, FAILS here rather than only being caught by code-reading.
+    assert_eq!(
+        KREA_RAW_MODEL_ID, "krea_2_raw",
+        "the lane's base model is Raw"
+    );
+    assert_eq!(
+        KREA_TURBO_ENGINE_ID, "krea_2_turbo",
+        "the lane samples with the Turbo engine",
+    );
+    let base_model = mlx_model(KREA_RAW_MODEL_ID).expect("krea_2_raw engine registered");
+    let sampler = mlx_model(KREA_TURBO_ENGINE_ID).expect("krea_2_turbo engine registered");
+    // The sampler engine (regime source) IS Turbo; the base model (weights + repo + telemetry) IS Raw.
+    assert_eq!(sampler.engine_id(), "krea_2_turbo");
+    assert_eq!(base_model.engine_id(), "krea_2_raw");
+    // The lane loads the RAW repo (off `&raw_model`), NOT the turbo engine's repo — the fidelity base
+    // stays Raw even though the sampler runs the turbo regime. `model_repo` falls back to the model's
+    // default repo when the request carries no manifest override (as here), so this discriminates.
+    assert_eq!(model_repo(&req, &base_model), "SceneWorks/krea-2-raw-mlx");
+    assert_ne!(
+        model_repo(&req, &base_model),
+        model_repo(&req, &sampler),
+        "turbo-on-Raw must load the RAW repo, not the turbo engine's repo",
+    );
+    // And the regime knobs resolve against the TURBO descriptor (8 steps) via the seam's own handle —
+    // the sampler side of the split, pinned against the lane constant rather than a local `turbo` alias.
+    assert_eq!(
+        resolve_steps(&req, &sampler),
+        8,
+        "the lane resolves the turbo 8-step regime against the KREA_TURBO_ENGINE_ID descriptor",
     );
 }
 


### PR DESCRIPTION
Epic 13879 **S3** (sc-13883). When the accelerator-role turbo LoRA (S2 `krea2_turbo_accel`, sc-13882) is selected on a `krea_2_raw` t2i job, run it through the **distilled Turbo sampling regime** — fixed mu 1.15 / ~8 steps / CFG-off — with the **Raw base + LoRA applied additively**.

## Engine unknown (STEP 0) → PATH A (worker-only, no inference change)

The story flagged an "engine unknown": whether Raw can be forced to fixed mu 1.15 + CFG-off via per-generation params, or whether the pinned Krea engine needs a new flag.

Traced through the pinned engine (`SceneWorks/inference` rev `cd46a91`, `mlx-gen-krea`):
- The Raw t2i path (`render_base_from` → `base_schedule`) hard-derives mu from **resolution** (`dynamic_mu(seq_len)`); the `scheduler` override only reshapes the curve over that same mu. There is **no per-call mu override** on the Raw generator — so keeping the `krea_2_raw` engine id could not achieve fixed mu 1.15.
- BUT the engine keys its whole sampling regime on the **descriptor id**, not per-gen params: `krea_2_turbo` always runs `render_turbo` (fixed mu `TURBO_MU = 1.15`, 8-step `turbo_schedule`, single conditional forward = CFG off), while `krea_2_raw` always runs `render_base` (dynamic mu, 52-step, true-CFG). `load()` (turbo) and `load_raw()` share one loader (`load_variant`) and read weights **straight off the `LoadSpec`**, independent of the descriptor. Adapters install in the shared heavy loader regardless of variant.

So **routing a Raw job (Raw weights + accelerator LoRA) to the `krea_2_turbo` engine** yields exactly "Raw base + LoRA additive, sampled as Turbo" with **no inference change**. This is the t2i sibling of `krea_edit.rs`'s `krea_2_turbo_edit` vs `krea_2_edit` engine pick.

## Changes

- **Worker** (`crates/sceneworks-worker`, macOS): new `ImageRoute::KreaTurboOnRaw` + `image_jobs/krea_turbo_raw.rs` lane. Detects `role: accelerator` on a `krea_2_raw` t2i job (not edit, no poses), resolves the **Raw** weights + tier, applies the LoRA(s) additively, and routes to the `krea_2_turbo` engine. The regime is resolved against the **Turbo descriptor**, so it falls out for free: `resolve_steps` defaults to the distilled **8** (an explicit `advanced.steps` is still honored), and guidance/negative are left **off** (single conditional forward). Placed after the edit/control lanes, before the generic `mlx_available` arm.
- **img2img reference jobs fall through** (adversarial-review fix): `krea_2_raw` ships `ui.img2img: true`, so a plain `text_to_image` job that carries an img2img reference (`referenceAssetId` + strength) **plus** the accelerator LoRA was being hijacked by this new lane and rendered as plain t2i — **silently dropping the reference** (the lane resolves no reference/conditioning). The gate now **excludes** the img2img-reference shape (`request_carries_img2img_reference` = `model_supports_img2img && has_reference`, mirroring the generic Mlx img2img arm's predicate; `edit_image` was already excluded). Such a job now **falls through to the generic `mlx_available` img2img arm**, which honors the reference **and still applies the accelerator LoRA additively** (Raw regime, not turbo). Turbo-on-Raw **img2img** is out of scope for this t2i story — only plain t2i + accelerator takes the turbo regime. Gate + router-arm doc-comments updated to state the exclusion.
- **`role` round-trip** (the plumbing S2 deferred to S3): `serializeLora` / `serializePresetLora` (web) and `serialize_job_lora` / the recipe-preset serializer (rust-api) now forward `role` **exactly like `conditioningRole`**, so the worker reads the marker off the payload `loras` entry. The catalog already passes `role` through (`normalize_lora_entry` is a passthrough).
- **No new manifest field**: the whole regime is determined by the engine-id route, so nothing new to add to the model/LoRA schema (no `parity`-lane schema churn).
- **MLX only**; candle parity is **S6**. All new worker code is `#[cfg(target_os = "macos")]`-gated, so the candle/Linux build is unaffected.

## Tests (all green locally)

- `krea_turbo_on_raw_routes_only_with_accelerator_lora` — routes to `KreaTurboOnRaw` **only** with the accelerator LoRA; a plain Raw t2i (or a plain character/style Raw LoRA) stays on `Mlx` (over-routing guard). **New (review fix):** a `krea_2_raw` job carrying an **img2img reference** (`ui.img2img` + `referenceAssetId`) **plus** the accelerator LoRA must **not** route to `KreaTurboOnRaw` — it must fall through to `Mlx` (the generic img2img arm). Mutation-verified: the case fails if the gate exclusion is removed.
- `krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime` — the **discriminating** param-selection test: pins the non-default turbo values (engine id `krea_2_turbo` = fixed mu; **8** steps; guidance **None**; negative **not** forwarded) against the Raw defaults (52 / 3.5 / forwarded), so it fails if the lane ever reverts to Raw. **New (review fix):** a **seam-level** assertion that the lane loads the **RAW** repo (`SceneWorks/krea-2-raw-mlx`, off `&raw_model`) while resolving the 8-step regime against the `krea_2_turbo` engine — proving the `&turbo`/`&raw_model` split via the lane's own resolved settings, not only the turbo descriptor directly.
- `lora_declares_accelerator_role_matches_only_the_accelerator_marker` — the role detector (case/separator normalized; rejects `conditioningRole`).
- `serializeLora` round-trip (web) + `serialize_job_lora_carries_accelerator_role_to_payload` (rust-api).

Checks run locally: `cargo test -p sceneworks-worker` (the turbo-on-Raw + routing/img2img tests) pass — the two turbo-on-Raw tests above extended with the review-fix cases (reference-exclusion + seam-level RAW-repo assertion); `-p sceneworks-rust-api serialize_job_lora` (2) pass; `cargo clippy -p sceneworks-worker -- -D warnings` clean; `cargo fmt --all -- --check` clean. Review-fix changes are entirely in the macOS-only `krea_turbo_raw.rs` (+ a comment-only router-arm edit), so the candle/Linux `parity` build is unaffected.

## Hardware validation (requires a Mac + GPU + the 469 MB LoRA — NOT runnable in CI/this environment)

These acceptance items need real renders and are **blockers for close**, not scope cuts:

1. **Coherent ~8-step output** from Raw + `krea2_turbo_accel`.
2. **A/B fidelity (the whole motivation)** — apply the S0 quality metrics across three arms at matched prompt/seed/resolution:
   - **A**: distilled `krea_2_turbo` (8 steps, mu 1.15, CFG off).
   - **B**: this lane — `krea_2_raw` + `krea2_turbo_accel` (8 steps, mu 1.15, CFG off).
   - **C**: ComfyUI raw+lora (same Raw checkpoint + the same rank-64 turbo LoRA, 8 steps, mu 1.15, CFG off) — the community "higher fidelity" reference.
   - **Procedure**: fixed seed set (e.g. 5 seeds), 3–5 prompts spanning portrait/scene/text, resolution 1024² (and one 1536²). For each (arm, prompt, seed) record the S0 metrics; report B vs A (does raw+lora beat distilled?) and B vs C (does our MLX path match ComfyUI's raw+lora?). Document the result on the story.
3. **User Raw-trained LoRA stack** — select `krea2_turbo_accel` **plus** a character/style LoRA trained on `krea_2_raw`; verify at least one stack renders coherently and capture weight-tuning notes for S4.

To run B on the Mac: install the S2 accelerator LoRA, open Image Studio on **Krea 2 Raw**, select the "Krea 2 Turbo (accelerator)" LoRA, generate. The recipe records `samplingRegime: krea_2_turbo` and `numInferenceSteps: 8` / `guidanceScale: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

