### PR TITLE
fix(desktop): track per-component provisioning so a retry doesn't re-download ~2.7 GB [sc-13614]

### DIFF
--- a/apps/desktop/src/cuda_provision.rs
+++ b/apps/desktop/src/cuda_provision.rs
@@ -30,6 +30,7 @@ use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
 use tauri::AppHandle;
 
+use crate::cuda_provision_check::{component_provisioned, dir_has_dll, write_component_marker};
 use crate::setup::{app_support_dir, emit};
 
 /// Bump this when the pinned manifest changes so an existing install re-provisions.
@@ -59,6 +60,10 @@ enum Dest {
 struct Component {
     /// Human label for progress UI ("cuDNN", "cuBLAS", …).
     label: &'static str,
+    /// Stable, filename-safe id used for this component's per-run completion marker
+    /// (`.component-<slug>.ok`). Kept separate from `label` so tweaking the display
+    /// string never silently orphans an on-disk marker.
+    slug: &'static str,
     /// Approximate download size, shown in the progress message.
     approx: &'static str,
     /// Pinned win_amd64 wheel URL (files.pythonhosted.org).
@@ -70,6 +75,15 @@ struct Component {
     /// Specific DLL basenames to extract, or `None` to extract every `*.dll` in the
     /// wheel (used for the single-purpose nvidia-*-cu12 wheels).
     dlls: Option<&'static [&'static str]>,
+    /// Sentinel DLL name(s) whose presence in `dest` marks this component's extracted
+    /// output. Matched by `dir_has_dll`: an exact filename when it ends in `.dll` (the
+    /// onnxruntime DLLs), else a case-insensitive, version-agnostic prefix (`cudart64_`
+    /// still resolves a `cudart64_13`). Drives both the pre-staged completeness check
+    /// (`is_staged_complete`) and the retry-skip guard (`component_provisioned`,
+    /// sc-13614). For a multi-DLL wheel a single prefix here is deliberate: the skip
+    /// guard pairs it with a completion marker written only after a verified full
+    /// extraction, so a partial unzip is never mistaken for complete.
+    sentinels: &'static [&'static str],
 }
 
 /// The pinned redist set — matches what the build previously bundled (CUDA 12.9 gen
