### PR TITLE
feat(desktop): provision Linux GPU runtime [sc-10376]

### DIFF
--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -41,7 +41,7 @@ tauri-plugin-updater = "2"
 # SIGTERM the Python worker / API sidecar for graceful shutdown before force-kill.
 nix = { version = "0.29", default-features = false, features = ["signal"] }
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(any(windows, target_os = "linux"))'.dependencies]
 # First-run CUDA/onnxruntime redist downloader (cuda_provision.rs): the heavy GPU
 # runtime DLLs are no longer bundled (NSIS ~2 GB limit) — they're fetched on first run
 # from pinned PyPI wheels (zips), sha256-verified, and unzipped into %APPDATA%. Feature
@@ -54,6 +54,8 @@ sha2 = "0.10"
 # buffered whole in RAM (F-129, sc-8931). Already in the workspace lock (0.3.x), so no
 # new locked version is pulled; `alloc` is needed for the stream combinators.
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+
+[target.'cfg(windows)'.dependencies]
 # Confine the API sidecar (and any child processes it spawns) to a kill-on-close Job
 # Object, so no orphan can outlive the desktop and pin the API's listening port on the
 # next launch (sc-11946). Already in the workspace lock (pulled transitively by tauri),

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -198,6 +198,17 @@ environment variables in parentheses override them for advanced setups.
 | Logs | `~/Library/Logs/SceneWorks` |
 | Model weights | `~/.cache/huggingface` (`HF_HOME`) |
 
+### Linux
+
+| What | Location |
+| --- | --- |
+| Projects & app data | `$XDG_DATA_HOME/SceneWorks` (default `~/.local/share/SceneWorks`) |
+| Config & manifests | `$XDG_CONFIG_HOME/SceneWorks` (default `~/.config/SceneWorks`) |
+| Cache | `$XDG_CACHE_HOME/SceneWorks` (default `~/.cache/SceneWorks`) |
+| Logs | `$XDG_STATE_HOME/SceneWorks/logs` (default `~/.local/state/SceneWorks/logs`) |
+| GPU runtime | `$XDG_DATA_HOME/SceneWorks/gpu-runtime` |
+| Model weights | `$XDG_CACHE_HOME/SceneWorks/huggingface` (`HF_HOME`) |
+
 Model weights default to the shared Hugging Face cache so SceneWorks reuses
 anything already downloaded by other tools on the machine (and vice versa). Point
 `HF_HOME` (or the splash field) at a larger drive if your boot volume is tight.
@@ -292,13 +303,13 @@ SceneWorks ships in two forms from the same codebase:
 | | **Desktop** (this app) | **Server** (Docker) |
 | --- | --- | --- |
 | Install | One installer, no Docker | `docker compose` stack |
-| Engine | MLX (Mac) / candle CUDA (Windows), in-app | candle CUDA worker container (NVIDIA + container toolkit) |
+| Engine | MLX (Mac) / candle CUDA (Windows and Linux), in-app | candle CUDA worker container (NVIDIA + container toolkit) |
 | Access | Local app window, loopback only | Web UI over the network (opt-in, token-gated) |
 | Credentials | OS keychain | `0600 credentials.json` / env vars |
 | Paths | Per-user OS app-data dirs | Fixed `/sceneworks/*` volumes |
 | Best for | A single creator on one workstation | Shared/remote GPUs, multiple users, headless hosts |
 
-**Use the desktop app** when you want a turnkey studio on your own Windows or Mac
+**Use the desktop app** when you want a turnkey studio on your own Windows, Linux, or Mac
 workstation. **Use the server stack** when the GPU lives on another machine, when
 several people share it, or when you want a headless/LAN deployment. The Docker
 stack lives at the repo root (`docker-compose.yml`); see the root
