### PR TITLE
feat(models): route imported same-family checkpoints + gate import kill-switch on a compatibility verdict [sc-14019]

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use sceneworks_core::base_weights::{detect_base_weight_file, import_detection_supported};
 use sceneworks_core::credentials::normalize_host;
 use sceneworks_core::lora_family::is_hidden_file;
 
@@ -875,20 +876,45 @@ fn converted_tier_real_bytes(tier_dir: &FsPath) -> u64 {
     total
 }
 
-/// Kill-switch for the model upload/import endpoint (sc-7081, epic 7080). Disabled on
-/// every platform until a real compatibility-check + conversion pipeline exists behind it:
-/// today an imported checkpoint never reaches a runnable engine. macOS dropped the torch
-/// worker (MLX-only, sc-3492) and resolves engines from a compile-time table a novel
-/// imported id is never in; the off-Mac diffusers path only loads full repos via
-/// `from_pretrained`, not the single files this endpoint accepts. Flip to `true` once the
-/// pipeline gates imports on an architecture-compatibility verdict (kept as a fn, not a
-/// `const`, so the guarded handler body stays reachable — no `unreachable_code`).
+/// Kill-switch for the model upload/import endpoint (sc-7081, epic 7080). Enabled as of sc-14019
+/// (epic 14015): a base-checkpoint import is now gated on the architecture-compatibility verdict of
+/// the base-weight detector ([`sceneworks_core::base_weights`]) via [`import_source_supported`] at
+/// queue time and the worker's `run_model_import_job` over the downloaded bytes. The gate accepts
+/// ONLY `(family, component, quant)` triples with a real loader today (`import_supported` — currently
+/// a dense-bf16 Krea 2 DiT, routed to the Krea MLX engine via the S0d family path); every other file
+/// is refused with a typed reason (NEVER a silent fallback). Kept as a fn, not a `const`, so the
+/// guarded handler body stays reachable (no `unreachable_code`) and the switch is trivially
+/// re-flippable if a regression surfaces.
 fn model_import_enabled() -> bool {
-    false
+    true
 }
 
 const MODEL_IMPORT_DISABLED_DETAIL: &str = "Model import is temporarily disabled while native \
      model support and conversion are being built. (LoRA import is unaffected.)";
+
+/// Import-compatibility gate for a base checkpoint (sc-14019, epic 14015): resolve the primary
+/// weight file under `source`, classify it with the base-weight detector, and refuse the import
+/// unless the verdict is one a real loader accepts today
+/// ([`sceneworks_core::base_weights::import_supported`]). The refusal reason is surfaced to the API
+/// client as a `400` so the upload flow gets a synchronous, actionable message rather than a queued
+/// job that fails later. This gate is **additive** to path confinement — `source` has already been
+/// confined by `validate_lora_import_source_path` (LAN-exposed jobs API, epic 4484); this never
+/// widens or bypasses that. The worker re-runs the same predicate over the downloaded bytes so repo/
+/// URL imports (whose file is not on disk at queue time) are covered there.
+fn import_source_supported(source: &FsPath) -> Result<(), ApiError> {
+    let weight_file = if source.is_dir() {
+        first_safetensors_path(source)
+    } else {
+        Some(source.to_path_buf())
+    };
+    let Some(weight_file) = weight_file else {
+        return Err(ApiError::bad_request(
+            "No safetensors base-weight file was found to import; single-file base-checkpoint import expects a .safetensors transformer.",
+        ));
+    };
+    let detection = detect_base_weight_file(&weight_file).map_err(model_family_inspection_error)?;
+    import_detection_supported(&detection).map_err(ApiError::bad_request)
+}
 
 pub(crate) async fn create_model_import_job(
     State(state): State<AppState>,
@@ -1019,6 +1045,11 @@ pub(crate) async fn queue_model_import_job(
             allowed_source_roots
         };
         validate_lora_import_source_path(source_path, &allowed_source_roots)?;
+        // Compatibility gate (sc-14019): refuse — synchronously, with the detector's typed reason —
+        // any staged/local base checkpoint whose (family, component, quant) has no loader today.
+        // Runs AFTER confinement above; it never widens the allowed roots. Repo/URL imports (no file
+        // on disk yet) are gated by the worker over the downloaded bytes instead.
+        import_source_supported(FsPath::new(source_path))?;
         let detected =
             detect_model_family(FsPath::new(source_path)).map_err(model_family_inspection_error)?;
         payload.family = reconcile_model_family(
@@ -1421,6 +1452,124 @@ fn backfill_current_receipt(
         )
         .ok()
     });
+}
+
+#[cfg(test)]
+mod import_gate_tests {
+    //! The queue-time base-checkpoint compatibility gate (sc-14019, epic 14015): `import_source_supported`
+    //! must accept a dense-bf16 Krea 2 DiT and refuse everything else with an actionable reason, so the
+    //! LAN-exposed import endpoint (now that the kill-switch is on) can never queue an un-runnable file.
+    use super::*;
+
+    /// Write a safetensors file whose header declares `(name, dtype)` tensors. The declared tensor
+    /// data must be present or the header is rejected as truncated (sc-6072), so the payload is padded
+    /// to the declared offsets — mirrors `external_base_models::tests::write_safetensors`.
+    fn write_safetensors(path: &FsPath, entries: &[(&str, &str)]) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("parent dir");
+        }
+        let mut header = serde_json::Map::new();
+        for (index, (key, dtype)) in entries.iter().enumerate() {
+            let start = index * 4;
+            header.insert(
+                (*key).to_owned(),
+                json!({ "dtype": dtype, "shape": [1], "data_offsets": [start, start + 4] }),
+            );
+        }
+        let header_bytes = serde_json::to_vec(&Value::Object(header)).expect("header json");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header_bytes.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&header_bytes);
+        bytes.extend(std::iter::repeat(0_u8).take(entries.len() * 4));
+        std::fs::write(path, bytes).expect("write safetensors");
+    }
+
+    /// A ComfyUI-native dense-bf16 Krea 2 DiT: the unique `txtfusion.` tower + BFL-style `blocks.*`
+    /// keys, all BF16 → detector `(krea_2, Transformer, Bf16)` — the one importable triple today.
+    fn krea2_bf16_dit_keys() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("model.diffusion_model.blocks.0.attn.wq.weight", "BF16"),
+            ("model.diffusion_model.blocks.0.mod.lin", "BF16"),
+            (
+                "model.diffusion_model.txtfusion.refiner_blocks.0.attn.wq.weight",
+                "BF16",
+            ),
+            ("model.diffusion_model.txtfusion.projector.weight", "BF16"),
+        ]
+    }
+
+    #[test]
+    fn krea2_bf16_upload_is_accepted() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("kreamania_variant5.safetensors");
+        write_safetensors(&file, &krea2_bf16_dit_keys());
+        assert!(
+            import_source_supported(&file).is_ok(),
+            "a dense-bf16 Krea 2 DiT upload must pass the import gate"
+        );
+    }
+
+    #[test]
+    fn krea2_packed_quant_upload_is_refused_with_reason() {
+        // Same family/component but `.comfy_quant` packed int8 → no loader yet → 400 with a reason.
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("kreamania_variant4.safetensors");
+        write_safetensors(
+            &file,
+            &[
+                ("model.diffusion_model.blocks.0.attn.wq.weight", "I8"),
+                ("model.diffusion_model.blocks.0.attn.wq.comfy_quant", "U8"),
+                ("model.diffusion_model.blocks.0.mod.lin", "BF16"),
+                (
+                    "model.diffusion_model.txtfusion.refiner_blocks.0.attn.wq.comfy_quant",
+                    "U8",
+                ),
+            ],
+        );
+        let error = import_source_supported(&file).expect_err("packed quant must be refused");
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert!(error.detail.contains("bf16"), "detail: {}", error.detail);
+    }
+
+    #[test]
+    fn unsupported_family_upload_is_refused() {
+        // A qwen-image plain-fp8 DiT is recognized but has no import loader → refused.
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("qwen_image.safetensors");
+        write_safetensors(
+            &file,
+            &[
+                ("model.diffusion_model.img_in.weight", "F8_E4M3"),
+                (
+                    "model.diffusion_model.transformer_blocks.0.attn.add_q_proj.weight",
+                    "F8_E4M3",
+                ),
+                (
+                    "model.diffusion_model.transformer_blocks.0.img_mlp.net.0.proj.weight",
+                    "F8_E4M3",
+                ),
+            ],
+        );
+        let error = import_source_supported(&file).expect_err("qwen import must be refused");
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert!(
+            error.detail.contains("qwen-image"),
+            "detail should name the unsupported family: {}",
+            error.detail
+        );
+    }
+
+    #[test]
+    fn unrecognized_file_upload_is_refused() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("mystery.safetensors");
+        write_safetensors(
+            &file,
+            &[("some.mystery.tensor", "BF16"), ("another.mystery", "BF16")],
+        );
+        let error = import_source_supported(&file).expect_err("unrecognized file must be refused");
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+    }
 }
 
 #[cfg(test)]
