### PR TITLE
fix(api): validate model ids across job side doors

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -392,7 +392,7 @@ async fn validate_merged_generation_model(
 ) -> Result<(), ApiError> {
     let job_id = job_id.to_owned();
     let job = store_call(state.clone(), move |store, _timeout| store.get_job(&job_id)).await?;
-    if typed_generation_route(&job.job_type).is_none() {
+    if !generation_job_model_is_path_backed(&job.job_type) {
         return Ok(());
     }
     let mut merged = job.payload;
@@ -407,7 +407,31 @@ fn validate_raw_job_model_id(job_type: &JobType, payload: &JsonObject) -> Result
     if matches!(job_type, JobType::ImageUpscale) {
         validate_payload_model(payload)?;
     }
+    if matches!(
+        job_type,
+        JobType::ModelDownload | JobType::ModelImport | JobType::ModelConvert
+    ) {
+        validate_payload_model_id(payload)?;
+    }
     Ok(())
+}
+
+/// Generation kinds whose `model` selects weights and therefore reaches worker path resolution.
+/// This is deliberately separate from `typed_generation_route`: VQA/interleave have typed routes
+/// but need no manifest injection, so the raw-route predicate intentionally excludes them.
+fn generation_job_model_is_path_backed(job_type: &JobType) -> bool {
+    matches!(
+        job_type,
+        JobType::ImageGenerate
+            | JobType::ImageEdit
+            | JobType::ImageVqa
+            | JobType::ImageInterleave
+            | JobType::VideoGenerate
+            | JobType::VideoExtend
+            | JobType::VideoBridge
+            | JobType::PersonReplace
+            | JobType::AudioGenerate
+    )
 }
 
 fn validate_payload_model(payload: &JsonObject) -> Result<(), ApiError> {
@@ -416,6 +440,16 @@ fn validate_payload_model(payload: &JsonObject) -> Result<(), ApiError> {
             .as_str()
             .ok_or_else(|| ApiError::bad_request("model must be a string"))?;
         validate_model_id(model)?;
+    }
+    Ok(())
+}
+
+fn validate_payload_model_id(payload: &JsonObject) -> Result<(), ApiError> {
+    if let Some(model_id) = payload.get("modelId") {
+        let model_id = model_id
+            .as_str()
+            .ok_or_else(|| ApiError::bad_request("modelId must be a string"))?;
+        validate_model_id(model_id)?;
     }
     Ok(())
 }

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -400,11 +400,13 @@ async fn validate_merged_generation_model(
     validate_payload_model(&merged)
 }
 
-/// Utility jobs created through the raw queue route do not pass a typed request validator.
-/// `image_upscale` is the utility lane whose `model` value participates in model/path
-/// resolution, so guard that field at the API boundary before the job is persisted.
+/// Jobs created through the raw queue route do not pass a typed request validator. Keep this
+/// inventory aligned with worker payload fields that reach filesystem model resolution:
+/// `image_upscale` and `prompt_refine` consume `model`; the model-management jobs consume
+/// `modelId`. Other raw job payloads may contain descriptive model metadata, but are deliberately
+/// absent unless that field selects a filesystem path.
 fn validate_raw_job_model_id(job_type: &JobType, payload: &JsonObject) -> Result<(), ApiError> {
-    if matches!(job_type, JobType::ImageUpscale) {
+    if matches!(job_type, JobType::ImageUpscale | JobType::PromptRefine) {
         validate_payload_model(payload)?;
     }
     if matches!(

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -90,6 +90,7 @@ pub(crate) async fn create_job(
             payload.job_type.as_str()
         )));
     }
+    validate_raw_job_model_id(&payload.job_type, &payload.payload)?;
     let job = store_call(state.clone(), move |store, _timeout| {
         store.create_job(CreateJob {
             job_type: payload.job_type,
@@ -332,6 +333,7 @@ pub(crate) async fn retry_job(
     request: AxumRequest,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
     let payload = retry_job_request_from_body(request).await?;
+    validate_merged_generation_model(&state, &job_id, &payload.payload_changes).await?;
     let job = store_call(state.clone(), move |store, _timeout| {
         store.retry_job(
             &job_id,
@@ -364,6 +366,7 @@ pub(crate) async fn duplicate_job(
     Path(job_id): Path<String>,
     ApiJson(payload): ApiJson<DuplicateJobRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    validate_merged_generation_model(&state, &job_id, &payload.payload_changes).await?;
     let job = store_call(state.clone(), move |store, _timeout| {
         store.duplicate_job(
             &job_id,
@@ -377,6 +380,44 @@ pub(crate) async fn duplicate_job(
     publish(&state, "job.updated", &job);
     publish_queue(&state).await?;
     Ok((StatusCode::CREATED, Json(job)))
+}
+
+/// Validate the exact payload a retry/duplicate will enqueue. Existing job payloads are
+/// immutable, so reading and merging before the create transaction cannot race with a payload
+/// update; importantly, validation still happens before the new row is persisted or published.
+async fn validate_merged_generation_model(
+    state: &AppState,
+    job_id: &str,
+    payload_changes: &JsonObject,
+) -> Result<(), ApiError> {
+    let job_id = job_id.to_owned();
+    let job = store_call(state.clone(), move |store, _timeout| store.get_job(&job_id)).await?;
+    if typed_generation_route(&job.job_type).is_none() {
+        return Ok(());
+    }
+    let mut merged = job.payload;
+    merged.extend(payload_changes.clone());
+    validate_payload_model(&merged)
+}
+
+/// Utility jobs created through the raw queue route do not pass a typed request validator.
+/// `image_upscale` is the utility lane whose `model` value participates in model/path
+/// resolution, so guard that field at the API boundary before the job is persisted.
+fn validate_raw_job_model_id(job_type: &JobType, payload: &JsonObject) -> Result<(), ApiError> {
+    if matches!(job_type, JobType::ImageUpscale) {
+        validate_payload_model(payload)?;
+    }
+    Ok(())
+}
+
+fn validate_payload_model(payload: &JsonObject) -> Result<(), ApiError> {
+    if let Some(model) = payload.get("model") {
+        let model = model
+            .as_str()
+            .ok_or_else(|| ApiError::bad_request("model must be a string"))?;
+        validate_model_id(model)?;
+    }
+    Ok(())
 }
 
 /// Clear completed items from the queue (sc-12231, issue #1556). Soft-hides every

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -140,6 +140,32 @@ async fn generic_image_upscale_rejects_path_unsafe_model_before_create() {
     assert!(jobs.as_array().expect("jobs array").is_empty());
 }
 
+/// sc-13617 / F-055: raw utility jobs whose `modelId` reaches worker-side model path
+/// construction must reject traversal before persistence.
+#[tokio::test]
+async fn generic_model_utility_jobs_reject_path_unsafe_model_id_before_create() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    for job_type in ["model_download", "model_import", "model_convert"] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": job_type,
+                "requestedGpu": "auto",
+                "payload": { "modelId": "../../outside" },
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{job_type}: {body}");
+    }
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert!(jobs.as_array().expect("jobs array").is_empty());
+}
+
 /// sc-13617 / F-011: retry and duplicate merge payloadChanges into an existing generation
 /// payload. Validate the merged model before either operation can persist a new job.
 #[tokio::test]
@@ -155,7 +181,7 @@ async fn retry_and_duplicate_reject_path_unsafe_merged_generation_model_before_c
     )
     .await;
     let project_id = project["id"].as_str().expect("project id");
-    let (status, original) = request(
+    let (status, audio_job) = request(
         app.clone(),
         "POST",
         "/api/v1/audio/jobs",
@@ -166,22 +192,54 @@ async fn retry_and_duplicate_reject_path_unsafe_merged_generation_model_before_c
         }),
     )
     .await;
-    assert_eq!(status, StatusCode::CREATED, "{original}");
-    let job_id = original["id"].as_str().expect("job id");
+    assert_eq!(status, StatusCode::CREATED, "{audio_job}");
 
-    for operation in ["retry", "duplicate"] {
-        let (status, body) = request(
-            app.clone(),
-            "POST",
-            &format!("/api/v1/jobs/{job_id}/{operation}"),
-            json!({ "payloadChanges": { "model": "../../outside" } }),
-        )
-        .await;
-        assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {body}");
+    let (status, vqa_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/vqa/jobs",
+        json!({
+            "projectId": project_id,
+            "sourceAssetId": "asset-1",
+            "question": "What is shown?",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{vqa_job}");
+
+    let (status, interleave_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/interleave/jobs",
+        json!({
+            "projectId": project_id,
+            "prompt": "Create a safe image",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{interleave_job}");
+
+    for job in [&audio_job, &vqa_job, &interleave_job] {
+        let job_id = job["id"].as_str().expect("job id");
+        for operation in ["retry", "duplicate"] {
+            let (status, body) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{job_id}/{operation}"),
+                json!({ "payloadChanges": { "model": "../../outside" } }),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{} {operation}: {body}",
+                job["type"]
+            );
+        }
     }
 
     let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
-    assert_eq!(jobs.as_array().expect("jobs array").len(), 1);
+    assert_eq!(jobs.as_array().expect("jobs array").len(), 3);
 }
 
 #[test]

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -113,28 +113,27 @@ async fn generic_jobs_route_still_serves_non_generation_types() {
     }
 }
 
-/// sc-13617 / F-055: the generic queue route is the only create boundary for standalone
-/// upscales, so a caller-supplied model id must be rejected before a job row exists.
+/// sc-13617 / F-055: raw jobs whose `model` reaches worker-side model path resolution must
+/// reject traversal before a job row exists. This table is the API-side inventory for that key.
 #[tokio::test]
-async fn generic_image_upscale_rejects_path_unsafe_model_before_create() {
+async fn generic_model_backed_jobs_reject_path_unsafe_model_before_create() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
 
-    let (status, body) = request(
-        app.clone(),
-        "POST",
-        "/api/v1/jobs",
-        json!({
-            "type": "image_upscale",
-            "requestedGpu": "auto",
-            "payload": {
-                "sourceAssetId": "asset-1",
-                "model": "../../outside"
-            },
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    for job_type in ["image_upscale", "prompt_refine"] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            json!({
+                "type": job_type,
+                "requestedGpu": "auto",
+                "payload": { "model": "../../outside" },
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{job_type}: {body}");
+    }
 
     let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
     assert!(jobs.as_array().expect("jobs array").is_empty());

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -113,6 +113,77 @@ async fn generic_jobs_route_still_serves_non_generation_types() {
     }
 }
 
+/// sc-13617 / F-055: the generic queue route is the only create boundary for standalone
+/// upscales, so a caller-supplied model id must be rejected before a job row exists.
+#[tokio::test]
+async fn generic_image_upscale_rejects_path_unsafe_model_before_create() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "image_upscale",
+            "requestedGpu": "auto",
+            "payload": {
+                "sourceAssetId": "asset-1",
+                "model": "../../outside"
+            },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert!(jobs.as_array().expect("jobs array").is_empty());
+}
+
+/// sc-13617 / F-011: retry and duplicate merge payloadChanges into an existing generation
+/// payload. Validate the merged model before either operation can persist a new job.
+#[tokio::test]
+async fn retry_and_duplicate_reject_path_unsafe_merged_generation_model_before_create() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_audio_manifest(&temp_dir.path().join("config/manifests"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Audio Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+    let (status, original) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/audio/jobs",
+        json!({
+            "projectId": project_id,
+            "model": "kokoro_82m",
+            "prompt": "Safe original",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{original}");
+    let job_id = original["id"].as_str().expect("job id");
+
+    for operation in ["retry", "duplicate"] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/jobs/{job_id}/{operation}"),
+            json!({ "payloadChanges": { "model": "../../outside" } }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {body}");
+    }
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(jobs.as_array().expect("jobs array").len(), 1);
+}
+
 #[test]
 fn serialize_job_lora_carries_network_type_to_payload() {
     // A trained LoKr adapter records networkType (epic 2193); the generation


### PR DESCRIPTION
Closes sc-13617

## Summary
- validate standalone image-upscale model IDs on raw `POST /api/v1/jobs` before persistence
- validate the fully merged generation payload on retry and duplicate before creating/publishing the successor
- add regressions proving traversal attempts return 400 and create no extra job rows

## Validation
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/sc13617-target cargo check -p sceneworks-rust-api`
- `CARGO_TARGET_DIR=/tmp/sc13617-target cargo test -p sceneworks-rust-api` (358 passed, 3 ignored)