### PR TITLE
ci(desktop): publish signed Linux releases [sc-10382]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
 name: Release (desktop)
 
 # Builds, signs, notarizes, staples, and publishes a DRAFT GitHub Release of the
-# desktop app when a `v*` tag is pushed (or via manual dispatch). Two jobs attach to
+# desktop app when a `v*` tag is pushed (or via manual dispatch). Three jobs attach to
 # the SAME draft release:
 #   macos   — signs + notarizes the .app via the APPLE_* env (from repo secrets),
 #             then staple-dmg.mjs staples the DMG; CREATES the draft release.
 #   windows — builds the candle/CUDA NSIS + MSI installers and UPLOADS them to the
 #             release the macos job created (needs: macos). Mirrors the build steps in
 #             desktop-windows.yml; keep the two in sync when either changes.
+#   linux   — builds the candle/CUDA AppImage + deb and UPLOADS them to that draft
+#             (needs: windows, which also serializes latest.json platform merges).
+#             Mirrors desktop-linux.yml; keep the two in sync when either changes.
 # Mirrors the local mac flow (`npm run release:mac`): `tauri build` signs + notarizes
 # the .app, then staple-dmg.mjs staples the DMG.
 #
@@ -194,7 +197,10 @@ jobs:
             'Signed & notarized build. Open the DMG and drag SceneWorks to Applications.' \
             '' \
             '## Windows (CUDA GPU)' \
-            'Run the .msi installer. Requires an NVIDIA GPU; the CUDA/cuDNN runtime is downloaded on first launch.')
+            'Run the .msi installer. Requires an NVIDIA GPU; the CUDA/cuDNN runtime is downloaded on first launch.' \
+            '' \
+            '## Linux x86_64 (CUDA GPU)' \
+            'Run the AppImage or install the .deb on Ubuntu 22.04/24.04. Requires an NVIDIA GPU; the CUDA/cuDNN runtime is downloaded on first launch.')
           args=(--draft --generate-notes --title "SceneWorks $TAG" --notes "$notes")
           case "$TAG" in *-*) args+=(--prerelease) ;; esac
           # Attach the DMG (fresh install) + the updater tarball (in-app update payload).
@@ -356,6 +362,140 @@ jobs:
           gh release download "$TAG" -p latest.json --clobber
           node apps/desktop/scripts/build-update-manifest.mjs \
             --target windows-x86_64 \
