### PR TITLE
chore(version): align Cargo workspace version with the product version [sc-13613]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-core"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "directories",
  "getrandom 0.3.4",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-desktop"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-image-quality"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "image",
  "image_hasher",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-mcp"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-api"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "fs2",
@@ -6166,7 +6166,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-worker"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "sceneworks-worker",
  "tokio",
@@ -6174,7 +6174,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-worker"
-version = "0.2.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.80"
 license-file = "LICENSE"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tauri:dev": "npm --prefix apps/desktop run dev",
     "tauri:build": "npm --prefix apps/desktop run build",
     "release": "node scripts/release.mjs",
-    "version": "node scripts/sync-version.mjs && git add apps/desktop/tauri.conf.json apps/desktop/package.json apps/desktop/package-lock.json apps/web/package.json apps/web/package-lock.json"
+    "version": "node scripts/sync-version.mjs && git add Cargo.toml Cargo.lock apps/desktop/tauri.conf.json apps/desktop/package.json apps/desktop/package-lock.json apps/web/package.json apps/web/package-lock.json"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -213,26 +213,52 @@ async function assertBuiltinPromptGuides() {
   }
 }
 
+function parseCargoWorkspaceVersion(relativePath, body) {
+  // The root Cargo.toml carries MANY `version = "…"` lines (workspace deps, the
+  // [patch] rev, member crates inherit via `version.workspace = true`). Only the
+  // one under [workspace.package] is the product version, so parse section-scoped
+  // rather than grabbing the first `version =` in the file.
+  const header = "[workspace.package]";
+  const start = body.indexOf(header);
+  if (start === -1) {
+    throw new Error(`${relativePath} has no [workspace.package] table`);
+  }
+  const afterHeader = start + header.length;
+  const rest = body.slice(afterHeader);
+  const nextHeaderRel = rest.search(/\n\[/);
+  const section = nextHeaderRel === -1 ? rest : rest.slice(0, nextHeaderRel);
+  const match = section.match(/^version\s*=\s*"([^"]*)"/m);
+  if (!match) {
+    throw new Error(`${relativePath} [workspace.package] has no version key`);
+  }
+  return match[1];
+}
+
 async function assertVersionsAligned() {
   // sync-version.mjs's contract is that one root `npm version` bumps every
-  // product-version field atomically (root + web + desktop package.json and
-  // tauri.conf.json), so the git tag can never drift from the shipped version.
-  // Assert the invariant here: if these four diverge, a root `npm version patch`
-  // can emit a tag BELOW the version users already run — the Tauri auto-updater
-  // (sc-1355) compares against latest.json and would then serve no update.
+  // product-version field atomically (root + web + desktop package.json,
+  // tauri.conf.json, and the root Cargo.toml [workspace.package] version), so
+  // the git tag can never drift from the shipped version. Assert the invariant
+  // here: if these diverge, a root `npm version patch` can emit a tag BELOW the
+  // version users already run — the Tauri auto-updater (sc-1355) compares against
+  // latest.json and would then serve no update. Cargo.toml is in the set because
+  // its workspace version feeds logs, /health payloads, and the project-file
+  // appVersion; it had silently drifted (0.2.0 vs a 0.8.0 product — sc-13613)
+  // because sync-version.mjs did not touch it and this gate did not cover it.
   const versionSources = [
     { path: "package.json", version: JSON.parse(await readFile(path.join(root, "package.json"), "utf8")).version },
     { path: "apps/web/package.json", version: JSON.parse(await readFile(path.join(root, "apps/web/package.json"), "utf8")).version },
     { path: "apps/desktop/package.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/package.json"), "utf8")).version },
     { path: "apps/desktop/tauri.conf.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/tauri.conf.json"), "utf8")).version },
+    { path: "Cargo.toml", version: parseCargoWorkspaceVersion("Cargo.toml", await readFile(path.join(root, "Cargo.toml"), "utf8")) },
   ];
-  // Scope of this assert: four-way ALIGNMENT only. Using versionSources[0]
+  // Scope of this assert: cross-file ALIGNMENT only. Using versionSources[0]
   // (root package.json) purely as the equality reference means we verify all
-  // four fields are equal, NOT that the version moved upward. A hypothetical
-  // synchronized all-four-down edit would pass this check. That's deliberate:
+  // fields are equal, NOT that the version moved upward. A hypothetical
+  // synchronized all-down edit would pass this check. That's deliberate:
   // upward-DIRECTION is owned by scripts/sync-version.mjs, whose only mutation
   // path is `npm version`, and `npm version` never moves a version down. There
