### PR TITLE
fix(worker): stamp family + krea_2 defaults on imported base checkpoints [sc-14108]

### DIFF
--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -382,6 +382,14 @@ pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
         // `anima_aesthetic` / `anima_turbo`), never instantiated through a Torch adapter. Lineage
         // label only (mirrors sd3 / bernini / scail2).
         "anima" => Some("anima"),
+        // Krea 2 (epic 14015): imported single-file Krea 2 checkpoints reuse the same MLX Krea
+        // adapter the builtin krea_2 catalog entries declare (`mlx_krea`), routed to the Krea MLX
+        // engine by family (sc-14108). The match scrutinee is the normalized family, so the arm keys
+        // on the hyphen form `krea-2` (`normalize_model_family("krea_2")`). Builtin krea_2 entries
+        // (`krea_2_turbo` / `krea_2_raw`) declare `adapter` explicitly, so
+        // `apply_model_manifest_defaults` (`or_insert_with`) never overrides them — this default only
+        // stamps user/imported krea_2 models that omit it.
+        "krea-2" => Some("mlx_krea"),
         _ => None,
     }
 }
@@ -413,6 +421,14 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         // surface, so the family default advertises only t2i + style variations (like z-image /
         // qwen-image / lens / flux).
         ("image", "anima") => vec!["text_to_image", "style_variations"],
+        // Krea 2 (epic 14015): imported single-file Krea 2 checkpoints. The KreaImported lane
+        // (sc-14018) is text-to-image ONLY — reference/edit for imports is deferred to sc-14071 — so
+        // the family default advertises just t2i + style variations, NOT `edit_image` /
+        // `character_image` (the builtin Turbo/Raw entries expose those, imports don't yet). The
+        // match keys on the normalized hyphen form `krea-2` (`normalize_model_family("krea_2")`).
+        // This default only affects imported/user krea_2 models; the builtin krea_2 entries declare
+        // their own `capabilities` explicitly, so `apply_model_manifest_defaults` never changes them.
+        ("image", "krea-2") => vec!["text_to_image", "style_variations"],
         // Bernini still-image companion (epic 4699 / sc-5424): the same `Modality::Both`
         // engine the video `bernini` family uses, but the image-typed catalog id
         // (`bernini_image`) exposes only the still tasks — t2i (text→image) and i2i
@@ -2983,6 +2999,30 @@ mod tests {
         );
         assert_eq!(entry["loraCompatibility"]["families"], json!(["wan-video"]));
         assert_eq!(entry["downloads"], json!([]));
