### PR TITLE
feat(desktop): configure Linux AppImage and Debian bundles [sc-10379]

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -4,11 +4,12 @@ name: Desktop (Windows)
 # sc-10456, follow-on to sc-10432):
 #
 #   build-windows  (pull_request, GitHub-hosted windows-2022) — CHEAP (~3–5 min):
-#     desktop-crate test + clippy + the gen-core skew guard. No CUDA Toolkit, no
-#     candle build, no packaging — the `sceneworks-desktop` crate is the Tauri host
-#     shell and links neither candle nor CUDA, so nvcc isn't needed to check it. This
-#     is the PR gate: the Linux `parity` job (check.yml) excludes the desktop crate,
-#     so this is the only lane that exercises it (epic 1330 Phase 3 / sc-1356).
+#     desktop-crate test + clippy + bundle-config tests + the gen-core skew guard.
+#     No CUDA Toolkit, candle build, or packaging — the `sceneworks-desktop` crate
+#     is the Tauri host shell and links neither candle nor CUDA, so nvcc isn't needed
+#     to check it. This is the PR gate: the Linux `parity` job (check.yml) excludes
+#     the desktop crate, so this is the only lane that exercises it
+#     (epic 1330 Phase 3 / sc-1356).
 #
 #   package-windows  (push:main + workflow_dispatch, SELF-HOSTED cuda box) — the full
 #     candle/CUDA sidecar build + NSIS/MSI packaging, as an UNSIGNED smoke so a
@@ -92,6 +93,12 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/desktop/package-lock.json
+      - name: Install desktop CLI and config-test dependencies
+        run: npm ci --prefix apps/desktop
+      - name: Validate desktop bundle configuration
+        run: npm --prefix apps/desktop test
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
           toolchain: stable

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -114,6 +114,55 @@ format), so the first launch downloads it — see [First run](#first-run).
 2. Launch it. The app is signed with a Developer ID and notarized, so it opens
    without a Gatekeeper override.
 
+### Linux
+
+Choose either Linux x86_64 package:
+
+- Install the `.deb` on Ubuntu 22.04 or 24.04 with
+  `sudo apt install ./SceneWorks_*.deb`. APT installs the declared
+  `libwebkit2gtk-4.1-0` and `libgtk-3-0` runtime dependencies.
+- Make the AppImage executable with `chmod +x SceneWorks_*.AppImage`, then run
+  it directly. The AppImage carries its GTK/WebKitGTK runtime and does not
+  require a package-manager install.
+
+Both packages require an NVIDIA driver, but not a system CUDA toolkit. SceneWorks
+downloads its pinned CUDA user-space runtime on first launch.
+
+#### Build Linux packages locally
+
+Linux bundles must be built on Linux. Use Ubuntu 22.04 as the baseline so the
+AppImage remains compatible with both Ubuntu 22.04 and 24.04. Install the
+[Tauri v2 Linux prerequisites](https://v2.tauri.app/start/prerequisites/), the
+repository's normal Node/Rust prerequisites, and dependencies for both apps,
+then run the opt-in package command:
+
+```sh
+npm --prefix apps/web ci
+npm --prefix apps/desktop ci
+npm --prefix apps/desktop run build:linux
+```
+
+This writes the AppImage and Debian package under
+`target/release/bundle/{appimage,deb}/`. The ordinary
+`npm --prefix apps/desktop run build` command produces the same two formats on
+Linux because Tauri automatically merges `tauri.linux.conf.json`.
+
+An Ubuntu 22.04 WSL2/WSLg distro can run the same commands for iterative
+packaging and GUI checks. It does not replace the final install and launch smoke
+test on a native Ubuntu 22.04/24.04 desktop.
+
+The Debian package intentionally uses the host's WebKitGTK 4.1 and GTK 3 through
+the package dependencies above. The AppImage follows Tauri's portable model:
+WebKitGTK and GTK are bundled from the Ubuntu 22.04 build host. Additional
+GStreamer multimedia plugins remain disabled (`bundleMediaFramework: false`);
+they are separate from the WebKitGTK runtime needed to launch and show the UI.
+
+Inspect a built Debian package's dependency declaration with:
+
+```sh
+dpkg-deb -f target/release/bundle/deb/*.deb Depends
+```
+
 ---
 
 ## First run

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@sceneworks/desktop",
       "version": "0.8.0",
       "devDependencies": {
-        "@tauri-apps/cli": "^2"
+        "@tauri-apps/cli": "^2",
+        "ajv": "8.20.0"
       }
     },
     "node_modules/@tauri-apps/cli": {
@@ -241,6 +242,64 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     }
   }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
     "dev": "tauri dev",
     "build": "tauri build",
     "build:linux": "tauri build --bundles appimage,deb",
