### PR TITLE
feat(worker,core): imported single-file Krea 2 img2img + builtin resolution/UI surface [sc-14071]

### DIFF
--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -349,6 +349,86 @@ pub fn apply_model_manifest_defaults(
             .entry("families".to_owned())
             .or_insert_with(|| json!([family]));
     }
+
+    apply_family_studio_surface_defaults(entry, &family);
+}
+
+/// Stamp the resolution / img2img Studio surface an imported model needs to match its builtin sibling
+/// (sc-14071, epic 14015). An imported entry ships empty `limits` / `defaults` / `ui`, so without this
+/// the Studio resolution picker falls back to its bare 4-option list (`selectedModel.limits.resolutions`
+/// is empty) and never offers img2img. Every field is `or_insert_with`, so an author-supplied value
+/// always wins — this only fills the gaps the import path leaves. Family-scoped: only families with a
+/// stamped surface below are touched; every other family is left exactly as before.
+///
+/// **`krea-2`** mirrors the builtin `krea_2_turbo` entry (config/manifests/builtin.models.jsonc): the
+/// 15-bucket ÷16-aligned ≤2048² resolution list, the 1024² default, `mlx.minMemoryGb` 48 (the ≤1536²
+/// visibility floor + the >1536² memory-gate anchor, sc-13959 — an empty `mlx` block would offer 2048²
+/// unconditionally on any Mac), and the `ui.img2img` toggle + `img2imgStrength` slider (reference-guided
+/// latent-init, resolved by the worker's `resolve_img2img_init_generic`). It does NOT stamp
+/// `ui.editReferences` or an `edit_image` capability — imported edit is a separate story (sc-14119).
+fn apply_family_studio_surface_defaults(entry: &mut Map<String, Value>, family: &str) {
+    if family != "krea-2" {
+        return;
+    }
+    if let Some(limits) = entry
+        .entry("limits".to_owned())
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+    {
+        limits.entry("resolutions".to_owned()).or_insert_with(|| {
+            json!([
+                "1024x1024",
+                "768x1024",
+                "1024x768",
+                "1280x720",
+                "720x1280",
+                "1216x832",
+                "832x1216",
+                "1152x896",
+                "896x1152",
+                "1536x1536",
+                "2048x1152",
+                "1152x2048",
+                "2048x1408",
+                "1408x2048",
+                "2048x2048"
+            ])
+        });
+    }
+    if let Some(defaults) = entry
+        .entry("defaults".to_owned())
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+    {
+        defaults
+            .entry("resolution".to_owned())
+            .or_insert_with(|| json!("1024x1024"));
+    }
+    if let Some(mlx) = entry
+        .entry("mlx".to_owned())
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+    {
+        mlx.entry("minMemoryGb".to_owned())
+            .or_insert_with(|| json!(48));
+    }
+    if let Some(ui) = entry
+        .entry("ui".to_owned())
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+    {
+        ui.entry("img2img".to_owned())
+            .or_insert_with(|| json!(true));
+        ui.entry("img2imgStrength".to_owned()).or_insert_with(|| {
+            json!({
+                "label": "Reference strength",
+                "default": 0.5,
+                "min": 0.0,
+                "max": 1.0,
+                "step": 0.05
+            })
+        });
+    }
 }
 
 pub fn model_adapter_for_family(family: &str) -> Option<&'static str> {
@@ -421,13 +501,15 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         // surface, so the family default advertises only t2i + style variations (like z-image /
         // qwen-image / lens / flux).
         ("image", "anima") => vec!["text_to_image", "style_variations"],
-        // Krea 2 (epic 14015): imported single-file Krea 2 checkpoints. The KreaImported lane
-        // (sc-14018) is text-to-image ONLY — reference/edit for imports is deferred to sc-14071 — so
-        // the family default advertises just t2i + style variations, NOT `edit_image` /
-        // `character_image` (the builtin Turbo/Raw entries expose those, imports don't yet). The
-        // match keys on the normalized hyphen form `krea-2` (`normalize_model_family("krea_2")`).
-        // This default only affects imported/user krea_2 models; the builtin krea_2 entries declare
-        // their own `capabilities` explicitly, so `apply_model_manifest_defaults` never changes them.
+        // Krea 2 (epic 14015): imported single-file Krea 2 checkpoints. The KreaImported lane serves
+        // text-to-image (sc-14018) plus img2img (sc-14071 — reference-guided latent-init, exposed via the
+        // `ui.img2img` toggle stamped by `apply_family_studio_surface_defaults`, NOT a capabilities value:
+        // z-image owns "image_to_image" for its edit-mode img2img). So the family default advertises just
+        // t2i + style variations, NOT `edit_image` / `character_image` (the builtin Turbo/Raw entries
+        // expose those; imports do not — imported edit is sc-14119). The match keys on the normalized
+        // hyphen form `krea-2` (`normalize_model_family("krea_2")`). This default only affects
+        // imported/user krea_2 models; the builtin krea_2 entries declare their own `capabilities`
+        // explicitly, so `apply_model_manifest_defaults` never changes them.
         ("image", "krea-2") => vec!["text_to_image", "style_variations"],
         // Bernini still-image companion (epic 4699 / sc-5424): the same `Modality::Both`
         // engine the video `bernini` family uses, but the image-typed catalog id
