### PR TITLE
chore: bump inference to cc5a1cf for Krea turbo-LoRA load fix [sc-14163]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "core-llm",
  "half",
@@ -4567,7 +4567,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5922,7 +5922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5979,7 +5979,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=2c8037e523df3a66aa31720f98958f646a89e8d9#2c8037e523df3a66aa31720f98958f646a89e8d9"
+source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -7323,7 +7323,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8480,7 +8480,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1" }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "2c8037e523df3a66aa31720f98958f646a89e8d9", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with


### PR DESCRIPTION
## What

Bumps the SceneWorks inference pin to **`cc5a1cf654f20cf6a78b517d104c3c2893c932f1`** (inference `main` HEAD), delivering the **Krea turbo-LoRA load fix (sc-14163)** into the product. This is the fix that adds the 7 native global-projection adapter aliases so the turbo LoRA `krea2_turbo_accel` actually LOADS onto imported single-file Krea 2 checkpoints — without it, shipped turbo-on-Raw and multi-phase render paths fail to load the adapter. Already render-proven on this Mac against the fixed inference build.

All four lockstep pin sites move together (via `scripts/bump-inference.mjs`):
- `crates/sceneworks-worker/Cargo.toml`: `sceneworks-gen-core`, `runtime-macos`, `runtime-cuda`
- root `Cargo.toml`: `[patch]` `candle-kernels`

`Cargo.lock` re-generated. `check-gen-core-skew.sh` confirms exactly one `sceneworks-gen-core` and one `pmetal-mlx-rs` resolution (no fork skew).

## Intervening inference commits

The base pin this PR replaces was already at `2c8037e` on `main` (origin/main advanced past the older `620cb2e` the task referenced), so this bump adds two of the four expected commits; the other two were already in the tree:

- **sc-14163** (this bump): `fix(krea): resolve 7 native global-projection adapter targets` + real-transformer additive-surface test — the turbo-LoRA load fix. Touches krea provider internals only (`candle-gen-krea` adapters/transformer, `mlx-gen-krea` transformer); no public signature change.
- **sc-13570** (this bump): `fix(moss-tts-realtime): restore reference delay-pattern text conditioning` — audio-only, no SceneWorks call-site impact.
- **sc-14119** (already in `2c8037e`): threaded adapters through the MLX native single-file loader — the `&[AdapterSpec]` signature change to `load_from_native_dit_file`.
- **sc-14023** (already in `2c8037e`): int8 single-row scalar-scale acceptance.

## Call-site status (sc-14119)

Because origin/main already pinned `2c8037e` (which includes sc-14119), the `krea_imported.rs` call site was **already correct** on `main` — no change was needed here:
- **MLX** (`runtime_macos`, 4-arg): passes the job's resolved `&adapters` (from `resolve_krea_imported_adapters_and_edit` — the sc-14111 LoRA/LoKr stack + sc-14119 edit adapters). This is the semantically correct value: it is exactly the adapter stack the turbo LoRA rides in on, which sc-14163 makes resolve.
- **candle** (`runtime_cuda`, 3-arg): the candle native loader takes no adapters (the candle imported lane is t2i/img2img-only, sc-14135), so the 3-arg call is correct.

`cargo build -p sceneworks-worker` is clean against the new pin, empirically confirming no call-site breakage anywhere.

## Verification

- `cargo build -p sceneworks-worker` — clean
- `cargo clippy -p sceneworks-worker --lib --tests -- -D warnings` — clean (exit 0)
- Krea routing tests pass: `krea_turbo_on_raw_routes_only_with_accelerator_lora`, `krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime`, `krea_multiphase_routes_only_with_phases_and_takes_precedence_over_turbo`, `multiphase_parses_and_maps_to_gen_core_phases`, `resolve_image_route_sends_imported_single_file_krea_to_the_bespoke_lane`, plus the krea_imported unit tests (real-weight GPU smoke stays `#[ignore]` by design)
- `cargo fmt` on the committed change is clean (manifest/lock only)

Web/parity untouched by this change.

sc-14163

🤖 Generated with [Claude Code](https://claude.com/claude-code)