@@ -314,9 +325,10 @@ stack lives at the repo root (`docker-compose.yml`); see the root
 | --- | --- |
 | macOS | `~/Library/Logs/SceneWorks/` |
 | Windows | `%LOCALAPPDATA%\SceneWorks\logs\` |
+| Linux | `$XDG_STATE_HOME/SceneWorks/logs/` (default `~/.local/state/SceneWorks/logs/`) |
 
 Key files: `api.log` (the API), and the engine worker log — `mlx-worker.log` on
-macOS, `candle-worker.log` on Windows. The current session's logs are also visible
+macOS, `candle-worker.log` on Windows/Linux. The current session's logs are also visible
 in-app on the **Logs** screen.
 
 ### Common issues
@@ -334,6 +346,14 @@ The first-run CUDA runtime download did not complete (network/disk). Check your
 connection and free space, then retry from the setup screen. The download resumes
 into `%APPDATA%\SceneWorks\gpu-runtime`. On a machine with no internet access, pre-stage
 the runtime instead — see [Offline / air-gapped install](docs/offline-install.md).
+
+**Linux: "GPU runtime setup failed" / "unresolved shared-library dependencies."**
+The first-run runtime download or ELF dependency check did not complete. Retry
+after checking network and disk space. If the message names `libgomp`, install
+the GNU OpenMP runtime (`sudo apt install libgomp1` on Debian/Ubuntu or
+`sudo dnf install libgomp` on Fedora/RHEL), then relaunch. Offline machines can
+copy a provisioned Linux runtime as described in
+[Offline / air-gapped install](docs/offline-install.md).
 
 **"The local API did not start in time."**
 The bundled API didn't become healthy within the startup window. Retry from the

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -7,6 +7,7 @@ the SceneWorks API and runs generation on a native, platform-specific engine:
 
 - **macOS** runs on Apple's **MLX** engine (Apple Silicon only).
 - **Windows** runs on the native **candle / CUDA** engine (NVIDIA only).
+- **Linux** runs on the native **candle / CUDA** engine (NVIDIA x86_64 only).
 
 There is **no Python virtual environment** on either platform — the generation
 engine is linked into the app, so first run starts straight on the native engine.
@@ -48,6 +49,19 @@ generate.
 
 Blackwell (sm_120) GPUs are supported. The bundled CUDA 12.9 runtime forward-JITs
 older PTX, so recent NVIDIA architectures work with a current driver.
+
+### Linux
+
+| Requirement | Detail |
+| --- | --- |
+| OS | x86_64 Linux desktop with glibc 2.27 or newer |
+| GPU | NVIDIA, CUDA-capable |
+| Driver | **575.51.03 or newer** (checked before the first-run download) |
+| VRAM | Per model class; 12 GB runs most images, while video and larger models want 24 GB+ |
+| Disk | ~2 GB for the app-managed GPU runtime, plus model weights |
+
+SceneWorks downloads its pinned CUDA 12.9/cuDNN 9/ONNX Runtime user-space
+libraries. A system CUDA toolkit is not required; only the NVIDIA driver is.
 
 ### macOS
 
@@ -124,6 +138,23 @@ On first launch a setup screen reports progress. What happens differs by platfor
 > `SCENEWORKS_GPU_RUNTIME_DIR` at it. See
 > [Offline / air-gapped install](docs/offline-install.md). (Model weights are a
 > separate download — that guide covers seeding them too.)
+
+### Linux (first run only)
+
+1. **GPU preflight.** SceneWorks checks `nvidia-smi` for an NVIDIA GPU and a
+   575.51.03-or-newer driver. Failure leaves the GPU lane dormant with an
+   actionable setup message; it does not start a retrying worker.
+2. **GPU runtime download (~1.9 GB, once).** Pinned, SHA-256-verified Linux
+   x86_64 wheels provide CUDA 12.9, cuDNN 9, cuFFT, nvJitLink, NVRTC, and
+   ONNX Runtime GPU under `$XDG_DATA_HOME/SceneWorks/gpu-runtime` (default
+   `~/.local/share/SceneWorks/gpu-runtime`).
+3. **Engine starts.** The runtime marker and full shared-library sentinel set
+   are rechecked on relaunch; complete installs skip the network and start the
+   candle worker.
+
+For an offline Linux machine, copy a provisioned Linux `gpu-runtime` directory
+or point `SCENEWORKS_GPU_RUNTIME_DIR` at one before launching. See
+[Offline / air-gapped install](docs/offline-install.md).
 
 ### macOS (first run)
 

--- a/apps/desktop/docs/offline-install.md
+++ b/apps/desktop/docs/offline-install.md
@@ -1,4 +1,50 @@
-# Offline / air-gapped install (Windows)
+# Offline / air-gapped GPU runtime install
+
+SceneWorks downloads its platform-specific NVIDIA user-space runtime once on
+Windows and Linux. The NVIDIA display driver must already be installed, but a
+system CUDA toolkit is not required.
+
+## Linux
+
+The connected-machine method is recommended:
+
+1. Launch SceneWorks once on a connected x86_64 Linux/NVIDIA machine and let
+   setup complete.
+2. Copy the whole runtime root to the offline user's XDG data location:
+
+   ```text
+   $XDG_DATA_HOME/SceneWorks/gpu-runtime
+   # default: ~/.local/share/SceneWorks/gpu-runtime
+   ```
+
+   The source and target must both be Linux; Windows DLLs are not compatible.
+3. Launch SceneWorks. It validates the pinned marker plus all CUDA, cuDNN,
+   cuFFT, nvJitLink, NVRTC, and ONNX Runtime sentinels and skips the network.
+
+For managed deployment, the copied root may live elsewhere. Set
+`SCENEWORKS_GPU_RUNTIME_DIR=/absolute/path/to/gpu-runtime` before first launch;
+SceneWorks copies and validates it into the target user's XDG data directory.
+The expected layout is:
+
+```text
+gpu-runtime/
+  cuda/lib64/
+  cublas/lib/
+  curand/lib/
+  cuda_nvrtc/lib/
+  cudnn/lib/
+  cufft/lib/
+  nvjitlink/lib/
+  onnxruntime/capi/
+```
+
+The authoritative Linux x86_64 wheel URLs, SHA-256 hashes, extraction rules,
+and version marker are in
+[`linux_cuda_provision.rs`](../src/linux_cuda_provision.rs). Do not substitute
+floating pip versions. An incomplete or corrupt stage is rejected and the GPU
+worker remains dormant rather than entering a crash loop.
+
+## Windows
 
 SceneWorks Desktop on Windows needs ~2.7 GB of NVIDIA CUDA runtime, cuDNN, and the
 ONNX Runtime GPU provider at runtime. These are **not** in the installer (the set

--- a/apps/desktop/src/linux_cuda_provision.rs
+++ b/apps/desktop/src/linux_cuda_provision.rs
@@ -162,10 +162,19 @@ fn component_complete(root: &Path, component: &Component) -> bool {
 }
 
 fn already_provisioned(root: &Path) -> bool {
+    top_marker_current(root) && runtime_complete(root)
+}
+
+fn top_marker_current(root: &Path) -> bool {
     fs::read_to_string(root.join(".redist-marker"))
         .map(|value| value.trim() == REDIST_VERSION)
         .unwrap_or(false)
-        && runtime_complete(root)
+}
+
+fn all_component_markers_current(root: &Path) -> bool {
+    COMPONENTS
+        .iter()
+        .all(|component| component_complete(root, component))
 }
 
 fn write_marker(root: &Path) -> Result<(), String> {
@@ -227,20 +236,18 @@ fn extract_shared_objects(
 }
 
 fn promote_component(stage: &Path, dest: &Path) -> Result<(), String> {
-    fs::create_dir_all(dest).map_err(|error| format!("create {}: {error}", dest.display()))?;
-    for entry in
-        fs::read_dir(stage).map_err(|error| format!("read {}: {error}", stage.display()))?
-    {
-        let entry = entry.map_err(|error| format!("read {}: {error}", stage.display()))?;
-        let target = dest.join(entry.file_name());
-        if target.exists() {
-            fs::remove_file(&target)
-                .map_err(|error| format!("replace {}: {error}", target.display()))?;
-        }
-        fs::rename(entry.path(), &target)
-            .map_err(|error| format!("promote {}: {error}", target.display()))?;
+    let parent = dest
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", dest.display()))?;
+    fs::create_dir_all(parent).map_err(|error| format!("create {}: {error}", parent.display()))?;
+    // A version bump must not leave older versioned SONAME files alongside the new
+    // wheel: setup's resolver sorts candidates and could otherwise select the stale
+    // one. The component marker is written only after this replacement succeeds, so
+    // a crash here remains safely incomplete/dormant.
+    if dest.exists() {
+        fs::remove_dir_all(dest).map_err(|error| format!("replace {}: {error}", dest.display()))?;
     }
-    Ok(())
+    fs::rename(stage, dest).map_err(|error| format!("promote {}: {error}", dest.display()))
 }
 
 fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
@@ -250,8 +257,16 @@ fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
             source.display()
         ));
     }
+    let pinned_source = top_marker_current(source) || all_component_markers_current(source);
+    if !pinned_source {
+        return Err(format!(
+            "{GPU_RUNTIME_DIR_ENV} ({}) has no current `{REDIST_VERSION}` marker evidence; \
+             copy a complete runtime provisioned by this SceneWorks version",
+            source.display()
+        ));
+    }
     if source == root {
-        return runtime_complete(root)
+        return (runtime_complete(root) && pinned_source)
             .then_some(())
             .ok_or_else(|| format!("{GPU_RUNTIME_DIR_ENV} points at an incomplete runtime"));
     }
@@ -265,6 +280,10 @@ fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
             ));
         }
         let dest = root.join(component.dest);
+        if dest.exists() {
+            fs::remove_dir_all(&dest)
+                .map_err(|error| format!("replace {}: {error}", dest.display()))?;
+        }
         fs::create_dir_all(&dest).map_err(|error| format!("create {}: {error}", dest.display()))?;
         for entry in
             fs::read_dir(&src).map_err(|error| format!("read {}: {error}", src.display()))?
@@ -276,13 +295,72 @@ fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
             }
         }
     }
-    runtime_complete(root).then_some(()).ok_or_else(|| {
-        format!(
+    if !runtime_complete(root) {
+        return Err(format!(
             "pre-staged GPU runtime from {} is incomplete; required CUDA/cuDNN/onnxruntime \
              shared objects are missing",
             source.display()
-        )
-    })
+        ));
+    }
+    for component in COMPONENTS {
+        write_component_marker(root, component.slug, REDIST_VERSION)?;
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+fn evaluate_ldd_report(success: bool, report: &str) -> Result<(), String> {
+    if success && !report.contains("not found") {
+        return Ok(());
+    }
+    Err(format!(
+        "the Linux GPU runtime has unresolved shared-library dependencies. Install the \
+         GNU OpenMP runtime if it is missing (Debian/Ubuntu: `sudo apt install libgomp1`; \
+         Fedora/RHEL: `sudo dnf install libgomp`) and relaunch SceneWorks. ldd reported: \
+         {}",
+        report.trim()
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn validate_runtime_dependencies(root: &Path) -> Result<(), String> {
+    let provider_dir = root.join("onnxruntime/capi");
+    let provider = fs::read_dir(&provider_dir)
+        .map_err(|error| format!("read {}: {error}", provider_dir.display()))?
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name == "libonnxruntime_providers_cuda.so"
+                        || name.starts_with("libonnxruntime_providers_cuda.so.")
+                })
+        })
+        .ok_or_else(|| "onnxruntime CUDA provider is missing after provisioning".to_owned())?;
+    let mut loader_dirs = Vec::new();
+    for component in COMPONENTS {
+        let path = root.join(component.dest);
+        if !loader_dirs.contains(&path) {
+            loader_dirs.push(path);
+        }
+    }
+    loader_dirs.extend(std::env::split_paths(
+        &std::env::var_os("LD_LIBRARY_PATH").unwrap_or_default(),
+    ));
+    let joined = std::env::join_paths(loader_dirs)
+        .map_err(|error| format!("compose LD_LIBRARY_PATH: {error}"))?;
+    let output = std::process::Command::new("ldd")
+        .arg(provider)
+        .env("LD_LIBRARY_PATH", joined)
+        .output()
+        .map_err(|error| format!("run Linux GPU runtime dependency check (`ldd`): {error}"))?;
+    let report = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    evaluate_ldd_report(output.status.success(), &report)
 }
 
 async fn fetch_component(
@@ -362,6 +440,7 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
     let root = gpu_runtime_dir();
     fs::create_dir_all(&root).map_err(|error| format!("create {}: {error}", root.display()))?;
     if already_provisioned(&root) {
+        validate_runtime_dependencies(&root)?;
         emit(app, "provision", "GPU runtime ready (cached).", false);
         return Ok(());
     }
@@ -379,17 +458,19 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
                 false,
             );
             install_from_staged(&source, &root)?;
+            validate_runtime_dependencies(&root)?;
             write_marker(&root)?;
             emit(app, "provision", "GPU runtime ready (pre-staged).", false);
             return Ok(());
         }
     }
-    if runtime_complete(&root) {
+    if all_component_markers_current(&root) {
+        validate_runtime_dependencies(&root)?;
         write_marker(&root)?;
         emit(
             app,
             "provision",
-            "Found a complete Linux GPU runtime; skipping download.",
+            "Recovered a verified Linux GPU runtime; skipping download.",
             false,
         );
         return Ok(());
@@ -438,6 +519,7 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
     if !runtime_complete(&root) {
         return Err("Linux GPU runtime is incomplete after extraction".to_owned());
     }
+    validate_runtime_dependencies(&root)?;
     write_marker(&root)?;
     emit(app, "provision", "Linux GPU runtime ready.", false);
     Ok(())
@@ -467,6 +549,13 @@ mod tests {
                 fs::write(dir.join(format!("{sentinel}.fixture")), b"fixture")
                     .expect("write sentinel");
             }
+        }
+    }
+
+    fn mark_components(root: &Path) {
+        for component in COMPONENTS {
+            write_component_marker(root, component.slug, REDIST_VERSION)
+                .expect("write component marker");
         }
     }
 
@@ -562,12 +651,15 @@ mod tests {
     fn staged_override_copies_complete_layout_and_rejects_partial() {
         let source = scratch("staged-source");
         touch_runtime(&source);
+        write_marker(&source).expect("mark pinned source");
         let target = scratch("staged-target");
         install_from_staged(&source, &target).expect("install complete stage");
         assert!(runtime_complete(&target));
+        assert!(all_component_markers_current(&target));
 
         let partial = scratch("staged-partial");
         touch_runtime(&partial);
+        write_marker(&partial).expect("mark pinned partial source");
         fs::remove_file(partial.join("cufft/lib/libcufft.so.fixture"))
             .expect("remove fixture sentinel");
         let rejected = scratch("staged-rejected");
@@ -576,6 +668,60 @@ mod tests {
         for root in [source, target, partial, rejected] {
             fs::remove_dir_all(root).expect("remove fixture");
         }
+    }
+
+    #[test]
+    fn staged_override_rejects_markerless_stale_and_mixed_runtimes() {
+        let markerless = scratch("staged-markerless");
+        touch_runtime(&markerless);
+        let target = scratch("staged-markerless-target");
+        let error =
+            install_from_staged(&markerless, &target).expect_err("markerless stage is unpinned");
+        assert!(error.contains("marker evidence"));
+
+        fs::write(markerless.join(".redist-marker"), "old-runtime-version")
+            .expect("write stale marker");
+        let error = install_from_staged(&markerless, &target).expect_err("stale stage is unpinned");
+        assert!(error.contains(REDIST_VERSION));
+
+        // Per-component evidence is an allowed recovery path only when every marker
+        // and sentinel belongs to the current manifest.
+        mark_components(&markerless);
+        fs::write(
+            markerless.join(".component-cudnn.ok"),
+            "old-runtime-version",
+        )
+        .expect("make one component stale");
+        let error = install_from_staged(&markerless, &target).expect_err("mixed stage is unpinned");
+        assert!(error.contains("marker evidence"));
+
+        for root in [markerless, target] {
+            fs::remove_dir_all(root).expect("remove fixture");
+        }
+    }
+
+    #[test]
+    fn promotion_removes_obsolete_versioned_libraries() {
+        let root = scratch("promote");
+        let stage = root.join("stage");
+        let dest = root.join("runtime/cudnn/lib");
+        fs::create_dir_all(&stage).expect("create stage");
+        fs::create_dir_all(&dest).expect("create old destination");
+        fs::write(stage.join("libcudnn.so.9"), b"new").expect("write new library");
+        fs::write(dest.join("libcudnn.so.8"), b"old").expect("write stale library");
+        promote_component(&stage, &dest).expect("replace component directory");
+        assert!(dest.join("libcudnn.so.9").is_file());
+        assert!(!dest.join("libcudnn.so.8").exists());
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn ldd_failure_maps_libgomp_and_other_missing_dependencies_actionably() {
+        assert!(evaluate_ldd_report(true, "libgomp.so.1 => /usr/lib/libgomp.so.1").is_ok());
+        let error = evaluate_ldd_report(false, "libgomp.so.1 => not found")
+            .expect_err("missing libgomp must fail before worker spawn");
+        assert!(error.contains("libgomp1"));
+        assert!(error.contains("not found"));
     }
 
     #[test]

--- a/apps/desktop/src/linux_cuda_provision.rs
+++ b/apps/desktop/src/linux_cuda_provision.rs
@@ -182,6 +182,13 @@ fn write_marker(root: &Path) -> Result<(), String> {
         .map_err(|error| format!("write marker: {error}"))
 }
 
+fn invalidate_markers(root: &Path) {
+    let _ = fs::remove_file(root.join(".redist-marker"));
+    for component in COMPONENTS {
+        let _ = fs::remove_file(root.join(format!(".component-{}.ok", component.slug)));
+    }
+}
+
 #[cfg(test)]
 fn hash_reader(mut reader: impl Read) -> Result<String, String> {
     let mut hasher = Sha256::new();
@@ -270,6 +277,14 @@ fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
             .then_some(())
             .ok_or_else(|| format!("{GPU_RUNTIME_DIR_ENV} points at an incomplete runtime"));
     }
+    // Invalidate every live completion witness before the first mutation. If the
+    // staged copy is interrupted, the next launch cannot trust old markers over a
+    // partially replaced runtime and will re-provision instead of starting a worker.
+    invalidate_markers(root);
+    let stage_root = root.join(".staged-install");
+    let _ = fs::remove_dir_all(&stage_root);
+    fs::create_dir_all(&stage_root)
+        .map_err(|error| format!("create {}: {error}", stage_root.display()))?;
     for component in COMPONENTS {
         let src = source.join(component.dest);
         if !src.is_dir() {
@@ -279,21 +294,30 @@ fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
                 component.dest
             ));
         }
-        let dest = root.join(component.dest);
-        if dest.exists() {
-            fs::remove_dir_all(&dest)
-                .map_err(|error| format!("replace {}: {error}", dest.display()))?;
-        }
-        fs::create_dir_all(&dest).map_err(|error| format!("create {}: {error}", dest.display()))?;
+        let stage = stage_root.join(component.slug);
+        fs::create_dir_all(&stage)
+            .map_err(|error| format!("create {}: {error}", stage.display()))?;
         for entry in
             fs::read_dir(&src).map_err(|error| format!("read {}: {error}", src.display()))?
         {
             let entry = entry.map_err(|error| format!("read {}: {error}", src.display()))?;
             if entry.path().is_file() {
-                fs::copy(entry.path(), dest.join(entry.file_name()))
+                fs::copy(entry.path(), stage.join(entry.file_name()))
                     .map_err(|error| format!("copy {}: {error}", entry.path().display()))?;
             }
         }
+        if !component
+            .sentinels
+            .iter()
+            .all(|name| dir_has_shared_object(&stage, name))
+        {
+            return Err(format!(
+                "pre-staged component {} is missing required shared objects",
+                component.label
+            ));
+        }
+        let dest = root.join(component.dest);
+        promote_component(&stage, &dest)?;
     }
     if !runtime_complete(root) {
         return Err(format!(
@@ -305,6 +329,7 @@ fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
     for component in COMPONENTS {
         write_component_marker(root, component.slug, REDIST_VERSION)?;
     }
+    let _ = fs::remove_dir_all(stage_root);
     Ok(())
 }
 
@@ -324,20 +349,7 @@ fn evaluate_ldd_report(success: bool, report: &str) -> Result<(), String> {
 
 #[cfg(target_os = "linux")]
 fn validate_runtime_dependencies(root: &Path) -> Result<(), String> {
-    let provider_dir = root.join("onnxruntime/capi");
-    let provider = fs::read_dir(&provider_dir)
-        .map_err(|error| format!("read {}: {error}", provider_dir.display()))?
-        .flatten()
-        .map(|entry| entry.path())
-        .find(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| {
-                    name == "libonnxruntime_providers_cuda.so"
-                        || name.starts_with("libonnxruntime_providers_cuda.so.")
-                })
-        })
-        .ok_or_else(|| "onnxruntime CUDA provider is missing after provisioning".to_owned())?;
+    let targets = dependency_probe_targets(root)?;
     let mut loader_dirs = Vec::new();
     for component in COMPONENTS {
         let path = root.join(component.dest);
@@ -350,17 +362,72 @@ fn validate_runtime_dependencies(root: &Path) -> Result<(), String> {
     ));
     let joined = std::env::join_paths(loader_dirs)
         .map_err(|error| format!("compose LD_LIBRARY_PATH: {error}"))?;
-    let output = std::process::Command::new("ldd")
-        .arg(provider)
-        .env("LD_LIBRARY_PATH", joined)
-        .output()
-        .map_err(|error| format!("run Linux GPU runtime dependency check (`ldd`): {error}"))?;
-    let report = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    evaluate_ldd_report(output.status.success(), &report)
+    let mut reports = String::new();
+    let mut success = true;
+    for target in targets {
+        let output = std::process::Command::new("ldd")
+            .arg(&target)
+            .env("LD_LIBRARY_PATH", &joined)
+            .output()
+            .map_err(|error| format!("run Linux GPU runtime dependency check (`ldd`): {error}"))?;
+        success &= output.status.success();
+        reports.push_str(&format!(
+            "\n{}:\n{}{}",
+            target.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    evaluate_ldd_report(success, &reports)
+}
+
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+fn dependency_probe_targets(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let capi = root.join("onnxruntime/capi");
+    let main = find_shared_object(&capi, "libonnxruntime.so").ok_or_else(|| {
+        "onnxruntime main shared library is missing after provisioning".to_owned()
+    })?;
+    let provider = find_shared_object(&capi, "libonnxruntime_providers_cuda.so")
+        .ok_or_else(|| "onnxruntime CUDA provider is missing after provisioning".to_owned())?;
+    let cudnn = root.join("cudnn/lib");
+    let mut targets = vec![main, provider];
+    let mut cudnn_libraries = fs::read_dir(&cudnn)
+        .map_err(|error| format!("read {}: {error}", cudnn.display()))?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.contains(".so"))
+        })
+        .collect::<Vec<_>>();
+    cudnn_libraries.sort();
+    targets.extend(cudnn_libraries);
+    Ok(targets)
+}
+
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+fn find_shared_object(dir: &Path, basename: &str) -> Option<PathBuf> {
+    let exact = dir.join(basename);
+    if exact.is_file() {
+        return Some(exact);
+    }
+    let mut candidates = fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(&format!("{basename}.")))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.into_iter().next()
 }
 
 async fn fetch_component(
@@ -664,7 +731,7 @@ mod tests {
             .expect("remove fixture sentinel");
         let rejected = scratch("staged-rejected");
         let error = install_from_staged(&partial, &rejected).expect_err("reject partial stage");
-        assert!(error.contains("incomplete"));
+        assert!(error.contains("missing required"));
         for root in [source, target, partial, rejected] {
             fs::remove_dir_all(root).expect("remove fixture");
         }
@@ -701,6 +768,30 @@ mod tests {
     }
 
     #[test]
+    fn interrupted_staged_replacement_invalidates_all_live_markers() {
+        let source = scratch("staged-interrupted-source");
+        touch_runtime(&source);
+        write_marker(&source).expect("mark pinned source");
+        // The first component can promote, then the second component fails.
+        fs::remove_dir_all(source.join(COMPONENTS[1].dest)).expect("remove later staged component");
+
+        let target = scratch("staged-interrupted-target");
+        touch_runtime(&target);
+        mark_components(&target);
+        write_marker(&target).expect("mark prior live runtime");
+        assert!(already_provisioned(&target));
+
+        install_from_staged(&source, &target).expect_err("staged install must fail partway");
+        assert!(!top_marker_current(&target));
+        assert!(!all_component_markers_current(&target));
+        assert!(!already_provisioned(&target));
+
+        for root in [source, target] {
+            fs::remove_dir_all(root).expect("remove fixture");
+        }
+    }
+
+    #[test]
     fn promotion_removes_obsolete_versioned_libraries() {
         let root = scratch("promote");
         let stage = root.join("stage");
@@ -722,6 +813,35 @@ mod tests {
             .expect_err("missing libgomp must fail before worker spawn");
         assert!(error.contains("libgomp1"));
         assert!(error.contains("not found"));
+    }
+
+    #[test]
+    fn dependency_probe_covers_main_ort_provider_and_cudnn_lazy_engines() {
+        let root = scratch("dependency-targets");
+        let capi = root.join("onnxruntime/capi");
+        let cudnn = root.join("cudnn/lib");
+        fs::create_dir_all(&capi).expect("create capi");
+        fs::create_dir_all(&cudnn).expect("create cudnn");
+        for path in [
+            capi.join("libonnxruntime.so.1.26.0"),
+            capi.join("libonnxruntime_providers_cuda.so"),
+            cudnn.join("libcudnn.so.9"),
+            cudnn.join("libcudnn_engines_precompiled.so.9"),
+        ] {
+            fs::write(path, b"fixture").expect("write dependency target");
+        }
+        let targets = dependency_probe_targets(&root).expect("resolve dependency targets");
+        assert_eq!(targets.len(), 4);
+        assert!(targets
+            .iter()
+            .any(|path| path.ends_with("libonnxruntime.so.1.26.0")));
+        assert!(targets
+            .iter()
+            .any(|path| path.ends_with("libonnxruntime_providers_cuda.so")));
+        assert!(targets
+            .iter()
+            .any(|path| path.ends_with("libcudnn_engines_precompiled.so.9")));
+        fs::remove_dir_all(root).expect("remove fixture");
     }
 
     #[test]

--- a/apps/desktop/src/linux_cuda_provision.rs
+++ b/apps/desktop/src/linux_cuda_provision.rs
@@ -1,0 +1,612 @@
+//! First-run Linux CUDA / cuDNN / onnxruntime-gpu provisioner.
+//!
+//! The NVIDIA driver remains a host prerequisite; pinned user-space libraries are
+//! downloaded once into `$XDG_DATA_HOME/SceneWorks/gpu-runtime`. The layout mirrors
+//! `docker/rust.Dockerfile` and the runtime contract consumed by `setup.rs`.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+use std::fs;
+#[cfg(test)]
+use std::io::Read;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use futures_util::StreamExt;
+use sha2::{Digest, Sha256};
+#[cfg(target_os = "linux")]
+use tauri::AppHandle;
+
+use crate::cuda_provision_check::write_component_marker;
+#[cfg(target_os = "linux")]
+use crate::setup::{emit, gpu_runtime_dir};
+
+const REDIST_VERSION: &str = "cuda12.9-ort1.26.0-cudnn9.23-linux-x86_64-1";
+const GPU_RUNTIME_DIR_ENV: &str = "SCENEWORKS_GPU_RUNTIME_DIR";
+
+#[derive(Debug)]
+struct Component {
+    label: &'static str,
+    slug: &'static str,
+    approx: &'static str,
+    url: &'static str,
+    sha256: &'static str,
+    dest: &'static str,
+    /// `None` retains every `*.so*`, including cuDNN's lazy sub-engines.
+    extract_prefixes: Option<&'static [&'static str]>,
+    sentinels: &'static [&'static str],
+}
+
+/// Linux x86_64 URLs/hashes resolved from authoritative PyPI JSON. Versions match
+/// the Docker candle image exactly; runtime provisioning never performs pip solving.
+const COMPONENTS: &[Component] = &[
+    Component {
+        label: "CUDA runtime",
+        slug: "cuda-runtime",
+        approx: "≈3 MB",
+        url: "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        sha256: "25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3",
+        dest: "cuda/lib64",
+        extract_prefixes: None,
+        sentinels: &["libcudart.so"],
+    },
+    Component {
+        label: "cuBLAS",
+        slug: "cublas",
+        approx: "≈554 MB",
+        url: "https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl",
+        sha256: "453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2",
+        dest: "cublas/lib",
+        extract_prefixes: None,
+        sentinels: &["libcublas.so", "libcublasLt.so"],
+    },
+    Component {
+        label: "cuRAND",
+        slug: "curand",
+        approx: "≈65 MB",
+        url: "https://files.pythonhosted.org/packages/31/44/193a0e171750ca9f8320626e8a1f2381e4077a65e69e2fb9708bd479e34a/nvidia_curand_cu12-10.3.10.19-py3-none-manylinux_2_27_x86_64.whl",
+        sha256: "49b274db4780d421bd2ccd362e1415c13887c53c214f0d4b761752b8f9f6aa1e",
+        dest: "curand/lib",
+        extract_prefixes: None,
+        sentinels: &["libcurand.so"],
+    },
+    Component {
+        label: "NVRTC",
+        slug: "nvrtc",
+        approx: "≈85 MB",
+        url: "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl",
+        sha256: "210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4",
+        dest: "cuda_nvrtc/lib",
+        extract_prefixes: None,
+        sentinels: &["libnvrtc.so"],
+    },
+    Component {
+        label: "cuDNN",
+        slug: "cudnn",
+        approx: "≈688 MB",
+        url: "https://files.pythonhosted.org/packages/7d/9d/1a383211b0967e702b9e84643986fb31bf35ca07bddc19e0cf139fd3291d/nvidia_cudnn_cu12-9.23.0.39-py3-none-manylinux_2_27_x86_64.whl",
+        sha256: "89d53e2a2b0614278afbeda67ac89594bdd74f9f283f22f2d34409d55859846f",
+        dest: "cudnn/lib",
+        extract_prefixes: None,
+        sentinels: &["libcudnn.so"],
+    },
+    Component {
+        label: "cuFFT",
+        slug: "cufft",
+        approx: "≈192 MB",
+        url: "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+        sha256: "c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28",
+        dest: "cufft/lib",
+        extract_prefixes: None,
+        sentinels: &["libcufft.so"],
+    },
+    Component {
+        label: "nvJitLink",
+        slug: "nvjitlink",
+        approx: "≈38 MB",
+        url: "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl",
+        sha256: "e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9",
+        dest: "nvjitlink/lib",
+        extract_prefixes: None,
+        sentinels: &["libnvJitLink.so"],
+    },
+    Component {
+        label: "onnxruntime (GPU)",
+        slug: "onnxruntime",
+        approx: "≈264 MB",
+        url: "https://files.pythonhosted.org/packages/94/fd/59bee7cffaa435da44fefdeb63e29c61de4dbfa4b279852f59cd02c042ae/onnxruntime_gpu-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+        sha256: "3c01119ed4d9449d60367fa8ccffcd02bd3fe736754284e4b198d131f54edad6",
+        dest: "onnxruntime/capi",
+        extract_prefixes: Some(&[
+            "libonnxruntime.so",
+            "libonnxruntime_providers_cuda.so",
+            "libonnxruntime_providers_shared.so",
+        ]),
+        sentinels: &[
+            "libonnxruntime.so",
+            "libonnxruntime_providers_cuda.so",
+            "libonnxruntime_providers_shared.so",
+        ],
+    },
+];
+
+fn dir_has_shared_object(dir: &Path, basename: &str) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            return false;
+        };
+        entry.path().is_file() && (name == basename || name.starts_with(&format!("{basename}.")))
+    })
+}
+
+fn runtime_complete(root: &Path) -> bool {
+    COMPONENTS.iter().all(|component| {
+        component
+            .sentinels
+            .iter()
+            .all(|name| dir_has_shared_object(&root.join(component.dest), name))
+    })
+}
+
+fn component_complete(root: &Path, component: &Component) -> bool {
+    fs::read_to_string(root.join(format!(".component-{}.ok", component.slug)))
+        .map(|value| value.trim() == REDIST_VERSION)
+        .unwrap_or(false)
+        && component
+            .sentinels
+            .iter()
+            .all(|name| dir_has_shared_object(&root.join(component.dest), name))
+}
+
+fn already_provisioned(root: &Path) -> bool {
+    fs::read_to_string(root.join(".redist-marker"))
+        .map(|value| value.trim() == REDIST_VERSION)
+        .unwrap_or(false)
+        && runtime_complete(root)
+}
+
+fn write_marker(root: &Path) -> Result<(), String> {
+    fs::write(root.join(".redist-marker"), REDIST_VERSION)
+        .map_err(|error| format!("write marker: {error}"))
+}
+
+#[cfg(test)]
+fn hash_reader(mut reader: impl Read) -> Result<String, String> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| format!("read for sha256: {error}"))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn extract_shared_objects(
+    wheel: &Path,
+    prefixes: Option<&[&str]>,
+    dest: &Path,
+) -> Result<usize, String> {
+    fs::create_dir_all(dest).map_err(|error| format!("create {}: {error}", dest.display()))?;
+    let file = fs::File::open(wheel).map_err(|error| format!("open wheel: {error}"))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| format!("open zip: {error}"))?;
+    let mut written = 0;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| format!("read zip entry: {error}"))?;
+        let Some(path) = entry.enclosed_name() else {
+            continue;
+        };
+        let Some(base) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !base.contains(".so")
+            || prefixes.is_some_and(|prefixes| {
+                !prefixes
+                    .iter()
+                    .any(|prefix| base == *prefix || base.starts_with(&format!("{prefix}.")))
+            })
+        {
+            continue;
+        }
+        let mut output =
+            fs::File::create(dest.join(base)).map_err(|error| format!("write {base}: {error}"))?;
+        std::io::copy(&mut entry, &mut output)
+            .map_err(|error| format!("extract {base}: {error}"))?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+fn promote_component(stage: &Path, dest: &Path) -> Result<(), String> {
+    fs::create_dir_all(dest).map_err(|error| format!("create {}: {error}", dest.display()))?;
+    for entry in
+        fs::read_dir(stage).map_err(|error| format!("read {}: {error}", stage.display()))?
+    {
+        let entry = entry.map_err(|error| format!("read {}: {error}", stage.display()))?;
+        let target = dest.join(entry.file_name());
+        if target.exists() {
+            fs::remove_file(&target)
+                .map_err(|error| format!("replace {}: {error}", target.display()))?;
+        }
+        fs::rename(entry.path(), &target)
+            .map_err(|error| format!("promote {}: {error}", target.display()))?;
+    }
+    Ok(())
+}
+
+fn install_from_staged(source: &Path, root: &Path) -> Result<(), String> {
+    if !source.is_dir() {
+        return Err(format!(
+            "{GPU_RUNTIME_DIR_ENV} points at a missing directory: {}",
+            source.display()
+        ));
+    }
+    if source == root {
+        return runtime_complete(root)
+            .then_some(())
+            .ok_or_else(|| format!("{GPU_RUNTIME_DIR_ENV} points at an incomplete runtime"));
+    }
+    for component in COMPONENTS {
+        let src = source.join(component.dest);
+        if !src.is_dir() {
+            return Err(format!(
+                "{GPU_RUNTIME_DIR_ENV} ({}) is missing `{}`",
+                source.display(),
+                component.dest
+            ));
+        }
+        let dest = root.join(component.dest);
+        fs::create_dir_all(&dest).map_err(|error| format!("create {}: {error}", dest.display()))?;
+        for entry in
+            fs::read_dir(&src).map_err(|error| format!("read {}: {error}", src.display()))?
+        {
+            let entry = entry.map_err(|error| format!("read {}: {error}", src.display()))?;
+            if entry.path().is_file() {
+                fs::copy(entry.path(), dest.join(entry.file_name()))
+                    .map_err(|error| format!("copy {}: {error}", entry.path().display()))?;
+            }
+        }
+    }
+    runtime_complete(root).then_some(()).ok_or_else(|| {
+        format!(
+            "pre-staged GPU runtime from {} is incomplete; required CUDA/cuDNN/onnxruntime \
+             shared objects are missing",
+            source.display()
+        )
+    })
+}
+
+async fn fetch_component(
+    client: &reqwest::Client,
+    root: &Path,
+    component: &'static Component,
+) -> Result<(), String> {
+    let tmp = root.join(".download-tmp");
+    fs::create_dir_all(&tmp).map_err(|error| format!("create temp dir: {error}"))?;
+    let wheel = tmp.join(format!("{}.whl", component.slug));
+    let response = client
+        .get(component.url)
+        .send()
+        .await
+        .map_err(|error| format!("download {}: {error}", component.label))?
+        .error_for_status()
+        .map_err(|error| format!("download {}: {error}", component.label))?;
+    let mut file = fs::File::create(&wheel).map_err(|error| format!("create wheel: {error}"))?;
+    let mut hasher = Sha256::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| format!("download {}: {error}", component.label))?;
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .map_err(|error| format!("write {}: {error}", component.label))?;
+    }
+    file.flush()
+        .map_err(|error| format!("write {}: {error}", component.label))?;
+    drop(file);
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != component.sha256 {
+        return Err(format!(
+            "{}: sha256 mismatch (expected {}, got {actual})",
+            component.label, component.sha256
+        ));
+    }
+
+    let stage = tmp.join(format!("extract-{}", component.slug));
+    let _ = fs::remove_dir_all(&stage);
+    let prefixes = component.extract_prefixes;
+    let wheel_for_extract = wheel.clone();
+    let stage_for_extract = stage.clone();
+    let written = tauri::async_runtime::spawn_blocking(move || {
+        extract_shared_objects(&wheel_for_extract, prefixes, &stage_for_extract)
+    })
+    .await
+    .map_err(|error| format!("{}: extract task failed: {error}", component.label))??;
+    if written == 0
+        || !component
+            .sentinels
+            .iter()
+            .all(|name| dir_has_shared_object(&stage, name))
+    {
+        return Err(format!(
+            "{}: wheel did not contain the required shared objects",
+            component.label
+        ));
+    }
+    promote_component(&stage, &root.join(component.dest))?;
+    write_component_marker(root, component.slug, REDIST_VERSION)?;
+    let _ = fs::remove_file(wheel);
+    let _ = fs::remove_dir_all(stage);
+    Ok(())
+}
+
+/// Download or adopt the complete Linux runtime. The top-level marker is written
+/// only after every component succeeds; a failed launch remains dormant and retries
+/// only missing/corrupt components next time.
+#[cfg(target_os = "linux")]
+pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
+    if std::env::consts::ARCH != "x86_64" {
+        return Err(format!(
+            "automatic Linux GPU runtime provisioning supports x86_64 (found {})",
+            std::env::consts::ARCH
+        ));
+    }
+    let root = gpu_runtime_dir();
+    fs::create_dir_all(&root).map_err(|error| format!("create {}: {error}", root.display()))?;
+    if already_provisioned(&root) {
+        emit(app, "provision", "GPU runtime ready (cached).", false);
+        return Ok(());
+    }
+    if let Ok(value) = std::env::var(GPU_RUNTIME_DIR_ENV) {
+        let value = value.trim();
+        if !value.is_empty() {
+            let source = PathBuf::from(value);
+            emit(
+                app,
+                "provision",
+                format!(
+                    "Installing pre-staged Linux GPU runtime from {}…",
+                    source.display()
+                ),
+                false,
+            );
+            install_from_staged(&source, &root)?;
+            write_marker(&root)?;
+            emit(app, "provision", "GPU runtime ready (pre-staged).", false);
+            return Ok(());
+        }
+    }
+    if runtime_complete(&root) {
+        write_marker(&root)?;
+        emit(
+            app,
+            "provision",
+            "Found a complete Linux GPU runtime; skipping download.",
+            false,
+        );
+        return Ok(());
+    }
+    emit(
+        app,
+        "provision",
+        "Downloading Linux GPU runtime (first run, ~1.9 GB)…",
+        false,
+    );
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .read_timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|error| format!("http client: {error}"))?;
+    for (index, component) in COMPONENTS.iter().enumerate() {
+        if component_complete(&root, component) {
+            emit(
+                app,
+                "provision",
+                format!(
+                    "Linux GPU runtime [{}/{}]: {} already present; skipping.",
+                    index + 1,
+                    COMPONENTS.len(),
+                    component.label
+                ),
+                false,
+            );
+            continue;
+        }
+        emit(
+            app,
+            "provision",
+            format!(
+                "Downloading Linux GPU runtime [{}/{}]: {} ({})…",
+                index + 1,
+                COMPONENTS.len(),
+                component.label,
+                component.approx
+            ),
+            false,
+        );
+        fetch_component(&client, &root, component).await?;
+    }
+    let _ = fs::remove_dir_all(root.join(".download-tmp"));
+    if !runtime_complete(&root) {
+        return Err("Linux GPU runtime is incomplete after extraction".to_owned());
+    }
+    write_marker(&root)?;
+    emit(app, "provision", "Linux GPU runtime ready.", false);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn scratch(tag: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "sw-linux-provision-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("create scratch");
+        root
+    }
+
+    fn touch_runtime(root: &Path) {
+        for component in COMPONENTS {
+            let dir = root.join(component.dest);
+            fs::create_dir_all(&dir).expect("create component dir");
+            for sentinel in component.sentinels {
+                fs::write(dir.join(format!("{sentinel}.fixture")), b"fixture")
+                    .expect("write sentinel");
+            }
+        }
+    }
+
+    fn fixture_wheel(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let cursor = Cursor::new(Vec::new());
+        let mut zip = zip::ZipWriter::new(cursor);
+        for (name, bytes) in entries {
+            zip.start_file(*name, zip::write::SimpleFileOptions::default())
+                .expect("start fixture entry");
+            zip.write_all(bytes).expect("write fixture entry");
+        }
+        zip.finish().expect("finish fixture wheel").into_inner()
+    }
+
+    #[test]
+    fn manifest_is_pinned_and_matches_docker_versions() {
+        assert_eq!(COMPONENTS.len(), 8);
+        let mut slugs = std::collections::HashSet::new();
+        for component in COMPONENTS {
+            assert!(component.url.starts_with("https://files.pythonhosted.org/"));
+            assert!(component.url.contains("x86_64"));
+            assert_eq!(component.sha256.len(), 64);
+            assert!(component.sha256.chars().all(|ch| ch.is_ascii_hexdigit()));
+            assert!(slugs.insert(component.slug));
+            assert!(!component.sentinels.is_empty());
+        }
+        let docker = include_str!("../../../docker/rust.Dockerfile");
+        for version in ["1.26.0", "9.23.0.39", "11.4.1.4", "12.9.86"] {
+            assert!(docker.contains(version), "Docker pin missing {version}");
+            assert!(
+                COMPONENTS
+                    .iter()
+                    .any(|component| component.url.contains(version)),
+                "Linux manifest missing {version}"
+            );
+        }
+    }
+
+    #[test]
+    fn sha256_verification_detects_corruption() {
+        let digest =
+            hash_reader(Cursor::new(b"small deterministic wheel fixture")).expect("hash fixture");
+        assert_eq!(
+            digest,
+            "3500f1c4a8dccd6de360fb9120e394494aba434fea810b45226f59fe54c387d1"
+        );
+        let corrupt = hash_reader(Cursor::new(b"small deterministic wheel fixturf"))
+            .expect("hash corrupt fixture");
+        assert_ne!(digest, corrupt);
+    }
+
+    #[test]
+    fn extraction_filters_shared_objects_and_rejects_traversal() {
+        let root = scratch("extract");
+        let wheel = root.join("fixture.whl");
+        fs::write(
+            &wheel,
+            fixture_wheel(&[
+                ("onnxruntime/capi/libonnxruntime.so.1.26.0", b"ort"),
+                ("onnxruntime/capi/libonnxruntime_providers_cuda.so", b"cuda"),
+                ("../../escape.so", b"escape"),
+                ("onnxruntime/capi/pybind_state.so", b"python"),
+            ]),
+        )
+        .expect("write fixture wheel");
+        let dest = root.join("out");
+        let count = extract_shared_objects(
+            &wheel,
+            Some(&["libonnxruntime.so", "libonnxruntime_providers_cuda.so"]),
+            &dest,
+        )
+        .expect("extract fixture");
+        assert_eq!(count, 2);
+        assert!(dest.join("libonnxruntime.so.1.26.0").is_file());
+        assert!(dest.join("libonnxruntime_providers_cuda.so").is_file());
+        assert!(!dest.join("pybind_state.so").exists());
+        assert!(!root.join("escape.so").exists());
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn marker_reuse_requires_current_version_and_all_sentinels() {
+        let root = scratch("marker");
+        touch_runtime(&root);
+        write_marker(&root).expect("write current marker");
+        assert!(already_provisioned(&root));
+        fs::remove_file(root.join("cudnn/lib/libcudnn.so.fixture")).expect("remove sentinel");
+        assert!(!already_provisioned(&root));
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn staged_override_copies_complete_layout_and_rejects_partial() {
+        let source = scratch("staged-source");
+        touch_runtime(&source);
+        let target = scratch("staged-target");
+        install_from_staged(&source, &target).expect("install complete stage");
+        assert!(runtime_complete(&target));
+
+        let partial = scratch("staged-partial");
+        touch_runtime(&partial);
+        fs::remove_file(partial.join("cufft/lib/libcufft.so.fixture"))
+            .expect("remove fixture sentinel");
+        let rejected = scratch("staged-rejected");
+        let error = install_from_staged(&partial, &rejected).expect_err("reject partial stage");
+        assert!(error.contains("incomplete"));
+        for root in [source, target, partial, rejected] {
+            fs::remove_dir_all(root).expect("remove fixture");
+        }
+    }
+
+    #[test]
+    fn component_marker_does_not_accept_partial_layout() {
+        let root = scratch("partial");
+        let component = &COMPONENTS[1];
+        let dest = root.join(component.dest);
+        fs::create_dir_all(&dest).expect("create component dest");
+        fs::write(dest.join("libcublas.so.12"), b"fixture").expect("write first sentinel");
+        write_component_marker(&root, component.slug, REDIST_VERSION).expect("write marker");
+        assert!(!component_complete(&root, component));
+        fs::write(dest.join("libcublasLt.so.12"), b"fixture").expect("write second sentinel");
+        assert!(component_complete(&root, component));
+        fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    /// Opt-in CI/manual seam for the real pinned transport without downloading the
+    /// multi-GB set. It exercises the smallest Linux wheel end to end.
+    #[test]
+    #[ignore = "network: downloads the ~3 MB pinned Linux CUDA runtime wheel"]
+    fn linux_downloader_smoke() {
+        let root = scratch("network-smoke");
+        let component = &COMPONENTS[0];
+        let client = reqwest::Client::builder().build().expect("HTTP client");
+        tauri::async_runtime::block_on(fetch_component(&client, &root, component))
+            .expect("download, hash, and extract pinned Linux wheel");
+        assert!(component_complete(&root, component));
+        assert!(dir_has_shared_object(
+            &root.join("cuda/lib64"),
+            "libcudart.so"
+        ));
+        fs::remove_dir_all(root).expect("remove network smoke runtime");
+    }
+}

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -10,6 +10,8 @@ mod cred_ipc;
 // run into %APPDATA%\SceneWorks\gpu-runtime and resolved from there.
 #[cfg(target_os = "windows")]
 mod cuda_provision;
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+mod linux_cuda_provision;
 // Pure, cross-platform filesystem predicates for `cuda_provision` (marker + sentinel
 // checks). NOT `cfg`-gated so the retry-skip guard (sc-13614) is unit-tested on any
 // host, not only the Windows-only lane where `cuda_provision` compiles.

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -2576,6 +2576,66 @@ fn cuda_preflight() -> Result<(), String> {
     evaluate_nvidia_preflight(Some(&stdout))
 }
 
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+const MIN_LINUX_NVIDIA_DRIVER: (u32, u32, u32) = (575, 51, 3);
+
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+fn parse_driver_version(value: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = value.split('.');
+    Some((
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next().unwrap_or("0").parse().ok()?,
+    ))
+}
+
+/// Linux counterpart of the Windows CUDA preflight. CUDA 12.9 requires the
+/// 575-series Linux driver; missing `nvidia-smi`, no GPU rows, and an old driver
+/// map to actionable setup errors before the multi-GB first-run download.
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+fn evaluate_linux_nvidia_preflight(smi_output: Option<&str>) -> Result<(), String> {
+    let Some(line) =
+        smi_output.and_then(|out| out.lines().map(str::trim).find(|line| !line.is_empty()))
+    else {
+        return Err(
+            "SceneWorks on Linux requires an NVIDIA GPU with driver 575.51.03 or newer. \
+             No NVIDIA GPU was detected (nvidia-smi is missing or returned no devices); \
+             the GPU worker will remain disabled."
+                .to_owned(),
+        );
+    };
+    let mut parts = line.split(',').map(str::trim);
+    let name = parts.next().unwrap_or("NVIDIA GPU");
+    let driver = parts.next().unwrap_or("");
+    if let Some(version) = parse_driver_version(driver) {
+        if version < MIN_LINUX_NVIDIA_DRIVER {
+            return Err(format!(
+                "SceneWorks on Linux requires NVIDIA driver 575.51.03 or newer for CUDA 12.9 \
+                 (found {driver} on {name}). Update the NVIDIA driver; the GPU worker will \
+                 remain disabled."
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn linux_cuda_preflight() -> Result<(), String> {
+    let output = std::process::Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=name,driver_version",
+            "--format=csv,noheader,nounits",
+        ])
+        .output();
+    let stdout = match output {
+        Ok(output) if output.status.success() => {
+            Some(String::from_utf8_lossy(&output.stdout).into_owned())
+        }
+        _ => None,
+    };
+    evaluate_linux_nvidia_preflight(stdout.as_deref())
+}
+
 /// Apple-Silicon Metal preflight (sc-8411): the macOS counterpart of the Windows
 /// `cuda_preflight`. The desktop crate doesn't link MLX, so probe by re-launching the
 /// bundled `sceneworks-api` sidecar in its one-shot `SCENEWORKS_GPU_CHECK=1` mode — a
@@ -2645,6 +2705,11 @@ async fn run_startup(app: AppHandle) {
         emit(&app, "error", error, true);
         return;
     }
+    #[cfg(target_os = "linux")]
+    if let Err(error) = linux_cuda_preflight() {
+        emit(&app, "error", error, true);
+        return;
+    }
     // First-run GPU runtime provisioning (Windows candle build): the CUDA runtime +
     // cuDNN + onnxruntime-gpu DLLs are no longer bundled (they exceeded NSIS's ~2 GB
     // datablock limit), so download them once into %APPDATA%\SceneWorks\gpu-runtime and
@@ -2660,6 +2725,20 @@ async fn run_startup(app: AppHandle) {
                 "GPU runtime setup failed: {error}. To install on a disconnected machine, \
                  pre-stage the runtime and set SCENEWORKS_GPU_RUNTIME_DIR — see \
                  docs/offline-install.md."
+            ),
+            true,
+        );
+        return;
+    }
+    #[cfg(target_os = "linux")]
+    if let Err(error) = crate::linux_cuda_provision::provision(&app).await {
+        emit(
+            &app,
+            "error",
+            format!(
+                "Linux GPU runtime setup failed: {error}. The GPU worker will remain disabled. \
+                 For an offline install, pre-stage a provisioned Linux gpu-runtime directory \
+                 and set SCENEWORKS_GPU_RUNTIME_DIR; see apps/desktop/docs/offline-install.md."
             ),
             true,
         );
@@ -3135,6 +3214,77 @@ mod preflight_tests {
     fn unparseable_driver_does_not_block_a_present_gpu() {
         // The GPU is present; an odd version string shouldn't hard-block startup.
         assert!(evaluate_nvidia_preflight(Some("NVIDIA RTX, not-a-version")).is_ok());
+    }
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "windows")))]
+mod linux_preflight_tests {
+    use super::evaluate_linux_nvidia_preflight;
+
+    #[test]
+    fn absent_linux_nvidia_runtime_maps_to_dormant_message() {
+        for output in [None, Some(""), Some(" \n")] {
+            let error = evaluate_linux_nvidia_preflight(output).expect_err("missing GPU must fail");
+            assert!(error.contains("575.51.03"));
+            assert!(error.contains("remain disabled"));
+        }
+    }
+
+    #[test]
+    fn linux_driver_floor_is_compared_by_version_components() {
+        assert!(evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 575.51.03\n")).is_ok());
+        assert!(evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 580.1.0\n")).is_ok());
+        let error = evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 575.50.99\n"))
+            .expect_err("old driver must fail");
+        assert!(error.contains("575.50.99"));
+        assert!(error.contains("CUDA 12.9"));
+    }
+
+    #[test]
+    fn unusual_linux_driver_text_defers_to_runtime_instead_of_false_negative() {
+        assert!(
+            evaluate_linux_nvidia_preflight(Some("NVIDIA Datacenter GPU, vendor-build")).is_ok()
+        );
+    }
+}
+
+/// Opt-in real-host validation seam for Linux packaging/CI. Normal tests remain
+/// fixture-only and never need an NVIDIA host or the multi-GB runtime.
+#[cfg(all(test, target_os = "linux"))]
+mod linux_runtime_smoke_tests {
+    use super::{
+        find_linux_shared_object, linux_candle_runtime, linux_cuda_preflight, prepend_loader_paths,
+    };
+
+    #[test]
+    #[ignore = "manual/CI: requires a provisioned Linux NVIDIA runtime"]
+    fn provisioned_runtime_resolves_every_onnxruntime_dependency() {
+        linux_cuda_preflight().expect("NVIDIA driver preflight");
+        let runtime = linux_candle_runtime().expect("complete XDG gpu-runtime");
+        let provider = runtime
+            .loader_dirs
+            .iter()
+            .find_map(|dir| find_linux_shared_object(dir, "libonnxruntime_providers_cuda.so"))
+            .expect("onnxruntime CUDA provider");
+        let inherited = std::env::var_os("LD_LIBRARY_PATH").unwrap_or_default();
+        let loader_paths =
+            prepend_loader_paths(&runtime.loader_dirs, std::env::split_paths(&inherited));
+        let joined = std::env::join_paths(loader_paths).expect("join LD_LIBRARY_PATH");
+        let output = std::process::Command::new("ldd")
+            .arg(provider)
+            .env("LD_LIBRARY_PATH", joined)
+            .output()
+            .expect("run ldd");
+        let report = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.status.success(), "ldd failed:\n{report}");
+        assert!(
+            !report.contains("not found"),
+            "onnxruntime CUDA dependency missing:\n{report}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- provision pinned Linux x86_64 CUDA 12.9, cuDNN 9.23, cuFFT, nvJitLink, NVRTC, cuBLAS, cuRAND, and ONNX Runtime GPU on first launch
- store the verified runtime under the XDG data `gpu-runtime` root and reuse current component/top-level markers on relaunch
- inject the merged ORT/CUDA/cuDNN/`LD_LIBRARY_PATH` contract and keep the candle supervisor dormant on preflight, provisioning, sentinel, or ELF dependency failure
- support marker-verified offline staging through `SCENEWORKS_GPU_RUNTIME_DIR`, with transactional component replacement and stale-library cleanup

Shortcut: https://app.shortcut.com/trefry/story/10376

## Acceptance coverage
- **Fresh Linux + NVIDIA:** NVIDIA driver preflight runs before download; pinned PyPI wheels stream to disk, verify SHA-256, extract through traversal-safe ZIP handling, and run `ldd` across main ORT, CUDA provider, and cuDNN lazy engines before worker startup.
- **Failure is dormant:** startup returns a visible actionable setup error before `gate_window`; existing supervisor sentinel gating prevents a crash loop.
- **XDG + reuse:** uses the merged `$XDG_DATA_HOME/SceneWorks/gpu-runtime` resolver; current full/component markers and sentinels skip network on relaunch.
- **Offline:** accepts only a current-version provisioned Linux runtime, invalidates live markers before mutation, stages components, and restores markers only after full validation.
- **Windows preserved:** the Windows provisioner remains separate; Linux fixture tests compile and run on the Windows desktop test lane.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p sceneworks-desktop linux_cuda_provision::tests:: --locked` (11 passed, 1 ignored)
- `cargo test -p sceneworks-desktop --locked` (84 passed, 0 failed, 2 ignored)
- `cargo clippy -p sceneworks-desktop --all-targets --locked -- -D warnings`
- `cargo build -p sceneworks-desktop --locked`
- opt-in pinned Linux wheel smoke (smallest ~3 MB component): 1 passed
- independent adversarial review: PASS, high confidence, no findings after three convergence cycles

## Platform limitation
Native Linux/NVIDIA hardware was unavailable in this Windows worktree, so the ignored Linux `nvidia-smi` + real XDG runtime `ldd` smoke was not run. The checked-in ignored seam is available for Linux packaging CI/manual validation and no native CUDA-load claim is made from this host.