### PR TITLE
build(desktop): enable candle sidecar on Linux [sc-10374]

### DIFF
--- a/apps/desktop/scripts/build-sidecar-platform.mjs
+++ b/apps/desktop/scripts/build-sidecar-platform.mjs
@@ -1,12 +1,34 @@
-export function shouldBuildCandle(
-  platform,
-  desktopCandle = process.env.SCENEWORKS_DESKTOP_CANDLE,
-) {
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function shouldBuildCandle(platform, desktopCandle) {
   if (platform === "linux") return true;
   return platform === "win32" && desktopCandle !== "0";
 }
 
-export function onnxruntimePlaceholder(platform) {
+export function sidecarBuildPlan(platform, env = {}) {
+  const candle = shouldBuildCandle(
+    platform,
+    env.SCENEWORKS_DESKTOP_CANDLE,
+  );
+  if (!candle) {
+    return {
+      candle,
+      npmScript: "api:build:embedded",
+      env: { VITE_API_BASE_URL: "" },
+    };
+  }
+
+  const computeCap = env.CUDA_COMPUTE_CAP || "80";
+  return {
+    candle,
+    npmScript: "api:build:embedded:candle",
+    computeCap,
+    env: { VITE_API_BASE_URL: "", CUDA_COMPUTE_CAP: computeCap },
+  };
+}
+
+function onnxruntimePlaceholder(platform) {
   if (platform === "linux") {
     return (
       "onnxruntime is not bundled on Linux yet; install it on the host until " +
@@ -21,7 +43,7 @@ export function onnxruntimePlaceholder(platform) {
   );
 }
 
-export function ffmpegPlaceholder(platform) {
+function ffmpegPlaceholder(platform) {
   if (platform === "linux") {
     return (
       "Static ffmpeg is not bundled on Linux yet; install ffmpeg on PATH until " +
@@ -29,4 +51,17 @@ export function ffmpegPlaceholder(platform) {
     );
   }
   return "Static ffmpeg is bundled on macOS only (sc-3767); Windows uses PATH ffmpeg.\n";
+}
+
+export function stageNonMacResourcePlaceholders(
+  platform,
+  { onnxruntimeDir, ffmpegDir },
+) {
+  const onnxruntimeReadme = join(onnxruntimeDir, "README.txt");
+  const ffmpegReadme = join(ffmpegDir, "README.txt");
+  mkdirSync(onnxruntimeDir, { recursive: true });
+  mkdirSync(ffmpegDir, { recursive: true });
+  writeFileSync(onnxruntimeReadme, onnxruntimePlaceholder(platform));
+  writeFileSync(ffmpegReadme, ffmpegPlaceholder(platform));
+  return { onnxruntimeReadme, ffmpegReadme };
 }

--- a/apps/desktop/scripts/build-sidecar-platform.mjs
+++ b/apps/desktop/scripts/build-sidecar-platform.mjs
@@ -1,0 +1,32 @@
+export function shouldBuildCandle(
+  platform,
+  desktopCandle = process.env.SCENEWORKS_DESKTOP_CANDLE,
+) {
+  if (platform === "linux") return true;
+  return platform === "win32" && desktopCandle !== "0";
+}
+
+export function onnxruntimePlaceholder(platform) {
+  if (platform === "linux") {
+    return (
+      "onnxruntime is not bundled on Linux yet; install it on the host until " +
+      "Linux runtime provisioning is implemented (sc-10376).\n"
+    );
+  }
+  return (
+    "onnxruntime is bundled on macOS (CoreML) only; the Windows candle build " +
+    "downloads the CUDA onnxruntime on first run into " +
+    "%APPDATA%\\SceneWorks\\gpu-runtime (cuda_provision.rs), not into this " +
+    "resource dir (sc-3487 / sc-5496).\n"
+  );
+}
+
+export function ffmpegPlaceholder(platform) {
+  if (platform === "linux") {
+    return (
+      "Static ffmpeg is not bundled on Linux yet; install ffmpeg on PATH until " +
+      "Linux runtime provisioning is implemented (sc-10376).\n"
+    );
+  }
+  return "Static ffmpeg is bundled on macOS only (sc-3767); Windows uses PATH ffmpeg.\n";
+}

--- a/apps/desktop/scripts/build-sidecar-platform.test.mjs
+++ b/apps/desktop/scripts/build-sidecar-platform.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  ffmpegPlaceholder,
+  onnxruntimePlaceholder,
+  shouldBuildCandle,
+} from "./build-sidecar-platform.mjs";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+
+test("Linux always selects the embedded candle API build", () => {
+  assert.equal(shouldBuildCandle("linux"), true);
+  assert.equal(shouldBuildCandle("linux", "0"), true);
+});
+
+test("Windows preserves its candle opt-out", () => {
+  assert.equal(shouldBuildCandle("win32"), true);
+  assert.equal(shouldBuildCandle("win32", "1"), true);
+  assert.equal(shouldBuildCandle("win32", "0"), false);
+});
+
+test("macOS preserves its non-candle MLX build", () => {
+  assert.equal(shouldBuildCandle("darwin"), false);
+});
+
+test("Linux resource placeholders satisfy both Tauri globs", () => {
+  const ort = onnxruntimePlaceholder("linux");
+  const ffmpeg = ffmpegPlaceholder("linux");
+
+  assert.match(ort, /not bundled on Linux yet/);
+  assert.match(ort, /sc-10376/);
+  assert.match(ffmpeg, /not bundled on Linux yet/);
+  assert.match(ffmpeg, /PATH/);
+  assert.match(ffmpeg, /sc-10376/);
+});
+
+test("build-sidecar stages files for every configured resource glob", () => {
+  const config = JSON.parse(
+    readFileSync(join(scriptsDir, "..", "tauri.conf.json"), "utf8"),
+  );
+  assert.ok(config.bundle.resources.includes("onnxruntime/**/*"));
+  assert.ok(config.bundle.resources.includes("ffmpeg/**/*"));
+
+  const source = readFileSync(join(scriptsDir, "build-sidecar.mjs"), "utf8");
+  assert.match(source, /onnxruntimePlaceholder\(process\.platform\)/);
+  assert.match(source, /ffmpegPlaceholder\(process\.platform\)/);
+});
+
+test("Windows placeholder guidance remains Windows-specific", () => {
+  assert.match(onnxruntimePlaceholder("win32"), /%APPDATA%/);
+  assert.match(ffmpegPlaceholder("win32"), /Windows uses PATH ffmpeg/);
+});

--- a/apps/desktop/scripts/build-sidecar-platform.test.mjs
+++ b/apps/desktop/scripts/build-sidecar-platform.test.mjs
@@ -1,56 +1,96 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import os from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
-  ffmpegPlaceholder,
-  onnxruntimePlaceholder,
-  shouldBuildCandle,
+  sidecarBuildPlan,
+  stageNonMacResourcePlaceholders,
 } from "./build-sidecar-platform.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 
-test("Linux always selects the embedded candle API build", () => {
-  assert.equal(shouldBuildCandle("linux"), true);
-  assert.equal(shouldBuildCandle("linux", "0"), true);
+test("Linux plans the embedded candle API build with compute capability 80", () => {
+  assert.deepEqual(sidecarBuildPlan("linux"), {
+    candle: true,
+    npmScript: "api:build:embedded:candle",
+    computeCap: "80",
+    env: { VITE_API_BASE_URL: "", CUDA_COMPUTE_CAP: "80" },
+  });
+  assert.deepEqual(sidecarBuildPlan("linux", { SCENEWORKS_DESKTOP_CANDLE: "0" }), {
+    candle: true,
+    npmScript: "api:build:embedded:candle",
+    computeCap: "80",
+    env: { VITE_API_BASE_URL: "", CUDA_COMPUTE_CAP: "80" },
+  });
+  assert.equal(
+    sidecarBuildPlan("linux", { CUDA_COMPUTE_CAP: "90" }).computeCap,
+    "90",
+  );
 });
 
 test("Windows preserves its candle opt-out", () => {
-  assert.equal(shouldBuildCandle("win32"), true);
-  assert.equal(shouldBuildCandle("win32", "1"), true);
-  assert.equal(shouldBuildCandle("win32", "0"), false);
+  assert.equal(sidecarBuildPlan("win32").candle, true);
+  assert.equal(
+    sidecarBuildPlan("win32", { SCENEWORKS_DESKTOP_CANDLE: "1" }).candle,
+    true,
+  );
+  assert.deepEqual(
+    sidecarBuildPlan("win32", { SCENEWORKS_DESKTOP_CANDLE: "0" }),
+    {
+      candle: false,
+      npmScript: "api:build:embedded",
+      env: { VITE_API_BASE_URL: "" },
+    },
+  );
 });
 
 test("macOS preserves its non-candle MLX build", () => {
-  assert.equal(shouldBuildCandle("darwin"), false);
+  assert.deepEqual(sidecarBuildPlan("darwin"), {
+    candle: false,
+    npmScript: "api:build:embedded",
+    env: { VITE_API_BASE_URL: "" },
+  });
 });
 
-test("Linux resource placeholders satisfy both Tauri globs", () => {
-  const ort = onnxruntimePlaceholder("linux");
-  const ffmpeg = ffmpegPlaceholder("linux");
-
-  assert.match(ort, /not bundled on Linux yet/);
-  assert.match(ort, /sc-10376/);
-  assert.match(ffmpeg, /not bundled on Linux yet/);
-  assert.match(ffmpeg, /PATH/);
-  assert.match(ffmpeg, /sc-10376/);
-});
-
-test("build-sidecar stages files for every configured resource glob", () => {
+test("Linux stages real files for every configured resource glob", (t) => {
+  const tempDir = mkdtempSync(join(os.tmpdir(), "sceneworks-sidecar-test-"));
+  t.after(() => rmSync(tempDir, { recursive: true }));
+  const onnxruntimeDir = join(tempDir, "onnxruntime");
+  const ffmpegDir = join(tempDir, "ffmpeg");
+  const staged = stageNonMacResourcePlaceholders("linux", {
+    onnxruntimeDir,
+    ffmpegDir,
+  });
   const config = JSON.parse(
     readFileSync(join(scriptsDir, "..", "tauri.conf.json"), "utf8"),
   );
-  assert.ok(config.bundle.resources.includes("onnxruntime/**/*"));
-  assert.ok(config.bundle.resources.includes("ffmpeg/**/*"));
-
-  const source = readFileSync(join(scriptsDir, "build-sidecar.mjs"), "utf8");
-  assert.match(source, /onnxruntimePlaceholder\(process\.platform\)/);
-  assert.match(source, /ffmpegPlaceholder\(process\.platform\)/);
+  for (const glob of ["onnxruntime/**/*", "ffmpeg/**/*"]) {
+    assert.ok(config.bundle.resources.includes(glob));
+    const resourceDir = join(tempDir, glob.split("/")[0]);
+    assert.ok(readdirSync(resourceDir).length > 0, `${glob} must match a file`);
+  }
+  assert.match(readFileSync(staged.onnxruntimeReadme, "utf8"), /sc-10376/);
+  assert.match(readFileSync(staged.ffmpegReadme, "utf8"), /PATH.*sc-10376/);
 });
 
-test("Windows placeholder guidance remains Windows-specific", () => {
-  assert.match(onnxruntimePlaceholder("win32"), /%APPDATA%/);
-  assert.match(ffmpegPlaceholder("win32"), /Windows uses PATH ffmpeg/);
+test("Windows stages its existing platform-specific placeholder guidance", (t) => {
+  const tempDir = mkdtempSync(join(os.tmpdir(), "sceneworks-sidecar-test-"));
+  t.after(() => rmSync(tempDir, { recursive: true }));
+  const staged = stageNonMacResourcePlaceholders("win32", {
+    onnxruntimeDir: join(tempDir, "onnxruntime"),
+    ffmpegDir: join(tempDir, "ffmpeg"),
+  });
+  assert.match(readFileSync(staged.onnxruntimeReadme, "utf8"), /%APPDATA%/);
+  assert.match(
+    readFileSync(staged.ffmpegReadme, "utf8"),
+    /Windows uses PATH ffmpeg/,
+  );
 });

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -17,6 +17,11 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
 import os from "node:os";
+import {
+  ffmpegPlaceholder,
+  onnxruntimePlaceholder,
+  shouldBuildCandle,
+} from "./build-sidecar-platform.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const desktopDir = resolve(scriptDir, ".."); // apps/desktop
@@ -192,19 +197,21 @@ function codesignForNotarization(file) {
 // talk to its own origin (the API serves it), so it works on the dynamic port
 // with no CORS.
 //
-// Candle (Windows/CUDA) backend — the DEFAULT for the Windows desktop (sc-5559 /
-// sc-5563): compile the sidecar with `--features embed-web,backend-candle` so the
-// desktop's Rust worker runs candle. Off-Mac is CUDA-only (product decision: no
-// CPU/AMD, and the Python torch worker was retired in Phase 7), so a plain Windows
-// build is a GPU-less shell with no inference backend at all — never what we ship.
-// Building it therefore REQUIRES the CUDA Toolkit 12.9 + VS2022 BuildTools MSVC
-// 14.44 on PATH (run from its vcvars64 — CUDA 12.9 rejects VS2026's 14.51); the
-// candle build aborts with a clear error otherwise. Opt OUT with
+// Candle (Windows/Linux CUDA) backend — the DEFAULT for the Windows desktop
+// (sc-5559 / sc-5563) and required for Linux (sc-10374): compile the sidecar with
+// `--features embed-web,backend-candle` so the desktop's Rust worker runs candle.
+// Off-Mac is CUDA-only (product decision: no CPU/AMD, and the Python torch worker
+// was retired in Phase 7), so a plain Windows/Linux build is a GPU-less shell with
+// no inference backend at all — never what we ship.
+// Building it therefore REQUIRES a compatible CUDA toolkit. Windows additionally
+// requires CUDA Toolkit 12.9 + VS2022 BuildTools MSVC 14.44 on PATH (run from its
+// vcvars64 — CUDA 12.9 rejects VS2026's 14.51). Opt OUT on Windows with
 // SCENEWORKS_DESKTOP_CANDLE=0 only for a deliberately GPU-less compile/packaging
 // check on a box without the CUDA toolkit (e.g. a fast windows-latest CI lane).
-// macOS is unaffected — it bakes MLX into the api binary and never builds candle.
-const candle =
-  process.platform === "win32" && process.env.SCENEWORKS_DESKTOP_CANDLE !== "0";
+// Linux always builds candle through the toolchain proven by
+// .github/workflows/server-candle-linux.yml. macOS is unaffected — it bakes MLX
+// into the api binary and never builds candle.
+const candle = shouldBuildCandle(process.platform);
 if (candle) {
   // CUDA_COMPUTE_CAP=80 builds `compute_80` PTX the driver JITs forward to sm_120
   // (Blackwell) — one binary covers Ampere→Blackwell (per sc-3676). That claim holds
@@ -309,7 +316,7 @@ if (triple.includes("apple-darwin")) {
 } else {
   writeFileSync(
     join(ortDir, "README.txt"),
-    "onnxruntime is bundled on macOS (CoreML) only; the Windows candle build downloads the CUDA onnxruntime on first run into %APPDATA%\\SceneWorks\\gpu-runtime (cuda_provision.rs), not into this resource dir (sc-3487 / sc-5496).\n",
+    onnxruntimePlaceholder(process.platform),
   );
   console.log(`build-sidecar: ${ortDir} placeholder (no bundled onnxruntime)`);
 }
@@ -344,7 +351,7 @@ if (triple.includes("apple-darwin")) {
 } else {
   writeFileSync(
     join(ffmpegDir, "README.txt"),
-    "Static ffmpeg is bundled on macOS only (sc-3767); Windows/Linux use PATH ffmpeg.\n",
+    ffmpegPlaceholder(process.platform),
   );
   console.log(`build-sidecar: ${ffmpegDir} placeholder (non-macOS, PATH ffmpeg)`);
 }

--- a/apps/desktop/scripts/build-sidecar.mjs
+++ b/apps/desktop/scripts/build-sidecar.mjs
@@ -18,9 +18,8 @@ import { fileURLToPath } from "node:url";
 import process from "node:process";
 import os from "node:os";
 import {
-  ffmpegPlaceholder,
-  onnxruntimePlaceholder,
-  shouldBuildCandle,
+  sidecarBuildPlan,
+  stageNonMacResourcePlaceholders,
 } from "./build-sidecar-platform.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -211,8 +210,8 @@ function codesignForNotarization(file) {
 // Linux always builds candle through the toolchain proven by
 // .github/workflows/server-candle-linux.yml. macOS is unaffected — it bakes MLX
 // into the api binary and never builds candle.
-const candle = shouldBuildCandle(process.platform);
-if (candle) {
+const buildPlan = sidecarBuildPlan(process.platform, process.env);
+if (buildPlan.candle) {
   // CUDA_COMPUTE_CAP=80 builds `compute_80` PTX the driver JITs forward to sm_120
   // (Blackwell) — one binary covers Ampere→Blackwell (per sc-3676). That claim holds
   // for candle-kernels' dense build_ptx() kernels only: the GGUF quant/moe kernels are
@@ -223,12 +222,8 @@ if (candle) {
   // below after the build (sc-13510 — the patch already dropped out silently once).
   // Honor an explicit override (e.g. a native-cap dev build; the vendored extra gencodes
   // are unconditional, so the quant fatbin stays multi-arch at any cap) if the env set it.
-  const candleEnv = { VITE_API_BASE_URL: "" };
-  if (!process.env.CUDA_COMPUTE_CAP) {
-    candleEnv.CUDA_COMPUTE_CAP = "80";
-  }
   console.log(
-    `build-sidecar: candle backend ON (CUDA_COMPUTE_CAP=${process.env.CUDA_COMPUTE_CAP ?? "80"})`,
+    `build-sidecar: candle backend ON (CUDA_COMPUTE_CAP=${buildPlan.computeCap})`,
   );
   // candle-kernels compiles its CUDA kernels with `cudaforge`, which fans out one
   // nvcc per .cu over a rayon pool sized to ~half the CPU count. On a high-core
@@ -249,8 +244,8 @@ if (candle) {
   //      rerun-if-env-changed set, so toggling it never forces a needless rebuild.
   const nvccCap = String(Math.min(8, Math.max(1, os.cpus().length)));
   try {
-    run(npmCmd, ["run", "api:build:embedded:candle"], {
-      ...candleEnv,
+    run(npmCmd, ["run", buildPlan.npmScript], {
+      ...buildPlan.env,
       CUDAFORGE_THREADS: nvccCap,
     });
   } catch (err) {
@@ -259,14 +254,14 @@ if (candle) {
         `with serial CUDA kernel compilation (CUDAFORGE_THREADS=1) to clear nvcc ` +
         `spawn contention / surface the real nvcc error`,
     );
-    run(npmCmd, ["run", "api:build:embedded:candle"], {
-      ...candleEnv,
+    run(npmCmd, ["run", buildPlan.npmScript], {
+      ...buildPlan.env,
       CUDAFORGE_THREADS: "1",
     });
   }
-  verifyCandleQuantFatbin(process.env.CUDA_COMPUTE_CAP || candleEnv.CUDA_COMPUTE_CAP);
+  verifyCandleQuantFatbin(buildPlan.computeCap);
 } else {
-  run(npmCmd, ["run", "api:build:embedded"], { VITE_API_BASE_URL: "" });
+  run(npmCmd, ["run", buildPlan.npmScript], buildPlan.env);
 }
 
 const src = join(repoRoot, "target", "release", `sceneworks-rust-api${exe}`);
@@ -294,6 +289,7 @@ console.log(`build-sidecar: staged ${dest}`);
 // cuda_provision.rs), pointed at by setup.rs. Windows therefore ships only the
 // placeholder below — the glob still matches and the install stays small.
 const ortDir = join(desktopDir, "onnxruntime");
+const ffmpegDir = join(desktopDir, "ffmpeg");
 mkdirSync(ortDir, { recursive: true });
 if (triple.includes("apple-darwin")) {
   const dylibDest = join(ortDir, "libonnxruntime.dylib");
@@ -314,10 +310,10 @@ if (triple.includes("apple-darwin")) {
   }
   console.log(`build-sidecar: staged onnxruntime MIT license + notice`);
 } else {
-  writeFileSync(
-    join(ortDir, "README.txt"),
-    onnxruntimePlaceholder(process.platform),
-  );
+  stageNonMacResourcePlaceholders(process.platform, {
+    onnxruntimeDir: ortDir,
+    ffmpegDir,
+  });
   console.log(`build-sidecar: ${ortDir} placeholder (no bundled onnxruntime)`);
 }
 
@@ -330,7 +326,6 @@ if (triple.includes("apple-darwin")) {
 // only macOS stages the real binary (Windows/Linux desktop + server/Docker use
 // PATH ffmpeg), other platforms ship a placeholder. GPLv3 — see
 // docs/sc-3767/ffmpeg-bundling.md.
-const ffmpegDir = join(desktopDir, "ffmpeg");
 mkdirSync(ffmpegDir, { recursive: true });
 if (triple.includes("apple-darwin")) {
   const ffmpegDest = join(ffmpegDir, "ffmpeg");
@@ -349,10 +344,6 @@ if (triple.includes("apple-darwin")) {
   }
   console.log(`build-sidecar: staged ffmpeg GPLv3 license + written offer`);
 } else {
-  writeFileSync(
-    join(ffmpegDir, "README.txt"),
-    ffmpegPlaceholder(process.platform),
-  );
   console.log(`build-sidecar: ${ffmpegDir} placeholder (non-macOS, PATH ffmpeg)`);
 }
 


### PR DESCRIPTION
## Summary
- select the embed-web + backend-candle API build on Linux with the existing CUDA_COMPUTE_CAP=80 default
- keep Windows candle opt-out and macOS MLX selection unchanged
- stage explicit Linux ffmpeg and onnxruntime placeholders so Tauri resource globs remain non-empty pending sc-10376
- add focused Node tests for all platform selections and resource coverage

## Validation
- node --test apps/desktop/scripts/build-sidecar-platform.test.mjs
- node --check apps/desktop/scripts/build-sidecar.mjs
- node --check apps/desktop/scripts/build-sidecar-platform.mjs
- npm.cmd run check
- git diff --cached --check

A full Linux CUDA/Tauri runtime build is not available on this Windows host. The existing server-candle-linux workflow proves the equivalent embed-web + backend-candle Cargo build on Ubuntu.