+            --version "${TAG#v}" \
+            --url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${payload_name}" \
+            --sig "$sig" \
+            --in latest.json \
+            --out latest.json
+          gh release upload "$TAG" --clobber latest.json
+
+  linux:
+    # Attach the Linux packages after Windows has merged its updater entry.
+    # Serializing the latest.json read/modify/write prevents platform entries
+    # from clobbering one another. Build steps mirror desktop-linux.yml.
+    needs: windows
+    if: ${{ github.repository == 'SceneWorks/SceneWorks' }}
+    runs-on: ubuntu-22.04
+    env:
+      # Build-side constant, not a secret. Keep this and the CUDA pin aligned
+      # with desktop-linux.yml, server-candle-linux.yml, and Windows.
+      CUDA_COMPUTE_CAP: "80"
+      CARGO_NET_OFFLINE: "true"
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            apps/web/package-lock.json
+            apps/desktop/package-lock.json
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+
+      # Match the manual Linux packaging lane. gstreamer1.0-libav supplies H.264
+      # decoding for WebKitGTK media playback on stock Ubuntu.
+      - name: Install GTK, WebKitGTK, and media dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            build-essential \
+            curl \
+            file \
+            gstreamer1.0-libav \
+            libayatana-appindicator3-dev \
+            libfuse2 \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            wget
+
+      - name: Fetch the private inference release
+        env:
+          CARGO_NET_OFFLINE: "false"
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
+          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
+        run: cargo fetch --locked
+
+      - name: Install CUDA Toolkit 12.9
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
+        with:
+          cuda: "12.9.1"
+          method: "network"
+          linux-local-args: '["--toolkit"]'
+
+      - name: Guard against gen-core version skew (candle)
+        run: |
+          bash scripts/check-gen-core-skew.sh --self-test
+          bash scripts/check-gen-core-skew.sh sceneworks-worker --features backend-candle
+          bash scripts/check-gen-core-skew.sh sceneworks-rust-api --features embed-web,backend-candle
+
+      # Keep install-time lifecycle scripts disabled on the signing lane. The
+      # updater private key is absent here and scoped only to the bundle step.
+      - name: Install web and desktop dependencies
+        run: |
+          npm ci --prefix apps/web --ignore-scripts
+          npm ci --prefix apps/desktop --ignore-scripts
+
+      - name: Validate desktop bundle configuration
+        run: npm --prefix apps/desktop test
+
+      # createUpdaterArtifacts emits the signed AppImage update payload beside
+      # the normal AppImage and deb. Only this step receives the minisign key.
+      - name: Build Linux candle packages + signed AppImage updater
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npm --prefix apps/desktop run build -- --bundles appimage,deb --config updater.release.conf.json
+
+      - name: Guard against NC model weights in the desktop bundle (sc-10526, sc-10551)
+        run: node scripts/check-no-nc-weights.mjs --dir target/release/bundle --scan-archives --skip-uninspectable
+
+      - name: Attach Linux packages + merge updater manifest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          shopt -s nullglob
+          appimages=(target/release/bundle/appimage/*.AppImage)
+          debs=(target/release/bundle/deb/*.deb)
+          if [ ${#appimages[@]} -eq 0 ] || [ ${#debs[@]} -eq 0 ]; then
+            echo "Expected an AppImage and deb under target/release/bundle/{appimage,deb}/" >&2
+            exit 1
+          fi
+          packages=("${appimages[@]}" "${debs[@]}")
+          sigs=(target/release/bundle/appimage/*.sig)
+          if [ ${#sigs[@]} -eq 0 ]; then
+            echo "No AppImage updater signature under target/release/bundle/appimage/*.sig" >&2
+            exit 1
+          fi
+          sig="${sigs[0]}"
+          payload="${sig%.sig}"
+          if [ ! -f "$payload" ]; then
+            echo "Signed AppImage updater payload is missing: $payload" >&2
+            exit 1
+          fi
+          payload_name="$(basename "$payload")"
+
+          gh release upload "$TAG" --clobber "${packages[@]}"
+          case " ${packages[*]} " in
+            *" $payload "*) : ;;  # the signed updater payload is the AppImage itself
+            *) gh release upload "$TAG" --clobber "$payload" ;;
+          esac
+
+          # Windows already merged its entry; add Linux last so the published
+          # manifest contains all three supported desktop targets.
+          gh release download "$TAG" -p latest.json --clobber
+          node apps/desktop/scripts/build-update-manifest.mjs \
+            --target linux-x86_64 \
             --version "${TAG#v}" \
             --url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${payload_name}" \
             --sig "$sig" \

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -123,7 +123,12 @@ Choose either Linux x86_64 package:
   `libwebkit2gtk-4.1-0` and `libgtk-3-0` runtime dependencies.
 - Make the AppImage executable with `chmod +x SceneWorks_*.AppImage`, then run
   it directly. The AppImage carries its GTK/WebKitGTK runtime and does not
-  require a package-manager install.
+  require a package-manager install. Release AppImages participate in the same
+  signed in-app auto-update flow as the macOS and Windows builds.
+
+The `.deb` does **not** self-update. Until SceneWorks publishes an APT repository,
+install a newer `.deb` from the GitHub release when upgrading; installing it over
+an existing package preserves the per-user SceneWorks data directories.
 
 Both packages require an NVIDIA driver, but not a system CUDA toolkit. SceneWorks
 downloads its pinned CUDA user-space runtime on first launch.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
     "dev": "tauri dev",
     "build": "tauri build",
     "build:linux": "tauri build --bundles appimage,deb",
-    "test": "node --test scripts/build-sidecar-platform.test.mjs scripts/linux-bundle-config.test.mjs",
+    "test": "node --test scripts/build-sidecar-platform.test.mjs scripts/build-update-manifest.test.mjs scripts/linux-bundle-config.test.mjs",
     "release:mac": "tauri build && node scripts/staple-dmg.mjs"
   },
   "devDependencies": {

--- a/apps/desktop/scripts/build-update-manifest.mjs
+++ b/apps/desktop/scripts/build-update-manifest.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 // Builds (or merges into) the Tauri updater manifest `latest.json` (sc-1355).
 //
-// The macOS and Windows release jobs build on separate runners, so neither can
-// produce a complete manifest alone. The macOS job runs this in "init" mode to
-// create latest.json with its `darwin-aarch64` entry; the Windows job (which
-// `needs: macos`) downloads that file and runs this again with `--in` to merge in
-// its `windows-x86_64` entry. The result is uploaded to the GitHub Release and
+// The platform release jobs build on separate runners, so none can produce the
+// complete manifest alone. macOS initializes `darwin-aarch64`, Windows (which
+// `needs: macos`) merges `windows-x86_64`, and Linux (which `needs: windows`)
+// merges `linux-x86_64`. Those dependencies serialize the manifest's
+// read/modify/write sequence. The result is uploaded to the GitHub Release and
 // served at plugins.updater.endpoints (…/releases/latest/download/latest.json).
 //
 // The per-platform `signature` is the CONTENTS of the `.sig` file emitted next to
@@ -54,6 +54,22 @@ if (!signature) {
 let manifest;
 if (args.in && existsSync(args.in)) {
   manifest = JSON.parse(readFileSync(args.in, "utf8"));
+  if (manifest.version !== args.version) {
+    console.error(
+      `build-update-manifest: input version ${manifest.version ?? "(missing)"} ` +
+        `does not match requested version ${args.version}`,
+    );
+    process.exit(1);
+  }
+  if (
+    manifest.platforms !== undefined &&
+    (manifest.platforms === null ||
+      typeof manifest.platforms !== "object" ||
+      Array.isArray(manifest.platforms))
+  ) {
+    console.error("build-update-manifest: input platforms must be an object");
+    process.exit(1);
+  }
   manifest.platforms ??= {};
 } else {
   manifest = {

--- a/apps/desktop/scripts/build-update-manifest.test.mjs
+++ b/apps/desktop/scripts/build-update-manifest.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const script = join(scriptsDir, "build-update-manifest.mjs");
+
+function runManifest(args) {
+  return spawnSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+  });
+}
+
+test("merges a signed linux-x86_64 updater without losing existing platforms", (t) => {
+  const tempDir = mkdtempSync(join(os.tmpdir(), "sceneworks-updater-test-"));
+  t.after(() => rmSync(tempDir, { recursive: true }));
+  const input = join(tempDir, "latest.json");
+  const output = join(tempDir, "merged.json");
+  const signature = join(tempDir, "SceneWorks.AppImage.tar.gz.sig");
+  writeFileSync(
+    input,
+    JSON.stringify({
+      version: "0.8.1",
+      notes: "SceneWorks v0.8.1",
+      pub_date: "2026-07-23T00:00:00.000Z",
+      platforms: {
+        "darwin-aarch64": { signature: "mac-signature", url: "https://mac" },
+        "windows-x86_64": {
+          signature: "windows-signature",
+          url: "https://windows",
+        },
+      },
+    }),
+  );
+  writeFileSync(signature, "linux-signature\n");
+
+  const result = runManifest([
+    "--target",
+    "linux-x86_64",
+    "--version",
+    "0.8.1",
+    "--url",
+    "https://github.com/SceneWorks/SceneWorks/releases/download/v0.8.1/SceneWorks.AppImage.tar.gz",
+    "--sig",
+    signature,
+    "--in",
+    input,
+    "--out",
+    output,
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(manifest.version, "0.8.1");
+  assert.equal(manifest.notes, "SceneWorks v0.8.1");
+  assert.equal(Object.keys(manifest.platforms).length, 3);
+  assert.deepEqual(manifest.platforms["linux-x86_64"], {
+    signature: "linux-signature",
+    url: "https://github.com/SceneWorks/SceneWorks/releases/download/v0.8.1/SceneWorks.AppImage.tar.gz",
+  });
+  assert.equal(
+    manifest.platforms["darwin-aarch64"].signature,
+    "mac-signature",
+  );
+  assert.equal(
+    manifest.platforms["windows-x86_64"].signature,
+    "windows-signature",
+  );
+});
+
+test("refuses to merge a platform into a manifest from another version", (t) => {
+  const tempDir = mkdtempSync(join(os.tmpdir(), "sceneworks-updater-test-"));
+  t.after(() => rmSync(tempDir, { recursive: true }));
+  const input = join(tempDir, "latest.json");
+  const output = join(tempDir, "merged.json");
+  const signature = join(tempDir, "payload.sig");
+  writeFileSync(
+    input,
+    JSON.stringify({ version: "0.8.0", platforms: {} }),
+  );
+  writeFileSync(signature, "linux-signature\n");
+
+  const result = runManifest([
+    "--target",
+    "linux-x86_64",
+    "--version",
+    "0.8.1",
+    "--url",
+    "https://example.invalid/update",
+    "--sig",
+    signature,
+    "--in",
+    input,
+    "--out",
+    output,
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /input version 0\.8\.0.*requested version 0\.8\.1/);
+});

--- a/apps/desktop/scripts/linux-bundle-config.test.mjs
+++ b/apps/desktop/scripts/linux-bundle-config.test.mjs
@@ -38,6 +38,7 @@ const macosOverlay = readJson("tauri.macos.conf.json");
 const packageJson = readJson("package.json");
 const tauriSchema = readJson("node_modules/@tauri-apps/cli/config.schema.json");
 const desktopReadme = readFileSync(join(desktopDir, "README.md"), "utf8");
+const updaterSource = readFileSync(join(desktopDir, "src", "update.rs"), "utf8");
 
 test("the Linux overlay is valid against the locked Tauri v2 schema", () => {
   // Tauri's schema intentionally escapes `:` in a character class. Node 24's
@@ -104,6 +105,14 @@ test("the AppImage WebKitGTK and media-framework decision is explicit", () => {
   );
   assert.match(desktopReadme, /AppImage carries its GTK\/WebKitGTK runtime/);
   assert.match(desktopReadme, /bundleMediaFramework: false/);
+});
+
+test("Linux release update behavior is explicit for each package format", () => {
+  assert.match(desktopReadme, /Release AppImages.*signed in-app auto-update/s);
+  assert.match(desktopReadme, /The `\.deb` does \*\*not\*\* self-update/);
+  assert.match(desktopReadme, /APT repository/);
+  assert.match(updaterSource, /target_os = "linux"/);
+  assert.match(updaterSource, /var_os\("APPIMAGE"\)\.is_none\(\)/);
 });
 
 test("the Linux overlay does not regress macOS or Windows bundle config", () => {

--- a/apps/desktop/src/update.rs
+++ b/apps/desktop/src/update.rs
@@ -3,10 +3,11 @@
 //! On launch the release build asks the GitHub "latest release" pointer
 //! (`plugins.updater.endpoints` in `tauri.conf.json`) whether a newer build
 //! exists for this platform. The endpoint serves a `latest.json` manifest with a
-//! per-target `platforms` map; `tauri-plugin-updater` picks `darwin-aarch64` /
-//! `windows-x86_64` for the running build, verifies the minisign signature against
-//! `plugins.updater.pubkey`, and — on user accept — downloads, installs, and
-//! restarts into the new version.
+//! per-target `platforms` map; `tauri-plugin-updater` picks `darwin-aarch64`,
+//! `windows-x86_64`, or `linux-x86_64` for the running build, verifies the minisign
+//! signature against `plugins.updater.pubkey`, and — on user accept — downloads,
+//! installs, and restarts into the new version. Linux self-update is supported by
+//! the AppImage release; `.deb` users upgrade through their package installer.
 //!
 //! Driven entirely from the Rust shell: the UI is the API-served React app at a
 //! loopback `http://127.0.0.1:<port>` origin, so a JS-side updater would need ACL
@@ -22,6 +23,14 @@ use tauri_plugin_updater::{Update, UpdaterExt};
 /// where the running version is the dev build and no signed bundle exists to swap.
 pub fn spawn_startup_check(app: &AppHandle) {
     if cfg!(debug_assertions) {
+        return;
+    }
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("APPIMAGE").is_none() {
+        // Tauri's Linux updater replaces the running AppImage in place. A deb
+        // install has no equivalent transaction (that requires an APT repo), so
+        // do not offer an update the package cannot safely install.
+        tracing::info!("auto-update: disabled for non-AppImage Linux package");
         return;
     }
     let app = app.clone();

--- a/docs/packaging-nc-weights-guard.md
+++ b/docs/packaging-nc-weights-guard.md
@@ -193,10 +193,12 @@ path is still flagged.
 - **`.github/workflows/check.yml`** (every PR): runs `--self-test` (which now also
   exercises the archive-scan positive/negative/bomb cases) then the default scan over
   the Docker build context / Tauri resource trees.
-- **`.github/workflows/release.yml`** (desktop release, macOS + Windows): scans the
+- **`.github/workflows/release.yml`** (desktop release, macOS + Windows + Linux): scans the
   freshly-built `target/release/bundle` tree before signing/publishing with
   `--scan-archives --skip-uninspectable` — the real-artifact form of the check, which
-  additionally decompresses the `*.app.tar.gz` / `*.nsis.zip` updater payloads.
+  additionally decompresses the `*.app.tar.gz` / `*.nsis.zip` updater payloads. The
+  AppImage is opaque to this pure-JS scanner, so its loose pre-bundle resource tree and
+  the always-on source-resource scan provide the same protection as for MSI/NSIS.
 
 ## Known limitation
 

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -101,6 +101,70 @@ async function assertDesktopLinuxPackagingWorkflow() {
   }
 }
 
+async function assertDesktopLinuxReleaseWorkflow() {
+  const workflowPath = ".github/workflows/release.yml";
+  const body = await readFile(path.join(root, workflowPath), "utf8");
+  const packageBody = await readFile(
+    path.join(root, ".github/workflows/desktop-linux.yml"),
+    "utf8",
+  );
+  const linuxJob = body.match(/\n  linux:\n([\s\S]*)$/)?.[1];
+  if (!linuxJob) {
+    throw new Error(`${workflowPath} must define a Linux release job`);
+  }
+
+  for (const field of [
+    "needs: windows",
+    "runs-on: ubuntu-22.04",
+    "gstreamer1.0-libav",
+    "scripts/check-gen-core-skew.sh --self-test",
+    "sceneworks-worker --features backend-candle",
+    "sceneworks-rust-api --features embed-web,backend-candle",
+    "--bundles appimage,deb --config updater.release.conf.json",
+    "target/release/bundle/appimage/*.AppImage",
+    "target/release/bundle/deb/*.deb",
+    "--target linux-x86_64",
+    "gh release upload",
+    "gh release download",
+  ]) {
+    if (!linuxJob.includes(field)) {
+      throw new Error(
+        `${workflowPath} Linux release job is missing required contract: ${field}`,
+      );
+    }
+  }
+
+  const cudaPin = linuxJob.match(/^\s+cuda:\s*"([^"]+)"/m)?.[1];
+  const packageCudaPin = packageBody.match(/^\s+cuda:\s*"([^"]+)"/m)?.[1];
+  const cudaAction = linuxJob.match(/uses:\s*Jimver\/cuda-toolkit@(\S+)/)?.[1];
+  const packageCudaAction = packageBody.match(
+    /uses:\s*Jimver\/cuda-toolkit@(\S+)/,
+  )?.[1];
+  if (cudaPin !== packageCudaPin || cudaAction !== packageCudaAction) {
+    throw new Error(
+      `${workflowPath} Linux release CUDA action/version must match desktop-linux.yml`,
+    );
+  }
+
+  const signingStep = linuxJob.match(
+    /- name: Build Linux candle packages \+ signed AppImage updater([\s\S]*?)(?=\n      - name:)/,
+  )?.[0];
+  if (
+    !signingStep?.includes("TAURI_SIGNING_PRIVATE_KEY:") ||
+    !signingStep.includes("TAURI_SIGNING_PRIVATE_KEY_PASSWORD:")
+  ) {
+    throw new Error(
+      `${workflowPath} Linux updater key must be scoped to the bundle step`,
+    );
+  }
+  const outsideSigningStep = linuxJob.replace(signingStep, "");
+  if (outsideSigningStep.includes("secrets.TAURI_SIGNING_PRIVATE_KEY")) {
+    throw new Error(
+      `${workflowPath} Linux updater key must never be job-wide or visible to other steps`,
+    );
+  }
+}
+
 const manifestSchemaPaths = [
   "packages/schemas/model-manifest.schema.json",
   "packages/schemas/lora-manifest.schema.json",
@@ -484,6 +548,7 @@ await assertManifestSchemaReferences();
 await assertManifestRootsMatchSchemas();
 await assertVersionsAligned();
 await assertDesktopLinuxPackagingWorkflow();
+await assertDesktopLinuxReleaseWorkflow();
 await assertBuiltinPromptGuides();
 await assertCharacterImageTuningSurface();
 await assertEntitlementsPlistsWellFormed();


### PR DESCRIPTION
Closes sc-10382. Adds the Ubuntu 22.04/CUDA Linux release job after Windows so AppImage and deb assets attach to the shared draft and latest.json merges linux-x86_64 without a write race. The AppImage uses Tauri signed updater artifacts; non-AppImage Linux installs skip the updater and the README documents manual deb upgrades. TAURI_SIGNING_PRIVATE_KEY is scoped only to the bundle step. Validation: desktop Node tests 14/14, npm run check, PyYAML parse, bash syntax for every Linux run step, cargo fmt, cargo check with generated bundle resources omitted, git diff --check, and fresh independent review PASS (high confidence). Live tag-driven hosted CUDA packaging and draft publication remain release-run validation.