### PR TITLE
chore(release): isolate signing material from npm lifecycle scripts [sc-13612]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,16 @@ name: Release (desktop)
 #                           is the signing Mac; a cloud runner would instead store
 #                           the .p8 contents as a secret and write it to a temp file)
 #
+# SIGNING-MATERIAL ISOLATION (sc-13612, F-050): the install step now uses
+# `npm ci --ignore-scripts` so a compromised transitive dep can't run install-time
+# code on this signing box. Two residual hardening items are HOST-side (this file
+# does no `security` keychain management and never writes the .p8, so they can't be
+# done purely in-repo) and are tracked as follow-ups:
+#   sc-14064 — move signing off the always-unlocked LOGIN keychain to a dedicated,
+#              per-use-unlocked temp keychain created+deleted within the run.
+#   sc-14065 — provision the .p8 from a secret into a chmod-600 mktemp path removed
+#              on exit, instead of a pre-placed file readable in the runner's HOME.
+#
 # Tag/dispatch only — never push/PR. NOTE: `codesign` needs the login keychain
 # unlocked in the runner's session; verify end-to-end with a throwaway tag (e.g.
 # v0.0.0-rc.1) before relying on this. See sc-5930.
@@ -54,8 +64,12 @@ jobs:
     timeout-minutes: 60
     # Signing/notarization secrets are scoped to the specific steps that consume
     # them (the bundle build + the DMG staple) — NOT set at job level — so that
-    # `npm ci` (postinstall scripts) and every crate build.rs never see the
-    # updater signing key or the Apple credentials (sc-8864).
+    # `npm ci` and every crate build.rs never see the updater signing key or the
+    # Apple credentials (sc-8864). Layered with `npm ci --ignore-scripts` on the
+    # install step (sc-13612): env-scoping keeps secrets out of an install script's
+    # ENV, and --ignore-scripts stops install scripts from running at all — needed
+    # because this box's login keychain holds the Developer ID cert, so a dep's
+    # postinstall could sign/notarize as us regardless of ENV scoping.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
@@ -76,10 +90,26 @@ jobs:
       # embedded UI, built by the tauri.conf beforeBuildCommand → api:build:embedded
       # → web:build) and apps/desktop (the @tauri-apps/cli that `tauri build` runs).
       # The repo root has no JS deps — it only orchestrates.
+      #
+      # --ignore-scripts (sc-13612, F-050): this box is the self-hosted signing Mac
+      # holding the Developer ID cert (login keychain) + notary .p8. Step-scoping the
+      # APPLE_*/TAURI_* secrets keeps them out of install-time scripts' ENV, but a
+      # compromised transitive dep's postinstall could still ask the unlocked login
+      # keychain to codesign/notarize arbitrary binaries as us. Disabling lifecycle
+      # scripts on the release lane removes that path. Safe here because the build runs
+      # via explicit `run build` steps (vite build / tauri build), not an install hook,
+      # and no needed dep relies on a postinstall: apps/desktop has ZERO install-script
+      # deps (@tauri-apps/cli resolves its platform binary via optionalDependencies);
+      # apps/web's only install-script deps are esbuild (works under --ignore-scripts —
+      # its platform binary is an optionalDependency resolved at runtime; the postinstall
+      # is a startup optimization only) and fsevents (optional, dev-server file-watching
+      # only — unused by `vite build`). Confirm with one real release test build.
+      # Residual host-side hardening tracked as follow-ups: sc-14064 (dedicated per-use
+      # keychain instead of the login keychain) and sc-14065 (.p8 off the readable path).
       - name: Install web + desktop JS deps
         run: |
-          npm ci --prefix apps/web
-          npm ci --prefix apps/desktop
+          npm ci --prefix apps/web --ignore-scripts
+          npm ci --prefix apps/desktop --ignore-scripts
 
       # `tauri build` runs the beforeBuildCommand (sidecar + web/api + the nested
       # binary pre-signing from #715) and, because the APPLE_* env is set, signs +
@@ -242,10 +272,15 @@ jobs:
           bash scripts/check-gen-core-skew.sh --self-test
           bash scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle
           bash scripts/check-gen-core-skew.sh sceneworks-rust-api --features embed-web,backend-candle
+      # --ignore-scripts (sc-13612, F-050): defense-in-depth on the release lane so a
+      # compromised transitive dep can't run install-time code during the release build.
+      # See the macos job's install step for the full lifecycle-script analysis (no
+      # needed dep relies on a postinstall; @tauri-apps/cli + esbuild resolve platform
+      # binaries via optionalDependencies). Confirm with one real release test build.
       - name: Install web dependencies
-        run: npm ci --prefix apps/web
+        run: npm ci --prefix apps/web --ignore-scripts
       - name: Install desktop dependencies
-        run: npm ci --prefix apps/desktop
+        run: npm ci --prefix apps/desktop --ignore-scripts
       # `tauri build` runs build-sidecar.mjs, which on Windows builds the candle
       # sidecar by default (nvcc compiles every provider's CUDA kernels) and stages
       # the ffmpeg resource, then packages both installers. The ~2.7 GB CUDA/cuDNN/


### PR DESCRIPTION
## sc-13612 — F-050 (Medium, security): isolate signing material from npm lifecycle scripts on the release Mac

