### PR TITLE
fix(krea): natural Krea 2 Raw defaults — guidance 1.0, no default negative [sc-14203]

### DIFF
--- a/apps/web/public/prompt-guides/krea-2-raw.md
+++ b/apps/web/public/prompt-guides/krea-2-raw.md
@@ -36,11 +36,12 @@ The goal is a clear prompt, not a long one:
 - **Specify the light.** "soft overcast light", "golden-hour backlight", "hard noon sun", "warm
   tungsten interior" — Krea is highly lighting-responsive, and its own showcase prompts all name the
   lighting. This is the single highest-value detail you can add.
-- **Use the negative prompt.** Because Raw runs true CFG, a concise **quality negative** measurably
-  sharpens the result. The Studio seeds a mild default (`blurry, soft focus, low detail, low quality`)
-  into the negative box; you can edit or clear it. Keep it *mild* — an aggressive skin/texture negative
-  (e.g. `plastic skin, waxy skin`) over-corrects into an artificial plastic look. State what you want in
-  the prompt; use the negative only to push away genuine quality faults.
+- **The negative prompt is optional — no default is used.** Because Raw runs true CFG it *supports* a
+  negative prompt, but the negative box starts **empty** and you rarely need it. Say what you want in the
+  positive prompt; reach for the negative only to push away a **specific** artifact you actually see
+  (e.g. an unwanted object, a color cast). Keep any negative *mild* and targeted — a broad quality
+  negative (`blurry, low quality`) or an aggressive skin/texture one (`plastic skin, waxy skin`) tends to
+  over-correct and flatten the image rather than help.
 
 ## Build The Prompt
 
@@ -74,10 +75,12 @@ realistic subjects you don't need to say "photorealistic"; that's already the de
 - **Resolution:** use a native bucket (1024² / 768×1024 / 1024×768 / 1280×720 / 720×1280 / 1536²); width
   and height must be multiples of 16. 1024² is the default.
 - **Steps:** ~52 (Raw is undistilled — it needs the full step budget, unlike few-step Turbo).
