### PR TITLE
feat(models): load Krea int8 per-row imports [sc-14023]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -1806,7 +1806,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "core-llm",
  "half",
@@ -4451,7 +4451,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4567,7 +4567,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5922,7 +5922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5979,7 +5979,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b4c46d89603468771ff7061269fc8406a60c56e3#b4c46d89603468771ff7061269fc8406a60c56e3"
+source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -7323,7 +7323,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8480,7 +8480,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7" }

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -881,7 +881,8 @@ fn converted_tier_real_bytes(tier_dir: &FsPath) -> u64 {
 /// the base-weight detector ([`sceneworks_core::base_weights`]) via [`import_source_supported`] at
 /// queue time and the worker's `run_model_import_job` over the downloaded bytes. The gate accepts
 /// ONLY `(family, component, quant)` triples with a real loader today (`import_supported` — currently
-/// a dense-bf16 Krea 2 DiT, routed to the Krea MLX engine via the S0d family path); every other file
+/// a dense-bf16 or descriptor-gated int8-per-row Krea 2 DiT, routed to the Krea engine via the S0d
+/// family path); every other file
 /// is refused with a typed reason (NEVER a silent fallback). Kept as a fn, not a `const`, so the
 /// guarded handler body stays reachable (no `unreachable_code`) and the switch is trivially
 /// re-flippable if a regression surfaces.
@@ -1457,8 +1458,8 @@ fn backfill_current_receipt(
 #[cfg(test)]
 mod import_gate_tests {
     //! The queue-time base-checkpoint compatibility gate (sc-14019, epic 14015): `import_source_supported`
-    //! must accept a dense-bf16 Krea 2 DiT and refuse everything else with an actionable reason, so the
-    //! LAN-exposed import endpoint (now that the kill-switch is on) can never queue an un-runnable file.
+    //! must accept a dense-bf16 or int8-per-row Krea 2 DiT and refuse unsupported triples with an
+    //! actionable reason, so the LAN-exposed import endpoint can never queue an un-runnable file.
     use super::*;
 
     /// Write a safetensors file whose header declares `(name, dtype)` tensors. The declared tensor
@@ -1485,7 +1486,7 @@ mod import_gate_tests {
     }
 
     /// A ComfyUI-native dense-bf16 Krea 2 DiT: the unique `txtfusion.` tower + BFL-style `blocks.*`
-    /// keys, all BF16 → detector `(krea_2, Transformer, Bf16)` — the one importable triple today.
+    /// keys, all BF16 → detector `(krea_2, Transformer, Bf16)` — one supported import triple.
     fn krea2_bf16_dit_keys() -> Vec<(&'static str, &'static str)> {
         vec![
             ("model.diffusion_model.blocks.0.attn.wq.weight", "BF16"),
@@ -1506,6 +1507,45 @@ mod import_gate_tests {
         assert!(
             import_source_supported(&file).is_ok(),
             "a dense-bf16 Krea 2 DiT upload must pass the import gate"
+        );
+    }
+
+    #[test]
+    fn krea2_int8_per_row_upload_is_accepted() {
+        // Header detection deliberately identifies the convention from bulk I8 weights plus
+        // `.comfy_quant`; the inference loader validates the actual descriptor JSON and scale shapes
+        // before dequantization. This reduced fixture pins the queue-time classification/gate seam.
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("kreamania_variant4.safetensors");
+        let mut names = Vec::new();
+        for index in 0..6 {
+            names.push((
+                format!("model.diffusion_model.blocks.{index}.attn.wq.weight"),
+                "I8",
+            ));
+            names.push((
+                format!("model.diffusion_model.blocks.{index}.attn.wq.weight_scale"),
+                "F32",
+            ));
+            names.push((
+                format!("model.diffusion_model.blocks.{index}.attn.wq.comfy_quant"),
+                "U8",
+            ));
+        }
+        names.push(("model.diffusion_model.blocks.0.mod.lin".to_owned(), "BF16"));
+        names.push((
+            "model.diffusion_model.txtfusion.projector.weight".to_owned(),
+            "F32",
+        ));
+        let entries: Vec<(&str, &str)> = names
+            .iter()
+            .map(|(name, dtype)| (name.as_str(), *dtype))
+            .collect();
+        write_safetensors(&file, &entries);
+
+        assert!(
+            import_source_supported(&file).is_ok(),
+            "a Krea 2 int8-per-row DiT upload must pass the import gate"
         );
     }
 

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -1280,6 +1280,48 @@ async fn model_import_route_is_enabled_and_detector_gated() {
     );
     assert_eq!(job["type"], "model_import");
 
+    // Supported multipart upload: the descriptor-gated Krea int8-per-row convention. The detector is
+    // intentionally header-only (bulk I8 + `.comfy_quant`); inference validates descriptor bytes and
+    // F32 per-row scale shapes before dequantization.
+    let mut int8_names = Vec::new();
+    for index in 0..6 {
+        int8_names.push((
+            format!("model.diffusion_model.blocks.{index}.attn.wq.weight"),
+            "I8",
+        ));
+        int8_names.push((
+            format!("model.diffusion_model.blocks.{index}.attn.wq.weight_scale"),
+            "F32",
+        ));
+        int8_names.push((
+            format!("model.diffusion_model.blocks.{index}.attn.wq.comfy_quant"),
+            "U8",
+        ));
+    }
+    int8_names.push(("model.diffusion_model.blocks.0.mod.lin".to_owned(), "BF16"));
+    int8_names.push((
+        "model.diffusion_model.txtfusion.projector.weight".to_owned(),
+        "F32",
+    ));
+    let int8_entries: Vec<(&str, &str)> = int8_names
+        .iter()
+        .map(|(name, dtype)| (name.as_str(), *dtype))
+        .collect();
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (int8_status, int8_job) = request_multipart_model_upload(
+        app,
+        &[("name", "Krea Int8 Import"), ("type", "image")],
+        "kreamania_variant4.safetensors",
+        &test_safetensors_bytes_with_typed_keys(&int8_entries),
+    )
+    .await;
+    assert_eq!(
+        int8_status,
+        StatusCode::CREATED,
+        "a Krea int8-per-row DiT upload must pass the gate and queue: {int8_job:?}"
+    );
+    assert_eq!(int8_job["type"], "model_import");
+
     // Unsupported multipart upload: an F8_E4M3 qwen-image DiT is a recognized family with no import
     // loader today -> refused AT THE ENDPOINT with 400 and the typed reason naming the family, before
     // any job is queued. This is the negative endpoint->gate wiring assertion.

--- a/crates/sceneworks-core/src/base_weights.rs
+++ b/crates/sceneworks-core/src/base_weights.rs
@@ -123,11 +123,10 @@ pub enum QuantFormat {
     /// carries none (it packs nibbles into `U8`). Both also carry bulk `U8`
     /// (int8 stores its `.comfy_quant` descriptors as small `U8` blobs), so `U8`
     /// alone cannot separate them — the `I8` weight dtype is the decisive signal.
-    /// A loadable quant *in principle* (the int8 single-file loader lands in
-    /// sc-14023); split out here (sc-14026) so the int8 Krea variant
+    /// Loaded by Krea's descriptor-gated single-file loader (sc-14023); split out
+    /// here (sc-14026) so the int8 Krea variant
     /// (`~/models/kreamania_variant4.safetensors`) is not mislabelled as the
-    /// unloadable fp4 bucket. Still refused by [`import_supported`] until its loader
-    /// lands — but with a distinct int8 reason, not the fp4 one.
+    /// unloadable fp4 bucket.
     Int8TensorwisePerRow,
     /// GGUF container (`Q8_0`, `Q4_K_S`, …) — detected by the `GGUF` magic, not the
     /// extension. Has no safetensors header; family/component are read from GGUF
@@ -212,16 +211,19 @@ pub const IMPORT_SUPPORTED_FAMILIES: &[&str] = &["krea_2"];
 ///
 /// Written as a `match` with **one arm per supported loader** so a follow-on family / component /
 /// quant (the S0c assembly slice and the epic's later families) is a single added arm, not a
-/// rewrite. Today exactly one triple is loadable: a dense-`bf16` Krea 2 DiT
-/// (`krea_2` / [`ComponentRole::Transformer`] / [`QuantFormat::Bf16`]), which reuses the existing
-/// Krea MLX engine via the family-routing path. Everything else — an unrecognized/absent family, a
+/// rewrite. Today two triples are loadable: a Krea 2 transformer in either dense `bf16` or
+/// descriptor-gated [`QuantFormat::Int8TensorwisePerRow`], both of which reuse the existing Krea
+/// engine via the family-routing path. Everything else — an unrecognized/absent family, a
 /// non-transformer component (VAE / text encoder / all-in-one checkpoint), or a deferred quant
-/// (plain/scaled/inline fp8, `comfy_quant` fp4-packed, int8-tensorwise-per-row, GGUF) — is refused
-/// with a specific reason (int8 carries its own reason distinct from the fp4/dense-bf16 one).
+/// (plain/scaled/inline fp8, `comfy_quant` fp4-packed, GGUF) — is refused with a specific reason.
 pub fn import_supported(verdict: &BaseWeightVerdict) -> Result<(), String> {
     match (verdict.family.as_deref(), verdict.component, verdict.quant) {
         // --- Supported loaders: one arm per landed loader (add the next family/quant here) ---
-        (Some("krea_2"), ComponentRole::Transformer, QuantFormat::Bf16) => Ok(()),
+        (
+            Some("krea_2"),
+            ComponentRole::Transformer,
+            QuantFormat::Bf16 | QuantFormat::Int8TensorwisePerRow,
+        ) => Ok(()),
 
         // --- Refusals: most specific first, each with an actionable, client-facing reason ---
         (None, _, _) => Err(
@@ -237,19 +239,9 @@ pub fn import_supported(verdict: &BaseWeightVerdict) -> Result<(), String> {
             "Model import for the '{family}' family currently supports only the diffusion \
              transformer, not a {component} file."
         )),
-        // int8-tensorwise-per-row is a distinct, loadable-in-principle quant (not the fp4/mxfp4
-        // reject bucket), but its single-file loader is not landed yet (sc-14023). Refuse with an
-        // int8-specific reason rather than the generic dense-bf16 message below, so the surface is
-        // accurate about *why* the file is deferred. Do NOT mark it loadable.
-        (Some(family), ComponentRole::Transformer, QuantFormat::Int8TensorwisePerRow) => {
-            Err(format!(
-                "Model import for the '{family}' family does not yet support int8 checkpoints \
-                 (the int8 loader is not landed yet). Re-export the checkpoint in bf16."
-            ))
-        }
         (Some(family), _, quant) => Err(format!(
-            "Model import for the '{family}' family currently supports only dense bf16 weights, \
-             not {quant}. Re-export the checkpoint in bf16."
+            "Model import for the '{family}' family currently supports only dense bf16 or \
+             descriptor-gated int8-per-row weights, not {quant}. Re-export the checkpoint in bf16."
         )),
     }
 }
@@ -1225,14 +1217,14 @@ mod tests {
     }
 
     #[test]
-    fn import_supported_accepts_only_krea2_transformer_bf16() {
-        // The single loadable triple today: a dense-bf16 Krea 2 DiT, routed to the Krea MLX engine.
-        assert!(import_supported(&verdict(
-            Some("krea_2"),
-            ComponentRole::Transformer,
-            QuantFormat::Bf16
-        ))
-        .is_ok());
+    fn import_supported_accepts_krea2_transformer_bf16_and_int8_per_row() {
+        for quant in [QuantFormat::Bf16, QuantFormat::Int8TensorwisePerRow] {
+            assert!(
+                import_supported(&verdict(Some("krea_2"), ComponentRole::Transformer, quant))
+                    .is_ok(),
+                "Krea 2 transformer {quant} has a landed single-file loader"
+            );
+        }
     }
 
     #[test]
@@ -1245,33 +1237,12 @@ mod tests {
         ))
         .expect_err("packed quant must be refused");
         assert!(
-            reason.contains("bf16"),
+            reason.contains("bf16") && reason.contains("int8"),
             "reason should name the required quant: {reason}"
         );
         assert!(
             reason.contains(QuantFormat::ComfyQuantPacked.as_str()),
             "reason should name the rejected quant: {reason}"
-        );
-    }
-
-    #[test]
-    fn import_supported_refuses_krea2_int8_with_distinct_reason() {
-        // int8-tensorwise-per-row is loadable in principle but its loader (sc-14023) is not
-        // landed — refuse with an int8-specific reason, NOT the fp4/dense-bf16 message.
-        let reason = import_supported(&verdict(
-            Some("krea_2"),
-            ComponentRole::Transformer,
-            QuantFormat::Int8TensorwisePerRow,
-        ))
-        .expect_err("int8 quant must still be refused (no loader yet)");
-        assert!(
-            reason.contains("int8"),
-            "reason should name int8 specifically: {reason}"
-        );
-        // Must NOT reuse the generic fp4/dense-bf16 phrasing that names the on-disk quant string.
-        assert!(
-            !reason.contains(QuantFormat::Int8TensorwisePerRow.as_str()),
-            "int8 refusal should use its own message, not the generic dense-bf16 one: {reason}"
         );
     }
 

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -3854,6 +3854,84 @@ mod candle_routing_tests {
     }
 
     #[test]
+    fn imported_krea_family_plain_single_file_job_is_candle_eligible() {
+        let plain = json!({
+            "projectId": "project_1",
+            "model": "kreamania_variant4",
+            "prompt": "a red fox",
+            "modelManifestEntry": {
+                "family": "krea_2",
+                "paths": { "model": "C:\\SceneWorks\\models\\imports\\kreamania_variant4" }
+            }
+        });
+
+        assert!(
+            !image_request_candle_eligible(
+                "kreamania_variant4",
+                plain.as_object().expect("payload object")
+            ),
+            "the builtin id table must not accidentally contain the imported id"
+        );
+        assert!(
+            image_job_is_candle_eligible(&image_generate_job(plain.clone())),
+            "the full scheduler must claim a novel imported id through family routing"
+        );
+        assert!(
+            worker_supports_job(&gpu_worker(CANDLE_CAPS), &image_generate_job(plain.clone())),
+            "a Candle worker must claim the imported family-routed job"
+        );
+
+        let direct_file = json!({
+            "model": "kreamania_variant4_direct",
+            "modelManifestEntry": {
+                "family": "krea_2",
+                "modelPath": "C:\\SceneWorks\\models\\kreamania_variant4.safetensors"
+            }
+        });
+        assert!(image_job_is_candle_eligible(&image_generate_job(
+            direct_file
+        )));
+
+        let mut unsupported_shapes = Vec::new();
+        for extra in [
+            json!({ "mode": "edit_image", "sourceAssetId": "source_1" }),
+            json!({ "mode": " edit_image ", "sourceAssetId": "source_1" }),
+            json!({ "referenceAssetId": "reference_1" }),
+            json!({ "referenceAssetIds": ["reference_1"] }),
+            json!({ "maskAssetId": "mask_1" }),
+            json!({ "characterId": "character_1" }),
+            json!({ "loras": [{ "id": "adapter_1" }] }),
+            json!({ "advanced": { "poses": [{ "id": "pose_1" }] } }),
+            json!({ "advanced": { "phases": [{ "steps": 4 }] } }),
+        ] {
+            let mut payload = plain.clone();
+            payload
+                .as_object_mut()
+                .expect("payload object")
+                .extend(extra.as_object().expect("extra object").clone());
+            unsupported_shapes.push(payload);
+        }
+        for payload in unsupported_shapes {
+            assert!(
+                !image_job_is_candle_eligible(&image_generate_job(payload.clone())),
+                "unsupported imported-Krea conditioning must fail closed: {payload}"
+            );
+        }
+
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "kreamania_variant4",
+            "modelManifestEntry": { "family": "krea_2" }
+        }))));
+        assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
+            "model": "foreign_import",
+            "modelManifestEntry": {
+                "family": "z-image",
+                "paths": { "model": "C:\\SceneWorks\\models\\imports\\foreign" }
+            }
+        }))));
+    }
+
+    #[test]
     fn base_z_image_txt2img_is_candle_eligible_but_edit_shapes_are_not() {
         // sc-8679: base `z_image` plain txt2img rides the candle lane (the base sibling of z_image_turbo);
         // its edit / reference / mask conditioning shapes still defer to the Python torch worker (no candle
@@ -6494,14 +6572,95 @@ mod candle_routing_tests {
 #[cfg(test)]
 mod mlx_routing_tests {
     use super::{
-        flux2_mlx_eligible, flux_mlx_eligible, image_request_mlx_eligible, instantid_mlx_eligible,
-        model_mac_support, qwen_edit_mlx_eligible, qwen_mlx_eligible, sdxl_mlx_eligible,
-        video_mode_is_mlx_eligible, z_image_mlx_eligible, VIDEO_MLX_ROUTED_MODELS,
+        flux2_mlx_eligible, flux_mlx_eligible, image_job_is_mlx_eligible,
+        image_request_mlx_eligible, instantid_mlx_eligible, model_mac_support,
+        qwen_edit_mlx_eligible, qwen_mlx_eligible, sdxl_mlx_eligible, video_mode_is_mlx_eligible,
+        worker_supports_job, z_image_mlx_eligible, JobSnapshot, WorkerSnapshot, MLX_ROUTED_MODELS,
+        VIDEO_MLX_ROUTED_MODELS,
     };
     use serde_json::{json, Map, Value};
 
     fn object(value: Value) -> Map<String, Value> {
         value.as_object().expect("test value is an object").clone()
+    }
+
+    fn image_generate_job(payload: Value) -> JobSnapshot {
+        serde_json::from_value(json!({
+            "id": "job_imported_krea",
+            "type": "image_generate",
+            "status": "queued",
+            "payload": payload,
+            "result": {},
+            "requestedGpu": "auto",
+            "progress": 0,
+            "stage": "queued",
+            "message": "",
+            "attempts": 1,
+            "cancelRequested": false,
+            "createdAt": "2026-07-23T00:00:00Z",
+            "updatedAt": "2026-07-23T00:00:00Z"
+        }))
+        .expect("valid image job")
+    }
+
+    fn mlx_worker() -> WorkerSnapshot {
+        serde_json::from_value(json!({
+            "id": "worker_mlx",
+            "gpuId": "mlx",
+            "status": "idle",
+            "capabilities": ["gpu", "image_generate"],
+            "loadedModels": [],
+            "registeredAt": "2026-07-23T00:00:00Z",
+            "lastSeenAt": "2026-07-23T00:00:00Z"
+        }))
+        .expect("valid MLX worker")
+    }
+
+    #[test]
+    fn imported_krea_family_plain_single_file_job_is_mlx_eligible() {
+        let plain = json!({
+            "projectId": "project_1",
+            "model": "kreamania_variant4",
+            "prompt": "a red fox",
+            "modelManifestEntry": {
+                "family": "krea_2",
+                "paths": { "model": "/app/models/imports/kreamania_variant4" }
+            }
+        });
+
+        assert!(
+            !MLX_ROUTED_MODELS.contains(&"kreamania_variant4"),
+            "the builtin id table must not accidentally contain the imported id"
+        );
+        assert!(
+            image_request_mlx_eligible(
+                "kreamania_variant4",
+                plain.as_object().expect("payload object")
+            ),
+            "the public MLX predicate must apply the imported-family fallback"
+        );
+        let job = image_generate_job(plain.clone());
+        assert!(
+            image_job_is_mlx_eligible(&job),
+            "the full scheduler must claim a novel imported id through family routing"
+        );
+        assert!(
+            worker_supports_job(&mlx_worker(), &job),
+            "an MLX worker must claim the imported family-routed job"
+        );
+
+        assert!(!image_job_is_mlx_eligible(&image_generate_job(json!({
+            "model": "kreamania_variant4",
+            "loras": [{ "id": "adapter_1" }],
+            "modelManifestEntry": {
+                "family": "krea_2",
+                "paths": { "model": "/app/models/imports/kreamania_variant4" }
+            }
+        }))));
+        assert!(!image_job_is_mlx_eligible(&image_generate_job(json!({
+            "model": "kreamania_variant4",
+            "modelManifestEntry": { "family": "krea_2" }
+        }))));
     }
 
     #[test]

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -5,7 +5,8 @@ use serde_json::{Map, Value};
 
 use crate::contracts::{JobSnapshot, JobType, WorkerSnapshot};
 use crate::jobs_store::routing::catalog::{
-    CANDLE_LORA_MODELS, CANDLE_QUANT_LORA_MODELS, CANDLE_QUANT_MODELS, CANDLE_ROUTED_MODELS,
+    imported_image_request_family_eligible, CANDLE_LORA_MODELS, CANDLE_QUANT_LORA_MODELS,
+    CANDLE_QUANT_MODELS, CANDLE_ROUTED_FAMILIES, CANDLE_ROUTED_MODELS,
     CANDLE_ROUTED_TRAINING_KERNELS, CANDLE_VIDEO_I2V_ROUTED_MODELS, CANDLE_VIDEO_ROUTED_MODELS,
     CANDLE_VIDEO_VACE_MODELS,
 };
@@ -44,6 +45,13 @@ pub(crate) fn image_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     let Some(model) = job.payload.get("model").and_then(Value::as_str) else {
         return false;
     };
+    // Imported Krea 2 single-file txt2img (sc-14023): imported ids are intentionally absent from
+    // `CANDLE_ROUTED_MODELS`, so claim them through the manifest family before the builtin id table.
+    // The worker repeats this gate and validates that the recorded app-managed path resolves to
+    // exactly one safetensors file before dispatching the native-file loader.
+    if imported_image_request_family_eligible(model, &job.payload, CANDLE_ROUTED_FAMILIES) {
+        return true;
+    }
     // InstantID (sc-5491, epic 5480): the candle `candle-gen-instantid` provider serves the SAME
     // identity-preserving surface as the MLX path (single-identity character_image, the angle set,
     // pose-library mode, face-restore) — a bespoke `generate_instantid_stream` lane, NOT the

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -103,15 +103,10 @@ pub(crate) fn image_model_mac_support(model: &str, family: Option<&str>) -> Mode
             return ModelMacSupport {
                 supported: true,
                 reason: None,
-                features: ModelMacFeatures {
-                    // MLX-routed ⇒ third-party LyCORIS applies on the provider (epic 3641). The
-                    // imported single-file checkpoint is a bare diffusion transformer, so the
-                    // conditioning features that need extra components/adapters (pose / reference /
-                    // edit) are deliberately NOT claimed here — S0c wires the actual assembly/load;
-                    // this story decides eligibility only.
-                    lycoris: true,
-                    ..ModelMacFeatures::default()
-                },
+                // The imported single-file checkpoint is a bare diffusion transformer. Adapters,
+                // pose, reference, and edit are deliberately rejected by both the scheduler and
+                // worker so the UI must not advertise those builtin-only capabilities.
+                features: ModelMacFeatures::default(),
             };
         }
         return ModelMacSupport {
@@ -890,11 +885,101 @@ pub(crate) fn image_family_is_mlx_routed(family: &str) -> bool {
     MLX_ROUTED_FAMILIES.contains(&family)
 }
 
+/// Architecture families whose existing Candle engine can serve a non-builtin imported/user
+/// same-family model. This is deliberately separate from [`CANDLE_ROUTED_MODELS`]: imported
+/// checkpoints have novel ids and are claimed only after the scheduler validates their manifest
+/// family and supported request shape. Seeded by the descriptor-gated Krea single-file lane
+/// (sc-14023).
+pub(crate) const CANDLE_ROUTED_FAMILIES: &[&str] = &["krea_2"];
+
 /// Whether `id` names a builtin image model (a row in [`IMAGE_MODEL_CAPS`]). The route-by-family
 /// path applies only to non-builtin (imported/user) ids, so a builtin's id-keyed routing is never
 /// overridden by its family (sc-14019).
 pub(crate) fn is_builtin_image_model(id: &str) -> bool {
     IMAGE_MODEL_CAPS.iter().any(|caps| caps.id == id)
+}
+
+/// Shared fail-closed request-shape gate for a non-builtin imported image id that reuses a native
+/// engine by family. The worker owns filesystem confinement and verifies that the recorded path
+/// resolves to exactly one safetensors file; the scheduler only admits the matching family, a
+/// non-empty installed path hint, and the bare-transformer txt2img surface implemented by both the
+/// MLX and Candle imported-Krea handlers.
+pub(crate) fn imported_image_request_family_eligible(
+    model: &str,
+    payload: &Map<String, Value>,
+    routed_families: &[&str],
+) -> bool {
+    if is_builtin_image_model(model) {
+        return false;
+    }
+    let Some(entry) = payload.get("modelManifestEntry").and_then(Value::as_object) else {
+        return false;
+    };
+    let family_is_routed = entry
+        .get("family")
+        .and_then(Value::as_str)
+        .is_some_and(|family| routed_families.contains(&family));
+    if !family_is_routed {
+        return false;
+    }
+    let has_nonempty_path = entry
+        .get("modelPath")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            entry
+                .get("paths")
+                .and_then(Value::as_object)
+                .and_then(|paths| paths.get("model"))
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .is_some_and(|path| !path.is_empty());
+    if !has_nonempty_path {
+        return false;
+    }
+    if payload.get("mode").and_then(Value::as_str).map(str::trim) == Some("edit_image") {
+        return false;
+    }
+    let has_nonempty_id = |key: &str| {
+        payload
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+    };
+    if [
+        "sourceAssetId",
+        "referenceAssetId",
+        "maskAssetId",
+        "characterId",
+        "characterLookId",
+    ]
+    .iter()
+    .any(|key| has_nonempty_id(key))
+    {
+        return false;
+    }
+    if payload
+        .get("referenceAssetIds")
+        .and_then(Value::as_array)
+        .is_some_and(|ids| !ids.is_empty())
+        || payload
+            .get("loras")
+            .and_then(Value::as_array)
+            .is_some_and(|loras| !loras.is_empty())
+    {
+        return false;
+    }
+    let advanced = payload.get("advanced").and_then(Value::as_object);
+    let has_poses = advanced
+        .and_then(|advanced| advanced.get("poses"))
+        .and_then(Value::as_array)
+        .is_some_and(|poses| !poses.is_empty());
+    let has_phases = advanced
+        .and_then(|advanced| advanced.get("phases"))
+        .and_then(Value::as_array)
+        .is_some_and(|phases| !phases.is_empty());
+    !has_poses && !has_phases
 }
 
 derive_model_list! {
@@ -1046,10 +1131,11 @@ mod tests {
 
     use super::{
         image_family_is_mlx_routed, image_model_mac_support, is_builtin_image_model,
-        CANDLE_LORA_MODELS, CANDLE_QUANT_LORA_MODELS, CANDLE_QUANT_MODELS, CANDLE_ROUTED_MODELS,
-        CANDLE_ROUTED_TRAINING_KERNELS, CANDLE_VIDEO_I2V_ROUTED_MODELS, CANDLE_VIDEO_ROUTED_MODELS,
-        CANDLE_VIDEO_VACE_MODELS, IMAGE_MODEL_CAPS, MLX_ONLY_TRAINING_KERNELS, MLX_ROUTED_FAMILIES,
-        MLX_ROUTED_MODELS, MLX_ROUTED_TRAINING_KERNELS, VIDEO_MLX_ROUTED_MODELS, VIDEO_MODEL_CAPS,
+        CANDLE_LORA_MODELS, CANDLE_QUANT_LORA_MODELS, CANDLE_QUANT_MODELS, CANDLE_ROUTED_FAMILIES,
+        CANDLE_ROUTED_MODELS, CANDLE_ROUTED_TRAINING_KERNELS, CANDLE_VIDEO_I2V_ROUTED_MODELS,
+        CANDLE_VIDEO_ROUTED_MODELS, CANDLE_VIDEO_VACE_MODELS, IMAGE_MODEL_CAPS,
+        MLX_ONLY_TRAINING_KERNELS, MLX_ROUTED_FAMILIES, MLX_ROUTED_MODELS,
+        MLX_ROUTED_TRAINING_KERNELS, VIDEO_MLX_ROUTED_MODELS, VIDEO_MODEL_CAPS,
     };
 
     /// Assert a table-derived list reproduces its pre-collapse snapshot EXACTLY as a set: same
@@ -1420,10 +1506,18 @@ mod tests {
     /// a deliberate edit (it makes every imported same-family checkpoint Mac-routable), so it must be
     /// mirrored here — the guardrail that a family is never silently added to the import surface.
     const EXPECTED_MLX_ROUTED_FAMILIES: &[&str] = &["krea_2"];
+    const EXPECTED_CANDLE_ROUTED_FAMILIES: &[&str] = &["krea_2"];
 
     #[test]
     fn mlx_routed_families_match_snapshot() {
         assert_eq!(MLX_ROUTED_FAMILIES, EXPECTED_MLX_ROUTED_FAMILIES);
+    }
+
+    #[test]
+    fn candle_routed_families_match_snapshot() {
+        assert_eq!(CANDLE_ROUTED_FAMILIES, EXPECTED_CANDLE_ROUTED_FAMILIES);
+        assert!(CANDLE_ROUTED_FAMILIES.contains(&"krea_2"));
+        assert!(!CANDLE_ROUTED_FAMILIES.contains(&"z-image"));
     }
 
     #[test]
@@ -1444,24 +1538,38 @@ mod tests {
     }
 
     #[test]
+    fn candle_routed_families_have_a_same_family_builtin_engine() {
+        for family in CANDLE_ROUTED_FAMILIES {
+            let has_routed_builtin = CANDLE_ROUTED_MODELS
+                .iter()
+                .any(|id| id.starts_with(family) && is_builtin_image_model(id));
+            assert!(
+                has_routed_builtin,
+                "CANDLE_ROUTED_FAMILIES lists '{family}' but no Candle-routed builtin id shares that family prefix"
+            );
+        }
+    }
+
+    #[test]
     fn mlx_routed_families_agree_with_import_supported_families() {
         // sc-14019: `MLX_ROUTED_FAMILIES` (routing, here) and `base_weights::IMPORT_SUPPORTED_FAMILIES`
         // (the model-import compatibility gate) are two independent `krea_2` allow-lists that must NOT
-        // silently drift. Route-by-family exists ONLY via MLX today, so the two sets must be identical:
-        // a family added to the import gate but not here would let a user import a checkpoint no engine
-        // can run, and a family added here but not to the gate would route one the gate refuses. This
-        // fails the moment either list gains or loses a family the other did not. If a non-MLX
-        // route-by-family lane (e.g. candle) is ever added, evolve this into a subset check over the
-        // union of route-by-family lists.
-        let routed: BTreeSet<&str> = MLX_ROUTED_FAMILIES.iter().copied().collect();
+        // silently drift. The route surface is the union of the MLX and Candle family lists: a family
+        // accepted by the import gate must have at least one native route, and a routed family must be
+        // admitted by the import gate.
+        let routed: BTreeSet<&str> = MLX_ROUTED_FAMILIES
+            .iter()
+            .chain(CANDLE_ROUTED_FAMILIES.iter())
+            .copied()
+            .collect();
         let importable: BTreeSet<&str> = crate::base_weights::IMPORT_SUPPORTED_FAMILIES
             .iter()
             .copied()
             .collect();
         assert_eq!(
             routed, importable,
-            "MLX_ROUTED_FAMILIES and IMPORT_SUPPORTED_FAMILIES disagree; add a family to BOTH the \
-             import gate and the route-by-family allow-list (or remove it from both)"
+            "the native route-by-family union and IMPORT_SUPPORTED_FAMILIES disagree; add a family \
+             to the import gate and at least one native route list (or remove it from both)"
         );
     }
 
@@ -1479,8 +1587,8 @@ mod tests {
             "an imported krea_2-family model should route via the family path"
         );
         assert!(support.reason.is_none());
-        // MLX-routed ⇒ LyCORIS applies; the bare-DiT conditioning features stay unclaimed (S0c).
-        assert!(support.features.lycoris);
+        // The bare-DiT lane is plain txt2img only; adapters and conditioning stay unclaimed.
+        assert!(!support.features.lycoris);
         assert!(!support.features.edit);
         assert!(!support.features.pose);
         assert!(!support.features.reference);

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -5,10 +5,9 @@ use serde_json::{Map, Value};
 
 use crate::contracts::{JobSnapshot, JobType};
 use crate::jobs_store::routing::catalog::{
-    image_family_is_mlx_routed, is_builtin_image_model, MLX_ONLY_TRAINING_KERNELS,
+    imported_image_request_family_eligible, MLX_ONLY_TRAINING_KERNELS, MLX_ROUTED_FAMILIES,
     MLX_ROUTED_MODELS, MLX_ROUTED_TRAINING_KERNELS, VIDEO_MLX_ROUTED_MODELS,
 };
-use crate::lora_family::normalize_model_family;
 
 /// Epic 3018 routing — does this image job belong on the in-process Rust MLX
 /// worker? This lifts the per-family `_should_route_*_to_mlx` decision (ported
@@ -55,10 +54,7 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
         // future) candle-only builtin — a builtin id absent from `MLX_ROUTED_MODELS` — not-eligible
         // here rather than family-routed. Today every builtin is `mlx_routed`, so this branch is only
         // ever reached by imported ids; the guard is defensive parity, not live behavior.
-        if !is_builtin_image_model(model) {
-            return imported_family_image_mlx_eligible(payload);
-        }
-        return false;
+        return imported_image_request_family_eligible(model, payload, MLX_ROUTED_FAMILIES);
     }
     match model {
         "z_image_turbo" | "z_image_edit" => z_image_mlx_eligible(payload),
@@ -97,41 +93,6 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
         "anima_base" | "anima_aesthetic" | "anima_turbo" => anima_mlx_eligible(payload),
         // Every model in MLX_ROUTED_MODELS must have an arm — enforced by
         // `every_mlx_routed_model_has_a_dispatch_arm` below, not just by this comment.
-        _ => false,
-    }
-}
-
-/// Route-by-family MLX-eligibility for a non-builtin (imported/user) image model whose novel id is
-/// in no routing table (sc-14109, epic 14015). Reads the catalog `family` off the job payload's
-/// `modelManifestEntry` — the full manifest entry apps/rust-api stamps into every generation job
-/// (`generation.rs`, the same entry the display badge reads its `family` from, so claim-time routing
-/// and the UI verdict share one source of truth). Eligible only when that family is an MLX-routed
-/// family ([`image_family_is_mlx_routed`], the same allow-list the badge uses — checked against the
-/// raw manifest token, which the detector emits in `MLX_ROUTED_FAMILIES` form), then dispatched to
-/// that family's existing per-family predicate. For `krea_2`, [`krea_mlx_eligible`] admits plain t2i
-/// and rejects an `edit_image` job on a non-builtin id (its edit arm gates on the builtin
-/// `krea_2_raw`/`krea_2_turbo` ids), which matches S0c's t2i-only import scope. A missing /
-/// family-less manifest entry, or a non-routed / not-yet-dispatched family, returns false —
-/// unchanged from the pre-sc-14109 blanket `return false`.
-fn imported_family_image_mlx_eligible(payload: &Map<String, Value>) -> bool {
-    let Some(family) = payload
-        .get("modelManifestEntry")
-        .and_then(Value::as_object)
-        .and_then(|entry| entry.get("family"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    else {
-        return false;
-    };
-    if !image_family_is_mlx_routed(family) {
-        return false;
-    }
-    // Dispatch on the normalized family token (`krea_2` → `krea-2`, mirroring lora_family's
-    // adapter/capabilities arms). Future importable families add an arm here alongside their
-    // `MLX_ROUTED_FAMILIES` / `IMPORT_SUPPORTED_FAMILIES` entry.
-    match normalize_model_family(family).as_str() {
-        "krea-2" => krea_mlx_eligible(payload),
         _ => false,
     }
 }
@@ -975,7 +936,11 @@ mod tests {
         let t2i = json!({
             "model": imported_id,
             "mode": "text_to_image",
-            "modelManifestEntry": { "id": imported_id, "family": "krea_2" },
+            "modelManifestEntry": {
+                "id": imported_id,
+                "family": "krea_2",
+                "paths": { "model": "/app/models/imports/kreamania_variant4" }
+            },
         });
         assert!(image_request_mlx_eligible(
             imported_id,
@@ -985,7 +950,11 @@ mod tests {
         // A bare request with no explicit mode is equally a t2i job, equally eligible.
         let bare = json!({
             "model": imported_id,
-            "modelManifestEntry": { "id": imported_id, "family": "krea_2" },
+            "modelManifestEntry": {
+                "id": imported_id,
+                "family": "krea_2",
+                "modelPath": "/app/models/imports/kreamania_variant4.safetensors"
+            },
         });
         assert!(image_request_mlx_eligible(
             imported_id,
@@ -1023,7 +992,10 @@ mod tests {
         let no_family = json!({
             "model": imported_id,
             "mode": "text_to_image",
-            "modelManifestEntry": { "id": imported_id },
+            "modelManifestEntry": {
+                "id": imported_id,
+                "paths": { "model": "/app/models/imports/user_zimage_import" }
+            },
         });
         assert!(!image_request_mlx_eligible(
             imported_id,
@@ -1031,9 +1003,8 @@ mod tests {
         ));
     }
 
-    /// Import scope is t2i-only (S0c). An `edit_image` job on an imported krea_2 id is NOT eligible:
-    /// `krea_mlx_eligible`'s edit arm gates on the builtin `krea_2_raw`/`krea_2_turbo` ids, and an
-    /// imported novel id is neither, so even a well-formed edit-with-source falls through to false.
+    /// Import scope is t2i-only (S0c). The shared imported-family gate rejects `edit_image` before
+    /// backend dispatch, so even a well-formed imported edit with a source remains ineligible.
     #[test]
     fn imported_krea_family_edit_is_not_mlx_eligible() {
         let imported_id = "user_kreamania_variant5";
@@ -1041,7 +1012,11 @@ mod tests {
             "model": imported_id,
             "mode": "edit_image",
             "sourceAssetId": "asset-1",
-            "modelManifestEntry": { "id": imported_id, "family": "krea_2" },
+            "modelManifestEntry": {
+                "id": imported_id,
+                "family": "krea_2",
+                "paths": { "model": "/app/models/imports/kreamania_variant4" }
+            },
         });
         assert!(!image_request_mlx_eligible(
             imported_id,

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "b4c46d89603468771ff7061269fc8406a60c56e3", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -954,6 +954,22 @@ pub(crate) async fn run_image_generate_job(
                     )
                     .await?;
                 }
+                // Imported/user Krea 2 single-file t2i (sc-14023): pair the imported bare DiT with
+                // the resident Krea base tier and load it through the selected runtime's native-file
+                // entrypoint. The resolver has already proved this is a non-builtin, single-file,
+                // unconditioned request; keep it distinct from the builtin registry path.
+                CandleImageRoute::KreaImported => {
+                    generate_krea_imported_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
                 // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g.
                 // sdxl) must be REJECTED with a clear error, not silently rendered as plain txt2img (poses
                 // dropped) and not bounced to torch. The candle worker CLAIMS these (jobs_store
@@ -1787,10 +1803,14 @@ include!("image_jobs/krea_multiphase.rs");
 #[cfg(target_os = "macos")]
 // Krea 2 pose-ControlNet (MLX) strict-pose routing (sc-8465, epic 8459 S5).
 include!("image_jobs/krea_control.rs");
-#[cfg(target_os = "macos")]
-// Imported single-file Krea 2 checkpoint routing (epic 14015 S0c, sc-14018): a user-imported `krea_2`-
-// family DiT single file → paired with a resident `krea_2` base tier (shared TE/VAE/tokenizer) and loaded
-// via the S0b MLX native single-file entrypoint, bypassing the registry snapshot-dir path.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+// Imported single-file Krea 2 checkpoint routing (epic 14015 S0c, sc-14018/sc-14023): a user-imported
+// `krea_2`-family DiT single file → paired with a resident base tier (shared TE/VAE/tokenizer) and
+// loaded through the selected runtime's native single-file entrypoint, bypassing the registry
+// snapshot-dir path. Shared by MLX and Candle so global import acceptance always has a real route.
 include!("image_jobs/krea_imported.rs");
 #[cfg(target_os = "macos")]
 // SenseNova edit routing.

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -357,6 +357,11 @@ enum CandleImageRoute {
     /// control. Loads the `krea_2_raw` engine (the driver keys on that descriptor id). Reference / edit /
     /// pose / PiD shapes are rejected loudly by the lane (multi-phase renders from pure noise).
     KreaMultiPhase,
+    /// An imported/user single-file Krea 2 transformer: pair the in-place DiT with the resident
+    /// shared-component base tier and load it through Candle's native single-file entrypoint. This is
+    /// the off-Mac twin of [`ImageRoute::KreaImported`], required because imported IDs are not registry
+    /// engine IDs and would otherwise fall through to the procedural stub.
+    KreaImported,
     /// Z-Image identity-init for Image Studio "With Character" (sc-8409).
     ZimageIdentity,
     /// SDXL IP-Adapter-Plus reference conditioning (sc-5488).
@@ -534,6 +539,10 @@ fn resolve_candle_image_route(
         // for this t2i story (sc-13883). The candle twin of the MLX `resolve_image_route` `KreaTurboOnRaw`
         // arm; placed AFTER the edit lane, BEFORE the generic txt2img arm.
         Some(CandleImageRoute::KreaTurboOnRaw)
+    } else if krea_imported_available(request, settings) {
+        // Imported/user Krea 2 single-file t2i: external IDs are absent from `is_candle_engine`, so
+        // this bespoke route must claim them before the generic/external fall-through.
+        Some(CandleImageRoute::KreaImported)
     } else if zimage_comfyui_available(request, settings) {
         // In-place ComfyUI Z-Image base (sc-10668): an `external_base_*` id, so it matches no
         // `is_candle_engine` arm below — route it here off the forwarded `modelManifestEntry`.

--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -1,55 +1,56 @@
-// macOS (MLX) in-place imported single-file Krea 2 checkpoint txt2img route (epic 14015 S0c, sc-14018).
+// Shared MLX/Candle in-place imported single-file Krea 2 checkpoint txt2img route
+// (epic 14015 S0c, sc-14018/sc-14023).
 // Renders a user-imported COMMUNITY checkpoint that is the Krea 2 **transformer only** (a bare DiT
 // single file, e.g. a ComfyUI-exported `kreamania_variant5.safetensors`) — read in place, no copy, no
 // re-download — by pairing it with a resident `krea_2` base tier that supplies the shared Qwen3-VL text
 // encoder, Qwen VAE, tokenizer, and the DiT architecture config the single file omits. The assembly is
-// the S0b MLX entrypoint `runtime_macos::providers::krea::load_from_native_dit_file(dit, base, descriptor)`
+// the selected runtime's `providers::krea::load_from_native_dit_file(dit, base, descriptor)`
 // — the sc-10670/10671 "read the DiT in place, source shared components from a resident tier" pattern, and
-// the MLX twin of the candle z-image `load_from_comfyui_components` lane (`zimage_comfyui_candle.rs`).
+// following the candle z-image `load_from_comfyui_components` in-place assembly pattern.
 //
-// **macOS-only**, and a **bespoke provider**: the loaded generator is not registry-resolvable (its
+// This is a **bespoke provider** on both backends: the loaded generator is not registry-resolvable (its
 // transformer is a single in-place file, not a diffusers snapshot dir), so it bypasses the registry
 // snapshot-dir descriptor path and is loaded fresh per job through `start_gen_stream` rather than the
 // cached registry path — like the z-image comfyui / Wan comfyui in-place lanes. This file is `include!`d
 // into the `image_jobs` module, sharing its imports.
 //
 // Routing (S0d, sc-14019) already marks an imported/user image model whose declared `family` is `krea_2`
-// as MLX-routable; this lane is what actually loads it. A builtin Krea model (`krea_2_turbo` /
+// as same-family routable; this lane is what actually loads it. A builtin Krea model (`krea_2_turbo` /
 // `krea_2_raw`, both in `MODEL_TABLE`) resolves through `mlx_model` and loads from its snapshot turnkey —
 // `resolve_imported_krea_dit` returns `None` for it, so the existing snapshot-dir Krea path is untouched.
 //
-// Scope (S0c): dense bf16 single-file DiT, txt2img only (the imported checkpoint is a bare transformer,
-// so pose / reference / edit conditioning is deliberately NOT claimed here — S0d did not claim those
-// features for imported models either). The 26 GB load + render is validated on GPU in S0f.
+// Scope (S0c + sc-14023): dense bf16 or descriptor-gated plain-int8-per-row single-file DiT, txt2img
+// only (the imported checkpoint is a bare transformer, so pose / reference / edit conditioning is
+// deliberately NOT claimed here). Descriptor contents and per-row scale shapes are validated by the
+// inference loader before dequantization; ConvRot descriptors remain on their separate loader arm.
 
 /// The adapter/engine id recorded on imported-Krea assets + telemetry (distinct from the registry
 /// `krea_2_turbo` / `krea_2_raw` builtins and their bespoke edit/control/multi-phase lanes).
 #[cfg(target_os = "macos")]
 const KREA_IMPORTED_ENGINE: &str = "mlx_krea_imported";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const KREA_IMPORTED_ENGINE: &str = "candle_krea_imported";
 /// The base tier whose shared Qwen3-VL text encoder + Qwen VAE + tokenizer + DiT architecture config the
 /// imported single-file transformer is paired with. The Turbo turnkey (`SceneWorks/krea-2-turbo-mlx`,
 /// sc-7573) is the default base — its published Krea 2 architecture matches the community merges, and its
-/// `bf16/` tier ships DENSE TE/VAE that pair correctly with the imported dense bf16 DiT. NOT configurable:
+/// `bf16/` tier ships DENSE TE/VAE that pair correctly with either supported imported DiT encoding. NOT
+/// configurable:
 /// the single fixed default keeps the assembly deterministic (a per-request base override is a follow-up
 /// if a Raw-base community checkpoint ever needs a different shared surface).
-#[cfg(target_os = "macos")]
 const KREA_IMPORTED_BASE_REPO: &str = "SceneWorks/krea-2-turbo-mlx";
 /// The dense `bf16/` subdir of [`KREA_IMPORTED_BASE_REPO`] — the DENSE TE/VAE tier (the `q4/`/`q8/` tiers
 /// ship a packed transformer, but their TE/VAE would not pair with a dense imported DiT). Same `bf16/`
 /// surface the candle INT8-ConvRot base uses (`resolve_krea_convrot`).
-#[cfg(target_os = "macos")]
 const KREA_IMPORTED_BASE_TIER: &str = "bf16";
 /// Denoise-steps fallback — the Krea 2 Turbo distilled default (the imported community merges are
 /// distilled-Turbo dense merges, like variant5). The UI normally supplies `advanced.steps`; this only
 /// applies when it does not.
-#[cfg(target_os = "macos")]
 const KREA_IMPORTED_DEFAULT_STEPS: u32 = 8;
 
 /// A single-file checkpoint is one on-disk `.safetensors` FILE (the imported transformer), as opposed to
 /// a diffusers snapshot DIRECTORY (a builtin turnkey tier). This is the single-file-vs-snapshot-dir
 /// decision at the heart of S0c: a `true` here routes to the native single-file entrypoint; a directory
 /// (`false`) keeps the registry snapshot-dir path. Pure (no settings / confinement), unit-testable alone.
-#[cfg(target_os = "macos")]
 fn is_single_file_checkpoint(path: &Path) -> bool {
     path.is_file()
         && path
@@ -62,7 +63,6 @@ fn is_single_file_checkpoint(path: &Path) -> bool {
 /// or a `transformer/` component subtree. Such a dir is a SNAPSHOT (the registry path), never a
 /// single-file import, so it is excluded from the native entrypoint even when it also holds loose
 /// `.safetensors` shards.
-#[cfg(target_os = "macos")]
 fn is_diffusers_snapshot_dir(dir: &Path) -> bool {
     dir.join("model_index.json").is_file()
         || dir.join("config.json").is_file()
@@ -75,7 +75,6 @@ fn is_diffusers_snapshot_dir(dir: &Path) -> bool {
 /// `<data>/models/imports/<name>/`, so the checkpoint is the one weight file there). `None` for a
 /// diffusers snapshot dir (a builtin turnkey tier — [`is_diffusers_snapshot_dir`]), a dir with zero or
 /// more than one top-level `.safetensors`, or a non-safetensors file — those are not a single-file import.
-#[cfg(target_os = "macos")]
 fn imported_dit_file(path: &Path) -> Option<PathBuf> {
     if is_single_file_checkpoint(path) {
         return Some(path.to_path_buf());
@@ -109,7 +108,6 @@ fn imported_dit_file(path: &Path) -> Option<PathBuf> {
 ///
 /// Each path is confined by `normalize_app_managed_model_path` (a payload can never point the checkpoint
 /// outside a declared root; LAN jobs API, epic 4484) — the same confinement `resolve_weights_dir` uses.
-#[cfg(target_os = "macos")]
 fn resolve_imported_krea_dit(
     request: &ImageRequest,
     settings: &Settings,
@@ -162,7 +160,6 @@ fn resolve_imported_krea_dit(
 /// config, plus POPULATED `text_encoder/ vae/ tokenizer/` component trees (weight files present, not
 /// just the directories, so a torn base is caught here); a clear typed error otherwise so the user knows
 /// to install the Krea 2 base first, rather than a raw mid-load "No such file or directory".
-#[cfg(target_os = "macos")]
 fn resolve_krea_imported_base_tier(settings: &Settings) -> WorkerResult<PathBuf> {
     let base_missing = || {
         WorkerError::InvalidPayload(
@@ -187,7 +184,6 @@ fn resolve_krea_imported_base_tier(settings: &Settings) -> WorkerResult<PathBuf>
 /// a half-downloaded / torn base whose component dirs were created but never filled would otherwise pass
 /// this gate and fail deep inside the S0b load with a generic Engine "load failed" instead of the
 /// friendly [`resolve_krea_imported_base_tier`] "install the Krea 2 base first" typed error.
-#[cfg(target_os = "macos")]
 fn krea_imported_base_tier_complete(dir: &Path) -> bool {
     dir.join("transformer").join("config.json").is_file()
         && dir_has_safetensors(&dir.join("text_encoder"))
@@ -198,7 +194,6 @@ fn krea_imported_base_tier_complete(dir: &Path) -> bool {
 /// True when `dir` holds at least one top-level `*.safetensors` weight file — the "is this component
 /// dir actually populated, not just an empty shell left by a torn download" probe
 /// [`krea_imported_base_tier_complete`] uses for the dense text encoder / VAE trees.
-#[cfg(target_os = "macos")]
 fn dir_has_safetensors(dir: &Path) -> bool {
     std::fs::read_dir(dir)
         .into_iter()
@@ -219,19 +214,26 @@ fn dir_has_safetensors(dir: &Path) -> bool {
 /// this lane does not stage). Deliberately does NOT gate on base-tier presence: a missing base surfaces
 /// as the loud [`resolve_krea_imported_base_tier`] error in the handler rather than a silent fall-through
 /// to the stub. Mirrors the shape of the other `…_available` predicates.
-#[cfg(target_os = "macos")]
 fn krea_imported_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.mode != "edit_image"
         && pose_entries(request).is_empty()
         && request.reference_asset_id.is_none()
         && request.reference_asset_ids.is_empty()
         && request.source_asset_id.is_none()
+        && request.mask_asset_id.is_none()
+        && request.character_id.is_none()
+        && request.character_look_id.is_none()
+        && request.loras.is_empty()
+        && !request
+            .advanced
+            .get("phases")
+            .and_then(Value::as_array)
+            .is_some_and(|phases| !phases.is_empty())
         && matches!(resolve_imported_krea_dit(request, settings), Ok(Some(_)))
 }
 
 /// Flat telemetry recorded on imported-Krea assets. No guidance — the imported distilled-Turbo merges
 /// are CFG-free (the Turbo descriptor advertises `supports_guidance=false`).
-#[cfg(target_os = "macos")]
 fn krea_imported_raw_settings(request: &ImageRequest, steps: u32) -> JsonObject {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
@@ -252,12 +254,10 @@ fn krea_imported_raw_settings(request: &ImageRequest, steps: u32) -> JsonObject 
     raw
 }
 
-/// Real MLX in-place imported single-file Krea 2 txt2img generation (epic 14015 S0c): resolve the
-/// imported DiT + the resident base tier on the async side, then load the S0b native entrypoint once +
-/// generate each image on the blocking thread. `request.count` images, each its own seed. The imported
-/// merge is distilled Turbo (no CFG / negative prompt). The loaded `Box<dyn Generator>` is bespoke (not
-/// registry-cached), driven like the z-image comfyui lane.
-#[cfg(target_os = "macos")]
+/// Real in-place imported single-file Krea 2 txt2img generation (epic 14015 S0c, sc-14023): resolve the
+/// imported DiT + resident base tier on the async side, then load the selected runtime's native
+/// entrypoint once and generate each image on the blocking thread. The merge is distilled Turbo
+/// (no CFG / negative prompt). The `Box<dyn Generator>` is bespoke (not registry-cached).
 async fn generate_krea_imported_stream(
     api: &ApiClient,
     settings: &Settings,
@@ -293,15 +293,25 @@ async fn generate_krea_imported_stream(
         KREA_IMPORTED_ENGINE,
         0,
         move || {
-            // Turbo descriptor (`variant5` and its siblings are distilled-Turbo dense merges). The S0b
+            // Turbo descriptor (`variant5` dense and `variant4` plain-int8 are distilled-Turbo merges).
+            // The S0b
             // entrypoint reads the DiT from the single file, key-remaps native→diffusers, coverage/
             // shape-validates it against the base tier's Krea 2 geometry (fail-closed — the
             // architecture-compatibility check happens here, before pairing), and sources the shared
             // TE/VAE/tokenizer from `base_dir`.
-            let descriptor = runtime_macos::providers::krea::descriptor();
-            let model = runtime_macos::providers::krea::load_from_native_dit_file(
-                &dit, &base_dir, descriptor,
-            )
+            #[cfg(target_os = "macos")]
+            let loaded = runtime_macos::providers::krea::load_from_native_dit_file(
+                &dit,
+                &base_dir,
+                runtime_macos::providers::krea::descriptor(),
+            );
+            #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+            let loaded = runtime_cuda::providers::krea::load_from_native_dit_file(
+                &dit,
+                &base_dir,
+                runtime_cuda::providers::krea::descriptor(),
+            );
+            let model = loaded
             .map_err(|error| {
                 WorkerError::Engine(format!("Krea 2 imported checkpoint load failed: {error}"))
             })?;

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -10676,7 +10676,10 @@ fn resolve_krea_control_base_descends_turnkey_root_into_tier_with_tokenizer() {
 /// The single-file-vs-snapshot-dir decision at the heart of S0c: a `.safetensors` FILE is a single-file
 /// checkpoint (→ the native entrypoint); a directory (a snapshot tier) is not (→ the registry snapshot
 /// path). A non-safetensors file (e.g. a `.ckpt`) is likewise not one — the S0b/S0a lane is safetensors.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn is_single_file_checkpoint_distinguishes_file_from_snapshot_dir() {
     let dir = tempfile::tempdir().unwrap();
@@ -10707,12 +10710,15 @@ fn is_single_file_checkpoint_distinguishes_file_from_snapshot_dir() {
 
 /// Seed an app-managed imported model file under `<data_dir>/models/…` and return a Settings pinned to
 /// that data dir. The confinement (`normalize_app_managed_model_path`) admits `<data_dir>` roots.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 fn imported_krea_settings_with_file(dir: &std::path::Path) -> (Settings, PathBuf) {
     let file = dir
         .join("models")
         .join("imported-krea")
-        .join("kreamania_variant5.safetensors");
+        .join("kreamania_variant4.safetensors");
     std::fs::create_dir_all(file.parent().unwrap()).unwrap();
     std::fs::write(&file, b"dit").unwrap();
     let mut settings = Settings::from_env();
@@ -10989,9 +10995,39 @@ fn resolve_image_route_sends_imported_single_file_krea_to_the_bespoke_lane() {
     );
 }
 
+/// Candle twin of the MLX route regression above: the external id is absent from the builtin table,
+/// yet a real app-managed single-file Krea manifest resolves to the bespoke Candle dispatch variant.
+/// The exhaustive match in `run_image_job` maps that variant to `generate_krea_imported_stream`.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn resolve_candle_image_route_sends_imported_single_file_krea_to_the_bespoke_lane() {
+    let dir = tempfile::tempdir().unwrap();
+    let (settings, file) = imported_krea_settings_with_file(dir.path());
+    let imported = request(json!({
+        "projectId": "p",
+        "model": "kreamania_variant4",
+        "prompt": "a cat",
+        "modelManifestEntry": {
+            "family": "krea_2",
+            "modelPath": file.to_str().unwrap()
+        }
+    }));
+
+    assert_eq!(
+        resolve_candle_image_route(&imported, &settings),
+        Some(CandleImageRoute::KreaImported),
+        "a novel imported Krea id must reach the Candle native-file lane"
+    );
+    assert!(krea_imported_available(&imported, &settings));
+    assert_eq!(KREA_IMPORTED_ENGINE, "candle_krea_imported");
+}
+
 /// A pose / edit / reference shape on an imported Krea 2 model is NOT claimed by the txt2img import lane
 /// (a bare imported DiT carries no conditioning components) — the availability predicate stays t2i-only.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn krea_imported_available_is_txt2img_only() {
     let dir = tempfile::tempdir().unwrap();
@@ -11020,12 +11056,36 @@ fn krea_imported_available_is_txt2img_only() {
 
     let reference = request(json!({
         "projectId": "p", "model": "kreamania_variant5", "referenceAssetId": "r",
-        "modelManifestEntry": base
+        "modelManifestEntry": base.clone()
     }));
     assert!(
         !krea_imported_available(&reference, &settings),
         "reference/img2img job excluded (t2i only in S0c)"
     );
+
+    for (label, extra) in [
+        ("mask", json!({ "maskAssetId": "m" })),
+        ("character", json!({ "characterId": "c" })),
+        ("adapter", json!({ "loras": [{ "id": "adapter" }] })),
+        (
+            "multi-phase",
+            json!({ "advanced": { "phases": [{ "steps": 4 }] } }),
+        ),
+    ] {
+        let mut payload = json!({
+            "projectId": "p",
+            "model": "kreamania_variant4",
+            "modelManifestEntry": base.clone()
+        });
+        payload
+            .as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().unwrap().clone());
+        assert!(
+            !krea_imported_available(&request(payload), &settings),
+            "{label} job excluded"
+        );
+    }
 }
 
 /// Real-weight GPU acceptance for the imported single-file Krea 2 lane (epic 14015 S0f, sc-14021).


### PR DESCRIPTION
Implements sc-14023 across SceneWorks after inference PR #209. Accepts Krea int8_tensorwise per-row imports, pins merged inference commit 620cb2e72af02a162b921bc4c70b452ebe5d6ca7, and routes installed single-file imported Krea checkpoints through both MLX and Candle native-file loaders. The scheduler and worker share a fail-closed plain-txt2img gate; adapters and conditioning are rejected. Existing ConvRot routing remains distinct. Validation: imported-Krea scheduler/worker regressions, Windows Candle resolver tests, backend-neutral and Candle all-target clippy with warnings denied, formatting, dependency skew check, API/import tests, and independent adversarial review PASS. Real variant4 weights were unavailable locally, so end-to-end generation remains covered by macOS/Windows CI rather than a local real-weight run. Shortcut: https://app.shortcut.com/trefry/story/14023