@@ -83,61 +97,79 @@ const COMPONENTS: &[Component] = &[
     // build-sidecar.mjs used to copy). Extract every DLL in each single-purpose wheel.
     Component {
         label: "CUDA runtime",
+        slug: "cuda-runtime",
         approx: "≈3 MB",
         url: "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl",
         sha256: "8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891",
         dest: Dest::Cuda,
         dlls: None,
+        sentinels: &["cudart64_"],
     },
     Component {
         label: "cuBLAS",
+        slug: "cublas",
         approx: "≈530 MB",
         url: "https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl",
         sha256: "1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf",
         dest: Dest::Cuda,
         dlls: None,
+        // `cublasLt` ships inside this same wheel, so `cublas64_` covers the component.
+        sentinels: &["cublas64_"],
     },
     Component {
         label: "cuRAND",
+        slug: "curand",
         approx: "≈66 MB",
         url: "https://files.pythonhosted.org/packages/e5/98/1bd66fd09cbe1a5920cb36ba87029d511db7cca93979e635fd431ad3b6c0/nvidia_curand_cu12-10.3.10.19-py3-none-win_amd64.whl",
         sha256: "e8129e6ac40dc123bd948e33d3e11b4aa617d87a583fa2f21b3210e90c743cde",
         dest: Dest::Cuda,
         dlls: None,
+        sentinels: &["curand64_"],
     },
     Component {
         label: "NVRTC",
+        slug: "nvrtc",
         approx: "≈73 MB",
         url: "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl",
         sha256: "72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349",
         dest: Dest::Cuda,
         dlls: None,
+        sentinels: &["nvrtc64_"],
     },
     // onnxruntime's CUDA execution provider needs cuDNN-9 (incl. its lazily-loaded
     // sub-engine DLLs), cuFFT, nvJitLink. Extract every DLL.
     Component {
         label: "cuDNN",
+        slug: "cudnn",
         approx: "≈660 MB",
         url: "https://files.pythonhosted.org/packages/b7/ec/d95cc4204dd45f40f2d1512f8ff0d4c3fb1810a893fecc79fcea05dfec0e/nvidia_cudnn_cu12-9.23.0.39-py3-none-win_amd64.whl",
         sha256: "357e5d59a1b79d27eef754aa79b3d9e7adf11baf86dc928dc114df0033c2c912",
         dest: Dest::Cuda,
         dlls: None,
+        // The wheel also ships cuDNN's lazily-loaded sub-engine DLLs; `cudnn64_` marks
+        // the component and the completion marker guarantees the rest extracted.
+        sentinels: &["cudnn64_"],
     },
     Component {
         label: "cuFFT",
+        slug: "cufft",
         approx: "≈190 MB",
         url: "https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl",
         sha256: "8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80",
         dest: Dest::Cuda,
         dlls: None,
+        sentinels: &["cufft64_"],
     },
     Component {
         label: "nvJitLink",
+        slug: "nvjitlink",
         approx: "≈34 MB",
         url: "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl",
         sha256: "cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db",
         dest: Dest::Cuda,
         dlls: None,
+        // nvJitLink_120_0.dll.
+        sentinels: &["nvjitlink"],
     },
     // onnxruntime-gpu's own DLLs. The cp312 wheel: the native DLLs are identical
     // across the cp311/cp312/cp313/cp314 ABI wheels (the cp tag only versions the
@@ -145,6 +177,7 @@ const COMPONENTS: &[Component] = &[
     // exactly the three the worker dlopens (TensorRT is deliberately not staged).
     Component {
         label: "onnxruntime (GPU)",
+        slug: "onnxruntime",
         approx: "≈216 MB",
         url: "https://files.pythonhosted.org/packages/a4/e4/9b378a5466ea0bed65e5beb8e09254973c580a6522810a38afbcc45e5105/onnxruntime_gpu-1.26.0-cp312-cp312-win_amd64.whl",
         sha256: "5f49c44689894650990e4c8a857d2edafc276fbd79bba57ceb224bd18d25d491",
@@ -154,6 +187,13 @@ const COMPONENTS: &[Component] = &[
             "onnxruntime_providers_cuda.dll",
             "onnxruntime_providers_shared.dll",
         ]),
+        // The exact three DLLs the worker dlopens — the full extracted set for this
+        // component, so all three double as its sentinels.
+        sentinels: &[
+            "onnxruntime.dll",
+            "onnxruntime_providers_cuda.dll",
+            "onnxruntime_providers_shared.dll",
+        ],
     },
 ];
 