-  // is no committed floor to compare against here — these four files ARE the
+  // is no committed floor to compare against here — these files ARE the
   // version sources — so a hardcoded baseline would be a rot-prone footgun
   // rather than a real guard. Alignment is the invariant this file owns.
   const reference = versionSources[0].version;
@@ -241,7 +267,7 @@ async function assertVersionsAligned() {
     const detail = versionSources.map((source) => `${source.path}=${source.version}`).join(", ");
     throw new Error(
       `Product version fields are not aligned: ${detail}. Run one root ` +
-        `\`npm version <x.y.z>\` (which invokes scripts/sync-version.mjs) so all four move together.`,
+        `\`npm version <x.y.z>\` (which invokes scripts/sync-version.mjs) so they all move together.`,
     );
   }
 }

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -234,6 +234,47 @@ function parseCargoWorkspaceVersion(relativePath, body) {
   return match[1];
 }
 
+async function readWorkspaceMemberCrateNames(cargoTomlBody) {
+  // The [workspace] members array holds directory paths; each member's own
+  // Cargo.toml declares the crate `name` that Cargo.lock records. Derive the set
+  // dynamically (rather than hardcoding) so a new/renamed member is covered
+  // automatically. Only the top-level `members = [...]` array — NOT
+  // `default-members` (line starts with `default-`, so the ^members anchor skips
+  // it) and NOT [workspace.dependencies].
+  const membersMatch = cargoTomlBody.match(/^\s*members\s*=\s*\[([\s\S]*?)\]/m);
+  if (!membersMatch) {
+    throw new Error("Cargo.toml has no [workspace] members array");
+  }
+  const memberDirs = [...membersMatch[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  const names = [];
+  for (const dir of memberDirs) {
+    const memberToml = await readFile(path.join(root, dir, "Cargo.toml"), "utf8");
+    const nameMatch = memberToml.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    if (!nameMatch) {
+      throw new Error(`${dir}/Cargo.toml has no package name`);
+    }
+    names.push(nameMatch[1]);
+  }
+  return names;
+}
+
+function parseCargoLockVersions(body) {
+  // Build a name -> version map from Cargo.lock's [[package]] blocks. Splitting on
+  // the block delimiter keeps each package's own `name`/`version` together (so we
+  // don't cross-read a dependency edge). Workspace members appear here with their
+  // inherited version; a stale lock is exactly what makes `cargo fetch --locked`
+  // fail in CI, so we assert these against the product version.
+  const map = new Map();
+  for (const block of body.split(/\n\[\[package\]\]\n/).slice(1)) {
+    const name = block.match(/^name = "([^"]+)"/m)?.[1];
+    const packageVersion = block.match(/^version = "([^"]+)"/m)?.[1];
+    if (name && packageVersion) {
+      map.set(name, packageVersion);
+    }
+  }
+  return map;
+}
+
 async function assertVersionsAligned() {
   // sync-version.mjs's contract is that one root `npm version` bumps every
   // product-version field atomically (root + web + desktop package.json,
@@ -245,13 +286,22 @@ async function assertVersionsAligned() {
   // its workspace version feeds logs, /health payloads, and the project-file
   // appVersion; it had silently drifted (0.2.0 vs a 0.8.0 product — sc-13613)
   // because sync-version.mjs did not touch it and this gate did not cover it.
+  // Cargo.lock's workspace-member versions are asserted too: bumping the
+  // workspace version without refreshing the lock leaves it stale, and CI's
+  // `cargo fetch --locked` (parity/release/candle/windows) hard-fails on that
+  // skew — so this gate catches lock drift before it ships, not in a red lane.
+  const cargoTomlBody = await readFile(path.join(root, "Cargo.toml"), "utf8");
   const versionSources = [
     { path: "package.json", version: JSON.parse(await readFile(path.join(root, "package.json"), "utf8")).version },
     { path: "apps/web/package.json", version: JSON.parse(await readFile(path.join(root, "apps/web/package.json"), "utf8")).version },
     { path: "apps/desktop/package.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/package.json"), "utf8")).version },
     { path: "apps/desktop/tauri.conf.json", version: JSON.parse(await readFile(path.join(root, "apps/desktop/tauri.conf.json"), "utf8")).version },
-    { path: "Cargo.toml", version: parseCargoWorkspaceVersion("Cargo.toml", await readFile(path.join(root, "Cargo.toml"), "utf8")) },
+    { path: "Cargo.toml", version: parseCargoWorkspaceVersion("Cargo.toml", cargoTomlBody) },
   ];
