### PR TITLE
fix(web): gate keep-alive editors' keydown shortcuts on screen activity [sc-13589]

### DIFF
--- a/apps/web/src/screens/EditorScreen.jsx
+++ b/apps/web/src/screens/EditorScreen.jsx
@@ -125,16 +125,24 @@ export function EditorScreen() {
     return () => cancelAnimationFrame(raf);
   }, [isPlaying, screenActive, duration]);
 
-  const shortcutStateRef = useRef({ undo, redo, removeSelectedItem, selectedItemId });
-  shortcutStateRef.current = { undo, redo, removeSelectedItem, selectedItemId };
+  const shortcutStateRef = useRef({ undo, redo, removeSelectedItem, selectedItemId, screenActive });
+  shortcutStateRef.current = { undo, redo, removeSelectedItem, selectedItemId, screenActive };
 
   useEffect(() => {
     function onKeyDown(event) {
+      const { undo, redo, removeSelectedItem, selectedItemId, screenActive } = shortcutStateRef.current;
+      // Under selective keep-alive (sc-11959) this editor stays mounted and this window
+      // listener stays subscribed even when another view is foregrounded, so gate every
+      // shortcut on the active flag — a backgrounded timeline must never eat Space (play),
+      // undo/redo, or Delete meant for the visible screen (sc-13589). Read it from the ref
+      // so the once-subscribed listener always sees the latest value.
+      if (!screenActive) {
+        return;
+      }
       const target = event.target;
       if (["INPUT", "TEXTAREA", "SELECT"].includes(target?.tagName)) {
         return;
       }
-      const { undo, redo, removeSelectedItem, selectedItemId } = shortcutStateRef.current;
       if (event.code === "Space") {
         event.preventDefault();
         setIsPlaying((value) => !value);

--- a/apps/web/src/screens/EditorScreen.test.jsx
+++ b/apps/web/src/screens/EditorScreen.test.jsx
@@ -245,3 +245,118 @@ describe("EditorScreen preview playback keep-alive gating (sc-11961)", () => {
     expect(pause).toHaveBeenCalled();
   });
 });
+
+// sc-13589 (F-008): under keep-alive the editor stays mounted and its window keydown
+// listener stays subscribed while another view is foregrounded. These tests assert the
+// timeline shortcuts fire only when the screen is the ACTIVE view — a backgrounded editor
+// must never mutate the hidden timeline in response to keys meant for the visible screen.
+// Mutation guard: with the screenActive gate removed, the "HIDDEN" case would run
+// removeSelectedItem -> commit -> setActiveTimeline and the assertion below goes red.
+describe("EditorScreen keep-alive keydown gating (sc-13589)", () => {
+  function makeVideoAsset() {
+    return {
+      id: "asset_v1",
+      type: "video",
+      displayName: "Clip A",
+      url: "/api/v1/files/v1.mp4",
+      file: { mimeType: "video/mp4", duration: 4 },
+    };
+  }
+
+  function makeTimelineWithVideoItem() {
+    return {
+      id: "tl_1",
+      name: "Main",
+      aspectRatio: "16:9",
+      fps: 30,
+      width: 1280,
+      height: 720,
+      tracks: [
+        {
+          id: "track_main",
+          name: "Main",
+          items: [
+            {
+              id: "item_1",
+              trackId: "track_main",
+              assetId: "asset_v1",
+              type: "video",
+              displayName: "Clip A",
+              sourceIn: 0,
+              sourceOut: 4,
+              timelineStart: 0,
+              timelineEnd: 4,
+              speed: 1,
+              fit: "fit",
+              volume: 1,
+              versionAssetIds: ["asset_v1"],
+              currentVersionAssetId: "asset_v1",
+              versionHistory: [{ assetId: "asset_v1", createdAt: null, source: "original", jobId: null, note: null }],
+              transitionIn: { id: "t_in", type: "cut", duration: 0 },
+              transitionOut: { id: "t_out", type: "cut", duration: 0 },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  function renderEditor(screenActive) {
+    const setActiveTimeline = vi.fn();
+    const timeline = makeTimelineWithVideoItem();
+    const value = {
+      activeProject: { id: "proj_1", name: "Proj" },
+      activeTimeline: timeline,
+      mediaAssets: [makeVideoAsset()],
+      timelines: [timeline],
+      selectedTimelineId: "tl_1",
+      setSelectedTimelineId: vi.fn(),
+      setActiveTimeline,
+      setPreviewAsset: vi.fn(),
+      sendAssetToImage: vi.fn(),
+      sendAssetToVideo: vi.fn(),
+      createTimeline: vi.fn(),
+      extractTimelineFrame: vi.fn(),
+      exportTimeline: vi.fn(),
+      queueTimelineVideoJob: vi.fn(),
+      saveTimeline: vi.fn(),
+      isActiveTimelineDirty: () => false,
+    };
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ScreenActiveContext.Provider value={screenActive}>
+            <EditorScreen />
+          </ScreenActiveContext.Provider>
+        </AppContext.Provider>,
+      );
+    });
+    return { setActiveTimeline };
+  }
+
+  // Clicking the clip sets selectedItemId; Delete then routes through removeSelectedItem.
+  function selectClipAndPressDelete() {
+    const clip = container.querySelector(".ve-clip");
+    act(() => clip.dispatchEvent(new window.MouseEvent("click", { bubbles: true })));
+    act(() => window.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Delete", bubbles: true })));
+  }
+
+  it("deletes the selected clip on Delete while it is the ACTIVE view", () => {
+    const { setActiveTimeline } = renderEditor(true);
+    selectClipAndPressDelete();
+
+    // removeSelectedItem -> commit -> setActiveTimeline with the selected clip filtered out.
+    expect(setActiveTimeline).toHaveBeenCalledTimes(1);
+    expect(setActiveTimeline.mock.calls[0][0].tracks[0].items).toHaveLength(0);
+  });
+
+  it("ignores Delete while the editor is HIDDEN under keep-alive", () => {
+    const { setActiveTimeline } = renderEditor(false);
+    selectClipAndPressDelete();
+
+    // The backgrounded editor's keydown handler early-returns, so the hidden timeline is
+    // never mutated by a Delete meant for the visible screen.
+    expect(setActiveTimeline).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -5,6 +5,7 @@ import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "reac
 import { apiFetch } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
+import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { appConfirm } from "../appConfirm.jsx";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
@@ -681,6 +682,10 @@ export function ImageEditor() {
     theme = "light",
     changeTheme,
   } = useAppContext();
+  // Selective keep-alive (sc-11959): this editor stays mounted (merely hidden) once visited,
+  // so it must consult this flag to avoid acting while it is the backgrounded view — the
+  // window keydown handler below is gated on it (sc-13589).
+  const screenActive = useScreenActive();
   // Mac UI gating (sc-3486): the upscale tool itself runs in-process on Rust (Real-ESRGAN,
   // sc-3489), so it is available on a gated Mac — this block is a defensive guard that stays
   // null. The second engine (AuraSR) is dropped on Mac (sc-3668) and gated per-engine below.
@@ -1317,6 +1322,12 @@ export function ImageEditor() {
   // zoom bar. `?` toggles the quick reference and works before an image is open.
   const onEditorKeyDownRef = useRef(null);
   onEditorKeyDownRef.current = (event) => {
+    // Under selective keep-alive (sc-11959) this editor stays mounted and this window
+    // listener stays subscribed even when another view is foregrounded, so gate every
+    // shortcut on the active flag — a backgrounded editor must never undo/redo, delete a
+    // box, switch tools, or toggle the reference in response to keys meant for the visible
+    // screen (sc-13589). The handler is reassigned each render, so `screenActive` is fresh.
+    if (!screenActive) return;
     const tag = event.target?.tagName;
     if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || event.target?.isContentEditable) return;
 

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -13,6 +13,7 @@ vi.mock("react-konva", async () => {
 });
 
 import { AppContext } from "../context/AppContext.js";
+import { ScreenActiveContext } from "../context/ScreenActiveContext.js";
 import {
   ImageEditor,
   cropRatioForKey,
@@ -207,6 +208,41 @@ describe("ImageEditor scaffold", () => {
     await press("?", input);
     expect(container.querySelector(".image-editor-shortcuts")).toBeNull();
     input.remove();
+  });
+
+  // sc-13589 (F-008): under keep-alive the editor stays mounted and its window keydown
+  // listener stays subscribed while another view is foregrounded. The `?` reference toggle
+  // is the jsdom-reachable shortcut (the tool hotkeys need the Konva stage), so it stands in
+  // for the whole handler: it must fire only when the screen is the active view. Mutation
+  // guard: drop the screenActive gate and the backgrounded assertion below goes red.
+  async function renderWithScreenActive(context, active) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ScreenActiveContext.Provider value={active}>
+            <ImageEditor />
+          </ScreenActiveContext.Provider>
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("gates the '?' shortcut on screen activity under keep-alive (sc-13589)", async () => {
+    const press = async () =>
+      act(async () => window.dispatchEvent(new KeyboardEvent("keydown", { key: "?", bubbles: true })));
+
+    // Backgrounded: the window listener is still subscribed, but the handler early-returns,
+    // so `?` does NOT open the reference on the hidden editor.
+    await renderWithScreenActive(baseContext(), false);
+    await press();
+    expect(container.querySelector(".image-editor-shortcuts")).toBeNull();
+
+    // Flip to the active view (the real keep-alive transition): the same key now opens the
+    // reference, proving the gate — not a broken handler — suppressed it while hidden.
+    await renderWithScreenActive(baseContext(), true);
+    await press();
+    expect(container.querySelector(".image-editor-shortcuts")).not.toBeNull();
   });
 
   // sc-8730: the editorLaunch channel routes an asset into the editor canvas from


### PR DESCRIPTION
## Story
[sc-13589](https://app.shortcut.com/trefry/story/13589) — [review][High] Gate keep-alive editors' global keydown handlers on screen activity. Epic [sc-13900](https://app.shortcut.com/trefry/epic/13900) (Code review 2026-07-20 — High findings, F-008). This is the last open story in the epic.

## Problem
Both `ImageEditor` and `EditorScreen` attach a **window** `keydown` listener on mount and stay mounted under selective keep-alive (`App.jsx` `KeepAlivePane`, views `"ImageEditor"` and `"Editor"` — `KeepAlivePane` only sets `hidden`, so the child never unmounts). Neither handler consulted `useScreenActive()`, so once either editor had been visited its shortcuts kept firing app-wide:

- Cmd+Z / Ctrl+Y — undo/redo
- Delete / Backspace — delete the selected timeline clip / delete the selected box
- Space — toggle play
- single-key tool switches — `c b e g t u d m + - _ = 0 1 ?`

Pressing Cmd+Z or Delete on any other screen (outside a text field) silently mutated the hidden editor documents — invisible state/data mutation with no feedback. If both editors had been visited, a single key could hit both at once.

## Fix
Read `useScreenActive()` in both screens and early-return from the keydown handler when the screen is the backgrounded view (the story's suggested fix). The gate is the first statement in each handler, ahead of every shortcut branch:

- **`ImageEditor.jsx`** — import `useScreenActive`, read `const screenActive = useScreenActive();`, and gate `onEditorKeyDownRef.current`. That handler is reassigned every render, so its closure always sees the current `screenActive`.
- **`EditorScreen.jsx`** — thread `screenActive` through the existing `shortcutStateRef` (the listener is subscribed once via `useEffect([], …)`, so it reads the latest value from the ref rather than a stale closure), then early-return.

No change to the active-view behavior; only a backgrounded editor is suppressed.

## Tests
Added mutation-checked tests that render each editor under `ScreenActiveContext.Provider value={false}`:

- `EditorScreen.test.jsx` — selecting a clip then pressing **Delete** mutates the timeline (`setActiveTimeline`) while active, and does **nothing** while hidden.
- `ImageEditor.test.jsx` — the `?` reference toggle (the jsdom-reachable shortcut; tool hotkeys need the Konva stage) opens the panel while active and is suppressed while hidden.

Verified the mutation kill: temporarily neutering both gates turns the two backgrounded assertions **red** while the active-case control stays green. Restored → 98/98 pass.

## Verification
- `vitest run --environment jsdom` on both suites — 98 passed
- `eslint src` — 0 errors (pre-existing warnings only, none in changed files)
- `vite build` — succeeds

## Scope
Confined to the two editor handlers (the story's scope). Other `keydown` listeners in the web app (`AccentPicker`, `CompactSelector`, `StylePicker`, `assetPanels` fullscreen/menu) are open-scoped popovers that only listen while their transient UI is open and only close themselves — not the always-mounted-under-keep-alive hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)