### PR TITLE
fix(desktop): narrow the remote IPC capability grant [sc-13610]

### DIFF
--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -1,9 +1,9 @@
 {
   "identifier": "default",
-  "description": "Default capability set for the SceneWorks desktop shell window. The `remote` grant is REQUIRED: after setup the shell navigates the main window from tauri:// to the API-served React UI at http://127.0.0.1:<port>, and every window.__TAURI__ invoke (set_credential, choose_data_dir, reveal_in_os, restart_worker, get_gpu_info, ...) is rejected by the ACL at that remote origin without it. Loopback-only; the shell health-gates the API (health_is_sceneworks) before navigating. Do not remove.",
+  "description": "Default capability set for the SceneWorks desktop shell window. The `remote` grant is REQUIRED: after setup the shell navigates the main window from tauri:// to the API-served React UI at http://127.0.0.1:<port>, and every window.__TAURI__ invoke (set_credential, choose_data_dir, reveal_in_os, restart_worker, get_gpu_info, ...) is rejected by the ACL at that remote origin without it. Loopback-only: the shell only ever navigates to http://127.0.0.1:<port> (setup.rs), so ONLY that origin is granted — http://localhost:* was dropped (sc-13610) because it is never navigated to and only doubled the trusted-origin/XSS-escalation surface. The shell health-gates the API (health_is_sceneworks) before navigating. Do not remove or re-broaden.",
   "windows": ["main"],
   "remote": {
-    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+    "urls": ["http://127.0.0.1:*"]
   },
   "permissions": [
     "core:default",

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
-use tauri_plugin_dialog::DialogExt;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
 use crate::setup::{app_support_dir, default_data_dir, shared_huggingface_home};
 
@@ -444,12 +444,47 @@ pub fn get_remote_access() -> RemoteAccessStatus {
     remote_access_status()
 }
 
+/// Whether a `set_remote_access(enabled, ..)` call is a deliberate LAN-exposure action that
+/// warrants a native confirmation (sc-13610). Only *enabling* binds the API to the LAN and
+/// widens the attack surface; *disabling* is fail-safe and never needs confirmation.
+fn remote_access_change_needs_confirmation(enabled: bool) -> bool {
+    enabled
+}
+
+/// Show a native OS confirmation for a deliberate remote-access admin action (sc-13610).
+/// Returns `true` only when the user explicitly confirms. This is defense-in-depth against a
+/// compromised/XSS'd webview: enabling LAN remote access and setting the LAN password are rare,
+/// intentional actions, and this dialog is drawn by the OS — a script that has hijacked
+/// `window.__TAURI__` on the loopback origin cannot forge, pre-answer, or dismiss it, so it
+/// cannot silently bind the API to the LAN or plant a password it knows. `body` names the
+/// specific action so the user can make an informed choice.
+fn confirm_remote_access_action(app: &AppHandle, title: &str, body: &str) -> bool {
+    app.dialog()
+        .message(body)
+        .title(title)
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Continue".to_string(),
+            "Cancel".to_string(),
+        ))
+        .blocking_show()
+}
+
 /// Enable/disable LAN remote access and set the port (story 4). Fail-closed: enabling
 /// is rejected unless a password is already set (mirrors the launcher guard, story 3),
 /// and a privileged/low port the app can't bind is rejected up front rather than
 /// bricking startup. The change takes effect on the next launch (sidecar relaunch).
+///
+/// Enabling additionally requires a native OS confirmation (sc-13610): binding the API to
+/// the LAN is a deliberate admin action, and the native dialog is a defense-in-depth gate a
+/// compromised webview cannot forge (unlike an in-page confirm). `async` so the blocking
+/// dialog runs off the main thread (same pattern as `save_asset_as`).
 #[tauri::command]