+    }
+
+    #[test]
+    fn imported_krea_2_gets_adapter_and_text_to_image_capability() {
+        // sc-14108 (epic 14015): an imported single-file krea_2 base checkpoint whose family the
+        // base-weight gate stamps must ALSO pick up the krea_2 family defaults, or it stays
+        // adapter-less with an empty `capabilities` array and the Image Studio picker (which filters
+        // on `text_to_image`) still hides it. `apply_model_manifest_defaults` is fed the canonical
+        // catalog token `krea_2` (from `reconcile_detected_family`); it normalizes to `krea-2`
+        // internally, which is the form the family-default arms key on.
+        let mut entry = serde_json::Map::new();
+        apply_model_manifest_defaults(&mut entry, "image", Some("krea_2"));
+
+        // The imported model is now MLX-Krea-routed and selectable as a text-to-image model.
+        assert_eq!(entry["adapter"], "mlx_krea");
+        // Text-to-image only (+ style_variations): the KreaImported lane is txt2img-only, so the
+        // default must NOT claim `edit_image` / `character_image` (deferred to sc-14071).
+        assert_eq!(
+            entry["capabilities"],
+            json!(["text_to_image", "style_variations"])
+        );
+        // `loraCompatibility.families` carries the normalized token (as every other family does,
+        // e.g. wan-video above) — Krea LoRAs resolve to it through `canonical_lora_family`.
+        assert_eq!(entry["loraCompatibility"]["families"], json!(["krea-2"]));
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1,6 +1,8 @@
 use super::*;
 
-use sceneworks_core::base_weights::{detect_base_weight_file, import_detection_supported};
+use sceneworks_core::base_weights::{
+    detect_base_weight_file, import_detection_supported, BaseWeightDetection,
+};
 
 /// Post the terminal `Completed` update for a Hugging Face cache download, building the shared
 /// `{<id_key>, repo, path, storage:"huggingface_cache", completedAt}` result object (F-116). Both
@@ -2861,7 +2863,7 @@ pub(crate) async fn run_model_import_job(
     // source-URL, and uploaded imports uniformly (the API's synchronous `import_source_supported`
     // only sees on-disk uploads at queue time). NEVER a silent fallback. `target_dir` is
     // app-managed (`resolve_model_import_target`) — this gate is purely additive to confinement.
-    match first_safetensors_path(&target_dir) {
+    let base_weight_family = match first_safetensors_path(&target_dir) {
         Some(weight_file) => match detect_base_weight_file(&weight_file) {
             Ok(detection) => {
                 if let Err(reason) = import_detection_supported(&detection) {
@@ -2872,6 +2874,17 @@ pub(crate) async fn run_model_import_job(
                         Some(reason),
                     )
                     .await;
+                }
+                // sc-14108: a single-file base checkpoint is a bare DiT — neither a diffusers
+                // directory nor a LoRA — so the LoRA-oriented `detect_model_family` below returns
+                // None for it. Reuse the family the gate's base-weight verdict already resolved so
+                // the import STAMPS it onto the manifest entry. Without a family the entry persists
+                // "unassociated": the catalog shows "Needs Family" and, because Mac routing keys off
+                // the family (sc-14019 `MLX_ROUTED_FAMILIES`), "Not On Mac" — so the model can't be
+                // selected in the Image Studio.
+                match detection {
+                    BaseWeightDetection::Recognized(verdict) => verdict.family,
+                    BaseWeightDetection::Unrecognized { .. } => None,
                 }
             }
             Err(error) => {
@@ -2897,10 +2910,12 @@ pub(crate) async fn run_model_import_job(
             )
             .await;
         }
-    }
+    };
 
     let detected_family = match detect_model_family(&target_dir) {
-        Ok(detected) => detected,
+        // A diffusers dir / LoRA is classified here; a bare base DiT is not, so fall back to the
+        // base-weight verdict's family (sc-14108).
+        Ok(detected) => detected.or(base_weight_family),
         Err(error) => {
             return fail_job(
                 api,

--- a/crates/sceneworks-worker/src/tests/hf_and_family.rs
+++ b/crates/sceneworks-worker/src/tests/hf_and_family.rs
@@ -228,6 +228,56 @@ fn download_family_check_proceeds_when_detection_matches_catalog() {
     ));
 }
 
+fn krea2_base_dit_safetensors_keys() -> Vec<String> {
+    // The ComfyUI-native Krea 2 DiT signature the base-weight classifier keys on: the
+    // `txtfusion.` text-fusion tower is unique to Krea 2.
+    vec![
+        "model.diffusion_model.blocks.0.attn.wq.weight".to_owned(),
+        "model.diffusion_model.blocks.0.mlp.gate.weight".to_owned(),
+        "model.diffusion_model.txtfusion.projector.weight".to_owned(),
+    ]
+}
+
+#[test]
+fn imported_base_krea_dit_gets_family_from_the_base_weight_verdict() {
+    // sc-14108 regression: a bare single-file Krea 2 DiT is neither a diffusers directory nor a
+    // LoRA, so the LoRA-oriented `detect_model_family` returns None. `run_model_import_job` therefore
+    // falls back to the base-weight gate's verdict — `detect_model_family(dir).or(base_weight_family)`
+    // — to stamp `krea_2`. Without the fallback the imported model persists family-less, so the
+    // catalog shows "Needs Family" / "Not On Mac" and it cannot be selected in the Image Studio.
+    use sceneworks_core::base_weights::{detect_base_weight_file, BaseWeightDetection};
+    use sceneworks_core::lora_family::{detect_model_family, first_safetensors_path};
+
+    let dir = tempdir().expect("tempdir creates");
+    write_safetensors_with_keys(
+        &dir.path().join("kreamania_v5.safetensors"),
+        &krea2_base_dit_safetensors_keys(),
+    );
+
+    // (1) The LoRA/diffusers detector cannot classify a bare base DiT.
+    assert_eq!(
+        detect_model_family(dir.path()).expect("detect_model_family runs"),
+        None,
+    );
+
+    // (2) The base-weight gate verdict supplies the family the import falls back to.
+    let file = first_safetensors_path(dir.path()).expect("a safetensors file");
+    let base_weight_family = match detect_base_weight_file(&file).expect("classifies") {
+        BaseWeightDetection::Recognized(verdict) => verdict.family,
+        BaseWeightDetection::Unrecognized { .. } => None,
+    };
+    assert_eq!(base_weight_family.as_deref(), Some("krea_2"));
+
+    // (3) The exact composition `run_model_import_job` stamps onto the manifest entry.
+    assert_eq!(
+        detect_model_family(dir.path())
+            .expect("detect_model_family runs")
+            .or(base_weight_family)
+            .as_deref(),
+        Some("krea_2"),
+    );
+}
+
 #[test]
 fn download_family_check_proceeds_for_derived_family_base_architecture() {
     // Regression: a catalog entry declares a model family whose downloaded weights detect


### PR DESCRIPTION
## sc-14108 (epic 14015)

An imported single-file base checkpoint (e.g. a community Krea 2 DiT) persisted **family-less** — the catalog showed **"Needs Family"** and, because Mac routing keys off the family (`MLX_ROUTED_FAMILIES`, sc-14019), **"Not On Mac"** — so the model could not be selected in the Image Studio. Two gaps compounded.

### Root cause

**Gap 1 — family never stamped.** `run_model_import_job` resolved the family via the LoRA-oriented `detect_model_family`, which returns `None` for a bare DiT (a single-file base checkpoint is neither a diffusers directory nor a LoRA). The import's base-weight gate had *already* classified the file with `detect_base_weight_file` and knew its family, but that verdict was **discarded** — the family field went unset.

**Gap 2 — no krea_2 family defaults.** Even once `family: krea_2` is stamped, `krea_2` had **no arm** in the family-default helpers (`model_adapter_for_family` / `model_capabilities_for_type_and_family`). So `apply_model_manifest_defaults` left the imported entry with **no adapter** and an **empty `capabilities` array**. The Image Studio picker filters on the `text_to_image` capability, so the model *still* would not appear even with a family.

### Fix

1. **Reuse the gate's verdict** (`crates/sceneworks-worker/src/model_jobs.rs`). The base-weight gate block now binds `base_weight_family` from its `Recognized` verdict, and family resolution falls back to it: `detect_model_family(dir).or(base_weight_family)`. No second `detect_base_weight_file` read — the gate's existing detection is reused.

2. **Add `krea_2` family defaults** (`crates/sceneworks-core/src/lora_family.rs`). The match scrutinee is the *normalized* family, so the arms key on the hyphen form `krea-2` (`normalize_model_family("krea_2")`, consistent with `z-image` / `wan-video`):
   - `model_adapter_for_family`: `"krea-2" => Some("mlx_krea")` — the same MLX Krea adapter the builtin krea_2 entries use.
   - `model_capabilities_for_type_and_family`: `("image", "krea-2") => vec!["text_to_image", "style_variations"]` — **text-to-image only**. The KreaImported lane (sc-14018) is txt2img-only; reference/edit for imports is deferred to **sc-14071**, so the default deliberately does **not** claim `edit_image` / `character_image`.

   This default only affects **imported/user** krea_2 models. The builtin krea_2 entries (`krea_2_turbo` / `krea_2_raw`) declare their own `adapter` and `capabilities` explicitly, and `apply_model_manifest_defaults` uses `or_insert_with`, so it never overrides them.

### Tests
- **Worker** — `imported_base_krea_dit_gets_family_from_the_base_weight_verdict`: a bare Krea 2 DiT detects `None` via the LoRA detector, and the import falls back to the base-weight verdict's `krea_2`, asserting the exact `detect_model_family(dir).or(base_weight_family)` composition the import stamps.
- **Core** — `imported_krea_2_gets_adapter_and_text_to_image_capability`: `apply_model_manifest_defaults(entry, "image", Some("krea_2"))` stamps `adapter: mlx_krea` and `capabilities: [text_to_image, style_variations]` (and `loraCompatibility.families: ["krea-2"]`, the normalized token every family stores). Proves an imported krea_2 model becomes a selectable text-to-image model.

### Verification
- `cargo test -p sceneworks-worker --lib` — all pass; `cargo test -p sceneworks-core --lib` — 557 pass.
- `cargo fmt --all --check` clean; `cargo clippy -p sceneworks-core` and `-p sceneworks-worker` `--all-targets -- -D warnings` clean.

### Note
The fix stamps **future** imports. **Already-imported** family-less entries need a **re-import** to pick up the family + defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)