### PR TITLE
Fix Candle VRAM tier parity

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -5051,6 +5051,19 @@ fn vram_reject_tail(installed_smaller: &[&str]) -> String {
     )
 }
 
+/// Build the candle reject advice for `rejected_tier` from the tiers the loader can actually resolve.
+/// Kept pure so bespoke candle lanes can share the same truthfulness contract as the main image lane.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn vram_reject_tail_for_tier(installed: Vec<&'static str>, rejected_tier: &str) -> String {
+    let smaller: Vec<&'static str> = installed
+        .into_iter()
+        .filter(|candidate| {
+            tier_quality_rank(candidate) < tier_quality_rank(rejected_tier)
+        })
+        .collect();
+    vram_reject_tail(&smaller)
+}
+
 /// Candle per-tier capability fit for the downtier chooser (sc-10733): fold the full candle fit decision
 /// (predicted resident peak vs the live budget, plus the sequential-residency second stage where the
 /// provider stages components) down to [`TierFit`]. `Fits` = runs resident OR sequentially; `TooBig` =

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -66,6 +66,26 @@ const KREA_CONTROL_OVERLAY_FILE: &str = "control_step5000.safetensors";
 /// `lfs.oid` from HF's tree API.
 const KREA_CONTROL_OVERLAY_REVISION: &str = "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac";
 
