### PR TITLE
docs(worker): correct the cudarc pool-retention framing for VRAM reclaim (sc-13960)

### DIFF
--- a/crates/sceneworks-worker/src/cache_thread.rs
+++ b/crates/sceneworks-worker/src/cache_thread.rs
@@ -326,12 +326,15 @@ pub(crate) fn release_backend_cache_after_evict() {
 }
 
 /// Off-Mac (candle/CUDA) this is intentionally a no-op (epic 10765, sc-10766). candle's CUDA backend
-/// uses cudarc's stream-ordered caching allocator, which exposes no `empty_cache` and does not reclaim
-/// on `Device::synchronize()`: dropping the evicted model already returns its pages to candle's
-/// in-process pool (where the next load reuses them), but there is no supported way to hand those pages
-/// back to the driver — so `nvidia-smi` resident VRAM stays flat across an evict regardless. A real
-/// driver-level trim would need a candle/cudarc fork (tracked as a separate optional spike under epic
-/// 10765), not this seam. The VRAM fit-gate therefore budgets on predicted peak, not resident deltas.
+/// uses cudarc, which exposes no `empty_cache`/trim to call here — but none is needed: dropping the
+/// evicted model is what frees its VRAM. GPU-measured (sc-13960, RTX PRO 6000): a full generator drop
+/// returns most of that VRAM to the DRIVER — `nvidia-smi` free RISES (a resident ~45.7 GB QwenEdit's
+/// drop gave ~45 GB back) — so the incoming load has room without any separate driver-level trim. (The
+/// stronger "cudarc keeps the freed pages pooled in-process so `nvidia-smi` free stays flat" framing
+/// holds at most for a WITHIN-DEVICE component free under sequential residency, where the device stays
+/// alive; it does NOT hold for a full evict, which drops the device.) The VRAM fit-gate therefore
+/// budgets on predicted peak, not resident deltas — and predicts the post-evict `free` via
+/// `reclaimable_pool_gb` rather than trying to read it (the gate runs before the evict).
 #[cfg(any(not(target_os = "macos"), test))]
 pub(crate) fn release_backend_cache_after_evict() {}
 

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -417,9 +417,10 @@ where
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel::<WorkerResult<R>>();
     let job: GeneratorJob = Box::new(move |cache: &mut GeneratorCache| {
         let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            // Free the resident cached generator (if any) before loading the fresh one, so the pool has
-            // room for the large in-place weights. On CUDA `release_backend_cache_after_evict` is a
-            // no-op (cudarc has no empty_cache); the drop returns the tensors' allocation to the pool.
+            // Free the resident cached generator (if any) before loading the fresh one, so the process
+            // has room for the large in-place weights. On CUDA `release_backend_cache_after_evict` is a
+            // no-op (cudarc has no empty_cache); the drop itself frees the VRAM (GPU-measured sc-13960:
+            // a full generator drop returns most of it to the driver — `nvidia-smi` free rises).
             if cache.evict().is_some() {
                 cache_thread::release_backend_cache_after_evict();
             }

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -445,10 +445,12 @@ pub(crate) async fn gpu_utilization(gpu_id: &str) -> Option<WorkerUtilizationSna
 /// (`memory.free`/`memory.total`, MiB → GiB). `None` off-NVIDIA (CPU / macOS with no visible NVIDIA
 /// GPU) or when the probe fails — the gate then no-ops.
 ///
-/// NOTE (caching allocator): candle's CUDA backend uses cudarc's stream-ordered caching allocator with
-/// no `empty_cache`, so `memory.free` reflects DRIVER-resident free and does NOT drop back after an
-/// in-process component is freed. Treat this as a pre-load admission signal, not a post-free accounting
-/// number (see `crate::vram_gate` module docs).
+/// NOTE (caching allocator): `memory.free` reflects DRIVER-resident free. Under sequential residency a
+/// freed WITHIN-DEVICE component (device still alive) returns to cudarc's in-process pool, so `free`
+/// does NOT drop back for it — but a full generator DROP (a cache evict) does return its VRAM to the
+/// driver (GPU-measured sc-13960: `free` rises). Either way, treat this as a pre-load admission signal,
+/// not a post-free accounting number; the gate predicts the post-evict `free` via `reclaimable_pool_gb`
+/// (see `crate::vram_gate` module docs).
 ///
 /// Gated to the candle lane (its only consumer, `generate_candle_stream`) so it isn't dead code under
 /// `-D warnings` in the non-candle / macOS builds.

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -5340,10 +5340,12 @@ async fn generate_candle_stream(
         crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
         crate::vram_gate::cuda_vram_cap_gb(),
     );
-    // sc-11023: the single-slot generator cache evicts its current occupant BEFORE the incoming load,
-    // and cudarc's caching allocator reuses those freed pages in-process — nvidia-smi `free` never rises
-    // after an in-process evict (the epic 10765 caching-allocator note). So the VRAM this process already
-    // holds is RECLAIMABLE by the incoming load; budget against `free + reclaimable` (capped to total),
+    // sc-11023: the single-slot generator cache evicts its current occupant BEFORE the incoming load.
+    // This gate reads `free` while that occupant is still resident (so raw `free` still counts the model
+    // it is about to replace); crediting the reclaimable pool predicts the `free` the imminent evict will
+    // PRODUCE. That prediction is right whether evicting returns the VRAM to the driver (GPU-measured
+    // sc-13960: a full generator drop frees most of it back, `nvidia-smi` free RISES) or a within-device
+    // component free keeps it pooled in-process. So budget against `free + reclaimable` (capped to total),
     // else a warm/swap re-gate falsely rejects a load that will actually fit (the "even with sequential
     // residency" 2nd-run reject a resident bf16 tier hits on the next generation).
     let budget = budget.map(|budget| {

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -5541,12 +5541,15 @@ fn wan_vram_preflight(
 /// `SCENEWORKS_CUDA_VRAM_CAP_GB` small-card emulation folded over it, then this process's reclaimable
 /// cudarc pool added back (sc-11023).
 ///
-/// The reclaimable fold IS correct here, unlike `krea_control_candle.rs` which deliberately omits it:
-/// video routes through `generator_cache::with_cached_generator` (the `comfyui` in-place MoE is the one
-/// uncached exception, and it is not Mochi), so the single exclusive cache slot evicts its occupant
-/// BEFORE the incoming load and cudarc reuses those pages in-process. Without the fold, a warm re-gate
-/// would be measured against a `free` that still counts the model it is about to replace. Matches
-/// `generate_candle_stream` (image_jobs/base.rs).
+/// The reclaimable fold IS correct here: video routes through `generator_cache::with_cached_generator`
+/// (the `comfyui` in-place MoE is the one uncached exception, and it is not Mochi), so the single
+/// exclusive cache slot evicts its occupant BEFORE the incoming load. This budget is read while that
+/// occupant is still resident, so raw `free` still counts the model it is about to replace; the fold
+/// predicts the `free` the imminent evict will produce (whether that VRAM returns to the driver — a full
+/// generator drop does, GPU-measured sc-13960 — or is reused in-process). Matches `generate_candle_stream`
+/// (image_jobs/base.rs). The bespoke edit/control lanes reached the same result differently: they load
+/// off the UNcached `start_gen_stream`, so they gate raw free and only EVICT-then-reclaim when it flips a
+/// downtier/reject (sc-13960 `gate_with_evict_reclaim`) — before sc-13960 they omitted the fold entirely.
 ///
 /// The reverse direction is deliberately NOT wired: an admitted Mochi job does not call
 /// [`crate::vram_gate::note_loaded_peak`], so it contributes nothing to the reclaimable high-water the

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -8,12 +8,14 @@
 //! box's 96 GB RTX PRO 6000s.
 //!
 //! ## Caching-allocator caveat (why this budgets on PREDICTED peak, not resident deltas)
-//! candle's CUDA backend uses cudarc's stream-ordered caching allocator: there is no `empty_cache`, and
-//! `Device::synchronize()` does not reclaim. So a freed component's pages return to candle's in-process
-//! pool (reused by the next allocation — which is what keeps a small card from OOMing under Phase 1
-//! sequential residency), but the DRIVER-resident `nvidia-smi` free number does NOT drop back. This
-//! gate is therefore a pre-load ADMISSION check keyed off the manifest's measured per-tier peak, never
-//! a post-free accounting number.
+//! candle's CUDA backend uses cudarc, with no `empty_cache` and no reclaim on `Device::synchronize()`.
+//! A freed WITHIN-DEVICE component — the text encoders dropped before the DiT under Phase 1 sequential
+//! residency, with the device still alive — returns to candle's in-process pool (reused by the next
+//! allocation, which is what keeps a small card from OOMing) WITHOUT the DRIVER-resident `nvidia-smi`
+//! free number dropping back. A full generator/device DROP is different: it destroys the device's pool
+//! and returns its VRAM to the driver, so `free` RISES (GPU-measured, sc-13960). Either way this gate is
+//! a pre-load ADMISSION check keyed off the manifest's measured per-tier peak — never a post-free
+//! accounting number, since it runs while the model it is about to replace is still resident.
 //!
 //! Everything here is pure and unit-tested; the live `nvidia-smi` reading lives in [`crate::gpu`] and
 //! the wiring is in `generate_candle_stream` (image_jobs/base.rs).
@@ -70,13 +72,15 @@ pub(crate) fn apply_vram_cap(real: Option<VramBudget>, cap: Option<f64>) -> Opti
     }
 }
 
-/// Fold this process's RECLAIMABLE in-process VRAM pool into the live budget (sc-11023): add
-/// `reclaimable_gb` to `free_gb`, clamped to the physical `total_gb`. The candle generator cache is a
-/// single exclusive slot that evicts its current occupant BEFORE loading the incoming model, and
-/// cudarc's caching allocator reuses the freed pages in-process (nvidia-smi `free` never rises after an
-/// evict — see the module caveat). So the VRAM this process already holds will be available to the next
-/// load; without this, a warm same-model re-gate or a swap-in is measured against `free` that still
-/// counts the model it is about to replace, falsely rejecting a load that fits. A no-op when
+/// Fold this process's RECLAIMABLE VRAM into the live budget (sc-11023): add `reclaimable_gb` to
+/// `free_gb`, clamped to the physical `total_gb`. The candle generator cache is a single exclusive slot
+/// that evicts its current occupant BEFORE loading the incoming model. This budget is read while that
+/// occupant is still resident (so raw `free` still counts the model it is about to replace); crediting
+/// the reclaimable pool predicts the `free` the imminent evict will PRODUCE, so a warm same-model
+/// re-gate or a swap-in isn't falsely rejected. That prediction holds whether evicting returns the VRAM
+/// to the driver (GPU-measured sc-13960: a full generator drop frees most of it back — `nvidia-smi`
+/// `free` rises) or a within-device component free keeps it pooled in-process — and the clamp to
+/// `total_gb` is the safety net that keeps it honest against a stale high-water. A no-op when
 /// `reclaimable_gb == 0` (nothing loaded yet), so a genuine cold first-load is gated exactly as before.
 pub(crate) fn with_reclaimable(budget: VramBudget, reclaimable_gb: f64) -> VramBudget {
     VramBudget {
@@ -85,10 +89,11 @@ pub(crate) fn with_reclaimable(budget: VramBudget, reclaimable_gb: f64) -> VramB
     }
 }
 
-/// Per-GPU high-water of the peak VRAM (GB) this process has admitted a load at — the size of the
-/// reclaimable cudarc pool (sc-11023). Keyed by `gpu_id` (a worker process is pinned to one card, but
-/// keying is defensive + explicit). The pool only ever grows (no `empty_cache`/trim), so the running
-/// MAX is exactly what a later swap-in can reuse.
+/// Per-GPU high-water of the peak VRAM (GB) this process has admitted a load at (sc-11023) — a bound on
+/// what evicting the current resident can free back for a swap-in. Keyed by `gpu_id` (a worker process
+/// is pinned to one card, but keying is defensive + explicit). It only ever grows (monotonic MAX), and
+/// [`with_reclaimable`] clamps the credit to `total_gb`, so a later gate can only under-credit, never
+/// over-admit — the safety that holds whether an evict frees to the driver or pools in-process.
 fn reclaimable_pool_store() -> &'static std::sync::Mutex<std::collections::HashMap<String, f64>> {
     static STORE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, f64>>> =
         std::sync::OnceLock::new();


### PR DESCRIPTION
Docs-only follow-on to [sc-13960](https://app.shortcut.com/trefry/story/13960) / #1713.

The sc-13960 GPU validation on the RTX PRO 6000 revealed that a **full candle generator drop returns most of its VRAM to the DRIVER** — `nvidia-smi` free *rises* (a resident ~45.7 GB QwenEdit's drop gave ~45 GB back, free 48.8 → 94.0). Several VRAM-gate docs asserted "cudarc reuses the freed pages in-process / `nvidia-smi` free never rises after an evict" as a **general rule**. That framing holds at most for a **within-device COMPONENT free** under sequential residency (the device stays alive), **not** for a full evict, which drops the device.

## What changed (comments/docs only, no behavior change)

Corrected the framing across the reclaim mechanism's docs so they explain *why* the credit is correct rather than leaning on the imprecise pool-retention claim:

- `vram_gate.rs` — module caching-allocator caveat, `with_reclaimable`, `note_loaded_peak` high-water doc.
- `image_jobs/base.rs` — the sc-11023 reclaim comment in `generate_candle_stream`.
- `cache_thread.rs` — `release_backend_cache_after_evict` (why the CUDA no-op is fine: the drop frees the VRAM).
- `gpu.rs` — `nvidia_vram_budget_gb` caching-allocator NOTE.
- `generator_cache.rs` — the `with_uncached_generator` evict comment.
- `video_jobs.rs` — `candle_video_vram_budget`.

The corrected explanation: the gate reads `free` **before** the imminent evict (while the occupant is still resident), so crediting `reclaimable_pool_gb` **predicts** the free the evict will produce — valid whether that VRAM returns to the driver or is pooled in-process — and `with_reclaimable`'s **clamp-to-total** is the safety net.

Also **de-staled** the `video_jobs` comment that said `krea_control` "deliberately omits" the reclaim fold — sc-13960 (#1713) gave the bespoke edit/control lanes an evict-then-reclaim path.

Verified: `fmt` + `clippy -p sceneworks-worker --features backend-candle --all-targets -D warnings` clean; diff is comment lines only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)