@@ -2613,7 +2762,15 @@ fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
             .get("type")
             .and_then(Value::as_str)
             .unwrap_or_default();
-        model_mac_support(id, model_type)
+        // Forward the catalog-declared family so an imported/user model whose id is in no routing
+        // table still routes to its family's MLX engine (route-by-family, sc-14019) instead of
+        // reporting "not available on Mac". Builtin ids are unaffected (they route by id).
+        let family = object
+            .get("family")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        model_mac_support(id, model_type, family)
     };
     if let Ok(mac_support) = serde_json::to_value(mac_support) {
         object.insert("macSupport".to_owned(), mac_support);

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -1216,13 +1216,14 @@ async fn paired_moe_lora_upload_writes_convention_files_and_records_base_model()
 }
 
 #[tokio::test]
-async fn model_import_route_is_disabled_on_every_platform() {
-    // sc-7081 (epic 7080): model upload/import is intentionally disabled until a real
-    // compatibility + conversion pipeline exists. Both the JSON and multipart entrypoints
-    // must short-circuit with an actionable 403 before any staging/queueing. The deeper
-    // validation/family-detection logic still lives behind `create_model_import_job` (and is
-    // covered by lora_family + worker tests); restore the route-level assertions when the
-    // feature is re-enabled.
+async fn model_import_route_is_enabled_and_detector_gated() {
+    // sc-14019 (epic 14015): the model-import kill-switch is ON, and each entrypoint is gated on the
+    // base-weight detector's compatibility verdict (`import_supported`) rather than unconditionally
+    // refused (the pre-sc-14019 contract this test used to pin). This drives the MOUNTED route through
+    // `create_app` so a regression in the `create_model_import_job` -> `queue_model_import_job` -> gate
+    // wiring is caught, not just the `import_source_supported` helper (unit-tested in
+    // `models::import_gate_tests`). Detection is header-only, so the fixtures are minimal synthetic
+    // safetensors headers built in-test — no real weights needed.
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
@@ -1253,9 +1254,67 @@ async fn model_import_route_is_disabled_on_every_platform() {
         std::fs::write(config_dir.join(name), body).expect("manifest writes");
     }
 
-    // JSON path: refused before any validation or queueing.
+    // Supported multipart upload: a dense-bf16 Krea 2 DiT (the unique `txtfusion.` tower + BFL-style
+    // `blocks.*` keys, all BF16) -> detector `(krea_2, Transformer, Bf16)` -> the gate accepts it and
+    // the endpoint queues the import (201). This is the positive endpoint->gate wiring assertion.
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let (status, error) = request(
+    let (status, job) = request_multipart_model_upload(
+        app,
+        &[("name", "Krea Import"), ("type", "image")],
+        "kreamania_variant5.safetensors",
+        &test_safetensors_bytes_with_typed_keys(&[
+            ("model.diffusion_model.blocks.0.attn.wq.weight", "BF16"),
+            ("model.diffusion_model.blocks.0.mod.lin", "BF16"),
+            (
+                "model.diffusion_model.txtfusion.refiner_blocks.0.attn.wq.weight",
+                "BF16",
+            ),
+            ("model.diffusion_model.txtfusion.projector.weight", "BF16"),
+        ]),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a dense-bf16 Krea 2 DiT upload must pass the gate and queue: {job:?}"
+    );
+    assert_eq!(job["type"], "model_import");
+
+    // Unsupported multipart upload: an F8_E4M3 qwen-image DiT is a recognized family with no import
+    // loader today -> refused AT THE ENDPOINT with 400 and the typed reason naming the family, before
+    // any job is queued. This is the negative endpoint->gate wiring assertion.
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (mp_status, mp_error) = request_multipart_model_upload(
+        app,
+        &[("name", "Qwen Import"), ("type", "image")],
+        "qwen_image.safetensors",
+        &test_safetensors_bytes_with_typed_keys(&[
+            ("model.diffusion_model.img_in.weight", "F8_E4M3"),
+            (
+                "model.diffusion_model.transformer_blocks.0.attn.add_q_proj.weight",
+                "F8_E4M3",
+            ),
+            (
+                "model.diffusion_model.transformer_blocks.0.img_mlp.net.0.proj.weight",
+                "F8_E4M3",
+            ),
+        ]),
+    )
+    .await;
+    assert_eq!(mp_status, StatusCode::BAD_REQUEST);
+    assert!(
+        mp_error["detail"]
+            .as_str()
+            .unwrap_or("")
+            .contains("qwen-image"),
+        "refusal detail should surface the typed reason naming the family: {mp_error:?}"
+    );
+
+    // Remote `sourceUrl` JSON import: there are no local bytes to inspect at queue time, so the gate
+    // correctly defers to the worker (which re-runs the same detector over the downloaded bytes). The
+    // endpoint queues the job (201) rather than refusing a file it cannot yet see.
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (url_status, url_job) = request(
         app,
         "POST",
         "/api/v1/models/import",
@@ -1265,23 +1324,12 @@ async fn model_import_route_is_disabled_on_every_platform() {
         }),
     )
     .await;
-    assert_eq!(status, StatusCode::FORBIDDEN);
-    assert!(error["detail"].as_str().unwrap_or("").contains("disabled"));
-
-    // Multipart path: refused before the upload is staged.
-    let app = create_app(test_settings(&temp_dir)).expect("app creates");
-    let (mp_status, mp_error) = request_multipart_model_upload(
-        app,
-        &[("name", "Disabled"), ("type", "image")],
-        "disabled.safetensors",
-        &test_safetensors_bytes_with_keys(&qwen_image_tensor_keys()),
-    )
-    .await;
-    assert_eq!(mp_status, StatusCode::FORBIDDEN);
-    assert!(mp_error["detail"]
-        .as_str()
-        .unwrap_or("")
-        .contains("disabled"));
+    assert_eq!(
+        url_status,
+        StatusCode::CREATED,
+        "a remote sourceUrl import has no local bytes, so it queues for the worker gate: {url_job:?}"
+    );
+    assert_eq!(url_job["type"], "model_import");
 }
 
 #[tokio::test]

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -209,6 +209,31 @@ pub(crate) fn test_safetensors_bytes_with_keys(tensor_keys: &[String]) -> Vec<u8
     bytes
 }
 