@@ -3014,8 +3096,9 @@ mod tests {
 
         // The imported model is now MLX-Krea-routed and selectable as a text-to-image model.
         assert_eq!(entry["adapter"], "mlx_krea");
-        // Text-to-image only (+ style_variations): the KreaImported lane is txt2img-only, so the
-        // default must NOT claim `edit_image` / `character_image` (deferred to sc-14071).
+        // Text-to-image + img2img (+ style_variations). img2img is a `ui.img2img` toggle (asserted
+        // below), NOT a capabilities value, so `capabilities` stays t2i + style_variations and must
+        // NOT claim `edit_image` / `character_image` (imported edit is deferred to sc-14119).
         assert_eq!(
             entry["capabilities"],
             json!(["text_to_image", "style_variations"])
@@ -3023,6 +3106,95 @@ mod tests {
         // `loraCompatibility.families` carries the normalized token (as every other family does,
         // e.g. wan-video above) — Krea LoRAs resolve to it through `canonical_lora_family`.
         assert_eq!(entry["loraCompatibility"]["families"], json!(["krea-2"]));
+    }
+
+    #[test]
+    fn imported_krea_2_gets_builtin_resolution_and_img2img_surface() {
+        // sc-14071 (epic 14015): an imported krea_2 entry ships empty limits/defaults/ui, so the Studio
+        // resolution picker would fall back to its 4-option list and never offer img2img. The family
+        // default must stamp the SAME resolution / img2img surface the builtin `krea_2_turbo` entry
+        // carries (config/manifests/builtin.models.jsonc): the 15-bucket resolution list, the 1024²
+        // default, `mlx.minMemoryGb` 48 (the >1536² memory-gate anchor, sc-13959), and the `ui.img2img`
+        // toggle + `img2imgStrength` slider. It must NOT stamp `ui.editReferences` or an `edit_image`
+        // capability — imported edit is sc-14119.
+        let mut entry = serde_json::Map::new();
+        apply_model_manifest_defaults(&mut entry, "image", Some("krea_2"));
+
+        // The exact 15-bucket resolution list the builtin Krea 2 Turbo ships (verbatim, same order).
+        let resolutions = entry["limits"]["resolutions"]
+            .as_array()
+            .expect("resolutions is an array");
+        assert_eq!(
+            resolutions.len(),
+            15,
+            "the builtin Krea Turbo resolution list has 15 buckets"
+        );
+        assert_eq!(
+            entry["limits"]["resolutions"],
+            json!([
+                "1024x1024",
+                "768x1024",
+                "1024x768",
+                "1280x720",
+                "720x1280",
+                "1216x832",
+                "832x1216",
+                "1152x896",
+                "896x1152",
+                "1536x1536",
+                "2048x1152",
+                "1152x2048",
+                "2048x1408",
+                "1408x2048",
+                "2048x2048"
+            ])
+        );
+        assert_eq!(entry["defaults"]["resolution"], "1024x1024");
+        // The ≤1536² visibility floor / >1536² memory-gate anchor — without it 2048² is offered
+        // unconditionally on any Mac (sc-13959).
+        assert_eq!(entry["mlx"]["minMemoryGb"], json!(48));
+        // img2img is exposed as the `ui.img2img` toggle + strength slider (worker resolves it via
+        // `resolve_img2img_init_generic`), NOT as a capability.
+        assert_eq!(entry["ui"]["img2img"], json!(true));
+        assert_eq!(entry["ui"]["img2imgStrength"]["default"], json!(0.5));
+        // Edit surface is NOT stamped here (sc-14119).
+        assert!(
+            entry["ui"].get("editReferences").is_none(),
+            "imported krea must not get editReferences (edit is sc-14119)"
+        );
+    }
+
+    #[test]
+    fn non_krea_families_get_no_studio_resolution_surface() {
+        // The krea-2 Studio-surface default (sc-14071) is family-scoped: every other family keeps its
+        // empty `limits` / `defaults` / `ui` blocks and gains no `mlx` block, so nothing else is
+        // perturbed by the new stamping.
+        for (model_type, family) in [("image", "z-image"), ("video", "wan_video")] {
+            let mut entry = serde_json::Map::new();
+            apply_model_manifest_defaults(&mut entry, model_type, Some(family));
+            assert!(
+                entry["limits"]
+                    .as_object()
+                    .expect("limits object")
+                    .is_empty(),
+                "{family} limits must stay empty"
+            );
+            assert!(
+                entry["defaults"]
+                    .as_object()
+                    .expect("defaults object")
+                    .is_empty(),
+                "{family} defaults must stay empty"
+            );
+            assert!(
+                entry["ui"].as_object().expect("ui object").is_empty(),
+                "{family} ui must stay empty"
+            );
+            assert!(
+                entry.get("mlx").is_none(),
+                "{family} must gain no mlx block"
+            );
+        }
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -18,9 +18,12 @@
 // `krea_2_raw`, both in `MODEL_TABLE`) resolves through `mlx_model` and loads from its snapshot turnkey —
 // `resolve_imported_krea_dit` returns `None` for it, so the existing snapshot-dir Krea path is untouched.
 //
-// Scope (S0c): dense bf16 single-file DiT, txt2img only (the imported checkpoint is a bare transformer,
-// so pose / reference / edit conditioning is deliberately NOT claimed here — S0d did not claim those
-// features for imported models either). The 26 GB load + render is validated on GPU in S0f.
+// Scope (S0c + sc-14071): dense bf16 single-file DiT, txt2img plus img2img (reference-guided latent-init
+// off a single `referenceAssetId` + strength, resolved through the shared `resolve_img2img_init_generic`
+// on the SAME Turbo t2i descriptor — the engine keys img2img off a `Conditioning::Reference` on a
+// non-edit descriptor). Pose / edit conditioning is still deliberately NOT claimed here (those need
+// base-tier control/edit components this lane does not stage — imported edit is sc-14119). The 26 GB
+// load + render is validated on GPU in S0f.
 
 /// The adapter/engine id recorded on imported-Krea assets + telemetry (distinct from the registry
 /// `krea_2_turbo` / `krea_2_raw` builtins and their bespoke edit/control/multi-phase lanes).
@@ -213,20 +216,39 @@ fn dir_has_safetensors(dir: &Path) -> bool {
         })
 }
 
-/// True when this is an in-place imported single-file Krea 2 **txt2img** job: an imported `krea_2`-family
-/// model whose `modelPath` resolves to a single `.safetensors` DiT, with no edit / pose / reference
-/// (the imported checkpoint is a bare transformer — those conditioning modes need base-tier components
-/// this lane does not stage). Deliberately does NOT gate on base-tier presence: a missing base surfaces
-/// as the loud [`resolve_krea_imported_base_tier`] error in the handler rather than a silent fall-through
-/// to the stub. Mirrors the shape of the other `…_available` predicates.
+/// True when this is an in-place imported single-file Krea 2 **txt2img or img2img** job: an imported
+/// `krea_2`-family model whose `modelPath` resolves to a single `.safetensors` DiT, with no edit / pose
+/// (an `edit_image` mode or a pose set needs base-tier components this bare-transformer lane does not
+/// stage — those are sc-14119 / out of scope). An img2img `referenceAssetId` / `sourceAssetId` (mode NOT
+/// `edit_image`) IS accepted (sc-14071): it resolves through the shared [`resolve_img2img_init_generic`]
+/// to a single `Conditioning::Reference` on the SAME Turbo t2i descriptor — exactly like the builtin
+/// generic MLX img2img lane (`resolve_generic_lane_conditioning`'s generic arm). The two-reference edit
+/// SET (`reference_asset_ids`, scene + person) stays rejected — that is the edit surface (sc-14119), not
+/// reference-guided latent-init. Deliberately does NOT gate on base-tier presence: a missing base
+/// surfaces as the loud [`resolve_krea_imported_base_tier`] error in the handler rather than a silent
+/// fall-through to the stub. Mirrors the shape of the other `…_available` predicates.
 #[cfg(target_os = "macos")]
 fn krea_imported_available(request: &ImageRequest, settings: &Settings) -> bool {
     request.mode != "edit_image"
         && pose_entries(request).is_empty()
-        && request.reference_asset_id.is_none()
         && request.reference_asset_ids.is_empty()
-        && request.source_asset_id.is_none()
         && matches!(resolve_imported_krea_dit(request, settings), Ok(Some(_)))
+}
+
+/// Build the img2img conditioning for the imported Krea lane (sc-14071): a resolved reference + strength
+/// becomes a single `Conditioning::Reference` — byte-identical to the generic lane's `identity_init`
+/// path, which the engine routes to `generate_turbo_img2img` off a Reference on the (non-edit) Turbo t2i
+/// descriptor. A plain txt2img job (`None`) yields the empty conditioning. Pure (no I/O), so the img2img
+/// wiring is unit-testable without loading a real reference asset or a generator.
+#[cfg(target_os = "macos")]
+fn krea_imported_conditioning(img2img: Option<(Image, f32)>) -> Vec<Conditioning> {
+    match img2img {
+        Some((image, strength)) => vec![Conditioning::Reference {
+            image,
+            strength: Some(strength),
+        }],
+        None => Vec::new(),
+    }
 }
 
 /// Flat telemetry recorded on imported-Krea assets. No guidance — the imported distilled-Turbo merges
@@ -252,11 +274,13 @@ fn krea_imported_raw_settings(request: &ImageRequest, steps: u32) -> JsonObject 
     raw
 }
 