-    "test": "node --test scripts/*.test.mjs",
+    "test": "node --test scripts/build-sidecar-platform.test.mjs scripts/linux-bundle-config.test.mjs",
     "release:mac": "tauri build && node scripts/staple-dmg.mjs"
   },
   "devDependencies": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "tauri dev",
     "build": "tauri build",
+    "build:linux": "tauri build --bundles appimage,deb",
+    "test": "node --test scripts/*.test.mjs",
     "release:mac": "tauri build && node scripts/staple-dmg.mjs"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2"
+    "@tauri-apps/cli": "^2",
+    "ajv": "8.20.0"
   }
 }

--- a/apps/desktop/scripts/linux-bundle-config.test.mjs
+++ b/apps/desktop/scripts/linux-bundle-config.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import Ajv from "ajv";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const desktopDir = join(scriptsDir, "..");
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(join(desktopDir, relativePath), "utf8"));
+}
+
+function mergeConfig(base, overlay) {
+  if (
+    base !== null &&
+    overlay !== null &&
+    typeof base === "object" &&
+    typeof overlay === "object" &&
+    !Array.isArray(base) &&
+    !Array.isArray(overlay)
+  ) {
+    const merged = { ...base };
+    for (const [key, value] of Object.entries(overlay)) {
+      merged[key] = key in base ? mergeConfig(base[key], value) : value;
+    }
+    return merged;
+  }
+
+  return overlay;
+}
+
+const baseConfig = readJson("tauri.conf.json");
+const linuxOverlay = readJson("tauri.linux.conf.json");
+const macosOverlay = readJson("tauri.macos.conf.json");
+const packageJson = readJson("package.json");
+const tauriSchema = readJson("node_modules/@tauri-apps/cli/config.schema.json");
+const desktopReadme = readFileSync(join(desktopDir, "README.md"), "utf8");
+
+test("the Linux overlay is valid against the locked Tauri v2 schema", () => {
+  // Tauri's schema intentionally escapes `:` in a character class. Node 24's
+  // Unicode RegExp mode rejects that harmless draft-07 pattern, while Tauri's
+  // Rust schema parser accepts it.
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    unicodeRegExp: false,
+    validateFormats: false,
+  });
+  const validate = ajv.compile(tauriSchema);
+  const linuxConfig = mergeConfig(baseConfig, linuxOverlay);
+
+  assert.equal(
+    validate(linuxConfig),
+    true,
+    ajv.errorsText(validate.errors, { separator: "\n" }),
+  );
+});
+
+test("the default Linux build produces only AppImage and deb bundles", () => {
+  const linuxConfig = mergeConfig(baseConfig, linuxOverlay);
+
+  assert.deepEqual(linuxConfig.bundle.targets, ["appimage", "deb"]);
+  assert.equal(packageJson.scripts.build, "tauri build");
+  assert.equal(
+    packageJson.scripts["build:linux"],
+    "tauri build --bundles appimage,deb",
+  );
+});
+
+test("the deb declares the Tauri v2 GTK and WebKitGTK runtime dependencies", () => {
+  assert.deepEqual(linuxOverlay.bundle.linux.deb.depends, [
+    "libwebkit2gtk-4.1-0",
+    "libgtk-3-0",
+  ]);
+});
+
+test("Linux bundles carry product metadata, category, and PNG icons", () => {
+  const linuxBundle = mergeConfig(baseConfig, linuxOverlay).bundle;
+
+  assert.equal(baseConfig.productName, "SceneWorks");
+  assert.equal(baseConfig.identifier, "net.trefry.sceneworks");
+  assert.match(baseConfig.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(linuxBundle.category, "GraphicsAndDesign");
+  assert.equal(linuxBundle.publisher, "SceneWorks");
+  assert.equal(linuxBundle.homepage, "https://github.com/SceneWorks/SceneWorks");
+  assert.equal(linuxBundle.license, "AGPL-3.0-or-later");
+  assert.match(linuxBundle.shortDescription, /image and video/i);
+  assert.match(linuxBundle.longDescription, /locally on an NVIDIA GPU/i);
+  assert.ok(linuxBundle.icon.length >= 3);
+
+  for (const icon of linuxBundle.icon) {
+    assert.equal(extname(icon), ".png", `${icon} must be a Linux PNG icon`);
+    assert.equal(existsSync(join(desktopDir, icon)), true, `${icon} must exist`);
+  }
+});
+
+test("the AppImage WebKitGTK and media-framework decision is explicit", () => {
+  assert.equal(
+    linuxOverlay.bundle.linux.appimage.bundleMediaFramework,
+    false,
+  );
+  assert.match(desktopReadme, /AppImage carries its GTK\/WebKitGTK runtime/);
+  assert.match(desktopReadme, /bundleMediaFramework: false/);
+});
+
+test("the Linux overlay does not regress macOS or Windows bundle config", () => {
+  const linuxConfig = mergeConfig(baseConfig, linuxOverlay);
+  const macosConfig = mergeConfig(baseConfig, macosOverlay);
+
+  assert.deepEqual(linuxConfig.bundle.macOS, baseConfig.bundle.macOS);
+  assert.deepEqual(linuxConfig.bundle.windows, baseConfig.bundle.windows);
+  assert.equal(macosConfig.bundle.targets, "all");
+  assert.deepEqual(macosConfig.bundle.windows, baseConfig.bundle.windows);
+  assert.equal(macosConfig.bundle.macOS.minimumSystemVersion, "26.2");
+  assert.equal(
+    macosConfig.bundle.windows.webviewInstallMode.type,
+    "downloadBootstrapper",
+  );
+});

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -371,15 +371,17 @@ fn read_hf_token_result() -> Result<Option<String>, String> {
 /// macOS no longer uses this eager push at all — the MLX worker pulls credentials
 /// lazily from the desktop credential socket (`cred_ipc`) — so it's compiled but
 /// uncalled there (the Python/candle spawn sites on other platforms still use it).
-#[cfg(target_os = "linux")]
-pub fn read_hf_token() -> Result<Option<String>, String> {
-    credential_read_for_platform(host_platform(), read_hf_token_result())
-}
-
-#[cfg(not(target_os = "linux"))]
 #[cfg_attr(target_os = "macos", allow(dead_code))]
-pub fn read_hf_token() -> Option<String> {
-    credential_read_for_platform(host_platform(), read_hf_token_result()).unwrap_or_default()
+pub fn read_hf_token() -> Result<Option<String>, String> {
+    let result = credential_read_for_platform(host_platform(), read_hf_token_result());
+    if cfg!(target_os = "linux") {
+        result
+    } else {
+        // Preserve macOS/Windows's existing best-effort keychain behavior while
+        // keeping one cross-platform return type so Linux's fallible contract is
+        // type-checked by every desktop CI lane.
+        Ok(result.unwrap_or_default())
+    }
 }
 
 /// The non-secret hosts that have a credential recorded, handed to the MLX worker so
@@ -453,15 +455,16 @@ fn credentials_env_json_result() -> Result<Option<String>, String> {
 ///
 /// macOS uses the lazy credential socket (`cred_ipc`) instead, so this is compiled
 /// but uncalled there (the Python/candle spawn sites on other platforms use it).
-#[cfg(target_os = "linux")]
-pub fn credentials_env_json() -> Result<Option<String>, String> {
-    credential_read_for_platform(host_platform(), credentials_env_json_result())
-}
-
-#[cfg(not(target_os = "linux"))]
 #[cfg_attr(target_os = "macos", allow(dead_code))]
-pub fn credentials_env_json() -> Option<String> {
-    credential_read_for_platform(host_platform(), credentials_env_json_result()).unwrap_or_default()
+pub fn credentials_env_json() -> Result<Option<String>, String> {
+    let result = credential_read_for_platform(host_platform(), credentials_env_json_result());
+    if cfg!(target_os = "linux") {
+        result
+    } else {
+        // See `read_hf_token`: non-Linux remains best-effort, but callers share
+        // Linux's explicit `Result` signature and cannot accidentally discard it.
+        Ok(result.unwrap_or_default())
+    }
 }
 
 fn worker_credential_preflight_with(
@@ -481,18 +484,8 @@ fn worker_credential_preflight_with(
 /// environment. The setup screen renders this error and offers Retry after the user
 /// starts/unlocks Secret Service. This is a no-op on macOS/Windows, preserving their
 /// existing lazy/best-effort behavior without touching the native keychain.
-#[cfg(target_os = "linux")]
 pub fn validate_worker_credentials() -> Result<(), String> {
     worker_credential_preflight_with(host_platform(), read_hf_token, credentials_env_json)
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn validate_worker_credentials() -> Result<(), String> {
-    worker_credential_preflight_with(
-        host_platform(),
-        || Ok(read_hf_token()),
-        || Ok(credentials_env_json()),
-    )
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -334,7 +334,7 @@ impl LinuxDesktopPaths {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     fn from_process_env() -> Result<LinuxDesktopPaths, String> {
-        Self::resolve(std::env::var_os)
+        Self::resolve(|name| std::env::var_os(name))
     }
 
     fn settings_file(&self) -> PathBuf {
@@ -1526,7 +1526,7 @@ fn supervise_worker(
     slot: fn(&Managed) -> &Mutex<Option<CommandChild>>,
     record_pid: fn(&AppHandle, Option<u32>),
     kill_stale: fn(CommandChild),
-    env_builder: impl Fn(Command, WorkerSpawnCtx) -> Command + Send + 'static,
+    env_builder: impl Fn(Command, WorkerSpawnCtx) -> Result<Command, String> + Send + 'static,
 ) {
     std::thread::spawn(move || {
         // sc-13605: exactly one supervisor owns the single worker slot. If one is
@@ -1580,7 +1580,7 @@ fn supervise_worker(
             // The ONLY substantive per-worker difference: build the child's env
             // block. Everything around it (spawn, PID record, recheck, backoff) is
             // identical across workers.
-            let command = env_builder(
+            let command = match env_builder(
                 sidecar,
                 WorkerSpawnCtx {
                     app: &app,
@@ -1588,7 +1588,22 @@ fn supervise_worker(
                     worker_id: &worker_id,
                     hf_home: &hf_home,
                 },
-            );
+            ) {
+                Ok(command) => command,
+                Err(error) => {
+                    // Linux Secret Service reads are deliberately fallible. Never
+                    // launch without recorded credentials: preserve the actionable
+                    // error, then retry so unlocking the service recovers without an
+                    // orphaned credential-less worker.
+                    append_log(
+                        &log_path,
+                        &format!("[desktop] {label} worker environment setup failed: {error}\n"),
+                    );
+                    std::thread::sleep(Duration::from_secs(backoff));
+                    backoff = (backoff * 2).min(30);
+                    continue;
+                }
+            };
             let spawned = command.spawn();
             let (mut events, child) = match spawned {
                 Ok(pair) => pair,
@@ -1800,7 +1815,7 @@ fn supervise_mlx_worker(app: AppHandle) {
             if let Some(token) = lan_access_token() {
                 command = command.env("SCENEWORKS_ACCESS_TOKEN", token);
             }
-            command
+            Ok(command)
         },
     );
 }
@@ -1909,10 +1924,10 @@ fn supervise_candle_worker(app: AppHandle) {
             if let Some(ffmpeg) = resolve_bundled_ffmpeg(ctx.app) {
                 command = command.env("SCENEWORKS_FFMPEG", ffmpeg);
             }
-            if let Some(token) = crate::settings::read_hf_token() {
+            if let Some(token) = crate::settings::read_hf_token()? {
                 command = command.env("HF_TOKEN", token);
             }
-            if let Some(credentials) = crate::settings::credentials_env_json() {
+            if let Some(credentials) = crate::settings::credentials_env_json()? {
                 command = command.env("SCENEWORKS_CREDENTIALS", credentials);
             }
             // LAN mode (epic 4484): the API now requires the password as an access
@@ -1921,7 +1936,7 @@ fn supervise_candle_worker(app: AppHandle) {
             if let Some(token) = lan_access_token() {
                 command = command.env("SCENEWORKS_ACCESS_TOKEN", token);
             }
-            command
+            Ok(command)
         },
     );
 }

--- a/apps/desktop/tauri.linux.conf.json
+++ b/apps/desktop/tauri.linux.conf.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": ["appimage", "deb"],
+    "publisher": "SceneWorks",
+    "homepage": "https://github.com/SceneWorks/SceneWorks",
+    "copyright": "Copyright © 2026 Michael Trefry and the SceneWorks contributors",
+    "license": "AGPL-3.0-or-later",
+    "category": "GraphicsAndDesign",
+    "shortDescription": "Local AI image and video generation studio.",
+    "longDescription": "SceneWorks is a desktop-native AI image and video generation studio that runs models locally on an NVIDIA GPU.",
+    "icon": [
+      "icons/32x32.png",
+      "icons/64x64.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.png"
+    ],
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": false
+      },
+      "deb": {
+        "depends": [
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0"
+        ]
+      }
+    }
+  }
+}

--- a/scripts/check-no-nc-weights.mjs
+++ b/scripts/check-no-nc-weights.mjs
@@ -676,6 +676,7 @@ function inspectResourceSpecs(specs, ncTokens) {
 async function inspectTauriConfigs(ncTokens) {
   const configRelPaths = [
     "apps/desktop/tauri.conf.json",
+    "apps/desktop/tauri.linux.conf.json",
     "apps/desktop/tauri.macos.conf.json",
     "apps/desktop/updater.release.conf.json",
   ];


### PR DESCRIPTION
## What does this PR do?

Adds the Tauri v2 Linux platform overlay for the v1 desktop distribution:

- limits Linux bundles to AppImage and Debian (`.deb`), leaving RPM for later;
- declares the Ubuntu 22.04/24.04 WebKitGTK 4.1 and GTK 3 runtime dependencies for the Debian package;
- supplies Linux PNG icons, desktop category, publisher/homepage/license, and product descriptions;
- documents the AppImage decision: Tauri bundles GTK/WebKitGTK from the Ubuntu 22.04 baseline, while extra GStreamer plugins remain opt-in;
- adds a locked-schema regression suite and runs it in the Windows desktop PR gate;
- includes the Linux overlay in the packaged-resource NC-weight guard.

The config follows Tauri's official [configuration schema](https://v2.tauri.app/reference/config/), [Debian packaging guidance](https://v2.tauri.app/distribute/debian/), and [AppImage guidance](https://v2.tauri.app/distribute/appimage/).

## Acceptance-criteria coverage

- `npm --prefix apps/desktop run build` automatically merges `tauri.linux.conf.json` on Linux and selects only `appimage` + `deb`; `build:linux` is an explicit equivalent.
- The `.deb` dependency list is exactly `libwebkit2gtk-4.1-0` and `libgtk-3-0` (no tray dependency because SceneWorks does not create a system tray).
- Install/launch commands and expected artifact locations are documented.
- Native AppImage/`.deb` production, Ubuntu 22.04/24.04 install, and GUI launch could not run on this Windows host and are not claimed here. sc-10381 will provide the native Linux automation; full webview behavior remains sc-10380.

## Related issue

[Shortcut sc-10379](https://app.shortcut.com/trefry/story/10379)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [ ] macOS (Apple Silicon / MLX)
- [x] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

Validation:

- `npm --prefix apps/desktop test` — 11 passed
- dependency mutation check — changing `libgtk-3-0` caused the focused config test to fail
- locked `@tauri-apps/cli` 2.11.2 schema validation — passed
- `npm --prefix apps/desktop audit --audit-level=moderate` — zero vulnerabilities
- `cargo fmt --all -- --check` — passed
- `cargo test -p sceneworks-desktop` — 84 passed, 2 ignored network smokes
- `cargo clippy -p sceneworks-desktop --all-targets -- -D warnings` — passed
- `npm run check` — passed
- `npm run check:nc-weights` and guard self-test — passed
- independent adversarial review — PASS, high confidence (2 convergence cycles)

Native Linux package/install/UI validation is pending by design; WSLg is documented only as an iterative environment, not final acceptance evidence.

## Checklist

- [x] I ran the applicable Rust formatting/tests/clippy and they passed
- [x] Web checks are not applicable (no web sources changed)
- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant
- [x] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [x] My PR is focused on a single logical change