### PR TITLE
feat(web): surface base-checkpoint import on the Image Models tab [sc-14069]

### DIFF
--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -1274,8 +1274,9 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    // The import form shares the LoRAs tab's import area (the existing scaffold home).
-    await selectModelTab("LoRAs");
+    // sc-14069: a base checkpoint is an image model, so the import affordance lives on the
+    // Image Models tab where a user looks for it — no longer the LoRAs tab scaffold home.
+    await selectModelTab("Image");
     const panel = modelImportPanel(container);
     expect(panel).not.toBeNull();
     expect(panel.textContent).toContain("Import model");
@@ -1283,6 +1284,35 @@ describe("SceneWorks app shell", () => {
     expect(field(panel, "Model File")).toBeTruthy();
     expect(field(panel, "Source URL")).toBeFalsy();
     expect(field(panel, "Type").value).toBe("image");
+  });
+
+  it("surfaces the base-checkpoint import affordance on the Image tab, not the LoRAs tab (sc-14069)", async () => {
+    // Discoverability relocation: S0e (sc-14020) first rendered the panel in the LoRAs tab
+    // import area (the pre-existing sc-7080 scaffold). A base checkpoint is an image model
+    // (Krea 2 today), so sc-14069 moves the affordance to the Image Models tab. It must be
+    // reachable from Image and absent from LoRAs.
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withModelManagerContext({
+          activeProject: null,
+          jobs: [],
+          loras: [],
+          models: [{ id: "z_image_turbo", name: "Z-Image Turbo", type: "image", family: "z-image" }],
+          onDownloadModel: () => {},
+          onImportLora: () => {},
+          onImportModel: vi.fn(),
+          onOpenQueue: () => {},
+        }),
+      );
+    });
+
+    await selectModelTab("Image");
+    expect(modelImportPanel(container)).not.toBeNull();
+    // The LoRAs tab keeps its own "Import LoRA" panel but no longer hosts the model importer.
+    await selectModelTab("LoRAs");
+    expect(loraPanel(container)).not.toBeNull();
+    expect(modelImportPanel(container)).toBeNull();
   });
 
   it("POSTs the pointed-at checkpoint as an image import, leaving family to auto-detect (sc-14020)", async () => {
@@ -1305,7 +1335,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await selectModelTab("LoRAs");
+    await selectModelTab("Image");
     const panel = modelImportPanel(container);
     const file = new File([new Uint8Array([1, 2, 3])], "krea2-checkpoint.safetensors");
     await changeFile(field(panel, "Model File"), file);
@@ -1345,7 +1375,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await selectModelTab("LoRAs");
+    await selectModelTab("Image");
     const panel = modelImportPanel(container);
     await changeFile(field(panel, "Model File"), new File([new Uint8Array([1])], "krea2.safetensors"));
     await act(async () => {
@@ -1383,7 +1413,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await selectModelTab("LoRAs");
+    await selectModelTab("Image");
     const panel = modelImportPanel(container);
     await changeFile(field(panel, "Model File"), new File([new Uint8Array([1])], "qwen.safetensors"));
     await act(async () => {
@@ -1480,7 +1510,7 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await selectModelTab("LoRAs");
+    await selectModelTab("Image");
     expect(container.textContent).toContain("Model imports in progress");
     expect(container.textContent).toContain("Model Import");
     expect(container.textContent).toContain("Downloading");

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1676,12 +1676,150 @@ export function ModelManagerScreen() {
     );
   }
 
+  // Base-checkpoint import affordance (epic 14015, sc-14020). Surfaced on the Image Models
+  // tab (sc-14069) rather than the LoRAs tab where the sc-7080 scaffold first placed it — a
+  // base checkpoint IS an image model (a Krea 2 DiT today), so this is where a user looks for
+  // it. Gated on MODEL_IMPORT_ENABLED (mirrors the backend kill-switch S0d opened); the
+  // section also surfaces any in-flight model-import progress. Factored out of the tab body so
+  // it can mount under any relevant model-type tab once more base-checkpoint types become
+  // importable — image is the only relevant tab today (the Type selector is image-locked).
+  function renderModelImportPanel() {
+    if (!MODEL_IMPORT_ENABLED && pendingModelImportJobs.length === 0) {
+      return null;
+    }
+    return (
+      <section className="model-import-panel-section">
+        {MODEL_IMPORT_ENABLED && (
+          <form className="models-accent-band models-import-panel" aria-label="Import model" onSubmit={importModel}>
+            <div className="models-accent-band-head">
+              <span className="models-accent-dot" aria-hidden="true" />
+              <p className="eyebrow">Import model</p>
+              <span className="models-accent-band-caption">
+                Point at a base checkpoint file — auto-detects family (Krea 2 today)
+              </span>
+            </div>
+            <div className="segmented-control compact-segment" aria-label="Model import source">
+              <button
+                className={modelImportForm.mode === "url" ? "active" : ""}
+                disabled={importingModel}
+                onClick={() => setModelImportForm((current) => ({ ...current, mode: "url" }))}
+                type="button"
+              >
+                URL
+              </button>
+              <button
+                className={modelImportForm.mode === "file" ? "active" : ""}
+                disabled={importingModel}
+                onClick={() => setModelImportForm((current) => ({ ...current, mode: "file" }))}
+                type="button"
+              >
+                Upload
+              </button>
+            </div>
+            <div className="models-import-grid">
+              <label>
+                Type
+                {/* Base-checkpoint import only produces image models today (a Krea 2 DiT).
+                    `queue_model_import_job` (models.rs) writes this type verbatim into the
+                    user manifest and never reconciles it against the detected family, so
+                    offering video/audio/utility here would let an image checkpoint be
+                    mis-typed. Constrain to Image (disabled) until more base-checkpoint types
+                    are importable, then drop the image-only filter to restore the full
+                    MODEL_TYPE_OPTIONS selector (sc-14020). */}
+                <select disabled value={modelImportForm.type} aria-readonly="true">
+                  {MODEL_TYPE_OPTIONS.filter((option) => option.value === "image").map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Family
+                <select
+                  disabled={importingModel || !families.length}
+                  onChange={(event) => setModelImportForm((current) => ({ ...current, family: event.target.value }))}
+                  value={modelImportForm.family}
+                >
+                  {families.length ? (
+                    <>
+                      <option value="">Auto-detect</option>
+                      {families.map((family) => (
+                        <option key={family} value={family}>
+                          {family}
+                        </option>
+                      ))}
+                    </>
+                  ) : (
+                    <option value="">No known families</option>
+                  )}
+                </select>
+              </label>
+              {isModelFileImport ? (
+                <label>
+                  Model File
+                  <span className="file-picker-row">
+                    <span className="file-upload-button">
+                      Choose
+                      <input
+                        accept=".safetensors,.ckpt,.pt,.bin"
+                        disabled={importingModel}
+                        key={modelFileInputKey}
+                        onChange={(event) => setModelImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
+                        type="file"
+                      />
+                    </span>
+                    <span className="selected-file-name">{modelImportForm.file?.name ?? "No file selected"}</span>
+                  </span>
+                </label>
+              ) : (
+                <label>
+                  Source URL
+                  <input
+                    disabled={importingModel}
+                    onChange={(event) => setModelImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
+                    placeholder="https://..."
+                    value={modelImportForm.sourceUrl}
+                  />
+                </label>
+              )}
+              <label>
+                Name
+                <input
+                  disabled={importingModel}
+                  onChange={(event) => setModelImportForm((current) => ({ ...current, name: event.target.value }))}
+                  placeholder="Optional"
+                  value={modelImportForm.name}
+                />
+              </label>
+              <button disabled={modelImportDisabled} type="submit">
+                {importingModel ? (isModelFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
+              </button>
+            </div>
+            {modelImportMessage.text ? <p className={modelImportMessage.tone === "success" ? "inline-success" : "inline-warning"}>{modelImportMessage.text}</p> : null}
+          </form>
+        )}
+        {pendingModelImportJobs.length ? (
+          <div className="lora-import-progress">
+            <strong>Model imports in progress</strong>
+            <div className="local-job-stack">
+              {pendingModelImportJobs.map((job) => (
+                <WorkerProgressCard job={job} key={job.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </section>
+    );
+  }
+
   // The catalog grid on the canvas: "All {type} models" (the non-recommended
   // rest). Recommended picks render separately in the work-panel above.
   function renderModelTabPanel(type) {
     const { recommended, others, othersHeading } = modelTabGroups(type);
     return (
       <div className="models-tab-panel">
+        {type === "image" ? renderModelImportPanel() : null}
         {others.length ? (
           <div className="models-section">
             <div className="models-section-heading">
@@ -2016,134 +2154,6 @@ export function ModelManagerScreen() {
               <div className="models-empty">No user LoRAs yet — import one above.</div>
             )}
           </div>
-
-          {/* Import a base checkpoint (epic 14015, sc-14020). Gated on MODEL_IMPORT_ENABLED, which
-              mirrors the backend kill-switch S0d opened; the section also surfaces any in-flight
-              model-import progress. The point-at-a-file picker is the primary affordance. */}
-          {MODEL_IMPORT_ENABLED || pendingModelImportJobs.length > 0 ? (
-            <section className="model-import-panel-section">
-              {MODEL_IMPORT_ENABLED && (
-                <form className="models-accent-band models-import-panel" aria-label="Import model" onSubmit={importModel}>
-                  <div className="models-accent-band-head">
-                    <span className="models-accent-dot" aria-hidden="true" />
-                    <p className="eyebrow">Import model</p>
-                    <span className="models-accent-band-caption">
-                      Point at a base checkpoint file — auto-detects family (Krea 2 today)
-                    </span>
-                  </div>
-                  <div className="segmented-control compact-segment" aria-label="Model import source">
-                    <button
-                      className={modelImportForm.mode === "url" ? "active" : ""}
-                      disabled={importingModel}
-                      onClick={() => setModelImportForm((current) => ({ ...current, mode: "url" }))}
-                      type="button"
-                    >
-                      URL
-                    </button>
-                    <button
-                      className={modelImportForm.mode === "file" ? "active" : ""}
-                      disabled={importingModel}
-                      onClick={() => setModelImportForm((current) => ({ ...current, mode: "file" }))}
-                      type="button"
-                    >
-                      Upload
-                    </button>
-                  </div>
-                  <div className="models-import-grid">
-                    <label>
-                      Type
-                      {/* Base-checkpoint import only produces image models today (a Krea 2 DiT).
-                          `queue_model_import_job` (models.rs) writes this type verbatim into the
-                          user manifest and never reconciles it against the detected family, so
-                          offering video/audio/utility here would let an image checkpoint be
-                          mis-typed. Constrain to Image (disabled) until more base-checkpoint types
-                          are importable, then drop the image-only filter to restore the full
-                          MODEL_TYPE_OPTIONS selector (sc-14020). */}
-                      <select disabled value={modelImportForm.type} aria-readonly="true">
-                        {MODEL_TYPE_OPTIONS.filter((option) => option.value === "image").map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <label>
-                      Family
-                      <select
-                        disabled={importingModel || !families.length}
-                        onChange={(event) => setModelImportForm((current) => ({ ...current, family: event.target.value }))}
-                        value={modelImportForm.family}
-                      >
-                        {families.length ? (
-                          <>
-                            <option value="">Auto-detect</option>
-                            {families.map((family) => (
-                              <option key={family} value={family}>
-                                {family}
-                              </option>
-                            ))}
-                          </>
-                        ) : (
-                          <option value="">No known families</option>
-                        )}
-                      </select>
-                    </label>
-                    {isModelFileImport ? (
-                      <label>
-                        Model File
-                        <span className="file-picker-row">
-                          <span className="file-upload-button">
-                            Choose
-                            <input
-                              accept=".safetensors,.ckpt,.pt,.bin"
-                              disabled={importingModel}
-                              key={modelFileInputKey}
-                              onChange={(event) => setModelImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
-                              type="file"
-                            />
-                          </span>
-                          <span className="selected-file-name">{modelImportForm.file?.name ?? "No file selected"}</span>
-                        </span>
-                      </label>
-                    ) : (
-                      <label>
-                        Source URL
-                        <input
-                          disabled={importingModel}
-                          onChange={(event) => setModelImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
-                          placeholder="https://..."
-                          value={modelImportForm.sourceUrl}
-                        />
-                      </label>
-                    )}
-                    <label>
-                      Name
-                      <input
-                        disabled={importingModel}
-                        onChange={(event) => setModelImportForm((current) => ({ ...current, name: event.target.value }))}
-                        placeholder="Optional"
-                        value={modelImportForm.name}
-                      />
-                    </label>
-                    <button disabled={modelImportDisabled} type="submit">
-                      {importingModel ? (isModelFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
-                    </button>
-                  </div>
-                  {modelImportMessage.text ? <p className={modelImportMessage.tone === "success" ? "inline-success" : "inline-warning"}>{modelImportMessage.text}</p> : null}
-                </form>
-              )}
-              {pendingModelImportJobs.length ? (
-                <div className="lora-import-progress">
-                  <strong>Model imports in progress</strong>
-                  <div className="local-job-stack">
-                    {pendingModelImportJobs.map((job) => (
-                      <WorkerProgressCard job={job} key={job.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-            </section>
-          ) : null}
         </div>
       ) : null}
     </section>

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -675,7 +675,10 @@ describe("ModelManagerScreen type-grouped layout", () => {
 
   it("shows a single '{Type} models' section (no Recommended band) when nothing is recommended", async () => {
     await render({ models: [MODELS[0]] }); // fixture has no recommended flag
-    expect(container.querySelector(".models-accent-band")).toBeNull();
+    // The Recommended band is its own container (.models-recommended, per the sibling test);
+    // assert on that rather than .models-accent-band, since the Image tab now also carries the
+    // base-checkpoint "Import model" accent-band (sc-14069) which is unrelated to recommendations.
+    expect(container.querySelector(".models-recommended")).toBeNull();
     const section = container.querySelector(".models-section");
     expect(section.textContent).toContain("Image models");
     expect(section.querySelectorAll(".model-card").length).toBe(1);


### PR DESCRIPTION
## Summary

Relocates the base-checkpoint **Import model** accent-band panel from the **LoRAs** tab to the **Image Models** tab, closing a discoverability gap.

S0e (sc-14020, merged) added the point-at-file base-checkpoint import panel but rendered it in the LoRAs tab's import area — the pre-existing sc-7080 scaffold home. A base checkpoint is an **image** model (Krea 2 today), so a user naturally looks for it under the **Image Models** tab.

### What changed
- Factored the panel JSX into a `renderModelImportPanel()` helper in `ModelManagerScreen.jsx` (no logic duplicated).
- The helper is tab-agnostic; it is mounted at the top of the Image Models tab body via `{type === "image" ? renderModelImportPanel() : null}` and removed from the LoRAs tab.
- Image is the only relevant tab today (the Type selector is image-locked); the factoring lets it mount under other model-type tabs once more base-checkpoint types become importable.
- **Backend untouched** — the S0d compatibility gate is unchanged.

### Tests
- Repointed the existing model-import tests (`App.models.test.jsx`) from the LoRAs tab to the Image tab.
- Added a dedicated sc-14069 test asserting the affordance is present on the **Image** tab and absent from the **LoRAs** tab (which keeps its own Import LoRA panel).
- Updated one `ModelManagerScreen.test.jsx` assertion to target the Recommended band's own container (`.models-recommended`) instead of the broader `.models-accent-band`, since the Image tab now also carries the import accent-band.

Verification: vitest (`ModelManagerScreen.test.jsx` 52 + `App.models.test.jsx` 33 = 85 passing) · `eslint src` (0 errors) · `vite build` (clean).

Epic sc-14015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)