### PR TITLE
fix(desktop): surface Linux Secret Service failures [sc-10378]

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -173,7 +173,8 @@ anything already downloaded by other tools on the machine (and vice versa). Poin
 
 Service credentials (gated Hugging Face / Civitai tokens) are **not** stored in
 these folders — they go in the per-user OS keychain (Windows Credential Manager,
-macOS Keychain). Add them under **Settings → Service credentials**.
+macOS Keychain, or Linux Secret Service through GNOME Keyring/KWallet). Add them
+under **Settings → Service credentials**.
 
 ---
 
@@ -327,3 +328,20 @@ Check `mlx-worker.log` — if nothing is being claimed, the worker may not be id
 Add the service token under **Settings → Service credentials** (e.g.
 `huggingface.co` for gated Hugging Face repos). Credential changes take effect on
 the next worker restart.
+
+**Linux: "Secret Service is unavailable or locked."**
+SceneWorks stores desktop tokens through the freedesktop Secret Service API. Start
+and unlock GNOME Keyring or KWallet in your graphical login session, and make sure
+the app has a D-Bus user session, then save the token again. Minimal window-manager
+or headless sessions need to launch a compatible Secret Service daemon first; use
+the server deployment's restricted credential file instead when no desktop secret
+store is available.
+
+To validate persistence on a Linux desktop, save a temporary Hugging Face token,
+quit SceneWorks completely, relaunch it, and confirm Settings still shows the
+credential without “token missing.” Maintainers can also exercise the native
+write/new-entry/read/delete flow with:
+
+```sh
+cargo test -p sceneworks-desktop linux_secret_service_round_trip -- --ignored
+```

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -358,12 +358,13 @@ pub fn resolve_credential_secret(host: &str) -> Option<(String, CredentialScheme
 }
 
 fn credentials_env_json_with(
+    platform: &str,
     settings: &AppSettings,
     read_secret: impl Fn(&str) -> Result<Option<String>, String>,
 ) -> Result<Option<String>, String> {
     let mut map = serde_json::Map::new();
     for meta in &settings.credentials {
-        if let Some(token) = read_secret(&meta.host)? {
+        if let Some(token) = credential_read_for_platform(platform, read_secret(&meta.host))? {
             let scheme = match meta.scheme {
                 CredentialScheme::Bearer => "bearer",
                 CredentialScheme::Query => "query",
@@ -384,7 +385,11 @@ fn credentials_env_json_with(
 }
 
 fn credentials_env_json_result() -> Result<Option<String>, String> {
-    credentials_env_json_with(&load_settings(), read_credential_secret_result)
+    credentials_env_json_with(
+        host_platform(),
+        &load_settings(),
+        read_credential_secret_result,
+    )
 }
 
 /// All stored credentials serialized as the worker's `SCENEWORKS_CREDENTIALS` JSON
@@ -1477,10 +1482,14 @@ mod tests {
             read_hf_token_with(&settings, |_| panic!("must not touch keyring")),
             Ok(None)
         );
-        assert_eq!(
-            credentials_env_json_with(&settings, |_| panic!("must not touch keyring")),
-            Ok(None)
-        );
+        for platform in ["linux", "macos", "windows"] {
+            assert_eq!(
+                credentials_env_json_with(platform, &settings, |_| {
+                    panic!("must not touch keyring")
+                }),
+                Ok(None)
+            );
+        }
     }
 
     #[test]
@@ -1503,18 +1512,68 @@ mod tests {
     #[test]
     fn generic_worker_read_preserves_secret_service_failure() {
         let settings = AppSettings {
-            credentials: vec![CredentialMeta {
-                host: "civitai.com".to_owned(),
-                label: "Civit.ai".to_owned(),
-                scheme: CredentialScheme::Query,
-            }],
+            credentials: vec![
+                CredentialMeta {
+                    host: "broken.example".to_owned(),
+                    label: "Broken".to_owned(),
+                    scheme: CredentialScheme::Bearer,
+                },
+                CredentialMeta {
+                    host: "later.example".to_owned(),
+                    label: "Later".to_owned(),
+                    scheme: CredentialScheme::Query,
+                },
+            ],
             ..AppSettings::default()
         };
         let detail = "Secret Service locked".to_owned();
         assert_eq!(
-            credentials_env_json_with(&settings, |_| Err(detail.clone())),
+            credentials_env_json_with("linux", &settings, |host| {
+                if host == "broken.example" {
+                    Err(detail.clone())
+                } else {
+                    panic!("Linux must fail fast before reading later credentials")
+                }
+            }),
             Err(detail)
         );
+    }
+
+    #[test]
+    fn non_linux_generic_worker_read_skips_only_unreadable_entry() {
+        let settings = AppSettings {
+            credentials: vec![
+                CredentialMeta {
+                    host: "broken.example".to_owned(),
+                    label: "Broken".to_owned(),
+                    scheme: CredentialScheme::Bearer,
+                },
+                CredentialMeta {
+                    host: "readable.example".to_owned(),
+                    label: "Readable".to_owned(),
+                    scheme: CredentialScheme::Query,
+                },
+            ],
+            ..AppSettings::default()
+        };
+
+        for platform in ["macos", "windows"] {
+            let json = credentials_env_json_with(platform, &settings, |host| match host {
+                "broken.example" => Err("native credential read failed".to_owned()),
+                "readable.example" => Ok(Some("later-token".to_owned())),
+                other => panic!("unexpected host: {other}"),
+            })
+            .expect("non-Linux credential assembly")
+            .expect("readable credential remains");
+            let value: serde_json::Value = serde_json::from_str(&json).expect("credential JSON");
+
+            assert!(value.get("broken.example").is_none());
+            assert_eq!(
+                value["readable.example"]["token"].as_str(),
+                Some("later-token")
+            );
+            assert_eq!(value["readable.example"]["scheme"].as_str(), Some("query"));
+        }
     }
 
     #[test]

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -86,13 +86,69 @@ fn normalize_host(input: &str) -> String {
         .to_ascii_lowercase()
 }
 
-/// The token stored for `host`, from the OS keychain. `None` when unset/unreadable.
+/// Render credential-store failures for a Tauri command. Linux's Secret Service
+/// errors are otherwise low-level D-Bus messages that do not tell a user how to
+/// recover from a missing/locked daemon. Other platforms retain keyring's existing
+/// error text so Keychain/Credential Manager behavior is unchanged.
+fn credential_store_error_for_platform(
+    platform: &str,
+    action: &str,
+    error: keyring::Error,
+) -> String {
+    let backend_unavailable = matches!(
+        &error,
+        keyring::Error::PlatformFailure(_) | keyring::Error::NoStorageAccess(_)
+    );
+    let detail = error.to_string();
+    if platform == "linux" && backend_unavailable {
+        format!(
+            "Couldn't {action} the credential because Linux Secret Service is unavailable or \
+             locked. Start and unlock GNOME Keyring or KWallet, make sure a D-Bus user session \
+             is running, then try again. Details: {detail}"
+        )
+    } else {
+        detail.to_owned()
+    }
+}
+
+fn credential_store_error(action: &str, error: keyring::Error) -> String {
+    credential_store_error_for_platform(host_platform(), action, error)
+}
+
+/// The token stored for `host`, from the OS keychain. `Ok(None)` means it is not
+/// set; backend access failures stay distinct so command callers can surface them.
+fn read_credential_secret_result(host: &str) -> Result<Option<String>, String> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, &cred_account(host))
+        .map_err(|error| credential_store_error("read", error))?;
+    match entry.get_password() {
+        Ok(token) => Ok({
+            let token = token.trim().to_owned();
+            (!token.is_empty()).then_some(token)
+        }),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(error) => Err(credential_store_error("read", error)),
+    }
+}
+
+/// Best-effort secret lookup for worker launch paths that historically return an
+/// `Option`. The Settings command uses [`read_credential_secret_result`] directly
+/// and therefore exposes backend failures to the user.
 fn read_credential_secret(host: &str) -> Option<String> {
-    keyring::Entry::new(KEYRING_SERVICE, &cred_account(host))
-        .ok()
-        .and_then(|entry| entry.get_password().ok())
-        .map(|token| token.trim().to_owned())
-        .filter(|token| !token.is_empty())
+    read_credential_secret_result(host).ok().flatten()
+}
+
+/// Linux command callers must distinguish a missing secret from an unavailable
+/// Secret Service daemon. macOS and Windows retain the existing listing behavior,
+/// where an unreadable native entry is reported as not present.
+fn credential_presence_for_platform(
+    platform: &str,
+    secret: Result<Option<String>, String>,
+) -> Result<bool, String> {
+    match secret {
+        Ok(secret) => Ok(secret.is_some()),
+        Err(error) if platform == "linux" => Err(error),
+        Err(_) => Ok(false),
+    }
 }
 
 /// Insert a credential's metadata, or update label/scheme in place if its host is
@@ -906,18 +962,21 @@ pub async fn save_asset_as(
 /// Enumerate stored credentials for the Settings screen: host, label, scheme, and
 /// whether the secret is present in the keychain. Never returns the token itself.
 #[tauri::command]
-pub fn list_credentials() -> Vec<CredentialStatus> {
+pub fn list_credentials() -> Result<Vec<CredentialStatus>, String> {
     load_settings()
         .credentials
         .into_iter()
         .map(|meta| {
-            let present = read_credential_secret(&meta.host).is_some();
-            CredentialStatus {
+            let present = credential_presence_for_platform(
+                host_platform(),
+                read_credential_secret_result(&meta.host),
+            )?;
+            Ok(CredentialStatus {
                 host: meta.host,
                 label: meta.label,
                 scheme: meta.scheme,
                 present,
-            }
+            })
         })
         .collect()
 }
@@ -941,9 +1000,9 @@ pub fn set_credential(
         return Err("A token is required; use Remove to clear a credential.".to_owned());
     }
     keyring::Entry::new(KEYRING_SERVICE, &cred_account(&host))
-        .map_err(|error| error.to_string())?
+        .map_err(|error| credential_store_error("save", error))?
         .set_password(token)
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| credential_store_error("save", error))?;
     let label = {
         let trimmed = label.trim();
         if trimmed.is_empty() {
@@ -965,7 +1024,7 @@ pub fn set_credential(
     // Drop any cached secret for this host so the worker pulls the new token on its
     // next download without an app restart (sc-5891).
     crate::setup::invalidate_credential_cache(&app, &host);
-    Ok(list_credentials())
+    list_credentials()
 }
 
 /// Remove a host's credential from the keychain and drop its metadata.
@@ -975,7 +1034,7 @@ pub fn delete_credential(app: AppHandle, host: String) -> Result<Vec<CredentialS
     if let Ok(entry) = keyring::Entry::new(KEYRING_SERVICE, &cred_account(&host)) {
         match entry.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => {}
-            Err(error) => return Err(error.to_string()),
+            Err(error) => return Err(credential_store_error("remove", error)),
         }
     }
     // Also clear the pre-migration HF account so removing HF can't be undone by a
@@ -991,7 +1050,7 @@ pub fn delete_credential(app: AppHandle, host: String) -> Result<Vec<CredentialS
     // Drop the cached secret so a revoked credential stops being served by the
     // credential socket without an app restart (sc-5891).
     crate::setup::invalidate_credential_cache(&app, &host);
-    Ok(list_credentials())
+    list_credentials()
 }
 
 #[tauri::command]
@@ -1338,6 +1397,102 @@ mod tests {
         let settings = AppSettings::default();
         assert!(!hf_credential_recorded(&settings));
         assert!(settings.credentials.is_empty());
+    }
+
+    #[test]
+    fn linux_credential_store_errors_are_actionable() {
+        let message = credential_store_error_for_platform(
+            "linux",
+            "save",
+            keyring::Error::PlatformFailure(Box::new(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "D-Bus is not available",
+            ))),
+        );
+        assert!(message.contains("Linux Secret Service is unavailable or locked"));
+        assert!(message.contains("Start and unlock GNOME Keyring or KWallet"));
+        assert!(message.contains("make sure a D-Bus user session is running"));
+        assert!(message.contains("D-Bus is not available"));
+    }
+
+    #[test]
+    fn non_linux_credential_store_errors_keep_existing_text() {
+        let error =
+            keyring::Error::PlatformFailure(Box::new(std::io::Error::other("native error")));
+        let detail = error.to_string();
+        assert_eq!(
+            credential_store_error_for_platform("macos", "save", error),
+            detail
+        );
+        let error =
+            keyring::Error::PlatformFailure(Box::new(std::io::Error::other("native error")));
+        assert_eq!(
+            credential_store_error_for_platform("windows", "save", error),
+            detail
+        );
+    }
+
+    #[test]
+    fn linux_validation_errors_keep_keyring_text() {
+        let error = keyring::Error::Invalid("username".to_owned(), "cannot be empty".to_owned());
+        let detail = error.to_string();
+        assert_eq!(
+            credential_store_error_for_platform("linux", "save", error),
+            detail
+        );
+    }
+
+    #[test]
+    fn linux_credential_listing_propagates_backend_failure() {
+        let detail = "Secret Service unavailable".to_owned();
+        assert_eq!(
+            credential_presence_for_platform("linux", Err(detail.clone())),
+            Err(detail)
+        );
+    }
+
+    #[test]
+    fn non_linux_credential_listing_keeps_missing_status_on_backend_failure() {
+        assert_eq!(
+            credential_presence_for_platform("macos", Err("native error".to_owned())),
+            Ok(false)
+        );
+        assert_eq!(
+            credential_presence_for_platform("windows", Err("native error".to_owned())),
+            Ok(false)
+        );
+    }
+
+    /// Opt-in native integration check for sc-10378. Run this on a Linux desktop
+    /// with an unlocked GNOME Keyring/KWallet session:
+    ///
+    /// `cargo test -p sceneworks-desktop linux_secret_service_round_trip -- --ignored`
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore = "requires a running, unlocked Linux Secret Service daemon"]
+    fn linux_secret_service_round_trip() {
+        let account = format!(
+            "sc-10378-test:{}:{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock")
+                .as_nanos()
+        );
+        let token = "sc-10378-secret-service-round-trip";
+        let entry = keyring::Entry::new(KEYRING_SERVICE, &account).expect("create entry");
+        entry.set_password(token).expect("save to Secret Service");
+
+        // A newly constructed Entry mirrors a later app process resolving the same
+        // service/account pair instead of reading an in-memory value.
+        let reopened = keyring::Entry::new(KEYRING_SERVICE, &account).expect("reopen entry");
+        assert_eq!(
+            reopened.get_password().expect("read from Secret Service"),
+            token
+        );
+        reopened
+            .delete_credential()
+            .expect("remove integration-test entry");
     }
 
     /// epic 4484 story 1: LAN remote access is OFF by default with no port and no

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -130,11 +130,25 @@ fn read_credential_secret_result(host: &str) -> Result<Option<String>, String> {
     }
 }
 
