### PR TITLE
fix(desktop): harden WebKitGTK SPA behavior [sc-10380]

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -120,7 +120,9 @@ Choose either Linux x86_64 package:
 
 - Install the `.deb` on Ubuntu 22.04 or 24.04 with
   `sudo apt install ./SceneWorks_*.deb`. APT installs the declared
-  `libwebkit2gtk-4.1-0` and `libgtk-3-0` runtime dependencies.
+  `libwebkit2gtk-4.1-0`, `libgtk-3-0`, and `gstreamer1.0-libav` runtime
+  dependencies. The GStreamer libav plugin supplies the H.264 decoder used by
+  WebKitGTK for MP4 preview playback.
 - Make the AppImage executable with `chmod +x SceneWorks_*.AppImage`, then run
   it directly. The AppImage carries its GTK/WebKitGTK runtime and does not
   require a package-manager install.
@@ -160,10 +162,12 @@ into DMA-BUF without setting WebKit's variable directly, launch with
 video playback on the target driver and desktop session.
 
 The Debian package intentionally uses the host's WebKitGTK 4.1 and GTK 3 through
-the package dependencies above. The AppImage follows Tauri's portable model:
-WebKitGTK and GTK are bundled from the Ubuntu 22.04 build host. Additional
-GStreamer multimedia plugins remain disabled (`bundleMediaFramework: false`);
-they are separate from the WebKitGTK runtime needed to launch and show the UI.
+the package dependencies above, including `gstreamer1.0-libav` for H.264 video
+decoding. The AppImage follows Tauri's portable model: WebKitGTK and GTK are
+bundled from the Ubuntu 22.04 build host, and Tauri's additional GStreamer
+playback libraries are included (`bundleMediaFramework: true`). This keeps MP4
+previews working on a stock supported Ubuntu install rather than relying on
+multimedia plugins that happen to be present on the build or user machine.
 
 Inspect a built Debian package's dependency declaration with:
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -151,6 +151,14 @@ An Ubuntu 22.04 WSL2/WSLg distro can run the same commands for iterative
 packaging and GUI checks. It does not replace the final install and launch smoke
 test on a native Ubuntu 22.04/24.04 desktop.
 
+SceneWorks sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` before creating its Linux
+webview. This avoids the blank-canvas and black-video failures that some
+WebKitGTK/compositor/NVIDIA combinations exhibit with DMA-BUF. An explicitly
+pre-set `WEBKIT_DISABLE_DMABUF_RENDERER` value is always preserved. To opt back
+into DMA-BUF without setting WebKit's variable directly, launch with
+`SCENEWORKS_WEBKIT_DMABUF=1`; use that override only after verifying canvas and
+video playback on the target driver and desktop session.
+
 The Debian package intentionally uses the host's WebKitGTK 4.1 and GTK 3 through
 the package dependencies above. The AppImage follows Tauri's portable model:
 WebKitGTK and GTK are bundled from the Ubuntu 22.04 build host. Additional

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -135,8 +135,16 @@ downloads its pinned CUDA user-space runtime on first launch.
 Linux bundles must be built on Linux. Use Ubuntu 22.04 as the baseline so the
 AppImage remains compatible with both Ubuntu 22.04 and 24.04. Install the
 [Tauri v2 Linux prerequisites](https://v2.tauri.app/start/prerequisites/), the
-repository's normal Node/Rust prerequisites, and dependencies for both apps,
-then run the opt-in package command:
+repository's normal Node/Rust prerequisites, and the GStreamer libav plugin:
+
+```sh
+sudo apt install gstreamer1.0-libav
+```
+
+The plugin must be present on the build host because Tauri copies the available
+GStreamer playback libraries into the AppImage when
+`bundleMediaFramework: true`. Then install dependencies for both apps and run
+the opt-in package command:
 
 ```sh
 npm --prefix apps/web ci

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -14,6 +14,7 @@ fn main() {
             "reveal_in_os",
             "resolve_asset_path",
             "save_asset_as",
+            "save_image_export",
             "list_credentials",
             "set_credential",
             "delete_credential",

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -21,6 +21,7 @@
     "allow-reveal-in-os",
     "allow-resolve-asset-path",
     "allow-save-asset-as",
+    "allow-save-image-export",
     "allow-list-credentials",
     "allow-set-credential",
     "allow-delete-credential",

--- a/apps/desktop/permissions/autogenerated/save_image_export.toml
+++ b/apps/desktop/permissions/autogenerated/save_image_export.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-save-image-export"
+description = "Enables the save_image_export command without any pre-configured scope."
+commands.allow = ["save_image_export"]
+
+[[permission]]
+identifier = "deny-save-image-export"
+description = "Denies the save_image_export command without any pre-configured scope."
+commands.deny = ["save_image_export"]

--- a/apps/desktop/scripts/linux-bundle-config.test.mjs
+++ b/apps/desktop/scripts/linux-bundle-config.test.mjs
@@ -71,10 +71,11 @@ test("the default Linux build produces only AppImage and deb bundles", () => {
   );
 });
 
