### PR TITLE
Run imported fused SDXL checkpoints natively [sc-14024]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "core-llm",
  "half",
@@ -4567,7 +4567,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5922,7 +5922,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5979,7 +5979,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=cc5a1cf654f20cf6a78b517d104c3c2893c932f1#cc5a1cf654f20cf6a78b517d104c3c2893c932f1"
+source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -7323,7 +7323,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8480,7 +8480,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b" }

--- a/crates/sceneworks-core/src/base_weights.rs
+++ b/crates/sceneworks-core/src/base_weights.rs
@@ -199,7 +199,7 @@ pub enum BaseWeightDetection {
 /// detector recognizes by its `txtfusion.` marker, whose builtins already route to the Krea MLX
 /// engine. Grows one entry per landed loader; keep it aligned with [`import_supported`]'s arms and
 /// with `MLX_ROUTED_FAMILIES` (routing).
-pub const IMPORT_SUPPORTED_FAMILIES: &[&str] = &["krea_2"];
+pub const IMPORT_SUPPORTED_FAMILIES: &[&str] = &["krea_2", "sdxl"];
 
 /// Whether an imported community single-file **base checkpoint** described by `verdict` can be
 /// assembled and run by a real engine today (sc-14019, epic 14015) — the compatibility gate behind
@@ -224,6 +224,11 @@ pub fn import_supported(verdict: &BaseWeightVerdict) -> Result<(), String> {
             ComponentRole::Transformer,
             QuantFormat::Bf16 | QuantFormat::Int8TensorwisePerRow,
         ) => Ok(()),
+        (
+            Some("sdxl"),
+            ComponentRole::Checkpoint,
+            QuantFormat::F16 | QuantFormat::Bf16 | QuantFormat::F32,
+        ) => Ok(()),
 
         // --- Refusals: most specific first, each with an actionable, client-facing reason ---
         (None, _, _) => Err(
@@ -235,13 +240,24 @@ pub fn import_supported(verdict: &BaseWeightVerdict) -> Result<(), String> {
             "Model import does not yet support the '{family}' family. Supported today: {}.",
             IMPORT_SUPPORTED_FAMILIES.join(", ")
         )),
-        (Some(family), component, _) if component != ComponentRole::Transformer => Err(format!(
-            "Model import for the '{family}' family currently supports only the diffusion \
-             transformer, not a {component} file."
+        (Some("krea_2"), component, _) if component != ComponentRole::Transformer => Err(format!(
+            "Model import for the 'krea_2' family requires a diffusion transformer, not a \
+             {component} file."
         )),
-        (Some(family), _, quant) => Err(format!(
-            "Model import for the '{family}' family currently supports only dense bf16 or \
-             descriptor-gated int8-per-row weights, not {quant}. Re-export the checkpoint in bf16."
+        (Some("sdxl"), component, _) if component != ComponentRole::Checkpoint => Err(format!(
+            "Model import for the 'sdxl' family requires a fused checkpoint containing the UNet, \
+             both text encoders, and VAE, not a {component} file."
+        )),
+        (Some("krea_2"), _, quant) => Err(format!(
+            "Model import for the 'krea_2' family supports dense bf16 or descriptor-gated \
+             int8-per-row weights, not {quant}. Re-export the checkpoint in bf16."
+        )),
+        (Some("sdxl"), _, quant) => Err(format!(
+            "Model import for the 'sdxl' family supports dense f16, bf16, or f32 fused checkpoints, \
+             not {quant}."
+        )),
+        (Some(family), _, _) => Err(format!(
+            "Model import has no compatible loader arm for the '{family}' family."
         )),
     }
 }
@@ -518,6 +534,17 @@ fn detect_base_family(keys: &[&str]) -> Option<String> {
 /// we ship, so one hit is decisive (mirroring the LoRA detector's
 /// `detect_unique_key_family` posture).
 fn detect_transformer_family(keys: &[&str]) -> Option<&'static str> {
+    // Classic SDXL LDM/A1111 fused checkpoint: a UNet under `model.diffusion_model.input_blocks`,
+    // dual CLIP conditioners, and a `first_stage_model` VAE. The UNet input/output/middle block
+    // grammar is distinct from modern DiTs; requiring the SDXL second conditioner prevents an SD1.5
+    // checkpoint from being misrouted into the dual-CLIP SDXL loader.
+    if any_key_contains(keys, "model.diffusion_model.input_blocks.")
+        && any_key_contains(keys, "model.diffusion_model.middle_block.")
+        && any_key_contains(keys, "conditioner.embedders.1.model.")
+        && any_key_contains(keys, "first_stage_model.")
+    {
+        return Some("sdxl");
+    }
     // Z-Image (epic 1408): `context_refiner`/`noise_refiner`/`cap_embedder` are
     // unique. Shares the bare `layers.N.attention.qkv` fused-QKV layout with
     // Ideogram, so it must be checked by its own refiner markers first.
@@ -704,6 +731,33 @@ mod tests {
         assert_eq!(verdict.family.as_deref(), Some("krea_2"));
         assert_eq!(verdict.component, ComponentRole::Transformer);
         assert_eq!(verdict.quant, QuantFormat::Bf16);
+    }
+
+    #[test]
+    fn fused_sdxl_a1111_file_is_checkpoint() {
+        let verdict = recognized(classify_base_header(&header(&[
+            (
+                "model.diffusion_model.input_blocks.7.0.out_layers.3.weight",
+                "F16",
+            ),
+            (
+                "model.diffusion_model.middle_block.1.transformer_blocks.0.attn1.to_q.weight",
+                "F16",
+            ),
+            (
+                "conditioner.embedders.0.transformer.text_model.embeddings.token_embedding.weight",
+                "F16",
+            ),
+            (
+                "conditioner.embedders.1.model.transformer.resblocks.9.attn.in_proj_weight",
+                "F16",
+            ),
+            ("first_stage_model.encoder.conv_in.weight", "F16"),
+            ("first_stage_model.decoder.conv_out.weight", "F16"),
+        ])));
+        assert_eq!(verdict.family.as_deref(), Some("sdxl"));
+        assert_eq!(verdict.component, ComponentRole::Checkpoint);
+        assert_eq!(verdict.quant, QuantFormat::F16);
     }
 
     #[test]
@@ -1228,6 +1282,27 @@ mod tests {
     }
 
     #[test]
+    fn import_supported_accepts_dense_fused_sdxl_only() {
+        for quant in [QuantFormat::F16, QuantFormat::Bf16, QuantFormat::F32] {
+            assert!(
+                import_supported(&verdict(Some("sdxl"), ComponentRole::Checkpoint, quant)).is_ok()
+            );
+        }
+        assert!(import_supported(&verdict(
+            Some("sdxl"),
+            ComponentRole::Transformer,
+            QuantFormat::F16
+        ))
+        .is_err());
+        assert!(import_supported(&verdict(
+            Some("sdxl"),
+            ComponentRole::Checkpoint,
+            QuantFormat::Fp8E4m3
+        ))
+        .is_err());
+    }
+
+    #[test]
     fn import_supported_refuses_krea2_transformer_deferred_quant() {
         // Same family + component, but a packed quant with no loader → refused with the quant named.
         let reason = import_supported(&verdict(
@@ -1314,13 +1389,13 @@ mod tests {
         // Guardrail: every family the gate advertises must actually have an Ok triple, so the
         // advertised set and the `match` arms can never drift (add the family here + its arm together).
         for family in IMPORT_SUPPORTED_FAMILIES {
+            let component = if *family == "sdxl" {
+                ComponentRole::Checkpoint
+            } else {
+                ComponentRole::Transformer
+            };
             assert!(
-                import_supported(&verdict(
-                    Some(family),
-                    ComponentRole::Transformer,
-                    QuantFormat::Bf16
-                ))
-                .is_ok(),
+                import_supported(&verdict(Some(family), component, QuantFormat::Bf16)).is_ok(),
                 "IMPORT_SUPPORTED_FAMILIES lists {family} but no bf16 transformer arm accepts it"
             );
         }

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -884,7 +884,7 @@ derive_model_list! {
 /// alone and has no id→family map; keep it aligned with the same-family builtins above and with the
 /// import gate (`sceneworks_core::base_weights::IMPORT_SUPPORTED_FAMILIES`). Pinned by the
 /// `EXPECTED_MLX_ROUTED_FAMILIES` snapshot test.
-pub(crate) const MLX_ROUTED_FAMILIES: &[&str] = &["krea_2"];
+pub(crate) const MLX_ROUTED_FAMILIES: &[&str] = &["krea_2", "sdxl"];
 
 /// Whether an image `family` string routes to an in-process MLX engine via the route-by-family path
 /// (sc-14019) — i.e. it is a member of [`MLX_ROUTED_FAMILIES`]. Consulted only for non-builtin ids.
@@ -897,7 +897,7 @@ pub(crate) fn image_family_is_mlx_routed(family: &str) -> bool {
 /// checkpoints have novel ids and are claimed only after the scheduler validates their manifest
 /// family and supported request shape. Seeded by the descriptor-gated Krea single-file lane
 /// (sc-14023).
-pub(crate) const CANDLE_ROUTED_FAMILIES: &[&str] = &["krea_2"];
+pub(crate) const CANDLE_ROUTED_FAMILIES: &[&str] = &["krea_2", "sdxl"];
 
 /// Whether `id` names a builtin image model (a row in [`IMAGE_MODEL_CAPS`]). The route-by-family
 /// path applies only to non-builtin (imported/user) ids, so a builtin's id-keyed routing is never
@@ -930,11 +930,8 @@ pub(crate) fn imported_image_request_family_eligible(
     let Some(entry) = payload.get("modelManifestEntry").and_then(Value::as_object) else {
         return false;
     };
-    let family_is_routed = entry
-        .get("family")
-        .and_then(Value::as_str)
-        .is_some_and(|family| routed_families.contains(&family));
-    if !family_is_routed {
+    let family = entry.get("family").and_then(Value::as_str);
+    if !family.is_some_and(|family| routed_families.contains(&family)) {
         return false;
     }
     let has_nonempty_path = entry
@@ -980,6 +977,23 @@ pub(crate) fn imported_image_request_family_eligible(
         .and_then(|advanced| advanced.get("phases"))
         .and_then(Value::as_array)
         .is_some_and(|phases| !phases.is_empty());
+
+    // A fused SDXL checkpoint contains the complete denoiser + dual text encoders + VAE, so its
+    // single-file lane is not Krea's bare-transformer assembly surface. Both native loaders accept
+    // UNet LoRA/LoKr adapters, but the worker lane intentionally claims only the descriptor's common
+    // txt2img surface; edit/reference/control requests keep flowing to their established specialized
+    // routes instead of silently dropping conditioning.
+    if family == Some("sdxl") {
+        return payload.get("mode").and_then(Value::as_str).map(str::trim) != Some("edit_image")
+            && !has_reference_list
+            && !has_nonempty_id("referenceAssetId")
+            && !has_nonempty_id("sourceAssetId")
+            && !has_poses
+            && !has_phases
+            && !has_nonempty_id("maskAssetId")
+            && !has_nonempty_id("characterId")
+            && !has_nonempty_id("characterLookId");
+    }
 
     // Never on this bare-transformer lane, on any backend: strict pose, multi-phase, inpaint mask,
     // and character / look identity conditioning (all need base-tier components it does not stage).
@@ -1542,8 +1556,8 @@ mod tests {
     /// The MLX-routed *family* allow-list, pinned like the model lists above. Adding a family here is
     /// a deliberate edit (it makes every imported same-family checkpoint Mac-routable), so it must be
     /// mirrored here — the guardrail that a family is never silently added to the import surface.
-    const EXPECTED_MLX_ROUTED_FAMILIES: &[&str] = &["krea_2"];
-    const EXPECTED_CANDLE_ROUTED_FAMILIES: &[&str] = &["krea_2"];
+    const EXPECTED_MLX_ROUTED_FAMILIES: &[&str] = &["krea_2", "sdxl"];
+    const EXPECTED_CANDLE_ROUTED_FAMILIES: &[&str] = &["krea_2", "sdxl"];
 
     #[test]
     fn mlx_routed_families_match_snapshot() {
@@ -1712,5 +1726,52 @@ mod tests {
         // Base-tier-only shapes stay rejected on both regardless of adapter support.
         let pose = payload(serde_json::json!({ "advanced": { "poses": [{}] } }));
         assert!(!mlx(&pose) && !candle(&pose), "pose rejected on both");
+    }
+
+    #[test]
+    fn imported_sdxl_family_gate_claims_t2i_on_both_backends_without_dropping_conditioning() {
+        let imported_id = "community_xl";
+        let payload = |extra: serde_json::Value| {
+            let mut value = serde_json::json!({
+                "model": imported_id,
+                "modelManifestEntry": {
+                    "id": imported_id,
+                    "family": "sdxl",
+                    "paths": { "model": "/app/models/imports/community-xl" }
+                }
+            });
+            value
+                .as_object_mut()
+                .unwrap()
+                .extend(extra.as_object().unwrap().clone());
+            value.as_object().unwrap().clone()
+        };
+        let eligible = |p: &serde_json::Map<String, serde_json::Value>| {
+            (
+                imported_image_request_family_eligible(imported_id, p, MLX_ROUTED_FAMILIES, true),
+                imported_image_request_family_eligible(
+                    imported_id,
+                    p,
+                    CANDLE_ROUTED_FAMILIES,
+                    false,
+                ),
+            )
+        };
+
+        assert_eq!(eligible(&payload(serde_json::json!({}))), (true, true));
+        assert_eq!(
+            eligible(&payload(
+                serde_json::json!({ "loras": [{ "id": "style" }] })
+            )),
+            (true, true),
+            "both fused SDXL loaders accept UNet adapters"
+        );
+        for conditioned in [
+            payload(serde_json::json!({ "referenceAssetId": "asset-1" })),
+            payload(serde_json::json!({ "mode": "edit_image", "sourceAssetId": "asset-1" })),
+            payload(serde_json::json!({ "advanced": { "poses": [{}] } })),
+        ] {
+            assert_eq!(eligible(&conditioned), (false, false));
+        }
     }
 }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "cc5a1cf654f20cf6a78b517d104c3c2893c932f1", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -490,6 +490,18 @@ pub(crate) async fn run_image_generate_job(
                 )
                 .await?;
             }
+            ImageRoute::SdxlImported => {
+                generate_sdxl_imported_stream(
+                    api,
+                    settings,
+                    job,
+                    &plan,
+                    &project_path,
+                    backend,
+                    &mut asset_writes,
+                )
+                .await?;
+            }
             ImageRoute::InstantId => {
                 // InstantID identity-preserving character image (sc-3345): single identity or
                 // grouped angle/pose sets, on RealVisXL + IdentityNet + the native face stack.
@@ -960,6 +972,18 @@ pub(crate) async fn run_image_generate_job(
                 // unconditioned request; keep it distinct from the builtin registry path.
                 CandleImageRoute::KreaImported => {
                     generate_krea_imported_stream(
+                        api,
+                        settings,
+                        job,
+                        &plan,
+                        &project_path,
+                        backend,
+                        &mut asset_writes,
+                    )
+                    .await?;
+                }
+                CandleImageRoute::SdxlImported => {
+                    generate_sdxl_imported_stream(
                         api,
                         settings,
                         job,
@@ -1812,6 +1836,11 @@ include!("image_jobs/krea_control.rs");
 // loaded through the selected runtime's native single-file entrypoint, bypassing the registry
 // snapshot-dir path. Shared by MLX and Candle so global import acceptance always has a real route.
 include!("image_jobs/krea_imported.rs");
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+include!("image_jobs/sdxl_imported.rs");
 #[cfg(target_os = "macos")]
 // SenseNova edit routing.
 include!("image_jobs/sensenova.rs");

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -113,6 +113,9 @@ enum ImageRoute {
     /// `resolve_imported_krea_dit` returns `None` for it, so the snapshot-dir Krea path is untouched.
     /// txt2img only (a bare imported DiT carries no conditioning components).
     KreaImported,
+    /// A fused SDXL LDM/A1111 single-file checkpoint. The file carries the UNet, both text encoders,
+    /// and VAE; tokenizer assets are borrowed from the installed SDXL base turnkey.
+    SdxlImported,
     InstantId,
     PulidFlux,
     SdxlAdvanced,
@@ -225,6 +228,8 @@ fn resolve_image_route(request: &ImageRequest, settings: &Settings) -> Option<Im
         // builtin Krea. The imported id is in no `MODEL_TABLE`, so `mlx_available` is `false` for it — this
         // arm is what routes it to real MLX generation at all (S0d marked it Mac-routable; this loads it).
         Some(ImageRoute::KreaImported)
+    } else if sdxl_imported_available(request, settings) {
+        Some(ImageRoute::SdxlImported)
     } else if instantid_available(request, settings) {
         Some(ImageRoute::InstantId)
     } else if pulid_flux_available(request, settings) {
@@ -307,6 +312,7 @@ impl ImageRoute {
             // Imported single-file Krea 2 (S0c) is plain per-image txt2img: `count` renders, each its own
             // seed. No angle/pose grouping (a bare imported DiT carries no conditioning).
             | ImageRoute::KreaImported
+            | ImageRoute::SdxlImported
             | ImageRoute::PoseControlBaseMissing
             | ImageRoute::PoseReject
             | ImageRoute::Mlx => request.count,
@@ -362,6 +368,9 @@ enum CandleImageRoute {
     /// the off-Mac twin of [`ImageRoute::KreaImported`], required because imported IDs are not registry
     /// engine IDs and would otherwise fall through to the procedural stub.
     KreaImported,
+    /// Off-Mac twin of [`ImageRoute::SdxlImported`], loaded by candle from the fused checkpoint plus
+    /// the three caller-staged SDXL components.
+    SdxlImported,
     /// Z-Image identity-init for Image Studio "With Character" (sc-8409).
     ZimageIdentity,
     /// SDXL IP-Adapter-Plus reference conditioning (sc-5488).
@@ -543,6 +552,8 @@ fn resolve_candle_image_route(
         // Imported/user Krea 2 single-file t2i: external IDs are absent from `is_candle_engine`, so
         // this bespoke route must claim them before the generic/external fall-through.
         Some(CandleImageRoute::KreaImported)
+    } else if sdxl_imported_available(request, settings) {
+        Some(CandleImageRoute::SdxlImported)
     } else if zimage_comfyui_available(request, settings) {
         // In-place ComfyUI Z-Image base (sc-10668): an `external_base_*` id, so it matches no
         // `is_candle_engine` arm below — route it here off the forwarded `modelManifestEntry`.

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
@@ -1,0 +1,356 @@
+// Shared MLX/Candle in-place loader for a fused SDXL LDM/A1111 checkpoint (sc-14024).
+// The checkpoint supplies UNet + CLIP-L + OpenCLIP-bigG + VAE. MLX borrows only tokenizer assets
+// from the installed SDXL turnkey; candle stages its existing tokenizer + fp16-fix VAE components.
+
+#[cfg(target_os = "macos")]
+const SDXL_IMPORTED_ENGINE: &str = "mlx_sdxl_imported";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const SDXL_IMPORTED_ENGINE: &str = "candle_sdxl_imported";
+
+const SDXL_IMPORTED_DEFAULT_STEPS: u32 = 30;
+const SDXL_IMPORTED_DEFAULT_GUIDANCE: f32 = 7.0;
+const SDXL_CLIP_L_REPO: &str = "openai/clip-vit-large-patch14";
+const SDXL_CLIP_L_REVISION: &str = "32bd64288804d66eefd0ccbe215aa642df71cc41";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const SDXL_CLIP_BIGG_REPO: &str = "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const SDXL_CLIP_BIGG_REVISION: &str = "743c27bd53dfe508a0ade0f50698f99b39d03bec";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const SDXL_VAE_REPO: &str = "madebyollin/sdxl-vae-fp16-fix";
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+const SDXL_VAE_REVISION: &str = "207b116dae70ace3637169f1ddd2434b91b3a8cd";
+
+fn resolve_imported_sdxl_file(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> WorkerResult<Option<PathBuf>> {
+    if request
+        .model_manifest_entry
+        .get("family")
+        .and_then(Value::as_str)
+        != Some("sdxl")
+        || mlx_model(&request.model).is_some()
+    {
+        return Ok(None);
+    }
+    let Some(raw_path) = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .or_else(|| {
+            request
+                .model_manifest_entry
+                .get("paths")
+                .and_then(|paths| paths.get("model"))
+        })
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    else {
+        return Ok(None);
+    };
+    let path = crate::paths::normalize_app_managed_model_path(
+        settings,
+        raw_path,
+        "Imported SDXL checkpoint",
+    )?;
+    Ok(imported_dit_file(&path))
+}
+
+fn sdxl_imported_available(request: &ImageRequest, settings: &Settings) -> bool {
+    request.mode != "edit_image"
+        && request.reference_asset_id.is_none()
+        && request.reference_asset_ids.is_empty()
+        && request.source_asset_id.is_none()
+        && request.mask_asset_id.is_none()
+        && request.character_id.is_none()
+        && request.character_look_id.is_none()
+        && pose_entries(request).is_empty()
+        && matches!(
+            resolve_imported_sdxl_file(request, settings),
+            Ok(Some(_))
+        )
+}
+
+async fn stage_sdxl_component_file(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    repo: &str,
+    revision: &str,
+    file: &str,
+    destination: &Path,
+) -> WorkerResult<()> {
+    if destination.is_file() {
+        return Ok(());
+    }
+    let client = crate::downloads::streaming_download_client();
+    let context = crate::downloads::DownloadContext {
+        api,
+        client: &client,
+        settings,
+        job_id: &job.id,
+        cancel_message: "SDXL generation canceled while staging shared components.",
+        fresh_download: false,
+    };
+    crate::downloads::ensure_hf_cached_file(
+        &context,
+        repo,
+        revision,
+        file,
+        destination,
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+async fn stage_sdxl_tokenizer(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<PathBuf> {
+    let root = settings
+        .data_dir
+        .join("cache")
+        .join("sdxl-imported-components");
+    for file in ["vocab.json", "merges.txt"] {
+        stage_sdxl_component_file(
+            api,
+            settings,
+            job,
+            SDXL_CLIP_L_REPO,
+            SDXL_CLIP_L_REVISION,
+            file,
+            &root.join("tokenizer").join(file),
+        )
+        .await?;
+    }
+    Ok(root)
+}
+
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+async fn attach_imported_sdxl_components(
+    spec: LoadSpec,
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<LoadSpec> {
+    let root = settings
+        .data_dir
+        .join("cache")
+        .join("sdxl-imported-components");
+    let clip_l = root.join("clip-l");
+    let clip_bigg = root.join("clip-bigg");
+    let vae = root.join("vae-fp16-fix");
+    for (repo, revision, file, destination) in [
+        (
+            SDXL_CLIP_L_REPO,
+            SDXL_CLIP_L_REVISION,
+            "tokenizer.json",
+            clip_l.join("tokenizer.json"),
+        ),
+        (
+            SDXL_CLIP_BIGG_REPO,
+            SDXL_CLIP_BIGG_REVISION,
+            "tokenizer.json",
+            clip_bigg.join("tokenizer.json"),
+        ),
+        (
+            SDXL_VAE_REPO,
+            SDXL_VAE_REVISION,
+            "diffusion_pytorch_model.safetensors",
+            vae.join("diffusion_pytorch_model.safetensors"),
+        ),
+    ] {
+        stage_sdxl_component_file(
+            api,
+            settings,
+            job,
+            repo,
+            revision,
+            file,
+            &destination,
+        )
+        .await?;
+    }
+    Ok(spec
+        .with_component(
+            "tokenizer_clip_l",
+            WeightsSource::Dir(clip_l),
+        )
+        .with_component(
+            "tokenizer_clip_bigg",
+            WeightsSource::Dir(clip_bigg),
+        )
+        .with_component(
+            "vae_fp16_fix",
+            WeightsSource::Dir(vae),
+        ))
+}
+
+async fn generate_sdxl_imported_stream(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    plan: &ImagePlan,
+    project_path: &Path,
+    backend: &str,
+    asset_writes: &mut Vec<Value>,
+) -> WorkerResult<()> {
+    let request = &plan.request;
+    let file = resolve_imported_sdxl_file(request, settings)?.ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Imported SDXL checkpoint could not be resolved as one confined .safetensors file"
+                .to_owned(),
+        )
+    })?;
+    let adapters = resolve_adapters(request, settings)?;
+    let adapter_count = adapters.len();
+    let steps =
+        resolve_advanced_or_manifest_u32(request, "steps", SDXL_IMPORTED_DEFAULT_STEPS, 1..=100);
+    let guidance = resolve_advanced_or_manifest_f32(
+        request,
+        "guidanceScale",
+        SDXL_IMPORTED_DEFAULT_GUIDANCE,
+        0.0..=30.0,
+    );
+    let (sampler, scheduler, scheduler_shift) = read_advanced_sampling_knobs(&request.advanced);
+    let descriptor = crate::inference_runtime::media_descriptor("sdxl").ok_or_else(|| {
+        WorkerError::Engine("native SDXL generator is not registered".to_owned())
+    })?;
+    let caps = &descriptor.capabilities;
+    let sampler = normalize_sampling_knob(
+        sampler,
+        &caps.samplers,
+        "sampler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let scheduler = normalize_sampling_knob(
+        scheduler,
+        &caps.schedulers,
+        "scheduler",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let guidance_method = normalize_sampling_knob(
+        read_advanced_guidance_method(&request.advanced),
+        &caps.supported_guidance_methods,
+        "guidanceMethod",
+        &request.model,
+        &job.id,
+        backend,
+    );
+    let pid_weights = resolve_pid_weights(request, &settings.data_dir, "sdxl")?;
+    let use_pid = pid_weights.is_some();
+    let negative_prompt = (!request.negative_prompt.trim().is_empty())
+        .then(|| request.negative_prompt.clone());
+    let (width, height) = (request.width, request.height);
+    let work: Vec<(i64, String)> = (0..request.count as usize)
+        .map(|index| (resolve_seed(request, index), request.prompt.clone()))
+        .collect();
+    let total = work.len();
+    let mut raw_settings = request.advanced.clone();
+    raw_settings.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw_settings.insert("numInferenceSteps".to_owned(), json!(steps));
+    raw_settings.insert("guidanceScale".to_owned(), json!(guidance));
+    raw_settings.insert(
+        "engine".to_owned(),
+        Value::String(SDXL_IMPORTED_ENGINE.to_owned()),
+    );
+    raw_settings.insert(
+        "importedCheckpoint".to_owned(),
+        Value::String(request.model.clone()),
+    );
+
+    let mut spec = LoadSpec::new(WeightsSource::File(file.clone())).with_adapters(adapters);
+    if let Some(pid) = pid_weights {
+        spec = spec.with_pid(pid.checkpoint, pid.gemma);
+    }
+    #[cfg(target_os = "macos")]
+    let spec = crate::mlx_fit_gate::apply_residency_policy(spec, "sdxl")?;
+    #[cfg(target_os = "macos")]
+    let tokenizer_root = stage_sdxl_tokenizer(api, settings, job).await?;
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    let spec = attach_imported_sdxl_components(spec, api, settings, job).await?;
+
+    let (cancel, rx, blocking) = start_gen_stream(
+        job.id.clone(),
+        SDXL_IMPORTED_ENGINE,
+        adapter_count,
+        move || {
+            #[cfg(target_os = "macos")]
+            let loaded = runtime_macos::providers::sdxl::load_from_ldm_file(
+                &spec,
+                &tokenizer_root,
+            );
+            #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+            let loaded = runtime_cuda::providers::sdxl::load(&spec);
+            loaded.map_err(|error| {
+                WorkerError::Engine(format!("SDXL imported checkpoint load failed: {error}"))
+            })
+        },
+        move |model, tx, cancel| {
+            drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
+                if cancel.is_cancelled() {
+                    return Ok(None);
+                }
+                let request = GenerationRequest {
+                    prompt,
+                    negative_prompt: negative_prompt.clone(),
+                    width,
+                    height,
+                    count: 1,
+                    seed: Some(seed as u64),
+                    steps: Some(steps),
+                    guidance: Some(guidance),
+                    sampler: sampler.clone(),
+                    scheduler: scheduler.clone(),
+                    scheduler_shift,
+                    guidance_method: guidance_method.clone(),
+                    use_pid,
+                    cancel: cancel.clone(),
+                    ..Default::default()
+                };
+                let output = model.generate(&request, &mut *on_progress).map_err(|error| {
+                    WorkerError::Engine(format!(
+                        "SDXL imported checkpoint generation failed: {error}"
+                    ))
+                })?;
+                match output {
+                    GenerationOutput::Images(mut images) => {
+                        let image = images.pop().ok_or_else(|| {
+                            WorkerError::Engine(
+                                "SDXL imported checkpoint produced no image".to_owned(),
+                            )
+                        })?;
+                        Ok(Some((seed, image.width, image.height, image.pixels)))
+                    }
+                    _ => Err(WorkerError::Engine(
+                        "SDXL imported checkpoint returned non-image output".to_owned(),
+                    )),
+                }
+            })
+        },
+    );
+
+    consume_gen_events(
+        api,
+        settings,
+        job,
+        plan,
+        project_path,
+        backend,
+        SDXL_IMPORTED_ENGINE,
+        &raw_settings,
+        total,
+        rx,
+        cancel,
+        blocking,
+        asset_writes,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -10998,6 +10998,63 @@ fn resolve_image_route_sends_imported_single_file_krea_to_the_bespoke_lane() {
     );
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn resolve_image_route_sends_only_plain_imported_sdxl_to_fused_lane() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir
+        .path()
+        .join("models")
+        .join("imports")
+        .join("community-xl.safetensors");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, b"sdxl").unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    let payload = |extra: Value| {
+        let mut value = json!({
+            "projectId": "p",
+            "model": "community_xl",
+            "prompt": "a fox",
+            "modelManifestEntry": {
+                "family": "sdxl",
+                "modelPath": file.to_str().unwrap()
+            }
+        });
+        value
+            .as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().unwrap().clone());
+        request(value)
+    };
+
+    let plain = payload(json!({}));
+    assert_eq!(
+        resolve_imported_sdxl_file(&plain, &settings).unwrap(),
+        Some(std::fs::canonicalize(&file).unwrap_or(file.clone()))
+    );
+    assert!(sdxl_imported_available(&plain, &settings));
+    assert_eq!(
+        resolve_image_route(&plain, &settings),
+        Some(ImageRoute::SdxlImported)
+    );
+
+    for conditioned in [
+        payload(json!({ "referenceAssetId": "asset-1" })),
+        payload(json!({ "mode": "edit_image", "sourceAssetId": "asset-1" })),
+        payload(json!({ "advanced": { "poses": [{}] } })),
+    ] {
+        assert!(
+            !sdxl_imported_available(&conditioned, &settings),
+            "conditioning must never be silently dropped by the fused txt2img lane"
+        );
+        assert_ne!(
+            resolve_image_route(&conditioned, &settings),
+            Some(ImageRoute::SdxlImported)
+        );
+    }
+}
+
 /// Candle twin of the MLX route regression above: the external id is absent from the builtin table,
 /// yet a real app-managed single-file Krea manifest resolves to the bespoke Candle dispatch variant.
 /// The exhaustive match in `run_image_job` maps that variant to `generate_krea_imported_stream`.


### PR DESCRIPTION
## Summary
- recognize dense fused SDXL LDM/A1111 safetensors during import and expose SDXL as a routed imported family
- add fail-closed imported-SDXL dispatch for MLX and Candle without changing builtin SDXL routes
- pin and stage shared tokenizer/fp16-VAE assets, forward sampling/PiD controls, adapters, and MLX residency policy
- pin inference support to SceneWorks/inference#217 commit b83b51da6ff5a6b9750a414730cf71ed7ac5269b

## Validation
- cargo check --locked -p sceneworks-worker
- cargo clippy --locked -p sceneworks-core -p sceneworks-worker --all-targets -- -D warnings
- base-weight tests: 29 passed, 1 ignored
- routing catalog tests: 14 passed
- imported-SDXL worker route regression passed
- independent adversarial review completed; all material findings addressed

## Dependency
- https://github.com/SceneWorks/inference/pull/217

Shortcut: https://app.shortcut.com/trefry/story/14024