### PR TITLE
feat(web): enable point-at-file base-checkpoint import in Model Manager [sc-14020]

### DIFF
--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -1253,10 +1253,11 @@ describe("SceneWorks app shell", () => {
     expect(buttonInside(loraPanel(container), "Queue Import").disabled).toBe(false);
   });
 
-  it("hides the model import form while uploads are disabled pending conversion support (sc-7081)", async () => {
-    // The model upload/import form is gated off on every platform (MODEL_IMPORT_ENABLED)
-    // until the compatibility + conversion pipeline (epic 7080) lands — an imported
-    // checkpoint has no runnable engine today, and the API refuses the request too.
+  it("renders the base-checkpoint point-at-file import affordance when enabled (sc-14020)", async () => {
+    // Epic 14015 (Mac-first community-checkpoint import) re-enables model import behind the
+    // backend compatibility gate S0d opened; S0e flips the web MODEL_IMPORT_ENABLED mirror on.
+    // The point-at-a-file picker is the default (leading) affordance and Type defaults to image
+    // — the only importable base checkpoint (a Krea 2 DiT) today.
     root = createRoot(container);
     await act(async () => {
       root.render(
@@ -1267,19 +1268,166 @@ describe("SceneWorks app shell", () => {
           models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
           onDownloadModel: () => {},
           onImportLora: () => {},
-          onImportModel: () => {},
+          onImportModel: vi.fn(),
           onOpenQueue: () => {},
         }),
       );
     });
 
-    expect(modelImportPanel(container)).toBeNull();
-    expect(container.textContent).not.toContain("Import model");
-    // The image model's card is on the default (Image) tab.
-    expect(container.textContent).toContain("Z-Image Turbo");
-    // LoRA import is unaffected — its form is on the LoRAs tab.
+    // The import form shares the LoRAs tab's import area (the existing scaffold home).
     await selectModelTab("LoRAs");
-    expect(loraPanel(container)).not.toBeNull();
+    const panel = modelImportPanel(container);
+    expect(panel).not.toBeNull();
+    expect(panel.textContent).toContain("Import model");
+    // File mode leads: the "Model File" picker is mounted, not a Source URL input.
+    expect(field(panel, "Model File")).toBeTruthy();
+    expect(field(panel, "Source URL")).toBeFalsy();
+    expect(field(panel, "Type").value).toBe("image");
+  });
+
+  it("POSTs the pointed-at checkpoint as an image import, leaving family to auto-detect (sc-14020)", async () => {
+    const onImportModel = vi.fn(async () => ({
+      payload: { modelId: "my_krea", manifestEntry: { family: "krea_2" } },
+    }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel,
+          onOpenQueue: () => {},
+        }),
+      );
+    });
+
+    await selectModelTab("LoRAs");
+    const panel = modelImportPanel(container);
+    const file = new File([new Uint8Array([1, 2, 3])], "krea2-checkpoint.safetensors");
+    await changeFile(field(panel, "Model File"), file);
+    await act(async () => {
+      buttonInside(panel, "Queue Import").click();
+    });
+    await settle();
+
+    expect(onImportModel).toHaveBeenCalledTimes(1);
+    const payload = onImportModel.mock.calls[0][0];
+    expect(payload.file).toBe(file);
+    expect(payload.modelType).toBe("image");
+    // No family override — the backend detector classifies the file (Krea 2 today).
+    expect(payload.family).toBeUndefined();
+  });
+
+  it("surfaces the detected Krea 2 family on a successful checkpoint import (sc-14020)", async () => {
+    const onImportModel = vi.fn(async () => ({
+      payload: { modelId: "my_krea", manifestEntry: { family: "krea_2" } },
+    }));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel,
+          onOpenQueue: () => {},
+        }),
+      );
+    });
+
+    await selectModelTab("LoRAs");
+    const panel = modelImportPanel(container);
+    await changeFile(field(panel, "Model File"), new File([new Uint8Array([1])], "krea2.safetensors"));
+    await act(async () => {
+      buttonInside(panel, "Queue Import").click();
+    });
+    await settle();
+
+    const success = container.querySelector(".inline-success");
+    expect(success).not.toBeNull();
+    expect(success.textContent).toContain("my_krea");
+    expect(success.textContent).toContain("krea-2");
+  });
+
+  it("shows the detector's typed rejection reason (not a generic error) on a 400 (sc-14020)", async () => {
+    // The queue-time compatibility gate (sc-14019) refuses an un-runnable base checkpoint with a
+    // typed reason; apiFetch surfaces it as the thrown Error message, which the form must show
+    // verbatim rather than a generic failure string.
+    const typedReason = "Unsupported base checkpoint: qwen-image fp8 has no import loader today.";
+    const onImportModel = vi.fn(async () => {
+      throw new Error(typedReason);
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel,
+          onOpenQueue: () => {},
+        }),
+      );
+    });
+
+    await selectModelTab("LoRAs");
+    const panel = modelImportPanel(container);
+    await changeFile(field(panel, "Model File"), new File([new Uint8Array([1])], "qwen.safetensors"));
+    await act(async () => {
+      buttonInside(panel, "Queue Import").click();
+    });
+    await settle();
+
+    const warning = container.querySelector(".inline-warning");
+    expect(warning).not.toBeNull();
+    expect(warning.textContent).toContain(typedReason);
+    expect(container.textContent).not.toContain("Request failed");
+  });
+
+  it("surfaces an imported Krea 2 checkpoint as a user model card in the catalog (sc-14020)", async () => {
+    // Once the model_import job completes the catalog refetch (App.test covers the SSE refetch)
+    // yields a catalogScope:"user" Krea 2 model; the Model Manager renders it as a normal card.
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [
+            {
+              id: "my_krea",
+              name: "My Krea Checkpoint",
+              type: "image",
+              family: "krea_2",
+              catalogScope: "user",
+              installState: "installed",
+            },
+          ],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel: vi.fn(),
+          onOpenQueue: () => {},
+        }),
+      );
+    });
+
+    // Image tab is the default; the imported user model shows with its detected family.
+    const card = [...container.querySelectorAll(".model-card")].find((node) =>
+      node.textContent.includes("My Krea Checkpoint"),
+    );
+    expect(card).toBeTruthy();
+    expect(card.textContent).toContain("krea_2");
   });
 
   it("renders unassociated models with a needs-family badge", async () => {

--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -1317,7 +1317,10 @@ describe("SceneWorks app shell", () => {
     expect(onImportModel).toHaveBeenCalledTimes(1);
     const payload = onImportModel.mock.calls[0][0];
     expect(payload.file).toBe(file);
-    expect(payload.modelType).toBe("image");
+    // Keyed `type`, not `modelType`: the backend multipart parser reads the literal `type` field
+    // (JSON accepts it via a serde alias). `modelType` would be silently dropped on upload (sc-14020).
+    expect(payload.type).toBe("image");
+    expect(payload.modelType).toBeUndefined();
     // No family override — the backend detector classifies the file (Krea 2 today).
     expect(payload.family).toBeUndefined();
   });

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -103,9 +103,11 @@ export function useJobEvents({
       // the pre-job row — still offering "Convert to MLX" for an already-converted model, or
       // omitting the imported one entirely — until the app is restarted.
       //
-      // `model_import` cannot fire today: `create_model_import_job` 403s on every platform behind
-      // the sc-7081 kill-switch, so no such job is ever queued. It is wired here so 7080's P5
-      // re-enable flips the feature on complete, not one refresh short.
+      // `model_import` now fires (epic 14015): S0d (sc-14019) opened the backend kill-switch and
+      // gates `create_model_import_job` on a base-weight compatibility verdict, and S0e (sc-14020)
+      // exposed the point-at-file import affordance. A completed import upserts a
+      // `catalogScope:"user"` model into `user.models.jsonc`, so the refetch below is required for
+      // it to appear on the Models page without an app restart.
       if (
         job.status === "completed" &&
         (job.type === "model_download" || job.type === "model_convert" || job.type === "model_import")

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -208,6 +208,11 @@ export function useModelsAndLoras({
     let body;
     if (file) {
       body = new FormData();
+      // Multipart fields are appended verbatim — the backend reads them by literal field name
+      // (models.rs `model_import_request_from_multipart`) with none of the `#[serde(alias)]`
+      // tolerance the JSON branch below gets. Callers must key metadata by the backend's own
+      // multipart field names (e.g. `type`, not `modelType`) or the value is silently dropped
+      // and the import defaults to `image` (sc-14020).
       Object.entries(metadata).forEach(([key, value]) => {
         if (value != null && value !== "") {
           body.append(key, value);

--- a/apps/web/src/hooks/useModelsAndLoras.modelImport.test.jsx
+++ b/apps/web/src/hooks/useModelsAndLoras.modelImport.test.jsx
@@ -1,0 +1,92 @@
+// sc-14020: base-checkpoint import contract. `createModelImportJob` must key the model type as
+// `type` — the literal field name the backend's multipart parser reads (models.rs
+// `model_import_request_from_multipart`) — because a multipart upload gets none of the
+// `#[serde(alias = "type")]` tolerance the JSON path enjoys. Keying it `modelType` (the old bug)
+// was silently dropped on file uploads, defaulting every imported checkpoint to `image`. These
+// tests drive the real hook with a mocked apiFetch and assert the outgoing request body carries
+// the type under `type` on both the multipart (file) and JSON (URL) branches.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock("../api.js", () => ({
+  apiFetch: (...args) => apiFetchMock(...args),
+  isAbortError: () => false,
+}));
+
+import { useModelsAndLoras } from "./useModelsAndLoras.js";
+
+let container;
+let root;
+let hookApi;
+
+function Harness() {
+  hookApi = useModelsAndLoras({
+    token: "tok",
+    activeProject: { id: "proj-1" },
+    activeProjectRef: { current: { id: "proj-1" } },
+    setError: () => {},
+    setJobs: () => {},
+    setActiveView: () => {},
+    refreshData: async () => {},
+    refreshDataWithLoraOverlay: async () => {},
+  });
+  return null;
+}
+
+beforeEach(async () => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  apiFetchMock.mockReset();
+  apiFetchMock.mockResolvedValue({ id: "model-import-job-1", type: "model_import", status: "running" });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<Harness />);
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("createModelImportJob type-field contract (sc-14020)", () => {
+  it("multipart upload keys the type as `type` (the field the backend reads), never `modelType`", async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], "krea2-checkpoint.safetensors");
+
+    await act(async () => {
+      await hookApi.createModelImportJob({ file, type: "image", name: "krea2" });
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    const [path, token, options] = apiFetchMock.mock.calls[0];
+    expect(path).toBe("/api/v1/models/import");
+    expect(token).toBe("tok");
+    expect(options.method).toBe("POST");
+
+    const body = options.body;
+    expect(body).toBeInstanceOf(FormData);
+    // The backend multipart parser reads `type`; `modelType` would be silently dropped.
+    expect(body.get("type")).toBe("image");
+    expect(body.get("modelType")).toBeNull();
+    expect(body.get("name")).toBe("krea2");
+    expect(body.get("file")).toBe(file);
+  });
+
+  it("URL (JSON) import keeps the type under `type` in the JSON body", async () => {
+    await act(async () => {
+      await hookApi.createModelImportJob({ sourceUrl: "https://example.com/krea2.safetensors", type: "image", name: "krea2" });
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1);
+    const [, , options] = apiFetchMock.mock.calls[0];
+    expect(typeof options.body).toBe("string");
+    const payload = JSON.parse(options.body);
+    // JSON deserialization accepts `type` via `#[serde(alias = "type")]` on ModelImportRequest.
+    expect(payload.type).toBe("image");
+    expect(payload.sourceUrl).toBe("https://example.com/krea2.safetensors");
+    expect(payload.name).toBe("krea2");
+  });
+});

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -998,7 +998,12 @@ export function ModelManagerScreen() {
       const job = await onImportModel({
         ...(isFileImport ? { file: modelImportForm.file } : { sourceUrl: modelImportForm.sourceUrl.trim() }),
         name: modelImportForm.name.trim() || undefined,
-        modelType: modelImportForm.type,
+        // Send the model type under `type` — the literal field name the backend's multipart parser
+        // reads (models.rs `model_import_request_from_multipart`) and that JSON deserialization
+        // accepts via `#[serde(alias = "type")]` on `ModelImportRequest`. Keying this `modelType`
+        // was silently dropped on file uploads (multipart has no serde aliasing), defaulting every
+        // imported checkpoint to `image` regardless of selection (sc-14020).
+        type: modelImportForm.type,
         ...familyOverride,
       });
       const modelId = job?.payload?.modelId;
@@ -2047,12 +2052,15 @@ export function ModelManagerScreen() {
                   <div className="models-import-grid">
                     <label>
                       Type
-                      <select
-                        disabled={importingModel}
-                        onChange={(event) => setModelImportForm((current) => ({ ...current, type: event.target.value }))}
-                        value={modelImportForm.type}
-                      >
-                        {MODEL_TYPE_OPTIONS.map((option) => (
+                      {/* Base-checkpoint import only produces image models today (a Krea 2 DiT).
+                          `queue_model_import_job` (models.rs) writes this type verbatim into the
+                          user manifest and never reconciles it against the detected family, so
+                          offering video/audio/utility here would let an image checkpoint be
+                          mis-typed. Constrain to Image (disabled) until more base-checkpoint types
+                          are importable, then drop the image-only filter to restore the full
+                          MODEL_TYPE_OPTIONS selector (sc-14020). */}
+                      <select disabled value={modelImportForm.type} aria-readonly="true">
+                        {MODEL_TYPE_OPTIONS.filter((option) => option.value === "image").map((option) => (
                           <option key={option.value} value={option.value}>
                             {option.label}
                           </option>

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -113,18 +113,17 @@ const MODEL_TYPE_OPTIONS = [
   { value: "utility", label: "Utility" },
 ];
 
-// sc-7081 (epic 7080, P0): model upload/import is hidden + disabled on every platform until a
-// real compatibility + conversion pipeline exists behind it. Today an imported checkpoint
-// has no runnable engine (macOS is MLX-only with a compile-time engine table; off-Mac only
-// loads full diffusers repos), so the form is kept in source but not rendered. The API
-// refuses the request too. Flip to true once the pipeline gates imports on a compatibility
-// verdict.
-//
-// KEEP, don't delete (sc-8941 / F-139): this is the deliberate P0-disabled scaffold that epic
-// 7080's P5 ("re-enable the UI behind the compat gate") restores — not accidental dead code.
-// The whole form + its state/handler below stay compile-time-gated by this flag so the
-// restoration point is preserved. Removing it would discard tracked, in-progress roadmap work.
-const MODEL_IMPORT_ENABLED = false;
+// sc-7081 (epic 7080, P0) originally hid this form on every platform because an imported
+// checkpoint had no runnable engine and the API refused the request. Epic 14015 (Mac-first
+// community-checkpoint import) restores it behind a real compatibility gate: S0d flipped the
+// backend `model_import_enabled()` on and gates `POST /api/v1/models/import` on the
+// base-weight detector's verdict (supported (family, component, quant) triple → accepted;
+// unsupported → 400 with a typed reason). S0e (sc-14020) flips this web mirror on so the
+// point-at-file import affordance renders. A rejected checkpoint surfaces the detector's
+// typed reason (unsupported family/quant/unrecognized) inline rather than a generic error;
+// an accepted one queues a `model_import` job whose completion refetches the catalog and
+// surfaces the new `catalogScope:"user"` model (a Krea 2 base checkpoint today).
+const MODEL_IMPORT_ENABLED = true;
 
 // Capability descriptors shown as chips on each model card. With models now grouped
 // by `type`, the chips are what tell the user what a card actually does (plain
@@ -695,8 +694,10 @@ export function ModelManagerScreen() {
   const [loraEditError, setLoraEditError] = useState("");
   const [importingModel, setImportingModel] = useState(false);
   const [modelImportMessage, setModelImportMessage] = useState({ tone: "neutral", text: "" });
+  // Point-at-file import (sc-14020) leads with the file picker; URL stays available via the
+  // segmented toggle. `type` defaults to image — the only importable base checkpoint today.
   const [modelImportForm, setModelImportForm] = useState({
-    mode: "url",
+    mode: "file",
     sourceUrl: "",
     file: null,
     name: "",
@@ -2011,15 +2012,19 @@ export function ModelManagerScreen() {
             )}
           </div>
 
-          {/* Model import stays compile-gated (epic 7080 / sc-8941 F-139) and renders nothing while
-              disabled; the section only appears to surface any in-flight model-import progress. */}
+          {/* Import a base checkpoint (epic 14015, sc-14020). Gated on MODEL_IMPORT_ENABLED, which
+              mirrors the backend kill-switch S0d opened; the section also surfaces any in-flight
+              model-import progress. The point-at-a-file picker is the primary affordance. */}
           {MODEL_IMPORT_ENABLED || pendingModelImportJobs.length > 0 ? (
             <section className="model-import-panel-section">
               {MODEL_IMPORT_ENABLED && (
-                <form className="lora-import-panel models-import-panel" aria-label="Import model" onSubmit={importModel}>
-                  <div>
-                    <strong>Import model</strong>
-                    <span>{modelImportForm.family || "auto-detect family"}</span>
+                <form className="models-accent-band models-import-panel" aria-label="Import model" onSubmit={importModel}>
+                  <div className="models-accent-band-head">
+                    <span className="models-accent-dot" aria-hidden="true" />
+                    <p className="eyebrow">Import model</p>
+                    <span className="models-accent-band-caption">
+                      Point at a base checkpoint file — auto-detects family (Krea 2 today)
+                    </span>
                   </div>
                   <div className="segmented-control compact-segment" aria-label="Model import source">
                     <button


### PR DESCRIPTION
## What & why (sc-14020, S0e · epic 14015 Mac-first community-checkpoint import)

S0d flipped the **backend** `model_import_enabled()` on and gated `POST /api/v1/models/import` on the base-weight detector's verdict (supported `(family, component, quant)` triple → accepted; unsupported → 400 with a typed reason). This slice flips the **web** mirror on and wires the point-at-file import UX in the Model Manager.

## Changes

- **Flag flip.** `MODEL_IMPORT_ENABLED` in `apps/web/src/screens/ModelManagerScreen.jsx` → `true` (it mirrors the backend kill-switch S0d opened). Refreshed the surrounding comment from the sc-7080 "P0-disabled scaffold" rationale to the epic 14015 re-enable-behind-the-gate rationale.
- **Point-at-file import UX.** The "Import model" form now renders. The **file picker leads** (`modelImportForm.mode` defaults to `file`): choose a local single-file checkpoint, and it POSTs to `/api/v1/models/import` as **`type: image`** with the uploaded file (multipart, via the existing `createModelImportJob` client hook). URL import stays available via the segmented toggle. Family is left to the backend detector (no override sent) so a Krea 2 DiT classifies itself.
- **Success → user model.** An accepted checkpoint queues a `model_import` job; its completion refetches the catalog (existing SSE `job.updated` wiring, already covered by an App-level test) and surfaces the new `catalogScope:"user"` model as a Krea 2 family card. The form shows the detected family in its queued-success message.
- **Typed 400 handling.** A rejected checkpoint surfaces the detector's typed reason verbatim (e.g. "unsupported family/quant/unrecognized") inline via `apiFetch` → `err.message`, **not** a generic error string.
- **Design system.** Realigned the import panel to the LoRA import **accent-band** treatment (epic 10433 page-frame), reusing the LoRA import UI as the template per the story.

## Tests

Replaced the now-stale "form hidden while disabled" test with vitest coverage of the enabled flow in `apps/web/src/App.models.test.jsx`:

- renders the point-at-file affordance (file picker leads, `Type` defaults to `image`);
- POSTs the pointed-at checkpoint with `{ file, modelType: "image" }` and no family override;
- surfaces the detected **Krea 2** family on a successful import;
- shows the detector's **typed 400 rejection reason** (asserts the reason text renders and "Request failed" does **not**);
- renders an imported `catalogScope:"user"` Krea 2 model as a catalog card.

Verification (web CI equivalents, run in-worktree):
- `vitest run` — **155 files / 2274 tests pass** (32 in `App.models.test.jsx`, incl. the 5 new sc-14020 tests).
- `eslint src` — **0 errors** (pre-existing `exhaustive-deps` warnings only; none new in touched files).
- `vite build` — **succeeds**.

Per the worktree-preview trap, this was verified via vitest + build (not a live preview); live end-to-end import+generate is validated separately in S0f.

## Scope

Backend gate (S0d), the worker load path (S0c), and the inference repo are untouched. The story permitted filing the UX remainder separately: the full file-picker UX is delivered here, and the one discoverability refinement — the import panel currently lives in the **LoRAs** tab's import area (the pre-existing scaffold home), whereas a *base checkpoint* is an image model users would look for under **Image Models** — is filed as **sc-14069** (chore, relates to sc-14020, under epic 14015).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
