### PR TITLE
chore(docker): pin candle worker NVIDIA runtime wheels [sc-13611]

### DIFF
--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -192,16 +192,32 @@ RUN apt-get update \
 
 # onnxruntime-gpu + the CUDA-12 deps its providers_cuda needs that the CUDA-runtime
 # base doesn't ship — cuDNN-9 (incl. lazily-loaded sub-engines), cuFFT, nvJitLink,
-# nvRTC. onnxruntime-gpu does NOT declare these as hard deps, so request them
-# explicitly (sc-6209). 1.26.0 matches the `ort` crate rc.12 (ORT API 24); validated
-# on RTX PRO 6000 with cuDNN-cu12 9.23.
+# nvRTC. onnxruntime-gpu does NOT declare these as hard deps (they sit behind its
+# `cuda`/`cudnn` extras), so request them explicitly (sc-6209). 1.26.0 matches the
+# `ort` crate rc.12 (ORT API 24); validated on RTX PRO 6000 with cuDNN-cu12 9.23.
+#
+# The four nvidia-*-cu12 versions below are PINNED to exactly match the desktop CUDA
+# provisioner (apps/desktop/src/cuda_provision.rs COMPONENTS table, REDIST_VERSION
+# `cuda12.9-ort1.26.0-cudnn9.23-1`) so both surfaces stage the identical CUDA set that
+# onnxruntime-gpu 1.26.0 was validated against — reproducible server builds, no silent
+# cuDNN 10.x / floating-range drift (sc-13611). Each also satisfies onnxruntime-gpu
+# 1.26.0's own declared ranges (cudnn~=9.0, cufft~=11.0, cuda-nvrtc~=12.0) and the
+# CUDA 12.9 runtime base. Pip --require-hashes hardening is tracked in sc-14078.
 ENV ORT_PY_SITE=/opt/ort/lib/python3.12/site-packages
 ARG ONNXRUNTIME_GPU_VERSION=1.26.0
+# Mirror apps/desktop/src/cuda_provision.rs — keep in lockstep if that manifest bumps.
+ARG NVIDIA_CUDNN_CU12_VERSION=9.23.0.39
+ARG NVIDIA_CUFFT_CU12_VERSION=11.4.1.4
+ARG NVIDIA_NVJITLINK_CU12_VERSION=12.9.86
+ARG NVIDIA_CUDA_NVRTC_CU12_VERSION=12.9.86
 RUN python3 -m venv /opt/ort \
     && /opt/ort/bin/pip install --no-cache-dir --upgrade pip \
     && /opt/ort/bin/pip install --no-cache-dir \
         "onnxruntime-gpu==${ONNXRUNTIME_GPU_VERSION}" \
-        nvidia-cudnn-cu12 nvidia-cufft-cu12 nvidia-nvjitlink-cu12 nvidia-cuda-nvrtc-cu12 \
+        "nvidia-cudnn-cu12==${NVIDIA_CUDNN_CU12_VERSION}" \
+        "nvidia-cufft-cu12==${NVIDIA_CUFFT_CU12_VERSION}" \
+        "nvidia-nvjitlink-cu12==${NVIDIA_NVJITLINK_CU12_VERSION}" \
+        "nvidia-cuda-nvrtc-cu12==${NVIDIA_CUDA_NVRTC_CU12_VERSION}" \
     && ORT_SO="$(ls ${ORT_PY_SITE}/onnxruntime/capi/libonnxruntime.so* | head -1)" \
     && test -n "${ORT_SO}" \
     && ln -sf "${ORT_SO}" "${ORT_PY_SITE}/onnxruntime/capi/libonnxruntime.so"


### PR DESCRIPTION
## What

Pins the four previously-unpinned NVIDIA runtime wheels in the candle GPU worker image (`docker/rust.Dockerfile`, `rust-worker-candle` stage) to exact `==` versions, closing finding **F-049** (Medium, security/reproducibility).

