### PR TITLE
feat(worker): assemble imported single-file Krea 2 checkpoints on MLX [sc-14018]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "core-llm",
  "half",
@@ -4567,7 +4567,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5922,7 +5922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5979,7 +5979,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=235ca214ffb65a4c115a9e3cfedb62436546c70f#235ca214ffb65a4c115a9e3cfedb62436546c70f"
+source = "git+https://github.com/SceneWorks/inference?rev=f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1#f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -7323,7 +7323,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8480,7 +8480,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1" }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "235ca214ffb65a4c115a9e3cfedb62436546c70f", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "f7c1780c5f5f5f7a66ca7c77bb4229b4cd3f06c1", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -475,6 +475,21 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::KreaImported => {
+                // Imported/user single-file Krea 2 checkpoint (epic 14015 S0c, sc-14018): pair the
+                // imported DiT with a resident `krea_2` base tier (shared TE/VAE/tokenizer) and load via
+                // the S0b MLX native single-file entrypoint. txt2img, `count` renders each its own seed.
+                generate_krea_imported_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::InstantId => {
                 // InstantID identity-preserving character image (sc-3345): single identity or
                 // grouped angle/pose sets, on RealVisXL + IdentityNet + the native face stack.
@@ -1721,6 +1736,11 @@ include!("image_jobs/krea_multiphase.rs");
 #[cfg(target_os = "macos")]
 // Krea 2 pose-ControlNet (MLX) strict-pose routing (sc-8465, epic 8459 S5).
 include!("image_jobs/krea_control.rs");
+#[cfg(target_os = "macos")]
+// Imported single-file Krea 2 checkpoint routing (epic 14015 S0c, sc-14018): a user-imported `krea_2`-
+// family DiT single file → paired with a resident `krea_2` base tier (shared TE/VAE/tokenizer) and loaded
+// via the S0b MLX native single-file entrypoint, bypassing the registry snapshot-dir path.
+include!("image_jobs/krea_imported.rs");
 #[cfg(target_os = "macos")]
 // SenseNova edit routing.
 include!("image_jobs/sensenova.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -105,6 +105,14 @@ enum ImageRoute {
     /// keys on that descriptor id), unlike S3 which swaps to `krea_2_turbo`. Reference/edit/pose/PiD
     /// shapes are rejected loudly by the lane (multi-phase renders from pure noise).
     KreaMultiPhase,
+    /// An imported/user single-file Krea 2 checkpoint (epic 14015 S0c, sc-14018): a non-builtin
+    /// `krea_2`-family model whose `modelPath` is a single `.safetensors` DiT → the bespoke in-place
+    /// assembly lane, which pairs the imported transformer with a resident `krea_2` base tier (shared
+    /// Qwen3-VL TE / Qwen VAE / tokenizer) and loads via the S0b MLX native single-file entrypoint. A
+    /// builtin Krea id (`krea_2_turbo` / `krea_2_raw`, in `MODEL_TABLE`) never reaches here —
+    /// `resolve_imported_krea_dit` returns `None` for it, so the snapshot-dir Krea path is untouched.
+    /// txt2img only (a bare imported DiT carries no conditioning components).
+    KreaImported,
     InstantId,
     PulidFlux,
     SdxlAdvanced,
@@ -209,6 +217,14 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         // additive) — turbo-on-Raw img2img is out of scope for this t2i story (sc-13883). The t2i
         // sibling of the `krea_edit_available` arm above.
         Some(ImageRoute::KreaTurboOnRaw)
+    } else if krea_imported_available(request, settings) {
+        // An imported/user single-file Krea 2 checkpoint (epic 14015 S0c, sc-14018): a non-builtin
+        // `krea_2`-family model whose `modelPath` is a single `.safetensors` DiT → the bespoke in-place
+        // assembly lane. A builtin Krea id never claims this (`resolve_imported_krea_dit` returns `None`
+        // for a `MODEL_TABLE` id), so the generic `mlx_available` snapshot-dir arm below is unchanged for
+        // builtin Krea. The imported id is in no `MODEL_TABLE`, so `mlx_available` is `false` for it — this
+        // arm is what routes it to real MLX generation at all (S0d marked it Mac-routable; this loads it).
+        Some(ImageRoute::KreaImported)
     } else if instantid_available(request, settings) {
         Some(ImageRoute::InstantId)
     } else if pulid_flux_available(request, settings) {
@@ -288,6 +304,9 @@ impl ImageRoute {
             // Multi-phase (S4) is likewise plain per-image: `count` renders, each its own seed, driven
             // through the phase plan. No angle/pose grouping.
             | ImageRoute::KreaMultiPhase
+            // Imported single-file Krea 2 (S0c) is plain per-image txt2img: `count` renders, each its own
+            // seed. No angle/pose grouping (a bare imported DiT carries no conditioning).
+            | ImageRoute::KreaImported
             | ImageRoute::PoseControlBaseMissing
             | ImageRoute::PoseReject
             | ImageRoute::Mlx => request.count,

--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -1,0 +1,343 @@
+// macOS (MLX) in-place imported single-file Krea 2 checkpoint txt2img route (epic 14015 S0c, sc-14018).
+// Renders a user-imported COMMUNITY checkpoint that is the Krea 2 **transformer only** (a bare DiT
+// single file, e.g. a ComfyUI-exported `kreamania_variant5.safetensors`) — read in place, no copy, no
+// re-download — by pairing it with a resident `krea_2` base tier that supplies the shared Qwen3-VL text
+// encoder, Qwen VAE, tokenizer, and the DiT architecture config the single file omits. The assembly is
+// the S0b MLX entrypoint `runtime_macos::providers::krea::load_from_native_dit_file(dit, base, descriptor)`
+// — the sc-10670/10671 "read the DiT in place, source shared components from a resident tier" pattern, and
+// the MLX twin of the candle z-image `load_from_comfyui_components` lane (`zimage_comfyui_candle.rs`).
+//
+// **macOS-only**, and a **bespoke provider**: the loaded generator is not registry-resolvable (its
+// transformer is a single in-place file, not a diffusers snapshot dir), so it bypasses the registry
+// snapshot-dir descriptor path and is loaded fresh per job through `start_gen_stream` rather than the
+// cached registry path — like the z-image comfyui / Wan comfyui in-place lanes. This file is `include!`d
+// into the `image_jobs` module, sharing its imports.
+//
+// Routing (S0d, sc-14019) already marks an imported/user image model whose declared `family` is `krea_2`
+// as MLX-routable; this lane is what actually loads it. A builtin Krea model (`krea_2_turbo` /
+// `krea_2_raw`, both in `MODEL_TABLE`) resolves through `mlx_model` and loads from its snapshot turnkey —
+// `resolve_imported_krea_dit` returns `None` for it, so the existing snapshot-dir Krea path is untouched.
+//
+// Scope (S0c): dense bf16 single-file DiT, txt2img only (the imported checkpoint is a bare transformer,
+// so pose / reference / edit conditioning is deliberately NOT claimed here — S0d did not claim those
+// features for imported models either). The 26 GB load + render is validated on GPU in S0f.
+
+/// The adapter/engine id recorded on imported-Krea assets + telemetry (distinct from the registry
+/// `krea_2_turbo` / `krea_2_raw` builtins and their bespoke edit/control/multi-phase lanes).
+#[cfg(target_os = "macos")]
+const KREA_IMPORTED_ENGINE: &str = "mlx_krea_imported";
+/// The base tier whose shared Qwen3-VL text encoder + Qwen VAE + tokenizer + DiT architecture config the
+/// imported single-file transformer is paired with. The Turbo turnkey (`SceneWorks/krea-2-turbo-mlx`,
+/// sc-7573) is the default base — its published Krea 2 architecture matches the community merges, and its
+/// `bf16/` tier ships DENSE TE/VAE that pair correctly with the imported dense bf16 DiT. NOT configurable:
+/// the single fixed default keeps the assembly deterministic (a per-request base override is a follow-up
+/// if a Raw-base community checkpoint ever needs a different shared surface).
+#[cfg(target_os = "macos")]
+const KREA_IMPORTED_BASE_REPO: &str = "SceneWorks/krea-2-turbo-mlx";
+/// The dense `bf16/` subdir of [`KREA_IMPORTED_BASE_REPO`] — the DENSE TE/VAE tier (the `q4/`/`q8/` tiers
+/// ship a packed transformer, but their TE/VAE would not pair with a dense imported DiT). Same `bf16/`
+/// surface the candle INT8-ConvRot base uses (`resolve_krea_convrot`).
+#[cfg(target_os = "macos")]
+const KREA_IMPORTED_BASE_TIER: &str = "bf16";
+/// Denoise-steps fallback — the Krea 2 Turbo distilled default (the imported community merges are
+/// distilled-Turbo dense merges, like variant5). The UI normally supplies `advanced.steps`; this only
+/// applies when it does not.
+#[cfg(target_os = "macos")]
+const KREA_IMPORTED_DEFAULT_STEPS: u32 = 8;
+
+/// A single-file checkpoint is one on-disk `.safetensors` FILE (the imported transformer), as opposed to
+/// a diffusers snapshot DIRECTORY (a builtin turnkey tier). This is the single-file-vs-snapshot-dir
+/// decision at the heart of S0c: a `true` here routes to the native single-file entrypoint; a directory
+/// (`false`) keeps the registry snapshot-dir path. Pure (no settings / confinement), unit-testable alone.
+#[cfg(target_os = "macos")]
+fn is_single_file_checkpoint(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("safetensors"))
+}
+
+/// A diffusers snapshot / turnkey tier directory — a `model_index.json` / `config.json` pipeline marker
+/// or a `transformer/` component subtree. Such a dir is a SNAPSHOT (the registry path), never a
+/// single-file import, so it is excluded from the native entrypoint even when it also holds loose
+/// `.safetensors` shards.
+#[cfg(target_os = "macos")]
+fn is_diffusers_snapshot_dir(dir: &Path) -> bool {
+    dir.join("model_index.json").is_file()
+        || dir.join("config.json").is_file()
+        || dir.join("transformer").is_dir()
+}
+
+/// The single-file DiT to load from a resolved weights location: the path itself when it is a single
+/// `.safetensors` FILE, or the LONE top-level `.safetensors` inside a single-file install DIRECTORY (the
+/// model-import job writes the imported checkpoint plus an install marker into
+/// `<data>/models/imports/<name>/`, so the checkpoint is the one weight file there). `None` for a
+/// diffusers snapshot dir (a builtin turnkey tier — [`is_diffusers_snapshot_dir`]), a dir with zero or
+/// more than one top-level `.safetensors`, or a non-safetensors file — those are not a single-file import.
+#[cfg(target_os = "macos")]
+fn imported_dit_file(path: &Path) -> Option<PathBuf> {
+    if is_single_file_checkpoint(path) {
+        return Some(path.to_path_buf());
+    }
+    if !path.is_dir() || is_diffusers_snapshot_dir(path) {
+        return None;
+    }
+    let mut found: Option<PathBuf> = None;
+    for entry in std::fs::read_dir(path).ok()?.flatten() {
+        let candidate = entry.path();
+        if is_single_file_checkpoint(&candidate) {
+            if found.is_some() {
+                // More than one loose weight file → not the single-file shape the S0b loader takes.
+                return None;
+            }
+            found = Some(candidate);
+        }
+    }
+    found
+}
+
+/// Resolve the imported single-file Krea 2 DiT for `request`, or `None` when this is not an imported
+/// single-file Krea job. `Some(file)` only when ALL hold:
+///   - the model's declared `family` is `krea_2` (the S0d route-by-family family),
+///   - the id is NOT a builtin engine model (`mlx_model` is `None`) — a builtin Krea loads from its
+///     snapshot turnkey, never a single file, so this keeps the existing snapshot-dir path untouched,
+///   - the model's weights location — an explicit `modelPath` (advanced or manifest) wins, else the
+///     manifest entry's `paths.model` install dir the model-import job records — resolves, confined to
+///     an app-managed root, to a single `.safetensors` DiT ([`imported_dit_file`]): the file directly,
+///     or the lone weight file inside its single-file install dir, but NOT a diffusers snapshot dir.
+///
+/// Each path is confined by `normalize_app_managed_model_path` (a payload can never point the checkpoint
+/// outside a declared root; LAN jobs API, epic 4484) — the same confinement `resolve_weights_dir` uses.
+#[cfg(target_os = "macos")]
+fn resolve_imported_krea_dit(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if request
+        .model_manifest_entry
+        .get("family")
+        .and_then(Value::as_str)
+        != Some("krea_2")
+    {
+        return Ok(None);
+    }
+    // A builtin Krea engine id (in `MODEL_TABLE`) loads from its snapshot turnkey via the normal MLX
+    // lane — never through the single-file entrypoint. Leaving those to the existing path is what keeps
+    // builtin Krea rendering byte-identical (S0c requirement #3).
+    if mlx_model(&request.model).is_some() {
+        return Ok(None);
+    }
+    // An explicit `modelPath` (a future assembler could pin the file directly) wins; otherwise the
+    // import job's recorded install dir (`paths.model`), which holds the single-file checkpoint.
+    let Some(raw_path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .or_else(|| {
+            request
+                .model_manifest_entry
+                .get("paths")
+                .and_then(|paths| paths.get("model"))
+        })
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    let path = crate::paths::normalize_app_managed_model_path(
+        settings,
+        raw_path,
+        "Imported Krea 2 checkpoint",
+    )?;
+    Ok(imported_dit_file(&path))
+}
+
+/// Resolve the resident `krea_2` base tier snapshot dir that supplies the shared text encoder, VAE,
+/// tokenizer, and DiT architecture config the imported single-file transformer omits — the `base_snapshot_dir`
+/// argument of the S0b entrypoint. The default base is the Turbo turnkey's dense `bf16/` tier
+/// ([`KREA_IMPORTED_BASE_REPO`] / [`KREA_IMPORTED_BASE_TIER`]), resolved from the HF cache via the shared
+/// repo→cache-path helper. REQUIRES it installed and complete (`transformer/config.json` for the arch
+/// config, plus `text_encoder/ vae/ tokenizer/`); a clear typed error otherwise so the user knows to
+/// install the Krea 2 base first, rather than a raw mid-load "No such file or directory".
+#[cfg(target_os = "macos")]
+fn resolve_krea_imported_base_tier(settings: &Settings) -> WorkerResult<PathBuf> {
+    let base_missing = || {
+        WorkerError::InvalidPayload(
+            "Krea 2 base model is not installed — install the Krea 2 (Turbo) base model first. An \
+             imported Krea 2 checkpoint is the transformer only; it is paired with the base model's \
+             text encoder, VAE, and tokenizer to run."
+                .to_owned(),
+        )
+    };
+    let base = huggingface_snapshot_dir(&settings.data_dir, KREA_IMPORTED_BASE_REPO)
+        .map(|root| root.join(KREA_IMPORTED_BASE_TIER))
+        .filter(|dir| krea_imported_base_tier_complete(dir))
+        .ok_or_else(base_missing)?;
+    Ok(base)
+}
+
+/// The base tier is loadable when it carries the shared components the single-file DiT pairs with: the
+/// transformer's `config.json` (the arch config `Krea2Config::from_snapshot` reads — the WEIGHTS are the
+/// imported file, not this tier's), plus the `text_encoder/ vae/ tokenizer/` component trees.
+#[cfg(target_os = "macos")]
+fn krea_imported_base_tier_complete(dir: &Path) -> bool {
+    dir.join("transformer").join("config.json").is_file()
+        && dir.join("text_encoder").is_dir()
+        && dir.join("vae").is_dir()
+        && dir.join("tokenizer").is_dir()
+}
+
+/// True when this is an in-place imported single-file Krea 2 **txt2img** job: an imported `krea_2`-family
+/// model whose `modelPath` resolves to a single `.safetensors` DiT, with no edit / pose / reference
+/// (the imported checkpoint is a bare transformer — those conditioning modes need base-tier components
+/// this lane does not stage). Deliberately does NOT gate on base-tier presence: a missing base surfaces
+/// as the loud [`resolve_krea_imported_base_tier`] error in the handler rather than a silent fall-through
+/// to the stub. Mirrors the shape of the other `…_available` predicates.
+#[cfg(target_os = "macos")]
+fn krea_imported_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.mode != "edit_image"
+        && pose_entries(request).is_empty()
+        && request.reference_asset_id.is_none()
+        && request.reference_asset_ids.is_empty()
+        && request.source_asset_id.is_none()
+        && matches!(resolve_imported_krea_dit(request, settings), Ok(Some(_)))
+}
+
+/// Flat telemetry recorded on imported-Krea assets. No guidance — the imported distilled-Turbo merges
+/// are CFG-free (the Turbo descriptor advertises `supports_guidance=false`).
+#[cfg(target_os = "macos")]
+fn krea_imported_raw_settings(request: &ImageRequest, steps: u32) -> JsonObject {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw.insert("mode".to_owned(), Value::String("text_to_image".to_owned()));
+    raw.insert(
+        "engine".to_owned(),
+        Value::String(KREA_IMPORTED_ENGINE.to_owned()),
+    );
+    raw.insert(
+        "importedCheckpoint".to_owned(),
+        Value::String(request.model.clone()),
+    );
+    raw.insert(
+        "kreaImportedBase".to_owned(),
+        Value::String(format!("{KREA_IMPORTED_BASE_REPO}#{KREA_IMPORTED_BASE_TIER}")),
+    );
+    raw
+}
+
+/// Real MLX in-place imported single-file Krea 2 txt2img generation (epic 14015 S0c): resolve the
+/// imported DiT + the resident base tier on the async side, then load the S0b native entrypoint once +
+/// generate each image on the blocking thread. `request.count` images, each its own seed. The imported
+/// merge is distilled Turbo (no CFG / negative prompt). The loaded `Box<dyn Generator>` is bespoke (not
+/// registry-cached), driven like the z-image comfyui lane.
+#[cfg(target_os = "macos")]
+async fn generate_krea_imported_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let dit = resolve_imported_krea_dit(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Imported Krea 2 checkpoint could not be resolved (family/modelPath/single-file)"
+                .to_owned(),
+        )
+    })?;
+    // Require the resident base tier before any compute — a clear "install the Krea 2 base first" error.
+    let base_dir = resolve_krea_imported_base_tier(settings)?;
+
+    let (width, height) = (request.width, request.height);
+    let steps =
+        resolve_advanced_or_manifest_u32(request, "steps", KREA_IMPORTED_DEFAULT_STEPS, 1..=100);
+    let raw_settings = krea_imported_raw_settings(request, steps);
+
+    // Per-image work items: (seed, prompt) — `request.count` renders, each its own seed.
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        KREA_IMPORTED_ENGINE,
+        0,
+        move || {
+            // Turbo descriptor (`variant5` and its siblings are distilled-Turbo dense merges). The S0b
+            // entrypoint reads the DiT from the single file, key-remaps native→diffusers, coverage/
+            // shape-validates it against the base tier's Krea 2 geometry (fail-closed — the
+            // architecture-compatibility check happens here, before pairing), and sources the shared
+            // TE/VAE/tokenizer from `base_dir`.
+            let descriptor = runtime_macos::providers::krea::descriptor();
+            let model = runtime_macos::providers::krea::load_from_native_dit_file(
+                &dit, &base_dir, descriptor,
+            )
+            .map_err(|error| {
+                WorkerError::Engine(format!("Krea 2 imported checkpoint load failed: {error}"))
+            })?;
+            Ok(model)
+        },
+        move |model, tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let request = GenerationRequest {
+                    prompt,
+                    width,
+                    height,
+                    count: 1,
+                    seed: Some(seed as u64),
+                    steps: Some(steps),
+                    cancel: cancel.clone(),
+                    ..Default::default()
+                };
+                let output = match model.generate(&request, &mut *on_progress) {
+                    Ok(output) => output,
+                    Err(_) if cancel.is_cancelled() => return Ok(None),
+                    Err(error) => {
+                        return Err(WorkerError::Engine(format!(
+                            "Krea 2 imported checkpoint generation failed: {error}"
+                        )));
+                    }
+                };
+                match output {
+                    GenerationOutput::Images(mut images) => {
+                        let image = images.pop().ok_or_else(|| {
+                            WorkerError::Engine(
+                                "Krea 2 imported checkpoint produced no image".to_owned(),
+                            )
+                        })?;
+                        Ok(Some((seed, image.width, image.height, image.pixels)))
+                    }
+                    _ => Err(WorkerError::Engine(
+                        "Krea 2 imported checkpoint returned non-image output".to_owned(),
+                    )),
+                }
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        KREA_IMPORTED_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -10430,3 +10430,279 @@ fn resolve_krea_control_base_descends_turnkey_root_into_tier_with_tokenizer() {
         "resolved base must carry the tokenizer whose absence produced the sc-11853 load failure"
     );
 }
