### PR TITLE
fix(ci): bound Docker API health probes [sc-14076]

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           npm run check
           npm run check:compose
+          npm run check:docker:rust-api:self-test
       - name: Guard against NC model weights in a published artifact (sc-10526, epic 10512)
         # SceneWorks converts weights at install and pulls them at runtime — it never
         # redistributes them. Baking a Non-Commercial family's weights (Anima /

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:nc-weights": "node scripts/check-no-nc-weights.mjs",
     "check:download-patterns": "node scripts/check-download-patterns.mjs",
     "hooks:install": "git config core.hooksPath scripts/git-hooks",
+    "check:docker:rust-api:self-test": "node --test scripts/check-docker-api-runtime.test.mjs",
     "check:docker:rust-api": "node scripts/check-docker-api-runtime.mjs",
     "bump:inference": "node scripts/bump-inference.mjs",
     "bump:inference:self-test": "node scripts/bump-inference.mjs --self-test",

--- a/scripts/check-docker-api-runtime.mjs
+++ b/scripts/check-docker-api-runtime.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
 
 const runtime = "rust";
 const port = process.env.SCENEWORKS_API_PORT || "18000";
@@ -24,13 +25,27 @@ function runDocker(args, env) {
   });
 }
 
-async function waitForHealth() {
-  const url = `http://127.0.0.1:${port}/api/v1/health`;
-  const deadline = Date.now() + 120_000;
+export async function waitForHealth({
+  url = `http://127.0.0.1:${port}/api/v1/health`,
+  readinessTimeoutMs = 120_000,
+  requestTimeoutMs = 5_000,
+  retryDelayMs = 2_000,
+} = {}) {
+  const deadline = Date.now() + readinessTimeoutMs;
   let lastError;
+  let attempts = 0;
   while (Date.now() < deadline) {
+    attempts += 1;
     try {
-      const response = await fetch(url);
+      // Publishing the Docker port can accept a connection before the API has
+      // finished create_app(). Bound every individual probe so a connection
+      // that accepts but never responds cannot make the overall deadline
+      // toothless and consume the parity job's 30-minute timeout (sc-14076).
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(
+          Math.max(1, Math.min(requestTimeoutMs, deadline - Date.now())),
+        ),
+      });
       if (response.ok) {
         const health = await response.json();
         if (health.runtime !== runtime) {
@@ -43,9 +58,15 @@ async function waitForHealth() {
     } catch (error) {
       lastError = error.message;
     }
-    await sleep(2_000);
+    const remainingMs = deadline - Date.now();
+    if (remainingMs > 0) {
+      await sleep(Math.min(retryDelayMs, remainingMs));
+    }
   }
-  throw new Error(`SceneWorks ${runtime} API did not become healthy: ${lastError}`);
+  throw new Error(
+    `SceneWorks ${runtime} API did not become healthy within ${readinessTimeoutMs}ms ` +
+      `after ${attempts} attempt(s): ${lastError}`,
+  );
 }
 
 async function main() {
@@ -95,7 +116,15 @@ async function main() {
     // in the run output. (This is no longer load-bearing for exit-13 avoidance — the
     // keepAlive handle and main() wrapper cover that — it's purely diagnostic now.)
     await runDocker([...compose, "logs", "--no-color", "api"], env).catch(() => {});
-    await waitForHealth();
+    try {
+      await waitForHealth();
+    } catch (error) {
+      // The initial log snapshot often happens before create_app reaches the
+      // stalled operation. Capture final health and boot logs at the deadline.
+      await runDocker([...compose, "ps", "--all"], env).catch(() => {});
+      await runDocker([...compose, "logs", "--no-color", "api"], env).catch(() => {});
+      throw error;
+    }
   } finally {
     // The api service runs as root in the container, so anything it seeds into the
     // bind-mounted data dir is root-owned — notably data/projects/global-poses.sceneworks,
@@ -117,10 +146,12 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  // A genuine failure (unhealthy container hitting the 120s waitForHealth deadline,
-  // an unexpected throw, etc.) surfaces as a normal rejection here and exits non-zero —
-  // not via Node's top-level-await exit-13 path.
-  console.error(error);
-  process.exitCode = 1;
-});
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    // A genuine failure (unhealthy container hitting the 120s waitForHealth deadline,
+    // an unexpected throw, etc.) surfaces as a normal rejection here and exits non-zero —
+    // not via Node's top-level-await exit-13 path.
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-docker-api-runtime.test.mjs
+++ b/scripts/check-docker-api-runtime.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import { waitForHealth } from "./check-docker-api-runtime.mjs";
+
+test("waitForHealth retries after a single request stalls", async (t) => {
+  let requests = 0;
+  const server = http.createServer((_request, response) => {
+    requests += 1;
+    if (requests === 1) {
+      // Accept the first connection without responding. The request timeout
+      // must abort it so a subsequent health probe can succeed.
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end('{"runtime":"rust"}');
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => {
+    server.closeAllConnections();
+    server.close();
+  });
+
+  const { port } = server.address();
+  const startedAt = Date.now();
+  await waitForHealth({
+    url: `http://127.0.0.1:${port}/api/v1/health`,
+    readinessTimeoutMs: 500,
+    requestTimeoutMs: 50,
+    retryDelayMs: 10,
+  });
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.equal(requests, 2, "stalled request was aborted and retried");
+  assert.ok(elapsedMs >= 40, `first request did not stall (${elapsedMs}ms)`);
+  assert.ok(elapsedMs < 500, `retry escaped the readiness deadline (${elapsedMs}ms)`);
+});
+
+test("waitForHealth enforces its deadline when a request never responds", async (t) => {
+  const server = http.createServer((_request, _response) => {
+    // Reproduce the Docker failure mode: accept the connection but never send
+    // headers or a body, as when create_app stalls before the API starts serving.
+  });
+  server.keepAliveTimeout = 1;
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => {
+    server.closeAllConnections();
+    server.close();
+  });
+
+  const { port } = server.address();
+  const startedAt = Date.now();
+  await assert.rejects(
+    waitForHealth({
+      url: `http://127.0.0.1:${port}/api/v1/health`,
+      readinessTimeoutMs: 200,
+      requestTimeoutMs: 50,
+      retryDelayMs: 10,
+    }),
+    /did not become healthy within 200ms after \d+ attempt\(s\)/,
+  );
+  const elapsedMs = Date.now() - startedAt;
+
+  assert.ok(elapsedMs >= 150, `deadline fired too early after ${elapsedMs}ms`);
+  assert.ok(elapsedMs < 1_000, `hung request escaped the deadline (${elapsedMs}ms)`);
+});


### PR DESCRIPTION
## Summary
- abort each Docker API health probe after 5 seconds while preserving the 120-second readiness budget
- capture final Compose state and API boot logs when startup never becomes ready
- add deterministic tests for stalled-connection retry and bounded failure, and run them in parity CI

## Acceptance criteria
- [x] A TCP connection that accepts but never responds cannot hang until the 30-minute parity cap
- [x] A transient stalled request is retried and can still become healthy
- [x] A persistently stalled startup fails at the readiness deadline with attempt/error context
- [x] Final container health and boot logs are emitted for create_app startup stalls

## Validation
- npm.cmd run check:docker:rust-api:self-test
- node --check scripts/check-docker-api-runtime.mjs
- npm.cmd run check
- npm.cmd run check:compose
- git diff --check
- independent adversarial review: PASS

Docker runtime smoke is CI-only on this host because the local Docker daemon is unavailable.

Shortcut: https://app.shortcut.com/trefry/story/14076