+  const lockVersions = parseCargoLockVersions(await readFile(path.join(root, "Cargo.lock"), "utf8"));
+  for (const crateName of await readWorkspaceMemberCrateNames(cargoTomlBody)) {
+    versionSources.push({ path: `Cargo.lock:${crateName}`, version: lockVersions.get(crateName) });
+  }
   // Scope of this assert: cross-file ALIGNMENT only. Using versionSources[0]
   // (root package.json) purely as the equality reference means we verify all
   // fields are equal, NOT that the version moved upward. A hypothetical

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -124,7 +124,7 @@ async function bumpPhase(bump) {
 
   run("git", ["push", "-u", "origin", relBranch], repoRoot);
   const body =
-    `Version bump to \`${newVersion}\` (root + tauri.conf.json + apps/desktop + apps/web via sync-version.mjs).\n\n` +
+    `Version bump to \`${newVersion}\` (root + tauri.conf.json + apps/desktop + apps/web + Cargo.toml via sync-version.mjs).\n\n` +
     "After this merges, cut the release:\n" +
     "```\ngit switch main && git pull\nnpm run release -- tag\n```\n" +
     "The tag push triggers `.github/workflows/release.yml`, which drafts the GitHub Release.";

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -43,13 +43,54 @@ for (const dir of ["apps/desktop", "apps/web"]) {
 // to preserve exact formatting (no JSON reparse/reformat churn).
 const conf = join(repoRoot, "apps", "desktop", "tauri.conf.json");
 const before = readFileSync(conf, "utf8");
-const after = before.replace(/"version":\s*"[^"]*"/, `"version": "${version}"`);
-if (after === before) {
+const tauriVersionKey = /"version":\s*"[^"]*"/;
+if (!tauriVersionKey.test(before)) {
   console.error('sync-version: no "version" field found in tauri.conf.json');
   process.exit(1);
 }
-writeFileSync(conf, after);
+// Distinguish "field missing" (fatal, above) from "already at target" (idempotent
+// no-op): only write when the value actually changes so re-runs don't error or churn.
+const after = before.replace(tauriVersionKey, `"version": "${version}"`);
+if (after !== before) {
+  writeFileSync(conf, after);
+}
+
+// Root Cargo.toml [workspace.package] version — the single source every local
+// crate inherits via `version.workspace = true`. It feeds logs, /health payloads,
+// and the project-file appVersion, so it must track the product version too
+// (sc-13613: it had drifted to 0.2.0 while the product shipped 0.8.0). Rewrite
+// ONLY the [workspace.package] table's `version` key: bound the edit to that
+// section so we never touch a member-crate `version.workspace = true` line, a
+// [workspace.dependencies] pin, or the [patch] rev. Idempotent — an already
+// aligned table is left untouched (no spurious write on re-runs).
+const cargoToml = join(repoRoot, "Cargo.toml");
+const cargoBefore = readFileSync(cargoToml, "utf8");
+const cargoHeader = "[workspace.package]";
+const cargoSectionStart = cargoBefore.indexOf(cargoHeader);
+if (cargoSectionStart === -1) {
+  console.error("sync-version: no [workspace.package] table found in Cargo.toml");
+  process.exit(1);
+}
+const cargoAfterHeader = cargoSectionStart + cargoHeader.length;
+const cargoNextHeaderRel = cargoBefore.slice(cargoAfterHeader).search(/\n\[/);
+const cargoSectionEnd =
+  cargoNextHeaderRel === -1 ? cargoBefore.length : cargoAfterHeader + cargoNextHeaderRel;
+const cargoSection = cargoBefore.slice(cargoSectionStart, cargoSectionEnd);
+const cargoVersionKey = /^version\s*=\s*"[^"]*"/m;
+if (!cargoVersionKey.test(cargoSection)) {
+  console.error("sync-version: no version key in Cargo.toml [workspace.package]");
+  process.exit(1);
+}
+const cargoPatchedSection = cargoSection.replace(cargoVersionKey, `version = "${version}"`);
+if (cargoPatchedSection !== cargoSection) {
+  writeFileSync(
+    cargoToml,
+    cargoBefore.slice(0, cargoSectionStart) +
+      cargoPatchedSection +
+      cargoBefore.slice(cargoSectionEnd),
+  );
+}
 
 console.log(
-  `sync-version: apps/desktop + apps/web + tauri.conf.json synced to ${version}`,
+  `sync-version: apps/desktop + apps/web + tauri.conf.json + Cargo.toml synced to ${version}`,
 );

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -89,8 +89,39 @@ if (cargoPatchedSection !== cargoSection) {
       cargoPatchedSection +
       cargoBefore.slice(cargoSectionEnd),
   );
+
+  // Cargo.lock records each workspace member's resolved version (they inherit
+  // `version.workspace = true`), so the rewrite above leaves the lockfile stale.
+  // A stale lock hard-fails the `cargo fetch --locked` that ~8 CI lanes run
+  // (parity / release / candle / windows), which would defeat the atomic-bump
+  // guarantee on the very first real `npm version`. Refresh ONLY the workspace
+  // members, offline (no registry access, no external-dep churn), in this same
+  // run so the bump commit carries a consistent lock. Gated on the version
+  // actually changing: an already-aligned re-run does no cargo work and needs no
+  // toolchain (idempotency is preserved on cargo-less machines).
+  try {
+    execFileSync("cargo", ["update", "--workspace", "--offline"], {
+      cwd: repoRoot,
+      stdio: "inherit",
+    });
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      console.error(
+        "sync-version: bumped Cargo.toml but `cargo` is not on PATH, so Cargo.lock " +
+          "is now STALE. Install the Rust toolchain and run " +
+          "`cargo update --workspace --offline` (then commit Cargo.lock) — otherwise " +
+          "CI's `cargo fetch --locked` will fail on the version skew.",
+      );
+    } else {
+      console.error(
+        `sync-version: \`cargo update --workspace --offline\` failed to refresh ` +
+          `Cargo.lock: ${error?.message ?? error}`,
+      );
+    }
+    process.exit(1);
+  }
 }
 
 console.log(
-  `sync-version: apps/desktop + apps/web + tauri.conf.json + Cargo.toml synced to ${version}`,
+  `sync-version: apps/desktop + apps/web + tauri.conf.json + Cargo.toml (+ Cargo.lock) synced to ${version}`,
 );