+
+// ---- Imported single-file Krea 2 checkpoint assembly (epic 14015 S0c, sc-14018) -----------------
+
+/// The single-file-vs-snapshot-dir decision at the heart of S0c: a `.safetensors` FILE is a single-file
+/// checkpoint (→ the native entrypoint); a directory (a snapshot tier) is not (→ the registry snapshot
+/// path). A non-safetensors file (e.g. a `.ckpt`) is likewise not one — the S0b/S0a lane is safetensors.
+#[cfg(target_os = "macos")]
+#[test]
+fn is_single_file_checkpoint_distinguishes_file_from_snapshot_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("kreamania.safetensors");
+    std::fs::write(&file, b"x").unwrap();
+    let snapshot = dir.path().join("bf16");
+    std::fs::create_dir_all(&snapshot).unwrap();
+    let other = dir.path().join("model.ckpt");
+    std::fs::write(&other, b"x").unwrap();
+
+    assert!(
+        is_single_file_checkpoint(&file),
+        "a .safetensors file is a single-file checkpoint (takes the native entrypoint)"
+    );
+    assert!(
+        !is_single_file_checkpoint(&snapshot),
+        "a snapshot directory is NOT a single-file checkpoint (takes the registry snapshot path)"
+    );
+    assert!(
+        !is_single_file_checkpoint(&other),
+        "a non-safetensors file is not a single-file checkpoint"
+    );
+    assert!(
+        !is_single_file_checkpoint(&dir.path().join("does-not-exist.safetensors")),
+        "an absent path is not a single-file checkpoint"
+    );
+}
+
+/// Seed an app-managed imported model file under `<data_dir>/models/…` and return a Settings pinned to
+/// that data dir. The confinement (`normalize_app_managed_model_path`) admits `<data_dir>` roots.
+#[cfg(target_os = "macos")]
+fn imported_krea_settings_with_file(dir: &std::path::Path) -> (Settings, PathBuf) {
+    let file = dir
+        .join("models")
+        .join("imported-krea")
+        .join("kreamania_variant5.safetensors");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, b"dit").unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.to_path_buf();
+    (settings, file)
+}
+
+/// `resolve_imported_krea_dit` returns the imported DiT only for a non-builtin `krea_2`-family model
+/// whose `modelPath` is a single `.safetensors` file — and returns `None` (leaving the existing
+/// snapshot-dir path untouched) for a builtin Krea id, a wrong family, or a directory `modelPath`.
+#[cfg(target_os = "macos")]
+#[test]
+fn resolve_imported_krea_dit_claims_only_non_builtin_single_file_krea2() {
+    let dir = tempfile::tempdir().unwrap();
+    let (settings, file) = imported_krea_settings_with_file(dir.path());
+    let path_str = file.to_str().unwrap();
+
+    // Imported (non-builtin) krea_2 with a single-file modelPath → Some(file).
+    let imported = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "modelManifestEntry": { "family": "krea_2", "modelPath": path_str }
+    }));
+    let resolved = resolve_imported_krea_dit(&imported, &settings)
+        .expect("resolve ok")
+        .expect("imported single-file krea2 resolves its DiT");
+    assert_eq!(
+        resolved,
+        std::fs::canonicalize(&file).unwrap_or(file.clone())
+    );
+
+    // A builtin Krea id (in MODEL_TABLE, mlx_model Some) with the SAME single-file modelPath → None:
+    // builtins keep loading from their snapshot turnkey, the S0c "snapshot path untouched" requirement.
+    assert!(
+        mlx_model("krea_2_turbo").is_some(),
+        "precondition: krea_2_turbo is a builtin engine on macOS"
+    );
+    let builtin = request(json!({
+        "projectId": "p", "model": "krea_2_turbo",
+        "modelManifestEntry": { "family": "krea_2", "modelPath": path_str }
+    }));
+    assert_eq!(
+        resolve_imported_krea_dit(&builtin, &settings).expect("resolve ok"),
+        None,
+        "a builtin Krea id must NOT take the single-file path"
+    );
+
+    // Wrong family → None.
+    let wrong_family = request(json!({
+        "projectId": "p", "model": "some_import",
+        "modelManifestEntry": { "family": "z-image", "modelPath": path_str }
+    }));
+    assert_eq!(
+        resolve_imported_krea_dit(&wrong_family, &settings).expect("resolve ok"),
+        None,
+        "a non-krea_2 family is not an imported Krea job"
+    );
+
+    // The REAL production shape: no explicit `modelPath`, only the import job's `paths.model` install
+    // dir (holding the single .safetensors checkpoint) → resolves to that lone weight file.
+    let install_dir = file.parent().unwrap();
+    let via_install_dir = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "modelManifestEntry": {
+            "family": "krea_2",
+            "paths": { "model": install_dir.to_str().unwrap() }
+        }
+    }));
+    assert_eq!(
+        resolve_imported_krea_dit(&via_install_dir, &settings)
+            .expect("resolve ok")
+            .expect("install-dir single-file import resolves its DiT"),
+        std::fs::canonicalize(&file).unwrap_or(file.clone()),
+        "the lone .safetensors inside the recorded install dir is the imported DiT"
+    );
+
+    // A diffusers snapshot directory (a builtin turnkey tier: model_index.json marker) → None, even
+    // though a bare .safetensors also sits alongside — it takes the registry snapshot path, not this lane.
+    let snap_dir = dir.path().join("models").join("imported-krea").join("snap");
+    std::fs::create_dir_all(&snap_dir).unwrap();
+    std::fs::write(snap_dir.join("model_index.json"), b"{}").unwrap();
+    std::fs::write(snap_dir.join("stray.safetensors"), b"x").unwrap();
+    let dir_job = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "modelManifestEntry": { "family": "krea_2", "modelPath": snap_dir.to_str().unwrap() }
+    }));
+    assert_eq!(
+        resolve_imported_krea_dit(&dir_job, &settings).expect("resolve ok"),
+        None,
+        "a diffusers snapshot directory is not a single-file import"
+    );
+
+    // A dir with MORE THAN ONE loose weight file is not the single-file shape → None.
+    let multi_dir = dir
+        .path()
+        .join("models")
+        .join("imported-krea")
+        .join("multi");
+    std::fs::create_dir_all(&multi_dir).unwrap();
+    std::fs::write(multi_dir.join("a.safetensors"), b"x").unwrap();
+    std::fs::write(multi_dir.join("b.safetensors"), b"x").unwrap();
+    let multi_job = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "modelManifestEntry": { "family": "krea_2", "paths": { "model": multi_dir.to_str().unwrap() } }
+    }));
+    assert_eq!(
+        resolve_imported_krea_dit(&multi_job, &settings).expect("resolve ok"),
+        None,
+        "more than one loose weight file is not a single-file import"
+    );
+}
+
+/// `resolve_krea_imported_base_tier` requires the resident Krea 2 base and fails with a clear
+/// "install the Krea 2 base first" message when it is absent; when the `bf16/` tier is installed and
+/// complete (config + TE/VAE/tokenizer) it resolves that dir.
+#[cfg(target_os = "macos")]
+#[test]
+fn resolve_krea_imported_base_tier_requires_installed_base() {
+    let dir = tempfile::tempdir().unwrap();
+    let hub = dir.path().join("hub");
+    std::fs::create_dir_all(&hub).unwrap();
+    let _hf = isolate_hf_hub_cache_to(&hub);
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+
+    // Base absent → loud typed error.
+    let err = resolve_krea_imported_base_tier(&settings)
+        .expect_err("no base installed must be an error, not a silent fall-through");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("Krea 2 base model is not installed") && msg.contains("install the Krea 2"),
+        "error must direct the user to install the Krea 2 base first, got: {msg}"
+    );
+
+    // Seed a complete `SceneWorks/krea-2-turbo-mlx` bf16 base tier (arch config + shared components).
+    let snapshot = hub
+        .join("models--SceneWorks--krea-2-turbo-mlx")
+        .join("snapshots")
+        .join("rev0");
+    let bf16 = snapshot.join("bf16");
+    for sub in ["transformer", "text_encoder", "vae", "tokenizer"] {
+        std::fs::create_dir_all(bf16.join(sub)).unwrap();
+    }
+    std::fs::write(bf16.join("transformer").join("config.json"), b"{}").unwrap();
+    let refs = hub
+        .join("models--SceneWorks--krea-2-turbo-mlx")
+        .join("refs");
+    std::fs::create_dir_all(&refs).unwrap();
+    std::fs::write(refs.join("main"), b"rev0").unwrap();
+
+    let base = resolve_krea_imported_base_tier(&settings).expect("installed base resolves");
+    assert_eq!(
+        base, bf16,
+        "the resolved base is the dense bf16 tier of the Turbo turnkey"
+    );
+}
+
+/// End-to-end routing decision: a plain-t2i imported single-file Krea 2 job routes to the bespoke
+/// `KreaImported` in-place lane (the imported id is in no MODEL_TABLE, so the generic `mlx_available`
+/// snapshot arm would never claim it — this arm is what makes it MLX-generatable), while a directory
+/// `modelPath` (a snapshot) does not take that lane.
+#[cfg(target_os = "macos")]
+#[test]
+fn resolve_image_route_sends_imported_single_file_krea_to_the_bespoke_lane() {
+    let dir = tempfile::tempdir().unwrap();
+    let (settings, file) = imported_krea_settings_with_file(dir.path());
+
+    let imported = request(json!({
+        "projectId": "p", "model": "kreamania_variant5", "prompt": "a cat",
+        "modelManifestEntry": { "family": "krea_2", "modelPath": file.to_str().unwrap() }
+    }));
+    assert_eq!(
+        resolve_image_route(&imported, &settings),
+        Some(ImageRoute::KreaImported),
+        "an imported single-file krea_2 t2i job routes to the bespoke in-place assembly lane"
+    );
+    assert!(krea_imported_available(&imported, &settings));
+
+    // A directory modelPath (a snapshot) is not a single-file import → the imported lane does not claim
+    // it (and with an unknown id + no resolvable snapshot it is not otherwise MLX-routable).
+    let snap_dir = dir.path().join("models").join("imported-krea").join("snap");
+    std::fs::create_dir_all(&snap_dir).unwrap();
+    let dir_job = request(json!({
+        "projectId": "p", "model": "kreamania_variant5", "prompt": "a cat",
+        "modelManifestEntry": { "family": "krea_2", "modelPath": snap_dir.to_str().unwrap() }
+    }));
+    assert!(
+        !krea_imported_available(&dir_job, &settings),
+        "a snapshot-directory modelPath must not take the single-file import lane"
+    );
+    assert_ne!(
+        resolve_image_route(&dir_job, &settings),
+        Some(ImageRoute::KreaImported)
+    );
+}
+
+/// A pose / edit / reference shape on an imported Krea 2 model is NOT claimed by the txt2img import lane
+/// (a bare imported DiT carries no conditioning components) — the availability predicate stays t2i-only.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_imported_available_is_txt2img_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let (settings, file) = imported_krea_settings_with_file(dir.path());
+    let path_str = file.to_str().unwrap().to_owned();
+    let base = json!({ "family": "krea_2", "modelPath": path_str });
+
+    let with_pose = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "advanced": { "poses": [{ "id": "a" }] },
+        "modelManifestEntry": base.clone()
+    }));
+    assert!(
+        !krea_imported_available(&with_pose, &settings),
+        "pose job excluded"
+    );
+
+    let edit = request(json!({
+        "projectId": "p", "model": "kreamania_variant5", "mode": "edit_image",
+        "sourceAssetId": "s", "modelManifestEntry": base.clone()
+    }));
+    assert!(
+        !krea_imported_available(&edit, &settings),
+        "edit job excluded"
+    );
+
+    let reference = request(json!({
+        "projectId": "p", "model": "kreamania_variant5", "referenceAssetId": "r",
+        "modelManifestEntry": base
+    }));
+    assert!(
+        !krea_imported_available(&reference, &settings),
+        "reference/img2img job excluded (t2i only in S0c)"
+    );
+}


