### PR TITLE
ci(workflows): add job-level timeout-minutes to the five workflows lacking it [sc-13603]

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -82,6 +82,11 @@ jobs:
     runs-on: windows-2022
     env:
       CARGO_NET_OFFLINE: "true"
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420, sc-13603). Hosted runner; well above the healthy
+    # ~4-8 min desktop-crate test+clippy, with headroom for a cold rust-cache
+    # miss that recompiles the desktop dependency graph.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -137,6 +142,13 @@ jobs:
       # candle-kernels artifacts never collide or thrash each other.
       CUDA_COMPUTE_CAP: "80"
       CARGO_NET_OFFLINE: "true"
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420). This is the full candle/CUDA sidecar build + NSIS/MSI
+    # packaging on the SOLE self-hosted cuda box (shared with windows-candle.yml),
+    # so a wedge here holds that box and starves every queued PR/main run on it
+    # (sc-13603). Well above the healthy ~13-17 min warm package — a cold candle
+    # rebuild fits.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # sc-13166: same self-hosted cuda box as windows-candle.yml — point this lane at

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -68,6 +68,13 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, nax]
     env:
       CARGO_NET_OFFLINE: "true"
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420). This lane is the SOLE self-hosted nax box and
+    # serializes main-push runs (github.sha concurrency), so a wedge here holds
+    # that box and starves every queued PR/main run on it (sc-13603). Well above
+    # the healthy ~6-14 min warm build+test+clippy — a cold MLX-from-source
+    # rebuild still fits.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,13 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, nax]
     env:
       CARGO_NET_OFFLINE: "true"
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420). Runs on the SOLE self-hosted nax box (shared with
+    # macos-mlx.yml), so a wedge holds that box against queued runs (sc-13603).
+    # Generous for the release path: a cold MLX-from-source rebuild plus Apple
+    # notarization's variable network round-trip sit on top of the healthy
+    # ~7-14 min.
+    timeout-minutes: 60
     # Signing/notarization secrets are scoped to the specific steps that consume
     # them (the bundle build + the DMG staple) — NOT set at job level — so that
     # `npm ci` (postinstall scripts) and every crate build.rs never see the
@@ -192,6 +199,11 @@ jobs:
       # signing key is scoped to the bundle step below, not here (sc-8864).
       CUDA_COMPUTE_CAP: "80"
       CARGO_NET_OFFLINE: "true"
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420, sc-13603). Hosted runner with no warm cache: a cold CUDA
+    # toolkit install + full candle/CUDA build + NSIS/MSI packaging is the healthy
+    # ~42-49 min, so this sits ~2x above that worst-case release build.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/server-candle-linux.yml
+++ b/.github/workflows/server-candle-linux.yml
@@ -34,6 +34,12 @@ jobs:
       # Ampere->Blackwell (mirrors the Windows lane / build-sidecar.mjs default).
       CUDA_COMPUTE_CAP: "80"
       CARGO_NET_OFFLINE: "true"
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420, sc-13603). workflow_dispatch-only full candle/CUDA
+    # release build (CUDA toolkit install + nvcc + web build); sized generously
+    # off the ~25 min observed run since it runs rarely and its rust-cache is
+    # usually cold.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -92,6 +92,13 @@ jobs:
       # SASS directly (no load-time JIT). compute_80 PTX would also forward-JIT.
       CUDA_COMPUTE_CAP: "120"
       CARGO_NET_OFFLINE: "true"
+    # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
+    # default (sc-10420). This lane is the SOLE self-hosted cuda box and
+    # serializes main-push runs (github.sha concurrency), so a wedge here holds
+    # that box and starves every queued PR/main run on it until the cap fires
+    # (sc-13603). Well above the healthy ~11-14 min build+test+clippy — a cold
+    # candle-kernels (nvcc) rebuild still fits comfortably.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # sc-13166: point this lane at the REAL rustup toolchain bin and prepend it to


### PR DESCRIPTION
## What

Adds a job-level `timeout-minutes` to every job in the five workflows that lacked one, closing the F-034 gap from sc-13603. Before this, only `check.yml` set a timeout; the other five rode GitHub's **6-hour default**. Three of them run on the **sole self-hosted box** and serialize main-push runs (`github.sha` concurrency), so one wedged step could hold that runner for up to 6h and starve every queued PR/main run on it.

No other workflow logic changed — this PR only inserts a `timeout-minutes:` key (plus an sc-10420 guardrail comment) at job scope.

## Sizing method

For each job I sampled recent **successful** runs and read **per-job** execution time via `gh run view <id> --json jobs` (start→complete, excluding queue). Each cap is set comfortably above the worst-case healthy run — including plausible cold rebuilds — but far below the 6h default, so a wedge dies in bounded time while a legitimately-slow run is never killed. When in doubt I sized up.

| File | Job | Runner | Observed median | Observed max | `timeout-minutes` | Rationale |
|------|-----|--------|-----------------|--------------|-------------------|-----------|
| `windows-candle.yml` | `candle-worker` | self-hosted `cuda` | ~11m | 13.8m | **45** | Warm build+test+clippy; headroom for a cold candle-kernels (nvcc) rebuild. |
| `desktop-windows.yml` | `build-windows` | hosted `windows-2022` | ~7m | 8.1m | **30** | Cheap desktop-crate test+clippy; headroom for a cold rust-cache miss. |
| `desktop-windows.yml` | `package-windows` | self-hosted `cuda` | ~14m | 16.6m | **90** | Full candle/CUDA sidecar + NSIS/MSI packaging; cold candle rebuild fits. |
| `macos-mlx.yml` | `nax-worker` | self-hosted `nax` | ~8.5m | 13.6m | **45** | Warm build+test+clippy; headroom for a cold MLX-from-source rebuild. |
| `release.yml` | `macos` | self-hosted `nax` | ~8m | 14.3m | **60** | Cold MLX rebuild + Apple notarization's variable network round-trip. |
| `release.yml` | `windows` | hosted `windows-2022` | ~45m | 49.1m | **90** | No warm cache: cold CUDA toolkit install + full candle build every run; ~2x the worst-case. |
| `server-candle-linux.yml` | `build-candle` | hosted `ubuntu-22.04` | 24.6m (n=1) | 24.6m | **90** | `workflow_dispatch`-only, runs rarely (rust-cache usually cold); generous single-data-point value. |

Note: the story's ballparks (windows-candle ~4min→~30; package/release→90–120) were used only as a sanity check. The real per-job durations drove the numbers — the windows-candle lane is now ~11m, not ~4m (it grew a sidecar `cargo check` + clippy since that estimate), so I sized it to 45 rather than 30 to keep cold nvcc rebuilds inside the cap.

## Convention

Matches `check.yml`: the `timeout-minutes:` key sits at **job scope**, placed after the job's `env:` block and immediately before `steps:`, preceded by a short comment referencing **sc-10420** (the six-hour-default hazard). Self-hosted jobs additionally note the sole-box starvation impact from sc-13603.

## Validation

- `actionlint` on all five files: **no findings on the added `timeout-minutes`**. The only output is the pre-existing "unknown label `cuda`/`nax`" note on the unchanged `runs-on:` lines (the repo's custom self-hosted labels; there is no `actionlint.yaml` declaring them) — confirmed present on `main` too, out of scope for this story.
- YAML parse of all five files: every job resolves an **integer** `timeout-minutes` at job scope (7/7 jobs).

Story: https://app.shortcut.com/trefry/story/13603
