### PR TITLE
feat(desktop): enforce Linux GPU support matrix [sc-10383]

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -33,9 +33,9 @@ engine is linked into the app, so first run starts straight on the native engine
 
 ## Hardware requirements
 
-SceneWorks generation is GPU-only on both platforms. **There is no CPU or AMD
-fallback** — a machine without a supported GPU can run the app shell but cannot
-generate.
+SceneWorks generation is GPU-only on every platform. **There is no CPU
+fallback.** Linux and Windows v1 require NVIDIA/CUDA; AMD/ROCm support is
+tracked separately in Shortcut epic 10386.
 
 ### Windows
 
@@ -54,14 +54,22 @@ older PTX, so recent NVIDIA architectures work with a current driver.
 
 | Requirement | Detail |
 | --- | --- |
-| OS | x86_64 Linux desktop with glibc 2.27 or newer |
-| GPU | NVIDIA, CUDA-capable |
+| Architecture | x86_64 |
+| Supported distro baseline | **Ubuntu 22.04 LTS or Ubuntu 24.04 LTS** |
+| Best-effort distros | Fedora and Arch Linux (not release-gated; package names and WebKitGTK integration may differ) |
+| Webview | **WebKitGTK 4.1** (`libwebkit2gtk-4.1-0` on Ubuntu) with GTK 3 |
+| GPU | **NVIDIA/CUDA only** for v1; Ampere (sm_80) through Blackwell (sm_120) |
+| CUDA build baseline | `CUDA_COMPUTE_CAP=80`; packaged kernels provide the forward-compatible coverage used through Blackwell. Turing (sm_75) is not built or validated |
 | Driver | **575.51.03 or newer** (checked before the first-run download) |
+| Host packages | WebKitGTK 4.1, GTK 3, GStreamer libav, and **FFmpeg** (required for generated-video finalization) |
 | VRAM | Per model class; 12 GB runs most images, while video and larger models want 24 GB+ |
 | Disk | ~2 GB for the app-managed GPU runtime, plus model weights |
 
 SceneWorks downloads its pinned CUDA 12.9/cuDNN 9/ONNX Runtime user-space
 libraries. A system CUDA toolkit is not required; only the NVIDIA driver is.
+Pre-Ampere GPUs, including Turing (sm_75), are outside the v1 package baseline.
+AMD/ROCm and CPU-only generation are not a silent fallback: startup stops with
+a requirement message before downloading the GPU runtime.
 
 ### macOS
 
@@ -120,13 +128,14 @@ Choose either Linux x86_64 package:
 
 - Install the `.deb` on Ubuntu 22.04 or 24.04 with
   `sudo apt install ./SceneWorks_*.deb`. APT installs the declared
-  `libwebkit2gtk-4.1-0`, `libgtk-3-0`, and `gstreamer1.0-libav` runtime
-  dependencies. The GStreamer libav plugin supplies the H.264 decoder used by
-  WebKitGTK for MP4 preview playback.
+  `libwebkit2gtk-4.1-0`, `libgtk-3-0`, `gstreamer1.0-libav`, and `ffmpeg`
+  runtime dependencies. The GStreamer libav plugin supplies the H.264 decoder
+  used by WebKitGTK for MP4 preview playback; FFmpeg finalizes generated video.
 - Make the AppImage executable with `chmod +x SceneWorks_*.AppImage`, then run
-  it directly. The AppImage carries its GTK/WebKitGTK runtime and does not
-  require a package-manager install. Release AppImages participate in the same
-  signed in-app auto-update flow as the macOS and Windows builds.
+  it directly. The AppImage carries its GTK/WebKitGTK playback runtime, but the
+  host must provide the `ffmpeg` executable (`sudo apt install ffmpeg` on
+  Ubuntu). Release AppImages participate in the same signed in-app auto-update
+  flow as the macOS and Windows builds.
 
 The `.deb` does **not** self-update. Until SceneWorks publishes an APT repository,
 install a newer `.deb` from the GitHub release when upgrading; installing it over
@@ -216,8 +225,10 @@ On first launch a setup screen reports progress. What happens differs by platfor
 ### Linux (first run only)
 
 1. **GPU preflight.** SceneWorks checks `nvidia-smi` for an NVIDIA GPU and a
