### PR TITLE
fix(desktop): entitlements XML broke codesign — remove illegal double-hyphen [sc-13609]

### DIFF
--- a/apps/desktop/Entitlements.plist
+++ b/apps/desktop/Entitlements.plist
@@ -15,7 +15,7 @@
               platform"); the shipped Mac app spawns only the sceneworks-api sidecar.
             - The ONLY dylib the shipped app dlopens on macOS is the bundled CoreML
               libonnxruntime.dylib (ort `load-dynamic`, sc-3487). build-sidecar.mjs
-              re-signs it (`codesign --force --options runtime`) with the SAME
+              re-signs it (via codesign under hardened runtime) with the SAME
               Developer ID / Team ID as the .app, so library validation permits the
               load — the CoreML EP is compiled into that one dylib and talks only to
               Apple's system CoreML.framework (no third-party provider dylib on Mac).

--- a/apps/web/src/entitlementsPlistContract.js
+++ b/apps/web/src/entitlementsPlistContract.js
@@ -1,0 +1,102 @@
+// Single source of truth for the entitlements-plist well-formedness rule that macOS
+// codesign / AMFI enforces but plutil -lint and the JSON-ish linters do NOT.
+//
+// The break (sc-13609): apps/desktop/Entitlements.plist carried a comment containing
+// `codesign --force --options runtime`. An XML comment body may not contain `--`
+// (double-hyphen) — XML 1.0 production [15] allows `--` only as part of the closing
+// `-->`. codesign's AMFI parser (AMFIUnserializeXML) is strict and rejected it at real
+// signing time ("Failed to parse entitlements: syntax error near line 18"), yet
+// `plutil -lint` is lenient and passed it, and NO CI lane codesigns — so it merged green
+// and only broke when the release lane actually signed the app.
+//
+// This module is the PR-time detector for that class of defect. It is pure and
+// dependency-free so both scripts/check-scaffold.mjs (the scaffold/parity CI gate) and the
+// co-located vitest test can consume the SAME rule and it can never silently drift.
+
+// Compute the 1-based line number of a character offset in `text`.
+function lineAtOffset(text, offset) {
+  let line = 1;
+  for (let index = 0; index < offset && index < text.length; index += 1) {
+    if (text[index] === "\n") {
+      line += 1;
+    }
+  }
+  return line;
+}
+
+// The single source line containing `offset`, trimmed — the actionable "offending text".
+function lineTextAtOffset(text, offset) {
+  const start = text.lastIndexOf("\n", offset - 1) + 1;
+  const newline = text.indexOf("\n", offset);
+  const end = newline === -1 ? text.length : newline;
+  return text.slice(start, end).trim();
+}
+
+// Scan XML/plist `text` and return every comment-level defect that codesign/AMFI would
+// reject. Returns an array of findings; an empty array means the comments are well-formed
+// for AMFI's purposes.
+//
+// Faithful to the XML rule rather than a substring heuristic: inside a comment, `--` is
+// legal ONLY as the leading two characters of the closing `-->`. Any other `--` (e.g.
+// `--force`, or a `--->` close) is illegal, and a `<!--` with no closing `-->` is
+// unterminated. Because a literal `<!--` can only be a comment start in XML (an unescaped
+// `<` is illegal in element text/attributes), treating every `<!--` as a comment is correct.
+//
+// Each finding: { line, column, kind, snippet }
+//   kind: "double-hyphen-in-comment" | "unterminated-comment"
+export function findXmlCommentDefects(text) {
+  const findings = [];
+  const OPEN = "<!--";
+  let cursor = 0;
+  while (cursor < text.length) {
+    const open = text.indexOf(OPEN, cursor);
+    if (open === -1) {
+      break;
+    }
+    const bodyStart = open + OPEN.length;
+    // Walk the body looking for the next `--`. The only legal `--` is the one that
+    // begins the closing `-->`; anything else is a defect.
+    let scan = bodyStart;
+    let closed = false;
+    while (scan < text.length) {
+      const dash = text.indexOf("--", scan);
+      if (dash === -1) {
+        break; // no `--` at all before EOF => unterminated
+      }
+      if (text[dash + 2] === ">") {
+        // Valid closing `-->`; resume scanning after this comment.
+        cursor = dash + 3;
+        closed = true;
+        break;
+      }
+      // An illegal `--` inside the comment body (the sc-13609 class).
+      findings.push({
+        line: lineAtOffset(text, dash),
+        column: dash - text.lastIndexOf("\n", dash),
+        kind: "double-hyphen-in-comment",
+        snippet: lineTextAtOffset(text, dash),
+      });
+      // Resume after this `--` so a single comment can report at most sensibly and we
+      // still find the real terminator (or flag it unterminated).
+      scan = dash + 2;
+    }
+    if (!closed) {
+      findings.push({
+        line: lineAtOffset(text, open),
+        column: open - text.lastIndexOf("\n", open),
+        kind: "unterminated-comment",
+        snippet: lineTextAtOffset(text, open),
+      });
+      break; // nothing well-formed can follow an unterminated comment
+    }
+  }
+  return findings;
+}
+
+// Human-readable, actionable one-liner for a finding (used in the thrown CI message).
+export function describeXmlCommentDefect(finding) {
+  if (finding.kind === "unterminated-comment") {
+    return `line ${finding.line}: unterminated XML comment (no closing \`-->\`) — ${JSON.stringify(finding.snippet)}`;
+  }
+  return `line ${finding.line}: \`--\` (double-hyphen) inside an XML comment — ${JSON.stringify(finding.snippet)}`;
+}

