### PR TITLE
feat(krea): multi-phase denoise worker wiring + inference pin bump [sc-13884]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -1806,7 +1806,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "core-llm",
  "half",
@@ -4326,7 +4326,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4451,7 +4451,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4567,7 +4567,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5922,7 +5922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5979,7 +5979,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cd46a91079e993b3cb3b9e4438b8dd819944255d#cd46a91079e993b3cb3b9e4438b8dd819944255d"
+source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -6673,7 +6673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7323,7 +7323,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7845,7 +7845,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8480,7 +8480,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "cd46a91079e993b3cb3b9e4438b8dd819944255d", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -458,6 +458,23 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::KreaMultiPhase => {
+                // Krea 2 Raw t2i + an explicit `advanced.phases` list (epic 13879 S4, sc-13884) → the
+                // multi-phase denoise driver: ONE Raw trajectory / global sigma schedule, per-phase
+                // guidance (CFG on/off) + per-phase toggling of the job's load-time LoRA stack (by
+                // index). Reference/edit/pose/PiD shapes are rejected loudly before the load (renders
+                // from pure noise). Takes precedence over the S3 turbo-on-Raw regime above.
+                generate_krea_multiphase_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::InstantId => {
                 // InstantID identity-preserving character image (sc-3345): single identity or
                 // grouped angle/pose sets, on RealVisXL + IdentityNet + the native face stack.
@@ -1696,6 +1713,11 @@ include!("image_jobs/krea_edit.rs");
 // Krea 2 single-phase turbo-on-Raw routing (epic 13879 S3, sc-13883): the accelerator LoRA on a
 // `krea_2_raw` t2i job → the distilled Turbo sampling regime (fixed mu 1.15 / ~8 steps / CFG-off).
 include!("image_jobs/krea_turbo_raw.rs");
+#[cfg(target_os = "macos")]
+// Krea 2 multi-phase denoise routing (epic 13879 S4, sc-13884): a `krea_2_raw` t2i job carrying an
+// explicit `advanced.phases` list → the multi-phase driver (one Raw trajectory / global schedule,
+// per-phase guidance + per-phase toggling of the job's load-time LoRA stack by index).
+include!("image_jobs/krea_multiphase.rs");
 #[cfg(target_os = "macos")]
 // Krea 2 pose-ControlNet (MLX) strict-pose routing (sc-8465, epic 8459 S5).
 include!("image_jobs/krea_control.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -96,6 +96,15 @@ enum ImageRoute {
     /// MODEL_TABLE, so `mlx_available` would otherwise render it as plain Raw t2i (52-step true-CFG)
     /// and never accelerate. The t2i sibling of [`ImageRoute::KreaEdit`].
     KreaTurboOnRaw,
+    /// A Krea 2 **Raw** t2i job carrying an explicit `advanced.phases` list (epic 13879 S4, sc-13884)
+    /// → the multi-phase denoise driver: ONE Raw trajectory over ONE global sigma schedule, each phase
+    /// a contiguous step slice with its own guidance (per-phase CFG on/off) and its own active subset of
+    /// the job's load-time LoRA stack (per-phase toggling). Wins over [`ImageRoute::KreaTurboOnRaw`] and
+    /// the generic `Mlx` arm — an explicit phase list is the FINER-GRAINED control and takes precedence
+    /// over S3's whole-job turbo-on-Raw regime. Loads the `krea_2_raw` engine (the multi-phase driver
+    /// keys on that descriptor id), unlike S3 which swaps to `krea_2_turbo`. Reference/edit/pose/PiD
+    /// shapes are rejected loudly by the lane (multi-phase renders from pure noise).
+    KreaMultiPhase,
     InstantId,
     PulidFlux,
     SdxlAdvanced,
@@ -175,6 +184,15 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         Some(ImageRoute::Flux2Edit)
     } else if qwen_edit_available(request, settings) {
         Some(ImageRoute::QwenEdit)
+    } else if krea_multiphase_available(request, settings) {
+        // Krea 2 Raw t2i + an explicit `advanced.phases` list (epic 13879 S4, sc-13884) → the
+        // multi-phase denoise lane. Placed FIRST among the `krea_2_raw` lanes so an explicit phase list
+        // takes precedence over the S3 whole-job turbo-on-Raw regime (`krea_turbo_on_raw_available`
+        // below) AND the generic Raw t2i (`mlx_available`): multi-phase is the finer-grained control.
+        // Only claims `krea_2_raw` + a present `advanced.phases`, so every non-phases job is unaffected;
+        // the lane itself rejects edit/pose/reference/PiD shapes loudly (multi-phase renders from noise),
+        // so claiming a conflicting shape here surfaces a clear error rather than diverting it silently.
+        Some(ImageRoute::KreaMultiPhase)
     } else if krea_edit_available(request, settings) {
         // Krea 2 Raw Kontext-style edit (mode edit_image + a source) → the `krea_2_edit` engine
         // (epic 10871). Wins over the generic MLX arm below — `krea_2_raw` is in MODEL_TABLE, so
@@ -267,6 +285,9 @@ impl ImageRoute {
             // Turbo-on-Raw is plain per-image (like Krea edit + the base MLX path): `count` renders of
             // the base prompt, each its own seed. No angle/pose grouping.
             | ImageRoute::KreaTurboOnRaw
+            // Multi-phase (S4) is likewise plain per-image: `count` renders, each its own seed, driven
+            // through the phase plan. No angle/pose grouping.
+            | ImageRoute::KreaMultiPhase
             | ImageRoute::PoseControlBaseMissing
             | ImageRoute::PoseReject
             | ImageRoute::Mlx => request.count,

--- a/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
@@ -1,0 +1,515 @@
+// ---------------------------------------------------------------------------
+// Krea 2 multi-phase denoise (macOS, epic 13879 S4, sc-13884): a `krea_2_raw` t2i job
+// carrying an explicit `advanced.phases` list rendered through the new multi-phase engine
+// primitive (inference PR #199). ONE Raw denoise trajectory over ONE global sigma schedule,
+// where each PHASE owns a contiguous step slice with its own guidance (per-phase true-CFG
+// on/off) AND its own active subset of the job's load-time LoRA stack (per-phase toggling).
+// The canonical workflow is "N steps Raw with true-CFG on, then M steps Raw + turbo-LoRA with
+// CFG off", but the lane is general over any ordered phase list. Routed here from
+// `ImageRoute::KreaMultiPhase`.
+//
+// # The phase list references the job's OWN LoRAs by index
+//
+// The gen-core contract (`GenerationRequest.phases`) references the load-time adapter stack
+// (`LoadSpec::adapters`) by INDEX: a `PhaseAdapter { adapter: usize, weight }` names which of the
+// already-loaded adapters this phase activates. The worker builds that stack from `request.loras`
+// via `resolve_adapters`, which emits exactly one `AdapterSpec` per lora entry, IN ORDER — so
+// `request.loras[i]` maps 1:1 to `LoadSpec::adapters[i]`. The client-supplied `advanced.phases`
+// therefore selects a phase's adapters by index into the SAME `loras` array the job already loads;
+// [`parse_multiphase_specs`] bounds-checks each index against `request.loras.len()` and
+// [`build_generation_phases`] maps it straight to `PhaseAdapter.adapter`.
+//
+// # Engine surface + what this lane rejects
+//
+// Multi-phase is the Raw t2i variant only: it renders from PURE NOISE, so the engine
+// (`mlx-gen-krea`'s `validate_phases`) rejects phases combined with reference/edit conditioning
+// or the PiD decoder, and rejects an empty list / a 0-step phase. It also loud-rejects a
+// multi-phase request on a model loaded with a ComfyUI `.diff`/`.diff_b` diff-patch adapter (that
+// delta folds irreversibly into the base and cannot be toggled off per phase). This lane mirrors
+// those rejects on the SceneWorks side ([`ensure_multiphase_job_shape`] + [`parse_multiphase_specs`])
+// so a bad shape fails fast with a clear error BEFORE the heavy load, rather than deep in the engine.
+//
+// The lane loads the `krea_2_raw` ENGINE (unlike S3's turbo-on-Raw, which swaps to the `krea_2_turbo`
+// engine): multi-phase is a Raw-trajectory decomposition, and the engine keys the driver on the
+// `krea_2_raw` descriptor id. This composes with — and takes PRECEDENCE over — the S3 whole-job
+// turbo-on-Raw regime: an explicit `advanced.phases` is the finer-grained control, so the router
+// checks this lane first (see `resolve_image_route`). The whole file is `include!`d only on macOS
+// (like `krea_turbo_raw.rs`), so nothing here needs a per-item cfg.
+// ---------------------------------------------------------------------------
+
+/// Sanity cap on the number of phases in one multi-phase render. The engine imposes none, but a
+/// legitimate Raw→Raw+turbo-LoRA workflow is 2–3 phases; a generous cap rejects an obviously
+/// malformed / abusive list without constraining any real split. Not a creative limit — a guardrail.
+const MAX_MULTIPHASE_PHASES: usize = 8;
+
+/// Sanity cap on the TOTAL denoise-step budget (the sum of every phase's steps, which is the length
+/// of the ONE global schedule). Single-phase Raw is 52 steps; a multi-phase split is typically well
+/// under that. A generous ceiling catches a runaway/typo total (e.g. a phase asking for thousands of
+/// steps) before it becomes a multi-minute render. Not a creative limit — a guardrail.
+const MAX_MULTIPHASE_TOTAL_STEPS: u32 = 150;
+
+/// One phase parsed from a job's `advanced.phases` — the SceneWorks-side mirror of gen-core's
+/// [`gen_core::GenerationPhase`]. `loras` reference the job's OWN LoRA stack by index (which maps
+/// 1:1 to `LoadSpec::adapters`); an EMPTY `loras` is a base-only phase (the common phase-1 case).
+#[derive(Clone, Debug, PartialEq)]
+struct MultiPhaseSpec {
+    /// Contiguous denoise steps this phase runs (≥ 1). The sum across phases is the total budget.
+    steps: u32,
+    /// Per-phase guidance: `Some(g > 0)` = true-CFG, `Some(0.0)` = CFG off, `None` inherits the
+    /// request/Raw default.
+    guidance: Option<f32>,
+    /// The load-time adapters this phase activates, referencing `request.loras` (== `LoadSpec::adapters`)
+    /// by index. Empty = base-only.
+    loras: Vec<PhaseLoraRef>,
+}
+
+/// One adapter a phase activates: an index into the job's `loras` array (== `LoadSpec::adapters`,
+/// since `resolve_adapters` emits one spec per lora in order) plus an optional per-phase weight
+/// override (`None` uses the adapter's load-time scale).
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct PhaseLoraRef {
+    index: usize,
+    weight: Option<f32>,
+}
+
+/// True when a job carries an explicit `advanced.phases` (a present, non-null value). Cheap presence
+/// check for the router gate — the shape is fully parsed + validated later by [`parse_multiphase_specs`],
+/// so a malformed `phases` still routes HERE and fails loudly rather than being silently dropped by
+/// falling through to another lane.
+fn request_has_multiphase(request: &ImageRequest) -> bool {
+    matches!(request.advanced.get("phases"), Some(value) if !value.is_null())
+}
+
+/// True when this is a Krea 2 **Raw** job carrying an explicit `advanced.phases` list and its Raw
+/// weights resolve locally — the multi-phase denoise lane (S4). Keyed on model `krea_2_raw` + a present
+/// `advanced.phases`, so EVERY job without `advanced.phases` is byte-for-byte unaffected. Placed FIRST
+/// among the `krea_2_raw` lanes in [`resolve_image_route`] so an explicit phase list takes precedence
+/// over the S3 whole-job turbo-on-Raw regime and the generic Raw t2i. The lane itself rejects
+/// edit/pose/reference/PiD shapes loudly (multi-phase renders from pure noise), so the gate claims the
+/// job and surfaces a clear error rather than diverting a conflicting shape elsewhere.
+fn krea_multiphase_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.model == KREA_RAW_MODEL_ID
+        && request_has_multiphase(request)
+        && matches!(resolve_weights_dir(request, settings), Ok(Some(_)))
+}
+
+/// Reject the job SHAPES the multi-phase engine rejects, loudly and BEFORE the heavy load (mirrors
+/// `mlx-gen-krea`'s `validate_phases`): multi-phase renders from pure noise, so edit mode, strict-pose
+/// conditioning, an img2img reference, and the PiD decoder are all unsupported in v1. Surfacing these
+/// here keeps a conflicting request from being silently rendered as bare-noise multi-phase (dropping
+/// the reference/pose/edit the user asked for) — the router sends any `krea_2_raw` + `advanced.phases`
+/// job to this lane, so this is where the conflict is caught.
+fn ensure_multiphase_job_shape(request: &ImageRequest) -> WorkerResult<()> {
+    if request.mode == "edit_image" {
+        return Err(WorkerError::InvalidPayload(
+            "Krea multi-phase denoise renders from pure noise — edit mode (edit_image) is not \
+             supported (sc-13884). Remove advanced.phases to run an edit."
+                .to_owned(),
+        ));
+    }
+    if !pose_entries(request).is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "Krea multi-phase denoise renders from pure noise — strict-pose conditioning is not \
+             supported (sc-13884)."
+                .to_owned(),
+        ));
+    }
+    if request_carries_img2img_reference(request) {
+        return Err(WorkerError::InvalidPayload(
+            "Krea multi-phase denoise renders from pure noise — an img2img reference is not \
+             supported (sc-13884)."
+                .to_owned(),
+        ));
+    }
+    if advanced::flag(&request.advanced, "usePid") {
+        return Err(WorkerError::InvalidPayload(
+            "Krea multi-phase denoise does not support the PiD decoder yet (sc-13884 follow-on)."
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+/// Parse + validate `advanced.phases` into the SceneWorks-side [`MultiPhaseSpec`] plan, bounds-checking
+/// each phase's lora index against the job's own `loras` stack (== `LoadSpec::adapters`).
+///
+/// Rejects, loudly, exactly what the engine would (so the failure is early + clear, not deep in the
+/// driver): a non-array / empty `phases`, more than [`MAX_MULTIPHASE_PHASES`] phases, a phase that is
+/// not an object, a missing / 0-step `steps`, a non-finite or negative `guidance`, a `loras` that is
+/// not an array, a lora entry missing `index`, a lora `index` out of range of the job's loras, a
+/// non-finite lora `weight`, or a total step budget over [`MAX_MULTIPHASE_TOTAL_STEPS`]. `steps` and
+/// numeric fields accept a JSON number or a numeric string (matching the rest of the `advanced` knobs).
+fn parse_multiphase_specs(request: &ImageRequest) -> WorkerResult<Vec<MultiPhaseSpec>> {
+    let raw = request.advanced.get("phases").ok_or_else(|| {
+        WorkerError::InvalidPayload("Krea multi-phase job is missing 'advanced.phases'.".to_owned())
+    })?;
+    let list = raw.as_array().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "'advanced.phases' must be an array of phase objects.".to_owned(),
+        )
+    })?;
+    if list.is_empty() {
+        return Err(WorkerError::InvalidPayload(
+            "'advanced.phases' must contain at least one phase.".to_owned(),
+        ));
+    }
+    if list.len() > MAX_MULTIPHASE_PHASES {
+        return Err(WorkerError::InvalidPayload(format!(
+            "'advanced.phases' has {} phases; at most {MAX_MULTIPHASE_PHASES} are supported.",
+            list.len()
+        )));
+    }
+
+    let lora_count = request.loras.len();
+    let mut specs = Vec::with_capacity(list.len());
+    let mut total_steps: u64 = 0;
+
+    for (i, entry) in list.iter().enumerate() {
+        let obj = entry.as_object().ok_or_else(|| {
+            WorkerError::InvalidPayload(format!("phase {i}: each phase must be a JSON object."))
+        })?;
+
+        // steps: required, ≥ 1.
+        let steps_raw = obj
+            .get("steps")
+            .and_then(|value| value.as_u64().or_else(|| value.as_str()?.trim().parse().ok()))
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload(format!(
+                    "phase {i}: 'steps' is required (a positive integer)."
+                ))
+            })?;
+        if steps_raw == 0 {
+            return Err(WorkerError::InvalidPayload(format!(
+                "phase {i}: 'steps' must be at least 1."
+            )));
+        }
+        // Clamp the cast; the total-budget cap below rejects any abusive value regardless.
+        let steps = steps_raw.min(u64::from(u32::MAX)) as u32;
+        total_steps += u64::from(steps);
+
+        // guidance: optional; finite and ≥ 0 when present (0 = CFG off, > 0 = CFG on).
+        let guidance = match obj.get("guidance") {
+            None | Some(Value::Null) => None,
+            Some(value) => {
+                let g = value
+                    .as_f64()
+                    .or_else(|| value.as_str()?.trim().parse().ok())
+                    .ok_or_else(|| {
+                        WorkerError::InvalidPayload(format!(
+                            "phase {i}: 'guidance' must be a number."
+                        ))
+                    })? as f32;
+                if !g.is_finite() || g < 0.0 {
+                    return Err(WorkerError::InvalidPayload(format!(
+                        "phase {i}: 'guidance' must be a finite value >= 0 (0 = CFG off, > 0 = CFG on)."
+                    )));
+                }
+                Some(g)
+            }
+        };
+
+        // loras: optional array; empty / absent = a base-only phase.
+        let loras = match obj.get("loras") {
+            None | Some(Value::Null) => Vec::new(),
+            Some(value) => {
+                let arr = value.as_array().ok_or_else(|| {
+                    WorkerError::InvalidPayload(format!(
+                        "phase {i}: 'loras' must be an array of {{ index, weight? }} entries."
+                    ))
+                })?;
+                let mut refs = Vec::with_capacity(arr.len());
+                for (m, lora) in arr.iter().enumerate() {
+                    let lora_obj = lora.as_object().ok_or_else(|| {
+                        WorkerError::InvalidPayload(format!(
+                            "phase {i} lora {m}: each entry must be a JSON object."
+                        ))
+                    })?;
+                    let index = lora_obj
+                        .get("index")
+                        .and_then(|value| {
+                            value.as_u64().or_else(|| value.as_str()?.trim().parse().ok())
+                        })
+                        .ok_or_else(|| {
+                            WorkerError::InvalidPayload(format!(
+                                "phase {i} lora {m}: 'index' is required (an index into the job's loras)."
+                            ))
+                        })? as usize;
+                    if index >= lora_count {
+                        return Err(WorkerError::InvalidPayload(format!(
+                            "phase {i} lora {m}: index {index} is out of range — the job loads \
+                             {lora_count} LoRA(s) (valid indices 0..{}).",
+                            lora_count.saturating_sub(1)
+                        )));
+                    }
+                    let weight = match lora_obj.get("weight") {
+                        None | Some(Value::Null) => None,
+                        Some(value) => {
+                            let w = value
+                                .as_f64()
+                                .or_else(|| value.as_str()?.trim().parse().ok())
+                                .ok_or_else(|| {
+                                    WorkerError::InvalidPayload(format!(
+                                        "phase {i} lora {m}: 'weight' must be a number."
+                                    ))
+                                })? as f32;
+                            if !w.is_finite() {
+                                return Err(WorkerError::InvalidPayload(format!(
+                                    "phase {i} lora {m}: 'weight' must be finite."
+                                )));
+                            }
+                            Some(w)
+                        }
+                    };
+                    refs.push(PhaseLoraRef { index, weight });
+                }
+                refs
+            }
+        };
+
+        specs.push(MultiPhaseSpec {
+            steps,
+            guidance,
+            loras,
+        });
+    }
+
+    if total_steps > u64::from(MAX_MULTIPHASE_TOTAL_STEPS) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "multi-phase total step budget is {total_steps}; at most {MAX_MULTIPHASE_TOTAL_STEPS} \
+             are supported."
+        )));
+    }
+
+    Ok(specs)
+}
+
+/// Map the parsed [`MultiPhaseSpec`] plan to the gen-core `phases` a `GenerationRequest` carries. Each
+/// phase's lora `index` becomes `PhaseAdapter.adapter` VERBATIM — the index into `LoadSpec::adapters`
+/// the engine bounds-checks against the loaded stack (which the worker builds from the same
+/// `request.loras`, in order). `steps`/`guidance`/`weight` pass through unchanged.
+fn build_generation_phases(specs: &[MultiPhaseSpec]) -> Vec<gen_core::GenerationPhase> {
+    specs
+        .iter()
+        .map(|phase| gen_core::GenerationPhase {
+            steps: phase.steps,
+            guidance: phase.guidance,
+            adapters: phase
+                .loras
+                .iter()
+                .map(|lora| gen_core::PhaseAdapter {
+                    adapter: lora.index,
+                    weight: lora.weight,
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+/// Flat telemetry for a multi-phase generation (parity with [`krea_turbo_on_raw_raw_settings`] /
+/// [`mlx_raw_settings`]). Records the Raw repo/tier that loaded, the TOTAL step budget (the sum of the
+/// phases' steps — the flat `numInferenceSteps`), a null job-level `guidanceScale` (per-phase guidance
+/// drives CFG), a `samplingRegime` marker, a `multiPhase` flag, and a compact replay-friendly summary
+/// of the resolved phase plan.
+fn krea_multiphase_raw_settings(
+    request: &ImageRequest,
+    repo: &str,
+    total_steps: u32,
+    quant_bits: Option<i64>,
+    specs: &[MultiPhaseSpec],
+) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("repo".to_owned(), Value::String(repo.to_owned()));
+    // The engine ignores the flat `steps` when phases are present; record the SUM it actually runs.
+    raw.insert("numInferenceSteps".to_owned(), json!(total_steps));
+    // No single job-level guidance scale — each phase carries its own (CFG on/off).
+    raw.insert("guidanceScale".to_owned(), Value::Null);
+    raw.insert(
+        "mlxQuantize".to_owned(),
+        quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
+    );
+    raw.insert(
+        "samplingRegime".to_owned(),
+        Value::String(format!("{KREA_RAW_MODEL_ID}_multiphase")),
+    );
+    raw.insert("multiPhase".to_owned(), Value::Bool(true));
+    // Replace the raw input `phases` with the resolved/normalized plan (indices + weights + steps) for
+    // lineage / replay.
+    let phases: Vec<Value> = specs
+        .iter()
+        .map(|phase| {
+            json!({
+                "steps": phase.steps,
+                "guidance": phase.guidance,
+                "loras": phase
+                    .loras
+                    .iter()
+                    .map(|lora| json!({ "index": lora.index, "weight": lora.weight }))
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    raw.insert("phases".to_owned(), Value::Array(phases));
+    raw
+}
+
+/// Generate one multi-phase image (plain t2i, no reference/edit conditioning). The `phases` drive the
+/// engine's multi-phase driver: ONE global schedule for the total step budget, each phase a contiguous
+/// slice with its own guidance (CFG on/off) + its own active LoRA subset (indices into the loaded
+/// stack). The flat `steps` is left `None` (ignored under `phases`); `guidance` is the request-level
+/// default a `None`-guidance phase inherits.
+#[allow(clippy::too_many_arguments)]
+fn krea_multiphase_generate_one(
+    generator: &dyn Generator,
+    prompt: &str,
+    negative_prompt: Option<String>,
+    width: u32,
+    height: u32,
+    seed: i64,
+    guidance: Option<f32>,
+    text_style_gain: Option<f32>,
+    phases: Vec<gen_core::GenerationPhase>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let request = GenerationRequest {
+        prompt: prompt.to_owned(),
+        // Raw supports a negative prompt for the true-CFG phases; forwarded when the job carries one.
+        negative_prompt,
+        width,
+        height,
+        count: 1,
+        seed: Some(seed as u64),
+        // Ignored when `phases` is present — the engine sums the phases' steps for the ONE schedule.
+        steps: None,
+        // Request-level default guidance a phase with `guidance: None` inherits (per-phase guidance
+        // overrides it). Matches the single-phase Raw default (`resolve_guidance`).
+        guidance,
+        text_style_gain,
+        phases: Some(phases),
+        cancel: cancel.clone(),
+        ..Default::default()
+    };
+    let output = generator.generate(&request, on_progress).map_err(|error| {
+        WorkerError::Engine(format!("Krea multi-phase generation failed: {error}"))
+    })?;
+    match output {
+        GenerationOutput::Images(mut images) => {
+            let image = images.pop().ok_or_else(|| {
+                WorkerError::Engine("Krea multi-phase generator produced no image".to_owned())
+            })?;
+            Ok((image.width, image.height, image.pixels))
+        }
+        _ => Err(WorkerError::Engine(
+            "Krea multi-phase generator returned non-image output".to_owned(),
+        )),
+    }
+}
+
+/// Real multi-phase generation (epic 13879 S4, sc-13884): validate the job shape + phase list, resolve
+/// the RAW weights + tier + the job's LoRA stack (the SAME stack the phases reference by index), load
+/// the `krea_2_raw` ENGINE (the multi-phase driver keys on its descriptor id), and drive one output per
+/// requested count through the phase plan. Mirrors [`generate_krea_turbo_on_raw_stream`]'s
+/// blocking-thread + streamed-events shape and reuses [`consume_gen_events`]; differs in loading the Raw
+/// (not Turbo) engine and passing `phases: Some(..)`.
+async fn generate_krea_multiphase_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+
+    // Reject shapes the engine will reject (edit / pose / img2img reference / PiD), loudly, before any
+    // heavy work — the router sends every `krea_2_raw` + `advanced.phases` job here, so this is the
+    // single place a conflicting shape is caught rather than silently rendered from bare noise.
+    ensure_multiphase_job_shape(request)?;
+    // Parse + validate the phase list against the job's own LoRA stack (indices bounds-checked here).
+    let specs = parse_multiphase_specs(request)?;
+
+    let raw_model = mlx_model(&request.model)
+        .ok_or_else(|| WorkerError::InvalidPayload("not an MLX-backed model".to_owned()))?;
+    let weights_dir = resolve_weights_dir(request, settings)?
+        .ok_or_else(|| WorkerError::InvalidPayload("Krea 2 Raw weights not found".to_owned()))?;
+    // The `krea_2_raw` engine IS the multi-phase driver — its descriptor id (`krea_2_raw`) is what the
+    // engine's `validate_phases` requires (multi-phase is the Raw t2i variant only). Distinct from the
+    // S3 turbo-on-Raw lane, which swaps to the `krea_2_turbo` engine.
+    let engine_id = raw_model.engine_id();
+
+    let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
+    // The SAME adapter stack the phases reference by index: `resolve_adapters` emits one `AdapterSpec`
+    // per `request.loras` entry, in order, so `LoadSpec::adapters[i]` is `request.loras[i]` and a
+    // phase's lora `index` selects it directly.
+    let adapters = resolve_adapters(request, settings)?;
+    let repo = model_repo(request, &raw_model);
+    let adapter_label = raw_model.adapter_label();
+    let text_style_gain = resolve_text_style_gain(request);
+    // Request-level default guidance for any phase that omits its own (the engine inherits
+    // `req.guidance.unwrap_or(DEFAULT_RAW_GUIDANCE)`) — the same Raw default the single-phase path uses.
+    let guidance = resolve_guidance(request, &raw_model);
+    let negative_prompt =
+        (!request.negative_prompt.trim().is_empty()).then(|| request.negative_prompt.clone());
+
+    let phases = build_generation_phases(&specs);
+    let total_steps: u32 = specs.iter().map(|phase| phase.steps).sum();
+
+    // Plain per-image work: `request.count` renders, each its own seed + the base prompt.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let raw_settings = krea_multiphase_raw_settings(request, &repo, total_steps, quant_bits, &specs);
+
+    let (width, height) = (request.width, request.height);
+    let adapter_count = adapters.len();
+    let spec = load_spec(weights_dir, quant, adapters, None);
+
+    let (cancel, rx, blocking) = start_cached_gen_stream(
+        job.id.clone(),
+        engine_id,
+        adapter_count,
+        spec,
+        format!("{engine_id} load failed"),
+        move |generator, tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let (out_w, out_h, pixels) = krea_multiphase_generate_one(
+                    generator,
+                    &prompt,
+                    negative_prompt.clone(),
+                    width,
+                    height,
+                    seed,
+                    guidance,
+                    text_style_gain,
+                    phases.clone(),
+                    &cancel,
+                    on_progress,
+                )?;
+                Ok(Some((seed, out_w, out_h, pixels)))
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        adapter_label,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
@@ -23,11 +23,17 @@
 //
 // Multi-phase is the Raw t2i variant only: it renders from PURE NOISE, so the engine
 // (`mlx-gen-krea`'s `validate_phases`) rejects phases combined with reference/edit conditioning
-// or the PiD decoder, and rejects an empty list / a 0-step phase. It also loud-rejects a
-// multi-phase request on a model loaded with a ComfyUI `.diff`/`.diff_b` diff-patch adapter (that
-// delta folds irreversibly into the base and cannot be toggled off per phase). This lane mirrors
-// those rejects on the SceneWorks side ([`ensure_multiphase_job_shape`] + [`parse_multiphase_specs`])
-// so a bad shape fails fast with a clear error BEFORE the heavy load, rather than deep in the engine.
+// or the PiD decoder, and rejects an empty list / a 0-step phase. This lane mirrors THOSE rejects
+// early on the SceneWorks side ([`ensure_multiphase_job_shape`] + [`parse_multiphase_specs`]) so a
+// bad shape fails fast with a clear error BEFORE the heavy load, rather than deep in the engine.
+//
+// NOT mirrored here: the engine ALSO loud-rejects a multi-phase request on a model loaded with a
+// ComfyUI `.diff`/`.diff_b` diff-patch adapter (that delta folds irreversibly into the base and
+// cannot be toggled off for a base-only phase). That reject is ENGINE-enforced only — it fires LATE,
+// after the adapters load, in the engine's `ensure_multiphase_allowed_for` (which sniffs the adapter
+// file headers). There is deliberately no early SceneWorks-side probe: the engine already rejects it
+// loudly, and the canonical workflow uses the ALLOWED low-rank turbo LoRA/LoKr (which toggles cleanly),
+// so an early header sniff here would be redundant work on the happy path.
 //
 // The lane loads the `krea_2_raw` ENGINE (unlike S3's turbo-on-Raw, which swaps to the `krea_2_turbo`
 // engine): multi-phase is a Raw-trajectory decomposition, and the engine keys the driver on the
@@ -99,6 +105,14 @@ fn krea_multiphase_available(request: &ImageRequest, settings: &Settings) -> boo
 /// here keeps a conflicting request from being silently rendered as bare-noise multi-phase (dropping
 /// the reference/pose/edit the user asked for) — the router sends any `krea_2_raw` + `advanced.phases`
 /// job to this lane, so this is where the conflict is caught.
+///
+/// AUTHORITATIVE guard, not a convenience: [`generate_krea_multiphase_stream`] builds a t2i-only
+/// `GenerationRequest` (empty `conditioning`, no `use_pid`), so the engine's own conditioning backstop
+/// (`validate_phases`' `!req.conditioning.is_empty()` / `use_pid` rejects) can NEVER fire — the engine
+/// only ever sees a clean t2i request from this lane. That makes THESE checks the sole protection
+/// against silently dropping a Raw conditioning source. Any future Raw conditioning entry point
+/// (a new img2img/edit/mask/reference shape that reaches multi-phase) MUST add its reject here, or it
+/// will be dropped with no error.
 fn ensure_multiphase_job_shape(request: &ImageRequest) -> WorkerResult<()> {
     if request.mode == "edit_image" {
         return Err(WorkerError::InvalidPayload(

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -5315,6 +5315,300 @@ fn krea_turbo_on_raw_routes_only_with_accelerator_lora() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// sc-13884 (epic 13879 S4): Krea 2 Raw multi-phase denoise wiring.
+// ---------------------------------------------------------------------------
+
+// A `krea_2_raw` t2i job carrying an explicit `advanced.phases` list routes to the multi-phase lane —
+// AND takes precedence over the S3 turbo-on-Raw regime (an explicit phase list is the finer-grained
+// control). The over-routing guards: the SAME shape WITHOUT `advanced.phases` is UNCHANGED (plain Raw
+// t2i → `Mlx`; accelerator LoRA + no phases → `KreaTurboOnRaw`), so a non-phases job is never diverted.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_multiphase_routes_only_with_phases_and_takes_precedence_over_turbo() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    let model_path = dir.path().to_string_lossy().to_string();
+
+    // Raw t2i + an explicit `advanced.phases` list → the multi-phase lane.
+    let with_phases = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "advanced": {
+            "modelPath": model_path.clone(),
+            "phases": [
+                { "steps": 20, "guidance": 3.5 },
+                { "steps": 8, "guidance": 0.0 }
+            ]
+        }
+    }));
+    assert_eq!(
+        resolve_image_route(&with_phases, &settings),
+        Some(ImageRoute::KreaMultiPhase),
+        "krea_2_raw t2i + advanced.phases must route to the multi-phase lane",
+    );
+
+    // Precedence over S3: the SAME job also carrying the accelerator LoRA still routes to multi-phase —
+    // an explicit phase list wins over the whole-job turbo-on-Raw regime.
+    let phases_and_accel = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "loras": [{ "id": "krea2_turbo_accel", "family": "krea_2", "role": "accelerator" }],
+        "advanced": {
+            "modelPath": model_path.clone(),
+            "phases": [
+                { "steps": 20, "guidance": 3.5 },
+                { "steps": 8, "guidance": 0.0, "loras": [{ "index": 0, "weight": 1.0 }] }
+            ]
+        }
+    }));
+    assert_eq!(
+        resolve_image_route(&phases_and_accel, &settings),
+        Some(ImageRoute::KreaMultiPhase),
+        "an explicit advanced.phases list must take precedence over the S3 turbo-on-Raw lane",
+    );
+
+    // Over-routing guard 1: accelerator LoRA but NO phases → the S3 turbo-on-Raw lane, UNCHANGED.
+    let accel_no_phases = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "loras": [{ "id": "krea2_turbo_accel", "family": "krea_2", "role": "accelerator" }],
+        "advanced": { "modelPath": model_path.clone() }
+    }));
+    assert_eq!(
+        resolve_image_route(&accel_no_phases, &settings),
+        Some(ImageRoute::KreaTurboOnRaw),
+        "an accelerator LoRA without advanced.phases must stay on the S3 turbo-on-Raw lane",
+    );
+
+    // Over-routing guard 2: plain Raw t2i, no phases → the generic `Mlx` (single-phase) lane, UNCHANGED.
+    let plain = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "advanced": { "modelPath": model_path }
+    }));
+    assert_eq!(
+        resolve_image_route(&plain, &settings),
+        Some(ImageRoute::Mlx),
+        "a plain Raw t2i without advanced.phases must stay on the single-phase Mlx lane",
+    );
+}
+
+// The `advanced.phases` presence check drives the router gate: present + non-null ⇒ the lane claims the
+// job (even an empty array, so a malformed list fails loudly in the lane rather than being dropped);
+// absent or explicit null ⇒ unaffected.
+#[cfg(target_os = "macos")]
+#[test]
+fn request_has_multiphase_detects_presence() {
+    let with = request(json!({ "model": "krea_2_raw", "advanced": { "phases": [] } }));
+    assert!(
+        request_has_multiphase(&with),
+        "an empty phases array is still 'present'"
+    );
+    let without = request(json!({ "model": "krea_2_raw", "advanced": {} }));
+    assert!(!request_has_multiphase(&without));
+    let null = request(json!({ "model": "krea_2_raw", "advanced": { "phases": null } }));
+    assert!(
+        !request_has_multiphase(&null),
+        "an explicit null is not 'present'"
+    );
+}
+
+// A valid `advanced.phases` parses into the SceneWorks plan with concrete steps / guidance / lora
+// selectors, and `build_generation_phases` maps that plan to gen-core `phases` VERBATIM — each phase's
+// lora `index` becomes `PhaseAdapter.adapter` (the index into `LoadSpec::adapters`), `weight`/`steps`/
+// `guidance` pass through. Pinned to concrete values so it discriminates a mis-map.
+#[cfg(target_os = "macos")]
+#[test]
+fn multiphase_parses_and_maps_to_gen_core_phases() {
+    // Two job LoRAs → the load-time adapter stack the phases reference by index (0 and 1).
+    let req = request(json!({
+        "model": "krea_2_raw",
+        "loras": [
+            { "id": "style", "installedPath": "/style.safetensors" },
+            { "id": "turbo", "installedPath": "/turbo.safetensors" }
+        ],
+        "advanced": {
+            "phases": [
+                { "steps": 20, "guidance": 3.5 },
+                { "steps": 8, "guidance": 0.0, "loras": [{ "index": 1, "weight": 0.9 }, { "index": 0 }] }
+            ]
+        }
+    }));
+
+    let specs = parse_multiphase_specs(&req).expect("valid phases parse");
+    assert_eq!(
+        specs,
+        vec![
+            MultiPhaseSpec {
+                steps: 20,
+                guidance: Some(3.5),
+                loras: vec![]
+            },
+            MultiPhaseSpec {
+                steps: 8,
+                guidance: Some(0.0),
+                loras: vec![
+                    PhaseLoraRef {
+                        index: 1,
+                        weight: Some(0.9)
+                    },
+                    PhaseLoraRef {
+                        index: 0,
+                        weight: None
+                    },
+                ],
+            },
+        ],
+    );
+
+    // Mapping: SceneWorks plan → gen-core phases. Phase 0 is base-only (no adapters); phase 1 activates
+    // load-time adapter #1 @ 0.9 then #0 @ its load-time scale (weight None), in the listed order.
+    let phases = build_generation_phases(&specs);
+    assert_eq!(
+        phases,
+        vec![
+            gen_core::GenerationPhase {
+                steps: 20,
+                guidance: Some(3.5),
+                adapters: vec![]
+            },
+            gen_core::GenerationPhase {
+                steps: 8,
+                guidance: Some(0.0),
+                adapters: vec![
+                    gen_core::PhaseAdapter {
+                        adapter: 1,
+                        weight: Some(0.9)
+                    },
+                    gen_core::PhaseAdapter {
+                        adapter: 0,
+                        weight: None
+                    },
+                ],
+            },
+        ],
+    );
+
+    // A base-only phase list with a numeric-string step (matching the rest of the advanced knobs) and
+    // no loras key still parses; an absent `loras` is a base-only phase.
+    let base_only = request(json!({
+        "model": "krea_2_raw", "loras": [],
+        "advanced": { "phases": [{ "steps": "12" }] }
+    }));
+    let specs = parse_multiphase_specs(&base_only).expect("string steps + no loras parse");
+    assert_eq!(
+        specs,
+        vec![MultiPhaseSpec {
+            steps: 12,
+            guidance: None,
+            loras: vec![]
+        }]
+    );
+}
+
+// The parse rejects — loudly, with a clear message — exactly the shapes the engine rejects (plus the
+// SceneWorks-side lora-index bound + sanity caps), so a bad list fails fast before the heavy load.
+#[cfg(target_os = "macos")]
+#[test]
+fn multiphase_parse_rejects_malformed_lists() {
+    let with_two_loras = |phases: serde_json::Value| {
+        request(json!({
+            "model": "krea_2_raw",
+            "loras": [
+                { "id": "a", "installedPath": "/a.safetensors" },
+                { "id": "b", "installedPath": "/b.safetensors" }
+            ],
+            "advanced": { "phases": phases }
+        }))
+    };
+    let err = |req: &ImageRequest| parse_multiphase_specs(req).unwrap_err().to_string();
+
+    // Non-array phases.
+    assert!(err(&with_two_loras(json!({ "steps": 8 }))).contains("must be an array"));
+    // Empty phase list.
+    assert!(err(&with_two_loras(json!([]))).contains("at least one phase"));
+    // A phase that is not an object.
+    assert!(err(&with_two_loras(json!([5]))).contains("must be a JSON object"));
+    // Missing steps.
+    assert!(err(&with_two_loras(json!([{ "guidance": 3.5 }]))).contains("'steps' is required"));
+    // 0-step phase.
+    assert!(err(&with_two_loras(json!([{ "steps": 0 }]))).contains("at least 1"));
+    // Non-finite / negative guidance.
+    assert!(
+        err(&with_two_loras(json!([{ "steps": 8, "guidance": -1.0 }])))
+            .contains("finite value >= 0")
+    );
+    // A lora index out of range of the job's TWO loras (valid indices 0..1; index 2 is out of range).
+    let oor = err(&with_two_loras(
+        json!([{ "steps": 8, "loras": [{ "index": 2 }] }]),
+    ));
+    assert!(oor.contains("out of range"), "got: {oor}");
+    assert!(
+        oor.contains("2 LoRA(s)"),
+        "the bound is the job's loras count: got: {oor}"
+    );
+    // A lora entry missing `index`.
+    assert!(err(&with_two_loras(
+        json!([{ "steps": 8, "loras": [{ "weight": 0.5 }] }])
+    ))
+    .contains("'index' is required"));
+    // Total step budget over the sanity cap.
+    assert!(err(&with_two_loras(json!([{ "steps": 200 }]))).contains("total step budget"));
+    // More than the max phase count.
+    let many: Vec<serde_json::Value> = (0..9).map(|_| json!({ "steps": 1 })).collect();
+    assert!(err(&with_two_loras(json!(many))).contains("at most"));
+}
+
+// The lane rejects the job SHAPES the engine rejects (multi-phase renders from pure noise): edit mode,
+// strict poses, an img2img reference, and the PiD decoder — each surfaced loudly BEFORE the heavy load.
+#[cfg(target_os = "macos")]
+#[test]
+fn multiphase_job_shape_rejects_non_t2i_conditioning() {
+    // A plain t2i job passes the shape guard.
+    let ok = request(json!({ "model": "krea_2_raw", "advanced": { "phases": [{ "steps": 8 }] } }));
+    assert!(ensure_multiphase_job_shape(&ok).is_ok());
+
+    // Edit mode.
+    let edit = request(json!({
+        "model": "krea_2_raw", "mode": "edit_image",
+        "advanced": { "phases": [{ "steps": 8 }] }
+    }));
+    assert!(ensure_multiphase_job_shape(&edit)
+        .unwrap_err()
+        .to_string()
+        .contains("edit mode"));
+
+    // Strict poses.
+    let pose = request(json!({
+        "model": "krea_2_raw",
+        "advanced": { "phases": [{ "steps": 8 }], "poses": [{ "keypoints": [] }] }
+    }));
+    assert!(ensure_multiphase_job_shape(&pose)
+        .unwrap_err()
+        .to_string()
+        .contains("strict-pose"));
+
+    // Img2img reference (`ui.img2img: true` + a non-empty referenceAssetId).
+    let img2img = request(json!({
+        "model": "krea_2_raw",
+        "modelManifestEntry": { "ui": { "img2img": true } },
+        "referenceAssetId": "asset-1",
+        "advanced": { "phases": [{ "steps": 8 }] }
+    }));
+    assert!(ensure_multiphase_job_shape(&img2img)
+        .unwrap_err()
+        .to_string()
+        .contains("img2img reference"));
+
+    // PiD decoder.
+    let pid = request(json!({
+        "model": "krea_2_raw",
+        "advanced": { "phases": [{ "steps": 8 }], "usePid": true }
+    }));
+    assert!(ensure_multiphase_job_shape(&pid)
+        .unwrap_err()
+        .to_string()
+        .contains("PiD"));
+}
+
 // sc-13883: the accelerator role detector recognizes `role: accelerator` (case- and separator-
 // normalized, mirroring `lora_declares_image_edit_role`) and rejects everything else — including the
 // `conditioningRole` sibling, which is a DIFFERENT axis (how a job is conditioned, not how it samples).


