### PR TITLE
feat(krea): candle S3/S4 (turbo-LoRA + multi-phase) routing parity + docs [sc-13887]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "core-llm",
  "half",
@@ -4567,7 +4567,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5922,7 +5922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5979,7 +5979,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -7323,7 +7323,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8480,7 +8480,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3" }

--- a/apps/web/public/prompt-guides/krea-2-raw.md
+++ b/apps/web/public/prompt-guides/krea-2-raw.md
@@ -94,6 +94,56 @@ default apply weight (1.5) than other families:
 - If a LoRA over-dominates, lower it. The weight slider is the main lever; the default is just a
   starting point.
 
+## Turbo Speed On Raw: the accelerator LoRA & multi-phase denoise
+
+Raw's full-fidelity regime is ~52 steps with true CFG. Two features let you keep that Raw base while
+paying far less of the step cost — both run **on the Raw base** (not on distilled Turbo), so you keep
+Raw's fidelity and control where it matters.
+
+### The accelerator (turbo) LoRA — one-click ~8-step Raw
+
+Select an **accelerator-role LoRA** — the builtin **Krea 2 Turbo (accelerator)**, or any LoRA of type
+`acceleration` — on a plain Raw **text-to-image** job. The render switches to the distilled **Turbo
+sampling regime**: a fixed few-step schedule (**~8 steps**, **CFG-off**), while still loading the **Raw
+base weights** with the LoRA folded in additively. Net effect: *Raw base + LoRA, sampled as Turbo* —
+roughly Turbo speed (~8 steps instead of 52) at close to Raw fidelity (the community `raw+lora` recipe).
+
+- The accelerated pass is **CFG-off**, so the **guidance slider and negative prompt are inert** for it
+  (exactly like Turbo). State everything you want in the positive prompt.
+- **Text-to-image only.** A Raw job that also carries an **img2img reference** keeps the normal full-CFG
+  Raw regime — the reference is honored and the accelerator LoRA still applies additively — it does not
+  switch to the few-step turbo pass.
+- Stack a **style/subject LoRA alongside** the accelerator to accelerate a LoRA render.
+
+### Multi-phase denoise — Raw structure, Turbo finish
+
+The Image Studio's **multi-phase editor** splits **one** Raw denoise trajectory (one global schedule)
+into ordered **phases**. Each phase has its own step count, its own guidance (**CFG on or off, per
+phase**), and its own active subset of the loaded LoRAs (**toggled per phase**). This lets you spend the
+expensive true-CFG Raw steps only where they matter — early, on structure and prompt adherence — then
+finish fast.
+
+The **canonical workflow** (the Studio's "Turbo finish (4+4)" preset) is two phases:
+
+1. **4 steps — Raw, true-CFG on (guidance ~3.5), no accelerator LoRA.** Builds composition, structure,
+   and prompt adherence with the full-fidelity base.
+2. **4 steps — Raw + the turbo (accelerator) LoRA, CFG off (guidance 0).** Fast distilled finishing on
+   the trajectory the first phase set up.
+
+Tune from there:
+
+- Want stronger adherence or cleaner structure? Add steps to **phase 1** (e.g. `6 + 4`, `8 + 4`).
+- Keep the **turbo/accelerator LoRA in the CFG-off phase**, and leave the CFG-on phase base-only (or with
+  just your style LoRA) so its guidance is honored.
+- Give the CFG-on phase a real guidance (**~3.5**, the Raw default); set each CFG-off phase's guidance to
+  **0**.
+- A style/subject LoRA can be toggled into either phase; the accelerator belongs only in a CFG-off phase.
+- Keep the total step budget modest — a 2–3 phase split well under the 52-step single-phase Raw cost is
+  the whole point.
+
+Multi-phase renders from **pure noise**, so it is text-to-image only: edit, strict-pose, img2img-
+reference, and PiD-decode jobs are not supported (remove the phase plan to run those).
+
 ## Example Prompts
 
 `A weathered lighthouse on a rocky cliff at golden hour, waves breaking below, gulls in the distance.

--- a/apps/web/public/prompt-guides/krea-2.md
+++ b/apps/web/public/prompt-guides/krea-2.md
@@ -84,6 +84,22 @@ weight (1.5)** than other families — they stay coherent well above that, so:
 - If a LoRA over-dominates, lower it. The weight slider is the main lever; the default is just a
   starting point tuned for the distilled Turbo.
 
+## Turbo-Fidelity Workflows Live On Krea 2 Raw
+
+Plain **Krea 2 Turbo** here is already the fully-distilled few-step model — fast by default and needing
+no extra setup. If you want **Turbo-like speed with more of Raw's fidelity and control**, two workflows
+run on the **Krea 2 Raw** model instead:
+
+- **The accelerator (turbo) LoRA on Raw** — selecting an accelerator-role LoRA (the builtin **Krea 2
+  Turbo (accelerator)**) on a Krea 2 Raw text-to-image job renders the Raw base in a distilled **~8-step,
+  CFG-off** pass: roughly Turbo speed at close to Raw fidelity.
+- **Multi-phase denoise** — the Image Studio's multi-phase editor runs one Raw trajectory as ordered
+  phases, e.g. the canonical **4 steps Raw (CFG on, guidance ~3.5) + 4 steps Raw + the turbo LoRA (CFG
+  off)**: Raw structure, Turbo finish.
+
+Switch the model to **Krea 2 Raw** to use either — see the **Krea 2 Raw prompt guide** for the
+recommended splits and weights.
+
 ## Example Prompts
 
 `A weathered lighthouse on a rocky cliff at golden hour, waves breaking below, gulls in the distance.

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -902,6 +902,43 @@ pub(crate) async fn run_image_generate_job(
                     )
                     .await?;
                 }
