### PR TITLE
chore(desktop): remove stale hardened-runtime weakenings from macOS entitlements [sc-13609]

### DIFF
--- a/apps/desktop/Entitlements.plist
+++ b/apps/desktop/Entitlements.plist
@@ -5,9 +5,30 @@
         <!-- WKWebView / Tauri IPC -->
         <key>com.apple.security.network.client</key><true/>
         <key>com.apple.security.network.server</key><true/>
-        <!-- The worker dlopens onnxruntime + spawns uv/python that load unsigned dylibs -->
-        <key>com.apple.security.cs.disable-library-validation</key><true/>
-        <!-- setup.rs sets ORT_DYLIB_PATH and friends; needed if any DYLD_* is used for subprocesses -->
-        <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+        <!--
+          Hardened-runtime weakenings removed (sc-13609) — do NOT re-add without cause:
+            * com.apple.security.cs.disable-library-validation
+            * com.apple.security.cs.allow-dyld-environment-variables
+          Their former justification (the app spawned uv/python that loaded unsigned
+          dylibs and set DYLD_* for subprocesses) is obsolete:
+            - The Python venv was retired app-wide (epic 3482 — "no Python venv on any
+              platform"); the shipped Mac app spawns only the sceneworks-api sidecar.
+            - The ONLY dylib the shipped app dlopens on macOS is the bundled CoreML
+              libonnxruntime.dylib (ort `load-dynamic`, sc-3487). build-sidecar.mjs
+              re-signs it (`codesign --force --options runtime`) with the SAME
+              Developer ID / Team ID as the .app, so library validation permits the
+              load — the CoreML EP is compiled into that one dylib and talks only to
+              Apple's system CoreML.framework (no third-party provider dylib on Mac).
+            - No DYLD_* env var is set anywhere (Rust/JS/shell/CI). ORT_DYLIB_PATH and
+              PMETAL_METALLIB_PATH are plain application env vars read by the ort crate
+              and the pmetal resolver — NOT dynamic-linker (DYLD_*) variables.
+          Full hardened runtime now blocks same-team-unsigned dylib injection and
+          DYLD_INSERT_LIBRARIES attacks on every process.
+          VALIDATION GATE: dropping disable-library-validation must be confirmed by a
+          notarized smoke build (the release lane) that verifies ort/CoreML pose
+          detection still loads. If that load fails under library validation, re-add
+          ONLY disable-library-validation here with this real (CoreML dlopen) reason —
+          never restore allow-dyld-environment-variables.
+        -->
     </dict>
 </plist>


### PR DESCRIPTION
## Summary

Removes **both** stale hardened-runtime weakenings from `apps/desktop/Entitlements.plist`:

- `com.apple.security.cs.disable-library-validation` — **removed**
- `com.apple.security.cs.allow-dyld-environment-variables` — **removed**

The former justification comment cited an architecture the repo deleted ("The worker dlopens onnxruntime + spawns uv/python that load unsigned dylibs" / "setup.rs sets ORT_DYLIB_PATH and friends; needed if any DYLD_* is used for subprocesses"). The comment is rewritten to record the real (now-satisfied) situation, the decision, and the validation gate.

Corresponds to the code-review finding F-044 in `CODE_REVIEW_2026-07-12.md` (the story references it as F-047; the finding text and location — `Entitlements.plist:8-11` — match exactly).

## Finding

> The notarized app still ships `disable-library-validation` and `allow-dyld-environment-variables`, justified by a comment about spawning uv/python — an architecture the repo deleted. Impact: same-team-unsigned dylib injection and `DYLD_INSERT_LIBRARIES` attacks remain possible on every process.

## Evidence

**1. `DYLD_*` grep (entire repo, excluding `node_modules/`, `target/`, `.git/`):** the ONLY hits are the stale comment in `Entitlements.plist` itself and the code-review doc describing this finding. **No `DYLD_*` env var is set anywhere** in Rust, JS, shell, or CI. `ORT_DYLIB_PATH` and `PMETAL_METALLIB_PATH` (set in `apps/desktop/src/setup.rs`) are **plain application env vars** — read by the `ort` crate (`load-dynamic`) and the pmetal metallib resolver respectively — **not** dynamic-linker (`DYLD_*`) variables. So `allow-dyld-environment-variables` protects nothing that is used → unconditional removal.

**2. uv/python architecture is gone at runtime:** epic 3482 (Python Eradication) retired the venv app-wide (README: "no Python venv on any platform"). `setup.rs` spawns only the `sceneworks-api` sidecar (the same binary re-launched in worker mode) — no `uv`, no `python`. The only `python3` invocations are **build-time** staging scripts (`stage-onnxruntime.py`, `stage-ffmpeg.py`) run on the build machine, not runtime subprocess spawns in the shipped app.

**3. Nested-dylib signing (crux for `disable-library-validation`):**
- The only dylib the shipped Mac app `dlopen`s at runtime is the bundled CoreML `libonnxruntime.dylib` (`crates/sceneworks-worker/Cargo.toml:72` — `ort` with `["coreml", "load-dynamic"]`; resolved via `ORT_DYLIB_PATH` in `setup.rs:595,977`).
- `apps/desktop/scripts/build-sidecar.mjs:179-188,296` re-signs that dylib with `codesign --force --sign <signingIdentity> --options runtime --timestamp`, where `signingIdentity = APPLE_SIGNING_IDENTITY || tauri.conf.json bundle.macOS.signingIdentity`.
- `apps/desktop/tauri.conf.json:47` sets that identity to `Developer ID Application: Michael Trefry (R2526H7YN9)` — the **same identity/Team ID (R2526H7YN9)** used to sign the `.app`. `release.yml` passes the same `APPLE_SIGNING_IDENTITY` secret on the release lane.
- macOS **library validation permits loading libraries signed by the same Team ID**. The CoreML execution provider is compiled into that single dylib and talks only to Apple's system `CoreML.framework` (always allowed) — there is no separate third-party/ad-hoc provider dylib on macOS (unlike the Windows CUDA path).
- `mlx.metallib` is a plain Metal resource sealed by the `.app` signature, not a Mach-O `dlopen` — not subject to library validation.

**Conclusion:** every dylib loaded on macOS is same-team-signed (or an Apple system framework), so per the decision rubric `disable-library-validation` is removable — this is the intended end state.

## Decision

| Key | Action | Reason |
|-----|--------|--------|
| `com.apple.security.cs.allow-dyld-environment-variables` | **Removed** | No `DYLD_*` set anywhere; the env vars in use are plain app vars, not linker vars. Unambiguous. |
| `com.apple.security.cs.disable-library-validation` | **Removed** | The sole macOS runtime `dlopen` target (`libonnxruntime.dylib`) is re-signed with the app's own Developer ID / Team ID; library validation permits same-team libs. Evidence-driven, not a hedge. |

## Validation

- `plutil -lint apps/desktop/Entitlements.plist` → **OK**. Parsed plist now contains only `com.apple.security.network.client` and `com.apple.security.network.server`.
- Entitlements are consumed at **codesign time** (wired via `tauri.conf.json` → `codesign --entitlements`). CI's parity/web lanes do **not** codesign, so a green CI does **NOT** prove the notarized app still loads ort/CoreML.

## ⚠️ VALIDATION GATE (required before next release ships)

**A notarized smoke build on the release Mac must confirm ort/CoreML pose detection still loads with both keys removed**, before the next release ships. This is the one thing that cannot be verified in this session (needs the Developer ID cert + notary `.p8` on the release Mac) — notarized runtime behavior is **UNVERIFIED here**. If the CoreML `dlopen` fails under library validation, re-add **ONLY** `disable-library-validation` with the corrected (CoreML dlopen) reason — **never** restore `allow-dyld-environment-variables`. The in-file comment records this gate.

Story: https://app.shortcut.com/trefry/story/13609

🤖 Generated with [Claude Code](https://claude.com/claude-code)