-pub fn set_remote_access(enabled: bool, port: u16) -> Result<RemoteAccessStatus, String> {
+pub async fn set_remote_access(
+    app: AppHandle,
+    enabled: bool,
+    port: u16,
+) -> Result<RemoteAccessStatus, String> {
     let mut settings = load_settings();
     if enabled && !settings.remote_password_set {
         return Err("Set a password before enabling remote access.".to_owned());
@@ -459,6 +494,16 @@ pub fn set_remote_access(enabled: bool, port: u16) -> Result<RemoteAccessStatus,
             "Choose a port between 1024 and 65535 — lower ports need administrator privileges."
                 .to_owned(),
         );
+    }
+    if remote_access_change_needs_confirmation(enabled)
+        && !confirm_remote_access_action(
+            &app,
+            "Enable remote access?",
+            "This binds SceneWorks to your local network so other devices can reach it \
+             after the next restart. Continue only if you started this from Settings.",
+        )
+    {
+        return Err("Remote access was not enabled — confirmation was declined.".to_owned());
     }
     settings.remote_access_enabled = enabled;
     // Persist a valid port choice even while disabled, so it's remembered for next time.
@@ -470,8 +515,24 @@ pub fn set_remote_access(enabled: bool, port: u16) -> Result<RemoteAccessStatus,
 }
 
 /// Set/change the LAN password (story 4). Stored in the OS keychain; never echoed back.
+///
+/// Gated behind a native OS confirmation (sc-13610): the LAN password protects remote access,
+/// and planting a known password is the first half of an XSS enable-remote-access chain, so
+/// the same native, un-forgeable confirmation as `set_remote_access` guards it. `async` so the
+/// blocking dialog runs off the main thread.
 #[tauri::command]