+                // Krea 2 Raw t2i + an explicit `advanced.phases` list (epic 13879 S4, sc-13884; candle
+                // sc-13887) → the multi-phase denoise driver: ONE Raw trajectory / global sigma schedule,
+                // per-phase guidance (CFG on/off) + per-phase toggling of the job's load-time LoRA stack (by
+                // index). Reference/edit/pose/PiD shapes are rejected loudly before the load (renders from
+                // pure noise). Takes precedence over the S3 turbo-on-Raw regime. The candle engine honors
+                // the backend-agnostic `GenerationRequest::phases` (inference PR #204); the handler is the
+                // SAME backend-neutral `generate_krea_multiphase_stream` the macOS `KreaMultiPhase` arm runs.
+                CandleImageRoute::KreaMultiPhase => {
+                    generate_krea_multiphase_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                // Krea 2 Raw t2i + the accelerator (turbo) LoRA (sc-13882) → the distilled Turbo sampling
+                // regime (fixed mu 1.15 / ~8 steps / CFG-off) on the Raw base + LoRA additive (epic 13879
+                // S3, sc-13883; candle sc-13887). Routes to the `krea_2_turbo` candle engine while loading
+                // the Raw weights — the engine keys the regime on that descriptor id (inference PR #204).
+                // The handler is the SAME backend-neutral `generate_krea_turbo_on_raw_stream` the macOS
+                // `KreaTurboOnRaw` arm runs.
+                CandleImageRoute::KreaTurboOnRaw => {
+                    generate_krea_turbo_on_raw_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
                 // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g.
                 // sdxl) must be REJECTED with a clear error, not silently rendered as plain txt2img (poses
                 // dropped) and not bounced to torch. The candle worker CLAIMS these (jobs_store
@@ -1709,14 +1746,28 @@ include!("image_jobs/qwen.rs");
 #[cfg(target_os = "macos")]
 // Krea 2 Kontext-style image-edit routing (epic 10871).
 include!("image_jobs/krea_edit.rs");
-#[cfg(target_os = "macos")]
 // Krea 2 single-phase turbo-on-Raw routing (epic 13879 S3, sc-13883): the accelerator LoRA on a
 // `krea_2_raw` t2i job → the distilled Turbo sampling regime (fixed mu 1.15 / ~8 steps / CFG-off).
+// Shared by the MLX path (macOS) AND the candle lane (Windows/Linux CUDA, sc-13887): the whole file
+// is backend-neutral — it resolves + samples through the same registry harness (`mlx_model` +
+// `start_cached_gen_stream`) both backends use, so no `_candle.rs` sibling is needed. The candle
+// engine (inference PR #204) keys the turbo regime on the `krea_2_turbo` descriptor id exactly like
+// MLX.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 include!("image_jobs/krea_turbo_raw.rs");
-#[cfg(target_os = "macos")]
 // Krea 2 multi-phase denoise routing (epic 13879 S4, sc-13884): a `krea_2_raw` t2i job carrying an
 // explicit `advanced.phases` list → the multi-phase driver (one Raw trajectory / global schedule,
-// per-phase guidance + per-phase toggling of the job's load-time LoRA stack by index).
+// per-phase guidance + per-phase toggling of the job's load-time LoRA stack by index). Shared by the
+// MLX path AND the candle lane (sc-13887): the multi-phase primitive consumes the backend-agnostic
+// `GenerationRequest::phases` contract, which the candle Krea engine also honors (inference PR #204),
+// so the shape-detection + `advanced.phases` parse/validate + engine invocation are all backend-neutral.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 include!("image_jobs/krea_multiphase.rs");
 #[cfg(target_os = "macos")]
 // Krea 2 pose-ControlNet (MLX) strict-pose routing (sc-8465, epic 8459 S5).

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -318,6 +318,26 @@ enum CandleImageRoute {
     /// Krea 2 Kontext-style dual-conditioned image-edit — `krea_2_raw` + `edit_image` + a source, with
     /// the required `krea2_identity_edit` LoRA (epic 10871).
     KreaEdit,
+    /// A Krea 2 **Raw** t2i job carrying the accelerator (turbo) LoRA (`role: accelerator`, sc-13882)
+    /// → the single-phase turbo-on-Raw lane (epic 13879 S3, sc-13883, brought to candle by sc-13887):
+    /// the Raw base + LoRA additive, sampled through the distilled Turbo regime (fixed mu 1.15 / ~8 steps
+    /// / CFG-off) by routing to the `krea_2_turbo` candle engine id (which keys that regime, inference PR
+    /// #204). The candle twin of the MLX `ImageRoute::KreaTurboOnRaw`; both dispatch to the SHARED,
+    /// backend-neutral `generate_krea_turbo_on_raw_stream` (`krea_turbo_raw.rs`). Wins over the generic
+    /// `CandleTxt2Img` arm for PLAIN t2i — `krea_2_raw` is a candle txt2img id, so it would otherwise run
+    /// the 52-step true-CFG Raw regime and never accelerate.
+    KreaTurboOnRaw,
+    /// A Krea 2 **Raw** t2i job carrying an explicit `advanced.phases` list (epic 13879 S4, sc-13884,
+    /// brought to candle by sc-13887) → the multi-phase denoise driver: ONE Raw trajectory over ONE
+    /// global sigma schedule, each phase a contiguous step slice with its own guidance (per-phase CFG
+    /// on/off) and its own active subset of the job's load-time LoRA stack (per-phase toggling). The
+    /// candle twin of the MLX `ImageRoute::KreaMultiPhase`; both dispatch to the SHARED, backend-neutral
+    /// `generate_krea_multiphase_stream` (`krea_multiphase.rs`), which passes the backend-agnostic
+    /// `GenerationRequest::phases` the candle Krea engine honors (inference PR #204). Wins over
+    /// `KreaTurboOnRaw` and the generic `CandleTxt2Img` arm — an explicit phase list is the finer-grained
+    /// control. Loads the `krea_2_raw` engine (the driver keys on that descriptor id). Reference / edit /
+    /// pose / PiD shapes are rejected loudly by the lane (multi-phase renders from pure noise).
+    KreaMultiPhase,
     /// Z-Image identity-init for Image Studio "With Character" (sc-8409).
     ZimageIdentity,
     /// SDXL IP-Adapter-Plus reference conditioning (sc-5488).
@@ -465,6 +485,17 @@ fn resolve_candle_image_route(
         // `Krea2Control` lane, diverted before the registry txt2img arm (which would render it as plain
         // txt2img and drop the poses). Mirrors `jobs_store::krea_control_candle_eligible`.
         Some(CandleImageRoute::KreaControl)
+    } else if krea_multiphase_available(request, settings) {
+        // Krea 2 Raw t2i + an explicit `advanced.phases` list (epic 13879 S4, sc-13884; candle sc-13887)
+        // → the multi-phase denoise lane (`generate_krea_multiphase_stream`, SHARED with MLX). Placed
+        // FIRST among the `krea_2_raw` t2i lanes so an explicit phase list takes precedence over the S3
+        // whole-job turbo-on-Raw regime (`krea_turbo_on_raw_available` below) AND the generic Raw t2i
+        // (`CandleTxt2Img`): multi-phase is the finer-grained control. Only claims `krea_2_raw` + a present
+        // `advanced.phases`, so every non-phases job is unaffected; the lane itself rejects
+        // edit/pose/reference/PiD shapes loudly (multi-phase renders from pure noise), so claiming a
+        // conflicting shape here surfaces a clear error rather than diverting it silently. The candle twin
+        // of the MLX `resolve_image_route` `KreaMultiPhase` arm.
+        Some(CandleImageRoute::KreaMultiPhase)
     } else if krea_edit_candle_available(request, settings) {
         // Krea 2 Kontext-style edit (epic 10871): `krea_2_raw` + `edit_image` + a source is the bespoke
         // candle `KreaEdit` lane (`generate_candle_krea_edit_stream`), NOT the generic t2i stream. Diverted
@@ -472,6 +503,18 @@ fn resolve_candle_image_route(
         // 9992) so an edit job runs the dual-conditioning Kontext render instead of being flattened to plain
         // txt2img. Mirrors `jobs_store::krea_edit_candle_eligible`.
         Some(CandleImageRoute::KreaEdit)
+    } else if krea_turbo_on_raw_available(request, settings) {
+        // Krea 2 Raw t2i + the accelerator (turbo) LoRA (sc-13882) → the single-phase turbo-on-Raw lane
+        // (epic 13879 S3, sc-13883; candle sc-13887): the Raw base + LoRA additive, sampled as Turbo
+        // (fixed mu 1.15 / ~8 steps / CFG-off) by routing to the `krea_2_turbo` candle engine
+        // (`generate_krea_turbo_on_raw_stream`, SHARED with MLX). Wins over the generic `CandleTxt2Img`
+        // arm for PLAIN t2i — a plain Raw t2i would otherwise run the 52-step true-CFG regime and ignore
+        // the accelerator's intent. A `krea_2_raw` job that ALSO carries an img2img reference is EXCLUDED
+        // by the gate and falls through to the generic `CandleTxt2Img` img2img path (reference honored via
+        // `render_base_img2img`, accelerator LoRA still additive) — turbo-on-Raw img2img is out of scope
+        // for this t2i story (sc-13883). The candle twin of the MLX `resolve_image_route` `KreaTurboOnRaw`
+        // arm; placed AFTER the edit lane, BEFORE the generic txt2img arm.
+        Some(CandleImageRoute::KreaTurboOnRaw)
     } else if zimage_comfyui_available(request, settings) {
         // In-place ComfyUI Z-Image base (sc-10668): an `external_base_*` id, so it matches no
         // `is_candle_engine` arm below — route it here off the forwarded `modelManifestEntry`.

--- a/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
@@ -1,7 +1,8 @@
 // ---------------------------------------------------------------------------
-// Krea 2 multi-phase denoise (macOS, epic 13879 S4, sc-13884): a `krea_2_raw` t2i job
+// Krea 2 multi-phase denoise (epic 13879 S4, sc-13884): a `krea_2_raw` t2i job
 // carrying an explicit `advanced.phases` list rendered through the new multi-phase engine
-// primitive (inference PR #199). ONE Raw denoise trajectory over ONE global sigma schedule,
+// primitive (inference PR #199 on MLX; PR #204 brought the candle sibling, sc-13887). ONE Raw
+// denoise trajectory over ONE global sigma schedule,
 // where each PHASE owns a contiguous step slice with its own guidance (per-phase true-CFG
 // on/off) AND its own active subset of the job's load-time LoRA stack (per-phase toggling).
 // The canonical workflow is "N steps Raw with true-CFG on, then M steps Raw + turbo-LoRA with
@@ -39,8 +40,14 @@
 // engine): multi-phase is a Raw-trajectory decomposition, and the engine keys the driver on the
 // `krea_2_raw` descriptor id. This composes with — and takes PRECEDENCE over — the S3 whole-job
 // turbo-on-Raw regime: an explicit `advanced.phases` is the finer-grained control, so the router
-// checks this lane first (see `resolve_image_route`). The whole file is `include!`d only on macOS
-// (like `krea_turbo_raw.rs`), so nothing here needs a per-item cfg.
+// checks this lane first (see `resolve_image_route` / `resolve_candle_image_route`).
+//
+// The whole file is backend-neutral and `include!`d on BOTH the macOS (MLX) build AND the candle
+// build (sc-13887, like `krea_turbo_raw.rs`): the shape-detection, the `advanced.phases`
+// parse/validate → `GenerationRequest::phases`, and the engine invocation all go through the shared
+// registry harness + the backend-agnostic gen-core `phases` contract, so nothing here is
+// MLX-specific and nothing needs a per-item cfg. The candle Krea engine honors `phases` too
+// (inference PR #204).
 // ---------------------------------------------------------------------------
 
 /// Sanity cap on the number of phases in one multi-phase render. The engine imposes none, but a

--- a/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
@@ -1,8 +1,9 @@
 // ---------------------------------------------------------------------------
-// Krea 2 single-phase "turbo-on-Raw" (macOS, epic 13879 S3, sc-13883): the Raw base
+// Krea 2 single-phase "turbo-on-Raw" (epic 13879 S3, sc-13883): the Raw base
 // DiT run through the DISTILLED TURBO SAMPLING REGIME when the accelerator-role turbo
 // LoRA (sc-13882 `krea2_turbo_accel`) is selected on a `krea_2_raw` t2i job. Routed here
-// from `ImageRoute::KreaTurboOnRaw`.
+// from `ImageRoute::KreaTurboOnRaw` (MLX / macOS) or `CandleImageRoute::KreaTurboOnRaw`
+// (candle / Windows-Linux CUDA, sc-13887).
 //
 // The Krea engine keys its sampling regime on the DESCRIPTOR id, not per-generation params:
 // the Raw generator (`krea_2_raw`) always runs the resolution-DYNAMIC-mu, 52-step, true-CFG
@@ -18,8 +19,15 @@
 // This is the t2i sibling of `krea_edit.rs::krea_edit_engine_id`, which likewise picks the
 // engine id (`krea_2_turbo_edit` vs `krea_2_edit`) by job shape. No inference-monorepo change
 // is required — the fixed-mu / CFG-off behavior is entirely the existing `krea_2_turbo`
-// generator's, reached by routing rather than by a new per-generation flag. (The whole file is
-// `include!`d only on macOS, so — like `krea_edit.rs` — nothing here needs a per-item cfg.)
+// generator's, reached by routing rather than by a new per-generation flag; the candle
+// `candle-gen-krea` generator keys the turbo regime on the same descriptor id (inference PR #204).
+//
+// The whole file is backend-neutral and `include!`d on BOTH the macOS (MLX) build AND the candle
+// build (sc-13887): every helper it uses — `mlx_model` (the shared registry join), `resolve_*`,
+// `load_spec`, `start_cached_gen_stream`, `consume_gen_events` — resolves against whichever backend
+// is compiled, so there is no MLX-specific engine call to gate. The `include!` in `image_jobs.rs`
+// carries the `any(macos, all(not-macos, backend-candle))` cfg; the "neither" build pulls in nothing.
+// Nothing here needs a per-item cfg.
 // ---------------------------------------------------------------------------
 
 /// The SceneWorks model id whose LoRA-training/Raw base this accelerator lane runs on. The

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -5830,6 +5830,246 @@ fn candle_image_route_sends_krea_img2img_to_txt2img() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// sc-13887 (epic 13879 S6): the S3 turbo-on-Raw + S4 multi-phase Krea lanes on the CANDLE backend —
+// the parity twins of the macOS `resolve_image_route` `KreaTurboOnRaw`/`KreaMultiPhase` tests above.
+// The shape-detection + `advanced.phases` parse/validate + engine invocation are SHARED (backend-
+// neutral) — see `krea_turbo_raw.rs`/`krea_multiphase.rs`; these lock the candle ROUTING decisions
+// (`resolve_candle_image_route`), which are the only backend-specific part. Candle-cfg only; they
+// first RUN on the `candle-worker` CI lane (this host cannot link libcuda).
+// ---------------------------------------------------------------------------
+
+// A `krea_2_raw` t2i job carrying an explicit `advanced.phases` list routes to the candle multi-phase
+// lane — AND takes precedence over the S3 turbo-on-Raw regime (an explicit phase list is the finer-
+// grained control), exactly like the macOS router. The over-routing guards: accelerator LoRA + no
+// phases → `KreaTurboOnRaw`; plain Raw t2i (no phases/accel) → `CandleTxt2Img` (the generic candle
+// lane, UNCHANGED). The exclusions: an img2img reference EXCLUDES turbo-on-Raw (→ `CandleTxt2Img`, the
+// reference honored via `render_base_img2img` + the LoRA still additive), and an `edit_image` job → the
+// bespoke `KreaEdit` lane, never turbo/multiphase.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_krea_multiphase_and_turbo_route_with_over_routing_guards() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    settings.backend_candle_enabled = true;
+    // `resolve_weights_dir` honors an explicit `modelPath` first, so the tempdir resolves the Raw
+    // weight-gate both lanes require (parity with the macOS S4 routing test).
+    let model_path = dir.path().to_string_lossy().to_string();
+    let accel = json!({ "id": "krea2_turbo_accel", "family": "krea_2", "role": "accelerator" });
+
+    // Raw t2i + an explicit `advanced.phases` list → the candle multi-phase lane.
+    let with_phases = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "advanced": {
+            "modelPath": model_path.clone(),
+            "phases": [{ "steps": 20, "guidance": 3.5 }, { "steps": 8, "guidance": 0.0 }]
+        }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&with_phases, &settings),
+        Some(CandleImageRoute::KreaMultiPhase),
+        "krea_2_raw t2i + advanced.phases must route to the candle multi-phase lane",
+    );
+
+    // Precedence over S3: the SAME job also carrying the accelerator LoRA still routes to multi-phase —
+    // an explicit phase list wins over the whole-job turbo-on-Raw regime.
+    let phases_and_accel = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "loras": [accel.clone()],
+        "advanced": {
+            "modelPath": model_path.clone(),
+            "phases": [
+                { "steps": 20, "guidance": 3.5 },
+                { "steps": 8, "guidance": 0.0, "loras": [{ "index": 0, "weight": 1.0 }] }
+            ]
+        }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&phases_and_accel, &settings),
+        Some(CandleImageRoute::KreaMultiPhase),
+        "an explicit advanced.phases list must take precedence over the S3 turbo-on-Raw lane on candle",
+    );
+
+    // Over-routing guard 1: accelerator LoRA but NO phases → the S3 candle turbo-on-Raw lane.
+    let accel_no_phases = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "loras": [accel.clone()],
+        "advanced": { "modelPath": model_path.clone() }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&accel_no_phases, &settings),
+        Some(CandleImageRoute::KreaTurboOnRaw),
+        "an accelerator LoRA without advanced.phases must route to the candle turbo-on-Raw lane",
+    );
+
+    // Over-routing guard 2: plain Raw t2i, no phases/accel → the generic candle txt2img lane, UNCHANGED.
+    let plain = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "advanced": { "modelPath": model_path.clone() }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&plain, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+        "a plain Raw t2i without advanced.phases/accelerator must stay on the generic candle lane",
+    );
+
+    // Exclusion 1: an img2img reference EXCLUDES turbo-on-Raw — the reference-bearing job falls through
+    // to the generic candle lane (which resolves the img2img init + still folds the accelerator LoRA),
+    // never the plain turbo-t2i render that would drop the reference (sc-13883 exclusion).
+    let accel_img2img = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "loras": [accel.clone()],
+        "modelManifestEntry": { "ui": { "img2img": true } },
+        "referenceAssetId": "asset-1",
+        "advanced": { "modelPath": model_path.clone(), "strength": 0.5 }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&accel_img2img, &settings),
+        Some(CandleImageRoute::CandleTxt2Img),
+        "a krea_2_raw + accelerator + img2img reference must fall through to the generic img2img lane, \
+         not the turbo-t2i lane that drops the reference",
+    );
+
+    // Exclusion 2: an `edit_image` job (a source) → the bespoke candle KreaEdit lane, never turbo/
+    // multiphase — even carrying the accelerator LoRA (turbo excludes edit_image; multiphase has no
+    // phases here).
+    let edit = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1, "mode": "edit_image",
+        "sourceAssetId": "src-1",
+        "loras": [accel],
+        "advanced": { "modelPath": model_path }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&edit, &settings),
+        Some(CandleImageRoute::KreaEdit),
+        "a krea_2_raw edit_image job must route to the bespoke candle KreaEdit lane, not turbo/multiphase",
+    );
+}
+
+// The candle multi-phase gate claims a `krea_2_raw` + `advanced.phases` job even when the shape is a
+// conflicting one (edit / pose / img2img / PiD) — so the lane can reject it LOUDLY (multi-phase renders
+// from pure noise) rather than silently diverting it. Locks that a present phases list wins the route on
+// candle regardless of a conflicting-but-non-edit shape (a strict-pose here), matching the macOS lane's
+// "claim then reject" contract (`ensure_multiphase_job_shape`).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_krea_multiphase_claims_conflicting_shapes_to_reject_them() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    settings.backend_candle_enabled = true;
+    let model_path = dir.path().to_string_lossy().to_string();
+
+    // krea_2_raw + advanced.phases + a strict pose → multi-phase CLAIMS it (present phases wins), so the
+    // lane surfaces the pose-unsupported error rather than the job being silently rendered pose-dropped.
+    let phases_and_pose = request(json!({
+        "projectId": "p", "model": "krea_2_raw", "count": 1,
+        "advanced": {
+            "modelPath": model_path,
+            "phases": [{ "steps": 8 }],
+            "poses": [{ "id": "a" }]
+        }
+    }));
+    assert_eq!(
+        resolve_candle_image_route(&phases_and_pose, &settings),
+        Some(CandleImageRoute::KreaMultiPhase),
+        "a present advanced.phases must be CLAIMED by multi-phase (to reject the conflict loudly), not \
+         diverted to a pose lane",
+    );
+    // The shared shape guard then rejects it loudly before the load (backend-neutral, exercised on both).
+    assert!(ensure_multiphase_job_shape(&phases_and_pose)
+        .unwrap_err()
+        .to_string()
+        .contains("strict-pose"));
+}
+
+// sc-13887 — the candle parity twin of the macOS `krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime`
+// discriminating test. The turbo-on-Raw lane resolves its sampling regime against the `krea_2_turbo`
+// descriptor (while loading Raw weights), so the whole regime falls out for free on candle too: the fixed-
+// mu Turbo engine id, ~8 steps, guidance off, no negative forwarded. `resolve_steps`/`resolve_guidance`/
+// `resolve_negative_prompt`/`model_repo`/`mlx_model` are all SHARED (the candle lane uses the same
+// registry join), so pinning the NON-default turbo values makes this FAIL if the candle lane ever reverts
+// to the Raw regime (52 steps / guidance 3.5 / negative forwarded) or loads the wrong repo/engine.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
+    let raw = mlx_model("krea_2_raw").expect("krea_2_raw candle engine registered");
+    let turbo = mlx_model("krea_2_turbo").expect("krea_2_turbo candle engine registered");
+
+    // The lane samples with the `krea_2_turbo` engine (fixed mu 1.15 / CFG-free), NOT `krea_2_raw`
+    // (dynamic mu / true CFG). This engine swap IS the mu-1.15 mechanism (the pinned candle engine keys
+    // the schedule on the descriptor id, inference PR #204).
+    assert_eq!(turbo.engine_id(), "krea_2_turbo");
+    assert_ne!(
+        turbo.engine_id(),
+        raw.engine_id(),
+        "candle turbo-on-Raw must sample with the turbo engine (fixed mu), not the raw engine",
+    );
+    // The lane's own constants pin the split: load Raw weights, sample with the Turbo engine.
+    assert_eq!(
+        KREA_RAW_MODEL_ID, "krea_2_raw",
+        "the lane's base model is Raw"
+    );
+    assert_eq!(
+        KREA_TURBO_ENGINE_ID, "krea_2_turbo",
+        "the lane samples with the Turbo engine",
+    );
+
+    // A Raw-shaped request (negative prompt set, NO explicit step override) resolved against the turbo
+    // descriptor yields the full turbo regime; the SAME request against raw yields the Raw defaults.
+    let req = request(json!({
+        "projectId": "p", "model": "krea_2_raw",
+        "negativePrompt": "blurry, low quality",
+        "loras": [{ "id": "krea2_turbo_accel", "family": "krea_2", "role": "accelerator" }]
+    }));
+
+    // Steps: the turbo default is the distilled 8 (MODEL_TABLE row, backend-independent), NOT the Raw 52.
+    assert_eq!(
+        resolve_steps(&req, &turbo),
+        8,
+        "candle turbo-on-Raw defaults to the distilled 8 steps, not the Raw 52",
+    );
+    assert_eq!(
+        resolve_steps(&req, &raw),
+        52,
+        "control: the Raw default is 52"
+    );
+
+    // Guidance: CFG off under the turbo (distilled) descriptor → None, NOT the Raw 3.5.
+    assert_eq!(
+        resolve_guidance(&req, &turbo),
+        None,
+        "candle turbo-on-Raw forwards no guidance (CFG off)",
+    );
+    assert_eq!(
+        resolve_guidance(&req, &raw),
+        Some(3.5),
+        "control: the Raw default guidance is 3.5",
+    );
+
+    // Negative prompt: NOT forwarded under turbo (distilled, no negative branch); the Raw path forwards it.
+    assert_eq!(
+        resolve_negative_prompt(&req, &turbo),
+        None,
+        "candle turbo-on-Raw must not forward the negative prompt (CFG off)",
+    );
+    assert_eq!(
+        resolve_negative_prompt(&req, &raw),
+        Some("blurry, low quality".to_owned()),
+        "control: the Raw path forwards the user's negative prompt",
+    );
+
+    // The lane loads the RAW repo (fidelity base stays Raw even though the sampler runs the turbo regime),
+    // NOT the turbo engine's repo — `model_repo` reads the backend-independent MODEL_TABLE row.
+    assert_eq!(model_repo(&req, &raw), "SceneWorks/krea-2-raw-mlx");
+    assert_ne!(
+        model_repo(&req, &raw),
+        model_repo(&req, &turbo),
+        "candle turbo-on-Raw must load the RAW repo, not the turbo engine's repo",
+    );
+}
+
 /// Isolate the HF hub-cache env (`HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME`) to an explicit
 /// dir for as long as the returned guard lives, restoring the previous values on drop. The
 /// control-base resolvers (both the candle lanes and the MLX `resolve_krea_control_base`) read the