### PR DESCRIPTION
## Summary

F-051 — the Rust workspace `[workspace.package].version` had drifted to `0.2.0` while the product shipped `0.8.0`. Every local crate inherits that version via `version.workspace = true`, so logs, `/health` payloads, and the project-file `appVersion` all reported `0.2.0` on a `0.8.0` install. Root cause: `sync-version.mjs` never touched `Cargo.toml`, and the scaffold check did not cover it, so the drift widened silently.

## Authoritative version source

Root `package.json` `version` is the single authoritative product version that `sync-version.mjs` reads (it mirrors it to `apps/web`, `apps/desktop`, and `tauri.conf.json`). Current value: **`0.8.0`**. Aligned `Cargo.toml [workspace.package].version` to `0.8.0` to match.

## Changes

- **`Cargo.toml`** — bump `[workspace.package].version` `0.2.0` → `0.8.0`. Diff is exactly that one line; member-crate `version.workspace = true`, `[workspace.dependencies]`, and the `[patch]` rev are untouched.
- **`Cargo.lock`** — regenerated with `cargo update --workspace`; the 7 workspace members (`sceneworks-core`, `-desktop`, `-image-quality`, `-mcp`, `-rust-api`, `-rust-worker`, `-worker`) now resolve at `0.8.0`. No external dependency changed. Required so CI `--locked` / parity stays green.
- **`scripts/sync-version.mjs`** — now also rewrites the `[workspace.package]` version, bounded to that table (finds the header, scopes to the next `[` table start) so it can never clobber a member `version.workspace = true` line, a workspace dependency pin, or the `[patch]` rev. Idempotent — an already-aligned table is left untouched. Also made the pre-existing `tauri.conf.json` write idempotent (distinguish "field missing" → fatal from "already at target" → no-op) so a standalone re-run no longer `exit(1)`s before reaching the new Cargo.toml step; this matches the sub-packages' existing `npm version --allow-same-version` idempotency.
- **`scripts/check-scaffold.mjs`** — added `Cargo.toml` to `assertVersionsAligned` with a section-scoped `[workspace.package]` version parser (not the first `version =` in the file). Future drift (Cargo workspace version ≠ product version) now FAILS the scaffold/parity check (`npm run check`, run in `.github/workflows/check.yml`).
- **`scripts/release.mjs`** — updated the release PR-body description string to note `Cargo.toml` is now part of the atomic bump.

## Verification

- `npm run check` (the CI scaffold check) **passes** with the aligned versions.
- **Drift-fails-check sanity**: temporarily reverted `Cargo.toml` workspace version to `0.2.0` and re-ran the check — it failed with `Product version fields are not aligned: … Cargo.toml=0.2.0` (exit 1) — then restored.
- **sync-version idempotency**: force-drifted `Cargo.toml` to `0.2.0`, ran `sync-version.mjs` (rewrote it back to `0.8.0`, section-scoped), ran it a second time (exit 0, no error, no churn).
- `cargo metadata --no-deps --locked` succeeds — `Cargo.toml` and `Cargo.lock` are consistent under `--locked`.
- No `.rs` files changed, so `cargo fmt` is a no-op for this change.

Story: https://app.shortcut.com/trefry/story/13613

🤖 Generated with [Claude Code](https://claude.com/claude-code)