Before, the `/opt/ort` venv installed `nvidia-cudnn-cu12 nvidia-cufft-cu12 nvidia-nvjitlink-cu12 nvidia-cuda-nvrtc-cu12` with no version constraint, so a cuDNN 10.x release (or any floating bump / index tampering) would flow silently into the next server image build — while the desktop provisioner (`apps/desktop/src/cuda_provision.rs`) already pins the same DLL set by URL+sha256. (`onnxruntime-gpu` was already pinned; `huggingface_hub` was already removed by sc-13604 / F-035 — untouched here.)

## Pins (mirror the desktop manifest)

| wheel | pinned version | mirrors `cuda_provision.rs` |
|---|---|---|
| `nvidia-cudnn-cu12` | `9.23.0.39` | `nvidia_cudnn_cu12-9.23.0.39` |
| `nvidia-cufft-cu12` | `11.4.1.4` | `nvidia_cufft_cu12-11.4.1.4` |
| `nvidia-nvjitlink-cu12` | `12.9.86` | `nvidia_nvjitlink_cu12-12.9.86` |
| `nvidia-cuda-nvrtc-cu12` | `12.9.86` | `nvidia_cuda_nvrtc_cu12-12.9.86` |

REDIST_VERSION on the desktop side: `cuda12.9-ort1.26.0-cudnn9.23-1`. Versions are lifted to `ARG`s with a comment tying them to the provisioner so the two surfaces stay in lockstep.

## Compatibility (onnxruntime-gpu 1.26.0)

Verified against ort 1.26.0's own `requires_dist`: it declares `nvidia-cudnn-cu12~=9.0`, `nvidia-cufft-cu12~=11.0`, `nvidia-cuda-nvrtc-cu12~=12.0` (behind its `cuda`/`cudnn` extras, which is why the Dockerfile installs them explicitly). All four pins satisfy those ranges **and** match the CUDA 12.9 runtime base **and** the Dockerfile's stated "validated on RTX PRO 6000 with cuDNN-cu12 9.23". No conflict between the desktop-manifest versions and the ort-required versions — they are the same validated set. `9.23.0.39` also explicitly blocks the cuDNN 10.x silent bump the finding calls out.

The exact linux x86_64 / cp312 wheels all exist and resolve cleanly — confirmed via `pip install --dry-run --report` (10-package closure: the 4 nvidia wheels + transitive `nvidia-cublas-cu12` + ort's hard deps flatbuffers/numpy/packaging/protobuf).

## `--require-hashes` decision — deferred to sc-14078

The finding says "ideally `--require-hashes`". `--require-hashes` is **all-or-nothing per pip invocation** (every package incl. transitive needs a hash). I resolved the full closure here, but **could not build-validate** an all-or-nothing hash file: the candle CUDA image builds only in the docker-compose / RunPod deploy pipeline (not in any GitHub Actions PR lane), and numpy publishes many wheel variants where a single missing hash fails the install. Shipping an unvalidated hash file would risk RED-ing the deploy build with no local safety net. The `==` pins already deliver the finding's core value (reproducibility + no silent cuDNN 10.x; PyPI filenames are immutable so `==` already blocks same-version re-publish). Hash hardening is tracked in **[sc-14078](https://app.shortcut.com/trefry/story/14078)** with the fully-resolved closure + sha256s attached as a head start, to be generated with `pip-compile --generate-hashes` and validated by an actual image build.

## Validation

- Version cross-check: all four pins byte-match `apps/desktop/src/cuda_provision.rs`. ✅
- ort 1.26.0 range compatibility: confirmed from PyPI `requires_dist`. ✅
- Linux wheel existence + clean resolution: `pip install --dry-run --report` (cp312 / manylinux). ✅
- hadolint: not runnable in this environment (no daemon), but pinning **resolves** DL3013 that the unpinned wheels would trigger; no new lint concerns.
- **Image build is not exercised by any PR CI lane** — it is built from `rust-worker-candle` via `docker-compose.yml` in the RunPod/registry deploy pipeline (epic 10362). That deploy build is the real validation gate.

Story: https://app.shortcut.com/trefry/story/13611
Follow-up: https://app.shortcut.com/trefry/story/14078

🤖 Generated with [Claude Code](https://claude.com/claude-code)