### PR TITLE
fix(desktop): finalize Linux XDG paths [sc-10377]

### DIFF
--- a/apps/desktop/src/cuda_provision.rs
+++ b/apps/desktop/src/cuda_provision.rs
@@ -31,7 +31,7 @@ use sha2::{Digest, Sha256};
 use tauri::AppHandle;
 
 use crate::cuda_provision_check::{component_provisioned, dir_has_dll, write_component_marker};
-use crate::setup::{app_support_dir, emit};
+use crate::setup::{emit, gpu_runtime_dir};
 
 /// Bump this when the pinned manifest changes so an existing install re-provisions.
 /// Written to `<root>\.redist-marker` after a fully successful provision; a run whose
@@ -199,7 +199,7 @@ const COMPONENTS: &[Component] = &[
 
 /// Root of the provisioned GPU runtime: `%APPDATA%\SceneWorks\gpu-runtime`.
 fn root() -> PathBuf {
-    app_support_dir().join("gpu-runtime")
+    gpu_runtime_dir()
 }
 
 /// Provisioned CUDA runtime DLL dir (`<root>\cuda`). The candle worker's PATH is

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
-use crate::setup::{app_support_dir, default_data_dir, shared_huggingface_home};
+use crate::setup::{default_data_dir, settings_file, shared_huggingface_home};
 
 const KEYRING_SERVICE: &str = "SceneWorks";
 /// Pre-migration account that held the single Hugging Face token. Retained only so
@@ -147,7 +147,7 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_dir: Option<String>,
     /// Hugging Face cache home (`HF_HOME`) for HF-downloaded model weights;
-    /// `None` uses the shared per-user cache (`~/.cache/huggingface`).
+    /// `None` uses the platform shared cache (the XDG cache base on Linux).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hf_home: Option<String>,
     /// Set once the first-run splash storage step (sc-1473 Step 1) has run, so
@@ -190,7 +190,7 @@ pub struct AppSettings {
 }
 
 fn settings_path() -> PathBuf {
-    app_support_dir().join("settings.json")
+    settings_file()
 }
 
 pub fn load_settings() -> AppSettings {

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -193,11 +193,66 @@ fn settings_path() -> PathBuf {
     settings_file()
 }
 
+/// Normalize an editable storage override. `linux_absolute` is explicit so the
+/// Linux rule is testable on Windows CI: Linux accepts only `/`-rooted paths,
+/// while macOS/Windows retain their existing relative-path behavior.
+pub(crate) fn storage_override_path(value: &str, linux_absolute: bool) -> Option<PathBuf> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(trimmed);
+    if linux_absolute && !path.as_os_str().to_string_lossy().starts_with('/') {
+        return None;
+    }
+    Some(path)
+}
+
+fn storage_override_input_for(
+    name: &str,
+    value: &str,
+    linux_absolute: bool,
+) -> Result<Option<String>, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    storage_override_path(trimmed, linux_absolute)
+        .map(|_| Some(trimmed.to_owned()))
+        .ok_or_else(|| format!("{name} must be an absolute path on Linux"))
+}
+
+fn storage_override_input(name: &str, value: &str) -> Result<Option<String>, String> {
+    storage_override_input_for(name, value, cfg!(all(unix, not(target_os = "macos"))))
+}
+
+#[cfg(any(all(unix, not(target_os = "macos")), test))]
+fn sanitize_storage_overrides(settings: &mut AppSettings, linux_absolute: bool) {
+    let sanitize = |value: Option<String>| {
+        value.and_then(|value| {
+            storage_override_path(&value, linux_absolute)
+                .map(|path| path.to_string_lossy().into_owned())
+        })
+    };
+    settings.data_dir = sanitize(settings.data_dir.take());
+    settings.hf_home = sanitize(settings.hf_home.take());
+}
+
 pub fn load_settings() -> AppSettings {
-    std::fs::read_to_string(settings_path())
+    let settings = std::fs::read_to_string(settings_path())
         .ok()
         .and_then(|body| serde_json::from_str(&body).ok())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let mut settings = settings;
+        sanitize_storage_overrides(&mut settings, true);
+        settings
+    }
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        settings
+    }
 }
 
 /// Write `body` to `path` atomically via temp-file + rename, so a crash / full disk