### PR DESCRIPTION
## S0c — DiT-only assembly: make an imported single-file Krea 2 checkpoint loadable on MLX

Story: [sc-14018](https://app.shortcut.com/trefry/story/14018) · Epic sc-14015 (Mac-first community-checkpoint import). Depends on S0b (merged in inference); blocks S0f.

An imported/user Krea 2 community checkpoint is the **transformer only** — a bare single-file DiT (e.g. a ComfyUI-exported `kreamania_variant5.safetensors`), not a diffusers snapshot dir. This wires the worker so such a file becomes loadable on MLX by pairing it with a resident `krea_2` base tier that supplies the shared Qwen3-VL text encoder, Qwen VAE, tokenizer, and DiT architecture config.

### 1. Inference pin bump (own commit)
`node scripts/bump-inference.mjs --sha f7c1780c…` moves `sceneworks-gen-core` / `runtime-macos` / `runtime-cuda` **and** the root `candle-kernels` `[patch]` in lockstep to `f7c1780c` (the S0b MLX single-file entrypoint), regenerates `Cargo.lock`, and passes the gen-core + mlx-rs skew check (one `sceneworks-gen-core`, one `pmetal-mlx-rs` resolution). Building `sceneworks-worker` against this pin is the real proof the entrypoint integrates.

### 2. The assembly seam
New bespoke MLX lane `crates/sceneworks-worker/src/image_jobs/krea_imported.rs` — the macOS twin of the candle z-image ComfyUI in-place lane (`zimage_comfyui_candle.rs`), loaded fresh per job via `start_gen_stream` (bypassing the registry snapshot-dir descriptor, as z-image's `load_from_comfyui_components` does):

- **`resolve_imported_krea_dit`** — the single-file-vs-snapshot-dir decision. Claims a **non-builtin** `krea_2`-family model whose weights location resolves, confined to an app-managed root, to a single `.safetensors` DiT: an explicit `modelPath` (a future assembler could pin the file), else the model-import job's recorded `paths.model` install dir — the file directly, or the lone weight file inside a single-file install dir, but **never** a diffusers snapshot dir. A builtin Krea id (`mlx_model` is `Some`) is excluded, so the existing snapshot-dir Krea path is byte-identical.
- **`resolve_krea_imported_base_tier`** — resolves the base tier (TE/VAE/tokenizer + arch config) from the HF cache via the existing repo→cache-path helper. **Default base: the Turbo turnkey `SceneWorks/krea-2-turbo-mlx`, dense `bf16/` tier** (dense TE/VAE pair correctly with the dense imported DiT). Not configurable — one fixed default. Requires it installed + complete; otherwise a clear typed error: *"Krea 2 base model is not installed — install the Krea 2 (Turbo) base model first…"*.
- **`generate_krea_imported_stream`** — loads via `runtime_macos::providers::krea::load_from_native_dit_file(dit, base_dir, descriptor())` (Turbo descriptor) and drives txt2img (`count` renders, each its own seed). The entrypoint coverage/shape-validates the DiT against krea_2 geometry before pairing (fail-closed — the architecture-compatibility check).

Routing: `ImageRoute::KreaImported` claims the plain-t2i imported single-file job before the generic MLX arm (the imported id is in no `MODEL_TABLE`, so `mlx_available` never claims it — this arm is what makes it MLX-generatable at all; S0d marked it Mac-routable, this loads it). Builtin Krea (`krea_2_turbo` / `krea_2_raw`) is untouched.

### Base-tier choice
Fixed to the Turbo base's dense `bf16/` tier (`SceneWorks/krea-2-turbo-mlx#bf16`). Not exposed as a per-request knob — kept deterministic. A per-request base override (e.g. a Raw-base community checkpoint) would be a follow-up.

### Tests (GPU-free)
- The single-file-vs-snapshot decision across every shape: bare `.safetensors` file, `paths.model` install dir with the lone weight file, diffusers snapshot dir (excluded), multi-weight dir (excluded), builtin id (excluded → snapshot path untouched), wrong family.
- Base-tier resolution + the missing-base error path.
- The `KreaImported` routing decision, and txt2img-only gating (pose / edit / reference excluded).

`cargo build -p sceneworks-worker` clean against the new pin. `cargo test -p sceneworks-worker --lib` (960 passed) and `cargo test -p sceneworks-core --lib` (554 passed) green. `cargo fmt --all --check` + `cargo clippy -p sceneworks-worker --all-targets` clean.

### Scope / deferred
- The 26 GB load + render is validated on GPU in **S0f** (not attempted here).
- No inference-repo or web-UI (S0e) changes; no re-implementation of routing (S0d) or detection (S0a).
- **txt2img only** — a bare imported DiT carries no conditioning components (S0d did not mark pose/reference/edit eligible for imported models). The Turbo engine advertises img2img `Reference`, so imported-Krea img2img reference is tracked as follow-up **sc-14071**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