-   575.51.03-or-newer driver. Failure leaves the GPU lane dormant with an
-   actionable setup message; it does not start a retrying worker.
+   575.51.03-or-newer driver. A missing command, non-NVIDIA device, unverifiable
+   driver, or older driver stops startup with an actionable message explaining
+   that Linux v1 has no AMD/ROCm or CPU-only fallback. It does not download the
+   runtime, launch a CPU generation path, or start a retrying worker.
 2. **GPU runtime download (~1.9 GB, once).** Pinned, SHA-256-verified Linux
    x86_64 wheels provide CUDA 12.9, cuDNN 9, cuFFT, nvJitLink, NVRTC, and
    ONNX Runtime GPU under `$XDG_DATA_HOME/SceneWorks/gpu-runtime` (default
@@ -428,6 +439,17 @@ the GNU OpenMP runtime (`sudo apt install libgomp1` on Debian/Ubuntu or
 `sudo dnf install libgomp` on Fedora/RHEL), then relaunch. Offline machines can
 copy a provisioned Linux runtime as described in
 [Offline / air-gapped install](docs/offline-install.md).
+
+**Linux: "requires an NVIDIA (CUDA) GPU."**
+Linux v1 supports NVIDIA GPUs from Ampere through Blackwell with driver
+575.51.03 or newer. If `nvidia-smi` is missing or does not list the GPU, install
+or update the NVIDIA driver and restart SceneWorks. AMD/ROCm (epic 10386),
+CPU-only generation, and Turing (sm_75) are not supported by this v1 package.
+
+**Linux: generated video fails during finalization / `ffmpeg` is missing.**
+Install FFmpeg (`sudo apt install ffmpeg` on Ubuntu, `sudo dnf install ffmpeg`
+on Fedora after enabling the appropriate multimedia repository, or
+`sudo pacman -S ffmpeg` on Arch), then retry the job.
 
 **"The local API did not start in time."**
 The bundled API didn't become healthy within the startup window. Retry from the

--- a/apps/desktop/scripts/linux-bundle-config.test.mjs
+++ b/apps/desktop/scripts/linux-bundle-config.test.mjs
@@ -72,11 +72,12 @@ test("the default Linux build produces only AppImage and deb bundles", () => {
   );
 });
 