-/// Real MLX in-place imported single-file Krea 2 txt2img generation (epic 14015 S0c): resolve the
-/// imported DiT + the resident base tier on the async side, then load the S0b native entrypoint once +
-/// generate each image on the blocking thread. `request.count` images, each its own seed. The imported
-/// merge is distilled Turbo (no CFG / negative prompt). The loaded `Box<dyn Generator>` is bespoke (not
-/// registry-cached), driven like the z-image comfyui lane.
+/// Real MLX in-place imported single-file Krea 2 txt2img / img2img generation (epic 14015 S0c +
+/// sc-14071): resolve the imported DiT, the resident base tier, and any img2img reference on the async
+/// side, then load the S0b native entrypoint once + generate each image on the blocking thread.
+/// `request.count` images, each its own seed. The imported merge is distilled Turbo (no CFG / negative
+/// prompt). An img2img `referenceAssetId` + strength is threaded to the engine as a single
+/// `Conditioning::Reference` on the Turbo t2i descriptor (mirrors the builtin generic MLX img2img lane).
+/// The loaded `Box<dyn Generator>` is bespoke (not registry-cached), driven like the z-image comfyui lane.
 #[cfg(target_os = "macos")]
 async fn generate_krea_imported_stream(
     api: &ApiClient,
@@ -276,6 +300,20 @@ async fn generate_krea_imported_stream(
     })?;
     // Require the resident base tier before any compute — a clear "install the Krea 2 base first" error.
     let base_dir = resolve_krea_imported_base_tier(settings)?;
