### PR TITLE
chore(schemas): even out manifest schema enforcement (loras/styles/control_overlays) [sc-13606]

### DIFF
--- a/config/manifests/builtin.control_overlays.jsonc
+++ b/config/manifests/builtin.control_overlays.jsonc
@@ -11,6 +11,7 @@
   // worker lane (`ensure_krea_control_weights`) already defaults to the same repo and lazy-downloads it, so
   // pose control works out-of-box even before the overlay is explicitly picked; a studio-trained overlay
   // always overrides the built-in.
+  "$schema": "../../packages/schemas/control-overlays.schema.json",
   "schemaVersion": 1,
   "controlOverlays": [
     {

--- a/packages/schemas/control-overlays.schema.json
+++ b/packages/schemas/control-overlays.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sceneworks.local/schemas/control-overlays.schema.json",
+  "title": "SceneWorks Control-Overlay Manifest",
+  "description": "The built-in (hosted) control-overlay catalog — the third source of the shared control-overlay registry (sc-8466, epic 8459 S6), alongside the user-global and per-project overlay manifests. Each entry reuses the LoRA entry shape so it normalizes through `normalize_lora_entry`: a hosted overlay resolves its install state from the HF cache and the ControlPanel picker (GET /api/v1/control-overlays?baseModel=…) lists it. This schema was added by sc-13606 (F-037) so authoring errors in the control-overlay catalog surface in CI, matching the model/lora/styles catalogs, rather than at runtime as a missing overlay.",
+  "type": "object",
+  "required": ["schemaVersion", "controlOverlays"],
+  "$defs": {
+    "hfRevision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Optional pinned 40-hex git commit SHA the download job forwards so the worker fetches that exact IMMUTABLE commit into snapshots/<sha>/ (defense-in-depth parity with the worker's KREA_CONTROL_OVERLAY_REVISION). A branch/tag/short/uppercase value is rejected by the pattern."
+    },
+    "overlaySource": {
+      "type": "object",
+      "description": "How the runtime resolves an overlay's weights (apps/rust-api/src/control_overlays.rs). A hosted overlay carries provider + repo (+ an optional file/files filter and an optional pinned revision). Closed keys so a typo'd `repo`/`file`/`files` fails CI instead of producing a failed download at runtime.",
+      "additionalProperties": false,
+      "required": ["provider", "repo"],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Download provider identifier; hosted overlays use `huggingface`."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Provider repository the overlay checkpoint is fetched from."
+        },
+        "file": {
+          "type": "string",
+          "description": "Single overlay checkpoint file to narrow the snapshot to. The runtime reads the top-level `files` list first, then falls back to `source.file`."
+        },
+        "files": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Explicit allow-list of provider file patterns to fetch."
+        },
+        "revision": { "$ref": "#/$defs/hfRevision" },
+        "path": {
+          "type": "string",
+          "description": "Local filesystem path for a non-hosted (studio-trained) overlay. Hosted builtin entries use provider + repo instead."
+        }
+      }
+    }
+  },
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "controlOverlays": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "baseModel", "controlType", "source"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_-]*$",
+            "description": "Stable overlay id the registry merges scopes by (builtin → user → project) and the ControlPanel keys on."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-facing display name shown in the ControlPanel overlay picker."
+          },
+          "baseModel": {
+            "type": "string",
+            "description": "The frozen INFERENCE base id this overlay applies on (NOT the training base). `list_control_overlays` filters the picker by this."
+          },
+          "controlType": {
+            "type": "string",
+            "description": "Control modality the overlay drives (e.g. 'pose', 'depth', 'canny')."
+          },
+          "controlEngine": {
+            "type": "string",
+            "description": "Worker STRICT_CONTROL_ENGINES key that loads and applies this overlay (backend-neutral; the OS/feature cfg picks the provider lane)."
+          },
+          "backbone": {
+            "type": "string",
+            "description": "Model backbone/family the overlay's control branch was trained against."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Overlay artifact kind (e.g. 'pose_control_branch')."
+          },
+          "experimental": {
+            "type": "boolean",
+            "description": "Marks a not-for-production feasibility-spike overlay (superseded by a full-corpus production overlay later)."
+          },
+          "source": { "$ref": "#/$defs/overlaySource" },
+          "files": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Overlay checkpoint file(s) the worker loads. Read before `source.file` when resolving the weights path."
+          },
+          "provenance": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Provenance metadata for the trained overlay checkpoint.",
+            "properties": {
+              "epic": { "type": "string" },
+              "story": { "type": "string" },
+              "spike": { "type": "string" },
+              "notForProduction": { "type": "boolean" }
+            }
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -4,13 +4,80 @@
   "title": "SceneWorks LoRA Manifest",
   "type": "object",
   "required": ["schemaVersion", "loras"],
