### PR TITLE
chore(docker): remove retired Python hf CLI from both runtime worker images [sc-13604]

### DIFF
--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -54,10 +54,10 @@ sha2 = "0.10"
 # buffered whole in RAM (F-129, sc-8931). Already in the workspace lock (0.3.x), so no
 # new locked version is pulled; `alloc` is needed for the stream combinators.
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-# Confine the API sidecar (and its whole descendant tree — the `hf` download CLI and the
-# `python.exe` it forks) to a kill-on-close Job Object, so no orphan can outlive the
-# desktop and pin the API's listening port on the next launch (sc-11946). Already in the
-# workspace lock (pulled transitively by tauri), so no new locked version is added.
+# Confine the API sidecar (and any child processes it spawns) to a kill-on-close Job
+# Object, so no orphan can outlive the desktop and pin the API's listening port on the
+# next launch (sc-11946). Already in the workspace lock (pulled transitively by tauri),
+# so no new locked version is added.
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [lints.rust]

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -634,9 +634,9 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         .spawn()
         .map_err(|error| format!("spawn api: {error}"))?;
     record_api_pid(app, child.pid());
-    // sc-11946: confine the API sidecar (and every process it later spawns — notably the `hf`
-    // download CLI and the `python.exe` its shim forks) to a kill-on-close Job Object, so the
-    // whole subtree dies with the desktop and no orphan can pin the API port on the next launch.
+    // sc-11946: confine the API sidecar (and every process it later spawns) to a kill-on-close
+    // Job Object, so the whole subtree dies with the desktop and no orphan can pin the API port
+    // on the next launch.
     #[cfg(windows)]
     sidecar_job::confine(child.pid());
     app.state::<Managed>()