@@ -674,18 +729,8 @@ pub fn get_storage_setup() -> StorageSetup {
 #[tauri::command]
 pub fn save_storage_setup(data_dir: String, hf_home: String) -> Result<AppSettings, String> {
     let mut settings = load_settings();
-    let data_trimmed = data_dir.trim();
-    settings.data_dir = if data_trimmed.is_empty() {
-        None
-    } else {
-        Some(data_trimmed.to_owned())
-    };
-    let hf_trimmed = hf_home.trim();
-    settings.hf_home = if hf_trimmed.is_empty() {
-        None
-    } else {
-        Some(hf_trimmed.to_owned())
-    };
+    settings.data_dir = storage_override_input("SceneWorks data directory", &data_dir)?;
+    settings.hf_home = storage_override_input("Hugging Face cache directory", &hf_home)?;
     settings.storage_configured = true;
     save_settings(&settings)?;
     Ok(settings)
@@ -725,12 +770,7 @@ pub async fn choose_folder(app: AppHandle) -> Option<String> {
 #[tauri::command]
 pub fn set_data_dir(path: String) -> Result<AppSettings, String> {
     let mut settings = load_settings();
-    let trimmed = path.trim();
-    settings.data_dir = if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_owned())
-    };
+    settings.data_dir = storage_override_input("SceneWorks data directory", &path)?;
     save_settings(&settings)?;
     Ok(settings)
 }
@@ -1070,6 +1110,69 @@ pub fn get_gpu_info() -> GpuInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn linux_storage_inputs_require_absolute_paths() {
+        assert_eq!(
+            storage_override_input_for("data directory", " /srv/sceneworks ", true)
+                .expect("absolute Linux path"),
+            Some("/srv/sceneworks".to_owned())
+        );
+        assert_eq!(
+            storage_override_input_for("data directory", "   ", true)
+                .expect("empty clears override"),
+            None
+        );
+        let data_error = storage_override_input_for("data directory", "relative/data", true)
+            .expect_err("relative Linux data directory must be rejected");
+        assert!(data_error.contains("absolute path on Linux"));
+        let hf_error = storage_override_input_for("HF cache", "./huggingface", true)
+            .expect_err("relative Linux HF cache must be rejected");
+        assert!(hf_error.contains("absolute path on Linux"));
+    }
+
+    #[test]
+    fn non_linux_storage_inputs_preserve_relative_path_behavior() {
+        assert_eq!(
+            storage_override_input_for("data directory", " relative/data ", false)
+                .expect("non-Linux relative path remains supported"),
+            Some("relative/data".to_owned())
+        );
+        assert_eq!(
+            storage_override_path("./huggingface", false),
+            Some(PathBuf::from("./huggingface"))
+        );
+    }
+
+    #[test]
+    fn legacy_linux_settings_drop_relative_storage_overrides() {
+        let mut settings = AppSettings {
+            data_dir: Some("relative/data".to_owned()),
+            hf_home: Some("./huggingface".to_owned()),
+            ..AppSettings::default()
+        };
+        sanitize_storage_overrides(&mut settings, true);
+        assert_eq!(settings.data_dir, None);
+        assert_eq!(settings.hf_home, None);
+
+        let mut mixed = AppSettings {
+            data_dir: Some(" /srv/sceneworks ".to_owned()),
+            hf_home: Some("relative-hf".to_owned()),
+            ..AppSettings::default()
+        };
+        sanitize_storage_overrides(&mut mixed, true);
+        assert_eq!(mixed.data_dir.as_deref(), Some("/srv/sceneworks"));
+        assert_eq!(mixed.hf_home, None);
+
+        let mut non_linux = AppSettings {
+            data_dir: Some(" relative/data ".to_owned()),
+            hf_home: Some(" ./huggingface ".to_owned()),
+            ..AppSettings::default()
+        };
+        sanitize_storage_overrides(&mut non_linux, false);
+        assert_eq!(non_linux.data_dir.as_deref(), Some("relative/data"));
+        assert_eq!(non_linux.hf_home.as_deref(), Some("./huggingface"));
+    }
 
     /// A unique scratch directory under the system temp dir, so the path-resolution
     /// tests below don't need a `tempfile` dependency. Cleaned up by the caller.

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -278,7 +278,10 @@ const APP_DIR_NAME: &str = "SceneWorks";
 /// Linux desktop paths resolved from the XDG base-directory environment.
 ///
 /// Kept as a pure helper (rather than reading the process environment directly)
-/// so all XDG override and fallback behavior is testable on every CI host.
+/// so all XDG override and fallback behavior is testable on every CI host. A
+/// missing absolute XDG base and missing absolute `HOME` is an error: falling
+/// back to `temp_dir()` would trust `TMPDIR`, permit relative/CWD writes, and use
+/// a predictable cross-user directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg(any(all(unix, not(target_os = "macos")), test))]
 struct LinuxDesktopPaths {
@@ -298,9 +301,8 @@ impl LinuxDesktopPaths {
             .then_some(path)
     }
 
-    fn resolve(get_env: impl Fn(&str) -> Option<OsString>, temp_dir: &Path) -> LinuxDesktopPaths {
+    fn resolve(get_env: impl Fn(&str) -> Option<OsString>) -> Result<LinuxDesktopPaths, String> {
         let home = get_env("HOME").and_then(LinuxDesktopPaths::absolute_linux_path);
-        let temp_root = temp_dir.join(APP_DIR_NAME);
         let xdg_dir = |name: &str, fallback: &[&str], temp_leaf: &str| {
             get_env(name)
                 .and_then(LinuxDesktopPaths::absolute_linux_path)
@@ -312,21 +314,59 @@ impl LinuxDesktopPaths {
                     })
                 })
                 .map(|base| base.join(APP_DIR_NAME))
-                .unwrap_or_else(|| temp_root.join(temp_leaf))
+                .ok_or_else(|| {
+                    format!(
+                        "cannot resolve Linux {temp_leaf} directory: set {name} or HOME to an absolute path"
+                    )
+                })
         };
 
-        LinuxDesktopPaths {
-            data_dir: xdg_dir("XDG_DATA_HOME", &[".local", "share"], "data"),
-            config_dir: xdg_dir("XDG_CONFIG_HOME", &[".config"], "config"),
-            cache_dir: xdg_dir("XDG_CACHE_HOME", &[".cache"], "cache"),
-            state_dir: xdg_dir("XDG_STATE_HOME", &[".local", "state"], "state"),
-        }
+        Ok(LinuxDesktopPaths {
+            data_dir: xdg_dir("XDG_DATA_HOME", &[".local", "share"], "data")?,
+            config_dir: xdg_dir("XDG_CONFIG_HOME", &[".config"], "config")?,
+            cache_dir: xdg_dir("XDG_CACHE_HOME", &[".cache"], "cache")?,
+            state_dir: xdg_dir("XDG_STATE_HOME", &[".local", "state"], "state")?,
+        })
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
-    fn from_process_env() -> LinuxDesktopPaths {
-        Self::resolve(std::env::var_os, &std::env::temp_dir())
+    fn from_process_env() -> Result<LinuxDesktopPaths, String> {
+        Self::resolve(std::env::var_os)
     }
+
+    fn settings_file(&self) -> PathBuf {
+        self.config_dir.join("settings.json")
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        self.data_dir.clone()
+    }
+
+    fn config_dir(&self) -> PathBuf {
+        self.config_dir.clone()
+    }
+
+    fn logs_dir(&self) -> PathBuf {
+        self.state_dir.join("logs")
+    }
+
+    fn huggingface_home(&self) -> PathBuf {
+        self.cache_dir.join("huggingface")
+    }
+
+    fn gpu_runtime_dir(&self) -> PathBuf {
+        self.data_dir.join("gpu-runtime")
+    }
+
+    fn sidecar_pidfile(&self) -> PathBuf {
+        self.state_dir.join("desktop-sidecars.json")
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_desktop_paths() -> LinuxDesktopPaths {
+    LinuxDesktopPaths::from_process_env()
+        .unwrap_or_else(|error| panic!("SceneWorks Linux path configuration is invalid: {error}"))
 }
 
 /// Per-OS application support root: `~/Library/Application Support/SceneWorks`
@@ -346,7 +386,7 @@ pub fn app_support_dir() -> PathBuf {
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        LinuxDesktopPaths::from_process_env().data_dir
+        linux_desktop_paths().data_dir()
     }
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
@@ -369,7 +409,7 @@ pub fn logs_dir() -> PathBuf {
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        LinuxDesktopPaths::from_process_env().state_dir.join("logs")
+        linux_desktop_paths().logs_dir()
     }
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
@@ -382,7 +422,7 @@ pub fn logs_dir() -> PathBuf {
 pub fn default_data_dir() -> PathBuf {
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        LinuxDesktopPaths::from_process_env().data_dir
+        linux_desktop_paths().data_dir()
     }
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
@@ -393,7 +433,7 @@ pub fn default_data_dir() -> PathBuf {
 pub(crate) fn config_dir() -> PathBuf {
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        LinuxDesktopPaths::from_process_env().config_dir
+        linux_desktop_paths().config_dir()
     }
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
@@ -404,7 +444,7 @@ pub(crate) fn config_dir() -> PathBuf {
 pub(crate) fn settings_file() -> PathBuf {
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        config_dir().join("settings.json")
+        linux_desktop_paths().settings_file()
     }
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
@@ -416,7 +456,14 @@ pub(crate) fn settings_file() -> PathBuf {
 /// consumes this path so its runtime stays under the XDG data base; the Windows
 /// value remains `%APPDATA%\SceneWorks\gpu-runtime`.
 pub fn gpu_runtime_dir() -> PathBuf {
-    app_support_dir().join("gpu-runtime")
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        linux_desktop_paths().gpu_runtime_dir()
+    }
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        app_support_dir().join("gpu-runtime")
+    }
 }
 
 /// Shared per-user Hugging Face cache — the default `HF_HOME` when the user
@@ -427,9 +474,7 @@ pub fn gpu_runtime_dir() -> PathBuf {
 pub fn shared_huggingface_home() -> PathBuf {
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        LinuxDesktopPaths::from_process_env()
-            .cache_dir
-            .join("huggingface")
+        linux_desktop_paths().huggingface_home()
     }
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
@@ -1623,9 +1668,7 @@ fn pid_alive(pid: u32) -> bool {
 fn sidecar_pidfile() -> PathBuf {
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        LinuxDesktopPaths::from_process_env()
-            .state_dir
-            .join("desktop-sidecars.json")
+        linux_desktop_paths().sidecar_pidfile()
     }
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
@@ -2253,32 +2296,30 @@ mod path_tests {
     use super::LinuxDesktopPaths;
     use std::collections::HashMap;
     use std::ffi::OsString;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
 
-    fn resolve(values: &[(&str, &str)], temp_dir: &Path) -> LinuxDesktopPaths {
+    fn resolve(values: &[(&str, &str)]) -> Result<LinuxDesktopPaths, String> {
         let env = values
             .iter()
             .map(|(name, value)| ((*name).to_owned(), OsString::from(value)))
             .collect::<HashMap<_, _>>();
-        LinuxDesktopPaths::resolve(|name| env.get(name).cloned(), temp_dir)
+        LinuxDesktopPaths::resolve(|name| env.get(name).cloned())
     }
 
     #[test]
     fn linux_xdg_overrides_cover_every_desktop_managed_location() {
-        let paths = resolve(
-            &[
-                ("HOME", "/home/alice"),
-                ("XDG_DATA_HOME", "/mnt/xdg-data"),
-                ("XDG_CONFIG_HOME", "/mnt/xdg-config"),
-                ("XDG_CACHE_HOME", "/mnt/xdg-cache"),
-                ("XDG_STATE_HOME", "/mnt/xdg-state"),
-            ],
-            Path::new("/tmp"),
-        );
+        let paths = resolve(&[
+            ("HOME", "relative-home"),
+            ("XDG_DATA_HOME", "/mnt/xdg-data"),
+            ("XDG_CONFIG_HOME", "/mnt/xdg-config"),
+            ("XDG_CACHE_HOME", "/mnt/xdg-cache"),
+            ("XDG_STATE_HOME", "/mnt/xdg-state"),
+        ])
+        .expect("absolute XDG overrides resolve");
 
-        assert_eq!(paths.data_dir, PathBuf::from("/mnt/xdg-data/SceneWorks"));
+        assert_eq!(paths.data_dir(), PathBuf::from("/mnt/xdg-data/SceneWorks"));
         assert_eq!(
-            paths.config_dir,
+            paths.config_dir(),
             PathBuf::from("/mnt/xdg-config/SceneWorks")
         );
         assert_eq!(paths.cache_dir, PathBuf::from("/mnt/xdg-cache/SceneWorks"));
@@ -2286,44 +2327,44 @@ mod path_tests {
 
         // Exact call surfaces owned by the desktop and its sidecars.
         assert_eq!(
-            paths.config_dir.join("settings.json"),
+            paths.settings_file(),
             PathBuf::from("/mnt/xdg-config/SceneWorks/settings.json")
         );
         assert_eq!(
-            paths.config_dir.join("manifests"),
+            paths.config_dir().join("manifests"),
             PathBuf::from("/mnt/xdg-config/SceneWorks/manifests")
         );
         assert_eq!(
-            paths.data_dir.join("cache").join("jobs.db"),
+            paths.data_dir().join("cache").join("jobs.db"),
             PathBuf::from("/mnt/xdg-data/SceneWorks/cache/jobs.db")
         );
         assert_eq!(
-            paths.state_dir.join("logs"),
+            paths.logs_dir(),
             PathBuf::from("/mnt/xdg-state/SceneWorks/logs")
         );
         assert_eq!(
-            paths.data_dir.join("gpu-runtime"),
+            paths.gpu_runtime_dir(),
             PathBuf::from("/mnt/xdg-data/SceneWorks/gpu-runtime")
         );
         assert_eq!(
-            paths.cache_dir.join("huggingface"),
+            paths.huggingface_home(),
             PathBuf::from("/mnt/xdg-cache/SceneWorks/huggingface")
         );
         assert_eq!(
-            paths.state_dir.join("desktop-sidecars.json"),
+            paths.sidecar_pidfile(),
             PathBuf::from("/mnt/xdg-state/SceneWorks/desktop-sidecars.json")
         );
     }
 
     #[test]
     fn linux_xdg_fallbacks_are_home_scoped_and_never_relative() {
-        let paths = resolve(&[("HOME", "/home/alice")], Path::new("/tmp"));
+        let paths = resolve(&[("HOME", "/home/alice")]).expect("absolute HOME resolves");
         assert_eq!(
-            paths.data_dir,
+            paths.data_dir(),
             PathBuf::from("/home/alice/.local/share/SceneWorks")
         );
         assert_eq!(
-            paths.config_dir,
+            paths.config_dir(),
             PathBuf::from("/home/alice/.config/SceneWorks")
         );
         assert_eq!(
@@ -2334,29 +2375,30 @@ mod path_tests {
             paths.state_dir,
             PathBuf::from("/home/alice/.local/state/SceneWorks")
         );
+    }
 
-        // The XDG spec requires absolute override values. Ignoring relative/empty
-        // values prevents an accidental write into the launch CWD.
-        let invalid = resolve(
-            &[
-                ("HOME", "relative-home"),
-                ("XDG_DATA_HOME", "relative-data"),
-                ("XDG_CONFIG_HOME", ""),
-            ],
-            Path::new("/var/tmp"),
+    #[test]
+    fn linux_paths_fail_without_absolute_xdg_or_home_even_with_relative_tmpdir() {
+        // The XDG spec requires absolute override values. `TMPDIR` is
+        // intentionally relative to reproduce the review finding: resolution
+        // must fail before any accessor can turn it into a launch-CWD write.
+        let error = resolve(&[
+            ("HOME", "relative-home"),
+            ("XDG_DATA_HOME", "relative-data"),
+            ("XDG_CONFIG_HOME", ""),
+            ("TMPDIR", "relative-tmp"),
+        ])
+        .expect_err("missing absolute XDG/HOME bases must stop startup");
+        assert!(
+            error.contains("XDG_DATA_HOME") && error.contains("HOME"),
+            "unexpected resolution error: {error}"
         );
-        assert_eq!(invalid.data_dir, PathBuf::from("/var/tmp/SceneWorks/data"));
-        assert_eq!(
-            invalid.config_dir,
-            PathBuf::from("/var/tmp/SceneWorks/config")
-        );
-        assert_eq!(
-            invalid.cache_dir,
-            PathBuf::from("/var/tmp/SceneWorks/cache")
-        );
-        assert_eq!(
-            invalid.state_dir,
-            PathBuf::from("/var/tmp/SceneWorks/state")
+
+        let absent = resolve(&[("TMPDIR", "relative-tmp")])
+            .expect_err("missing HOME and XDG bases must stop startup");
+        assert!(
+            absent.contains("XDG_DATA_HOME") && absent.contains("HOME"),
+            "unexpected resolution error: {absent}"
         );
     }
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -498,21 +498,55 @@ pub fn shared_huggingface_home() -> PathBuf {
 /// `tauri dev`), then the user's persisted choice from the first-run splash, then
 /// the shared per-user cache. Because the splash persists this *before* the
 /// sidecars spawn, the chosen location takes effect with no app restart.
+fn select_huggingface_home(
+    ambient: Option<&str>,
+    persisted: Option<&str>,
+    shared: PathBuf,
+    linux_absolute: bool,
+) -> PathBuf {
+    ambient
+        .and_then(|value| crate::settings::storage_override_path(value, linux_absolute))
+        .or_else(|| {
+            persisted
+                .and_then(|value| crate::settings::storage_override_path(value, linux_absolute))
+        })
+        .unwrap_or(shared)
+}
+
+fn huggingface_cache_env(hf_home: &str, linux_absolute: bool) -> Vec<(&'static str, String)> {
+    let home = crate::settings::storage_override_path(hf_home, linux_absolute)
+        .expect("resolved HF_HOME must satisfy the platform path invariant");
+    let home = home.to_string_lossy().into_owned();
+    let mut env = vec![("HF_HOME", home.clone())];
+    if linux_absolute {
+        let hub = if home == "/" {
+            "/hub".to_owned()
+        } else {
+            format!("{}/hub", home.trim_end_matches('/'))
+        };
+        // The core resolver reads these before HF_HOME. Pin both like Docker so
+        // inherited relative values cannot redirect Linux sidecars into CWD.
+        env.push(("HF_HUB_CACHE", hub.clone()));
+        env.push(("HUGGINGFACE_HUB_CACHE", hub));
+    }
+    env
+}
+
+fn inject_huggingface_cache_env(command: Command, hf_home: &str) -> Command {
+    huggingface_cache_env(hf_home, cfg!(all(unix, not(target_os = "macos"))))
+        .into_iter()
+        .fold(command, |command, (name, value)| command.env(name, value))
+}
+
 fn huggingface_home() -> PathBuf {
-    if let Ok(value) = std::env::var("HF_HOME") {
-        let trimmed = value.trim();
-        if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
-        }
-    }
-    if let Some(dir) = crate::settings::load_settings()
-        .hf_home
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-    {
-        return PathBuf::from(dir);
-    }
-    shared_huggingface_home()
+    let ambient = std::env::var("HF_HOME").ok();
+    let persisted = crate::settings::load_settings().hf_home;
+    select_huggingface_home(
+        ambient.as_deref(),
+        persisted.as_deref(),
+        shared_huggingface_home(),
+        cfg!(all(unix, not(target_os = "macos"))),
+    )
 }
 
 /// Seed the builtin model/LoRA/recipe-preset catalogs into the desktop's
@@ -820,6 +854,7 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
             &format!("[desktop] {warning}\n"),
         );
     }
+    let hf_home = huggingface_home().to_string_lossy().into_owned();
     let mut command = app
         .shell()
         .sidecar("sceneworks-api")
@@ -848,10 +883,10 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
         .env(
             "SCENEWORKS_CONFIG_DIR",
             config_dir().to_string_lossy().to_string(),
-        )
-        // The catalog's install-state detection resolves the HF cache from this;
-        // it must match the worker's download root or every model reads "missing".
-        .env("HF_HOME", huggingface_home().to_string_lossy().to_string());
+        );
+    // The catalog's install-state detection resolves the HF cache from these;
+    // they must match the worker's download root or every model reads "missing".
+    command = inject_huggingface_cache_env(command, &hf_home);
     // Epic 3482 (Python Eradication) final cutover (sc-3492) — macOS runs MLX-only.
     // `Settings.mlx_required` ← `SCENEWORKS_MLX_REQUIRED` (sc-3483): the MPS/torch worker
     // never claims an MLX-eligible job, and an MLX-eligible job that no live `mlx` worker
@@ -1466,7 +1501,6 @@ fn supervise_mlx_worker(app: AppHandle) {
                 .env("SCENEWORKS_GPU_ID", "mlx")
                 .env("SCENEWORKS_WORKER_ID", ctx.worker_id)
                 .env("SCENEWORKS_API_URL", ctx.api_url)
-                .env("HF_HOME", ctx.hf_home)
                 // Parent-death watchdog (run_worker() honours this): a force-quit
                 // self-terminates the worker so its multi-GB MLX model isn't
                 // orphaned to launchd.
@@ -1479,6 +1513,7 @@ fn supervise_mlx_worker(app: AppHandle) {
                     "SCENEWORKS_CONFIG_DIR",
                     config_dir().to_string_lossy().to_string(),
                 );
+            command = inject_huggingface_cache_env(command, ctx.hf_home);
             // sc-7821 (epic 7819): the user's GPU memory ceiling, as fraction × total unified
             // memory. run_worker_loop applies it to the MLX runtime process-globally (covers
             // generations, upscales, AND LoRA training). Absent ⇒ no env ⇒ MLX default budget.
@@ -1588,7 +1623,6 @@ fn supervise_candle_worker(app: AppHandle) {
                 .env("SCENEWORKS_BACKEND_CANDLE_ENABLED", "true")
                 .env("SCENEWORKS_WORKER_ID", ctx.worker_id)
                 .env("SCENEWORKS_API_URL", ctx.api_url)
-                .env("HF_HOME", ctx.hf_home)
                 // Parent-death watchdog (run_worker() honours this): a force-quit
                 // self-terminates the worker so its multi-GB model + CUDA context
                 // isn't orphaned.
@@ -1601,6 +1635,7 @@ fn supervise_candle_worker(app: AppHandle) {
                     "SCENEWORKS_CONFIG_DIR",
                     config_dir().to_string_lossy().to_string(),
                 );
+            command = inject_huggingface_cache_env(command, ctx.hf_home);
             // cudarc dynamic-linking `LoadLibrary`s the CUDA runtime DLLs by name;
             // prepend the bundled redist dir to this worker's PATH so they resolve
             // without a CUDA Toolkit on the machine (sc-5560).
@@ -2293,7 +2328,7 @@ pub async fn start_setup(app: AppHandle) {
 
 #[cfg(test)]
 mod path_tests {
-    use super::LinuxDesktopPaths;
+    use super::{huggingface_cache_env, select_huggingface_home, LinuxDesktopPaths};
     use std::collections::HashMap;
     use std::ffi::OsString;
     use std::path::PathBuf;
@@ -2399,6 +2434,73 @@ mod path_tests {
         assert!(
             absent.contains("XDG_DATA_HOME") && absent.contains("HOME"),
             "unexpected resolution error: {absent}"
+        );
+    }
+
+    #[test]
+    fn linux_hf_home_ignores_relative_ambient_and_legacy_overrides() {
+        let shared = PathBuf::from("/home/alice/.cache/SceneWorks/huggingface");
+        assert_eq!(
+            select_huggingface_home(
+                Some("relative-ambient"),
+                Some("/mnt/models/huggingface"),
+                shared.clone(),
+                true,
+            ),
+            PathBuf::from("/mnt/models/huggingface")
+        );
+        assert_eq!(
+            select_huggingface_home(
+                Some("/mnt/ambient/huggingface"),
+                Some("/mnt/persisted/huggingface"),
+                shared.clone(),
+                true,
+            ),
+            PathBuf::from("/mnt/ambient/huggingface")
+        );
+        assert_eq!(
+            select_huggingface_home(
+                Some("./ambient"),
+                Some("persisted-relative"),
+                shared.clone(),
+                true,
+            ),
+            shared
+        );
+    }
+
+    #[test]
+    fn non_linux_hf_home_preserves_relative_ambient_override() {
+        assert_eq!(
+            select_huggingface_home(
+                Some("relative-ambient"),
+                Some("relative-persisted"),
+                PathBuf::from("shared"),
+                false,
+            ),
+            PathBuf::from("relative-ambient")
+        );
+        assert_eq!(
+            huggingface_cache_env("relative-ambient", false),
+            vec![("HF_HOME", "relative-ambient".to_owned())]
+        );
+    }
+
+    #[test]
+    fn linux_hf_cache_env_pins_every_hub_override_to_absolute_xdg_home() {
+        assert_eq!(
+            huggingface_cache_env("/mnt/cache/SceneWorks/huggingface", true),
+            vec![
+                ("HF_HOME", "/mnt/cache/SceneWorks/huggingface".to_owned()),
+                (
+                    "HF_HUB_CACHE",
+                    "/mnt/cache/SceneWorks/huggingface/hub".to_owned()
+                ),
+                (
+                    "HUGGINGFACE_HUB_CACHE",
+                    "/mnt/cache/SceneWorks/huggingface/hub".to_owned()
+                ),
+            ]
         );
     }
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -5,6 +5,8 @@
 //! then spawns the API sidecar, health-gates it, and navigates the window to the
 //! local API. `start_setup` is also the retry entry point.
 
+#[cfg(any(all(unix, not(target_os = "macos")), test))]
+use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -270,9 +272,66 @@ pub(crate) fn emit(app: &AppHandle, phase: &str, message: impl Into<String>, err
     );
 }
 
+#[cfg(any(all(unix, not(target_os = "macos")), test))]
+const APP_DIR_NAME: &str = "SceneWorks";
+
+/// Linux desktop paths resolved from the XDG base-directory environment.
+///
+/// Kept as a pure helper (rather than reading the process environment directly)
+/// so all XDG override and fallback behavior is testable on every CI host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(any(all(unix, not(target_os = "macos")), test))]
+struct LinuxDesktopPaths {
+    data_dir: PathBuf,
+    config_dir: PathBuf,
+    cache_dir: PathBuf,
+    state_dir: PathBuf,
+}
+
+#[cfg(any(all(unix, not(target_os = "macos")), test))]
+impl LinuxDesktopPaths {
+    fn absolute_linux_path(value: OsString) -> Option<PathBuf> {
+        let path = PathBuf::from(value);
+        path.as_os_str()
+            .to_string_lossy()
+            .starts_with('/')
+            .then_some(path)
+    }
+
+    fn resolve(get_env: impl Fn(&str) -> Option<OsString>, temp_dir: &Path) -> LinuxDesktopPaths {
+        let home = get_env("HOME").and_then(LinuxDesktopPaths::absolute_linux_path);
+        let temp_root = temp_dir.join(APP_DIR_NAME);
+        let xdg_dir = |name: &str, fallback: &[&str], temp_leaf: &str| {
+            get_env(name)
+                .and_then(LinuxDesktopPaths::absolute_linux_path)
+                .or_else(|| {
+                    home.as_ref().map(|home| {
+                        fallback
+                            .iter()
+                            .fold(home.clone(), |path, component| path.join(component))
+                    })
+                })
+                .map(|base| base.join(APP_DIR_NAME))
+                .unwrap_or_else(|| temp_root.join(temp_leaf))
+        };
+
+        LinuxDesktopPaths {
+            data_dir: xdg_dir("XDG_DATA_HOME", &[".local", "share"], "data"),
+            config_dir: xdg_dir("XDG_CONFIG_HOME", &[".config"], "config"),
+            cache_dir: xdg_dir("XDG_CACHE_HOME", &[".cache"], "cache"),
+            state_dir: xdg_dir("XDG_STATE_HOME", &[".local", "state"], "state"),
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn from_process_env() -> LinuxDesktopPaths {
+        Self::resolve(std::env::var_os, &std::env::temp_dir())
+    }
+}
+
 /// Per-OS application support root: `~/Library/Application Support/SceneWorks`
-/// (macOS), `%APPDATA%\SceneWorks` (Windows), `$XDG_DATA_HOME/sceneworks` or
-/// `~/.local/share/sceneworks` (Linux). Mirrors the API's path resolver.
+/// (macOS), `%APPDATA%\SceneWorks` (Windows), `$XDG_DATA_HOME/SceneWorks` or
+/// `~/.local/share/SceneWorks` (Linux).
 pub fn app_support_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     if let Ok(home) = std::env::var("HOME") {
@@ -287,17 +346,12 @@ pub fn app_support_dir() -> PathBuf {
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        if let Ok(data) = std::env::var("XDG_DATA_HOME") {
-            return PathBuf::from(data).join("sceneworks");
-        }
-        if let Ok(home) = std::env::var("HOME") {
-            return PathBuf::from(home)
-                .join(".local")
-                .join("share")
-                .join("sceneworks");
-        }
+        LinuxDesktopPaths::from_process_env().data_dir
     }
-    std::env::temp_dir().join("SceneWorks")
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        std::env::temp_dir().join("SceneWorks")
+    }
 }
 
 /// Platform-appropriate logs directory (also used for the API/worker logs).
@@ -315,42 +369,79 @@ pub fn logs_dir() -> PathBuf {
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        if let Ok(state) = std::env::var("XDG_STATE_HOME") {
-            return PathBuf::from(state).join("sceneworks").join("logs");
-        }
-        if let Ok(home) = std::env::var("HOME") {
-            return PathBuf::from(home)
-                .join(".local")
-                .join("state")
-                .join("sceneworks")
-                .join("logs");
-        }
+        LinuxDesktopPaths::from_process_env().state_dir.join("logs")
     }
-    std::env::temp_dir().join("SceneWorks").join("logs")
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        std::env::temp_dir().join("SceneWorks").join("logs")
+    }
 }
 
 /// Platform default workspace data directory, used when the user hasn't picked a
 /// custom location in the first-run splash / Settings.
 pub fn default_data_dir() -> PathBuf {
-    app_support_dir().join("data")
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        LinuxDesktopPaths::from_process_env().data_dir
+    }
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        app_support_dir().join("data")
+    }
 }
 
 pub(crate) fn config_dir() -> PathBuf {
-    app_support_dir().join("config")
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        LinuxDesktopPaths::from_process_env().config_dir
+    }
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        app_support_dir().join("config")
+    }
 }
 
-/// Shared per-user Hugging Face cache (`~/.cache/huggingface`) — the default
-/// `HF_HOME` when the user hasn't chosen a custom location. Dedups with other
-/// HF-based tools on the machine and reuses anything already downloaded.
-pub fn shared_huggingface_home() -> PathBuf {
-    if let Some(home) = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .ok()
-        .filter(|value| !value.trim().is_empty())
+pub(crate) fn settings_file() -> PathBuf {
+    #[cfg(all(unix, not(target_os = "macos")))]
     {
-        return PathBuf::from(home).join(".cache").join("huggingface");
+        config_dir().join("settings.json")
     }
-    app_support_dir().join("cache").join("huggingface")
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        app_support_dir().join("settings.json")
+    }
+}
+
+/// Root for the provisioned native GPU runtime. Linux provisioning (sc-10376)
+/// consumes this path so its runtime stays under the XDG data base; the Windows
+/// value remains `%APPDATA%\SceneWorks\gpu-runtime`.
+pub fn gpu_runtime_dir() -> PathBuf {
+    app_support_dir().join("gpu-runtime")
+}
+
+/// Shared per-user Hugging Face cache — the default `HF_HOME` when the user
+/// hasn't chosen a custom location. Linux uses
+/// `$XDG_CACHE_HOME/SceneWorks/huggingface` (or
+/// `~/.cache/SceneWorks/huggingface`); macOS and Windows retain the existing
+/// `~/.cache/huggingface` convention.
+pub fn shared_huggingface_home() -> PathBuf {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        LinuxDesktopPaths::from_process_env()
+            .cache_dir
+            .join("huggingface")
+    }
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        if let Some(home) = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+        {
+            return PathBuf::from(home).join(".cache").join("huggingface");
+        }
+        app_support_dir().join("cache").join("huggingface")
+    }
 }
 
 /// Hugging Face cache home injected into both sidecars so the rust-api model
@@ -1527,9 +1618,19 @@ fn pid_alive(pid: u32) -> bool {
 }
 
 /// File holding this launch's sidecar PIDs, used to reap orphans left by a prior
-/// unclean exit. Lives alongside the app's data so it survives across launches.
+/// unclean exit. Linux treats it as mutable state under `XDG_STATE_HOME`; other
+/// platforms retain the existing application-support location.
 fn sidecar_pidfile() -> PathBuf {
-    app_support_dir().join("desktop-sidecars.json")
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        LinuxDesktopPaths::from_process_env()
+            .state_dir
+            .join("desktop-sidecars.json")
+    }
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    {
+        app_support_dir().join("desktop-sidecars.json")
+    }
 }
 
 /// Persist the current sidecar PIDs (best effort, atomic via temp+rename).
@@ -2145,6 +2246,119 @@ pub async fn start_setup(app: AppHandle) {
     app.state::<Managed>()
         .running
         .store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::LinuxDesktopPaths;
+    use std::collections::HashMap;
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+
+    fn resolve(values: &[(&str, &str)], temp_dir: &Path) -> LinuxDesktopPaths {
+        let env = values
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), OsString::from(value)))
+            .collect::<HashMap<_, _>>();
+        LinuxDesktopPaths::resolve(|name| env.get(name).cloned(), temp_dir)
+    }
+
+    #[test]
+    fn linux_xdg_overrides_cover_every_desktop_managed_location() {
+        let paths = resolve(
+            &[
+                ("HOME", "/home/alice"),
+                ("XDG_DATA_HOME", "/mnt/xdg-data"),
+                ("XDG_CONFIG_HOME", "/mnt/xdg-config"),
+                ("XDG_CACHE_HOME", "/mnt/xdg-cache"),
+                ("XDG_STATE_HOME", "/mnt/xdg-state"),
+            ],
+            Path::new("/tmp"),
+        );
+
+        assert_eq!(paths.data_dir, PathBuf::from("/mnt/xdg-data/SceneWorks"));
+        assert_eq!(
+            paths.config_dir,
+            PathBuf::from("/mnt/xdg-config/SceneWorks")
+        );
+        assert_eq!(paths.cache_dir, PathBuf::from("/mnt/xdg-cache/SceneWorks"));
+        assert_eq!(paths.state_dir, PathBuf::from("/mnt/xdg-state/SceneWorks"));
+
+        // Exact call surfaces owned by the desktop and its sidecars.
+        assert_eq!(
+            paths.config_dir.join("settings.json"),
+            PathBuf::from("/mnt/xdg-config/SceneWorks/settings.json")
+        );
+        assert_eq!(
+            paths.config_dir.join("manifests"),
+            PathBuf::from("/mnt/xdg-config/SceneWorks/manifests")
+        );
+        assert_eq!(
+            paths.data_dir.join("cache").join("jobs.db"),
+            PathBuf::from("/mnt/xdg-data/SceneWorks/cache/jobs.db")
+        );
+        assert_eq!(
+            paths.state_dir.join("logs"),
+            PathBuf::from("/mnt/xdg-state/SceneWorks/logs")
+        );
+        assert_eq!(
+            paths.data_dir.join("gpu-runtime"),
+            PathBuf::from("/mnt/xdg-data/SceneWorks/gpu-runtime")
+        );
+        assert_eq!(
+            paths.cache_dir.join("huggingface"),
+            PathBuf::from("/mnt/xdg-cache/SceneWorks/huggingface")
+        );
+        assert_eq!(
+            paths.state_dir.join("desktop-sidecars.json"),
+            PathBuf::from("/mnt/xdg-state/SceneWorks/desktop-sidecars.json")
+        );
+    }
+
+    #[test]
+    fn linux_xdg_fallbacks_are_home_scoped_and_never_relative() {
+        let paths = resolve(&[("HOME", "/home/alice")], Path::new("/tmp"));
+        assert_eq!(
+            paths.data_dir,
+            PathBuf::from("/home/alice/.local/share/SceneWorks")
+        );
+        assert_eq!(
+            paths.config_dir,
+            PathBuf::from("/home/alice/.config/SceneWorks")
+        );
+        assert_eq!(
+            paths.cache_dir,
+            PathBuf::from("/home/alice/.cache/SceneWorks")
+        );
+        assert_eq!(
+            paths.state_dir,
+            PathBuf::from("/home/alice/.local/state/SceneWorks")
+        );
+
+        // The XDG spec requires absolute override values. Ignoring relative/empty
+        // values prevents an accidental write into the launch CWD.
+        let invalid = resolve(
+            &[
+                ("HOME", "relative-home"),
+                ("XDG_DATA_HOME", "relative-data"),
+                ("XDG_CONFIG_HOME", ""),
+            ],
+            Path::new("/var/tmp"),
+        );
+        assert_eq!(invalid.data_dir, PathBuf::from("/var/tmp/SceneWorks/data"));
+        assert_eq!(
+            invalid.config_dir,
+            PathBuf::from("/var/tmp/SceneWorks/config")
+        );
+        assert_eq!(
+            invalid.cache_dir,
+            PathBuf::from("/var/tmp/SceneWorks/cache")
+        );
+        assert_eq!(
+            invalid.state_dir,
+            PathBuf::from("/var/tmp/SceneWorks/state")
+        );
+    }
 }
 
 #[cfg(all(test, target_os = "windows"))]


### PR DESCRIPTION
## Summary
- centralize Linux desktop path resolution on the XDG data, config, cache, and state bases
- place settings/manifests under config, workspace/jobs and GPU runtime under data, HF weights under cache, and logs/PID state under state
- reject empty or relative XDG/HOME values so fallback writes never target the launch CWD
- retain the existing macOS and Windows resolutions while sharing the GPU-runtime helper with the current Windows provisioner and future Linux provisioning

## Acceptance criteria
- XDG overrides: covered by cross-platform pure-helper tests for XDG_DATA_HOME, XDG_CONFIG_HOME, XDG_CACHE_HOME, and XDG_STATE_HOME
- no HOME-root/CWD writes: home fallbacks remain under .local/.config/.cache and invalid relative values fall back to an absolute temp hierarchy
- macOS/Windows unchanged: non-Linux cfg branches retain their existing paths; the desktop crate compiles/tests/lints on Windows
- managed artifacts: tests pin settings.json, manifests, jobs.db, logs, HF_HOME, desktop-sidecars.json, and gpu-runtime destinations

## Validation
- cargo fmt --all -- --check
- cargo test -p sceneworks-desktop --no-fail-fast (45 passed, 1 ignored network smoke)
- cargo clippy -p sceneworks-desktop --all-targets -- -D warnings

Native Linux runtime evidence is unavailable from the Windows implementation host; Linux semantics are covered through the cfg-independent resolver tests.

Shortcut: https://app.shortcut.com/trefry/story/10377