+  "$defs": {
+    "hfRevision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Optional pinned 40-hex git commit SHA the download job forwards so the worker fetches that exact IMMUTABLE commit into snapshots/<sha>/ (parity with the model schema's F-029 pin, sc-13659). Absent means the worker resolves `main` at install time. A branch/tag/short/uppercase value is rejected by the pattern because it resolves online but hard-fails the offline pinned-SHA resolver."
+    },
+    "loraSource": {
+      "type": "object",
+      "description": "How the runtime resolves a LoRA's weights (apps/rust-api/src/loras.rs::download_lora). A hosted adapter carries provider + repo (+ an optional file/files narrowing filter and an optional pinned revision); a local adapter carries a path. Closed keys so a typo'd `repo`/`file`/`files` — the sc-12288 field class that silently produced a failed download — fails CI instead of at runtime.",
+      "additionalProperties": false,
+      "required": ["provider", "repo"],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Download provider identifier; hosted catalog LoRAs use `huggingface`."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Provider repository the adapter weights are fetched from."
+        },
+        "file": {
+          "type": "string",
+          "description": "Single adapter file to narrow the snapshot to (the common case). The runtime reads `file` first, then falls back to the `files` list."
+        },
+        "files": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Explicit allow-list of provider file patterns to fetch. An empty list lets the worker fetch the (small) repo."
+        },
+        "revision": { "$ref": "#/$defs/hfRevision" },
+        "path": {
+          "type": "string",
+          "description": "Local filesystem path for a non-hosted adapter (external/studio-installed LoRAs). Hosted catalog entries use provider + repo instead."
+        }
+      }
+    }
+  },
   "properties": {
     "schemaVersion": { "type": "integer", "minimum": 1 },
     "loras": {
       "type": "array",
       "items": {
         "type": "object",
+        "required": ["id"],
+        "additionalProperties": false,
         "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9_-]*$",
+            "description": "Stable catalog id the picker, job payloads, and compatibility checks key on."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-facing display name shown in the LoRA picker."
+          },
+          "family": {
+            "type": "string",
+            "description": "Model family this adapter is compatible with (the compatibility gate reads this and `compatibility.families`)."
+          },
+          "compatibility": {
+            "type": "object",
+            "description": "Which model families this LoRA may attach to (validate_job_lora_compatibility). Left open (additionalProperties:true) because callers may carry richer compatibility metadata.",
+            "properties": {
+              "families": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          },
+          "defaultWeight": {
+            "type": "number",
+            "description": "Default residual weight applied when the LoRA is selected."
+          },
           "triggerWords": {
             "type": "array",
             "items": { "type": "string" },
@@ -30,9 +97,9 @@
             "type": "string",
             "description": "Sampling-regime role marker (the sibling of 'conditioningRole', which is about how a job is CONDITIONED). 'accelerator' = a step-distill / turbo LoRA (e.g. the Krea 2 turbo adapter, sc-13882) whose weights load additively like any other LoRA but whose intent is to change the sampler regime — fewer steps, CFG off. Selecting one auto-switching the model to that regime is separately wired per model; absent that wiring the weights still stack as a plain residual.",
             "enum": ["accelerator"]
-          }
-        },
-        "additionalProperties": true
+          },
+          "source": { "$ref": "#/$defs/loraSource" }
+        }
       }
     }
   }

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -20,9 +20,13 @@ const requiredPaths = [
   "packages/schemas/model-manifest.schema.json",
   "packages/schemas/lora-manifest.schema.json",
   "packages/schemas/recipe-preset.schema.json",
+  "packages/schemas/styles.schema.json",
+  "packages/schemas/control-overlays.schema.json",
   "config/manifests/builtin.models.jsonc",
   "config/manifests/builtin.loras.jsonc",
   "config/manifests/builtin.recipe-presets.jsonc",
+  "config/manifests/builtin.styles.jsonc",
+  "config/manifests/builtin.control_overlays.jsonc",
   "data/projects/.gitkeep",
   "data/models/.gitkeep",
   "data/loras/.gitkeep",
@@ -46,12 +50,16 @@ const manifestSchemaPaths = [
   "packages/schemas/model-manifest.schema.json",
   "packages/schemas/lora-manifest.schema.json",
   "packages/schemas/recipe-preset.schema.json",
+  "packages/schemas/styles.schema.json",
+  "packages/schemas/control-overlays.schema.json",
 ];
 
 const manifestPaths = [
   "config/manifests/builtin.models.jsonc",
   "config/manifests/builtin.loras.jsonc",
   "config/manifests/builtin.recipe-presets.jsonc",
+  "config/manifests/builtin.styles.jsonc",
+  "config/manifests/builtin.control_overlays.jsonc",
 ];
 
 const manifestSchemaPairs = [
@@ -66,6 +74,14 @@ const manifestSchemaPairs = [
   {
     manifestPath: "config/manifests/builtin.recipe-presets.jsonc",
     schemaPath: "packages/schemas/recipe-preset.schema.json",
+  },
+  {
+    manifestPath: "config/manifests/builtin.styles.jsonc",
+    schemaPath: "packages/schemas/styles.schema.json",
+  },
+  {
+    manifestPath: "config/manifests/builtin.control_overlays.jsonc",
+    schemaPath: "packages/schemas/control-overlays.schema.json",
   },
 ];
 

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -986,3 +986,361 @@ def test_hide_reference_strength_models_declare_a_variation_knob():
         f"with NO identity tuning control. Add `variationStrength` or drop "
         f"`hideReferenceStrength`."
     )
+
+
+# ---------------------------------------------------------------------------
+# sc-13606 (F-037): even out schema enforcement across the SIBLING builtin
+# catalogs (loras / styles / control_overlays / recipe-presets).
+#
+# Before this, only builtin.models.jsonc got full JSON-Schema CI validation
+# (sc-12338, the audits above). The lora schema required nothing per entry and
+# left `source` wide open (additionalProperties:true), so a typo'd
+# `source.repo`/`source.file` — the sc-12288 field class behind a silent failed
+# download — passed; builtin.styles.jsonc declared a `$schema` NO check
+# validated; builtin.control_overlays.jsonc had no schema at all. Authoring
+# errors therefore surfaced at runtime (failed downloads, missing overlays /
+# styles) instead of in CI. These tests mirror the model audit above: load each
+# JSONC catalog, validate it against its schema, and prove each new constraint
+# catches a deliberately-broken entry with a schema-keyword-DISCRIMINATING
+# mutation check — NOT a test that merely asserts the current catalog passes.
+#
+# The check-scaffold registry (scripts/check-scaffold.mjs) is kept in lockstep:
+# it now lists all five schema/manifest pairs so the scaffold/parity lane knows
+# the styles + control-overlays pairs exist and reference a real schema; the
+# DEEP jsonschema validation is this pytest lane's job (the scaffold has no
+# jsonschema dependency), the same division of labour the model catalog uses.
+# ---------------------------------------------------------------------------
+
+LORA_MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.loras.jsonc"
+LORA_SCHEMA_PATH = ROOT / "packages" / "schemas" / "lora-manifest.schema.json"
+STYLES_MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.styles.jsonc"
+STYLES_SCHEMA_PATH = ROOT / "packages" / "schemas" / "styles.schema.json"
+CONTROL_OVERLAYS_MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.control_overlays.jsonc"
+CONTROL_OVERLAYS_SCHEMA_PATH = ROOT / "packages" / "schemas" / "control-overlays.schema.json"
+RECIPE_PRESETS_MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.recipe-presets.jsonc"
+RECIPE_PRESET_SCHEMA_PATH = ROOT / "packages" / "schemas" / "recipe-preset.schema.json"
+
+
+def _load_jsonc(path: Path) -> dict:
+    """Generalization of `_load_builtin_models_manifest` for the sibling catalogs."""
+    return json.loads(_strip_jsonc_comments(path.read_text(encoding="utf-8")))
+
+
+def _schema_errors(manifest: dict, schema_path: Path) -> list:
+    """Validate `manifest` against the schema at `schema_path`, returning the
+    (path-sorted) validation errors. Also asserts the schema itself is a legal
+    Draft 2020-12 document (a broken schema is a silent all-pass otherwise)."""
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return sorted(
+        jsonschema.Draft202012Validator(schema).iter_errors(manifest),
+        key=lambda error: list(error.absolute_path),
+    )
+
+
+def _format_errors(errors) -> str:
+    return "\n".join(
+        f"- {'.'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
+        for error in errors
+    )
+
+
+# --- LoRA catalog (builtin.loras.jsonc) ------------------------------------
+
+
+def _sample_lora_entry() -> dict:
+    """A minimal schema-valid LoRA entry for exercising the entry/source schema in
+    isolation (never shipped — real entries live in builtin.loras.jsonc)."""
+    return {
+        "id": "sample_lora",
+        "name": "Sample LoRA",
+        "family": "krea_2",
+        "compatibility": {"families": ["krea_2"]},
+        "defaultWeight": 1.0,
+        "source": {
+            "provider": "huggingface",
+            "repo": "namespace/sample-lora",
+            "file": "sample.safetensors",
+        },
+    }
+
+
+def test_builtin_loras_manifest_satisfies_authoring_schema():
+    """sc-13606: builtin.loras.jsonc is now a full-jsonschema CI contract, not just
+    a shallow root-key check (parity with the model catalog)."""
+    errors = _schema_errors(_load_jsonc(LORA_MANIFEST_PATH), LORA_SCHEMA_PATH)
+    assert not errors, "builtin.loras.jsonc violates lora-manifest.schema.json:\n" + _format_errors(errors)
+
+
+def test_lora_schema_requires_entry_id():
+    """A LoRA entry must carry `id` (the picker / job payloads / compatibility
+    checks all key on it). Discriminate on the `required` keyword + its value so a
+    schema revert dropping `required:[id]` goes red rather than passing on an
+    unrelated error."""
+    entry = _sample_lora_entry()
+    del entry["id"]
+    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+    assert any(
+        error.validator == "required"
+        and error.validator_value == ["id"]
+        and list(error.absolute_path) == ["loras", 0]
+        for error in errors
+    ), "a LoRA entry without `id` must be rejected by the entry's required:['id']"
+
+
+def test_lora_schema_rejects_a_typod_source_key():
+    """The sc-12288 field class: a typo'd `source.file` (or `repo`) key silently
+    produced a failed download. The typed loraSource is additionalProperties:false,
+    so the typo now fails at authoring time. Pin the keyword + path so a revert to
+    an open source object goes red."""
+    entry = _sample_lora_entry()
+    entry["source"]["filez"] = entry["source"].pop("file")
+    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+    assert any(
+        error.validator == "additionalProperties"
+        and list(error.absolute_path) == ["loras", 0, "source"]
+        and "'filez'" in error.message
+        for error in errors
+    ), "a typo'd key under `source` must be rejected by additionalProperties:false"
+
+
+def test_lora_schema_requires_repo_on_source():
+    """The typed source requires `provider`+`repo` (all builtin entries are HF
+    hosted; the runtime errors without a repo). A `source` missing `repo` fails."""
+    entry = _sample_lora_entry()
+    del entry["source"]["repo"]
+    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+    assert any(
+        error.validator == "required"
+        and "repo" in error.validator_value
+        and list(error.absolute_path) == ["loras", 0, "source"]
+        for error in errors
+    ), "a `source` without `repo` must be rejected by the typed source's required list"
+
+
+def test_lora_schema_rejects_an_unknown_entry_key():
+    """The entry object is additionalProperties:false, so a decorative/typo'd
+    entry-level key (the model-catalog `recommendded` mutation, ported) fails."""
+    entry = _sample_lora_entry()
+    entry["recommendded"] = True
+    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+    assert any(
+        error.validator == "additionalProperties"
+        and list(error.absolute_path) == ["loras", 0]
+        and "'recommendded'" in error.message
+        for error in errors
+    )
+
+
+def test_lora_schema_rejects_a_non_40hex_source_revision():
+    """`source.revision` reuses the model schema's 40-hex pin pattern, so a
+    branch/tag value is rejected by the `pattern` keyword."""
+    entry = _sample_lora_entry()
+    entry["source"]["revision"] = "main"
+    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+    assert any(
+        error.validator == "pattern"
+        and list(error.absolute_path) == ["loras", 0, "source", "revision"]
+        for error in errors
+    ), "a non-40-hex source.revision must be rejected by the pattern"
+
+
+def test_lora_source_guard_is_live_against_the_real_catalog():
+    """Mutation guard: the typed-source rule is LIVE on the SHIPPED catalog, not
+    decoration on a synthetic fixture. Typo the first real entry's `source.repo`
+    and validation must fail (proving the guard exercises the real file)."""
+    manifest = _load_jsonc(LORA_MANIFEST_PATH)
+    manifest["loras"][0]["source"]["reppo"] = manifest["loras"][0]["source"].pop("repo")
+    errors = _schema_errors(manifest, LORA_SCHEMA_PATH)
+    assert any(
+        error.validator == "additionalProperties"
+        and list(error.absolute_path) == ["loras", 0, "source"]
+        and "'reppo'" in error.message
+        for error in errors
+    )
+
+
+# --- Control-overlay catalog (builtin.control_overlays.jsonc) ---------------
+
+
+def _sample_control_overlay_entry() -> dict:
+    """A minimal schema-valid control-overlay entry (never shipped)."""
+    return {
+        "id": "sample_overlay",
+        "name": "Sample Overlay",
+        "baseModel": "krea_2_turbo",
+        "controlType": "pose",
+        "source": {
+            "provider": "huggingface",
+            "repo": "namespace/sample-overlay",
+            "file": "control.safetensors",
+        },
+        "files": ["control.safetensors"],
+    }
+
+
+def test_builtin_control_overlays_manifest_satisfies_authoring_schema():
+    """sc-13606: builtin.control_overlays.jsonc previously had NO schema at all; it
+    now validates against control-overlays.schema.json in CI."""
+    errors = _schema_errors(
+        _load_jsonc(CONTROL_OVERLAYS_MANIFEST_PATH), CONTROL_OVERLAYS_SCHEMA_PATH
+    )
+    assert not errors, (
+        "builtin.control_overlays.jsonc violates control-overlays.schema.json:\n"
+        + _format_errors(errors)
+    )
+
+
+def test_control_overlay_schema_requires_its_core_fields():
+    """Each of id/name/baseModel/controlType/source is load-bearing (the picker
+    filters by baseModel + controlType; the registry keys on id; the runtime reads
+    source). Dropping any one must produce a `required` error at the entry."""
+    for field in ("id", "name", "baseModel", "controlType", "source"):
+        entry = _sample_control_overlay_entry()
+        del entry[field]
+        errors = _schema_errors(
+            {"schemaVersion": 1, "controlOverlays": [entry]}, CONTROL_OVERLAYS_SCHEMA_PATH
+        )
+        assert any(
+            error.validator == "required"
+            and field in error.validator_value
+            and list(error.absolute_path) == ["controlOverlays", 0]
+            for error in errors
+        ), f"a control overlay without `{field}` must be rejected by the entry required list"
+
+
+def test_control_overlay_schema_rejects_a_typod_source_key():
+    """The sc-12288 field class on the overlay source (additionalProperties:false)."""
+    entry = _sample_control_overlay_entry()
+    entry["source"]["repoo"] = entry["source"].pop("repo")
+    errors = _schema_errors(
+        {"schemaVersion": 1, "controlOverlays": [entry]}, CONTROL_OVERLAYS_SCHEMA_PATH
+    )
+    assert any(
+        error.validator == "additionalProperties"
+        and list(error.absolute_path) == ["controlOverlays", 0, "source"]
+        and "'repoo'" in error.message
+        for error in errors
+    )
+
+
+def test_control_overlay_schema_rejects_an_unknown_entry_key():
+    """The overlay entry is additionalProperties:false — a typo'd field name fails."""
+    entry = _sample_control_overlay_entry()
+    entry["controlTyp"] = "pose"
+    errors = _schema_errors(
+        {"schemaVersion": 1, "controlOverlays": [entry]}, CONTROL_OVERLAYS_SCHEMA_PATH
+    )
+    assert any(
+        error.validator == "additionalProperties"
+        and list(error.absolute_path) == ["controlOverlays", 0]
+        and "'controlTyp'" in error.message
+        for error in errors
+    )
+
+
+def test_control_overlay_guard_is_live_against_the_real_catalog():
+    """Mutation guard: the overlay schema is LIVE on the shipped catalog. Typo the
+    real entry's `source.file` and validation must fail."""
+    manifest = _load_jsonc(CONTROL_OVERLAYS_MANIFEST_PATH)
+    source = manifest["controlOverlays"][0]["source"]
+    source["fil"] = source.pop("file")
+    errors = _schema_errors(manifest, CONTROL_OVERLAYS_SCHEMA_PATH)
+    assert any(
+        error.validator == "additionalProperties"
+        and list(error.absolute_path) == ["controlOverlays", 0, "source"]
+        and "'fil'" in error.message
+        for error in errors
+    )
+
+
+# --- Style catalog (builtin.styles.jsonc) ----------------------------------
+
+
+def test_builtin_styles_manifest_satisfies_authoring_schema():
+    """sc-13606: builtin.styles.jsonc declared a `$schema` that NO check validated
+    (F-037). It is now an enforced CI contract like the model catalog. (The catalog
+    is machine-generated from documents/style.txt and drift-guarded by
+    styleCatalog.test.js; this only validates its shape, it does not hand-edit it.)"""
+    errors = _schema_errors(_load_jsonc(STYLES_MANIFEST_PATH), STYLES_SCHEMA_PATH)
+    assert not errors, "builtin.styles.jsonc violates styles.schema.json:\n" + _format_errors(errors)
+
+
+def test_styles_schema_rejects_an_unknown_style_key_on_the_real_catalog():
+    """Mutation guard: the styles schema pins additionalProperties:false on each
+    style object. Injecting a decorative/typo'd key into the first real style must
+    fail — proving the now-enforced schema is live, not merely declared."""
+    manifest = _load_jsonc(STYLES_MANIFEST_PATH)
+    manifest["groups"][0]["styles"][0]["prromt"] = "typo"
+    errors = _schema_errors(manifest, STYLES_SCHEMA_PATH)
+    assert any(
+        error.validator == "additionalProperties"
+        and list(error.absolute_path) == ["groups", 0, "styles", 0]
+        and "'prromt'" in error.message
+        for error in errors
+    )
+
+
+def test_styles_schema_requires_a_style_prompt():
+    """A style object requires id/name/prompt; dropping `prompt` from the first
+    real style must be rejected by the style object's required list."""
+    manifest = _load_jsonc(STYLES_MANIFEST_PATH)
+    del manifest["groups"][0]["styles"][0]["prompt"]
+    errors = _schema_errors(manifest, STYLES_SCHEMA_PATH)
+    assert any(
+        error.validator == "required"
+        and "prompt" in error.validator_value
+        and list(error.absolute_path) == ["groups", 0, "styles", 0]
+        for error in errors
+    )
+
+
+# --- Recipe-preset catalog (builtin.recipe-presets.jsonc) -------------------
+
+
+def test_builtin_recipe_presets_manifest_satisfies_authoring_schema():
+    """sc-13606: the recipe-preset catalog now gets full jsonschema validation in
+    the pytest lane (previously only the shallow check-scaffold root-key check).
+    The shipped catalog is currently empty, so the discriminating guards below run
+    against synthetic presets — the schema, not the catalog, carries the rules."""
+    errors = _schema_errors(_load_jsonc(RECIPE_PRESETS_MANIFEST_PATH), RECIPE_PRESET_SCHEMA_PATH)
+    assert not errors, (
+        "builtin.recipe-presets.jsonc violates recipe-preset.schema.json:\n" + _format_errors(errors)
+    )
+
+
+def test_recipe_preset_schema_requires_id_and_name():
+    """Every preset requires id + name. Dropping `name` from an otherwise-valid
+    general preset must be rejected by the entry's required list."""
+    preset = {"id": "sample_preset", "name": "Sample Preset", "kind": "general"}
+    del preset["name"]
+    errors = _schema_errors({"schemaVersion": 1, "presets": [preset]}, RECIPE_PRESET_SCHEMA_PATH)
+    assert any(
+        error.validator == "required"
+        and "name" in error.validator_value
+        and list(error.absolute_path) == ["presets", 0]
+        for error in errors
+    )
+
+
+def test_recipe_preset_schema_requires_model_and_workflow_for_model_presets():
+    """A preset with no `kind` is a MODEL preset; the schema's allOf conditional
+    then requires model + workflow. A bare {id,name} model preset must fail — this
+    only holds while that conditional exists (discriminates a revert)."""
+    preset = {"id": "sample_model_preset", "name": "Sample"}
+    errors = _schema_errors({"schemaVersion": 1, "presets": [preset]}, RECIPE_PRESET_SCHEMA_PATH)
+    assert any(
+        error.validator == "required" and set(error.validator_value) == {"model", "workflow"}
+        for error in errors
+    ), "a model (non-general) preset must require model + workflow via the allOf conditional"
+
+
+def test_recipe_preset_schema_rejects_a_bad_id_pattern():
+    """The preset `id` is pattern-constrained (lowercase slug); an id with spaces /
+    capitals / punctuation is rejected by the `pattern` keyword."""
+    preset = {"id": "Bad Id!", "name": "Sample", "kind": "general"}
+    errors = _schema_errors({"schemaVersion": 1, "presets": [preset]}, RECIPE_PRESET_SCHEMA_PATH)
+    assert any(
+        error.validator == "pattern" and list(error.absolute_path) == ["presets", 0, "id"]
+        for error in errors
+    )


### PR DESCRIPTION
## sc-13606 — F-037: even out manifest schema enforcement

**Story:** https://app.shortcut.com/trefry/story/13606

### Problem
Only `builtin.models.jsonc` got full JSON-Schema CI validation (sc-12338, closed keys). Four of the five builtin catalogs were under-guarded, so authoring errors surfaced at runtime (failed downloads, missing overlays/styles) instead of in CI:
- `lora-manifest.schema.json` required nothing per entry and left `source` wide open (`additionalProperties:true`) — a typo'd `source.repo`/`source.file` (the **sc-12288** field class behind a silent failed download) passed.
- `builtin.styles.jsonc` declared a `$schema` that **no check validated**.
- `builtin.control_overlays.jsonc` had **no schema at all**.

### Already done (model half — untouched)
The MODEL-manifest audit was completed earlier: `model-manifest.schema.json` constrains `revision` to `^[0-9a-f]{40}$`, typed `componentId` via `allOf`, requires `ui.promptGuide` on non-utility entries, with ~271 lines of schema-keyword-discriminating pytest + self-cleaning grandfather allowlists reconciled with check-scaffold. **This PR does not touch it — it uses it as the template.**

### What this PR adds (loras / styles / control_overlays / recipe-presets)
- **`lora-manifest.schema.json` tightened:** require per-entry `id`; a typed `$defs.loraSource` (`additionalProperties:false`, required `provider`+`repo`, 40-hex `revision` pattern reused from the model schema) so a typo'd `source.repo`/`file`/`files` key now FAILS; entry object closed (`additionalProperties:false`).
- **`control-overlays.schema.json` (new):** required `id`/`name`/`baseModel`/`controlType`/`source`, typed closed `overlaySource`, closed entry + `provenance`; `builtin.control_overlays.jsonc` `$schema` wired to it (consistent with the sibling catalogs that already carry `$schema`).
- **`styles.schema.json` now ENFORCED** against `builtin.styles.jsonc` (was declared but validated by nothing). The catalog is machine-generated and unchanged — only its shape is validated.
- **Recipe-presets** now get full jsonschema validation in the pytest lane (previously only the shallow check-scaffold root-key check). The shipped catalog is empty, so its guards run against synthetic presets.
- **pytest extension** (`tests/test_builtin_manifest_audit.py`): each new constraint has a schema-keyword-**discriminating** mutation test (missing `id`, typo'd `source` key, missing `repo`, non-40-hex revision, unknown entry key, missing style `prompt`, model-preset missing `model`/`workflow`, bad id pattern) plus live-against-the-real-catalog guards — **not** assert-the-catalog-passes tests.
- **`check-scaffold.mjs`:** registered the styles + control-overlays schema/manifest pairs in all four registries (`requiredPaths`, `manifestSchemaPaths`, `manifestPaths`, `manifestSchemaPairs`). Deep jsonschema validation stays in the pytest lane (the scaffold has no jsonschema dep) — the same division of labour the model catalog uses.

### Grandfather entries
**None.** The tightened/added schemas validate the current loras/styles/control_overlays/recipe-presets catalogs with **zero** errors — no allowlist needed.

### Discrimination (proof the guards are real, not false greens)
Reverting each schema to a permissive/loose version turns the discriminating tests RED while the "real catalog validates" test stays green:
- lora: 6 tightening guards fail on the loose original schema.
- control-overlays: 4 guards fail on a permissive schema.
- styles: 2 guards fail on a permissive schema.
- recipe-presets: 3 guards fail on a permissive schema.

### Validation
- `python -m pytest -q tests/ -m "not e2e and not parity" --strict-markers` → **52 passed** (pinned CI deps: pytest 9.0.2, jsonschema 4.25.1, httpx 0.28.1).
- `npm run check` (scaffold) → **passed**.
- No Rust build needed (schemas + Python + JS-scaffold only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)