-/// Best-effort secret lookup for worker launch paths that historically return an
-/// `Option`. The Settings command uses [`read_credential_secret_result`] directly
-/// and therefore exposes backend failures to the user.
+/// Best-effort lookup retained for the macOS lazy credential socket, whose protocol
+/// represents unavailable secrets as absent. Eager Linux worker reads use the
+/// fallible helpers below instead.
+#[cfg(target_os = "macos")]
 fn read_credential_secret(host: &str) -> Option<String> {
     read_credential_secret_result(host).ok().flatten()
+}
+
+/// Linux must retain secure-storage read failures so startup can surface them.
+/// macOS/Windows keep their historical best-effort `Option` behavior.
+fn credential_read_for_platform<T: Default>(
+    platform: &str,
+    read: Result<T, String>,
+) -> Result<T, String> {
+    match read {
+        Err(error) if platform == "linux" => Err(error),
+        Err(_) => Ok(T::default()),
+        Ok(value) => Ok(value),
+    }
 }
 
 /// Linux command callers must distinguish a missing secret from an unavailable
@@ -144,11 +158,7 @@ fn credential_presence_for_platform(
     platform: &str,
     secret: Result<Option<String>, String>,
 ) -> Result<bool, String> {
-    match secret {
-        Ok(secret) => Ok(secret.is_some()),
-        Err(error) if platform == "linux" => Err(error),
-        Err(_) => Ok(false),
-    }
+    credential_read_for_platform(platform, secret).map(|secret| secret.is_some())
 }
 
 /// Insert a credential's metadata, or update label/scheme in place if its host is
