### PR TITLE
build(win): bypass fragile .cargo\bin rustup proxies in local builds (sc-13166)

### DIFF
--- a/scripts/win/use-real-rust-toolchain.cmd
+++ b/scripts/win/use-real-rust-toolchain.cmd
@@ -1,0 +1,41 @@
+@echo off
+rem =============================================================================
+rem use-real-rust-toolchain.cmd  (sc-13166)
+rem
+rem Prepend the REAL rustup toolchain bin to PATH so local Windows builds resolve
+rem cargo/rustc/clippy directly, BYPASSING the fragile %USERPROFILE%\.cargo\bin
+rem rustup proxies. On the self-hosted CUDA box those 13 proxies are 0-byte
+rem symlinks to rustup.exe; a `rustup` self-update recreates them and Defender
+rem then deletes rustup.exe, leaving every proxy dangling -- so `cargo` dies with
+rem   "failed to run `cargo metadata` ... The system cannot find the file
+rem    specified. (os error 2)"
+rem CI already dodges this via .github/actions/prepare-rust-runner (it prepends
+rem the real toolchain bin to $GITHUB_PATH); this is the local-build equivalent.
+rem
+rem CALL it (do NOT run in a child shell) so the PATH change reaches the caller:
+rem     call "%~dp0scripts\win\use-real-rust-toolchain.cmd"
+rem
+rem It reads the pinned channel from rust-toolchain.toml at the repo root
+rem (two levels up from this script), defaulting to "stable", and NEVER invokes
+rem rustup (rustup.exe is itself one of the broken proxies). Sets ERRORLEVEL 1 if
+rem no real toolchain is found. Leaves SW_RUST_TC_BIN set to the chosen bin dir.
+rem =============================================================================
+set "SW_REPO_ROOT=%~dp0..\..\"
+set "SW_RUST_CHANNEL=stable"
+if exist "%SW_REPO_ROOT%rust-toolchain.toml" (
+  for /f "tokens=2 delims== " %%c in ('findstr /r /c:"^ *channel *=" "%SW_REPO_ROOT%rust-toolchain.toml"') do set "SW_RUST_CHANNEL=%%~c"
+)
+set "SW_RUST_TC_BIN=%USERPROFILE%\.rustup\toolchains\%SW_RUST_CHANNEL%-x86_64-pc-windows-msvc\bin"
+if not exist "%SW_RUST_TC_BIN%\cargo.exe" (
+  rem channel parse missed or toolchain dir named differently -- fall back to any
+  rem installed toolchain that has a real (non-proxy) cargo.exe.
+  for /d %%d in ("%USERPROFILE%\.rustup\toolchains\*") do if exist "%%d\bin\cargo.exe" set "SW_RUST_TC_BIN=%%d\bin"
+)
+if not exist "%SW_RUST_TC_BIN%\cargo.exe" (
+  echo [rust] ERROR: no real Rust toolchain under "%USERPROFILE%\.rustup\toolchains" ^(sc-13166^).
+  echo         Reinstall it:  rustup toolchain install %SW_RUST_CHANNEL% --force
+  exit /b 1
+)
+set "PATH=%SW_RUST_TC_BIN%;%PATH%"
+echo [rust] real toolchain bin on PATH, bypassing .cargo\bin ^(sc-13166^): %SW_RUST_TC_BIN%
+exit /b 0


### PR DESCRIPTION
## Problem

On the self-hosted Windows/CUDA box, the 13 rustup proxies in `%USERPROFILE%\.cargo\bin` (`cargo.exe`, `rustc.exe`, …) are **0-byte symlinks to `rustup.exe`**. A `rustup` self-update recreates them and Defender then deletes `rustup.exe`, leaving every proxy dangling. Because `.cargo\bin` is the only cargo on that box's PATH, local cargo invocations then die with:

```
failed to run 'cargo metadata' … The system cannot find the file specified. (os error 2)
```

This surfaced when a local `build.bat` → `tauri build` → `cargo metadata` failed right after (re)configuring the CUDA action runners. It recurs whenever the proxies get recreated + `rustup.exe` re-deleted.

## Why CI is already fine, and what's missing

CI lanes dodge this via [`.github/actions/prepare-rust-runner`](.github/actions/prepare-rust-runner/action.yml), which prepends the **real** toolchain bin (`%USERPROFILE%\.rustup\toolchains\<channel>\bin`) to `$GITHUB_PATH`. Local/interactive builds on the box never got that treatment — so they break while CI passes.

## Change

Adds `scripts/win/use-real-rust-toolchain.cmd` — the local-build equivalent of the CI action. It:

- reads the pinned channel from `rust-toolchain.toml` (defaults to `stable`),
- resolves `%USERPROFILE%\.rustup\toolchains\<channel>-x86_64-pc-windows-msvc\bin` (with a fallback scan for any toolchain that has a real `cargo.exe`),
- **never invokes `rustup`** (it is itself one of the broken proxies),
- prepends that bin to PATH, and fails loudly (exit 1) if no real toolchain is found.

Local Windows build scripts `call` it before invoking cargo/tauri:

```bat
call "%~dp0scripts\win\use-real-rust-toolchain.cmd" || exit /b 1
```

(The repo's `build.bat` is a personal, git-ignored convenience script, so it isn't part of this PR; it's been pointed at this helper locally.)

## Testing

Verified on the affected box **while `.cargo\bin` was in the broken (dangling-symlink) state**: after `call`-ing the helper, `where cargo` resolves to the real toolchain bin first and `cargo metadata --no-deps --format-version 1` against `apps/desktop` exits 0.

Extends sc-13166 (prior: #1626, #1630) from CI to local builds.