+
+    // img2img reference-guided latent-init (sc-14071): the SAME generic seam the builtin Krea Turbo
+    // img2img lane uses (`resolve_generic_lane_conditioning`'s generic arm). Resolved on the async side
+    // (decode → `Send` `Image` moved into the worker thread), gated on the model's `ui.img2img` manifest
+    // flag ([`model_supports_img2img`]) + a non-edit mode; `resolve_img2img_init_generic` yields `None`
+    // for a plain txt2img job (no `referenceAssetId`). Fed to the engine as a single
+    // `Conditioning::Reference` on the SAME Turbo t2i descriptor below — the engine keys img2img off a
+    // Reference on a non-edit descriptor, so no descriptor change is needed. Edit conditioning is NOT
+    // resolved here (sc-14119).
+    let img2img = if model_supports_img2img(request) && request.mode != "edit_image" {
+        resolve_img2img_init_generic(request, settings, project_path)?
+    } else {
+        None
+    };
 
     let (width, height) = (request.width, request.height);
     let steps =
@@ -308,6 +346,9 @@ async fn generate_krea_imported_stream(
             Ok(model)
         },
         move |model, tx, cancel| {
+            // Build the img2img conditioning once (the resolved reference + strength → a single
+            // `Conditioning::Reference`), then clone it per rendered image. Empty for a plain txt2img job.
+            let conditioning = krea_imported_conditioning(img2img);
             drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
@@ -319,6 +360,7 @@ async fn generate_krea_imported_stream(
                     count: 1,
                     seed: Some(seed as u64),
                     steps: Some(steps),
+                    conditioning: conditioning.clone(),
                     cancel: cancel.clone(),
                     ..Default::default()
                 };

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -10989,16 +10989,40 @@ fn resolve_image_route_sends_imported_single_file_krea_to_the_bespoke_lane() {
     );
 }
 
