### PR TITLE
chore(worker): harden imported-Krea base-tier completeness check [sc-14074]

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -158,9 +158,10 @@ fn resolve_imported_krea_dit(
 /// tokenizer, and DiT architecture config the imported single-file transformer omits — the `base_snapshot_dir`
 /// argument of the S0b entrypoint. The default base is the Turbo turnkey's dense `bf16/` tier
 /// ([`KREA_IMPORTED_BASE_REPO`] / [`KREA_IMPORTED_BASE_TIER`]), resolved from the HF cache via the shared
-/// repo→cache-path helper. REQUIRES it installed and complete (`transformer/config.json` for the arch
-/// config, plus `text_encoder/ vae/ tokenizer/`); a clear typed error otherwise so the user knows to
-/// install the Krea 2 base first, rather than a raw mid-load "No such file or directory".
+/// repo→cache-path helper. REQUIRES it installed and complete — `transformer/config.json` for the arch
+/// config, plus POPULATED `text_encoder/ vae/ tokenizer/` component trees (weight files present, not
+/// just the directories, so a torn base is caught here); a clear typed error otherwise so the user knows
+/// to install the Krea 2 base first, rather than a raw mid-load "No such file or directory".
 #[cfg(target_os = "macos")]
 fn resolve_krea_imported_base_tier(settings: &Settings) -> WorkerResult<PathBuf> {
     let base_missing = || {
@@ -180,13 +181,36 @@ fn resolve_krea_imported_base_tier(settings: &Settings) -> WorkerResult<PathBuf>
 
 /// The base tier is loadable when it carries the shared components the single-file DiT pairs with: the
 /// transformer's `config.json` (the arch config `Krea2Config::from_snapshot` reads — the WEIGHTS are the
-/// imported file, not this tier's), plus the `text_encoder/ vae/ tokenizer/` component trees.
+/// imported file, not this tier's), plus POPULATED `text_encoder/`, `vae/`, and `tokenizer/` component
+/// trees. Each component dir is probed for an actual payload file — a `.safetensors` weight for the
+/// dense TE/VAE, the `tokenizer.json` the tokenizer loads — not merely for the directory's existence:
+/// a half-downloaded / torn base whose component dirs were created but never filled would otherwise pass
+/// this gate and fail deep inside the S0b load with a generic Engine "load failed" instead of the
+/// friendly [`resolve_krea_imported_base_tier`] "install the Krea 2 base first" typed error.
 #[cfg(target_os = "macos")]
 fn krea_imported_base_tier_complete(dir: &Path) -> bool {
     dir.join("transformer").join("config.json").is_file()
-        && dir.join("text_encoder").is_dir()
-        && dir.join("vae").is_dir()
-        && dir.join("tokenizer").is_dir()
+        && dir_has_safetensors(&dir.join("text_encoder"))
+        && dir_has_safetensors(&dir.join("vae"))
+        && dir.join("tokenizer").join("tokenizer.json").is_file()
+}
+
+/// True when `dir` holds at least one top-level `*.safetensors` weight file — the "is this component
+/// dir actually populated, not just an empty shell left by a torn download" probe
+/// [`krea_imported_base_tier_complete`] uses for the dense text encoder / VAE trees.
+#[cfg(target_os = "macos")]
+fn dir_has_safetensors(dir: &Path) -> bool {
+    std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .any(|entry| {
+            entry
+                .path()
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("safetensors"))
+        })
 }
 
 /// True when this is an in-place imported single-file Krea 2 **txt2img** job: an imported `krea_2`-family

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -10825,8 +10825,11 @@ fn resolve_imported_krea_dit_claims_only_non_builtin_single_file_krea2() {
 }
 
 /// `resolve_krea_imported_base_tier` requires the resident Krea 2 base and fails with a clear
-/// "install the Krea 2 base first" message when it is absent; when the `bf16/` tier is installed and
-/// complete (config + TE/VAE/tokenizer) it resolves that dir.
+/// "install the Krea 2 base first" message when it is absent OR TORN (component dirs present but empty —
+/// a half-finished download); only when the `bf16/` tier is installed and complete (arch config + a
+/// weight file in each of TE/VAE plus the tokenizer's `tokenizer.json`) does it resolve that dir. The
+/// torn-base case is what keeps the friendly typed error firing instead of a generic mid-load Engine
+/// "load failed" (sc-14074).
 #[cfg(target_os = "macos")]
 #[test]
 fn resolve_krea_imported_base_tier_requires_installed_base() {
@@ -10837,36 +10840,110 @@ fn resolve_krea_imported_base_tier_requires_installed_base() {
     let mut settings = Settings::from_env();
     settings.data_dir = dir.path().to_path_buf();
 
-    // Base absent → loud typed error.
-    let err = resolve_krea_imported_base_tier(&settings)
-        .expect_err("no base installed must be an error, not a silent fall-through");
-    let msg = format!("{err}");
-    assert!(
-        msg.contains("Krea 2 base model is not installed") && msg.contains("install the Krea 2"),
-        "error must direct the user to install the Krea 2 base first, got: {msg}"
-    );
+    let assert_install_base_error = |label: &str| {
+        let err = resolve_krea_imported_base_tier(&settings).expect_err(&format!(
+            "{label}: expected the friendly install-base typed error, not an Ok resolve"
+        ));
+        let msg = format!("{err}");
+        assert!(
+            matches!(err, WorkerError::InvalidPayload(_)),
+            "{label}: must be the friendly typed InvalidPayload error, not a generic Engine load \
+             failure, got: {err:?}"
+        );
+        assert!(
+            msg.contains("Krea 2 base model is not installed")
+                && msg.contains("install the Krea 2"),
+            "{label}: error must direct the user to install the Krea 2 base first, got: {msg}"
+        );
+    };
 
-    // Seed a complete `SceneWorks/krea-2-turbo-mlx` bf16 base tier (arch config + shared components).
+    // Base absent → loud typed error.
+    assert_install_base_error("absent base");
+
     let snapshot = hub
         .join("models--SceneWorks--krea-2-turbo-mlx")
         .join("snapshots")
         .join("rev0");
     let bf16 = snapshot.join("bf16");
-    for sub in ["transformer", "text_encoder", "vae", "tokenizer"] {
-        std::fs::create_dir_all(bf16.join(sub)).unwrap();
-    }
-    std::fs::write(bf16.join("transformer").join("config.json"), b"{}").unwrap();
     let refs = hub
         .join("models--SceneWorks--krea-2-turbo-mlx")
         .join("refs");
     std::fs::create_dir_all(&refs).unwrap();
     std::fs::write(refs.join("main"), b"rev0").unwrap();
 
+    // TORN base: the arch config lands but the component dirs exist EMPTY (an interrupted download). The
+    // old existence-only gate passed this and then failed deep in the load; the tightened gate rejects
+    // it up front with the same friendly typed error.
+    for sub in ["transformer", "text_encoder", "vae", "tokenizer"] {
+        std::fs::create_dir_all(bf16.join(sub)).unwrap();
+    }
+    std::fs::write(bf16.join("transformer").join("config.json"), b"{}").unwrap();
+    assert_install_base_error("torn base (empty component dirs)");
+
+    // Now POPULATE each component dir with its expected payload → complete → resolves.
+    std::fs::write(bf16.join("text_encoder").join("model.safetensors"), b"te").unwrap();
+    std::fs::write(
+        bf16.join("vae").join("diffusion_pytorch_model.safetensors"),
+        b"vae",
+    )
+    .unwrap();
+    std::fs::write(bf16.join("tokenizer").join("tokenizer.json"), b"{}").unwrap();
+
     let base = resolve_krea_imported_base_tier(&settings).expect("installed base resolves");
     assert_eq!(
         base, bf16,
         "the resolved base is the dense bf16 tier of the Turbo turnkey"
     );
+}
+
+/// `krea_imported_base_tier_complete` probes each shared component for an actual payload file, not just
+/// the directory's existence (sc-14074): a fully populated tier is complete, but dropping the arch
+/// config, either TE/VAE `.safetensors`, or the tokenizer's `tokenizer.json` makes it incomplete — each
+/// dropped file discriminates a distinct torn-download shape.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_imported_base_tier_complete_requires_populated_components() {
+    let dir = tempfile::tempdir().unwrap();
+    let bf16 = dir.path().join("bf16");
+    for sub in ["transformer", "text_encoder", "vae", "tokenizer"] {
+        std::fs::create_dir_all(bf16.join(sub)).unwrap();
+    }
+
+    // Empty component dirs (only the dirs exist) → NOT complete, even with the arch config present.
+    std::fs::write(bf16.join("transformer").join("config.json"), b"{}").unwrap();
+    assert!(
+        !krea_imported_base_tier_complete(&bf16),
+        "empty component dirs (a torn download) must not count as a complete base tier"
+    );
+
+    // Fully populated → complete.
+    let config = bf16.join("transformer").join("config.json");
+    let te = bf16.join("text_encoder").join("model.safetensors");
+    let vae = bf16.join("vae").join("diffusion_pytorch_model.safetensors");
+    let tok = bf16.join("tokenizer").join("tokenizer.json");
+    std::fs::write(&te, b"te").unwrap();
+    std::fs::write(&vae, b"vae").unwrap();
+    std::fs::write(&tok, b"{}").unwrap();
+    assert!(
+        krea_imported_base_tier_complete(&bf16),
+        "arch config + a weight file in TE/VAE + tokenizer.json is a complete base tier"
+    );
+
+    // Dropping any single required payload makes it incomplete (mutation-discriminating).
+    for (label, victim) in [
+        ("transformer/config.json", &config),
+        ("text_encoder/*.safetensors", &te),
+        ("vae/*.safetensors", &vae),
+        ("tokenizer/tokenizer.json", &tok),
+    ] {
+        std::fs::remove_file(victim).unwrap();
+        assert!(
+            !krea_imported_base_tier_complete(&bf16),
+            "a base tier missing {label} must be incomplete"
+        );
+        // Restore for the next iteration.
+        std::fs::write(victim, b"x").unwrap();
+    }
 }
 
 /// End-to-end routing decision: a plain-t2i imported single-file Krea 2 job routes to the bespoke
@@ -10890,10 +10967,14 @@ fn resolve_image_route_sends_imported_single_file_krea_to_the_bespoke_lane() {
     );
     assert!(krea_imported_available(&imported, &settings));
 
-    // A directory modelPath (a snapshot) is not a single-file import → the imported lane does not claim
-    // it (and with an unknown id + no resolvable snapshot it is not otherwise MLX-routable).
+    // A diffusers snapshot-directory modelPath (a `model_index.json` pipeline marker, even alongside a
+    // loose `.safetensors`) is not a single-file import → the imported lane does not claim it. Seeding
+    // the marker makes this genuinely exercise the snapshot-dir exclusion (`is_diffusers_snapshot_dir`),
+    // not merely an empty dir that happens to hold no weight file.
     let snap_dir = dir.path().join("models").join("imported-krea").join("snap");
     std::fs::create_dir_all(&snap_dir).unwrap();
+    std::fs::write(snap_dir.join("model_index.json"), b"{}").unwrap();
+    std::fs::write(snap_dir.join("stray.safetensors"), b"x").unwrap();
     let dir_job = request(json!({
         "projectId": "p", "model": "kreamania_variant5", "prompt": "a cat",
         "modelManifestEntry": { "family": "krea_2", "modelPath": snap_dir.to_str().unwrap() }


### PR DESCRIPTION
## Summary

Two minor follow-on items from the epic 14015 S0c review (sc-14074, epic sc-14015).

1. **Tighten `krea_imported_base_tier_complete`** (`crates/sceneworks-worker/src/image_jobs/krea_imported.rs`). It previously checked only that the `text_encoder/`, `vae/`, and `tokenizer/` component directories *existed*. A half-downloaded / torn Krea 2 base — component dirs created but never filled — passed the gate and then failed deep inside the S0b load with a generic Engine "load failed" instead of the friendly "install the Krea 2 base first" typed error. The check now probes each required component dir for an actual payload file: a `*.safetensors` weight in `text_encoder/` and `vae/`, and the tokenizer's expected `tokenizer.json`. A torn base is rejected up front with the friendly `InvalidPayload` typed error.

2. **Fix an imprecise test comment** (`crates/sceneworks-worker/src/image_jobs/tests.rs`). In `resolve_image_route_sends_imported_single_file_krea_to_the_bespoke_lane`, the negative `dir_job` case used an empty directory (which resolves to `None` for lack of a weight file, not because it is a snapshot). Seeded a `model_index.json` marker + a stray `.safetensors` so it genuinely exercises the snapshot-dir exclusion (`is_diffusers_snapshot_dir`), and corrected the comment.

## Tests

- Extended `resolve_krea_imported_base_tier_requires_installed_base` with a **torn-base** sub-case (arch config present, component dirs empty → still the friendly typed error) and asserts the error variant is `WorkerError::InvalidPayload`, not a generic Engine failure. Populates weight files → resolves.
- Added `krea_imported_base_tier_complete_requires_populated_components` — a mutation-discriminating unit test that drops each required payload in turn (config / TE safetensors / VAE safetensors / tokenizer.json) and asserts each makes the tier incomplete.
- All 5 existing S0c tests + builtin Krea stay green.

## Verification (matches CI)

- `cargo test -p sceneworks-worker --lib` → 961 passed, 0 failed, 176 ignored (GPU smoke stays `#[ignore]`d).
- `cargo fmt --all --check` → clean.
- `cargo clippy -p sceneworks-worker --all-targets` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)