-- **Guidance:** a real classifier-free-guidance scale; **~3.5** is the reference default. Raise it a
-  little for stronger prompt adherence, lower it for a softer, more natural look.
-- **Negative prompt:** supported and recommended (see above). A concise quality negative is the biggest
-  lever on sharpness.
+- **Guidance:** a real classifier-free-guidance scale; **~1.0** is the default and renders the most
+  natural look. Note Krea's nominal 3.5 is defined differently from standard CFG — it is effectively
+  standard-CFG **4.5**, which oversaturates on this pipeline (over-warm, crunchy). Start at ~1.0; raise it
+  only a little for stronger prompt adherence, and expect saturation/contrast to climb quickly.
+- **Negative prompt:** supported but **off by default** — the box starts empty. Add a short, targeted
+  negative only to push away a specific artifact you see; you don't need one for normal renders (see above).
 - **Sampler / scheduler:** `default` is the native rectified-flow loop and the best starting point; the
   curated samplers/schedulers are exposed for experimentation.
 - **Quantization:** Q8 is the default (near-lossless, ~20.5 GB download — needs a 48 GB-class Mac or a
@@ -125,8 +128,10 @@ finish fast.
 
 The **canonical workflow** (the Studio's "Turbo finish (4+4)" preset) is two phases:
 
-1. **4 steps — Raw, true-CFG on (guidance ~3.5), no accelerator LoRA.** Builds composition, structure,
-   and prompt adherence with the full-fidelity base.
+1. **4 steps — Raw, true-CFG on (the preset uses guidance ~3.5 for this structure phase), no accelerator
+   LoRA.** Builds composition, structure, and prompt adherence with the full-fidelity base. (This phase
+   deliberately runs a higher guidance than the plain single-pass t2i default of ~1.0, because it is only
+   a few structure steps; lower it toward ~1.0 if the finish comes out oversaturated.)
 2. **4 steps — Raw + the turbo (accelerator) LoRA, CFG off (guidance 0).** Fast distilled finishing on
    the trajectory the first phase set up.
 
@@ -135,8 +140,8 @@ Tune from there:
 - Want stronger adherence or cleaner structure? Add steps to **phase 1** (e.g. `6 + 4`, `8 + 4`).
 - Keep the **turbo/accelerator LoRA in the CFG-off phase**, and leave the CFG-on phase base-only (or with
   just your style LoRA) so its guidance is honored.
-- Give the CFG-on phase a real guidance (**~3.5**, the Raw default); set each CFG-off phase's guidance to
-  **0**.
+- Give the CFG-on phase a real guidance (the Turbo-finish preset uses **~3.5** for its short structure
+  phase; the plain single-pass Raw default is **~1.0**); set each CFG-off phase's guidance to **0**.
 - A style/subject LoRA can be toggled into either phase; the accelerator belongs only in a CFG-off phase.
 - Keep the total step budget modest — a 2–3 phase split well under the 52-step single-phase Raw cost is
   the whole point.

--- a/apps/web/src/imageMultiPhase.js
+++ b/apps/web/src/imageMultiPhase.js
@@ -76,7 +76,9 @@ export function acceleratorLoraIndex(selectedLoras = []) {
   );
 }
 
-// A fresh phase: 4 steps, true-CFG on (guidance 3.5, the Raw default), base-only.
+// A fresh phase: 4 steps, true-CFG on, base-only. Seeds guidance 3.5 as the short structure-phase value
+// for the "Turbo finish" workflow (NOT the single-pass Raw default — that is ~1.0 as of sc-14203); a few
+// high-CFG structure steps are the point here, and the user can retune per phase.
 export function newPhase(overrides = {}) {
   return { steps: 4, guidance: 3.5, loras: [], ...overrides };
 }
@@ -84,7 +86,8 @@ export function newPhase(overrides = {}) {
 // The canonical S4 "Turbo finish (4+4)" example: phase 1 = 4 steps Raw true-CFG base-only; phase 2 =
 // 4 steps Raw + the selected turbo accelerator LoRA, CFG off. When no accelerator LoRA is selected,
 // phase 2 is left base-only (the Studio surfaces the "select the turbo LoRA" hint) so the structure
-// is still produced — the per-phase toggle can wire the LoRA once it is picked.
+// is still produced — the per-phase toggle can wire the LoRA once it is picked. Phase 1's guidance 3.5
+// is the deliberate short structure-phase value (the single-pass Raw default is now ~1.0, sc-14203).
 export function buildTurboFinishPhases(selectedLoras = []) {
   const accel = acceleratorLora(selectedLoras);
   return [

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -3016,10 +3016,13 @@
       },
       "defaults": {
         // Raw: undistilled base, TRUE CFG (the engine forwards a real guidance value + negative prompt),
-        // resolution-dynamic mu. Reference Raw preset (sc-7566 spike): 52 steps / guidance 3.5.
+        // resolution-dynamic mu. 52 steps / guidance 1.0. sc-14203: lowered the default from 3.5 to 1.0 —
+        // Krea's nominal 3.5 is effectively standard-CFG 4.5 on this true-CFG pipeline and oversaturates;
+        // ~1.0 renders natural (on-device render-validated). This is the Guidance-slider placeholder the
+        // Studio shows (guidanceDefaultFromModel) and the worker's resolve_guidance fallback both resolve to.
         "resolution": "1024x1024",
         "steps": 52,
-        "guidanceScale": 3.5,
+        "guidanceScale": 1.0,
         "count": 1,
         "sampler": "default",
         "scheduler": "default"
@@ -3105,27 +3108,26 @@
           "secondaryLabel": "Image 2 (optional)",
           "secondaryHint": "Optional — a second image combined with Image 1 in a fixed order (Image 1, then Image 2). In your instruction, refer to each subject by position (\"the person in image 1 / image 2\") or by description (\"the woman in the green jacket\") — either works."
         },
-        // sc-13881 (epic 13879): curated default negative prompt. UNLIKE the CFG-free Turbo (no negative),
-        // Raw runs TRUE classifier-free guidance and USES a negative — a concise quality negative is the
-        // single biggest lever on Raw's "soft/over-warm" look (S0 sc-13880 proved the pipeline is faithful;
-        // the softness was prompting/defaults, not an engine bug). Image Studio seeds this into an EMPTY
-        // negative box on text-to-image / character mode (promptSeed.seedsNegativeInMode + the seeding
-        // effect in ImageStudio.jsx), so it rides the SAME `negativePrompt` path Raw already forwards to
-        // the TRUE-CFG denoise — no new manifest key, no Rust wiring. User-overridable and clearable (a
-        // cleared box stays cleared; an empty override yields no negative). Deliberately MILD: the
-        // aggressive "smooth waxy skin, plastic skin" variant over-corrected into plastic. Cross-platform.
-        "defaultNegativePrompt": "blurry, soft focus, low detail, low quality",
+        // sc-14203 (partially revises sc-13881): NO default negative is seeded. sc-13881 shipped a curated
+        // default negative ("blurry, soft focus, low detail, low quality") to fight Raw's "soft/over-warm"
+        // look, but on-device render-validation showed the heat was driven by the guidance default (Krea's
+        // nominal 3.5 ≡ standard-CFG 4.5), and the S1 negative was a co-cause of the oversaturation: guidance
+        // 1.0 WITH the S1 negative still rendered hot, while guidance ~1.0 + an EMPTY negative renders
+        // natural. So a fresh Krea 2 Raw job now starts with an empty negative box. The negative-prompt
+        // CAPABILITY is unchanged — Raw still runs TRUE CFG and forwards a user-typed negative to the denoise
+        // — only the default seeding is removed. (Turbo remains CFG-free with no negative.)
         "label": "Krea 2 Raw",
-        "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~3.5) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Runs on Apple Silicon (MLX) and Windows/Linux NVIDIA GPUs (candle/CUDA, sc-9994); needs a 48 GB-class Mac or a ~32 GB-class CUDA GPU.",
+        "description": "Krea 2 Raw — Krea AI's undistilled 12B single-stream rectified-flow DiT with a Qwen3-VL-4B text encoder, native MLX (Apple Silicon). The full-fidelity, TRUE classifier-free-guidance counterpart to the fast CFG-free Krea 2 Turbo: run ~52 steps with a real guidance scale (~1.0 renders natural on this pipeline) and an optional negative prompt for the highest quality and the most control. Pre-quantized Q8 (~20.5 GB download, default); the dense bf16 tier doubles as the Krea 2 LoRA training base. Krea 2 Community License (non-commercial). Runs on Apple Silicon (MLX) and Windows/Linux NVIDIA GPUs (candle/CUDA, sc-9994); needs a 48 GB-class Mac or a ~32 GB-class CUDA GPU.",
         "recommendedFor": ["text_to_image"],
         // PiD decoder (epic 7840, qwenimage latent space — Krea 2 Raw reuses the Qwen VAE, like Turbo) —
         // optional per-generation VAE replacement, decode + 2K/4K SR; NC output. See `qwen_image`.
         "pid": { "checkpointId": "pid_qwenimage" },
         // sc-13881 (epic 13879): Raw gets its OWN guide. The shared krea-2.md is TURBO-specific — it says
         // "no negative prompt", "~8 steps", "guidance none/CFG-off", all WRONG for Raw and steering users
-        // (and the Refine feature, which fetches this path) away from the negative + true-CFG regime that
-        // fixes Raw. krea-2-raw.md documents the real Raw regime: TRUE-CFG, ~52 steps, guidance ~3.5, USE a
-        // concise quality negative, SPECIFY lighting. Turbo (krea_2_turbo) still points at krea-2.md.
+        // (and the Refine feature, which fetches this path) away from the true-CFG regime Raw needs.
+        // krea-2-raw.md documents the real Raw regime: TRUE-CFG, ~52 steps, guidance ~1.0 (sc-14203 — Krea's
+        // nominal 3.5 ≡ std-CFG 4.5 and oversaturates), no default negative (add one only to steer away from
+        // a specific artifact), SPECIFY lighting. Turbo (krea_2_turbo) still points at krea-2.md.
         "promptGuide": {
           "title": "Krea 2 Raw Prompt Guide",
           "path": "/prompt-guides/krea-2-raw.md",

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -184,13 +184,15 @@ mod tests {
     }
 
     #[test]
-    fn krea_2_raw_declares_the_sc13881_default_negative_and_raw_guide() {
-        // sc-13881 (epic 13879): Raw's UX/defaults fix set (NOT a pipeline fix — S0 sc-13880 proved the
-        // pipeline is faithful). Two source-of-truth manifest facts:
-        //   1. Raw seeds a MILD quality negative (biggest lever: Raw is TRUE-CFG and uses a negative,
-        //      unlike CFG-free Turbo). The aggressive "plastic skin" variant over-corrected, so the
-        //      shipped default is deliberately the conservative string.
-        //   2. Raw points at its OWN guide krea-2-raw.md (the shared krea-2.md is Turbo-specific — "no
+    fn krea_2_raw_declares_no_default_negative_and_low_guidance_with_raw_guide() {
+        // sc-14203 (partially revises sc-13881): Raw's defaults fix. On-device render-validation showed the
+        // "soft/over-warm" heat was driven by the guidance default (Krea's nominal 3.5 ≡ standard-CFG 4.5)
+        // AND the sc-13881 S1 negative was a CO-CAUSE — guidance 1.0 WITH the S1 negative still rendered hot,
+        // while guidance ~1.0 + an EMPTY negative renders natural. Source-of-truth manifest facts now:
+        //   1. Raw seeds NO default negative (the sc-13881 seeding is removed — a fresh job starts empty).
+        //      The negative-prompt capability is unchanged; only the default is gone.
+        //   2. Raw's default guidance is 1.0 (down from 3.5).
+        //   3. Raw points at its OWN guide krea-2-raw.md (the shared krea-2.md is Turbo-specific — "no
         //      negative", "~8 steps", "CFG-off" — all wrong for Raw); Turbo keeps krea-2.md.
         let stripped = crate::jsonc::strip_jsonc_comments(embedded("builtin.models.jsonc"));
         let manifest: serde_json::Value =
@@ -206,10 +208,18 @@ mod tests {
         };
 
         let raw = find("krea_2_raw");
+        // No default negative is seeded (sc-14203). Discriminating: this fails if a default negative — the
+        // sc-13881 string or any other — is re-added under ui.defaultNegativePrompt.
+        assert!(
+            raw["ui"]["defaultNegativePrompt"].is_null(),
+            "krea_2_raw declares no default negative (sc-14203 dropped the sc-13881 seeding), got {:?}",
+            raw["ui"]["defaultNegativePrompt"]
+        );
+        // Default guidance is 1.0, not the old 3.5 (pins the non-default so it discriminates a revert).
         assert_eq!(
-            raw["ui"]["defaultNegativePrompt"].as_str(),
-            Some("blurry, soft focus, low detail, low quality"),
-            "krea_2_raw seeds the sc-13881 mild quality negative"
+            raw["defaults"]["guidanceScale"].as_f64(),
+            Some(1.0),
+            "krea_2_raw defaults to guidance 1.0 (sc-14203)"
         );
         assert_eq!(
             raw["ui"]["promptGuide"]["path"].as_str(),

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -561,7 +561,9 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     },
     // Krea 2 Raw (epic 9992) — native MLX, the undistilled 12B DiT run with TRUE classifier-free guidance
     // (the `krea_2_raw` descriptor advertises supports_guidance + supports_negative_prompt, unlike the
-    // CFG-free Turbo). 52 steps / guidance 3.5. Loads the packed bf16 / Q8 (default) / Q4 turnkey subdir
+    // CFG-free Turbo). 52 steps / guidance 1.0. sc-14203: lowered the default from 3.5 to 1.0 — Krea's
+    // nominal 3.5 is effectively standard-CFG 4.5 on this true-CFG pipeline and oversaturates; ~1.0 renders
+    // natural (on-device render-validated). Loads the packed bf16 / Q8 (default) / Q4 turnkey subdir
     // (`SceneWorks/krea-2-raw-mlx`, the same `krea_model_subdir` resolver as Turbo). Shares the Krea
     // pipeline with Turbo (arch-identical); the `krea_2_raw` id is also the LoRA-training base (Path 1).
     ModelRow {
@@ -569,7 +571,7 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
         engine_id: "krea_2_raw",
         default_repo: "SceneWorks/krea-2-raw-mlx",
         default_steps: 52,
-        default_guidance: 3.5,
+        default_guidance: 1.0,
         adapter_label: "mlx_krea",
     },
     // Stable Diffusion 3.5 Large (epic 7841 / sc-7871) — native MLX, gated. 8B MMDiT + triple text

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -5680,7 +5680,7 @@ fn lora_declares_accelerator_role_matches_only_the_accelerator_marker() {
 // its sampling regime against the `krea_2_turbo` descriptor (while loading Raw weights), so the whole
 // regime falls out for free: fixed-mu engine, ~8 steps, guidance off, no negative forwarded. Pinning
 // the NON-default turbo values here makes the test FAIL if the lane ever reverts to the Raw defaults
-// (52 steps / guidance 3.5 / dynamic-mu / negative forwarded). mu itself is engine-internal
+// (52 steps / guidance 1.0 / dynamic-mu / negative forwarded). mu itself is engine-internal
 // (`TURBO_MU = 1.15` in the pinned Krea engine's `turbo_sigmas`), reached by selecting the
 // `krea_2_turbo` engine id — so asserting that engine id IS the worker-observable proof of fixed mu.
 #[cfg(target_os = "macos")]
@@ -5720,7 +5720,7 @@ fn krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
         "control: the Raw default is 52"
     );
 
-    // Guidance: CFG off (the turbo descriptor advertises no guidance → None), NOT the Raw 3.5.
+    // Guidance: CFG off (the turbo descriptor advertises no guidance → None), NOT the Raw 1.0.
     assert_eq!(
         resolve_guidance(&req, &turbo),
         None,
@@ -5728,8 +5728,8 @@ fn krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
     );
     assert_eq!(
         resolve_guidance(&req, &raw),
-        Some(3.5),
-        "control: the Raw default guidance is 3.5",
+        Some(1.0),
+        "control: the Raw default guidance is 1.0",
     );
 
     // Negative prompt: NOT forwarded under turbo (the descriptor advertises no negative), even though
@@ -6034,7 +6034,7 @@ fn candle_krea_multiphase_claims_conflicting_shapes_to_reject_them() {
 // mu Turbo engine id, ~8 steps, guidance off, no negative forwarded. `resolve_steps`/`resolve_guidance`/
 // `resolve_negative_prompt`/`model_repo`/`mlx_model` are all SHARED (the candle lane uses the same
 // registry join), so pinning the NON-default turbo values makes this FAIL if the candle lane ever reverts
-// to the Raw regime (52 steps / guidance 3.5 / negative forwarded) or loads the wrong repo/engine.
+// to the Raw regime (52 steps / guidance 1.0 / negative forwarded) or loads the wrong repo/engine.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[test]
 fn candle_krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
@@ -6080,7 +6080,7 @@ fn candle_krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
         "control: the Raw default is 52"
     );
 
-    // Guidance: CFG off under the turbo (distilled) descriptor → None, NOT the Raw 3.5.
+    // Guidance: CFG off under the turbo (distilled) descriptor → None, NOT the Raw 1.0.
     assert_eq!(
         resolve_guidance(&req, &turbo),
         None,
@@ -6088,8 +6088,8 @@ fn candle_krea_turbo_on_raw_selects_the_turbo_regime_not_the_raw_regime() {
     );
     assert_eq!(
         resolve_guidance(&req, &raw),
-        Some(3.5),
-        "control: the Raw default guidance is 3.5",
+        Some(1.0),
+        "control: the Raw default guidance is 1.0",
     );
 
     // Negative prompt: NOT forwarded under turbo (distilled, no negative branch); the Raw path forwards it.

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1759,6 +1759,47 @@ fn resolve_guidance_none_for_distilled_set_for_dev() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn fresh_krea_2_raw_job_resolves_default_guidance_1_and_empty_negative() {
+    // sc-14203: a fresh Krea 2 Raw job (no advanced.guidanceScale, no negativePrompt) must resolve to the
+    // TRUE-CFG guidance default 1.0 and an EMPTY negative. Raw advertises supports_guidance +
+    // supports_negative_prompt, so this exercises the real product path: `resolve_guidance` falls back to
+    // the ModelRow `default_guidance` (1.0, down from 3.5) and `resolve_negative_prompt` returns None
+    // because nothing is seeded server-side (the sc-13881 default-negative seeding was dropped).
+    let raw = mlx_model("krea_2_raw").unwrap();
+    // Pins the non-default 1.0 so it discriminates a revert to 3.5.
+    assert_eq!(
+        resolve_guidance(&request(json!({ "projectId": "p" })), &raw),
+        Some(1.0),
+        "fresh krea_2_raw resolves the sc-14203 default guidance 1.0"
+    );
+    // An explicit advanced.guidanceScale still overrides the default.
+    assert_eq!(
+        resolve_guidance(
+            &request(json!({ "projectId": "p", "advanced": { "guidanceScale": 3.5 } })),
+            &raw
+        ),
+        Some(3.5),
+        "krea_2_raw honors an explicit guidance override"
+    );
+    // No negative is provided → empty (the worker never seeds one; the default seeding was removed).
+    assert_eq!(
+        resolve_negative_prompt(&request(json!({ "projectId": "p" })), &raw),
+        None,
+        "fresh krea_2_raw carries no default negative (sc-14203)"
+    );
+    // A user-typed negative is still honored — the capability is unchanged.
+    assert_eq!(
+        resolve_negative_prompt(
+            &request(json!({ "projectId": "p", "negativePrompt": "blurry" })),
+            &raw
+        ),
+        Some("blurry".to_owned()),
+        "krea_2_raw still forwards a user-typed negative"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn adapter_id_reports_per_family_mlx_label() {
     assert_eq!(
         adapter_id(&request(json!({ "model": "z_image_turbo" }))),


### PR DESCRIPTION
## sc-14203 — Krea 2 Raw natural defaults

Krea 2 Raw shipped with an over-warm / oversaturated default look. On-device render-validation traced the heat to **two defaults**, not the pipeline (S0/sc-13880 already proved the pipeline is faithful):

1. **Guidance 3.5 → 1.0.** Krea's *nominal* 3.5 is defined differently from standard CFG — it is effectively **standard-CFG ~4.5**, which oversaturates on this true-CFG pipeline. On-device render-validated that **~1.0 + an empty negative renders natural**.
2. **Drop the S1 default negative.** The sc-13881 seeding (`blurry, soft focus, low detail, low quality`) was a **co-cause** of the heat: guidance 1.0 **with** the S1 negative still rendered hot; guidance ~1.0 + an **empty** negative is the natural look. A fresh Raw job now starts with an empty negative box. The negative-prompt **capability is unchanged** — users can still type one, and Raw still forwards it to the true-CFG denoise.

### Guidance sites set to 1.0 (every user-facing default)
- `crates/sceneworks-worker/src/engines.rs` — `ModelRow{krea_2_raw}` `default_guidance: 3.5 → 1.0`. This is what `resolve_guidance` (image_jobs/base.rs) falls back to when the Studio's Guidance slider is left empty, i.e. the default job path (the web sends no `guidanceScale` then).
- `config/manifests/builtin.models.jsonc` — `defaults.guidanceScale: 3.5 → 1.0`. This drives the Studio's Guidance-slider **placeholder** (`guidanceDefaultFromModel`). Confirmed the web has **no separate hardcoded** krea_2_raw default (not in `constants.js` fallbackModels; the catalog is server-authoritative), so the web default is now 1.0.
- Cross-repo engine fallback `DEFAULT_RAW_GUIDANCE` **untouched**: `resolve_guidance` always returns `Some(default_guidance())` for Raw (it advertises `supports_guidance`), so the engine fallback is off the product path.

The multi-phase **"Turbo finish (4+4)"** preset's own `guidance: 3.5` (its short structure phase, sc-13885, with its own tests) is intentionally left as-is — out of scope for sc-14203.

### Negative drop
Removed `ui.defaultNegativePrompt` for `krea_2_raw` from the manifest (the only source — the Rust manifest is embedded from the JSONC, so there is no separate literal to change). The generic seeding effect (`promptSeed.seedsNegativeInMode` + ImageStudio) now finds no key and leaves the box empty.

### Guide (`apps/web/public/prompt-guides/krea-2-raw.md`)
Recommend **guidance ~1.0** (with the nominal-3.5 ≡ std-CFG-4.5 oversaturation note); state **no default negative** is used (add one only to steer away from a specific artifact); kept the true-CFG framing and the specify-lighting advice; corrected the multi-phase wording that called 3.5 "the Raw default".

### Tests
- Updated the sc-13881 core test (`sceneworks-core/src/builtin_manifests.rs`) to assert the default negative is now **ABSENT** (`is_null`) — still discriminating (fails if any default negative is re-added) — plus a new discriminating `defaults.guidanceScale == 1.0` assertion. Kept the raw-guide-path + Turbo-unchanged assertions.
- Added a worker test (`image_jobs/tests.rs`) that a fresh `krea_2_raw` request resolves guidance `Some(1.0)` and an empty negative (`None`), and that explicit `guidanceScale` overrides and user-typed negatives still work.
- Green: `cargo test -p sceneworks-core builtin_manifests`, worker guidance/negative tests, `every_builtin_model_prompt_guide_exists`; web `promptSeed`/`imageMultiPhase`/`constants` tests. `cargo fmt --all` clean; clippy `-D warnings` clean on touched crates (lib+tests).

Partially revises **sc-13881**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)