+/// Like [`test_safetensors_bytes_with_keys`] but with a per-tensor dtype, so a fixture can drive the
+/// base-weight detector's dtype-sensitive quant classification (sc-14019): a BF16 Krea 2 DiT lands as
+/// `(krea_2, Transformer, Bf16)` (importable) while an F8_E4M3 qwen DiT lands as a refused quant. Same
+/// header + padded-data completeness posture as [`test_safetensors_bytes_with_keys`].
+pub(crate) fn test_safetensors_bytes_with_typed_keys(entries: &[(&str, &str)]) -> Vec<u8> {
+    const TENSOR_DATA_END: u64 = 32768;
+    let mut object = serde_json::Map::new();
+    object.insert("__metadata__".to_owned(), json!({"format": "pt"}));
+    let mut data_end = 0_u64;
+    for (key, dtype) in entries {
+        object.insert(
+            (*key).to_owned(),
+            json!({"dtype": dtype, "shape": [16, 1024], "data_offsets": [0, TENSOR_DATA_END]}),
+        );
+        data_end = data_end.max(TENSOR_DATA_END);
+    }
+    let header = serde_json::to_vec(&Value::Object(object)).expect("header serializes");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(&header);
+    let data_len = usize::try_from(data_end.max(12)).expect("data length fits usize");
+    bytes.resize(bytes.len() + data_len, 0);
+    bytes
+}
+
 pub(crate) fn z_image_tensor_keys() -> Vec<String> {
     mm_dit_tensor_keys(24)
 }

--- a/crates/sceneworks-core/src/base_weights.rs
+++ b/crates/sceneworks-core/src/base_weights.rs
@@ -171,6 +171,73 @@ pub enum BaseWeightDetection {
     },
 }
 
+// ---------------------------------------------------------------------------
+// Import compatibility (sc-14019, epic 14015)
+// ---------------------------------------------------------------------------
+
+/// Architecture families the single-file **model-import** pipeline can assemble and load today
+/// (sc-14019, epic 14015). An imported checkpoint of one of these families is registered as a
+/// user model and routed to that family's existing in-process engine (the S0d family-routing path
+/// in `jobs_store::routing::catalog`). Seeded with `krea_2` — the community Krea 2 DiT export the
+/// detector recognizes by its `txtfusion.` marker, whose builtins already route to the Krea MLX
+/// engine. Grows one entry per landed loader; keep it aligned with [`import_supported`]'s arms and
+/// with `MLX_ROUTED_FAMILIES` (routing).
+pub const IMPORT_SUPPORTED_FAMILIES: &[&str] = &["krea_2"];
+
+/// Whether an imported community single-file **base checkpoint** described by `verdict` can be
+/// assembled and run by a real engine today (sc-14019, epic 14015) — the compatibility gate behind
+/// the model-import kill-switch (`apps/rust-api::model_import_enabled`). `Ok(())` means the
+/// `(family, component, quant)` triple has a landed single-file import loader; `Err(reason)` is a
+/// client-facing explanation of why the file is refused. There is **no silent fallback**: a triple
+/// with no loader fails closed with a reason (the sc-10509 posture), never a best-effort load that
+/// would decode to noise.
+///
+/// Written as a `match` with **one arm per supported loader** so a follow-on family / component /
+/// quant (the S0c assembly slice and the epic's later families) is a single added arm, not a
+/// rewrite. Today exactly one triple is loadable: a dense-`bf16` Krea 2 DiT
+/// (`krea_2` / [`ComponentRole::Transformer`] / [`QuantFormat::Bf16`]), which reuses the existing
+/// Krea MLX engine via the family-routing path. Everything else — an unrecognized/absent family, a
+/// non-transformer component (VAE / text encoder / all-in-one checkpoint), or a deferred quant
+/// (plain/scaled/inline fp8, `comfy_quant` packed, GGUF) — is refused with a specific reason.
+pub fn import_supported(verdict: &BaseWeightVerdict) -> Result<(), String> {
+    match (verdict.family.as_deref(), verdict.component, verdict.quant) {
+        // --- Supported loaders: one arm per landed loader (add the next family/quant here) ---
+        (Some("krea_2"), ComponentRole::Transformer, QuantFormat::Bf16) => Ok(()),
+
+        // --- Refusals: most specific first, each with an actionable, client-facing reason ---
+        (None, _, _) => Err(
+            "The architecture family could not be identified from the file, so the import is \
+             refused rather than guessing at a loader."
+                .to_owned(),
+        ),
+        (Some(family), _, _) if !IMPORT_SUPPORTED_FAMILIES.contains(&family) => Err(format!(
+            "Model import does not yet support the '{family}' family. Supported today: {}.",
+            IMPORT_SUPPORTED_FAMILIES.join(", ")
+        )),
+        (Some(family), component, _) if component != ComponentRole::Transformer => Err(format!(
+            "Model import for the '{family}' family currently supports only the diffusion \
+             transformer, not a {component} file."
+        )),
+        (Some(family), _, quant) => Err(format!(
+            "Model import for the '{family}' family currently supports only dense bf16 weights, \
+             not {quant}. Re-export the checkpoint in bf16."
+        )),
+    }
+}
+
+/// [`import_supported`] lifted over a whole [`BaseWeightDetection`]: a `Recognized` verdict defers to
+/// `import_supported`, while an `Unrecognized` file is refused carrying the detector's own reason.
+/// The single entry point the API/worker import gates call over a detected file (sc-14019).
+pub fn import_detection_supported(detection: &BaseWeightDetection) -> Result<(), String> {
+    match detection {
+        BaseWeightDetection::Recognized(verdict) => import_supported(verdict),
+        BaseWeightDetection::Unrecognized { reason } => Err(format!(
+            "The file is not a recognized base-weight checkpoint ({reason}), so it cannot be \
+             imported."
+        )),
+    }
+}
+
 /// The GGUF container magic — the first four bytes of every `.gguf` file. Detected
 /// by content, not extension, per the story (a renamed `.bin`/`.sft` GGUF must
 /// still classify).
@@ -1041,5 +1108,129 @@ mod tests {
             ("transformer_blocks.0.attn2.to_k.weight", "BF16"),
         ])));
         assert_eq!(verdict.quant, QuantFormat::Bf16);