-test("the deb declares the Tauri v2 GTK and WebKitGTK runtime dependencies", () => {
+test("the deb declares its WebKitGTK, GTK, and H.264 playback dependencies", () => {
   assert.deepEqual(linuxOverlay.bundle.linux.deb.depends, [
     "libwebkit2gtk-4.1-0",
     "libgtk-3-0",
+    "gstreamer1.0-libav",
   ]);
 });
 
@@ -98,13 +99,15 @@ test("Linux bundles carry product metadata, category, and PNG icons", () => {
   }
 });
 
-test("the AppImage WebKitGTK and media-framework decision is explicit", () => {
+test("Linux bundles carry the media framework needed for H.264 playback", () => {
   assert.equal(
     linuxOverlay.bundle.linux.appimage.bundleMediaFramework,
-    false,
+    true,
   );
   assert.match(desktopReadme, /AppImage carries its GTK\/WebKitGTK runtime/);
-  assert.match(desktopReadme, /bundleMediaFramework: false/);
+  assert.match(desktopReadme, /bundleMediaFramework: true/);
+  assert.match(desktopReadme, /gstreamer1\.0-libav/);
+  assert.match(desktopReadme, /H\.264/);
 });
 
 test("the WebKitGTK compatibility contract remains configured", () => {

--- a/apps/desktop/scripts/linux-bundle-config.test.mjs
+++ b/apps/desktop/scripts/linux-bundle-config.test.mjs
@@ -38,6 +38,7 @@ const macosOverlay = readJson("tauri.macos.conf.json");
 const packageJson = readJson("package.json");
 const tauriSchema = readJson("node_modules/@tauri-apps/cli/config.schema.json");
 const desktopReadme = readFileSync(join(desktopDir, "README.md"), "utf8");
+const webStyles = readFileSync(join(desktopDir, "..", "web", "src", "styles.css"), "utf8");
 
 test("the Linux overlay is valid against the locked Tauri v2 schema", () => {
   // Tauri's schema intentionally escapes `:` in a character class. Node 24's
@@ -104,6 +105,28 @@ test("the AppImage WebKitGTK and media-framework decision is explicit", () => {
   );
   assert.match(desktopReadme, /AppImage carries its GTK\/WebKitGTK runtime/);
   assert.match(desktopReadme, /bundleMediaFramework: false/);
+});
+
+test("the WebKitGTK compatibility contract remains configured", () => {
+  assert.equal(baseConfig.app.windows[0].dragDropEnabled, false);
+  assert.match(desktopReadme, /WEBKIT_DISABLE_DMABUF_RENDERER=1/);
+  assert.match(desktopReadme, /SCENEWORKS_WEBKIT_DMABUF=1/);
+
+  const unprefixedBlur = /(?<!-webkit-)backdrop-filter:\s*([^;]+);/g;
+  for (const match of webStyles.matchAll(unprefixedBlur)) {
+    const declarationStart = match.index;
+    const precedingRule = webStyles.slice(
+      Math.max(0, declarationStart - 100),
+      declarationStart,
+    );
+    assert.match(
+      precedingRule,
+      new RegExp(
+        `-webkit-backdrop-filter:\\s*${match[1].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*;`,
+      ),
+      `backdrop-filter at byte ${declarationStart} needs a matching WebKit prefix`,
+    );
+  }
 });
 
 test("the Linux overlay does not regress macOS or Windows bundle config", () => {

--- a/apps/desktop/scripts/linux-bundle-config.test.mjs
+++ b/apps/desktop/scripts/linux-bundle-config.test.mjs
@@ -107,6 +107,7 @@ test("Linux bundles carry the media framework needed for H.264 playback", () => 
   assert.match(desktopReadme, /AppImage carries its GTK\/WebKitGTK runtime/);
   assert.match(desktopReadme, /bundleMediaFramework: true/);
   assert.match(desktopReadme, /gstreamer1\.0-libav/);
+  assert.match(desktopReadme, /sudo apt install gstreamer1\.0-libav/);
   assert.match(desktopReadme, /H\.264/);
 });
 

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -23,10 +23,15 @@ mod setup;
 // In-app cross-platform auto-updater (sc-1355): startup check against the GitHub
 // "latest release" pointer, user-prompted download + install + restart.
 mod update;
+#[cfg(any(target_os = "linux", test))]
+mod webkitgtk;
 
 use tauri::RunEvent;
 
 fn main() {
+    #[cfg(target_os = "linux")]
+    webkitgtk::configure_environment();
+
     // Windows/WebView2: opening a native file dialog (or any window that takes the
     // foreground) makes Chromium's native window-occlusion tracker mark the webview
     // occluded and stop compositing to save power; on the return trip it fails to
@@ -77,6 +82,7 @@ fn main() {
             // Save an asset to a user-chosen destination + resolve an asset's
             // project-relative path to its absolute on-disk path (sc-8726).
             settings::save_asset_as,
+            settings::save_image_export,
             settings::resolve_asset_path,
             settings::list_credentials,
             settings::set_credential,

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -1033,6 +1033,48 @@ fn sanitized_start_dir(start_dir: Option<&str>) -> Option<PathBuf> {
     }
 }
 
+fn sanitized_export_filename(value: &str) -> String {
+    let trimmed = value.trim();
+    std::path::Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty() && *name != "." && *name != "..")
+        .unwrap_or("SceneWorks-export.png")
+        .to_owned()
+}
+
+/// Save a browser-generated image through the native dialog. WebKitGTK and
+/// WKWebView have inconsistent `<a download>` behavior for blob URLs, while this
+/// path gives every desktop platform the intended filename and a real save
+/// destination. The explicit size ceiling prevents an untrusted webview payload
+/// from causing an unbounded allocation in the shell.
+#[tauri::command]
+pub async fn save_image_export(
+    app: AppHandle,
+    image_bytes: Vec<u8>,
+    suggested_filename: String,
+) -> Result<Option<String>, String> {
+    const MAX_EXPORT_BYTES: usize = 256 * 1024 * 1024;
+    if image_bytes.is_empty() {
+        return Err("The exported image was empty.".to_owned());
+    }
+    if image_bytes.len() > MAX_EXPORT_BYTES {
+        return Err("The exported image exceeds the 256 MB desktop limit.".to_owned());
+    }
+
+    let destination = app
+        .dialog()
+        .file()
+        .set_file_name(sanitized_export_filename(&suggested_filename))
+        .blocking_save_file()
+        .and_then(|file| file.into_path().ok());
+    let Some(destination) = destination else {
+        return Ok(None);
+    };
+    std::fs::write(&destination, image_bytes).map_err(|error| error.to_string())?;
+    Ok(Some(destination.to_string_lossy().into_owned()))
+}
+
 /// Save an asset file to a user-chosen destination (sc-8726). Opens the native "save as"
 /// dialog pre-filled with `suggested_filename`, then copies the bytes from `source_path`
 /// to the chosen destination. `source_path` must be an already-resolved absolute path
@@ -1406,7 +1448,11 @@ mod tests {
             .iter()
             .filter_map(|value| value.as_str())
             .collect::<Vec<_>>();
-        for permission in ["allow-resolve-asset-path", "allow-save-asset-as"] {
+        for permission in [
+            "allow-resolve-asset-path",
+            "allow-save-asset-as",
+            "allow-save-image-export",
+        ] {
             assert!(
                 permissions.contains(&permission),
                 "capabilities/default.json is missing `{permission}` — the command would \
@@ -1470,6 +1516,16 @@ mod tests {
         assert_eq!(sanitized_start_dir(Some(&padded)), Some(dir.clone()));
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn export_filename_cannot_escape_the_save_dialog_name() {
+        assert_eq!(sanitized_export_filename("shot.png"), "shot.png");
+        assert_eq!(
+            sanitized_export_filename("../../outside.png"),
+            "outside.png"
+        );
+        assert_eq!(sanitized_export_filename("   "), "SceneWorks-export.png");
     }
 
     /// sc-8929 (F-127): the settings writer is atomic — the final file holds exactly

--- a/apps/desktop/src/webkitgtk.rs
+++ b/apps/desktop/src/webkitgtk.rs
@@ -1,0 +1,64 @@
+use std::ffi::OsStr;
+
+#[cfg(target_os = "linux")]
+const SCENEWORKS_DMABUF_OPT_IN: &str = "SCENEWORKS_WEBKIT_DMABUF";
+#[cfg(target_os = "linux")]
+const WEBKIT_DISABLE_DMABUF_RENDERER: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+
+fn opt_in_enabled(value: Option<&OsStr>) -> bool {
+    value
+        .and_then(OsStr::to_str)
+        .map(str::trim)
+        .is_some_and(|value| {
+            value.eq_ignore_ascii_case("1")
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("yes")
+                || value.eq_ignore_ascii_case("on")
+        })
+}
+
+pub(crate) fn should_disable_dmabuf(
+    sceneworks_opt_in: Option<&OsStr>,
+    existing_webkit_value: Option<&OsStr>,
+) -> bool {
+    existing_webkit_value.is_none() && !opt_in_enabled(sceneworks_opt_in)
+}
+
+/// Configure WebKitGTK before Tauri creates the webview. The DMA-BUF renderer is
+/// still driver/compositor-sensitive on the supported Ubuntu range and can yield
+/// blank canvases or black video. Prefer the broadly compatible renderer by
+/// default while preserving any explicit WebKit setting and providing an opt-in
+/// for users who have validated DMA-BUF on their stack.
+#[cfg(target_os = "linux")]
+pub(crate) fn configure_environment() {
+    if should_disable_dmabuf(
+        std::env::var_os(SCENEWORKS_DMABUF_OPT_IN).as_deref(),
+        std::env::var_os(WEBKIT_DISABLE_DMABUF_RENDERER).as_deref(),
+    ) {
+        std::env::set_var(WEBKIT_DISABLE_DMABUF_RENDERER, "1");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_disable_dmabuf;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn disables_dmabuf_by_default() {
+        assert!(should_disable_dmabuf(None, None));
+    }
+
+    #[test]
+    fn preserves_an_explicit_webkit_setting() {
+        assert!(!should_disable_dmabuf(None, Some(OsStr::new("custom"))));
+    }
+
+    #[test]
+    fn sceneworks_opt_in_accepts_common_truthy_values() {
+        for value in ["1", "true", "YES", "on"] {
+            assert!(!should_disable_dmabuf(Some(OsStr::new(value)), None));
+        }
+        assert!(should_disable_dmabuf(Some(OsStr::new("0")), None));
+    }
+}

--- a/apps/desktop/tauri.linux.conf.json
+++ b/apps/desktop/tauri.linux.conf.json
@@ -18,12 +18,13 @@
     ],
     "linux": {
       "appimage": {
-        "bundleMediaFramework": false
+        "bundleMediaFramework": true
       },
       "deb": {
         "depends": [
           "libwebkit2gtk-4.1-0",
-          "libgtk-3-0"
+          "libgtk-3-0",
+          "gstreamer1.0-libav"
         ]
       }
     }

--- a/apps/web/src/accessToken.js
+++ b/apps/web/src/accessToken.js
@@ -34,15 +34,27 @@ function storage() {
 
 // The persisted access token, or "" when none is stored / storage is unavailable.
 export function readAccessToken() {
-  return storage()?.getItem(ACCESS_TOKEN_KEY) ?? "";
+  try {
+    return storage()?.getItem(ACCESS_TOKEN_KEY) ?? "";
+  } catch {
+    return "";
+  }
 }
 
 // Persist the verified access token so it survives reloads (see threat-model note).
 export function storeAccessToken(token) {
-  storage()?.setItem(ACCESS_TOKEN_KEY, token);
+  try {
+    storage()?.setItem(ACCESS_TOKEN_KEY, token);
+  } catch {
+    // Storage may reject writes in private/restricted WebKit contexts.
+  }
 }
 
 // Forget the stored token (the "lock"/forget affordance re-shows the login gate).
 export function clearAccessToken() {
-  storage()?.removeItem(ACCESS_TOKEN_KEY);
+  try {
+    storage()?.removeItem(ACCESS_TOKEN_KEY);
+  } catch {
+    // Treat an unavailable store as already empty.
+  }
 }

--- a/apps/web/src/accessToken.test.js
+++ b/apps/web/src/accessToken.test.js
@@ -55,4 +55,25 @@ describe("accessToken (sc-8880)", () => {
     expect(readAccessToken()).toBe("");
     expect(() => clearAccessToken()).not.toThrow();
   });
+
+  it("degrades gracefully when individual storage operations throw", () => {
+    originalStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem() {
+          throw new Error("read denied");
+        },
+        setItem() {
+          throw new Error("quota exceeded");
+        },
+        removeItem() {
+          throw new Error("write denied");
+        },
+      },
+    });
+    expect(readAccessToken()).toBe("");
+    expect(() => storeAccessToken("x")).not.toThrow();
+    expect(() => clearAccessToken()).not.toThrow();
+  });
 });

--- a/apps/web/src/clipboard.js
+++ b/apps/web/src/clipboard.js
@@ -1,0 +1,39 @@
+// Clipboard writes are normally available in the secure Tauri webview context.
+// WebKitGTK can still deny navigator.clipboard (session policy / compositor
+// integration), so keep the user-gesture-compatible execCommand fallback.
+export async function writeClipboardText(
+  text,
+  {
+    clipboard = globalThis.navigator?.clipboard,
+    documentRef = globalThis.document,
+  } = {},
+) {
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the WebKit-compatible selection/copy path.
+    }
+  }
+
+  if (!documentRef?.body || typeof documentRef.execCommand !== "function") {
+    return false;
+  }
+  const textarea = documentRef.createElement("textarea");
+  textarea.value = text;
+  textarea.readOnly = true;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  documentRef.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+  try {
+    return documentRef.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}

--- a/apps/web/src/clipboard.test.js
+++ b/apps/web/src/clipboard.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { writeClipboardText } from "./clipboard.js";
+
+describe("writeClipboardText WebKit compatibility", () => {
+  it("uses the asynchronous Clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      writeClipboardText("hello", {
+        clipboard: { writeText },
+        documentRef: document,
+      }),
+    ).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to a selected textarea when WebKit denies clipboard access", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    const execCommand = vi.fn(() => true);
+    const documentRef = Object.create(document);
+    Object.defineProperty(documentRef, "body", { value: document.body });
+    documentRef.createElement = document.createElement.bind(document);
+    documentRef.execCommand = execCommand;
+
+    await expect(
+      writeClipboardText("fallback", {
+        clipboard: { writeText },
+        documentRef,
+      }),
+    ).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("reports failure when neither clipboard path is available", async () => {
+    await expect(
+      writeClipboardText("nope", {
+        clipboard: null,
+        documentRef: null,
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/web/src/components/assetMedia.test.jsx
+++ b/apps/web/src/components/assetMedia.test.jsx
@@ -122,6 +122,17 @@ describe("AssetMedia audio rendering (epic 13400 A5)", () => {
     expect(container.querySelector("video")).not.toBeNull();
   });
 
+  it("uses WebKit-safe inline metadata playback for generated MP4 video", async () => {
+    await act(() => root.render(<AssetMedia asset={videoAsset} />));
+    const video = container.querySelector("video");
+    expect(video).not.toBeNull();
+    expect(video.controls).toBe(true);
+    expect(video.muted).toBe(true);
+    expect(video.playsInline).toBe(true);
+    expect(video.preload).toBe("metadata");
+    expect(video.getAttribute("src")).toContain("clip.mp4");
+  });
+
   it("honors controls={false} so a custom transport can drive the element", async () => {
     await act(() => root.render(<AssetMedia asset={audioAsset} controls={false} />));
     const audio = container.querySelector("audio");

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -7,6 +7,7 @@ import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
 import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { appConfirm } from "../appConfirm.jsx";
+import { isDesktop, tauriInvoke } from "../runtime.js";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 import { assetUrl, assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { DatasetAddDialog } from "../components/DatasetAddDialog.jsx";
@@ -518,6 +519,61 @@ function cropOverlayRects(imgW, imgH, rect) {
 export const BLANK_CANVAS_MIN = 256;
 export const BLANK_CANVAS_MAX = 2048;
 export const BLANK_CANVAS_SIZES = [512, 768, 1024, 1536, 2048];
+// A conservative cross-WebKit ceiling. WebKitGTK builds and GPU drivers vary in
+// their exact canvas allocation limit; keeping both the longest side and total
+// area bounded prevents the silent transparent-canvas failure seen above these
+// values while retaining the largest normal SceneWorks generation size.
+export const EDITOR_CANVAS_MAX_SIDE = 4096;
+export const EDITOR_CANVAS_MAX_AREA =
+  EDITOR_CANVAS_MAX_SIDE * EDITOR_CANVAS_MAX_SIDE;
+
+export function boundedEditorCanvasDimensions(width, height) {
+  const sourceWidth = Math.max(1, Math.round(Number(width) || 0));
+  const sourceHeight = Math.max(1, Math.round(Number(height) || 0));
+  const sideScale = Math.min(
+    1,
+    EDITOR_CANVAS_MAX_SIDE / sourceWidth,
+    EDITOR_CANVAS_MAX_SIDE / sourceHeight,
+  );
+  const areaScale = Math.min(
+    1,
+    Math.sqrt(EDITOR_CANVAS_MAX_AREA / (sourceWidth * sourceHeight)),
+  );
+  const scale = Math.min(sideScale, areaScale);
+  return {
+    width: Math.max(1, Math.floor(sourceWidth * scale)),
+    height: Math.max(1, Math.floor(sourceHeight * scale)),
+    scaled: scale < 1,
+    sourceWidth,
+    sourceHeight,
+  };
+}
+
+export async function exportEditorFile(
+  file,
+  {
+    desktop = isDesktop,
+    invoke = tauriInvoke,
+    documentRef = globalThis.document,
+    urlApi = globalThis.URL,
+  } = {},
+) {
+  if (desktop) {
+    return invoke("save_image_export", {
+      imageBytes: Array.from(new Uint8Array(await file.arrayBuffer())),
+      suggestedFilename: file.name,
+    });
+  }
+  const url = urlApi.createObjectURL(file);
+  const anchor = documentRef.createElement("a");
+  anchor.href = url;
+  anchor.download = file.name;
+  documentRef.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  urlApi.revokeObjectURL(url);
+  return null;
+}
 
 // Snap a pixel dimension to a multiple of 16 within [256, 2048] (Ideogram limits).
 function snapCanvasDim(px) {
@@ -556,6 +612,52 @@ function blobToImage(blob) {
     };
     image.src = objectUrl;
   });
+}
+
+// Decode an editor source and, only when it exceeds the conservative WebKit
+// canvas ceiling, rasterize it directly into a bounded surface before any Konva
+// or export canvas is allocated. The caller owns the returned object URL.
+async function blobToEditorImage(blob) {
+  const decoded = await blobToImage(blob);
+  const dimensions = boundedEditorCanvasDimensions(
+    decoded.image.naturalWidth,
+    decoded.image.naturalHeight,
+  );
+  if (!dimensions.scaled) {
+    return { ...decoded, blob, downscaled: null };
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = dimensions.width;
+  canvas.height = dimensions.height;
+  let resizedBlob;
+  try {
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Could not create a 2D editor canvas.");
+    }
+    context.drawImage(
+      decoded.image,
+      0,
+      0,
+      dimensions.width,
+      dimensions.height,
+    );
+    resizedBlob = await new Promise((resolve) =>
+      canvas.toBlob(resolve, "image/png"),
+    );
+  } finally {
+    URL.revokeObjectURL(decoded.objectUrl);
+  }
+  if (!resizedBlob) {
+    throw new Error("Could not prepare this large image for the editor.");
+  }
+  const resized = await blobToImage(resizedBlob);
+  return {
+    ...resized,
+    blob: resizedBlob,
+    downscaled: dimensions,
+  };
 }
 
 // ── Undo/redo history (sc-6106) ────────────────────────────────────────────
@@ -1419,8 +1521,16 @@ export function ImageEditor() {
     async (blob, source) => {
       setStatus({ loading: true, error: "" });
       try {
-        const { image, objectUrl } = await blobToImage(blob);
-        installWorkingImage(image, objectUrl, blob, source);
+        const prepared = await blobToEditorImage(blob);
+        const preparedSource = prepared.downscaled
+          ? { ...source, editorDownscaled: prepared.downscaled }
+          : source;
+        installWorkingImage(
+          prepared.image,
+          prepared.objectUrl,
+          prepared.blob,
+          preparedSource,
+        );
         // A freshly opened image is a clean session — clear edit/provenance state
         // and start a fresh undo/redo history rooted at this bitmap (sc-6106).
         setEdits([]);
@@ -2271,15 +2381,28 @@ export function ImageEditor() {
         const res = await fetch(assetUrl(resultAsset));
         if (!res.ok) throw new Error(`Failed to load result (${res.status})`);
         const blob = await res.blob();
-        const { image, objectUrl } = await blobToImage(blob);
+        const prepared = await blobToEditorImage(blob);
         checkpoint();
         // Active-layer op (same-size edit / detail) → write the result back into the
         // target layer, preserving the rest of the stack; document op (upscale /
         // outpaint / box edit) → flatten the stack into one new base layer (sc-6119).
         if (writeBack === "activeLayer" && targetLayerId && layerById(workingRef.current, targetLayerId)) {
-          replaceLayerImage(targetLayerId, image, objectUrl, blob);
+          replaceLayerImage(
+            targetLayerId,
+            prepared.image,
+            prepared.objectUrl,
+            prepared.blob,
+          );
         } else {
-          installWorkingImage(image, objectUrl, blob, source);
+          const preparedSource = prepared.downscaled
+            ? { ...source, editorDownscaled: prepared.downscaled }
+            : source;
+          installWorkingImage(
+            prepared.image,
+            prepared.objectUrl,
+            prepared.blob,
+            preparedSource,
+          );
         }
         if (edit) setEdits((prev) => [...prev, edit]);
         setDirty(true);
@@ -2330,14 +2453,7 @@ export function ImageEditor() {
     if (!working) return;
     try {
       const file = await workingImageToFile(editedFilename(working.source));
-      const url = URL.createObjectURL(file);
-      const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.download = file.name;
-      document.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-      URL.revokeObjectURL(url);
+      await exportEditorFile(file);
     } catch (err) {
       setStatus({ loading: false, error: `Could not export: ${err.message || err}` });
     }
@@ -3949,6 +4065,20 @@ export function ImageEditor() {
           <div className="ie-hint">
             {EDITOR_TOOL_ICONS[tool]}
             <span>{toolHint}</span>
+          </div>
+        ) : null}
+        {working?.source?.editorDownscaled ? (
+          <div
+            className="ie-hint"
+            role="status"
+            style={{ top: "58px", borderColor: "color-mix(in srgb, var(--ie-warn) 55%, var(--ie-border))" }}
+          >
+            <span>
+              Large source scaled from{" "}
+              {working.source.editorDownscaled.sourceWidth} x{" "}
+              {working.source.editorDownscaled.sourceHeight} to {working.width} x{" "}
+              {working.height} for reliable WebKit editing and export.
+            </span>
           </div>
         ) : null}
         {working && stageSize.width > 0 && stageSize.height > 0 ? (

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -59,6 +59,10 @@ import {
   boxMetadataGaps,
   blankCanvasDims,
   BLANK_CANVAS_SIZES,
+  boundedEditorCanvasDimensions,
+  EDITOR_CANVAS_MAX_AREA,
+  EDITOR_CANVAS_MAX_SIDE,
+  exportEditorFile,
   paintBoxesOnContext,
   colorName,
   composeColorPrompt,
@@ -422,6 +426,78 @@ describe("Close/Discard + unsaved indicator logic (sc-11968)", () => {
     expect(saveStatusIndicator({ dirty: false, savedAssetId: null })).toBeNull();
     // A dirty edit made after a Save reads as unsaved again, not "saved".
     expect(saveStatusIndicator({ dirty: true, savedAssetId: "asset-9" })).toBe("unsaved");
+  });
+});
+
+describe("WebKit-safe editor canvas and export (sc-10380)", () => {
+  it("keeps ordinary images at their source dimensions", () => {
+    expect(boundedEditorCanvasDimensions(2048, 1536)).toEqual({
+      width: 2048,
+      height: 1536,
+      scaled: false,
+      sourceWidth: 2048,
+      sourceHeight: 1536,
+    });
+  });
+
+  it("preserves the supported 4096-square boundary without resampling", () => {
+    expect(boundedEditorCanvasDimensions(4096, 4096)).toEqual({
+      width: 4096,
+      height: 4096,
+      scaled: false,
+      sourceWidth: 4096,
+      sourceHeight: 4096,
+    });
+    expect(EDITOR_CANVAS_MAX_AREA).toBe(4096 * 4096);
+  });
+
+  it("bounds both the longest side and total area while preserving aspect", () => {
+    const wide = boundedEditorCanvasDimensions(8192, 4096);
+    expect(wide.scaled).toBe(true);
+    expect(wide.width).toBeLessThanOrEqual(EDITOR_CANVAS_MAX_SIDE);
+    expect(wide.height).toBeLessThanOrEqual(EDITOR_CANVAS_MAX_SIDE);
+    expect(wide.width * wide.height).toBeLessThanOrEqual(EDITOR_CANVAS_MAX_AREA);
+    expect(wide.width / wide.height).toBeCloseTo(2, 2);
+
+    const square = boundedEditorCanvasDimensions(5000, 5000);
+    expect(square.width * square.height).toBeLessThanOrEqual(EDITOR_CANVAS_MAX_AREA);
+    expect(square.width).toBe(square.height);
+  });
+
+  it("routes desktop-generated PNG bytes through the native save command", async () => {
+    const file = {
+      name: "shot-edited.png",
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    };
+    const invoke = vi.fn().mockResolvedValue("/tmp/shot-edited.png");
+    await expect(
+      exportEditorFile(file, { desktop: true, invoke }),
+    ).resolves.toBe("/tmp/shot-edited.png");
+    expect(invoke).toHaveBeenCalledWith("save_image_export", {
+      imageBytes: [1, 2, 3],
+      suggestedFilename: "shot-edited.png",
+    });
+  });
+
+  it("retains browser download behavior outside the desktop shell", async () => {
+    const file = new File(["png"], "shot.png", { type: "image/png" });
+    const click = vi
+      .spyOn(window.HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    const urlApi = {
+      createObjectURL: vi.fn(() => "blob:test"),
+      revokeObjectURL: vi.fn(),
+    };
+    await expect(
+      exportEditorFile(file, {
+        desktop: false,
+        documentRef: document,
+        urlApi,
+      }),
+    ).resolves.toBeNull();
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(urlApi.revokeObjectURL).toHaveBeenCalledWith("blob:test");
+    expect(document.querySelector("a[download]")).toBeNull();
   });
 });
 

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -14,6 +14,7 @@ import {
   readDefaultGenerationQuality,
   writeDefaultGenerationQuality,
 } from "../generationQuality.js";
+import { writeClipboardText } from "../clipboard.js";
 
 // The data-dir / GPU / worker / wizard / remote-access controls are desktop-only
 // (backed by Tauri commands in the shell) and are gated behind `isDesktop` so a
@@ -283,10 +284,9 @@ export function SettingsScreen() {
     if (!remote?.url) {
       return;
     }
-    try {
-      await navigator.clipboard.writeText(remote.url);
+    if (await writeClipboardText(remote.url)) {
       setStatus(`Copied ${remote.url}`);
-    } catch {
+    } else {
       setStatus("Couldn't copy to clipboard.");
     }
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -9178,7 +9178,7 @@ details[open] > summary.lora-scope-group-heading::before,
 .ie-hint svg { width: 15px; height: 15px; flex: 0 0 auto; }
 .ie-hint b { color: var(--ie-text); font-weight: 600; }
 
-.ie-busy { position: absolute; inset: 0; display: grid; place-items: center; background: color-mix(in srgb, var(--ie-bg) 55%, transparent); backdrop-filter: blur(2px); z-index: 6; }
+.ie-busy { position: absolute; inset: 0; display: grid; place-items: center; background: color-mix(in srgb, var(--ie-bg) 55%, transparent); -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px); z-index: 6; }
 .ie-busy-card { width: 300px; padding: 20px; background: var(--ie-surface); border: 1px solid var(--ie-border); border-radius: 14px; box-shadow: var(--ie-shadow-lg); text-align: center; }
 .ie-busy-title { font-weight: 600; margin: 0 0 4px; }
 .ie-busy-msg { font-size: 12.5px; color: var(--ie-muted); margin: 0 0 14px; }


### PR DESCRIPTION
## Summary

- default Linux WebKitGTK to the compatible non-DMA-BUF renderer with a documented opt-in
- bound oversized editor canvases while preserving the supported 4096-square boundary; use native desktop export and WebKit-safe clipboard fallback
- pin drag-drop, blur, MP4 playback, token-storage, canvas, export, and Linux configuration behavior with regression coverage

## Validation

- npm --prefix apps/web test (158 files, 2295 tests)
- npm --prefix apps/web run lint -- --quiet
- npm --prefix apps/web run build
- npm --prefix apps/desktop test (12 tests)
- cargo test -p sceneworks-desktop (88 passed, 2 ignored network smokes)
- cargo clippy -p sceneworks-desktop --all-targets -- -D warnings
- cargo fmt --all -- --check
- independent review cycle 1: one 4096-square boundary regression found and fixed
- independent review cycle 2: PASS (high confidence)

Native Ubuntu 22.04/24.04 WSLg bundle launch and visual/interaction validation is owned by the epic coordinator before merge.

Shortcut: https://app.shortcut.com/trefry/story/10380