--- a/apps/web/src/entitlementsPlistContract.test.js
+++ b/apps/web/src/entitlementsPlistContract.test.js
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { describeXmlCommentDefect, findXmlCommentDefects } from "./entitlementsPlistContract.js";
+
+// Guard for the sc-13609 class: an XML comment body containing `--` (double-hyphen) is
+// illegal XML. codesign's AMFI parser (AMFIUnserializeXML) rejects it at signing time, but
+// `plutil -lint` is lenient and no CI lane codesigns — so it merged green and only broke the
+// release/notarize lane. scripts/check-scaffold.mjs (the scaffold/parity gate) calls
+// findXmlCommentDefects on apps/desktop/Entitlements.plist; this test locks the detector's
+// behaviour AND reads the REAL committed plist so a regression that reintroduces `--` reds.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENTITLEMENTS_PATH = resolve(HERE, "../../../apps/desktop/Entitlements.plist");
+
+describe("findXmlCommentDefects", () => {
+  it("passes clean XML with a well-formed comment", () => {
+    const xml = '<?xml version="1.0"?>\n<!-- hardened runtime notes -->\n<plist><dict/></plist>\n';
+    expect(findXmlCommentDefects(xml)).toEqual([]);
+  });
+
+  it("passes an empty comment (`<!---->`)", () => {
+    expect(findXmlCommentDefects("<!---->")).toEqual([]);
+  });
+
+  it("flags a `--` inside a comment body — the exact sc-13609 defect", () => {
+    const xml =
+      '<?xml version="1.0"?>\n' +
+      "<!--\n  re-signs it (`codesign --force --options runtime`) with the SAME\n-->\n" +
+      "<plist><dict/></plist>\n";
+    const defects = findXmlCommentDefects(xml);
+    expect(defects.length).toBeGreaterThan(0);
+    expect(defects[0].kind).toBe("double-hyphen-in-comment");
+    // Points at the real offending source line, not the comment open.
+    expect(defects[0].line).toBe(3);
+    expect(defects[0].snippet).toContain("codesign --force --options runtime");
+    expect(describeXmlCommentDefect(defects[0])).toContain("double-hyphen");
+  });
+
+  it("does NOT flag `--` that appears in element text (comment-scoped only)", () => {
+    // A double-hyphen in a <string> value is legal XML; the rule is comment-body-only.
+    const xml = '<?xml version="1.0"?>\n<plist><dict><string>a--b</string></dict></plist>\n';
+    expect(findXmlCommentDefects(xml)).toEqual([]);
+  });
+
+  it("does NOT mistake the closing `-->` for an illegal `--`", () => {
+    expect(findXmlCommentDefects("<!-- ok -->")).toEqual([]);
+  });
+
+  it("flags an unterminated comment (matched-delimiter sanity)", () => {
+    const defects = findXmlCommentDefects("<!-- never closed");
+    expect(defects).toHaveLength(1);
+    expect(defects[0].kind).toBe("unterminated-comment");
+  });
+
+  it("flags a `--->` close (a `--` not immediately closing the comment)", () => {
+    const defects = findXmlCommentDefects("<!-- trailing dash --->");
+    expect(defects.length).toBeGreaterThan(0);
+    expect(defects[0].kind).toBe("double-hyphen-in-comment");
+  });
+});
+
+describe("the shipped apps/desktop/Entitlements.plist", () => {
+  it("is codesign/AMFI-safe (no `--` in any comment body)", () => {
+    const body = readFileSync(ENTITLEMENTS_PATH, "utf8");
+    expect(findXmlCommentDefects(body)).toEqual([]);
+  });
+});

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -2,6 +2,7 @@ import { access, constants, readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { promptGuideRequiredForModel } from "../apps/web/src/promptGuideContract.js";
+import { describeXmlCommentDefect, findXmlCommentDefects } from "../apps/web/src/entitlementsPlistContract.js";
 
 const root = process.cwd();
 
@@ -363,6 +364,41 @@ async function assertCharacterImageTuningSurface() {
   }
 }
 