+/// The Krea control fit-ladder tier for the base directory the resolver will actually load.
+///
+/// Standard turnkey basenames are authoritative because `krea_model_subdir` can clamp/fall back away
+/// from the requested bits. Opaque dense roots deliberately fall through to the request key; NVFP4 is
+/// likewise used only when no standard tier basename resolved.
+fn krea_control_gate_tier(
+    resolved_base: &Path,
+    advanced: &JsonObject,
+    manifest_entry: &JsonObject,
+    nvfp4: bool,
+) -> &'static str {
+    gate_tier_key(
+        /* convrot_resolved */ false,
+        resolved_base,
+        advanced,
+        manifest_entry,
+        nvfp4,
+    )
+}
+
 /// Model ids the candle Krea strict-pose control route accepts (the deployed base the overlay applies on).
 fn is_krea_control_model(model: &str) -> bool {
     model == "krea_2_turbo"
@@ -460,8 +480,7 @@ async fn generate_candle_krea_control_stream(
     // resolver clamps/falls back to an installed tier, so request bits can disagree with the directory
     // that loads (for example, requested q4 with only q8 installed). Dense/opaque roots have no tier
     // basename and deliberately retain the request/NVFP4 fallback.
-    let tier = gate_tier_key(
-        /* convrot_resolved */ false,
+    let tier = krea_control_gate_tier(
         &base,
         &request.advanced,
         &request.model_manifest_entry,
@@ -625,8 +644,7 @@ mod krea_control_tier_reconcile_tests {
 
         // Installed-tier fallback: a q4 request that resolved q8 must budget q8.
         assert_eq!(
-            gate_tier_key(
-                false,
+            krea_control_gate_tier(
                 Path::new("/cache/SceneWorks/krea-2-turbo-mlx/q8"),
                 &req.advanced,
                 &req.model_manifest_entry,
@@ -644,16 +662,65 @@ mod krea_control_tier_reconcile_tests {
             "the request key intentionally differs in this regression"
         );
 
+        // Every recognized resolved tier is authoritative, independent of the requested q4.
+        assert_eq!(
+            krea_control_gate_tier(
+                Path::new("/cache/SceneWorks/krea-2-turbo-mlx/q4"),
+                &req.advanced,
+                &req.model_manifest_entry,
+                false,
+            ),
+            "q4"
+        );
+        assert_eq!(
+            krea_control_gate_tier(
+                Path::new("/cache/SceneWorks/krea-2-turbo-mlx/bf16"),
+                &req.advanced,
+                &req.model_manifest_entry,
+                false,
+            ),
+            "bf16"
+        );
+
+        // An eligible NVFP4 selection survives only when the resolved directory is itself NVFP4/opaque;
+        // a standard installed fallback remains authoritative.
+        assert_eq!(
+            krea_control_gate_tier(
+                Path::new("/cache/SceneWorks/krea-2-turbo-mlx/nvfp4"),
+                &req.advanced,
+                &req.model_manifest_entry,
+                true,
+            ),
+            NVFP4_TIER
+        );
+        assert_eq!(
+            krea_control_gate_tier(
+                Path::new("/cache/SceneWorks/krea-2-turbo-mlx/q8"),
+                &req.advanced,
+                &req.model_manifest_entry,
+                true,
+            ),
+            "q8"
+        );
+
         // Bring-your-own dense snapshots have opaque basenames, preserving the request-derived fallback.
         assert_eq!(
-            gate_tier_key(
-                false,
+            krea_control_gate_tier(
                 Path::new("/models/krea-dense-snapshot"),
                 &req.advanced,
                 &req.model_manifest_entry,
                 false,
             ),
             "q4"
+        );
+        assert_eq!(
+            krea_control_gate_tier(
+                Path::new("/models/krea-dense-snapshot"),
+                &req.advanced,
+                &req.model_manifest_entry,
+                true,
+            ),
+            NVFP4_TIER
         );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -456,10 +456,13 @@ async fn generate_candle_krea_control_stream(
     // plan — fixing the repeated-control-render needless downtier / reject. Same treatment as
     // `qwen_edit_candle.rs`; base.rs already gets it for free via the evicting cache. The admitted peak is
     // recorded (`note_loaded_peak` below) so a repeated control render can reclaim these pooled pages.
-    // sc-11042: `base` is the tier dir this lane resolved (`krea_model_subdir`'s output when the user has
-    // the packed MLX turnkey; a dense diffusers snapshot root otherwise, which is never an `nvfp4/` dir),
-    // so the NVFP4 tier is sized only when it is the tier that actually resolved.
-    let tier = crate::vram_gate::requested_tier_key(
+    // sc-11042 / sc-13619: budget the tier `resolve_krea_control_base` ACTUALLY selected. The turnkey
+    // resolver clamps/falls back to an installed tier, so request bits can disagree with the directory
+    // that loads (for example, requested q4 with only q8 installed). Dense/opaque roots have no tier
+    // basename and deliberately retain the request/NVFP4 fallback.
+    let tier = gate_tier_key(
+        /* convrot_resolved */ false,
+        &base,
         &request.advanced,
         &request.model_manifest_entry,
         nvfp4_selected(request, nvfp4_host_eligible(), Some(&base)),
@@ -597,4 +600,60 @@ async fn generate_candle_krea_control_stream(
         asset_writes,
     )
     .await
+}
+
+#[cfg(test)]
+mod krea_control_tier_reconcile_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(bits: i64) -> ImageRequest {
+        ImageRequest::from_payload(
+            json!({
+                "model": "krea_2_turbo",
+                "advanced": { "mlxQuantize": bits },
+                "modelManifestEntry": {}
+            })
+            .as_object()
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn fit_ladder_sizes_the_resolved_base_tier_before_request_fallback() {
+        let req = request(4);
+
+        // Installed-tier fallback: a q4 request that resolved q8 must budget q8.
+        assert_eq!(
+            gate_tier_key(
+                false,
+                Path::new("/cache/SceneWorks/krea-2-turbo-mlx/q8"),
+                &req.advanced,
+                &req.model_manifest_entry,
+                false,
+            ),
+            "q8"
+        );
+        assert_eq!(
+            crate::vram_gate::requested_tier_key(
+                &req.advanced,
+                &req.model_manifest_entry,
+                false,
+            ),
+            "q4",
+            "the request key intentionally differs in this regression"
+        );
+
+        // Bring-your-own dense snapshots have opaque basenames, preserving the request-derived fallback.
+        assert_eq!(
+            gate_tier_key(
+                false,
+                Path::new("/models/krea-dense-snapshot"),
+                &req.advanced,
+                &req.model_manifest_entry,
+                false,
+            ),
+            "q4"
+        );
+    }
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -531,6 +531,11 @@ async fn generate_candle_qwen_edit_stream(
         )
         .await?;
         let available_gb = budget.map_or(0.0, |b| b.free_gb);
+        // sc-13619: the quant picker is hidden when no alternative tier is installed. Derive advice
+        // from the same forced-tier probes as the main candle lane so both reject arms name only
+        // smaller tiers this installation can really load.
+        let reject_tail =
+            vram_reject_tail_for_tier(installed_tier_keys(request, settings), tier);
         match plan {
             crate::vram_gate::LoadPlan::Sequential => {
                 tracing::info!(
@@ -559,12 +564,12 @@ async fn generate_candle_qwen_edit_stream(
                     return Err(WorkerError::InvalidPayload(format!(
                         "{model} at the {tier} tier needs ~{seq} GB of VRAM even with sequential \
                          component residency (loading one component at a time), but GPU {gpu} has \
-                         ~{available} GB available. Pick a lower tier (Q4/Q8), lower the output \
-                         resolution, or run on a card with more VRAM.",
+                         ~{available} GB available. {tail}",
                         model = request.model,
                         seq = seq_gb.round() as i64,
                         available = available_gb.round() as i64,
                         gpu = settings.gpu_id,
+                        tail = reject_tail,
                     )));
                 }
                 // Defensive: a resident overflow with no staging — unreachable for this lane (it is always
@@ -572,12 +577,12 @@ async fn generate_candle_qwen_edit_stream(
                 // honest message rather than an unwrap if that ever changes.
                 return Err(WorkerError::InvalidPayload(format!(
                     "{model} at the {tier} tier needs ~{needed} GB of VRAM (with headroom) but GPU \
-                     {gpu} has ~{available} GB available. Pick a lower tier (Q4/Q8), lower the output \
-                     resolution, or run on a card with more VRAM.",
+                     {gpu} has ~{available} GB available. {tail}",
                     model = request.model,
                     needed = needed.unwrap_or(0.0).round() as i64,
                     available = available_gb.round() as i64,
                     gpu = settings.gpu_id,
+                    tail = reject_tail,
                 )));
             }
             // Resident admit (`Fits`) — or `Unknown` when a tier is unmeasured. Record the RESIDENT peak
@@ -864,6 +869,19 @@ mod qwen_edit_tier_reconcile_tests {
             gate_tier_key(false, opaque.path(), &req.advanced, entry, false),
             "q4"
         );
+    }
+
+    #[test]
+    fn reject_advice_names_only_smaller_installed_tiers() {
+        let none = vram_reject_tail_for_tier(vec!["q8"], "q8");
+        assert!(none.contains("No smaller tier is installed"));
+        assert!(!none.contains("Pick a lower tier"));
+        assert!(!none.contains("Q4/Q8"));
+
+        let q4 = vram_reject_tail_for_tier(vec!["bf16", "q8", "q4"], "q8");
+        assert!(q4.contains("(Q4)"));
+        assert!(!q4.contains("BF16"));
+        assert!(!q4.contains("Q8 /"));
     }
 
     /// The PRODUCTION default path, end to end: a stock install fetches only the `default: true` q4


### PR DESCRIPTION
## Summary
- make Qwen Edit reject advice reflect only smaller installed tiers
- size the Krea Control fit ladder from the resolved base tier, preserving dense-root fallback semantics
- add deterministic regressions for installed-tier advice and requested-versus-resolved tier selection

## Validation
- cargo fmt --all -- --check
- cargo test --locked -p sceneworks-worker --lib (967 passed, 176 ignored)
- Candle Linux cross-check attempted; blocked locally because candle-kernels requires nvcc, unavailable on this Mac

Shortcut: [sc-13619](https://app.shortcut.com/trefry/story/13619)