-pub fn set_remote_access_password(password: String) -> Result<RemoteAccessStatus, String> {
+pub async fn set_remote_access_password(
+    app: AppHandle,
+    password: String,
+) -> Result<RemoteAccessStatus, String> {
+    if !confirm_remote_access_action(
+        &app,
+        "Set remote-access password?",
+        "This sets the password that protects LAN access to SceneWorks. Continue only if \
+         you started this from Settings.",
+    ) {
+        return Err("Password was not changed — confirmation was declined.".to_owned());
+    }
     set_remote_password(&password)?;
     Ok(remote_access_status())
 }
@@ -1338,5 +1399,21 @@ mod tests {
         assert!(!settings.remote_access_enabled);
         // Port choice is preserved across a clear (the user's preference persists).
         assert_eq!(settings.remote_port, Some(DEFAULT_REMOTE_PORT));
+    }
+
+    /// sc-13610: the native confirmation gates only *enabling* remote access. Disabling is
+    /// fail-safe (it narrows exposure) and must never be blocked behind a dialog — otherwise a
+    /// user could get stuck unable to turn the LAN bind back off. Discriminating on both arms so
+    /// flipping the predicate can't pass.
+    #[test]
+    fn remote_access_confirmation_gates_enable_only() {
+        assert!(
+            remote_access_change_needs_confirmation(true),
+            "enabling the LAN bind must require native confirmation"
+        );
+        assert!(
+            !remote_access_change_needs_confirmation(false),
+            "disabling is fail-safe and must not be gated"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Security hardening (F-048, Medium). Narrows the Tauri `default` capability grant on the desktop shell so a webview XSS on the loopback UI has a smaller escalation surface.

Story: https://app.shortcut.com/trefry/story/13610

## Topology found

- There is **one** window: `main` (`tauri.conf.json`). After setup, `setup.rs:767` navigates it from `tauri://` to the API-served React UI at `http://127.0.0.1:<port>`. The `remote` grant is what lets `window.__TAURI__` invoke work at that loopback origin (Tauri's ACL rejects IPC from remote origins otherwise).
- **Local and remote are the same window/origin.** The trusted Settings UI (where `set_credential`, `set_remote_access`, `set_remote_access_password` are all invoked from — `apps/web/src/screens/SettingsScreen.jsx`, `apps/web/src/credentials.js`) runs at `http://127.0.0.1`. There is no separate local-vs-remote window to scope a capability to.
- A genuinely-remote LAN client (epic 4484 remote access) is just a browser with **no `window.__TAURI__`** (`apps/web/src/runtime.js:10-17`) — it cannot invoke any Tauri command. So the only threat vector for these commands is an XSS of the shell's own loopback webview.
- The three commands live in `apps/desktop/src/settings.rs`: `set_credential` (keychain write, called during normal HF-token/credential setup), `set_remote_access` (LAN-bind toggle), `set_remote_access_password` (LAN password).
- Confirmed the shell **never** navigates to `http://localhost` — only `http://127.0.0.1` — so dropping `localhost:*` is safe.

## Changes

### Part A — drop the unused origin (`apps/desktop/capabilities/default.json`)
Removed `http://localhost:*` from `remote.urls`, leaving only `http://127.0.0.1:*`. The app never navigates to localhost, so this grant only doubled the trusted-origin/XSS surface for the full command set. Updated the capability description to record why it must not be re-broadened.

### Part B — gate the deliberate LAN-exposure admin actions behind a native OS confirmation (`apps/desktop/src/settings.rs`)
Because the trusted Settings UI **is** the loopback-origin webview, an origin/window capability split cannot separate these commands without breaking Settings. The realizable defense-in-depth is a **native OS dialog** the webview cannot forge or dismiss (an in-page confirm offers no protection against injected JS):

- `set_remote_access` now prompts a native confirm **only when enabling** (disabling is fail-safe and never gated). This is the action that actually binds the API to the LAN.
- `set_remote_access_password` now prompts a native confirm before storing — planting a known password is the first half of an XSS enable-remote-access chain (enabling is fail-closed unless a password is already set).
- Both became `async fn` so `blocking_show()` runs off the main thread (the established pattern used by `save_asset_as` / `choose_folder`). Tauri injects `AppHandle`; the JS invoke args/return shape are unchanged, and both command names are already in `build.rs`'s allowlist, so no web or build.rs change was needed.
- Follows the existing dialog convention in `apps/desktop/src/update.rs` (`DialogExt`, `MessageDialogKind`, `MessageDialogButtons::OkCancelCustom`). On decline the command returns an `Err`, which the existing `SettingsScreen` catch surfaces as a status message and leaves the toggle state unchanged.

### `set_credential` — deliberately NOT gated (UX consideration)
`set_credential` is a normal local Settings/onboarding action (adding an HF/CivitAI token). Per the story's own guidance, an OS dialog on every credential save would harm UX. It cannot be separated local-from-remote either, because the only IPC-capable origin is the shared `127.0.0.1` webview that Settings legitimately uses. Narrowing it further needs a product decision (see Residual risk / follow-up) rather than a silent change.

## Tests / validation
- `apps/desktop/capabilities/default.json` parses; `remote.urls` is still a valid `string[]` (schema-valid; parity/web lanes validate the capability schema).
- `cargo fmt -p sceneworks-desktop -- --check` — clean.
- `cargo check -p sceneworks-desktop` — compiles (had to stage the gitignored `binaries/` sidecar + `onnxruntime`/`ffmpeg`/`mlx` bundle-resource dirs locally, a pre-existing worktree requirement, then removed them; not a code issue).
- `cargo clippy -p sceneworks-desktop --all-targets -- -D warnings` — clean.
- `cargo test -p sceneworks-desktop remote_access` — 3 passed, including the new `remote_access_confirmation_gates_enable_only` test, which discriminates both arms (enable ⇒ confirm, disable ⇒ no confirm) so flipping the predicate fails.
- No web changes; the JS invoke contract is unchanged, so the web suite was not exercised.

## Residual risk / follow-up
- `set_credential` keychain-write via webview XSS remains reachable from the loopback origin (write-only; the token is never read back to the UI). Fully closing it needs a product decision — e.g. move credential entry to the `tauri://` setup surface, or add an explicit re-auth/confirm step — because the current Settings flow shares the `127.0.0.1` origin. Recommend a follow-up story if this residual is unacceptable.
- The confirm dialogs are macOS/Windows native; on the deliberate enable/set-password paths this is low-frequency, so no UX regression for normal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)