@@ -201,57 +241,25 @@ fn already_provisioned(root: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// One sentinel per pinned CUDA component whose presence in the `cuda\` dir marks a
-/// complete CUDA redist. Matched case-insensitively by *prefix* so a CUDA point-release
-/// (`cudart64_12` → `cudart64_13`) still resolves — the version-agnostic match the
-/// sc-5560 bundling resolver used. `cublasLt` ships inside the cuBLAS wheel, so
-/// `cublas64_` covers it.
-const CUDA_DLL_SENTINELS: &[&str] = &[
-    "cudart64_", // CUDA runtime
-    "cublas64_", // cuBLAS (+ cublasLt)
-    "curand64_", // cuRAND
-    "nvrtc64_",  // NVRTC
-    "cudnn64_",  // cuDNN
-    "cufft64_",  // cuFFT
-    "nvjitlink", // nvJitLink (nvJitLink_120_0.dll)
-];
-
-/// The three onnxruntime DLLs the worker dlopens — exact names (no version suffix).
-const ORT_DLL_SENTINELS: &[&str] = &[
-    "onnxruntime.dll",
-    "onnxruntime_providers_cuda.dll",
-    "onnxruntime_providers_shared.dll",
-];
-
-/// True when `dir` holds a `*.dll` matching `needle`: an exact filename check when
-/// `needle` ends in `.dll`, else a case-insensitive prefix match (version-agnostic).
-fn dir_has_dll(dir: &Path, needle: &str) -> bool {
-    if needle.ends_with(".dll") {
-        return dir.join(needle).is_file();
+/// Which provisioned dir a component's sentinels live in.
+fn dest_dir<'a>(component: &Component, cuda: &'a Path, ort: &'a Path) -> &'a Path {
+    match component.dest {
+        Dest::Cuda => cuda,
+        Dest::Onnxruntime => ort,
     }
-    let needle = needle.to_ascii_lowercase();
-    let Ok(entries) = fs::read_dir(dir) else {
-        return false;
-    };
-    entries.flatten().any(|entry| {
-        entry
-            .file_name()
-            .to_str()
-            .map(|name| {
-                let name = name.to_ascii_lowercase();
-                name.starts_with(&needle) && name.ends_with(".dll")
-            })
-            .unwrap_or(false)
-    })
 }
 
-/// True when both provisioned dirs hold the full sentinel set — i.e. a pre-staged redist
-/// is complete enough to run without downloading. Deliberately stricter than the single-
-/// DLL `*_if_present` resolver probes (which only gate the candle lane): a partial stage
+/// True when both provisioned dirs hold every component's sentinel DLL(s) — i.e. a
+/// pre-staged redist is complete enough to run without downloading. Derived from the
+/// single `COMPONENTS` table (one source of truth for what a component's DLLs are), so
+/// adding a component can't skew this check. Deliberately stricter than the single-DLL
+/// `*_if_present` resolver probes (which only gate the candle lane): a partial stage
 /// that passed a one-DLL probe but was missing cuDNN/nvJitLink would hard-fail at load.
 fn is_staged_complete(cuda: &Path, ort: &Path) -> bool {
-    CUDA_DLL_SENTINELS.iter().all(|dll| dir_has_dll(cuda, dll))
-        && ORT_DLL_SENTINELS.iter().all(|dll| dir_has_dll(ort, dll))
+    COMPONENTS.iter().all(|component| {
+        let dir = dest_dir(component, cuda, ort);
+        component.sentinels.iter().all(|dll| dir_has_dll(dir, dll))
+    })
 }
 
 /// Copy every `*.dll` from `src` into `dst` (flat). Returns how many were copied. Used
@@ -524,6 +532,36 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
 
     let mut outcome: Result<(), String> = Ok(());
     for (index, component) in COMPONENTS.iter().enumerate() {
+        let dest = dest_dir(component, &cuda, &ort);
+
+        // Retry-skip (sc-13614): a component that a prior (partial) run already fully
+        // provisioned carries a current-version completion marker AND its sentinel DLL(s)
+        // on disk — skip it instead of re-downloading. Without this, a failure on any one
+        // of the ~8 components aborted the run and left no per-component state, so the
+        // next launch re-fetched the whole ~2.7 GB set. Requiring the marker (written
+        // only after a verified full extraction) means a partial/truncated extract is
+        // never mistaken for complete.
+        if component_provisioned(
+            &root,
+            dest,
+            component.slug,
+            REDIST_VERSION,
+            component.sentinels,
+        ) {
+            emit(
+                app,
+                "provision",
+                format!(
+                    "GPU runtime [{}/{}]: {} already present; skipping.",
+                    index + 1,
+                    COMPONENTS.len(),
+                    component.label
+                ),
+                false,
+            );
+            continue;
+        }
+
         emit(
             app,
             "provision",
@@ -551,6 +589,15 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
                     outcome = Err(format!("{}: no DLLs found in wheel", component.label));
                     break;
                 }
+                // Download + sha256 + extraction all succeeded with the expected DLL count.
+                // Record the per-component completion marker LAST (only here) so a retry
+                // after a *later* component fails skips re-downloading this one (sc-13614).
+                // A partial/truncated extract never reaches this point, so the marker is a
+                // trustworthy completion witness.
+                if let Err(error) = write_component_marker(&root, component.slug, REDIST_VERSION) {
+                    outcome = Err(error);
+                    break;
+                }
             }
             Err(error) => {
                 outcome = Err(error);
@@ -575,10 +622,13 @@ mod tests {
     use super::*;
 
     /// The pinned set must stay internally consistent: every component has a non-empty
-    /// pinned URL pointing at the PyPI CDN and a 64-hex-char sha256. Cheap, offline.
+    /// pinned URL pointing at the PyPI CDN and a 64-hex-char sha256, plus a filename-safe,
+    /// UNIQUE slug and at least one sentinel (both load-bearing for the per-component
+    /// completion marker + retry-skip guard, sc-13614). Cheap, offline.
     #[test]
     fn manifest_is_well_formed() {
         assert!(!COMPONENTS.is_empty());
+        let mut slugs = std::collections::HashSet::new();
         for component in COMPONENTS {
             assert!(
                 component.url.starts_with("https://files.pythonhosted.org/"),
@@ -604,6 +654,43 @@ mod tests {
                 "{}: sha256 must be lowercase hex",
                 component.label
             );
+            // Slug is the marker-filename identity: non-empty, filename-safe, and unique
+            // so two components can't collide on `.component-<slug>.ok`.
+            assert!(
+                !component.slug.is_empty(),
+                "{}: empty slug",
+                component.label
+            );
+            assert!(
+                component
+                    .slug
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-'),
+                "{}: slug must be filename-safe (alnum/-): {:?}",
+                component.label,
+                component.slug
+            );
+            assert!(
+                slugs.insert(component.slug),
+                "{}: duplicate slug {:?} would collide markers",
+                component.label,
+                component.slug
+            );
+            // At least one sentinel — the retry-skip guard needs something to probe.
+            assert!(
+                !component.sentinels.is_empty(),
+                "{}: needs at least one sentinel",
+                component.label
+            );
+            // When an explicit DLL allow-list is given, its exact names double as the
+            // sentinels (nothing else identifies the component's output on disk).
+            if let Some(dlls) = component.dlls {
+                assert_eq!(
+                    component.sentinels, dlls,
+                    "{}: explicit-DLL component sentinels must equal its dll list",
+                    component.label
+                );
+            }
         }
     }
 
@@ -640,26 +727,6 @@ mod tests {
         "onnxruntime_providers_cuda.dll",
         "onnxruntime_providers_shared.dll",
     ];
-
-    /// `dir_has_dll` matches exact `.dll` names directly and everything else by
-    /// case-insensitive prefix (so a CUDA point-release still resolves).
-    #[test]
-    fn dir_has_dll_exact_and_prefix() {
-        let dir = scratch("has-dll");
-        touch(&dir, &["cudart64_13.dll", "onnxruntime.dll", "notes.txt"]);
-
-        // Exact name (ends in .dll).
-        assert!(dir_has_dll(&dir, "onnxruntime.dll"));
-        assert!(!dir_has_dll(&dir, "onnxruntime_providers_cuda.dll"));
-        // Version-agnostic prefix: a 13.x cudart still satisfies the `cudart64_` sentinel.
-        assert!(dir_has_dll(&dir, "cudart64_"));
-        // Case-insensitive.
-        assert!(dir_has_dll(&dir, "CUDART64_"));
-        // Absent component.
-        assert!(!dir_has_dll(&dir, "cudnn64_"));
-
-        let _ = fs::remove_dir_all(&dir);
-    }
 
     /// `is_staged_complete` requires the FULL sentinel set in both dirs — a stage
     /// missing even one component (here cuDNN) is rejected, unlike the one-DLL probes.

--- a/apps/desktop/src/cuda_provision_check.rs
+++ b/apps/desktop/src/cuda_provision_check.rs
@@ -1,0 +1,183 @@
+//! Pure, cross-platform filesystem predicates for the first-run GPU-runtime
+//! provisioner (`cuda_provision`).
+//!
+//! `cuda_provision` is `#[cfg(target_os = "windows")]`, so any test living inside it
+//! only ever runs on the Windows CI lane. These predicates — the "is this component
+//! already extracted?" checks that gate the retry-skip guard (sc-13614) and the
+//! pre-staged-redist completeness check — are factored out here, behind NO `cfg`, so
+//! they compile and unit-test on any host (a plain `cargo test -p sceneworks-desktop`
+//! on macOS/Linux exercises them). Off Windows the only non-test caller
+//! (`cuda_provision`) is compiled out, so the `dead_code` lint is relaxed there; on
+//! Windows every item has a real caller.
+#![cfg_attr(not(target_os = "windows"), allow(dead_code))]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// True when `dir` holds a `*.dll` matching `needle`: an exact filename check when
+/// `needle` ends in `.dll`, else a case-insensitive prefix match. The prefix form is
+/// version-agnostic, so a CUDA point-release (`cudart64_12` → `cudart64_13`) still
+/// resolves — the version-agnostic match the sc-5560 bundling resolver used.
+pub(crate) fn dir_has_dll(dir: &Path, needle: &str) -> bool {
+    if needle.ends_with(".dll") {
+        return dir.join(needle).is_file();
+    }
+    let needle = needle.to_ascii_lowercase();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_str()
+            .map(|name| {
+                let name = name.to_ascii_lowercase();
+                name.starts_with(&needle) && name.ends_with(".dll")
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Path of a component's per-run completion marker under the provisioned root
+/// (`<root>\.component-<slug>.ok`). Distinct from the top-level `.redist-marker` (which
+/// records that the *whole* set succeeded): one of these is written per component, so a
+/// run that fails partway still records which components already landed.
+fn component_marker(root: &Path, slug: &str) -> PathBuf {
+    root.join(format!(".component-{slug}.ok"))
+}
+
+/// Record that a component fully provisioned into place for `version`. The caller writes
+/// this ONLY after the wheel downloaded, sha256-verified, and extracted with its full
+/// expected DLL count — so the marker is a trustworthy completion witness that a
+/// mid-unzip crash (a partial or truncated DLL set) cannot forge.
+pub(crate) fn write_component_marker(root: &Path, slug: &str, version: &str) -> Result<(), String> {
+    fs::write(component_marker(root, slug), version)
+        .map_err(|error| format!("write component marker {slug}: {error}"))
+}
+
+/// True when component `slug` is already fully provisioned into `dest` for `version` and
+/// so can be skipped on a retry (sc-13614) instead of re-downloading it.
+///
+/// Requires BOTH:
+///   1. a completion marker for THIS `version` (written last, only after a verified full
+///      extraction) — a partial or truncated extract never leaves one, so a corrupt
+///      component is re-fetched rather than mistaken for complete; and
+///   2. the component's sentinel DLL(s) still present on disk — so a component whose
+///      files were deleted after the marker was written self-heals by re-downloading.
+///
+/// The marker is the primary guard against a partial/corrupt extract; the on-disk DLL
+/// check guards against later deletion. Both must hold for a skip.
+pub(crate) fn component_provisioned(
+    root: &Path,
+    dest: &Path,
+    slug: &str,
+    version: &str,
+    sentinels: &[&str],
+) -> bool {
+    let marker_current = fs::read_to_string(component_marker(root, slug))
+        .map(|marker| marker.trim() == version)
+        .unwrap_or(false);
+    marker_current && sentinels.iter().all(|dll| dir_has_dll(dest, dll))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh, unique temp dir for a test (offline; cleaned by the caller). Rolled by
+    /// hand (as the sibling `cuda_provision` tests do) so no `tempfile` dev-dep is added.
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "sw-provcheck-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id(),
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create scratch");
+        dir
+    }
+
+    fn touch(dir: &Path, names: &[&str]) {
+        fs::create_dir_all(dir).expect("create dir");
+        for name in names {
+            fs::write(dir.join(name), b"").expect("touch dll");
+        }
+    }
+
+    /// `dir_has_dll` matches exact `.dll` names directly and everything else by
+    /// case-insensitive prefix (so a CUDA point-release still resolves).
+    #[test]
+    fn dir_has_dll_exact_and_prefix() {
+        let dir = scratch("has-dll");
+        touch(&dir, &["cudart64_13.dll", "onnxruntime.dll", "notes.txt"]);
+
+        // Exact name (ends in .dll).
+        assert!(dir_has_dll(&dir, "onnxruntime.dll"));
+        assert!(!dir_has_dll(&dir, "onnxruntime_providers_cuda.dll"));
+        // Version-agnostic prefix: a 13.x cudart still satisfies the `cudart64_` sentinel.
+        assert!(dir_has_dll(&dir, "cudart64_"));
+        // Case-insensitive.
+        assert!(dir_has_dll(&dir, "CUDART64_"));
+        // Absent component.
+        assert!(!dir_has_dll(&dir, "cudnn64_"));
+        // A non-DLL file with a matching prefix does NOT count.
+        assert!(!dir_has_dll(&dir, "notes"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// `component_provisioned` discriminates a genuinely-complete component from every
+    /// partial state: it is true ONLY when the current-version marker AND the sentinel
+    /// DLL(s) are both present. This is the retry-skip safety net (sc-13614) — a partial
+    /// extract (DLLs but no marker) or a stale/missing marker must NOT skip.
+    #[test]
+    fn component_provisioned_requires_marker_and_dlls() {
+        const VERSION: &str = "cuda12.9-test-1";
+        const SENTINELS: &[&str] = &["cublas64_", "cublasLt64_"];
+
+        let root = scratch("provisioned");
+        let dest = root.join("cuda");
+        fs::create_dir_all(&dest).expect("create dest");
+
+        // Nothing yet: no marker, no DLLs.
+        assert!(!component_provisioned(
+            &root, &dest, "cublas", VERSION, SENTINELS
+        ));
+
+        // DLLs present but no marker — the exact "partial/interrupted extract" shape a
+        // mid-unzip crash leaves (files on disk, completion never recorded). Must NOT skip.
+        touch(&dest, &["cublas64_12.dll", "cublasLt64_12.dll"]);
+        assert!(!component_provisioned(
+            &root, &dest, "cublas", VERSION, SENTINELS
+        ));
+
+        // Marker written last, after a verified full extraction → now complete → skip.
+        write_component_marker(&root, "cublas", VERSION).expect("write marker");
+        assert!(component_provisioned(
+            &root, &dest, "cublas", VERSION, SENTINELS
+        ));
+
+        // A sentinel DLL deleted after the marker was written → no longer complete
+        // (self-heals by re-downloading rather than trusting a stale marker).
+        fs::remove_file(dest.join("cublasLt64_12.dll")).expect("rm dll");
+        assert!(!component_provisioned(
+            &root, &dest, "cublas", VERSION, SENTINELS
+        ));
+
+        // Restore the DLL but bump the version → the old-version marker no longer counts
+        // (a REDIST_VERSION bump must re-provision every component).
+        touch(&dest, &["cublasLt64_12.dll"]);
+        assert!(component_provisioned(
+            &root, &dest, "cublas", VERSION, SENTINELS
+        ));
+        assert!(!component_provisioned(
+            &root,
+            &dest,
+            "cublas",
+            "cuda12.9-test-2",
+            SENTINELS
+        ));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -10,6 +10,10 @@ mod cred_ipc;
 // run into %APPDATA%\SceneWorks\gpu-runtime and resolved from there.
 #[cfg(target_os = "windows")]
 mod cuda_provision;
+// Pure, cross-platform filesystem predicates for `cuda_provision` (marker + sentinel
+// checks). NOT `cfg`-gated so the retry-skip guard (sc-13614) is unit-tested on any
+// host, not only the Windows-only lane where `cuda_provision` compiles.
+mod cuda_provision_check;
 // Likely-LAN-address discovery for the remote-access URL (epic 4484, story 5).
 mod net;
 mod settings;


### PR DESCRIPTION
## Story
[sc-13614](https://app.shortcut.com/trefry/story/13614) — [review][Med] Track per-component provisioning so a retry doesn't re-download ~2.7 GB (F-052, efficiency).

## Current behavior (the bug)
`apps/desktop/src/cuda_provision.rs` downloads ~8 pinned wheels (~2.7 GB of CUDA/cuDNN/onnxruntime DLLs) on first run. The download loop `break`s on the first failed component and writes **no per-component state** — only the top-level `.redist-marker` (written after *total* success) or a pre-staged offline redist (`SCENEWORKS_GPU_RUNTIME_DIR` / an already-complete target dir) short-circuits a later run. So a partial first run on a flaky/metered link re-downloads the **entire** set every retry, multiplying first-run cost per failure.

## What changed
**Per-component completion markers + a retry-skip guard.**

- Each `Component` gains a stable `slug` and its sentinel DLL name(s) (`sentinels`).
- After a component's wheel downloads, sha256-verifies, and extracts with its expected DLL count, the loop writes a completion marker `<root>\.component-<slug>.ok` containing `REDIST_VERSION`. **Written last**, only on full success.
- At the top of the loop, a component is **skipped** when `component_provisioned(...)` is true — i.e. its current-version marker **and** its sentinel DLL(s) are both present on disk. A retry then re-fetches only the components that did not previously complete.
- `is_staged_complete` (the pre-staged-redist adoption check) now derives its sentinel set from the single `COMPONENTS` table instead of two parallel `*_DLL_SENTINELS` constants — one source of truth, so adding a component can't skew it. Its behavior is unchanged (same sentinel set, same per-dir mapping), so the existing offline/pre-staged short-circuits (`SCENEWORKS_GPU_RUNTIME_DIR`, implicit fully-staged adoption) are preserved.

### markers vs. `dir_has_dll`
The story preferred a per-component `dir_has_dll` check but explicitly allowed per-component markers "if the component set makes them cleaner/more robust." I used **markers as the completion witness, paired with `dir_has_dll` as an on-disk presence guard**, because the CUDA wheels each extract **multiple** DLLs (cuBLAS → `cublas64_`+`cublasLt64_`; cuDNN → `cudnn64_` + a version-fragile set of sub-engine DLLs; cuFFT, NVRTC likewise). A single-sentinel `dir_has_dll` alone would treat a partially-unzipped multi-DLL wheel as complete, and enumerating every sub-DLL is version-fragile. A marker written only after the verified full extraction sidesteps enumeration entirely.

## How partial / corrupt extracts are handled
- **Download failure** (the dominant flaky-link case): extraction only runs *after* the wheel is fully streamed and sha256-verified, so a failed download never writes DLLs to `dest`. Earlier fully-marked components skip; the failed one + all later ones re-fetch.
- **Crash mid-unzip (partial/truncated DLLs on disk):** the marker is written *after* `extract_dlls` returns the full expected count, so a partial or truncated extract **never** leaves a marker → the component is re-fetched (re-extraction overwrites the partial files). This is the "a DLL present but incomplete" case the story flagged.
- **Files deleted after the marker was written:** the supplementary `dir_has_dll` sentinel check fails → the component self-heals by re-downloading rather than trusting a stale marker.
- **`REDIST_VERSION` bump:** markers carry the version; old-version markers no longer match → every component re-provisions.

## Testability
The pure "is this component provisioned?" predicate lives in a **new, non-`cfg`-gated** module `apps/desktop/src/cuda_provision_check.rs` (`dir_has_dll`, `component_provisioned`, `write_component_marker`). This matters because `cuda_provision` is `#![cfg(target_os = "windows")]`, so its own tests only ever run on the Windows CI lane. The new module carries a **discriminating** cross-platform unit test (`component_provisioned_requires_marker_and_dlls`) that asserts:
- no marker + no DLLs → false
- DLLs present but **no marker** (the partial-extract shape) → false
- marker + DLLs → true
- sentinel DLL deleted → false
- version bump → false

`manifest_is_well_formed` was extended to enforce non-empty, filename-safe, **unique** slugs (marker filenames derive from them) and ≥1 sentinel per component, and that an explicit-DLL component's sentinels equal its dll list.

## Validation
- `cargo test -p sceneworks-desktop` → **29 passed** on macOS (incl. the 2 new cross-platform tests). The moved `dir_has_dll` test now runs off-Windows too.
- `npm run desktop:check` (`cargo clippy -p sceneworks-desktop --all-targets -- -D warnings`) → clean.
- `cargo check -p sceneworks-desktop` → clean (macOS).
- `cargo fmt --all` applied.

**Locally vs. CI:** `cuda_provision.rs` is `cfg(target_os="windows")`, so its body (the `Component` fields, loop integration, `is_staged_complete` rewrite) is **not** compiled on macOS — the **`build-windows` PR lane** (`cargo test -p sceneworks-desktop` + `desktop:check` on `windows-2022`) is the real compile gate for it. A local `--target x86_64-pc-windows-gnu` cross-check couldn't complete (a C dependency needs `x86_64-w64-mingw32-gcc`, which isn't installed) — an environmental gap, not a code issue. The cross-platform predicate module and the changes to `main.rs` are fully validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)