@@ -1309,16 +1309,14 @@ fn record_api_pid(app: &AppHandle, pid: u32) {
 
 /// Windows sidecar-tree containment (sc-11946).
 ///
-/// The API sidecar shells out to the `hf` CLI for whole-repo model downloads, and that
-/// `hf.exe` pip shim in turn forks a `python.exe` (`huggingface_hub`). If the desktop dies
-/// without cleanly reaping that subtree — a clean API self-exit orphans it, and a force-quit
-/// races the `taskkill /T` walk — the orphaned child keeps the API's listening socket handle
-/// it inherited, pinning the port so the next launch fails to bind ("local API stopped
-/// unexpectedly" / AddrInUse).
+/// The API sidecar can spawn child processes. If the desktop dies without cleanly reaping
+/// that subtree — a clean API self-exit orphans it, and a force-quit races the `taskkill /T`
+/// walk — an orphaned child keeps the API's listening socket handle it inherited, pinning the
+/// port so the next launch fails to bind ("local API stopped unexpectedly" / AddrInUse).
 ///
 /// We create ONE process-lifetime Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and
 /// assign the API sidecar to it. Descendants a job member spawns join the job automatically
-/// (nested jobs, Win8+), so the whole `api → hf.exe → python.exe` tree is in it. When the
+/// (nested jobs, Win8+), so the whole API subtree is in it. When the
 /// desktop process ends for ANY reason — graceful exit, panic, or hard kill — the OS closes
 /// our handle and terminates every process still in the job. Nothing can be orphaned. This is
 /// the OS-enforced backstop the pidfile `taskkill /T` reaping ([`kill_pid`]) can't guarantee

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -79,15 +79,13 @@ CMD ["sceneworks-rust-api"]
 # --- Rust worker runtime ------------------------------------------------------
 FROM debian:bookworm-slim AS rust-worker
 
+# ffmpeg: candle video lanes encode mp4. No Python here: model downloads are the
+# native in-process `ensure_hf_files_cached` path (sc-12227 / sc-12232), so the
+# retired `huggingface_hub[cli]` venv is gone — keeping this image Python-free
+# (epic 3482). Don't re-add the hf CLI; it would bypass the native download watchdog.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates ffmpeg python3 python3-venv \
+    && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
     && rm -rf /var/lib/apt/lists/*
-
-RUN python3 -m venv /opt/hf-cli \
-    && /opt/hf-cli/bin/pip install --no-cache-dir --upgrade pip \
-    && /opt/hf-cli/bin/pip install --no-cache-dir "huggingface_hub[cli]>=0.36,<1"
-
-ENV PATH="/opt/hf-cli/bin:${PATH}"
 
 COPY --from=builder /out/sceneworks-rust-worker /usr/local/bin/sceneworks-rust-worker
 
@@ -184,8 +182,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # no Python) — its older-glibc binary runs fine on 24.04 (glibc is backward-compatible).
 FROM nvidia/cuda:12.9.1-runtime-ubuntu24.04 AS rust-worker-candle
 ENV DEBIAN_FRONTEND=noninteractive
-# ffmpeg: candle video lanes encode mp4. python3/venv: stage onnxruntime-gpu + the hf
-# CLI for model downloads. libgomp1: onnxruntime's OpenMP runtime.
+# ffmpeg: candle video lanes encode mp4. python3/venv: stage onnxruntime-gpu (model
+# downloads are the native in-process path, no hf CLI — sc-12227 / sc-12232).
+# libgomp1: onnxruntime's OpenMP runtime.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates curl ffmpeg python3 python3-venv libgomp1 \
@@ -195,7 +194,7 @@ RUN apt-get update \
 # base doesn't ship — cuDNN-9 (incl. lazily-loaded sub-engines), cuFFT, nvJitLink,
 # nvRTC. onnxruntime-gpu does NOT declare these as hard deps, so request them
 # explicitly (sc-6209). 1.26.0 matches the `ort` crate rc.12 (ORT API 24); validated
-# on RTX PRO 6000 with cuDNN-cu12 9.23. Also installs the hf CLI for downloads.
+# on RTX PRO 6000 with cuDNN-cu12 9.23.
 ENV ORT_PY_SITE=/opt/ort/lib/python3.12/site-packages
 ARG ONNXRUNTIME_GPU_VERSION=1.26.0
 RUN python3 -m venv /opt/ort \
@@ -203,7 +202,6 @@ RUN python3 -m venv /opt/ort \
     && /opt/ort/bin/pip install --no-cache-dir \
         "onnxruntime-gpu==${ONNXRUNTIME_GPU_VERSION}" \
         nvidia-cudnn-cu12 nvidia-cufft-cu12 nvidia-nvjitlink-cu12 nvidia-cuda-nvrtc-cu12 \
-        "huggingface_hub[cli]>=0.36,<1" \
     && ORT_SO="$(ls ${ORT_PY_SITE}/onnxruntime/capi/libonnxruntime.so* | head -1)" \
     && test -n "${ORT_SO}" \
     && ln -sf "${ORT_SO}" "${ORT_PY_SITE}/onnxruntime/capi/libonnxruntime.so"


### PR DESCRIPTION
## Summary

F-035 (dead-code). Both worker images still installed `huggingface_hub[cli]` in a venv, but the worker retired the `hf` CLI subprocess download path in **sc-12227 / sc-12232** (issue #1554). Downloads now go through the native in-process `ensure_hf_files_cached` path. This removes the dead venv from both images — ~100+MB of dead layers per image, restores the plain `rust-worker` image to Python-free (epic 3482), and closes a stale escape hatch that would bypass the native download watchdog if re-invoked.

## Proof the hf CLI is dead (no live caller)

- `grep -rn 'Command::new("hf")'` across the repo: **zero hits**. No subprocess spawns `hf`/`huggingface-cli` anywhere (confirmed no `Command::new(` in `model_jobs.rs`).
- The only live install of `huggingface_hub[cli]` in the repo was in `docker/rust.Dockerfile` (the two stages this PR touches).
- Every other `hf download` / `huggingface-cli` occurrence is a **developer-facing doc-comment or smoke-test panic/skip hint** (e.g. `sana_mlx_smoke.rs`, `mochi_mlx_smoke.rs`, `*_tier_build.rs`) telling a dev how to manually pull models — not a runtime invocation.
- The retirement is documented in-code at `crates/sceneworks-worker/src/model_jobs.rs` (the `ensure_hf_files_cached` doc block): *"Replaces the retired Python `hf`/`huggingface-cli` path (sc-12227 / sc-12232, issue #1554)"* — the native path has real byte-level progress, the sc-11939 stall watchdog, HTTP-Range resume, and honors a custom `huggingface_base_url` the CLI could not.
- **`python3`-only-for-hf confirmation (rust-worker stage):** the plain `rust-worker` stage's only Python consumer was the `/opt/hf-cli` venv. It copies just the built binary and runs it — no entrypoint/scripts use Python; `ffmpeg` is a native package. So `python3 + python3-venv` existed solely for the hf CLI.

## What changed

**`rust-worker` stage** (`docker/rust.Dockerfile`)
- Removed `python3` + `python3-venv` from the apt install (kept `ca-certificates`, `ffmpeg`).
- Removed the `/opt/hf-cli` venv creation + `huggingface_hub[cli]` pip install.
- Removed the now-dead `ENV PATH="/opt/hf-cli/bin:${PATH}"`.
- Added a short comment noting downloads are native + a "don't re-add the hf CLI" warning.

**`rust-worker-candle` stage**
- Removed `"huggingface_hub[cli]>=0.36,<1"` from the `/opt/ort` pip install line.
- **Kept** the venv, `onnxruntime-gpu`, and the pinned nvidia wheels (cuDNN/cuFFT/nvJitLink/nvRTC) — the venv is still needed for onnxruntime-gpu; a separate story pins those wheels.
- Updated two stale comments that said the venv also stages "the hf CLI for downloads".

**Stale comment cleanup (desktop — comments only, no logic change)**
- `apps/desktop/Cargo.toml`: `windows-sys` note no longer claims the confined descendant tree is "the `hf` download CLI and the `python.exe` it forks".
- `apps/desktop/src/setup.rs`: the `sidecar_job::confine` call-site comment and the `sidecar_job` module doc no longer describe an `api → hf.exe → python.exe` subtree. The Windows Job Object containment (sc-11946) is unchanged — it still confines the API sidecar and any descendants.

**Dead PATH/ENV cleanup:** the `/opt/hf-cli/bin` PATH prepend was the only dangling env; removed. The candle stage's `PATH="/opt/ort/bin:${PATH}"` is retained (still points at the live onnxruntime venv).

## Validation

- `cargo fmt --all --check`: clean (CI parity runs `--all --check`).
- `cargo check -p sceneworks-desktop`: **Finished** — the comment-only Rust edits compile. (Required temporarily staging a gitignored placeholder sidecar + `resources` glob dirs for tauri's build.rs; none committed.)
- `hadolint`: not installed in this environment; RUN/pip multi-line syntax sanity-checked by eye (the candle `pip install` continuation stays valid — the nvidia-wheels line still flows into `&& ORT_SO=…`).
- **The Docker image build itself is a CI/registry concern** — it needs a CUDA base + GPU toolchain and is not run here.

## Scope

All F-035 acceptance items done: rust-worker removal, candle `huggingface_hub[cli]` removal (venv kept), desktop comment updates, dead PATH/ENV cleanup.

No pre-existing unrelated issues found beyond the known bare-worktree desktop-staging gap (missing `binaries/` + `resources` dirs), which is environmental, not a regression.

Story: https://app.shortcut.com/trefry/story/13604

🤖 Generated with [Claude Code](https://claude.com/claude-code)