-/// A pose / edit / reference shape on an imported Krea 2 model is NOT claimed by the txt2img import lane
-/// (a bare imported DiT carries no conditioning components) — the availability predicate stays t2i-only.
+/// The imported Krea 2 lane accepts a plain txt2img job AND an img2img `referenceAssetId` (mode NOT
+/// `edit_image`, sc-14071 — reference-guided latent-init), while STILL rejecting an `edit_image` job, a
+/// pose set, and the two-reference edit SET (`referenceAssetIds`, the scene+person surface) — those need
+/// base-tier edit/control components this bare-transformer lane does not stage (imported edit is sc-14119).
 #[cfg(target_os = "macos")]
 #[test]
-fn krea_imported_available_is_txt2img_only() {
+fn krea_imported_available_allows_img2img_but_rejects_edit_and_pose() {
     let dir = tempfile::tempdir().unwrap();
     let (settings, file) = imported_krea_settings_with_file(dir.path());
     let path_str = file.to_str().unwrap().to_owned();
     let base = json!({ "family": "krea_2", "modelPath": path_str });
 
+    // Plain txt2img: accepted.
+    let t2i = request(json!({
+        "projectId": "p", "model": "kreamania_variant5", "prompt": "a cat",
+        "modelManifestEntry": base.clone()
+    }));
+    assert!(
+        krea_imported_available(&t2i, &settings),
+        "plain txt2img is accepted"
+    );
+
+    // img2img: a `referenceAssetId` on a non-edit mode is now ACCEPTED (sc-14071).
+    let img2img = request(json!({
+        "projectId": "p", "model": "kreamania_variant5", "referenceAssetId": "r",
+        "advanced": { "strength": 0.5 },
+        "modelManifestEntry": base.clone()
+    }));
+    assert!(
+        krea_imported_available(&img2img, &settings),
+        "an img2img referenceAssetId (mode t2i) is accepted"
+    );
+
+    // A pose set is still rejected.
     let with_pose = request(json!({
         "projectId": "p", "model": "kreamania_variant5",
         "advanced": { "poses": [{ "id": "a" }] },
@@ -11009,6 +11033,7 @@ fn krea_imported_available_is_txt2img_only() {
         "pose job excluded"
     );
 
+    // An `edit_image` job is still rejected (imported edit is sc-14119).
     let edit = request(json!({
         "projectId": "p", "model": "kreamania_variant5", "mode": "edit_image",
         "sourceAssetId": "s", "modelManifestEntry": base.clone()
@@ -11018,13 +11043,62 @@ fn krea_imported_available_is_txt2img_only() {
         "edit job excluded"
     );
 
-    let reference = request(json!({
-        "projectId": "p", "model": "kreamania_variant5", "referenceAssetId": "r",
+    // The two-reference edit SET (scene + person) is still rejected — that is the edit surface, not
+    // reference-guided latent-init.
+    let two_ref = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "referenceAssetIds": ["scene", "person"],
         "modelManifestEntry": base
     }));
     assert!(
-        !krea_imported_available(&reference, &settings),
-        "reference/img2img job excluded (t2i only in S0c)"
+        !krea_imported_available(&two_ref, &settings),
+        "the two-reference edit set is excluded"
+    );
+}
+
+/// The imported Krea lane threads a resolved img2img reference into a single `Conditioning::Reference`
+/// (strength carried) on the Turbo t2i descriptor, and a plain txt2img job into the empty conditioning
+/// (sc-14071). Also pins the manifest→worker seam: the `ui.img2img` flag the core stamps on an imported
+/// krea_2 entry (sc-14071 Part B) is exactly what `model_supports_img2img` reads to engage the img2img
+/// resolve. Pure — no reference-asset I/O or generator load.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_imported_conditioning_threads_the_img2img_reference() {
+    // A resolved reference → one `Conditioning::Reference` carrying the strength.
+    let reference = synthetic_rgb(8, 8, |_, _| [10, 20, 30]);
+    let conditioning = krea_imported_conditioning(Some((reference.clone(), 0.4)));
+    match conditioning.as_slice() {
+        [Conditioning::Reference { image, strength }] => {
+            assert_eq!(image.width, 8);
+            assert_eq!(image.height, 8);
+            assert_eq!(*strength, Some(0.4));
+        }
+        other => panic!("expected a single Conditioning::Reference, got {other:?}"),
+    }
+
+    // A plain txt2img job (no resolved reference) → the empty conditioning.
+    assert!(
+        krea_imported_conditioning(None).is_empty(),
+        "plain txt2img carries no conditioning"
+    );
+
+    // Manifest→worker seam: the `ui.img2img` flag `apply_family_studio_surface_defaults` stamps on an
+    // imported krea_2 entry (Part B) is what `model_supports_img2img` reads to engage the img2img arm.
+    let img2img_entry = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "modelManifestEntry": { "family": "krea_2", "ui": { "img2img": true } }
+    }));
+    assert!(
+        model_supports_img2img(&img2img_entry),
+        "the stamped ui.img2img flag engages the img2img resolve"
+    );
+    let no_flag = request(json!({
+        "projectId": "p", "model": "kreamania_variant5",
+        "modelManifestEntry": { "family": "krea_2" }
+    }));
+    assert!(
+        !model_supports_img2img(&no_flag),
+        "without ui.img2img the lane stays plain txt2img"
     );
 }
 


### PR DESCRIPTION
## sc-14071 (epic 14015)

Gives the imported single-file Krea 2 lane **img2img** plus the **same resolution / img2img UI surface as builtin Krea**. No inference change. Edit is a separate story (sc-14119) and is deliberately NOT implemented here.

### Part A — img2img on the imported worker lane (`crates/sceneworks-worker/src/image_jobs/krea_imported.rs`)
- `krea_imported_available` relaxed to **accept an img2img reference** (a `referenceAssetId` / `sourceAssetId`, mode ≠ `edit_image`) while still rejecting `edit_image` mode, poses, and the two-reference edit set (`reference_asset_ids`, the scene+person surface — that is sc-14119).
- `generate_krea_imported_stream` resolves the source with the existing builtin helper `resolve_img2img_init_generic` (gated on `model_supports_img2img` + non-edit mode) and threads it into a single `Conditioning::Reference { image, strength }` on the **same Turbo t2i `descriptor()`**. The engine keys img2img off a `Reference` on a non-edit descriptor, mirroring `resolve_generic_lane_conditioning`'s generic img2img arm — so no descriptor or routing change is needed.
- Routing already admits it: `krea_mlx_eligible`'s non-edit branch returns true and sc-14109's `imported_family_image_mlx_eligible` routes `krea-2` through it. Verified — no routing change.

### Part B — resolutions + UI defaults (`crates/sceneworks-core/src/lora_family.rs`)
`apply_model_manifest_defaults` now stamps the **`krea-2`** family Studio surface (new `apply_family_studio_surface_defaults`), mirroring builtin `krea_2_turbo` in `config/manifests/builtin.models.jsonc`:
- `limits.resolutions` = the exact builtin 15-bucket list (verbatim).
- `defaults.resolution = "1024x1024"`.
- `mlx.minMemoryGb = 48` (so >1536² buckets are memory-gated like builtin Krea, sc-13959 — an empty `mlx` block would offer 2048² unconditionally).
- `ui.img2img = true` + `ui.img2imgStrength` (`Reference strength`, default 0.5, 0–1, step 0.05).

No `edit_image` capability / `ui.editReferences` (edit = sc-14119). Every field is `or_insert_with` (author-supplied values win); family-scoped, other families untouched.

### Tests
- Core: extended `imported_krea_2_gets_adapter_and_text_to_image_capability`; new `imported_krea_2_gets_builtin_resolution_and_img2img_surface` (asserts the 15-bucket list, 1024² default, `mlx.minMemoryGb` 48, `ui.img2img`, no `editReferences`) and `non_krea_families_get_no_studio_resolution_surface` (isolation).
- Worker: rewrote `krea_imported_available_*` — accepts img2img, rejects edit/pose/two-ref; new `krea_imported_conditioning_threads_the_img2img_reference` (builds a single `Conditioning::Reference` with strength; manifest→worker seam on `ui.img2img`).
- `cargo test -p sceneworks-core --lib` (563 pass) · worker krea/img2img tests pass · `cargo build -p sceneworks-worker` · `cargo fmt --all --check` clean · `cargo clippy -p sceneworks-core -p sceneworks-worker --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)