### PR DESCRIPTION
## What & why (sc-13887, epic 13879 S6 — cross-backend Krea parity + docs)

Phase B (SceneWorks side) of sc-13887: pin the inference monorepo forward to the merged candle-Krea-parity rev, then make the S3 (turbo-on-Raw) and S4 (multi-phase denoise) Krea 2 Raw worker lanes route on the **candle** backend at parity with the macOS MLX path, and document the workflow.

### 1. Pin bump
Bumps the SceneWorks inference pin `235ca214…` → **`b4c46d89603468771ff7061269fc8406a60c56e3`** via `scripts/bump-inference.mjs` (worker `sceneworks-gen-core` / `runtime-macos` / `runtime-cuda` + root `[patch]` `candle-kernels`, all lockstep; `Cargo.lock` re-locked). This rev brings `candle-gen-krea` to MLX parity: additive turbo-LoRA, turbo regime via descriptor id, and the multi-phase denoise primitive consuming the backend-agnostic `GenerationRequest::phases` contract (inference PR #204).

**Intervening commits** (candle Krea work + MLX community-DiT-load sc-14017 + candle-audio fix sc-13698 + CI wiring) verified clean: `cargo build -p sceneworks-worker` (macOS/MLX) builds; no gen-core / mlx-rs skew (`check-gen-core-skew.sh`). No breakage attributable to the intervening commits.

### 2. Candle S3 + S4 routing (the parity core)
The two lane files `krea_turbo_raw.rs` / `krea_multiphase.rs` are **fully backend-neutral** — shape detection, the `advanced.phases` parse/validate → `GenerationRequest::phases`, **and** the engine invocation all go through the same registry harness (`mlx_model` + `start_cached_gen_stream` + `consume_gen_events`) and gen-core contract that the candle txt2img path (`generate_candle_stream`) already uses. So rather than duplicate a `*_candle.rs` sibling, the two `include!`s are **un-gated** from `#[cfg(target_os = "macos")]` to the shared `any(macos, all(not-macos, backend-candle))` cfg. There is **no MLX-specific engine call to gate** — the candle Krea engine keys the turbo regime on the `krea_2_turbo` descriptor id and honors `phases`, exactly like MLX.

Wiring:
- `CandleImageRoute` gains `KreaTurboOnRaw` + `KreaMultiPhase` variants.
- `resolve_candle_image_route` gains the two arms — multi-phase **before** the candle edit lane (an explicit phase list wins), turbo-on-Raw **after** edit / before the generic txt2img arm — mirroring the MLX precedence.
- The candle dispatch calls the **shared** `generate_krea_multiphase_stream` / `generate_krea_turbo_on_raw_stream`.
- `image_count` uses the existing per-image catch-all (both are plain per-image).
- Same routing decisions as MLX: turbo-on-Raw loads Raw weights under the `krea_2_turbo` engine id; multi-phase loads the Raw engine + passes `phases`; the img2img / edit / pose exclusions; the diff-patch reject stays engine-enforced.

### 3. Docs
- **`krea-2-raw.md`** (the guide `krea_2_raw` points at — where feature users are): new section on the accelerator (turbo) LoRA (~8-step CFG-off turbo on the Raw base; t2i-only, img2img keeps full-CFG Raw) and the Studio multi-phase editor — per-phase CFG + per-phase LoRA toggling, the canonical **Turbo finish (4+4)** split (4 Raw CFG-on ~3.5 + 4 Raw + turbo LoRA CFG-off), recommended splits/weights, pure-noise constraint.
- **`krea-2.md`** (shared Turbo guide): a consistent cross-reference pointing to Raw for these Turbo-fidelity workflows.

Content matches shipped behavior (`imageMultiPhase.js` "Turbo finish (4+4)" preset). The builtin-manifest prompt-guide-exists test stays green.

### Tests
- New **candle-cfg routing tests** mirror the macOS ones: routing + precedence + over-routing guards, the img2img/edit exclusions, the claim-then-reject-conflict contract, and the turbo-regime discriminator (8 steps / CFG-off / no negative / Raw repo). They **first RUN on the `candle-worker` CI lane** (this host can't link libcuda); locally they typecheck under `-D warnings`.
- macOS S3/S4 routing + parse tests unchanged and green.

### Verification
- Candle typecheck (windows-candle lane proxy, `-D warnings` incl. test targets): **green**.
- Neither/parity config (candle off, Linux cross-compile): **green**.
- macOS MLX: build + clippy + S3/S4 routing tests: **green**. `cargo fmt --all`: **clean**.

### Follow-on (not runnable here)
- **Cross-backend equivalent-quality render (Mac MLX vs a CUDA box)** is a hardware validation — proven here via unit tests + the CI candle/parity build lanes, not an actual render. Left as a hardware follow-on.

sc-13887