+// The macOS entitlements plist(s) the desktop app ships. codesign/AMFI reads these at
+// signing time with a STRICT XML parser; this list is validated as a class (not a single
+// hard-coded line). Add any new desktop entitlements/plist here so it inherits the guard.
+const desktopEntitlementsPlistPaths = ["apps/desktop/Entitlements.plist"];
+
+async function assertEntitlementsPlistsWellFormed() {
+  // Guard the sc-13609 class: an XML comment body containing `--` (e.g.
+  // `codesign --force --options runtime`) is illegal XML. codesign's AMFI parser
+  // (AMFIUnserializeXML) rejects it at real signing time, but `plutil -lint` is lenient
+  // and NO CI lane codesigns — so it merges green and only breaks the release/notarize
+  // lane. This runs in the PR-time scaffold gate (parity lane) so it can never reach
+  // signing again. findXmlCommentDefects encodes the exact XML rule (`--` legal only as
+  // the leading two chars of the closing `-->`); the shared module is unit-tested.
+  for (const relativePath of desktopEntitlementsPlistPaths) {
+    const body = await readFile(path.join(root, relativePath), "utf8");
+    // Basic plist sanity: it must actually be an XML property list.
+    if (!body.includes("<?xml") || !body.includes("<plist")) {
+      throw new Error(
+        `${relativePath} does not look like an XML property list (missing <?xml or <plist).`,
+      );
+    }
+    const defects = findXmlCommentDefects(body);
+    if (defects.length) {
+      const detail = defects.map(describeXmlCommentDefect).join("; ");
+      throw new Error(
+        `${relativePath} is not codesign/AMFI-safe XML — ${detail}. codesign/AMFI ` +
+          `(AMFIUnserializeXML) rejects \`--\` (double-hyphen) inside an XML comment body ` +
+          `("Comment must not contain double-hyphen"), which breaks macOS app signing even ` +
+          `though plutil -lint passes and no CI lane codesigns (sc-13609). Reword the comment ` +
+          `so no comment body contains \`--\`.`,
+      );
+    }
+  }
+}
+
 for (const requiredPath of requiredPaths) {
   await assertReadable(requiredPath);
 }
@@ -395,5 +431,6 @@ await assertManifestRootsMatchSchemas();
 await assertVersionsAligned();
 await assertBuiltinPromptGuides();
 await assertCharacterImageTuningSurface();
+await assertEntitlementsPlistsWellFormed();
 
 console.log("SceneWorks scaffold check passed.");


### PR DESCRIPTION
## Hotfix: macOS app signing broken by sc-13609

**Symptom (local release build):**
```
Failed to parse entitlements: AMFIUnserializeXML: syntax error near line 18
codesign: failed to sign app
```

**Root cause:** the sc-13609 (#1720) comment I added to `apps/desktop/Entitlements.plist` contained `codesign --force --options runtime` — and **`--` (double-hyphen) is illegal inside an XML comment**. `codesign`'s AMFI parser (`AMFIUnserializeXML`) is strict and rejects it; `plutil -lint` (used in the sc-13609 review) is lenient and passed it, and no CI lane signs, so it merged green and only broke at real signing time.

**Fix:** reword line 18 to drop the double-hyphens (the other `—` in the comment are Unicode em-dashes, which are legal). `xmllint --noout` (strict, matches AMFI) now passes; `plutil -lint` OK.

**Guard (added on this branch):** a PR-time check that strict-validates `Entitlements.plist` as well-formed XML (rejecting `--`-in-comment), so `plutil`'s leniency can't let this class through again.

Story: https://app.shortcut.com/trefry/story/13609