### PR TITLE
feat(core): detect Krea 2 single-file DiT in base-weight classifier (sc-14016)

### DIFF
--- a/crates/sceneworks-core/src/base_weights.rs
+++ b/crates/sceneworks-core/src/base_weights.rs
@@ -423,6 +423,16 @@ fn detect_transformer_family(keys: &[&str]) -> Option<&'static str> {
     {
         return Some("z-image");
     }
+    // Krea 2 (epic 8588): the ComfyUI-native MMDiT export carries a unique
+    // `txtfusion.` text-fusion tower (`txtfusion.{layerwise,refiner}_blocks`,
+    // `txtfusion.projector`) alongside BFL-style `blocks.N.attn.{wq,wk,wv,wo}`,
+    // `qknorm`, and `mod.lin`. `txtfusion.` appears in no other family we ship, so
+    // one hit is decisive. This classifies the community single-file DiT export
+    // (`model.diffusion_model.*`, native keys) — the diffusers-key snapshot layout
+    // (`transformer_blocks.*`) is loaded by the Krea snapshot path, not here.
+    if any_key_contains(keys, "txtfusion.") {
+        return Some("krea_2");
+    }
     // Ideogram 4 (epic 6561): single-stream `layers.N.attention.qkv` +
     // `adaln_modulation` (lowercase) + `feed_forward.w`, with the unique
     // `embed_image_indicator` / `llm_cond_proj` / `adaln_proj` head keys.
@@ -563,6 +573,56 @@ mod tests {
         assert_eq!(verdict.family.as_deref(), Some("z-image"));
         assert_eq!(verdict.component, ComponentRole::Transformer);
         assert_eq!(verdict.quant, QuantFormat::Bf16);
+    }
+
+    #[test]
+    fn krea2_native_bf16_single_file_is_transformer() {
+        // ~/models/kreamania_variant5.safetensors (measured: 430 tensors, DiT-only,
+        // 415 BF16 + 15 F32, ComfyUI-native keys, no quant markers) — the dense-bf16
+        // community Krea 2 checkpoint that anchors the single-file import skeleton.
+        let verdict = recognized(classify_base_header(&header(&[
+            ("model.diffusion_model.blocks.0.attn.wq.weight", "BF16"),
+            ("model.diffusion_model.blocks.0.attn.wk.weight", "BF16"),
+            (
+                "model.diffusion_model.blocks.0.attn.qknorm.qnorm.scale",
+                "BF16",
+            ),
+            ("model.diffusion_model.blocks.0.mlp.gate.weight", "BF16"),
+            ("model.diffusion_model.blocks.0.mod.lin", "BF16"),
+            (
+                "model.diffusion_model.txtfusion.refiner_blocks.0.attn.wq.weight",
+                "BF16",
+            ),
+            ("model.diffusion_model.txtfusion.projector.weight", "F32"),
+            ("model.diffusion_model.first.weight", "F32"),
+            ("model.diffusion_model.last.linear.weight", "F32"),
+        ])));
+        assert_eq!(verdict.family.as_deref(), Some("krea_2"));
+        assert_eq!(verdict.component, ComponentRole::Transformer);
+        assert_eq!(verdict.quant, QuantFormat::Bf16);
+    }
+
+    #[test]
+    fn krea2_native_int8_single_file_is_transformer_but_packed_quant() {
+        // ~/models/kreamania_variant4.safetensors (measured: 958 tensors, DiT-only,
+        // int8 per-row `{"format":"int8_tensorwise","per_row":true}` with `.comfy_quant`
+        // descriptors). The family/component classify the same as the bf16 sibling; the
+        // quant lands in the packed bucket we do not yet load — proving detection is a
+        // prerequisite that already separates the loadable (bf16) from the deferred (int8)
+        // case rather than mislabelling one as the other.
+        let verdict = recognized(classify_base_header(&header(&[
+            ("model.diffusion_model.blocks.0.attn.wq.weight", "I8"),
+            ("model.diffusion_model.blocks.0.attn.wq.weight_scale", "F32"),
+            ("model.diffusion_model.blocks.0.attn.wq.comfy_quant", "U8"),
+            ("model.diffusion_model.blocks.0.mod.lin", "BF16"),
+            (
+                "model.diffusion_model.txtfusion.refiner_blocks.1.attn.wq.comfy_quant",
+                "U8",
+            ),
+        ])));
+        assert_eq!(verdict.family.as_deref(), Some("krea_2"));
+        assert_eq!(verdict.component, ComponentRole::Transformer);
+        assert_eq!(verdict.quant, QuantFormat::ComfyQuantPacked);
     }
 
     #[test]


### PR DESCRIPTION
## Story
sc-14016 (S0a) — first slice of epic sc-14015 (import community single-file checkpoints of supported families, Mac-first). The pipeline's **entry seam**: classify a community single-file Krea DiT so downstream can route/load it.

## What changed
- Add a **Krea 2 arm** to `detect_transformer_family` in `crates/sceneworks-core/src/base_weights.rs`. Because `has_transformer_signature` == `detect_transformer_family(..).is_some()`, this single arm also makes the component role resolve to `Transformer`.
- **Marker:** `txtfusion.` — the Krea 2 text-fusion tower (`txtfusion.{layerwise,refiner}_blocks`, `txtfusion.projector`). Verified unique across every family we ship (z-image/ideogram/ltx/flux2/anima/wan/flux/qwen-image) and orthogonal to their markers. Emits the canonical catalog token `krea_2`.
- Scope note in-code: this classifies the **ComfyUI-native single-file** export (`model.diffusion_model.*`); the diffusers-key snapshot layout is handled by the Krea snapshot loader, not this classifier.

## Tests
Two new tests use headers taken directly from the real files on the author's Mac:
- `krea2_native_bf16_single_file_is_transformer` — `kreamania_variant5.safetensors` (dense bf16) → `Recognized{krea_2, Transformer, Bf16}`.
- `krea2_native_int8_single_file_is_transformer_but_packed_quant` — `kreamania_variant4.safetensors` (int8 per-row + `.comfy_quant`) → `Recognized{krea_2, Transformer, ComfyQuantPacked}`, proving detection separates the loadable bf16 case from the deferred-quant int8 case rather than mislabelling either.

`cargo test -p sceneworks-core --lib base_weights::` → 19 passed, 0 failed. `cargo fmt`/`clippy -p sceneworks-core` clean.

## Verification
Headers decoded directly from the two 12.8/26.3 GB files; the synthetic test headers mirror the real key names + dtypes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)