### PR TITLE
fix(models): pin variant4 scalar-scale support [sc-14023]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "core-llm",
  "half",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=620cb2e72af02a162b921bc4c70b452ebe5d6ca7#620cb2e72af02a162b921bc4c70b452ebe5d6ca7"
+source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9" }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "620cb2e72af02a162b921bc4c70b452ebe5d6ca7", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -4,7 +4,7 @@
 // single file, e.g. a ComfyUI-exported `kreamania_variant5.safetensors`) — read in place, no copy, no
 // re-download — by pairing it with a resident `krea_2` base tier that supplies the shared Qwen3-VL text
 // encoder, Qwen VAE, tokenizer, and the DiT architecture config the single file omits. The assembly is
-// the selected runtime's `providers::krea::load_from_native_dit_file(dit, base, descriptor)`
+// the selected runtime's `providers::krea::load_from_native_dit_file(dit, base, adapters, descriptor)`
 // — the sc-10670/10671 "read the DiT in place, source shared components from a resident tier" pattern, and
 // following the candle z-image `load_from_comfyui_components` in-place assembly pattern.
 //
@@ -303,6 +303,7 @@ async fn generate_krea_imported_stream(
             let loaded = runtime_macos::providers::krea::load_from_native_dit_file(
                 &dit,
                 &base_dir,
+                &[],
                 runtime_macos::providers::krea::descriptor(),
             );
             #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -11101,7 +11101,7 @@ fn krea_imported_available_is_txt2img_only() {
 ///      admits it, exactly the install-dir shape the import job records).
 ///   3. `resolve_krea_imported_base_tier` → the resident `SceneWorks/krea-2-turbo-mlx` dense `bf16/`
 ///      tier that supplies the shared Qwen3-VL text encoder, Qwen VAE, tokenizer, and arch config.
-///   4. `runtime_macos::providers::krea::load_from_native_dit_file(dit, base, descriptor())` → the S0b
+///   4. `runtime_macos::providers::krea::load_from_native_dit_file(dit, base, &[], descriptor())` → the S0b
 ///      MLX native single-file entrypoint, then a real Metal txt2img.
 ///
 /// The NEGATIVE CONTROL (the sc-10539 with/without-adapter methodology) proves the imported DiT is
@@ -11221,7 +11221,7 @@ fn krea_imported_mlx_gpu_smoke() {
     let descriptor = runtime_macos::providers::krea::descriptor();
     let t0 = std::time::Instant::now();
     let variant5 =
-        runtime_macos::providers::krea::load_from_native_dit_file(&dit, &base, descriptor)
+        runtime_macos::providers::krea::load_from_native_dit_file(&dit, &base, &[], descriptor)
             .expect("load imported Krea 2 DiT (variant5) paired with the bf16 base");
     let mut last_a = String::new();
     let out_a = variant5


### PR DESCRIPTION
## Summary
- pin all SceneWorks inference dependencies to merged inference PR #210 / commit 2c8037e523df3a66aa31720f98958f646a89e8d9
- consume scalar weight_scale support for the real kreamania_variant4 checkpoint
- keep Cargo.lock limited to the 86 inference source replacements with no unrelated resolver churn

## Validation
- cargo check --locked -p sceneworks-worker --features backend-candle
- 33 Krea worker tests passed; 3 real-weight tests ignored
- core variant4 classifier regression passed
- cargo metadata --locked, formatting, diff, and single-source pin checks passed
- independent review: PASS

Inference: https://github.com/SceneWorks/inference/pull/210
Shortcut: sc-14023