-test("the deb declares its WebKitGTK, GTK, and H.264 playback dependencies", () => {
+test("the deb declares its Linux webview, playback, and video-finalization dependencies", () => {
   assert.deepEqual(linuxOverlay.bundle.linux.deb.depends, [
     "libwebkit2gtk-4.1-0",
     "libgtk-3-0",
     "gstreamer1.0-libav",
+    "ffmpeg",
   ]);
 });
 
@@ -105,7 +106,7 @@ test("Linux bundles carry the media framework needed for H.264 playback", () => 
     linuxOverlay.bundle.linux.appimage.bundleMediaFramework,
     true,
   );
-  assert.match(desktopReadme, /AppImage carries its GTK\/WebKitGTK runtime/);
+  assert.match(desktopReadme, /AppImage carries its GTK\/WebKitGTK (?:playback )?runtime/);
   assert.match(desktopReadme, /bundleMediaFramework: true/);
   assert.match(desktopReadme, /gstreamer1\.0-libav/);
   assert.match(desktopReadme, /sudo apt install gstreamer1\.0-libav/);
@@ -132,6 +133,18 @@ test("the WebKitGTK compatibility contract remains configured", () => {
       `backdrop-filter at byte ${declarationStart} needs a matching WebKit prefix`,
     );
   }
+});
+
+test("the documented Linux v1 support matrix stays explicit", () => {
+  assert.match(desktopReadme, /Ubuntu 22\.04 LTS or Ubuntu 24\.04 LTS/);
+  assert.match(desktopReadme, /Fedora and Arch Linux.*not release-gated/);
+  assert.match(desktopReadme, /WebKitGTK 4\.1/);
+  assert.match(desktopReadme, /NVIDIA\/CUDA only.*v1/);
+  assert.match(desktopReadme, /Ampere \(sm_80\) through Blackwell \(sm_120\)/);
+  assert.match(desktopReadme, /Turing \(sm_75\).*not built or validated/);
+  assert.match(desktopReadme, /AMD\/ROCm and CPU-only generation.*not a silent fallback/s);
+  assert.match(desktopReadme, /FFmpeg.*generated-video finalization/);
+  assert.match(desktopReadme, /sudo apt install ffmpeg/);
 });
 
 test("Linux release update behavior is explicit for each package format", () => {

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -2595,6 +2595,20 @@ fn cuda_preflight() -> Result<(), String> {
 const MIN_LINUX_NVIDIA_DRIVER: (u32, u32, u32) = (575, 51, 3);
 
 #[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+const MIN_LINUX_COMPUTE_CAP: (u32, u32) = (8, 0);
+
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+const MAX_LINUX_COMPUTE_CAP: (u32, u32) = (12, 0);
+
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+const LINUX_CUDA_REQUIREMENT: &str =
+    "SceneWorks on Linux requires an NVIDIA (CUDA) GPU with driver 575.51.03 or newer. \
+     NVIDIA Ampere (compute capability 8.0) through Blackwell (compute capability 12.0) is \
+     supported in v1; Turing and older NVIDIA GPUs, AMD/ROCm, and CPU-only generation are not \
+     supported. Install or update the NVIDIA driver, verify `nvidia-smi` lists a supported GPU, \
+     then restart SceneWorks.";
+
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
 fn parse_driver_version(value: &str) -> Option<(u32, u32, u32)> {
     let mut parts = value.split('.');
     Some((
@@ -2604,41 +2618,88 @@ fn parse_driver_version(value: &str) -> Option<(u32, u32, u32)> {
     ))
 }
 
+#[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
+fn parse_compute_capability(value: &str) -> Option<(u32, u32)> {
+    let mut parts = value.split('.');
+    Some((
+        parts.next()?.parse().ok()?,
+        parts.next().unwrap_or("0").parse().ok()?,
+    ))
+}
+
 /// Linux counterpart of the Windows CUDA preflight. CUDA 12.9 requires the
-/// 575-series Linux driver; missing `nvidia-smi`, no GPU rows, and an old driver
-/// map to actionable setup errors before the multi-GB first-run download.
+/// 575-series Linux driver and the packaged kernels target Ampere through
+/// Blackwell. Missing `nvidia-smi`, no GPU rows, an old driver, or any GPU
+/// outside that architecture range maps to an actionable setup error before
+/// the multi-GB first-run download.
 #[cfg(any(target_os = "linux", all(test, target_os = "windows")))]
 fn evaluate_linux_nvidia_preflight(smi_output: Option<&str>) -> Result<(), String> {
-    let Some(line) =
-        smi_output.and_then(|out| out.lines().map(str::trim).find(|line| !line.is_empty()))
-    else {
-        return Err(
-            "SceneWorks on Linux requires an NVIDIA GPU with driver 575.51.03 or newer. \
-             No NVIDIA GPU was detected (nvidia-smi is missing or returned no devices); \
-             the GPU worker will remain disabled."
-                .to_owned(),
-        );
+    let Some(output) = smi_output.filter(|output| !output.trim().is_empty()) else {
+        return Err(format!(
+            "{LINUX_CUDA_REQUIREMENT}\n\nNo NVIDIA GPU was detected: `nvidia-smi` is missing, \
+             failed, or returned no devices."
+        ));
     };
-    let mut parts = line.split(',').map(str::trim);
-    let name = parts.next().unwrap_or("NVIDIA GPU");
-    let driver = parts.next().unwrap_or("");
-    if let Some(version) = parse_driver_version(driver) {
-        if version < MIN_LINUX_NVIDIA_DRIVER {
+
+    let mut supported_gpu_count = 0;
+    for line in output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        let mut parts = line.split(',').map(str::trim);
+        let name = parts.next().unwrap_or("");
+        let driver = parts.next().unwrap_or("");
+        let compute_capability = parts.next().unwrap_or("");
+        if !name.to_ascii_lowercase().contains("nvidia") {
+            let detail = if name.is_empty() {
+                "`nvidia-smi` returned a GPU row without a recognizable vendor.".to_owned()
+            } else {
+                format!("Detected unsupported GPU: {name}.")
+            };
+            return Err(format!("{LINUX_CUDA_REQUIREMENT}\n\n{detail}"));
+        }
+        let Some(driver_version) = parse_driver_version(driver) else {
             return Err(format!(
-                "SceneWorks on Linux requires NVIDIA driver 575.51.03 or newer for CUDA 12.9 \
-                 (found {driver} on {name}). Update the NVIDIA driver; the GPU worker will \
-                 remain disabled."
+                "{LINUX_CUDA_REQUIREMENT}\n\nSceneWorks could not verify the NVIDIA driver \
+                 version reported for {name} (reported value: {driver:?})."
+            ));
+        };
+        if driver_version < MIN_LINUX_NVIDIA_DRIVER {
+            return Err(format!(
+                "{LINUX_CUDA_REQUIREMENT}\n\nThe detected NVIDIA driver is too old for CUDA 12.9 \
+                 (found {driver} on {name})."
             ));
         }
+        let Some(compute_capability_version) = parse_compute_capability(compute_capability) else {
+            return Err(format!(
+                "{LINUX_CUDA_REQUIREMENT}\n\nSceneWorks could not verify the CUDA compute \
+                 capability reported for {name} (reported value: {compute_capability:?})."
+            ));
+        };
+        if !(MIN_LINUX_COMPUTE_CAP..=MAX_LINUX_COMPUTE_CAP).contains(&compute_capability_version) {
+            return Err(format!(
+                "{LINUX_CUDA_REQUIREMENT}\n\n{name} reports compute capability \
+                 {compute_capability}, outside the supported 8.0 through 12.0 range."
+            ));
+        }
+        supported_gpu_count += 1;
     }
-    Ok(())
+
+    if supported_gpu_count == 0 {
+        Err(format!(
+            "{LINUX_CUDA_REQUIREMENT}\n\n`nvidia-smi` returned no recognizable GPU rows."
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(target_os = "linux")]
 fn linux_cuda_preflight() -> Result<(), String> {
     let output = std::process::Command::new("nvidia-smi")
         .args([
-            "--query-gpu=name,driver_version",
+            "--query-gpu=name,driver_version,compute_cap",
             "--format=csv,noheader,nounits",
         ])
         .output();
@@ -3237,29 +3298,103 @@ mod linux_preflight_tests {
     use super::evaluate_linux_nvidia_preflight;
 
     #[test]
-    fn absent_linux_nvidia_runtime_maps_to_dormant_message() {
+    fn absent_linux_nvidia_runtime_fails_with_an_actionable_requirement() {
         for output in [None, Some(""), Some(" \n")] {
             let error = evaluate_linux_nvidia_preflight(output).expect_err("missing GPU must fail");
             assert!(error.contains("575.51.03"));
-            assert!(error.contains("remain disabled"));
+            assert!(error.contains("NVIDIA"));
+            assert!(error.contains("CPU-only"));
+            assert!(error.contains("AMD"));
+        }
+    }
+
+    #[test]
+    fn non_nvidia_gpu_is_rejected_instead_of_entering_a_silent_cpu_path() {
+        let error =
+            evaluate_linux_nvidia_preflight(Some("AMD Radeon RX 7900 XTX, 575.51.03, 12.0\n"))
+                .expect_err("the Linux v1 desktop must reject non-NVIDIA GPUs");
+        assert!(error.contains("AMD Radeon RX 7900 XTX"));
+        assert!(error.contains("NVIDIA"));
+        assert!(error.contains("CPU-only"));
+        assert!(error.contains("AMD"));
+    }
+
+    #[test]
+    fn missing_or_unparseable_driver_version_is_rejected_actionably() {
+        for output in [
+            "NVIDIA RTX 4090,, 8.9\n",
+            "NVIDIA RTX 4090, unknown, 8.9\n",
+            "NVIDIA RTX 4090, 575.invalid, 8.9\n",
+        ] {
+            let error = evaluate_linux_nvidia_preflight(Some(output))
+                .expect_err("an unverifiable CUDA driver must fail startup");
+            assert!(error.contains("NVIDIA RTX 4090"));
+            assert!(error.contains("575.51.03"));
+            assert!(error.contains("driver"));
         }
     }
 
     #[test]
     fn linux_driver_floor_is_compared_by_version_components() {
-        assert!(evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 575.51.03\n")).is_ok());
-        assert!(evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 580.1.0\n")).is_ok());
-        let error = evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 575.50.99\n"))
+        assert!(evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 575.51.03, 8.9\n")).is_ok());
+        assert!(evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 580.1.0, 8.9\n")).is_ok());
+        let error = evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 575.50.99, 8.9\n"))
             .expect_err("old driver must fail");
         assert!(error.contains("575.50.99"));
         assert!(error.contains("CUDA 12.9"));
     }
 
     #[test]
-    fn unusual_linux_driver_text_defers_to_runtime_instead_of_false_negative() {
-        assert!(
-            evaluate_linux_nvidia_preflight(Some("NVIDIA Datacenter GPU, vendor-build")).is_ok()
-        );
+    fn multi_gpu_output_accepts_a_supported_nvidia_device() {
+        assert!(evaluate_linux_nvidia_preflight(Some(
+            "NVIDIA RTX 4090, 580.1.0, 8.9\nNVIDIA RTX PRO 6000 Blackwell, 580.1.0, 12.0\n"
+        ))
+        .is_ok());
+    }
+
+    #[test]
+    fn all_nvidia_devices_below_the_driver_floor_are_rejected() {
+        let error = evaluate_linux_nvidia_preflight(Some(
+            "NVIDIA RTX 3090, 570.10.0, 8.6\nNVIDIA RTX 4090, 575.50.99, 8.9\n",
+        ))
+        .expect_err("one old NVIDIA device must not make another old device acceptable");
+        assert!(error.contains("too old"));
+        assert!(error.contains("CUDA 12.9"));
+        assert!(error.contains("575.51.03"));
+    }
+
+    #[test]
+    fn turing_pascal_and_unvalidated_future_architectures_are_rejected() {
+        for (name, cap) in [
+            ("NVIDIA GeForce RTX 2080 Ti", "7.5"),
+            ("NVIDIA GeForce GTX 1080 Ti", "6.1"),
+            ("NVIDIA Future GPU", "13.0"),
+        ] {
+            let output = format!("{name}, 580.65.06, {cap}\n");
+            let error = evaluate_linux_nvidia_preflight(Some(&output))
+                .expect_err("GPU outside Ampere-through-Blackwell must fail startup");
+            assert!(error.contains(name));
+            assert!(error.contains(cap));
+            assert!(error.contains("8.0 through 12.0"));
+        }
+    }
+
+    #[test]
+    fn mixed_supported_and_unsupported_nvidia_gpus_are_rejected() {
+        let error = evaluate_linux_nvidia_preflight(Some(
+            "NVIDIA RTX 4090, 580.65.06, 8.9\nNVIDIA RTX 2080 Ti, 580.65.06, 7.5\n",
+        ))
+        .expect_err("the auto supervisor would spawn on every GPU, so every GPU must be supported");
+        assert!(error.contains("NVIDIA RTX 2080 Ti"));
+        assert!(error.contains("7.5"));
+    }
+
+    #[test]
+    fn missing_compute_capability_is_rejected_before_runtime_download() {
+        let error = evaluate_linux_nvidia_preflight(Some("NVIDIA RTX 4090, 580.65.06,\n"))
+            .expect_err("an unverifiable architecture must fail startup");
+        assert!(error.contains("compute capability"));
+        assert!(error.contains("NVIDIA RTX 4090"));
     }
 }
 

--- a/apps/desktop/tauri.linux.conf.json
+++ b/apps/desktop/tauri.linux.conf.json
@@ -24,7 +24,8 @@
         "depends": [
           "libwebkit2gtk-4.1-0",
           "libgtk-3-0",
-          "gstreamer1.0-libav"
+          "gstreamer1.0-libav",
+          "ffmpeg"
         ]
       }
     }


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/trefry/story/10383

Summary:
- document the Linux v1 baseline: Ubuntu 22.04/24.04, WebKitGTK 4.1, NVIDIA Ampere through Blackwell, Fedora/Arch best effort
- fail startup before provisioning for missing nvidia-smi, non-NVIDIA devices, unverifiable/old drivers, unsupported compute capability, or mixed unsupported GPU sets
- declare and document FFmpeg as required for generated-video finalization

Validation:
- Ubuntu 22.04 WSL focused Linux preflight: 9 passed
- full desktop Rust suite: 86 passed, 3 intentional ignored
- desktop Node/config/docs suite: 16 passed
- cargo fmt --all -- --check: passed
- desktop clippy: passed with only the pre-existing Linux app_support_dir dead-code warning suppressed
- live nvidia-smi query: 2x RTX PRO 6000 Blackwell, driver 596.36, compute capability 12.0
- independent adversarial review: PASS, high confidence