Story: https://app.shortcut.com/trefry/story/13612
Epic: Platform-layer hardening backlog (code review 2026-07-20) — sc-13581

### Finding
The release `macos` job runs on the self-hosted `nax` signing Mac. That box's **login keychain holds the Developer ID Application cert** and its **disk holds the App Store Connect notary `.p8`**. Plain `npm ci` runs dependency lifecycle scripts (postinstall etc.). Because the login keychain is unlocked in the runner session, a **compromised transitive npm dependency's postinstall could invoke `codesign`/notary to sign or notarize arbitrary binaries as the developer.** Step-scoping the `APPLE_*`/`TAURI_*` secrets (sc-8864) keeps secrets out of an install script's ENV but does **not** protect the keychain or disk.

### Current flow (as read from `release.yml`)
- **`npm ci` sites (4 total):** `macos` job installs `apps/web` + `apps/desktop` (lines ~81-82 pre-change); `windows` job installs the same two (lines ~246-248 pre-change). Root repo has no JS deps. The actual app build runs via **explicit `run build` steps** — `npm --prefix apps/desktop run build` → `tauri build`, with `apps/web` built through the tauri `beforeBuildCommand` → `web:build` (`vite build`). No install lifecycle hook is on the build-critical path.
- **Keychain:** the workflow contains **no `security` CLI calls at all**. The Developer ID cert lives in the runner user's **login keychain** and `codesign` uses it directly (documented in the file header). Keychain lifecycle is **entirely host-managed**.
- **`.p8`:** provided as `APPLE_API_KEY_PATH` — a **secret holding a path to a pre-placed file** on the runner disk. `staple-dmg.mjs` and `tauri build` only **read** that path. Nothing in-repo writes the `.p8`.

### Changes
**a) `npm ci --ignore-scripts` at all four release-lane sites** (macos web+desktop, windows web+desktop). This is the fully in-repo-implementable part of the fix.

**b) Dedicated per-use-unlock keychain — HOST-side, filed as follow-up sc-14064.** There is no in-repo keychain management to harden; the cert is in the host login keychain. Switching to a dedicated temp keychain requires host-provisioned secrets (cert as base64 `.p12` + passwords) — wiring `security create-keychain`/`import` against secrets that don't exist would break the currently-working login-keychain release. Concrete recommended design captured on sc-14064. A pointer comment was added at the point of use.

**c) Move the `.p8` off the runner-readable path — HOST-side, filed as follow-up sc-14065.** The workflow never writes the `.p8` (it consumes a host path), so relocation to a chmod-600 temp path is a host/secrets change, not an in-repo edit. Recommended design (store `.p8` contents as a secret → `mktemp` 600 → `$GITHUB_ENV` → `if: always()` cleanup) captured on sc-14065. Pointer comment added at the point of use.

### `--ignore-scripts` safety analysis (justifies (a))
Authoritative signal = `hasInstallScript` in each `package-lock.json` (npm records it for any pkg with preinstall/install/postinstall):

- **Root / `apps/web` / `apps/desktop`**: declare **no** own install hooks. App build is explicit `run build`, not an install hook.
- **`apps/desktop`: ZERO install-script deps.** `@tauri-apps/cli` 2.11.2 and all its platform packages have `hasInstallScript=false` — the platform binary is an `optionalDependency`. `--ignore-scripts` has no effect on the desktop install.
- **`apps/web`: only two install-script deps —**
  - **`esbuild` 0.25.12** — main pkg has a postinstall, but all 26 `@esbuild/<platform>` binary packages are `optionalDependencies` with `hasInstallScript=false`. esbuild resolves its platform binary at runtime via that optionalDependency; the postinstall is a **startup optimization only** and esbuild is designed to work under `--ignore-scripts`. `@esbuild/darwin-arm64` and `@esbuild/win32-x64` are in the lock and installed by `npm ci` regardless.
  - **`fsevents` 2.3.3** — `optional`, `os: darwin`, used only for **dev-server native file-watching**; `vite build` does not use it.

Conclusion: `--ignore-scripts` is **safe for the release build** (high confidence). Per the finding's Medium-confidence caveat, a real test build is the confirmation.

### Validation
- `actionlint` on `release.yml`: **clean apart from the pre-existing `nax` self-hosted-runner-label note** (present on `origin/main`; the line moved 45→55 only because header comments were added).
- YAML parses.
- `--ignore-scripts` safety reasoned from the two lockfiles' `hasInstallScript` markers (above).

### ⚠️ VALIDATION GATE — requires one real release/signing test build on the release Mac before shipping
Signing/notarization behavior is **UNVERIFIED in-session** — the signing flow can only run on the self-hosted `nax` Mac (Developer ID cert + notary `.p8`) and was not exercised here. Before relying on this, run a throwaway-tag release build (e.g. `v0.0.0-rc.1`) on the nax box and confirm the bundle still signs, notarizes, and staples with `--ignore-scripts`.

### Host-side follow-ups (out-of-repo, tracked)
- **sc-14064** — dedicated per-use-unlock keychain instead of the login keychain.
- **sc-14065** — provision the `.p8` from a secret into a chmod-600 mktemp path, removed on exit, off the runner user's readable HOME.

🤖 Generated with [Claude Code](https://claude.com/claude-code)