@@ -281,6 +291,20 @@ fn save_settings(settings: &AppSettings) -> Result<(), String> {
     atomic_write(&settings_path(), body.as_bytes())
 }
 
+fn read_hf_token_with(
+    settings: &AppSettings,
+    read_secret: impl FnOnce(&str) -> Result<Option<String>, String>,
+) -> Result<Option<String>, String> {
+    if !hf_credential_recorded(settings) {
+        return Ok(None);
+    }
+    read_secret(HF_HOST)
+}
+
+fn read_hf_token_result() -> Result<Option<String>, String> {
+    read_hf_token_with(&load_settings(), read_credential_secret_result)
+}
+
 /// Hugging Face token for injecting `HF_TOKEN` into the worker, from the host-keyed
 /// `huggingface.co` credential. Gated on the non-secret `settings.json` metadata
 /// first: if no `huggingface.co` credential is recorded, returns `None` *without
@@ -292,12 +316,15 @@ fn save_settings(settings: &AppSettings) -> Result<(), String> {
 /// macOS no longer uses this eager push at all — the MLX worker pulls credentials
 /// lazily from the desktop credential socket (`cred_ipc`) — so it's compiled but
 /// uncalled there (the Python/candle spawn sites on other platforms still use it).
+#[cfg(target_os = "linux")]
+pub fn read_hf_token() -> Result<Option<String>, String> {
+    credential_read_for_platform(host_platform(), read_hf_token_result())
+}
+
+#[cfg(not(target_os = "linux"))]
 #[cfg_attr(target_os = "macos", allow(dead_code))]
 pub fn read_hf_token() -> Option<String> {
-    if !hf_credential_recorded(&load_settings()) {
-        return None;
-    }
-    read_credential_secret(HF_HOST)
+    credential_read_for_platform(host_platform(), read_hf_token_result()).unwrap_or_default()
 }
 
 /// The non-secret hosts that have a credential recorded, handed to the MLX worker so
@@ -330,18 +357,13 @@ pub fn resolve_credential_secret(host: &str) -> Option<(String, CredentialScheme
     Some((token, meta.scheme))
 }
 
-/// All stored credentials serialized as the worker's `SCENEWORKS_CREDENTIALS` JSON
-/// map (`{ host: { token, scheme } }`), reading each secret from the keychain.
-/// `None` when no credentials are stored. Injected into the worker at spawn.
-///
-/// macOS uses the lazy credential socket (`cred_ipc`) instead, so this is compiled
-/// but uncalled there (the Python/candle spawn sites on other platforms use it).
-#[cfg_attr(target_os = "macos", allow(dead_code))]
-pub fn credentials_env_json() -> Option<String> {
-    let settings = load_settings();
+fn credentials_env_json_with(
+    settings: &AppSettings,
+    read_secret: impl Fn(&str) -> Result<Option<String>, String>,
+) -> Result<Option<String>, String> {
     let mut map = serde_json::Map::new();
     for meta in &settings.credentials {
-        if let Some(token) = read_credential_secret(&meta.host) {
+        if let Some(token) = read_secret(&meta.host)? {
             let scheme = match meta.scheme {
                 CredentialScheme::Bearer => "bearer",
                 CredentialScheme::Query => "query",
@@ -353,10 +375,64 @@ pub fn credentials_env_json() -> Option<String> {
         }
     }
     if map.is_empty() {
-        None
+        Ok(None)
     } else {
-        serde_json::to_string(&serde_json::Value::Object(map)).ok()
+        serde_json::to_string(&serde_json::Value::Object(map))
+            .map(Some)
+            .map_err(|error| error.to_string())
     }
+}
+
+fn credentials_env_json_result() -> Result<Option<String>, String> {
+    credentials_env_json_with(&load_settings(), read_credential_secret_result)
+}
+
+/// All stored credentials serialized as the worker's `SCENEWORKS_CREDENTIALS` JSON
+/// map (`{ host: { token, scheme } }`), reading each secret from the keychain.
+/// `None` when no credentials are stored. Injected into the worker at spawn.
+///
+/// macOS uses the lazy credential socket (`cred_ipc`) instead, so this is compiled
+/// but uncalled there (the Python/candle spawn sites on other platforms use it).
+#[cfg(target_os = "linux")]
+pub fn credentials_env_json() -> Result<Option<String>, String> {
+    credential_read_for_platform(host_platform(), credentials_env_json_result())
+}
+
+#[cfg(not(target_os = "linux"))]
+#[cfg_attr(target_os = "macos", allow(dead_code))]
+pub fn credentials_env_json() -> Option<String> {
+    credential_read_for_platform(host_platform(), credentials_env_json_result()).unwrap_or_default()
+}
+
+fn worker_credential_preflight_with(
+    platform: &str,
+    read_hf: impl FnOnce() -> Result<Option<String>, String>,
+    read_all: impl FnOnce() -> Result<Option<String>, String>,
+) -> Result<(), String> {
+    if platform != "linux" {
+        return Ok(());
+    }
+    let _ = credential_read_for_platform(platform, read_hf())?;
+    let _ = credential_read_for_platform(platform, read_all())?;
+    Ok(())
+}
+
+/// Fail Linux startup before spawning a worker with silently missing credential
+/// environment. The setup screen renders this error and offers Retry after the user
+/// starts/unlocks Secret Service. This is a no-op on macOS/Windows, preserving their
+/// existing lazy/best-effort behavior without touching the native keychain.
+#[cfg(target_os = "linux")]
+pub fn validate_worker_credentials() -> Result<(), String> {
+    worker_credential_preflight_with(host_platform(), read_hf_token, credentials_env_json)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn validate_worker_credentials() -> Result<(), String> {
+    worker_credential_preflight_with(
+        host_platform(),
+        || Ok(read_hf_token()),
+        || Ok(credentials_env_json()),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1389,14 +1465,93 @@ mod tests {
     /// metadata before any `keyring::Entry`/`get_password()` is constructed, so a
     /// no-credential install never touches the OS keychain. `hf_credential_recorded`
     /// is that gate for `read_hf_token`; an empty `credentials` list is likewise the
-    /// gate for `credentials_env_json` (its loop body — the only `read_credential_secret`
-    /// site — never runs). This headless test asserts the gate predicate without
+    /// gate for `credentials_env_json` (its fallible resolver loop never runs). This
+    /// headless test asserts the gate predicate without
     /// touching the keychain (which `read_hf_token` itself would, once past the gate).
     #[test]
     fn no_recorded_credential_means_no_keychain_gate() {
         let settings = AppSettings::default();
         assert!(!hf_credential_recorded(&settings));
         assert!(settings.credentials.is_empty());
+        assert_eq!(
+            read_hf_token_with(&settings, |_| panic!("must not touch keyring")),
+            Ok(None)
+        );
+        assert_eq!(
+            credentials_env_json_with(&settings, |_| panic!("must not touch keyring")),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn hf_worker_read_preserves_secret_service_failure() {
+        let settings = AppSettings {
+            credentials: vec![CredentialMeta {
+                host: HF_HOST.to_owned(),
+                label: "Hugging Face".to_owned(),
+                scheme: CredentialScheme::Bearer,
+            }],
+            ..AppSettings::default()
+        };
+        let detail = "Secret Service unavailable".to_owned();
+        assert_eq!(
+            read_hf_token_with(&settings, |_| Err(detail.clone())),
+            Err(detail)
+        );
+    }
+
+    #[test]
+    fn generic_worker_read_preserves_secret_service_failure() {
+        let settings = AppSettings {
+            credentials: vec![CredentialMeta {
+                host: "civitai.com".to_owned(),
+                label: "Civit.ai".to_owned(),
+                scheme: CredentialScheme::Query,
+            }],
+            ..AppSettings::default()
+        };
+        let detail = "Secret Service locked".to_owned();
+        assert_eq!(
+            credentials_env_json_with(&settings, |_| Err(detail.clone())),
+            Err(detail)
+        );
+    }
+
+    #[test]
+    fn linux_worker_preflight_surfaces_hf_and_generic_read_failures() {
+        let hf_detail = "HF Secret Service unavailable".to_owned();
+        assert_eq!(
+            worker_credential_preflight_with(
+                "linux",
+                || Err(hf_detail.clone()),
+                || panic!("generic read must stop after HF failure")
+            ),
+            Err(hf_detail)
+        );
+
+        let generic_detail = "generic Secret Service unavailable".to_owned();
+        assert_eq!(
+            worker_credential_preflight_with(
+                "linux",
+                || Ok(Some("hf-token".to_owned())),
+                || Err(generic_detail.clone())
+            ),
+            Err(generic_detail)
+        );
+    }
+
+    #[test]
+    fn non_linux_worker_preflight_preserves_no_touch_behavior() {
+        for platform in ["macos", "windows"] {
+            assert_eq!(
+                worker_credential_preflight_with(
+                    platform,
+                    || panic!("must not eagerly read native keychain"),
+                    || panic!("must not eagerly read native keychain")
+                ),
+                Ok(())
+            );
+        }
     }
 
     #[test]

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -2110,6 +2110,14 @@ async fn run_startup(app: AppHandle) {
         emit(&app, "error", error, true);
         return;
     }
+    // Linux credentials are eagerly handed to the native worker. If Secret Service
+    // is unavailable/locked, stop on the visible setup screen with the actionable
+    // keyring error instead of spawning a worker without HF/service tokens and
+    // producing an opaque downstream 401.
+    if let Err(error) = crate::settings::validate_worker_credentials() {
+        emit(&app, "error", error, true);
+        return;
+    }
     // No Python venv on ANY platform: macOS went MLX-only (epic 3482, sc-3492/sc-3493)
     // and off-Mac went candle-only (epic 5483 Phase 7, sc-5563), so first run starts
     // straight on the native engine with no Python provisioning step.

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -121,7 +121,12 @@ export function SettingsScreen() {
     };
   }, [gpu]);
 
-  const secretStore = gpu?.platform === "windows" ? "Credential Manager" : "Keychain";
+  const secretStore =
+    gpu?.platform === "windows"
+      ? "Credential Manager"
+      : gpu?.platform === "linux"
+        ? "Secret Service (GNOME Keyring or KWallet)"
+        : "Keychain";
   const credentialLocation = isDesktop
     ? `the system ${secretStore}`
     : "the server's credential store (a restricted file in the config directory)";

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -107,6 +107,33 @@ describe("SettingsScreen service credentials", () => {
     expect(container.textContent).not.toContain("key123");
   });
 
+  it("surfaces an actionable Linux Secret Service save failure", async () => {
+    invoke.mockImplementation(async (command) => {
+      if (command === "get_app_settings") return {};
+      if (command === "get_gpu_info") return { platform: "linux", devices: [] };
+      if (command === "list_credentials") return [];
+      if (command === "set_credential") {
+        throw new Error(
+          "Couldn't save the credential because Linux Secret Service is unavailable or locked. " +
+            "Start and unlock GNOME Keyring or KWallet, make sure a D-Bus user session is running, then try again.",
+        );
+      }
+      return null;
+    });
+    await render();
+    expect(container.textContent).toContain("Secret Service (GNOME Keyring or KWallet)");
+
+    await changeField(container.querySelector('[aria-label="Credential host"]'), "huggingface.co");
+    await changeField(container.querySelector('[aria-label="Credential token"]'), "hf_secret");
+    await click(container.querySelector(".settings-credential-form button"));
+
+    expect(container.querySelector(".settings-status").textContent).toContain(
+      "Start and unlock GNOME Keyring or KWallet",
+    );
+    expect(container.textContent).not.toContain("Credential saved.");
+    expect(container.textContent).not.toContain("hf_secret");
+  });
+
   it("removes a credential via delete_credential", async () => {
     credentials = [{ host: "civitai.com", label: "Civit.ai", scheme: "query", present: true }];
     await render();


### PR DESCRIPTION
## Summary

- map Linux Secret Service/D-Bus storage failures to an actionable GNOME Keyring/KWallet message
- propagate Linux credential-list access failures through Tauri while preserving macOS/Windows listing behavior and native error text
- identify Secret Service correctly in Settings and document Linux daemon/fallback/restart validation
- add deterministic Rust platform/error tests, a frontend rejection-path test, and an opt-in native Linux keyring round trip

## Acceptance criteria

- GNOME/KDE persistence: the existing host-keyed keyring Entry write/read path remains in place; an ignored Linux-only integration test exercises write, a newly constructed Entry read, and delete against the live Secret Service. The README documents the full quit/relaunch persistence check. This Windows host could not execute live GNOME/KDE validation.
- No daemon: PlatformFailure and NoStorageAccess now surface an actionable Secret Service/D-Bus recovery message through the Tauri command and visible Settings status.
- macOS/Windows unchanged: native keyring error text and prior credential-list missing-status semantics are covered by deterministic tests.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p sceneworks-desktop --all-targets -- -D warnings
- cargo test -p sceneworks-desktop (48 passed, 1 network test ignored)
- npm --prefix apps/web run lint (0 errors; pre-existing warnings)
- npm --prefix apps/web test (2,286 passed)
- npm --prefix apps/web run build
- focused integrated SettingsScreen test (16 passed)

Shortcut: https://app.shortcut.com/trefry/story/10378