### PR TITLE
feat(krea): Image Studio multi-phase denoise editor [sc-13885]

### DIFF
--- a/apps/web/src/components/MultiPhaseEditor.jsx
+++ b/apps/web/src/components/MultiPhaseEditor.jsx
@@ -1,0 +1,233 @@
+import React from "react";
+import { Icon } from "./Icons.jsx";
+import {
+  MULTIPHASE_MAX_PHASES,
+  TURBO_FINISH_PRESET,
+  acceleratorLoraIndex,
+  addPhase,
+  effectiveTotalSteps,
+  movePhase,
+  newPhase,
+  phaseHasLora,
+  removePhase,
+  setPhaseLoraWeight,
+  togglePhaseLora,
+  updatePhase,
+} from "../imageMultiPhase.js";
+
+// Krea 2 multi-phase denoise editor (epic 13879 S5, sc-13885). A controlled, presentational editor
+// for the ordered phase list that rides the image job as `advanced.phases`. Each phase owns a step
+// count, a guidance value (0 = true-CFG off), and a per-selected-LoRA on/off + optional weight —
+// the per-phase LoRA toggles reference the job's CURRENTLY-SELECTED LoRAs by index, so the emitted
+// `loras:[{ index, weight? }]` maps 1:1 to the worker's load-time adapter stack.
+//
+// It surfaces under an experimental AdvancedSection (default collapsed) in ImageStudio; all state
+// mutation goes through the pure helpers in imageMultiPhase.js so the same logic the tests pin also
+// drives the UI. Error surfacing (empty list, 0-step phase, …) is the shared ValidationSummary via
+// multiPhaseIssues — the app-wide requirement/error split.
+export function MultiPhaseEditor({
+  enabled,
+  onToggleEnabled,
+  phases = [],
+  onChange,
+  selectedLoras = [],
+  onApplyTurboFinish,
+}) {
+  const accelIndex = acceleratorLoraIndex(selectedLoras);
+  const total = effectiveTotalSteps(phases);
+  const atMaxPhases = phases.length >= MULTIPHASE_MAX_PHASES;
+
+  return (
+    <div className="multiphase-editor">
+      <label className="checkline multiphase-enable">
+        <input
+          checked={enabled}
+          onChange={(event) => onToggleEnabled(event.target.checked)}
+          type="checkbox"
+        />
+        Enable multi-phase denoise
+      </label>
+      <p className="field-hint multiphase-intro">
+        Split ONE Raw denoise into ordered phases over a single schedule — each phase its own step
+        count, guidance (0 = CFG off), and active LoRAs. The canonical flow is a few true-CFG Raw
+        steps, then a few CFG-off steps with the turbo LoRA.
+      </p>
+
+      <div className="multiphase-presets">
+        <button
+          className="multiphase-btn multiphase-preset-btn"
+          onClick={() => onApplyTurboFinish()}
+          type="button"
+        >
+          {TURBO_FINISH_PRESET.label}
+        </button>
+        {accelIndex < 0 ? (
+          <span className="field-hint multiphase-accel-hint">
+            Select the Krea turbo LoRA above to wire it into the CFG-off finishing phase.
+          </span>
+        ) : null}
+      </div>
+
+      {enabled ? (
+        <>
+          {phases.length ? (
+            <p className="field-hint multiphase-effective" role="status">
+              Effective steps: <strong>{total}</strong> (sum of {phases.length}{" "}
+              {phases.length === 1 ? "phase" : "phases"}). Phases drive the schedule — the Steps and
+              Guidance fields above are ignored while multi-phase is on.
+            </p>
+          ) : null}
+
+          <ol className="multiphase-phase-list">
+            {phases.map((phase, phaseIndex) => {
+              const guidance = Number(phase.guidance);
+              const cfgOn = Number.isFinite(guidance) && guidance > 0;
+              return (
+                <li className="multiphase-phase" key={phaseIndex}>
+                  <div className="multiphase-phase-head">
+                    <span className="eyebrow multiphase-phase-title">Phase {phaseIndex + 1}</span>
+                    <div className="multiphase-phase-actions">
+                      <button
+                        aria-label={`Move phase ${phaseIndex + 1} up`}
+                        className="icon-btn"
+                        disabled={phaseIndex === 0}
+                        onClick={() => onChange(movePhase(phases, phaseIndex, -1))}
+                        type="button"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        aria-label={`Move phase ${phaseIndex + 1} down`}
+                        className="icon-btn"
+                        disabled={phaseIndex === phases.length - 1}
+                        onClick={() => onChange(movePhase(phases, phaseIndex, 1))}
+                        type="button"
+                      >
+                        ↓
+                      </button>
+                      <button
+                        aria-label={`Remove phase ${phaseIndex + 1}`}
+                        className="icon-btn multiphase-remove"
+                        onClick={() => onChange(removePhase(phases, phaseIndex))}
+                        type="button"
+                      >
+                        <Icon.Trash />
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="multiphase-phase-fields">
+                    <label>
+                      Steps
+                      <input
+                        min="1"
+                        onChange={(event) =>
+                          onChange(
+                            updatePhase(phases, phaseIndex, {
+                              steps: event.target.value === "" ? "" : Number(event.target.value),
+                            }),
+                          )
+                        }
+                        type="number"
+                        value={phase.steps}
+                      />
+                    </label>
+                    <label>
+                      Guidance
+                      <input
+                        min="0"
+                        onChange={(event) =>
+                          onChange(
+                            updatePhase(phases, phaseIndex, {
+                              guidance:
+                                event.target.value === "" ? "" : Number(event.target.value),
+                            }),
+                          )
+                        }
+                        step="0.1"
+                        type="number"
+                        value={phase.guidance}
+                      />
+                      <span className="field-hint multiphase-cfg-hint">
+                        {cfgOn ? "CFG on" : "CFG off"}
+                      </span>
+                    </label>
+                  </div>
+
+                  <div className="multiphase-phase-loras">
+                    <span className="eyebrow">Active LoRAs</span>
+                    {selectedLoras.length ? (
+                      selectedLoras.map((lora, loraIndex) => {
+                        const ref = (phase.loras ?? []).find((entry) => entry.id === lora.id);
+                        const active = phaseHasLora(phase, lora.id);
+                        return (
+                          <div className="multiphase-lora-row" key={lora.id ?? loraIndex}>
+                            <label className="checkline">
+                              <input
+                                checked={active}
+                                onChange={() =>
+                                  onChange(
+                                    updatePhase(phases, phaseIndex, togglePhaseLora(phase, lora.id)),
+                                  )
+                                }
+                                type="checkbox"
+                              />
+                              {lora.name ?? lora.id}
+                              {loraIndex === accelIndex ? (
+                                <span className="badge multiphase-accel-badge">turbo</span>
+                              ) : null}
+                            </label>
+                            {active ? (
+                              <input
+                                aria-label={`Phase ${phaseIndex + 1} weight for ${lora.name ?? lora.id}`}
+                                className="multiphase-lora-weight"
+                                onChange={(event) =>
+                                  onChange(
+                                    updatePhase(
+                                      phases,
+                                      phaseIndex,
+                                      setPhaseLoraWeight(
+                                        phase,
+                                        lora.id,
+                                        event.target.value === "" ? null : Number(event.target.value),
+                                      ),
+                                    ),
+                                  )
+                                }
+                                placeholder="load-time"
+                                step="0.05"
+                                type="number"
+                                value={ref?.weight ?? ""}
+                              />
+                            ) : null}
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <span className="field-hint">
+                        No LoRAs selected — this phase renders base-only. Pick LoRAs above to toggle
+                        them per phase.
+                      </span>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+
+          <button
+            className="multiphase-btn multiphase-add"
+            disabled={atMaxPhases}
+            onClick={() => onChange(addPhase(phases, newPhase()))}
+            type="button"
+          >
+            <Icon.Plus /> Add phase
+          </button>
+          {atMaxPhases ? (
+            <span className="field-hint">Maximum of {MULTIPHASE_MAX_PHASES} phases.</span>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/imageJobAdvanced.js
+++ b/apps/web/src/imageJobAdvanced.js
@@ -74,6 +74,12 @@ export function buildImageJobAdvanced(state) {
     // Style Catalog recipe round-trip (sc-13132). Both are undefined unless a style is applied.
     styleId,
     styleUserPrompt,
+    // Krea 2 multi-phase denoise (epic 13879 S5, sc-13885). `multiPhaseActive` is the resolved gate
+    // (model advertises the acceleration compat + text-to-image mode + the editor enabled); `phases`
+    // is the ALREADY-SERIALIZED emit-shape list (serializePhases runs in ImageStudio, where the
+    // selected-LoRA list resolves each phase LoRA id → index). Emitted only when active AND non-empty.
+    multiPhaseActive,
+    phases,
   } = state;
 
   return {
@@ -251,5 +257,13 @@ export function buildImageJobAdvanced(state) {
     // block. Emitted ONLY when a style is applied (styleId set), so styleless recipes stay
     // byte-identical. `stylePrompt` may be "" (a style with no user prose still round-trips exactly).
     ...(styleId ? { styleId, stylePrompt: styleUserPrompt ?? "" } : {}),
+    // Krea 2 multi-phase denoise (epic 13879 S5, sc-13885): the ordered `advanced.phases` list the
+    // worker's `parse_multiphase_specs` consumes (crates/sceneworks-worker/.../krea_multiphase.rs).
+    // Emitted ONLY when the multi-phase editor is active (krea_2_raw + text-to-image + enabled) AND
+    // carries at least one phase — so a normal single-phase Raw job (editor off/empty, or any other
+    // model) adds NOTHING new and stays byte-for-byte unchanged. `phases` is already in the exact
+    // { steps, guidance, loras:[{ index, weight? }] } shape the worker parses; the omit-when-inactive
+    // rule keeps the round-trip lossless.
+    ...(multiPhaseActive && Array.isArray(phases) && phases.length ? { phases } : {}),
   };
 }

--- a/apps/web/src/imageJobAdvanced.test.js
+++ b/apps/web/src/imageJobAdvanced.test.js
@@ -107,6 +107,28 @@ describe("buildImageJobAdvanced", () => {
     ).toBe(1.5);
   });
 
+  it("emits advanced.phases only when multi-phase is active AND non-empty (sc-13885)", () => {
+    // The canonical S4 example is ALREADY serialized (index-shaped) by the time it reaches the
+    // builder — serializePhases runs in ImageStudio, where the selected-LoRA list resolves ids.
+    const canonicalPhases = [
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 4, guidance: 0, loras: [{ index: 0 }] },
+    ];
+    // Inactive (editor off / non-Krea model) → NOTHING emitted even with a phase list present, so a
+    // single-phase Raw job is byte-for-byte unchanged.
+    expect(
+      buildImageJobAdvanced(offState({ multiPhaseActive: false, phases: canonicalPhases })),
+    ).toEqual({ resolution: "1024x1024" });
+    // Active but empty → still omitted.
+    expect(
+      buildImageJobAdvanced(offState({ multiPhaseActive: true, phases: [] })),
+    ).not.toHaveProperty("phases");
+    // Active + non-empty → the phase list rides advanced.phases VERBATIM (the worker's parse shape).
+    expect(
+      buildImageJobAdvanced(offState({ multiPhaseActive: true, phases: canonicalPhases })).phases,
+    ).toEqual(canonicalPhases);
+  });
+
   it("omits guidanceMethod for the engine no-op 'cfg' and rides a non-default method", () => {
     expect(buildImageJobAdvanced(offState({ guidanceMethod: "cfg" }))).not.toHaveProperty("guidanceMethod");
     expect(buildImageJobAdvanced(offState({ guidanceMethod: "cfg_pp" })).guidanceMethod).toBe("cfg_pp");

--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -100,6 +100,9 @@ export function buildImageJobRequest(state) {
     controlPassthroughId,
     effectiveControlScale,
     controlOverlayId,
+    // Krea 2 multi-phase denoise (epic 13879 S5, sc-13885) — delegated to buildImageJobAdvanced.
+    multiPhaseActive,
+    phases,
   } = state;
 
   // sc-13130 / sc-13224: apply the Style Catalog as the LAST wrap on the outgoing prompt. It is a
@@ -268,6 +271,10 @@ export function buildImageJobRequest(state) {
       //    store "" — the raw prompt lives in the caption blob, not here.
       styleId: styleApplied ? styleId : undefined,
       styleUserPrompt: styleApplied ? (structuredInjected ? "" : promptToSend) : undefined,
+      // Krea 2 multi-phase denoise (epic 13879 S5, sc-13885): the resolved gate + the editor's phase
+      // list. buildImageJobAdvanced emits `advanced.phases` only when active + non-empty.
+      multiPhaseActive,
+      phases,
     }),
   };
 }

--- a/apps/web/src/imageJobRequest.test.js
+++ b/apps/web/src/imageJobRequest.test.js
@@ -152,6 +152,43 @@ describe("buildImageJobRequest", () => {
     expect(request.referenceAssetId).toBe("character-ref");
     expect(request.advanced).not.toHaveProperty("strength");
   });
+
+  // Krea 2 multi-phase denoise round-trip (epic 13879 S5, sc-13885): a krea_2_raw t2i job with the
+  // editor active carries the serialized `advanced.phases` verbatim, and the phase LoRA indices
+  // point into the request's OWN `loras` array — the SAME order the worker resolves to
+  // `LoadSpec::adapters`. The canonical S4 example: 4 steps Raw CFG-on base-only, then 4 steps Raw +
+  // the turbo LoRA (index 1) CFG off.
+  it("round-trips advanced.phases only when multi-phase is active, indexing the request's own loras", () => {
+    const loras = [
+      { id: "style-lora", name: "Watercolor" },
+      { id: "krea2_turbo_accel", name: "Krea Turbo" },
+    ];
+    const canonicalPhases = [
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 4, guidance: 0, loras: [{ index: 1 }] },
+    ];
+    const state = img2imgPidState({
+      model: "krea_2_raw",
+      supportsImg2img: false,
+      img2imgReferenceAssetId: null,
+      showPidToggle: false,
+      usePid: false,
+      loras,
+      multiPhaseActive: true,
+      phases: canonicalPhases,
+    });
+
+    const request = buildImageJobRequest(state);
+    // The phase list rides advanced.phases unchanged (the worker parse shape).
+    expect(request.advanced.phases).toEqual(canonicalPhases);
+    // Index 1 in the phase's loras resolves to the turbo LoRA in the request's own loras array.
+    expect(request.loras[request.advanced.phases[1].loras[0].index].id).toBe("krea2_turbo_accel");
+
+    // Inactive editor → NO advanced.phases (a single-phase Raw job is byte-for-byte unchanged).
+    expect(
+      buildImageJobRequest({ ...state, multiPhaseActive: false }).advanced,
+    ).not.toHaveProperty("phases");
+  });
 });
 
 // sc-13224: the Style axis applied to a structured JSON-caption model (Ideogram 4). The style is

--- a/apps/web/src/imageMultiPhase.js
+++ b/apps/web/src/imageMultiPhase.js
@@ -1,0 +1,238 @@
+import { issue } from "./validation/issues.js";
+
+// Krea 2 multi-phase denoise editor (epic 13879 S5, sc-13885). The pure state → payload core for
+// the Image Studio phase editor: it builds, mutates, validates and SERIALIZES the ordered phase
+// list that rides the image job as `advanced.phases`, the contract the SceneWorks worker consumes in
+// `crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs` (`parse_multiphase_specs` /
+// `build_generation_phases`, sc-13884 / S4).
+//
+// The emitted shape MUST match that parser EXACTLY so the request round-trips to the worker
+// unchanged:
+//
+//   advanced.phases = [
+//     { steps: <int ≥ 1>, guidance: <number ≥ 0>, loras: [ { index: <int>, weight?: <number> }, … ] },
+//     …
+//   ]
+//
+//   - `steps`      contiguous denoise steps for the phase; the schedule length is the SUM.
+//   - `guidance`   per-phase true-CFG: 0 = CFG off, > 0 = CFG on. (The worker also accepts an
+//                  omitted/null guidance = inherit the request default; the editor always writes an
+//                  explicit value, so this module always emits one.)
+//   - `loras`      the load-time adapters this phase activates, referencing the job's OWN selected
+//                  LoRA list BY INDEX. `index` is the position in `request.loras` — the SAME array
+//                  the worker resolves 1:1 to `LoadSpec::adapters`. An empty list = base-only.
+//   - `weight`     optional per-phase weight override; omitted = the adapter's load-time scale.
+//
+// INTERNAL representation vs the CONTRACT: the editor stores each phase's LoRA references by the
+// LoRA's stable `id` (`{ id, weight }`), NOT by raw index. `serializePhases` maps those ids to the
+// CURRENT index in `selectedLoras` at emit time — so the emitted `index` is always valid, a reorder
+// reindexes automatically, and a deselected LoRA is pruned, with no stale-index bookkeeping and no
+// async-hydration hazard (indices are never persisted). The canonical S4 workflow (Comfy 4+4) is 4
+// steps Raw true-CFG on (base-only), then 4 steps Raw + the turbo accelerator LoRA CFG off —
+// `buildTurboFinishPhases` produces exactly that, wired to whichever selected LoRA carries
+// `role: "accelerator"` (the `krea2_turbo_accel` builtin, sc-13882).
+
+// Worker guardrails mirrored so an invalid list is caught BEFORE submit (krea_multiphase.rs
+// MAX_MULTIPHASE_PHASES / MAX_MULTIPHASE_TOTAL_STEPS). Not creative limits — guardrails.
+export const MULTIPHASE_MAX_PHASES = 8;
+export const MULTIPHASE_MAX_TOTAL_STEPS = 150;
+
+// The sampling-regime role a LoRA declares to be a step-distill / turbo accelerator (sc-13882,
+// serialized by presetUtils.serializeLora as `role`). Phase 2 of the turbo-finish preset toggles it.
+export const ACCELERATOR_ROLE = "accelerator";
+
+// The LoRA-compat type only the model with the multi-phase worker lane advertises: krea_2_raw's
+// `loraCompatibility.types` includes "acceleration" (config/manifests/builtin.models.jsonc, sc-13882).
+// This is the DECLARATIVE gate for showing the editor — no hardcoded model id — and matches the
+// worker gate (`request.model == KREA_RAW_MODEL_ID`), since only Raw declares this compat today.
+export const MULTIPHASE_COMPAT_TYPE = "acceleration";
+
+// Turbo-finish preset identity (the canonical S4 example).
+export const TURBO_FINISH_PRESET = { id: "turbo_finish_4_4", label: "Turbo finish (4+4)" };
+
+// True when the selected model exposes the multi-phase denoise lane. Gated on the acceleration LoRA
+// compat the Raw model declares — the same signal that surfaces the turbo accelerator LoRA in the
+// picker (sc-13882). The Studio further gates on text-to-image mode (multi-phase renders from pure
+// noise; the worker rejects edit/pose/reference/PiD shapes).
+export function modelSupportsMultiPhase(model) {
+  const types = model?.loraCompatibility?.types;
+  return Array.isArray(types) && types.includes(MULTIPHASE_COMPAT_TYPE);
+}
+
+// The selected turbo accelerator LoRA (the one carrying `role: "accelerator"`), or null.
+export function acceleratorLora(selectedLoras = []) {
+  return (
+    selectedLoras.find(
+      (lora) => String(lora?.role ?? "").trim().toLowerCase() === ACCELERATOR_ROLE,
+    ) ?? null
+  );
+}
+
+// The index of the selected accelerator LoRA in `selectedLoras`, or -1. (Index into the SAME array
+// `request.loras` is built from, so it is a valid phase index — used by the editor's "turbo" badge.)
+export function acceleratorLoraIndex(selectedLoras = []) {
+  return selectedLoras.findIndex(
+    (lora) => String(lora?.role ?? "").trim().toLowerCase() === ACCELERATOR_ROLE,
+  );
+}
+
+// A fresh phase: 4 steps, true-CFG on (guidance 3.5, the Raw default), base-only.
+export function newPhase(overrides = {}) {
+  return { steps: 4, guidance: 3.5, loras: [], ...overrides };
+}
+
+// The canonical S4 "Turbo finish (4+4)" example: phase 1 = 4 steps Raw true-CFG base-only; phase 2 =
+// 4 steps Raw + the selected turbo accelerator LoRA, CFG off. When no accelerator LoRA is selected,
+// phase 2 is left base-only (the Studio surfaces the "select the turbo LoRA" hint) so the structure
+// is still produced — the per-phase toggle can wire the LoRA once it is picked.
+export function buildTurboFinishPhases(selectedLoras = []) {
+  const accel = acceleratorLora(selectedLoras);
+  return [
+    { steps: 4, guidance: 3.5, loras: [] },
+    { steps: 4, guidance: 0, loras: accel ? [{ id: accel.id, weight: null }] : [] },
+  ];
+}
+
+export function addPhase(phases = [], phase = newPhase()) {
+  return [...phases, phase];
+}
+
+export function removePhase(phases = [], at) {
+  return phases.filter((_, index) => index !== at);
+}
+
+// Move the phase at `at` by `delta` (-1 up / +1 down); a no-op at the ends.
+export function movePhase(phases = [], at, delta) {
+  const target = at + delta;
+  if (at < 0 || at >= phases.length || target < 0 || target >= phases.length) {
+    return phases;
+  }
+  const next = [...phases];
+  [next[at], next[target]] = [next[target], next[at]];
+  return next;
+}
+
+export function updatePhase(phases = [], at, patch) {
+  return phases.map((phase, index) => (index === at ? { ...phase, ...patch } : phase));
+}
+
+// Toggle a selected LoRA (by its stable id) on/off for one phase.
+export function togglePhaseLora(phase, loraId) {
+  const loras = phase.loras ?? [];
+  const existing = loras.some((ref) => ref.id === loraId);
+  return {
+    ...phase,
+    loras: existing
+      ? loras.filter((ref) => ref.id !== loraId)
+      : [...loras, { id: loraId, weight: null }],
+  };
+}
+
+// Set (or clear, with null) a phase LoRA's per-phase weight override.
+export function setPhaseLoraWeight(phase, loraId, weight) {
+  return {
+    ...phase,
+    loras: (phase.loras ?? []).map((ref) => (ref.id === loraId ? { ...ref, weight } : ref)),
+  };
+}
+
+// True when a phase currently activates the given LoRA id.
+export function phaseHasLora(phase, loraId) {
+  return (phase?.loras ?? []).some((ref) => ref.id === loraId);
+}
+
+// The effective total denoise budget = the sum of the phases' steps (the length of the ONE global
+// schedule). Surfaced so the single flat "Steps" control isn't misleading when phases are active.
+export function effectiveTotalSteps(phases = []) {
+  return phases.reduce((sum, phase) => {
+    const steps = Number(phase.steps);
+    return sum + (Number.isFinite(steps) ? Math.max(0, Math.trunc(steps)) : 0);
+  }, 0);
+}
+
+// Serialize the editor phase list into the EXACT `advanced.phases` shape the worker's
+// `parse_multiphase_specs` accepts, resolving each phase LoRA's stable id to its CURRENT index in
+// `selectedLoras` (== the `request.loras` order). This is where reindex + prune happen: a LoRA that
+// is no longer selected is dropped, a reorder shifts the index, duplicates collapse — so the emitted
+// `index` is always valid against the job's own LoRA stack. `steps` → an integer; `guidance` → a
+// finite number (0 = CFG off); `weight` is emitted only when a finite override is set (absent =
+// the adapter's load-time scale, the worker's `None`). `loras` is always emitted (an empty array =
+// base-only, the canonical phase-1 shape).
+export function serializePhases(phases = [], selectedLoras = []) {
+  const indexById = new Map(selectedLoras.map((lora, index) => [lora.id, index]));
+  return phases.map((phase) => {
+    const out = { steps: Math.trunc(Number(phase.steps)) };
+    const guidance = Number(phase.guidance);
+    if (Number.isFinite(guidance)) {
+      out.guidance = guidance;
+    }
+    const seen = new Set();
+    out.loras = (phase.loras ?? []).flatMap((ref) => {
+      const index = indexById.get(ref.id);
+      if (index == null || seen.has(index)) {
+        return []; // deselected LoRA (prune) or already referenced (dedupe).
+      }
+      seen.add(index);
+      const entry = { index };
+      const weight = Number(ref.weight);
+      if (ref.weight != null && ref.weight !== "" && Number.isFinite(weight)) {
+        entry.weight = weight;
+      }
+      return [entry];
+    });
+    return out;
+  });
+}
+
+// The multi-phase rule set, in the app-wide validation vocabulary (epic 10644). Errors, not silent
+// requirements: an enabled-but-broken phase list blocks Generate and nothing else on the form
+// explains why. Returns [] when the editor is disabled — a disabled editor emits no phases, so a
+// single-phase Raw job is byte-for-byte unchanged. Mirrors the worker's own rejects (empty list,
+// 0-step phase, > MAX phases, total-step budget) so the request never leaves broken.
+export function multiPhaseIssues({ enabled = false, phases = [] } = {}) {
+  if (!enabled) {
+    return [];
+  }
+  const issues = [];
+  if (!phases.length) {
+    issues.push(
+      issue.error("multiPhase", "Add at least one phase, or turn off multi-phase denoise."),
+    );
+    return issues;
+  }
+  if (phases.length > MULTIPHASE_MAX_PHASES) {
+    issues.push(
+      issue.error(
+        "multiPhase",
+        `Multi-phase supports at most ${MULTIPHASE_MAX_PHASES} phases — remove ${
+          phases.length - MULTIPHASE_MAX_PHASES
+        }.`,
+      ),
+    );
+  }
+  phases.forEach((phase, index) => {
+    const steps = Number(phase.steps);
+    if (!Number.isFinite(steps) || !Number.isInteger(steps) || steps < 1) {
+      issues.push(issue.error("multiPhase", `Phase ${index + 1} needs at least 1 step.`));
+    }
+    const guidance = Number(phase.guidance);
+    if (!Number.isFinite(guidance) || guidance < 0) {
+      issues.push(
+        issue.error(
+          "multiPhase",
+          `Phase ${index + 1} guidance must be 0 or greater (0 = CFG off).`,
+        ),
+      );
+    }
+  });
+  const total = effectiveTotalSteps(phases);
+  if (total > MULTIPHASE_MAX_TOTAL_STEPS) {
+    issues.push(
+      issue.error(
+        "multiPhase",
+        `Multi-phase total steps ${total} exceed the ${MULTIPHASE_MAX_TOTAL_STEPS}-step budget — reduce phase steps.`,
+      ),
+    );
+  }
+  return issues;
+}

--- a/apps/web/src/imageMultiPhase.test.js
+++ b/apps/web/src/imageMultiPhase.test.js
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import { summarize } from "./validation/issues.js";
+import {
+  MULTIPHASE_MAX_PHASES,
+  MULTIPHASE_MAX_TOTAL_STEPS,
+  TURBO_FINISH_PRESET,
+  acceleratorLora,
+  acceleratorLoraIndex,
+  addPhase,
+  buildTurboFinishPhases,
+  effectiveTotalSteps,
+  modelSupportsMultiPhase,
+  movePhase,
+  multiPhaseIssues,
+  newPhase,
+  phaseHasLora,
+  removePhase,
+  serializePhases,
+  setPhaseLoraWeight,
+  togglePhaseLora,
+  updatePhase,
+} from "./imageMultiPhase.js";
+
+// Krea 2 multi-phase denoise editor (epic 13879 S5, sc-13885). The load-bearing guarantee is the
+// ROUND-TRIP: the editor must emit the EXACT `advanced.phases` shape the worker's
+// `parse_multiphase_specs` accepts (crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs), so
+// a job built here renders on the worker unchanged. These tests pin that shape and the state ops
+// (add/remove/reorder, per-phase LoRA toggle by the selected-LoRA list, reindex/prune, validation).
+
+// Two selected LoRAs — a style adapter and the turbo accelerator (role: "accelerator"). This is the
+// job's own LoRA stack; a phase references it by INDEX (== request.loras == LoadSpec::adapters).
+const STYLE = { id: "style-lora", name: "Watercolor", role: null };
+const TURBO = { id: "krea2_turbo_accel", name: "Krea Turbo", role: "accelerator" };
+
+describe("modelSupportsMultiPhase", () => {
+  it("is true only for a model advertising the acceleration LoRA compat (krea_2_raw, sc-13882)", () => {
+    expect(
+      modelSupportsMultiPhase({ loraCompatibility: { types: ["character", "style", "acceleration"] } }),
+    ).toBe(true);
+    // Turbo advertises character/style but NOT acceleration → no multi-phase lane.
+    expect(modelSupportsMultiPhase({ loraCompatibility: { types: ["character", "style"] } })).toBe(false);
+    expect(modelSupportsMultiPhase({})).toBe(false);
+    expect(modelSupportsMultiPhase(null)).toBe(false);
+  });
+});
+
+describe("acceleratorLora / acceleratorLoraIndex", () => {
+  it("finds the selected LoRA carrying role accelerator, or -1 / null", () => {
+    expect(acceleratorLoraIndex([STYLE, TURBO])).toBe(1);
+    expect(acceleratorLora([STYLE, TURBO])).toBe(TURBO);
+    expect(acceleratorLoraIndex([STYLE])).toBe(-1);
+    expect(acceleratorLora([STYLE])).toBeNull();
+  });
+});
+
+describe("buildTurboFinishPhases + serializePhases — the canonical S4 (Comfy 4+4) round-trip", () => {
+  it("produces EXACTLY the worker-shaped phase list wired to the selected turbo LoRA", () => {
+    const phases = buildTurboFinishPhases([STYLE, TURBO]);
+    // The emitted shape MUST equal what parse_multiphase_specs expects: phase 1 Raw true-CFG
+    // base-only, phase 2 Raw + the turbo LoRA (index 1 in the job's loras) with CFG off.
+    expect(serializePhases(phases, [STYLE, TURBO])).toEqual([
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 4, guidance: 0, loras: [{ index: 1 }] },
+    ]);
+  });
+
+  it("wires the accelerator at whatever index it occupies in the selected-LoRA list", () => {
+    // Turbo first, style second → the finishing phase references index 0.
+    const phases = buildTurboFinishPhases([TURBO, STYLE]);
+    expect(serializePhases(phases, [TURBO, STYLE])[1].loras).toEqual([{ index: 0 }]);
+  });
+
+  it("leaves the finishing phase base-only when no accelerator LoRA is selected", () => {
+    const phases = buildTurboFinishPhases([STYLE]);
+    expect(serializePhases(phases, [STYLE])).toEqual([
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 4, guidance: 0, loras: [] },
+    ]);
+  });
+
+  it("has stable preset identity", () => {
+    expect(TURBO_FINISH_PRESET).toEqual({ id: "turbo_finish_4_4", label: "Turbo finish (4+4)" });
+  });
+});
+
+describe("serializePhases — emit shape matches parse_multiphase_specs", () => {
+  it("emits steps as int, guidance as a number (0 kept), and per-lora { index, weight? }", () => {
+    // Mirror the worker's own multiphase test fixture (tests.rs): two loras, a base-only CFG-on
+    // phase then a CFG-off phase activating adapter 1 @ 0.9 then adapter 0 at load-time scale.
+    const phases = [
+      { steps: 20, guidance: 3.5, loras: [] },
+      {
+        steps: 8,
+        guidance: 0,
+        loras: [
+          { id: TURBO.id, weight: 0.9 },
+          { id: STYLE.id, weight: null },
+        ],
+      },
+    ];
+    expect(serializePhases(phases, [STYLE, TURBO])).toEqual([
+      { steps: 20, guidance: 3.5, loras: [] },
+      { steps: 8, guidance: 0, loras: [{ index: 1, weight: 0.9 }, { index: 0 }] },
+    ]);
+  });
+
+  it("truncates a fractional steps and drops a blank weight override", () => {
+    const phases = [{ steps: 6, guidance: 2, loras: [{ id: STYLE.id, weight: "" }] }];
+    expect(serializePhases(phases, [STYLE])).toEqual([{ steps: 6, guidance: 2, loras: [{ index: 0 }] }]);
+  });
+});
+
+describe("serializePhases — reindex + prune when the selected-LoRA list changes (no stale index)", () => {
+  // A phase built against [STYLE, TURBO] that activates the turbo LoRA (stored by stable id).
+  const phases = [
+    { steps: 4, guidance: 3.5, loras: [] },
+    { steps: 4, guidance: 0, loras: [{ id: TURBO.id, weight: null }] },
+  ];
+
+  it("REINDEXES when the selected LoRAs are reordered", () => {
+    // Turbo moves from index 1 to index 0 → the emitted index follows the LoRA, not the slot.
+    expect(serializePhases(phases, [TURBO, STYLE])[1].loras).toEqual([{ index: 0 }]);
+    expect(serializePhases(phases, [STYLE, TURBO])[1].loras).toEqual([{ index: 1 }]);
+  });
+
+  it("PRUNES a reference whose LoRA is no longer selected", () => {
+    // Turbo deselected → the finishing phase drops it (no dangling index), becomes base-only.
+    expect(serializePhases(phases, [STYLE])[1].loras).toEqual([]);
+    expect(serializePhases(phases, [])[1].loras).toEqual([]);
+  });
+
+  it("reindexes correctly after an insertion shifts positions", () => {
+    const extra = { id: "extra-lora", role: null };
+    // Insert a new LoRA before turbo → turbo shifts to index 2.
+    expect(serializePhases(phases, [STYLE, extra, TURBO])[1].loras).toEqual([{ index: 2 }]);
+  });
+});
+
+describe("phase list state ops (add / remove / reorder / update / toggle / weight)", () => {
+  it("adds and removes phases without mutating the input", () => {
+    const base = [newPhase()];
+    const added = addPhase(base, newPhase({ steps: 8 }));
+    expect(added).toHaveLength(2);
+    expect(base).toHaveLength(1); // immutable
+    expect(removePhase(added, 0)).toEqual([{ steps: 8, guidance: 3.5, loras: [] }]);
+  });
+
+  it("reorders phases with movePhase and no-ops at the ends", () => {
+    const phases = [{ steps: 1 }, { steps: 2 }, { steps: 3 }];
+    expect(movePhase(phases, 0, 1)).toEqual([{ steps: 2 }, { steps: 1 }, { steps: 3 }]);
+    expect(movePhase(phases, 2, -1)).toEqual([{ steps: 1 }, { steps: 3 }, { steps: 2 }]);
+    expect(movePhase(phases, 0, -1)).toBe(phases); // top phase can't move up
+    expect(movePhase(phases, 2, 1)).toBe(phases); // bottom phase can't move down
+  });
+
+  it("updates a single phase's fields", () => {
+    const phases = [newPhase(), newPhase()];
+    expect(updatePhase(phases, 1, { steps: 12, guidance: 0 })[1]).toEqual({
+      steps: 12,
+      guidance: 0,
+      loras: [],
+    });
+    expect(updatePhase(phases, 1, { steps: 12 })[0]).toEqual(newPhase()); // other phase untouched
+  });
+
+  it("toggles a LoRA on/off for a phase by stable id and edits its weight", () => {
+    const phase = newPhase();
+    const withTurbo = togglePhaseLora(phase, TURBO.id);
+    expect(phaseHasLora(withTurbo, TURBO.id)).toBe(true);
+    expect(withTurbo.loras).toEqual([{ id: TURBO.id, weight: null }]);
+    const weighted = setPhaseLoraWeight(withTurbo, TURBO.id, 0.8);
+    expect(weighted.loras).toEqual([{ id: TURBO.id, weight: 0.8 }]);
+    expect(phaseHasLora(togglePhaseLora(weighted, TURBO.id), TURBO.id)).toBe(false); // toggled off
+  });
+});
+
+describe("effectiveTotalSteps", () => {
+  it("sums the phases' steps (the ONE global schedule length)", () => {
+    expect(effectiveTotalSteps([{ steps: 4 }, { steps: 8 }, { steps: 2 }])).toBe(14);
+    expect(effectiveTotalSteps([{ steps: "" }, { steps: 6 }])).toBe(6); // blank counts as 0
+    expect(effectiveTotalSteps([])).toBe(0);
+  });
+});
+
+describe("multiPhaseIssues — the requirement/error split (epic 10644)", () => {
+  const kinds = (issues) => issues.map((i) => i.kind);
+
+  it("is silent (no issues) when the editor is disabled", () => {
+    expect(multiPhaseIssues({ enabled: false, phases: [] })).toEqual([]);
+    // Even a broken list is silent while disabled — a disabled editor emits no phases.
+    expect(multiPhaseIssues({ enabled: false, phases: [{ steps: 0 }] })).toEqual([]);
+  });
+
+  it("ERRORS (not a silent requirement) when enabled with no phases", () => {
+    const issues = multiPhaseIssues({ enabled: true, phases: [] });
+    expect(kinds(issues)).toEqual(["error"]);
+    // An error surfaces and blocks; a requirement would block silently.
+    const rolled = summarize(issues);
+    expect(rolled.ready).toBe(false);
+    expect(rolled.surfaced).toHaveLength(1);
+  });
+
+  it("ERRORS on a 0-step / blank phase", () => {
+    expect(summarize(multiPhaseIssues({ enabled: true, phases: [{ steps: 0, guidance: 3.5 }] })).ready).toBe(false);
+    const blank = multiPhaseIssues({ enabled: true, phases: [{ steps: "", guidance: 3.5 }] });
+    expect(kinds(blank)).toContain("error");
+  });
+
+  it("ERRORS on a negative guidance", () => {
+    const issues = multiPhaseIssues({ enabled: true, phases: [{ steps: 4, guidance: -1 }] });
+    expect(kinds(issues)).toContain("error");
+  });
+
+  it("ERRORS over the phase-count and total-step guardrails (mirrors the worker)", () => {
+    const many = Array.from({ length: MULTIPHASE_MAX_PHASES + 1 }, () => ({ steps: 1, guidance: 1 }));
+    expect(summarize(multiPhaseIssues({ enabled: true, phases: many })).ready).toBe(false);
+    const overBudget = [{ steps: MULTIPHASE_MAX_TOTAL_STEPS + 1, guidance: 1 }];
+    expect(summarize(multiPhaseIssues({ enabled: true, phases: overBudget })).ready).toBe(false);
+  });
+
+  it("passes a valid canonical list", () => {
+    const phases = buildTurboFinishPhases([STYLE, TURBO]);
+    expect(summarize(multiPhaseIssues({ enabled: true, phases })).ready).toBe(true);
+  });
+});

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -52,6 +52,10 @@ export function imageGenerateValidation({
   presetIncompatible = [],
   loraIncompatible = [],
   modelName,
+  // Krea 2 multi-phase denoise (epic 13879 S5, sc-13885): pre-computed issues from
+  // imageMultiPhase.multiPhaseIssues (an enabled-but-broken phase list blocks Generate with an
+  // error). Empty when the editor is off or the model has no multi-phase lane.
+  multiPhaseIssues = [],
 } = {}) {
   const issues = [];
   if (!activeProject) {
@@ -98,6 +102,8 @@ export function imageGenerateValidation({
     issues.push(issue.requirement("editLora", "Download the required edit LoRA to run edits"));
   }
   issues.push(...presetLoraIssues({ presetMissing, presetIncompatible, loraIncompatible, modelName }));
+  // Multi-phase denoise problems (sc-13885) — already kinded (errors) by multiPhaseIssues.
+  issues.push(...multiPhaseIssues);
   return issues;
 }
 

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { summarize } from "./validation/issues.js";
+import { issue, summarize } from "./validation/issues.js";
 import {
   batchPromptBudgetOverages,
   imageBatchValidation,
@@ -42,6 +42,21 @@ describe("imageGenerateValidation", () => {
     const issues = imageGenerateValidation({ ...whole, prompt: "   " });
     expect(kinds(issues, "prompt")).toEqual(["requirement"]);
     expect(summarize(issues).surfaced).toEqual([]);
+  });
+
+  it("surfaces multi-phase denoise errors and stays silent when there are none (sc-13885)", () => {
+    // No multi-phase issues (editor off / valid) → nothing added, draft still ready.
+    expect(summarize(imageGenerateValidation({ ...whole, multiPhaseIssues: [] })).ready).toBe(true);
+    // A multi-phase error blocks Generate AND surfaces (it is an error, not a silent requirement).
+    const withError = imageGenerateValidation({
+      ...whole,
+      multiPhaseIssues: [issue.error("multiPhase", "Add at least one phase, or turn off multi-phase denoise.")],
+    });
+    const rolled = summarize(withError);
+    expect(rolled.ready).toBe(false);
+    expect(rolled.surfaced.map((i) => i.message)).toContain(
+      "Add at least one phase, or turn off multi-phase denoise.",
+    );
   });
 
   it("requires caption content on a structured model, silently", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -4,6 +4,13 @@ import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetUrl } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { AdvancedSection } from "../components/AdvancedSection.jsx";
+import { MultiPhaseEditor } from "../components/MultiPhaseEditor.jsx";
+import {
+  buildTurboFinishPhases,
+  modelSupportsMultiPhase,
+  multiPhaseIssues as computeMultiPhaseIssues,
+  serializePhases,
+} from "../imageMultiPhase.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
@@ -574,6 +581,15 @@ export function ImageStudio() {
   // 1.0 = no-op; >1 warmer/richer (early Qwen3-VL taps), <1 late-biased. Resets to the model default on
   // model change like the other tuning knobs; emitted to advanced.textStyleGain only when off default.
   const [textStyleGain, setTextStyleGain] = useState(saved.textStyleGain ?? 1.0);
+  // Krea 2 multi-phase denoise (epic 13879 S5, sc-13885). `multiPhaseEnabled` opts the job into the
+  // multi-phase lane; `multiPhasePhases` is the editor's ordered phase list (LoRA refs stored by
+  // stable id — serializePhases resolves them to indices at emit time). `multiPhaseOpen` is the
+  // experimental disclosure's collapsed/expanded state (default collapsed, busy-page guidance).
+  const [multiPhaseEnabled, setMultiPhaseEnabled] = useState(saved.multiPhaseEnabled ?? false);
+  const [multiPhasePhases, setMultiPhasePhases] = useState(
+    Array.isArray(saved.multiPhasePhases) ? saved.multiPhasePhases : [],
+  );
+  const [multiPhaseOpen, setMultiPhaseOpen] = useState(saved.multiPhaseOpen ?? false);
   const [controlnetScale, setControlnetScale] = useState(saved.controlnetScale ?? 0.8);
   // Variation knob for backbones whose CFG is decoupled from IP-Adapter:
   // FLUX (true_cfg_scale alongside ipAdapterScale) and Qwen-Image-Edit (true_cfg_scale
@@ -1523,6 +1539,34 @@ export function ImageStudio() {
   const pickerSelectedLoraIds = managedEditLoraId
     ? selectedLoraIds.filter((id) => id !== managedEditLoraId)
     : selectedLoraIds;
+
+  // ---- Krea 2 multi-phase denoise (epic 13879 S5, sc-13885) ----
+  // Shown only for the model that advertises the "acceleration" LoRA compat (krea_2_raw, sc-13882)
+  // AND in text-to-image mode — matching the worker gate (`request.model == krea_2_raw`, t2i only;
+  // multi-phase renders from pure noise, so edit/pose/reference are rejected). `multiPhaseActive`
+  // additionally requires the editor toggle to be on: only then does `advanced.phases` ride the
+  // request, so every other job is byte-for-byte unchanged. The per-phase LoRA toggles reference the
+  // job's OWN selected LoRAs (`buildLorasPayload` order == `request.loras` == the worker's
+  // `LoadSpec::adapters`); serializePhases resolves each stored LoRA id to its current index there,
+  // so the emitted `loras:[{ index, weight? }]` is always valid, reindexed on reorder, pruned on
+  // deselect. Weighed against the SAME `selectedLoras` the payload maps, so the indices line up.
+  const supportsMultiPhase = modelSupportsMultiPhase(selectedModel);
+  const multiPhaseAvailable = supportsMultiPhase && mode === "text_to_image";
+  const multiPhaseActive = multiPhaseAvailable && multiPhaseEnabled;
+  const serializedPhases = useMemo(
+    () => serializePhases(multiPhasePhases, selectedLoras),
+    [multiPhasePhases, selectedLoras],
+  );
+  const multiPhaseValidationIssues = useMemo(
+    () => computeMultiPhaseIssues({ enabled: multiPhaseActive, phases: multiPhasePhases }),
+    [multiPhaseActive, multiPhasePhases],
+  );
+  const applyTurboFinishPreset = useCallback(() => {
+    setMultiPhasePhases(buildTurboFinishPhases(selectedLoras));
+    setMultiPhaseEnabled(true);
+    setMultiPhaseOpen(true);
+  }, [selectedLoras]);
+
   // sc-10516: a preset launch (Presets → "Use in Studio"). `availablePresets` filters on
   // mode + model, so the preset only resolves once both match — set them alongside the id.
   // Changing the model otherwise wipes the steps/guidance overrides (the advanced-defaults
@@ -1892,6 +1936,12 @@ export function ImageStudio() {
     selectedLoraIds,
     loraWeights,
     showIncompatibleLoras,
+    // Krea 2 multi-phase denoise (sc-13885): persist the editor toggle, phase list, and disclosure
+    // state alongside the rest of the studio snapshot (LoRA refs are by stable id, so they survive
+    // reload regardless of the selected-LoRA list's async hydration).
+    multiPhaseEnabled,
+    multiPhasePhases,
+    multiPhaseOpen,
     selectedPresetId,
     generalStackIds,
     batchMode,
@@ -2134,6 +2184,11 @@ export function ImageStudio() {
       controlPassthroughId,
       effectiveControlScale,
       controlOverlayId,
+      // Krea 2 multi-phase denoise (sc-13885): the resolved gate + the serialized phase list. The
+      // advanced builder emits `advanced.phases` only when active + non-empty, so a normal
+      // single-phase Raw job (editor off, or any other model/mode) stays byte-for-byte unchanged.
+      multiPhaseActive,
+      phases: serializedPhases,
     });
   };
 
@@ -2345,6 +2400,8 @@ export function ImageStudio() {
       presetIncompatible: presetValidationResult.incompatible,
       loraIncompatible: selectedLoraValidationResult.incompatible,
       modelName: selectedModel?.name,
+      // Multi-phase denoise problems (sc-13885): an enabled-but-broken phase list blocks Generate.
+      multiPhaseIssues: multiPhaseValidationIssues,
     }),
     [
       activeProject,
@@ -2364,6 +2421,7 @@ export function ImageStudio() {
       presetValidationResult,
       selectedLoraValidationResult,
       selectedModel,
+      multiPhaseValidationIssues,
     ],
   );
   const batchValidity = useValidation(imageBatchValidation, batchDraft, undefined);
@@ -3524,6 +3582,29 @@ export function ImageStudio() {
               />
             </div>
           </AdvancedSection>
+
+          {/* Krea 2 multi-phase denoise (epic 13879 S5, sc-13885). Its own EXPERIMENTAL disclosure,
+              default collapsed (busy-page guidance), shown only for the model that advertises the
+              acceleration LoRA compat (krea_2_raw) in text-to-image mode — matching the worker gate.
+              The phase editor references the LoRAs picked in the Advanced section above by index. */}
+          {multiPhaseAvailable ? (
+            <AdvancedSection
+              className="multiphase-section"
+              hint="experimental — split the Raw denoise into phases"
+              label="Multi-phase denoise (experimental)"
+              onToggle={() => setMultiPhaseOpen((value) => !value)}
+              open={multiPhaseOpen}
+            >
+              <MultiPhaseEditor
+                enabled={multiPhaseEnabled}
+                onApplyTurboFinish={applyTurboFinishPreset}
+                onChange={setMultiPhasePhases}
+                onToggleEnabled={setMultiPhaseEnabled}
+                phases={multiPhasePhases}
+                selectedLoras={selectedLoras}
+              />
+            </AdvancedSection>
+          ) : null}
 
           {/* The preset/LoRA problems that used to be three separate .inline-warning
               paragraphs (sc-10649). Requirements — no project, empty prompt — stay silent. */}

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -2087,3 +2087,115 @@ describe("Image Studio batch — New batch clears a restored loaded batch", () =
     expect(snap.batchName).toBe("");
   });
 });
+
+// Krea 2 multi-phase denoise Studio UI (epic 13879 S5, sc-13885). The editor is an experimental
+// disclosure (default collapsed) shown ONLY for the model that advertises the "acceleration" LoRA
+// compat (krea_2_raw) in text-to-image mode — matching the worker gate. The load-bearing acceptance
+// is the ROUND-TRIP: the Turbo finish (4+4) preset builds a request whose `advanced.phases` equals
+// the exact shape the worker's parse_multiphase_specs consumes, indexed into the job's own loras.
+describe("ImageStudio multi-phase denoise (epic 13879 S5, sc-13885)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  const KREA_RAW_MP = {
+    ...Z_IMAGE,
+    id: "krea_2_raw",
+    name: "Krea 2 Raw",
+    family: "krea_2",
+    capabilities: ["text_to_image", "edit_image"],
+    loraCompatibility: { families: ["krea_2"], types: ["character", "style", "acceleration"] },
+  };
+  const TURBO_LORA = {
+    id: "krea2_turbo_accel",
+    name: "Krea Turbo",
+    family: "krea_2",
+    role: "accelerator",
+    scope: "builtin",
+    installState: "installed",
+    installedPath: "/loras/krea2_turbo_accel",
+  };
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const MULTI_PHASE_LABEL = "Multi-phase denoise (experimental)";
+  const hasMultiPhaseSection = () => document.body.textContent.includes(MULTI_PHASE_LABEL);
+  // Open the AdvancedSection disclosure whose header label matches `label`.
+  const openSection = async (label) => {
+    const section = [...document.body.querySelectorAll(".advanced-section")].find((node) =>
+      node.querySelector(".advanced-section-label")?.textContent.trim() === label,
+    );
+    await click(section.querySelector(".advanced-section-toggle"));
+  };
+
+  it("shows the multi-phase disclosure only for an acceleration-compat model in text mode", async () => {
+    // A model without the acceleration compat → no multi-phase disclosure.
+    await render(baseContext({ imageModels: [Z_IMAGE] }));
+    expect(hasMultiPhaseSection()).toBe(false);
+
+    // krea_2_raw (advertises acceleration) in the default text-to-image mode → the disclosure shows,
+    // collapsed (header only — the editor body is not rendered until expanded).
+    await render(baseContext({ imageModels: [KREA_RAW_MP], loras: [TURBO_LORA] }));
+    expect(hasMultiPhaseSection()).toBe(true);
+    expect(document.body.textContent).not.toContain("Enable multi-phase denoise");
+
+    // Switching to Edit mode hides it — multi-phase renders from pure noise (worker rejects edits).
+    await click([...document.body.querySelectorAll(".mode-tabs button")].find((b) => b.textContent === "Edit"));
+    expect(hasMultiPhaseSection()).toBe(false);
+  });
+
+  it("builds the canonical Turbo finish (4+4) request end-to-end and round-trips advanced.phases", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(baseContext({ createImageJob, imageModels: [KREA_RAW_MP], loras: [TURBO_LORA] }));
+
+    // Select the turbo accelerator LoRA in the Advanced LoRA picker (it becomes request.loras[0]).
+    await openSection("Advanced");
+    await click(document.body.querySelector(".lora-add"));
+    await click(document.body.querySelector(".lora-pick-row"));
+
+    // Open the experimental disclosure and apply the Turbo finish (4+4) preset.
+    await openSection(MULTI_PHASE_LABEL);
+    expect(document.body.textContent).toContain("Enable multi-phase denoise");
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Turbo finish (4+4)"));
+
+    // Generate — the request must carry the phase list the worker parses, unchanged.
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+
+    const payload = createImageJob.mock.calls[0][0];
+    // request.loras carries the turbo LoRA; the phase index points back into it.
+    const turboIndex = payload.loras.findIndex((l) => l.id === "krea2_turbo_accel");
+    expect(turboIndex).toBeGreaterThanOrEqual(0);
+    expect(payload.advanced.phases).toEqual([
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 4, guidance: 0, loras: [{ index: turboIndex }] },
+    ]);
+  });
+
+  it("omits advanced.phases when the editor is left off (single-phase Raw is unchanged)", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(baseContext({ createImageJob, imageModels: [KREA_RAW_MP], loras: [TURBO_LORA] }));
+    // Do NOT enable multi-phase — just generate a plain Raw job.
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.advanced).not.toHaveProperty("phases");
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15057,3 +15057,92 @@ textarea[aria-invalid="true"]:focus {
   border-color: var(--danger);
   box-shadow: 0 0 0 4px color-mix(in oklch, var(--danger) 18%, transparent);
 }
+
+/* Krea 2 multi-phase denoise editor (epic 13879 S5, sc-13885). Its own experimental
+   AdvancedSection, so it renders as a plain column (not the .advanced-panel override grid). */
+.multiphase-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.multiphase-editor .multiphase-intro {
+  margin-top: 0;
+}
+.multiphase-presets {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.multiphase-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  color: var(--text);
+  cursor: pointer;
+}
+.multiphase-btn:hover {
+  border-color: var(--accent);
+}
+.multiphase-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.multiphase-effective {
+  margin-top: 0;
+}
+.multiphase-phase-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.multiphase-phase {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 10px;
+  background: var(--bg-1);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.multiphase-phase-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.multiphase-phase-actions {
+  display: flex;
+  gap: 4px;
+}
+.multiphase-phase-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.multiphase-phase-loras {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.multiphase-lora-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.multiphase-lora-weight {
+  width: 92px;
+}
+.multiphase-accel-badge {
+  margin-left: 6px;
+}
+.multiphase-cfg-hint {
+  margin-top: 2px;
+}


### PR DESCRIPTION
## sc-13885 (epic 13879 S5) — Studio UI for Krea multi-phase experimentation

Adds the Image Studio phase editor that lets a user build and run a Krea 2 Raw **multi-phase denoise** job end-to-end, emitting the exact `advanced.phases` contract the S4 worker (`parse_multiphase_specs`, sc-13884) consumes. **No Rust touched** — the worker contract is consumed unchanged.

### The phase editor UI
- New **experimental AdvancedSection disclosure** ("Multi-phase denoise (experimental)"), **default collapsed** per the busy-page guidance — its own section alongside the existing Advanced panel, so **every existing Raw control is preserved** (design-refactor guidance).
- Ordered phase list: per-phase **step count**, **guidance** (0 = CFG off, > 0 = CFG on), and **per-selected-LoRA on/off + optional weight**; **add / remove / reorder** phases; an **"Enable multi-phase denoise"** toggle.
- **Preset**: "Turbo finish (4+4)" → the canonical S4 example (4 steps Raw true-CFG base-only, then 4 steps Raw + the selected turbo accelerator LoRA CFG off), wired to whichever selected LoRA carries `role: "accelerator"` (`krea2_turbo_accel`, sc-13882).
- **Effective steps** readout (sum of phase steps) so the flat Steps field isn't misleading when phases are active.

### Gating (matches the worker)
- Shown **only** for the model advertising the `"acceleration"` LoRA compat (`krea_2_raw` — the only image model that declares it) **in text-to-image mode**, mirroring the worker gate (`request.model == krea_2_raw`, t2i only; multi-phase renders from pure noise). Hidden everywhere else.

### The `advanced.phases` round-trip contract
- `serializePhases` emits **exactly** `[{ steps:<int>, guidance:<number>, loras:[{ index:<int>, weight?:<number> }] }, …]` — the shape `parse_multiphase_specs` accepts (field names/types verified against `crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs` and its worker tests).
- Phase LoRA refs are stored **by stable LoRA id** and resolved to the **current index in the job's own selected-LoRA list** (`buildLorasPayload` order == `request.loras` == the worker's `LoadSpec::adapters`) at emit time — so the emitted `index` is always valid, **reindexed on reorder, pruned on deselect**, with no async-hydration hazard.
- Emitted **only** when the editor is active **and** non-empty, so a normal single-phase Raw job (editor off, or any other model/mode) is **byte-for-byte unchanged**.

### Validation (requirement/error split, epic 10644)
- An enabled-but-broken phase list (empty, 0-step, over the phase/step guardrails, negative guidance) surfaces an **error** (blocks + says why), not a silent requirement.

### Tests (vitest)
- `imageMultiPhase.test.js` — serialize/round-trip incl. the **canonical 4+4**, reindex/prune under reorder/remove/insert, state ops, validation split, gating predicate.
- `imageJobAdvanced.test.js` / `imageJobRequest.test.js` — emit gating (active + non-empty only) and a **full request-level round-trip** asserting `advanced.phases` matches the worker shape with indices pointing into the request's own `loras`.
- `imageStudioValidation.test.js` — multi-phase error surfaces via `summarize`.
- `ImageStudio.test.jsx` — `krea_2_raw` + t2i-only gating (hidden for non-acceleration models / in Edit mode) and an **end-to-end** build: select the turbo LoRA → Turbo finish (4+4) → Generate → assert the payload's `advanced.phases`.
- Full web suite (2270) + eslint (0 errors) + `npm run build` green.

### Follow-on
- The literal GPU render/reproduce-the-image step is the tracked **hardware follow-on (sc-13994)** — it needs shared GPU hardware and is not runnable here. This PR proves the UI builds and round-trips the correct worker request via tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)