+    }
+
+    // --- import compatibility gate (sc-14019, epic 14015) -----------------------
+
+    fn verdict(
+        family: Option<&str>,
+        component: ComponentRole,
+        quant: QuantFormat,
+    ) -> BaseWeightVerdict {
+        BaseWeightVerdict {
+            family: family.map(str::to_owned),
+            component,
+            quant,
+        }
+    }
+
+    #[test]
+    fn import_supported_accepts_only_krea2_transformer_bf16() {
+        // The single loadable triple today: a dense-bf16 Krea 2 DiT, routed to the Krea MLX engine.
+        assert!(import_supported(&verdict(
+            Some("krea_2"),
+            ComponentRole::Transformer,
+            QuantFormat::Bf16
+        ))
+        .is_ok());
+    }
+
+    #[test]
+    fn import_supported_refuses_krea2_transformer_deferred_quant() {
+        // Same family + component, but a packed quant with no loader → refused with the quant named.
+        let reason = import_supported(&verdict(
+            Some("krea_2"),
+            ComponentRole::Transformer,
+            QuantFormat::ComfyQuantPacked,
+        ))
+        .expect_err("packed quant must be refused");
+        assert!(
+            reason.contains("bf16"),
+            "reason should name the required quant: {reason}"
+        );
+        assert!(
+            reason.contains(QuantFormat::ComfyQuantPacked.as_str()),
+            "reason should name the rejected quant: {reason}"
+        );
+    }
+
+    #[test]
+    fn import_supported_refuses_krea2_wrong_component() {
+        // A Krea-family VAE (or any non-transformer component) is not the transformer we load.
+        for component in [
+            ComponentRole::Vae,
+            ComponentRole::TextEncoder,
+            ComponentRole::Checkpoint,
+        ] {
+            let reason = import_supported(&verdict(Some("krea_2"), component, QuantFormat::Bf16))
+                .expect_err("non-transformer component must be refused");
+            assert!(
+                reason.contains("transformer"),
+                "reason should explain the transformer-only rule: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn import_supported_refuses_unsupported_and_absent_family() {
+        // A recognized-but-unsupported family (z-image) is refused, naming the supported set.
+        let z_reason = import_supported(&verdict(
+            Some("z-image"),
+            ComponentRole::Transformer,
+            QuantFormat::Bf16,
+        ))
+        .expect_err("unsupported family must be refused");
+        assert!(z_reason.contains("z-image"), "reason: {z_reason}");
+        assert!(
+            z_reason.contains("krea_2"),
+            "reason should name the supported set: {z_reason}"
+        );
+        // A component with no family label (None) is refused rather than guessed at.
+        assert!(import_supported(&verdict(
+            None,
+            ComponentRole::Transformer,
+            QuantFormat::Bf16
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn import_detection_supported_refuses_unrecognized_with_reason() {
+        let detection = BaseWeightDetection::Unrecognized {
+            reason: "no recognized component-role signature".to_owned(),
+        };
+        let reason =
+            import_detection_supported(&detection).expect_err("unrecognized must be refused");
+        assert!(
+            reason.contains("no recognized component-role signature"),
+            "the detector's own reason must be surfaced: {reason}"
+        );
+    }
+
+    #[test]
+    fn import_detection_supported_accepts_recognized_krea2_bf16() {
+        let detection = BaseWeightDetection::Recognized(verdict(
+            Some("krea_2"),
+            ComponentRole::Transformer,
+            QuantFormat::Bf16,
+        ));
+        assert!(import_detection_supported(&detection).is_ok());
+    }
+
+    #[test]
+    fn import_supported_families_are_a_subset_of_the_ok_arms() {
+        // Guardrail: every family the gate advertises must actually have an Ok triple, so the
+        // advertised set and the `match` arms can never drift (add the family here + its arm together).
+        for family in IMPORT_SUPPORTED_FAMILIES {
+            assert!(
+                import_supported(&verdict(
+                    Some(family),
+                    ComponentRole::Transformer,
+                    QuantFormat::Bf16
+                ))
+                .is_ok(),
+                "IMPORT_SUPPORTED_FAMILIES lists {family} but no bf16 transformer arm accepts it"
+            );
+        }
     }
 }

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -6798,7 +6798,7 @@ mod mlx_routing_tests {
         // and `features.edit` is now true (drives the Image Studio Edit tab alongside the catalog
         // `edit_image` capability). `reference`/`pose` remain true — inert, since the catalog
         // capabilities (not these flags) drive the UI affordances.
-        let support = model_mac_support("ideogram_4", "image");
+        let support = model_mac_support("ideogram_4", "image", None);
         assert!(support.supported, "ideogram_4 must be Mac-supported");
         assert!(
             support.features.edit,
@@ -6813,7 +6813,7 @@ mod mlx_routing_tests {
             "ideogram_4_turbo",
             &object(json!({ "mode": "edit_image", "sourceAssetId": "asset_1" }))
         ));
-        let turbo = model_mac_support("ideogram_4_turbo", "image");
+        let turbo = model_mac_support("ideogram_4_turbo", "image", None);
         assert!(turbo.supported, "ideogram_4_turbo must be Mac-supported");
         assert!(turbo.features.edit, "ideogram_4_turbo supports edit");
     }
@@ -6859,20 +6859,24 @@ mod mlx_routing_tests {
         // this flag both gate the Edit tab to `boogu_image_edit`).
         for model in ["boogu_image", "boogu_image_turbo", "boogu_image_edit"] {
             assert!(
-                model_mac_support(model, "image").supported,
+                model_mac_support(model, "image", None).supported,
                 "{model} must be Mac-supported"
             );
         }
         assert!(
-            model_mac_support("boogu_image_edit", "image").features.edit,
+            model_mac_support("boogu_image_edit", "image", None)
+                .features
+                .edit,
             "boogu_image_edit supports edit"
         );
         assert!(
-            !model_mac_support("boogu_image", "image").features.edit,
+            !model_mac_support("boogu_image", "image", None)
+                .features
+                .edit,
             "boogu_image (Base) is text-to-image only"
         );
         assert!(
-            !model_mac_support("boogu_image_turbo", "image")
+            !model_mac_support("boogu_image_turbo", "image", None)
                 .features
                 .edit,
             "boogu_image_turbo is text-to-image only"
@@ -6907,7 +6911,7 @@ mod mlx_routing_tests {
             "krea_2_turbo edit_image without a source is rejected"
         );
 
-        let support = model_mac_support("krea_2_turbo", "image");
+        let support = model_mac_support("krea_2_turbo", "image", None);
         assert!(support.supported, "krea_2_turbo must be Mac-supported");
         assert!(
             support.features.edit,
@@ -6943,7 +6947,7 @@ mod mlx_routing_tests {
             "krea_2_raw edit_image without a source is rejected"
         );
 
-        let support = model_mac_support("krea_2_raw", "image");
+        let support = model_mac_support("krea_2_raw", "image", None);
         assert!(support.supported, "krea_2_raw must be Mac-supported");
         assert!(
             support.features.edit,
@@ -6979,7 +6983,7 @@ mod mlx_routing_tests {
             );
 
             // UI gating oracle: Mac-supported (reaches the picker), text-to-image only (no edit tab).
-            let support = model_mac_support(model, "image");
+            let support = model_mac_support(model, "image", None);
             assert!(support.supported, "{model} must be Mac-supported");
             assert!(!support.features.edit, "{model} is text-to-image only");
         }

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -69,9 +69,19 @@ pub(crate) fn probe_payload(model: &str, entries: &[(&str, Value)]) -> Map<Strin
 /// Non-image/video types (utility/infra: upscalers, captioners) are reported `supported` — their
 /// Python-only *actions* are gated by [`mac_capabilities`] at the job-type level, not by hiding
 /// the model from a picker. Same source of truth as [`mac_rust_supported`].
-pub fn model_mac_support(model_id: &str, model_type: &str) -> ModelMacSupport {
+///
+/// `family` is the model's catalog-declared architecture family (`None` for a builtin whose routing
+/// is purely id-keyed). It is consulted only for the image route-by-family path (sc-14019): a
+/// non-builtin (imported/user) image model whose family is MLX-routed is Mac-routable even though
+/// its novel id is in no routing table. Builtin routing is unaffected (a builtin short-circuits on
+/// its id).
+pub fn model_mac_support(
+    model_id: &str,
+    model_type: &str,
+    family: Option<&str>,
+) -> ModelMacSupport {
     match model_type {
-        "image" => image_model_mac_support(model_id),
+        "image" => image_model_mac_support(model_id, family),
         "video" => video_model_mac_support(model_id),
         _ => ModelMacSupport {
             supported: true,
@@ -81,8 +91,29 @@ pub fn model_mac_support(model_id: &str, model_type: &str) -> ModelMacSupport {
     }
 }
 
-pub(crate) fn image_model_mac_support(model: &str) -> ModelMacSupport {
+pub(crate) fn image_model_mac_support(model: &str, family: Option<&str>) -> ModelMacSupport {
     if !MLX_ROUTED_MODELS.contains(&model) {
+        // Route-by-family for non-builtin (imported/user) models (sc-14019, epic 14015): a model
+        // whose id is in no routing table but whose declared `family` is an MLX-routed family reuses
+        // that family's existing in-process engine, so it is Mac-routable rather than hidden behind
+        // "Not available on Mac (MLX only)". Guarded on `!is_builtin_image_model` so builtin id-keyed
+        // routing is never altered — a builtin always short-circuits on `MLX_ROUTED_MODELS` above (or,
+        // if some future builtin is candle-only, keeps its id-keyed not-supported verdict here).
+        if !is_builtin_image_model(model) && family.is_some_and(image_family_is_mlx_routed) {
+            return ModelMacSupport {
+                supported: true,
+                reason: None,
+                features: ModelMacFeatures {
+                    // MLX-routed ⇒ third-party LyCORIS applies on the provider (epic 3641). The
+                    // imported single-file checkpoint is a bare diffusion transformer, so the
+                    // conditioning features that need extra components/adapters (pose / reference /
+                    // edit) are deliberately NOT claimed here — S0c wires the actual assembly/load;
+                    // this story decides eligibility only.
+                    lycoris: true,
+                    ..ModelMacFeatures::default()
+                },
+            };
+        }
         return ModelMacSupport {
             supported: false,
             reason: Some(classify_image_gap(&probe_payload(model, &[]))),
@@ -841,6 +872,31 @@ derive_model_list! {
     pub(crate) MLX_ROUTED_MODELS, IMAGE_MODEL_CAPS, mlx_routed
 }
 
+/// Architecture families whose MLX-routed builtins define an in-process image engine that a
+/// **non-builtin (imported/user) same-family model reuses** (sc-14019, epic 14015). A builtin's
+/// routing is decided by its id ([`MLX_ROUTED_MODELS`]); an imported checkpoint carries a novel id
+/// that is in no table, so [`image_model_mac_support`] falls back to its declared *family* — if the
+/// family is one of these, it routes to that family's existing MLX engine. Seeded with `krea_2`
+/// (its builtins `krea_2_turbo` / `krea_2_raw` already route to the Krea MLX engine). This is an
+/// explicit allow-list, not derived from the id table, because the routing catalog is keyed on ids
+/// alone and has no id→family map; keep it aligned with the same-family builtins above and with the
+/// import gate (`sceneworks_core::base_weights::IMPORT_SUPPORTED_FAMILIES`). Pinned by the
+/// `EXPECTED_MLX_ROUTED_FAMILIES` snapshot test.
+pub(crate) const MLX_ROUTED_FAMILIES: &[&str] = &["krea_2"];
+
+/// Whether an image `family` string routes to an in-process MLX engine via the route-by-family path
+/// (sc-14019) — i.e. it is a member of [`MLX_ROUTED_FAMILIES`]. Consulted only for non-builtin ids.
+pub(crate) fn image_family_is_mlx_routed(family: &str) -> bool {
+    MLX_ROUTED_FAMILIES.contains(&family)
+}
+
+/// Whether `id` names a builtin image model (a row in [`IMAGE_MODEL_CAPS`]). The route-by-family
+/// path applies only to non-builtin (imported/user) ids, so a builtin's id-keyed routing is never
+/// overridden by its family (sc-14019).
+pub(crate) fn is_builtin_image_model(id: &str) -> bool {
+    IMAGE_MODEL_CAPS.iter().any(|caps| caps.id == id)
+}
+
 derive_model_list! {
     /// The models the candle (Windows/CUDA) lane can serve for base txt2img (derived from
     /// [`IMAGE_MODEL_CAPS`]`.candle_routed`, sc-9495). Mirrors the worker's `image_jobs::is_candle_engine`.
@@ -989,10 +1045,11 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::{
+        image_family_is_mlx_routed, image_model_mac_support, is_builtin_image_model,
         CANDLE_LORA_MODELS, CANDLE_QUANT_LORA_MODELS, CANDLE_QUANT_MODELS, CANDLE_ROUTED_MODELS,
         CANDLE_ROUTED_TRAINING_KERNELS, CANDLE_VIDEO_I2V_ROUTED_MODELS, CANDLE_VIDEO_ROUTED_MODELS,
-        CANDLE_VIDEO_VACE_MODELS, IMAGE_MODEL_CAPS, MLX_ONLY_TRAINING_KERNELS, MLX_ROUTED_MODELS,
-        MLX_ROUTED_TRAINING_KERNELS, VIDEO_MLX_ROUTED_MODELS, VIDEO_MODEL_CAPS,
+        CANDLE_VIDEO_VACE_MODELS, IMAGE_MODEL_CAPS, MLX_ONLY_TRAINING_KERNELS, MLX_ROUTED_FAMILIES,
+        MLX_ROUTED_MODELS, MLX_ROUTED_TRAINING_KERNELS, VIDEO_MLX_ROUTED_MODELS, VIDEO_MODEL_CAPS,
     };
 
     /// Assert a table-derived list reproduces its pre-collapse snapshot EXACTLY as a set: same
@@ -1355,5 +1412,80 @@ mod tests {
             VIDEO_MODEL_CAPS.len(),
             "VIDEO_MODEL_CAPS has duplicate model ids"
         );
+    }
+
+    // --- route-by-family for imported models (sc-14019, epic 14015) -------------
+
+    /// The MLX-routed *family* allow-list, pinned like the model lists above. Adding a family here is
+    /// a deliberate edit (it makes every imported same-family checkpoint Mac-routable), so it must be
+    /// mirrored here — the guardrail that a family is never silently added to the import surface.
+    const EXPECTED_MLX_ROUTED_FAMILIES: &[&str] = &["krea_2"];
+
+    #[test]
+    fn mlx_routed_families_match_snapshot() {
+        assert_eq!(MLX_ROUTED_FAMILIES, EXPECTED_MLX_ROUTED_FAMILIES);
+    }
+
+    #[test]
+    fn mlx_routed_families_have_a_same_family_builtin_engine() {
+        // Every allow-listed family must actually be one an MLX-routed builtin defines an engine for
+        // (the routing catalog has no id→family map, so this asserts the family token is real: at
+        // least one builtin id begins with the family token, and it is MLX-routed). krea_2 →
+        // krea_2_turbo / krea_2_raw. This catches a typo'd or dead family token in the allow-list.
+        for family in MLX_ROUTED_FAMILIES {
+            let has_routed_builtin = MLX_ROUTED_MODELS
+                .iter()
+                .any(|id| id.starts_with(family) && is_builtin_image_model(id));
+            assert!(
+                has_routed_builtin,
+                "MLX_ROUTED_FAMILIES lists '{family}' but no MLX-routed builtin id shares that family prefix"
+            );
+        }
+    }
+
+    #[test]
+    fn imported_same_family_model_routes_via_family_path() {
+        // An imported model id that is in NO routing table, declaring family krea_2, resolves as
+        // Mac-routable (supported) via the family path — not hidden behind "not available on Mac".
+        let imported_id = "user_kreamania_variant5"; // a novel id, never a builtin
+        assert!(!is_builtin_image_model(imported_id));
+        assert!(!MLX_ROUTED_MODELS.contains(&imported_id));
+
+        let support = image_model_mac_support(imported_id, Some("krea_2"));
+        assert!(
+            support.supported,
+            "an imported krea_2-family model should route via the family path"
+        );
+        assert!(support.reason.is_none());
+        // MLX-routed ⇒ LyCORIS applies; the bare-DiT conditioning features stay unclaimed (S0c).
+        assert!(support.features.lycoris);
+        assert!(!support.features.edit);
+        assert!(!support.features.pose);
+        assert!(!support.features.reference);
+    }
+
+    #[test]
+    fn imported_non_routed_family_model_stays_unsupported() {
+        // A non-MLX-routed family (or no family) does NOT get the family path — it stays hidden with
+        // the standard "not available on Mac" gap reason, exactly as before sc-14019.
+        assert!(!image_family_is_mlx_routed("z-image")); // detector family for an unsupported import
+        let unsupported = image_model_mac_support("user_zimage_import", Some("z-image"));
+        assert!(!unsupported.supported);
+        assert!(unsupported.reason.is_some());
+
+        let no_family = image_model_mac_support("user_mystery_import", None);
+        assert!(!no_family.supported);
+    }
+
+    #[test]
+    fn builtin_image_routing_is_unaffected_by_family_argument() {
+        // A builtin short-circuits on its id: passing a (possibly wrong) family never changes its
+        // verdict, so builtin id-keyed routing stays byte-identical (sc-14019 constraint).
+        let with_family = image_model_mac_support("krea_2_turbo", Some("krea_2"));
+        let without_family = image_model_mac_support("krea_2_turbo", None);
+        let mismatched_family = image_model_mac_support("krea_2_turbo", Some("z-image"));
+        assert!(with_family.supported);
+        assert_eq!(with_family, without_family);
+        assert_eq!(with_family, mismatched_family);
     }
 }

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -1444,6 +1444,28 @@ mod tests {
     }
 
     #[test]
+    fn mlx_routed_families_agree_with_import_supported_families() {
+        // sc-14019: `MLX_ROUTED_FAMILIES` (routing, here) and `base_weights::IMPORT_SUPPORTED_FAMILIES`
+        // (the model-import compatibility gate) are two independent `krea_2` allow-lists that must NOT
+        // silently drift. Route-by-family exists ONLY via MLX today, so the two sets must be identical:
+        // a family added to the import gate but not here would let a user import a checkpoint no engine
+        // can run, and a family added here but not to the gate would route one the gate refuses. This
+        // fails the moment either list gains or loses a family the other did not. If a non-MLX
+        // route-by-family lane (e.g. candle) is ever added, evolve this into a subset check over the
+        // union of route-by-family lists.
+        let routed: BTreeSet<&str> = MLX_ROUTED_FAMILIES.iter().copied().collect();
+        let importable: BTreeSet<&str> = crate::base_weights::IMPORT_SUPPORTED_FAMILIES
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(
+            routed, importable,
+            "MLX_ROUTED_FAMILIES and IMPORT_SUPPORTED_FAMILIES disagree; add a family to BOTH the \
+             import gate and the route-by-family allow-list (or remove it from both)"
+        );
+    }
+
+    #[test]
     fn imported_same_family_model_routes_via_family_path() {
         // An imported model id that is in NO routing table, declaring family krea_2, resolves as
         // Mac-routable (supported) via the family path — not hidden behind "not available on Mac".

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -3592,7 +3592,7 @@ fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
     // lacking a dedicated port epic, reports "needs an epic" (suggested_epic None). No real image
     // model is torch-only anymore: Lens — formerly this example — is MLX-routed after epic 3164 /
     // sc-5105 (asserted below), as is pulid_flux_dev after sc-3344.
-    let torch_only = model_mac_support("unported_image_model", "image");
+    let torch_only = model_mac_support("unported_image_model", "image", None);
     assert!(!torch_only.supported);
     assert!(torch_only.reason.is_some());
     assert_eq!(
@@ -3606,89 +3606,93 @@ fn model_mac_support_hides_torch_only_models_keeps_mlx_models() {
     // and in the picker with no gap reason. The edit-mode gating (Lens has no edit path) is asserted
     // in `model_mac_support_feature_flags_mirror_routing_without_over_gating`.
     for id in ["lens", "lens_turbo"] {
-        let lens = model_mac_support(id, "image");
+        let lens = model_mac_support(id, "image", None);
         assert!(lens.supported, "{id} should be MLX-supported");
         assert!(lens.reason.is_none(), "{id} should carry no gap reason");
     }
     // PuLID-FLUX (sc-3344) is MLX-routed now — it stays in the picker as a supported face-ID
     // backbone (character_image reference), no longer a torch-only port-epic gap.
-    let pulid = model_mac_support("pulid_flux_dev", "image");
+    let pulid = model_mac_support("pulid_flux_dev", "image", None);
     assert!(pulid.supported);
     assert!(pulid.features.reference);
     // Kolors runs its full surface on MLX (epic 3090): T2I (sc-3875), img2img (sc-4765), the
     // IP-Adapter-Plus reference (sc-4767) and the strict-pose tier (sc-4766 / engine sc-5012), so all
     // three advanced features are enabled.
-    let kolors = model_mac_support("kolors", "image");
+    let kolors = model_mac_support("kolors", "image", None);
     assert!(kolors.supported);
     assert!(kolors.features.edit);
     assert!(kolors.features.pose);
     assert!(kolors.features.reference);
     // An MLX-routed base family stays in the picker.
-    let z_image = model_mac_support("z_image_turbo", "image");
+    let z_image = model_mac_support("z_image_turbo", "image", None);
     assert!(z_image.supported);
     assert!(z_image.reason.is_none());
     // Base (undistilled, full-CFG) Z-Image is MLX-routed on macOS too (real `z_image` MODEL_TABLE
     // engine + `ZImageBaseControl`), so it must NOT be hidden behind "Not available on Mac" — the
     // sc-8320/sc-8251 wiring gap this fix closes.
-    let z_image_base = model_mac_support("z_image", "image");
+    let z_image_base = model_mac_support("z_image", "image", None);
     assert!(z_image_base.supported);
     assert!(z_image_base.reason.is_none());
     // Chroma (epic 3531 / sc-3843) is now MLX-routed — all three variants stay in the picker
     // and no longer report an `mlx_unsupported` port-epic gap.
     for id in ["chroma1_hd", "chroma1_base", "chroma1_flash"] {
-        let chroma = model_mac_support(id, "image");
+        let chroma = model_mac_support(id, "image", None);
         assert!(chroma.supported, "{id} should be MLX-supported");
         assert!(chroma.reason.is_none(), "{id} should carry no gap reason");
     }
     // SVD is now MLX-routed (sc-3523, image→video only) so it stays in the picker, like Wan/LTX;
     // a genuinely engine-less video model id is still hidden.
-    assert!(model_mac_support("svd", "video").supported);
-    assert!(model_mac_support("wan_2_2", "video").supported);
-    assert!(!model_mac_support("some_torch_only_video", "video").supported);
+    assert!(model_mac_support("svd", "video", None).supported);
+    assert!(model_mac_support("wan_2_2", "video", None).supported);
+    assert!(!model_mac_support("some_torch_only_video", "video", None).supported);
     // Utility/infra models are never hidden by model-level gating (their actions are
     // gated by mac_capabilities at the job-type level instead).
-    assert!(model_mac_support("real_esrgan", "utility").supported);
+    assert!(model_mac_support("real_esrgan", "utility", None).supported);
 }
 
 #[test]
 fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     // Base Qwen strict-pose ControlNet, Z-Image, and SDXL pose are MLX → enabled.
-    assert!(model_mac_support("qwen_image", "image").features.pose);
-    assert!(model_mac_support("z_image_turbo", "image").features.pose);
-    assert!(model_mac_support("sdxl", "image").features.pose);
+    assert!(model_mac_support("qwen_image", "image", None).features.pose);
+    assert!(
+        model_mac_support("z_image_turbo", "image", None)
+            .features
+            .pose
+    );
+    assert!(model_mac_support("sdxl", "image", None).features.pose);
     // Z-Image reference-identity (no pose) is ported to MLX (sc-3619) → reference enabled;
     // img2img-edit is now ported too (epic 3529 / sc-3923) → edit enabled.
-    let z_image = model_mac_support("z_image_turbo", "image");
+    let z_image = model_mac_support("z_image_turbo", "image", None);
     assert!(z_image.features.reference);
     assert!(z_image.features.edit);
     // The dedicated z_image_edit model is supported on Mac with edit enabled (no dead-end).
-    let z_image_edit = model_mac_support("z_image_edit", "image");
+    let z_image_edit = model_mac_support("z_image_edit", "image", None);
     assert!(z_image_edit.supported);
     assert!(z_image_edit.features.edit);
     // Base Z-Image: pose (base Fun-Controlnet-Union) + reference (generic img2img-init) are MLX, so both
     // are enabled — but the base has NO `edit_image` checkpoint (that's Turbo-weights-only), so `edit`
     // must stay FALSE. This discriminates the base arm from Turbo's (which enables edit).
-    let z_image_base = model_mac_support("z_image", "image");
+    let z_image_base = model_mac_support("z_image", "image", None);
     assert!(z_image_base.features.pose);
     assert!(z_image_base.features.reference);
     assert!(!z_image_base.features.edit);
     // FLUX.1 reference (XLabs IP-Adapter) is ported to MLX (epic 3621) → reference enabled on
     // both variants; edit_image stays off (no FLUX.1 edit on any platform — future Kontext).
-    let flux = model_mac_support("flux_dev", "image");
+    let flux = model_mac_support("flux_dev", "image", None);
     assert!(flux.features.reference);
     assert!(!flux.features.edit);
-    let flux_schnell = model_mac_support("flux_schnell", "image");
+    let flux_schnell = model_mac_support("flux_schnell", "image", None);
     assert!(flux_schnell.features.reference);
     assert!(!flux_schnell.features.edit);
     // SDXL + FLUX.2 do reference/edit on MLX (epic 3041 / MLX-only family) → enabled.
-    let sdxl = model_mac_support("sdxl", "image");
+    let sdxl = model_mac_support("sdxl", "image", None);
     assert!(sdxl.features.reference);
     assert!(sdxl.features.edit);
-    let flux2 = model_mac_support("flux2_klein_9b", "image");
+    let flux2 = model_mac_support("flux2_klein_9b", "image", None);
     assert!(flux2.features.reference);
     assert!(flux2.features.edit);
     // Qwen-Image-Edit conditions reference/edit on its modes → both enabled (no over-gate).
-    let qwen_edit = model_mac_support("qwen_image_edit_2511", "image");
+    let qwen_edit = model_mac_support("qwen_image_edit_2511", "image", None);
     assert!(qwen_edit.features.reference);
     assert!(qwen_edit.features.edit);
     // Lens / Lens-Turbo (epic 3164 / sc-5105) are pure T2I — no edit path on any platform, so
@@ -3696,7 +3700,7 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     // T2I against a dropped source image.
     for id in ["lens", "lens_turbo"] {
         assert!(
-            !model_mac_support(id, "image").features.edit,
+            !model_mac_support(id, "image", None).features.edit,
             "{id} has no edit path → edit must be gated off"
         );
     }
@@ -3705,7 +3709,7 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     // gates only `edit_image`, so the "available in some MLX config" `reference`/`pose` probes come
     // out permissively true — harmless: the manifest `capabilities` are the real UI gate and the
     // engine ignores a stray reference on a t2i job. The meaningful flag here is `edit`.)
-    let bernini_image = model_mac_support("bernini_image", "image");
+    let bernini_image = model_mac_support("bernini_image", "image", None);
     assert!(
         bernini_image.supported,
         "bernini_image should be MLX-supported"
@@ -3713,9 +3717,11 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     assert!(bernini_image.reason.is_none());
     assert!(bernini_image.features.edit, "bernini_image i2i is MLX");
     // Third-party LyCORIS now applies on every MLX provider (epic 3641) → supported.
-    assert!(model_mac_support("sdxl", "image").features.lycoris);
+    assert!(model_mac_support("sdxl", "image", None).features.lycoris);
     // Video models expose per-mode eligibility.
-    let wan = model_mac_support("wan_2_2", "video").features.video_modes;
+    let wan = model_mac_support("wan_2_2", "video", None)
+        .features
+        .video_modes;
     assert_eq!(wan.get("text_to_video"), Some(&true));
     assert_eq!(wan.get("image_to_video"), Some(&true));
     assert_eq!(wan.get("first_last_frame"), Some(&true)); // Wan TI2V-5B FLF is MLX
@@ -3724,12 +3730,14 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     assert_eq!(wan.get("extend_clip"), Some(&true));
     assert_eq!(wan.get("video_bridge"), Some(&true));
     // LTX serves the IC-LoRA clip-conditioning modes on MLX → extend/bridge enabled (sc-3522/3773).
-    let ltx = model_mac_support("ltx_2_3", "video").features.video_modes;
+    let ltx = model_mac_support("ltx_2_3", "video", None)
+        .features
+        .video_modes;
     assert_eq!(ltx.get("extend_clip"), Some(&true));
     assert_eq!(ltx.get("video_bridge"), Some(&true));
     // The 14B Wan MoE engines have no FLF Keyframe path → torch.
     assert_eq!(
-        model_mac_support("wan_2_2_t2v_14b", "video")
+        model_mac_support("wan_2_2_t2v_14b", "video", None)
             .features
             .video_modes
             .get("first_last_frame"),
@@ -3738,7 +3746,7 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     // Bernini (epic 4699) is MLX-routed text-to-video only. Its renderer is
     // Wan2.2-T2V, so still-image-to-video is off; the editing/reference video
     // modes are net-new vocabulary (sc-4703), off until then.
-    let bernini = model_mac_support("bernini", "video");
+    let bernini = model_mac_support("bernini", "video", None);
     assert!(bernini.supported, "bernini should be MLX-supported");
     assert!(bernini.reason.is_none());
     assert_eq!(
@@ -3761,7 +3769,7 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
     // cross-identity replace_person (sc-5452 — the same engine, replace_flag=true, as the integrated
     // backend behind the person-track pipeline); the worker paints its masks from native SAM3. No
     // text/image-to-video.
-    let scail2 = model_mac_support("scail2_14b", "video");
+    let scail2 = model_mac_support("scail2_14b", "video", None);
     assert!(scail2.supported, "scail2 should be MLX-supported");
     assert!(scail2.reason.is_none());
     assert_eq!(

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use sceneworks_core::base_weights::{detect_base_weight_file, import_detection_supported};
+
 /// Post the terminal `Completed` update for a Hugging Face cache download, building the shared
 /// `{<id_key>, repo, path, storage:"huggingface_cache", completedAt}` result object (F-116). Both
 /// model download paths (`modelId`) and the LoRA path (`loraId`) funnel through here so the result
@@ -2849,6 +2851,51 @@ pub(crate) async fn run_model_import_job(
                 )
                 .await;
             }
+        }
+    }
+
+    // sc-14019 (epic 14015): compatibility gate behind the now-enabled model-import kill-switch.
+    // Classify the downloaded base weights with the base-weight detector and refuse the import —
+    // with the detector's typed reason — unless the (family, component, quant) triple has a real
+    // loader today (`import_detection_supported`). Runs over the bytes on disk, so it covers HF-repo,
+    // source-URL, and uploaded imports uniformly (the API's synchronous `import_source_supported`
+    // only sees on-disk uploads at queue time). NEVER a silent fallback. `target_dir` is
+    // app-managed (`resolve_model_import_target`) — this gate is purely additive to confinement.
+    match first_safetensors_path(&target_dir) {
+        Some(weight_file) => match detect_base_weight_file(&weight_file) {
+            Ok(detection) => {
+                if let Err(reason) = import_detection_supported(&detection) {
+                    return fail_job(
+                        api,
+                        &job.id,
+                        "Model import is not supported for this file.",
+                        Some(reason),
+                    )
+                    .await;
+                }
+            }
+            Err(error) => {
+                return fail_job(
+                    api,
+                    &job.id,
+                    "Model import failed.",
+                    Some(model_family_detection_error(error)),
+                )
+                .await;
+            }
+        },
+        None => {
+            return fail_job(
+                api,
+                &job.id,
+                "Model import is not supported for this file.",
+                Some(
+                    "No safetensors base-weight file was found in the imported model; single-file \
+                     base-checkpoint import expects a .safetensors transformer."
+                        .to_owned(),
+                ),
+            )
+            .await;
         }
     }
 


### PR DESCRIPTION
## What & why (sc-14019, S0d of epic 14015 — import community single-file checkpoints, Mac-first)

S0a (the Krea base-weight detector arm) already merged. This story wires two eligibility/gating seams so an imported single-file Krea checkpoint stops reporting "Not available on Mac" and the model-import kill-switch can be turned on safely. **Scope is eligibility + gating only** — no DiT assembly/load (that's S0c), no inference-repo changes.

## 1. Route-by-family for imported/user models

`crates/sceneworks-core/src/jobs_store/routing/catalog.rs` decided Mac/MLX eligibility purely by **id** membership (`MLX_ROUTED_MODELS.contains(id)`), so an imported model — which has a novel id never in the table — always reported `MAC_NOT_AVAILABLE_LABEL`.

- **Seam:** `image_model_mac_support(model, family)` now, when the id is not a builtin, consults the model's declared **family**. `model_mac_support` gains a `family: Option<&str>` argument, forwarded from the catalog entry's `family` field in `apps/rust-api/src/models.rs`.
- New `MLX_ROUTED_FAMILIES` allow-list (`["krea_2"]`) + helpers `image_family_is_mlx_routed` / `is_builtin_image_model`. A non-builtin id whose family is MLX-routed is treated as MLX-routable, reusing that family's existing engine.
- **Builtin routing is byte-identical:** a builtin short-circuits on `MLX_ROUTED_MODELS` before the family branch, and the branch is guarded by `!is_builtin_image_model`, so a builtin's id-keyed verdict never changes (proven by a test passing a mismatched family). It's an explicit allow-list, not derived, because the routing catalog is keyed on ids alone and has no id→family map.
- The imported checkpoint is a bare DiT (Transformer only), so only base txt2img is claimed (`lycoris: true`); pose/reference/edit stay unclaimed pending S0c.
- Every existing routing snapshot (`EXPECTED_MLX_ROUTED_MODELS`, …) stays green; a new `EXPECTED_MLX_ROUTED_FAMILIES` snapshot pins the allow-list.

## 2. Import compatibility predicate + kill-switch gate

- New **`sceneworks_core::base_weights::import_supported(&BaseWeightVerdict) -> Result<(), String>`** — a `match` with **one arm per supported loader** (so follow-on families/quants slot in). Today exactly one triple returns `Ok`: `krea_2` / `Transformer` / `Bf16`. Everything else — unrecognized/absent family, non-transformer component, or a deferred quant (plain/scaled/inline fp8, `comfy_quant` packed, GGUF) — is refused with a typed, client-facing reason. **Never a silent fallback.** `import_detection_supported(&BaseWeightDetection)` lifts it over the whole detection (Unrecognized → refused with the detector's own reason).
- `apps/rust-api/src/models.rs::model_import_enabled()` flipped `false → true`.
- **Gate (both source classes):**
  - `queue_model_import_job` refuses a staged/local checkpoint **synchronously (400)** via `import_source_supported`, so the upload flow gets an actionable message before a job is queued.
  - The worker's `run_model_import_job` (`crates/sceneworks-worker/src/model_jobs.rs`) re-runs `detect_base_weight_file` over the **downloaded bytes** (covering HF-repo / source-URL imports whose file isn't on disk at queue time) and `fail_job`s with the reason unless the verdict passes.

## Security — confinement preserved

The detector gate is **purely additive** to path confinement. The import source is still confined by `validate_lora_import_source_path` / `normalize_app_managed_model_path` (LAN-exposed jobs API, epic 4484); roots stay operator/app-managed and are never payload-derived. This change decides *eligibility* only and never widens the allowed roots or bypasses confinement.

## Tests / checks

- `base_weights` (core `--lib`): 7 cases — `krea_2`/Transformer/Bf16 → Ok; packed-quant, wrong component, unsupported family (`z-image`), `None` family, and `Unrecognized` → Err; plus an allow-list↔arms guardrail.
- Routing (core `--lib`): imported `krea_2` model resolves supported via the family path; a non-routed family / no family stays unsupported; builtins unaffected by the family arg; `MLX_ROUTED_FAMILIES` snapshot; and **`mlx_routed_families_agree_with_import_supported_families`** — a drift guard asserting the two independent `["krea_2"]` allow-lists (`MLX_ROUTED_FAMILIES` ↔ `base_weights::IMPORT_SUPPORTED_FAMILIES`) stay identical, so a family added to one but not the other fails a test.
- rust-api (`--lib`): the queue-gate **helper** unit tests (`models::import_gate_tests`: accept dense-bf16 Krea 2 DiT; refuse packed-quant/qwen-image/unrecognized) **plus** the new **endpoint-level** `model_import_route_is_enabled_and_detector_gated`, which drives the mounted route through `create_app` and proves the `create_model_import_job → queue_model_import_job → gate` wiring: a `krea_2` bf16 multipart upload is accepted (201 queued), a qwen-image DiT multipart upload is refused (400, reason names the family), and a remote `sourceUrl` JSON import queues (201 — no local bytes, so the gate defers to the worker). This **replaces** the stale `model_import_route_is_disabled_on_every_platform`, which still asserted the removed unconditional-403 contract and was reddening the parity lane. A dtype-aware `test_safetensors_bytes_with_typed_keys` fixture helper builds the minimal synthetic safetensors headers (header-only detection).
- Full `cargo test -p sceneworks-rust-api --lib` (355) + `cargo test -p sceneworks-core --lib` (554) green. `cargo fmt --all --check` clean; `cargo clippy --all-targets -D warnings` clean on sceneworks-core / sceneworks-rust-api.

## Follow-ups (out of scope here)

- **S0e:** flip the web `MODEL_IMPORT_ENABLED` in `apps/web/src/screens/ModelManagerScreen.jsx` (left `false` on purpose — backend-only here).
- **S0c:** the actual DiT-only assembly/load for the imported Krea checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