### PR DESCRIPTION
Epic 13879 (Krea Raw fidelity / turbo LoRA / multi-phase), **Phase B of sc-13884**: bump the pinned inference rev to pick up the merged multi-phase Krea MLX engine primitive, then wire the worker to drive it.

## Commit 1 — pin bump (`chore`)
Bumps `SceneWorks/inference` `cd46a910` → **`235ca214`** (inference PR #199) via `scripts/bump-inference.mjs` (both manifests + the root `candle-kernels` `[patch]` in lockstep) + `cargo update`. `check-gen-core-skew.sh` confirms one `sceneworks-gen-core` and one `pmetal-mlx-rs` resolution (no skew).

The new rev adds the gen-core contract `GenerationRequest.phases: Option<Vec<GenerationPhase>>` (`GenerationPhase { steps, guidance?, adapters: Vec<PhaseAdapter> }`, `PhaseAdapter { adapter: usize, weight? }`, `adapter` indexing `LoadSpec::adapters`) plus the Krea MLX multi-phase driver (one global sigma schedule, per-phase guidance, per-phase adapter toggling via a job-local DiT clone). `phases: None` = existing single-phase behavior (backward-compatible).

The **~13 intervening inference commits** are mostly **candle-audio fixes** (device caching, contiguity, upsample portability) + CI/doc changes. **The bump alone was verified in isolation** (worker builds clean, exit 0) BEFORE any wiring — no audio or other breakage from the intervening commits. **SceneWorks CI validates the full integration** (build + parity/candle lanes).

## Commit 2 — worker wiring (`feat`, macOS/MLX)
A `krea_2_raw` t2i job carrying a phase list renders through the new multi-phase primitive.

- **`advanced.phases` contract** (client → worker, in `ImageRequest.advanced`): a list of `{ steps, guidance?, loras: [{ index, weight? }] }`. A phase's lora `index` selects into the job's OWN LoRA stack.
- **phase → `LoadSpec::adapters` index mapping**: `resolve_adapters` emits one `AdapterSpec` per `request.loras` entry, in order, so `request.loras[i]` maps 1:1 to `LoadSpec::adapters[i]` — the index passes straight to gen-core `PhaseAdapter.adapter`. `parse_multiphase_specs` bounds-checks each index against the job's lora count and validates the list (≥1 phase, each ≥1 step, finite/≥0 guidance, sanity caps on phase count + total steps), rejecting malformed shapes with clear errors **before** the heavy load. `ensure_multiphase_job_shape` rejects the shapes the engine rejects (edit mode / strict pose / img2img reference / PiD — multi-phase renders from pure noise).
- **Routing / precedence**: a new `ImageRoute::KreaMultiPhase`, gated on `model == krea_2_raw` + a present `advanced.phases`, placed **first** among the `krea_2_raw` lanes so an explicit phase list takes precedence over S3's whole-job turbo-on-Raw regime (sc-13883) and the generic single-phase `Mlx` lane — multi-phase is the finer-grained control. The lane loads the `krea_2_raw` engine (the multi-phase driver keys on that descriptor id), unlike S3 which swaps to `krea_2_turbo`. A job **without** `advanced.phases` is byte-for-byte unchanged.
- **macOS-gating**: all new code lives in a macOS-only `include!`'d file (`image_jobs/krea_multiphase.rs`) + existing `#[cfg(target_os = "macos")]` regions (the `ImageRoute` enum, `resolve_image_route`, the dispatch match). gen-core phase types are referenced fully-qualified (`gen_core::GenerationPhase`/`PhaseAdapter`) to avoid touching the shared cross-cfg `use` block — so the Linux `parity` / `candle-worker` build is untouched.

## Tests (macOS, all green)
- **parse + validation**: a valid list parses to the pinned `MultiPhaseSpec` plan; each malformed shape (non-array, empty, non-object phase, missing/0-step `steps`, non-finite/negative guidance, out-of-range lora index, missing `index`, over-cap total steps, over-cap phase count) is rejected with a clear message.
- **mapping**: plan → gen-core `phases` pinned to concrete `PhaseAdapter` indices / weights / steps / guidance (discriminates a mis-map); base-only + numeric-string-steps cases.
- **routing / precedence**: `advanced.phases` → `KreaMultiPhase`; an explicit phase list wins over S3 turbo-on-Raw; no-phases jobs unchanged (`KreaTurboOnRaw` with an accelerator LoRA, `Mlx` for plain Raw).
- **job-shape rejects**: edit / pose / img2img reference / PiD.

`cargo fmt --all` clean; `cargo clippy -p sceneworks-worker --all-targets -- -D warnings` clean; `cargo build -p sceneworks-worker` clean; the 5 new tests pass.

## Follow-on
The **GPU render itself** (real end-to-end multi-phase image on Metal) is a **hardware follow-on — sc-13994** — it needs a GPU and is not faked here. This PR proves the full SceneWorks-side path (parse → validate → map → route → build `GenerationRequest.phases`) up to the engine boundary.

sc-13884