### PR TITLE
test(models): pin torn quant-tier detection for flux1-dev-mlx q8 [sc-13815]

### DIFF
--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -1981,6 +1981,87 @@ fn cache_health_does_not_let_an_appledouble_sidecar_satisfy_a_required_pattern()
 }
 
 #[test]
+fn quant_tier_with_an_empty_weight_component_reads_incomplete_not_installed() {
+    // sc-13815: the flux1-dev-mlx q8 tier loaded with an EMPTY `text_encoder_2/` on a dev host, so
+    // the render fell back to q4. The question was whether the manifest allow-list omits those
+    // weights (a provisioning bug) or the host cache was torn (host state). This pins BOTH halves of
+    // the answer — the allow-list is correct and a torn tier is detected — so the same symptom can
+    // never be misread as an allow-list gap again.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let repo_root = temp_dir.path().join("models--SceneWorks--flux1-dev-mlx");
+    let snapshot = repo_root.join("snapshots/abc123");
+    let q8 = snapshot.join("q8");
+    std::fs::create_dir_all(repo_root.join("refs")).expect("refs creates");
+    std::fs::write(repo_root.join("refs/main"), "abc123").expect("ref writes");
+    // The real `SceneWorks/flux1-dev-mlx` q8 `model_index.json` (FluxPipeline), verbatim in shape:
+    // `text_encoder_2` is a weight-bearing T5EncoderModel, so its directory must hold config +
+    // weights. The tokenizers/scheduler are weightless and only need a non-empty directory.
+    std::fs::create_dir_all(q8.join("text_encoder_2")).expect("text_encoder_2 creates");
+    std::fs::write(
+        q8.join("model_index.json"),
+        r#"{
+            "_class_name": "FluxPipeline",
+            "scheduler": ["diffusers", "FlowMatchEulerDiscreteScheduler"],
+            "text_encoder": ["transformers", "CLIPTextModel"],
+            "text_encoder_2": ["transformers", "T5EncoderModel"],
+            "tokenizer": ["transformers", "CLIPTokenizer"],
+            "tokenizer_2": ["transformers", "T5TokenizerFast"],
+            "transformer": ["diffusers", "FluxTransformer2DModel"],
+            "vae": ["diffusers", "AutoencoderKL"]
+        }"#,
+    )
+    .expect("q8 model_index writes");
+    for component in ["text_encoder", "transformer", "vae"] {
+        std::fs::create_dir_all(q8.join(component)).expect("component creates");
+        std::fs::write(q8.join(component).join("config.json"), "{}").expect("config writes");
+        std::fs::write(q8.join(component).join("model.safetensors"), "weights")
+            .expect("weights write");
+    }
+    for component in ["scheduler", "tokenizer", "tokenizer_2"] {
+        std::fs::create_dir_all(q8.join(component)).expect("component creates");
+        std::fs::write(q8.join(component).join("config.json"), "{}").expect("config writes");
+    }
+
+    // The `q8/*` allow-list glob is RECURSIVE — it selects `q8/text_encoder_2/model.safetensors`
+    // just as it selects `q8/model_index.json`. The manifest entry is therefore NOT the gap; the
+    // weights were always in scope for the download.
+    assert!(
+        crate::pattern_matches("q8/*", "q8/text_encoder_2/model.safetensors"),
+        "`q8/*` must select nested tier weights, or the allow-list really would be the bug"
+    );
+    assert!(
+        !crate::pattern_matches("q8/*", "q4/text_encoder_2/model.safetensors"),
+        "`q8/*` must not leak across tiers"
+    );
+
+    // A torn tier — every other component present, `text_encoder_2/` empty — is INCOMPLETE, and
+    // names the offending component so the Fix button can repair it. A coarse `q8/*` glob alone is
+    // satisfied by the sibling files, so this is exactly the case the tier-completeness
+    // augmentation exists to catch.
+    let torn = crate::models::huggingface_cache_health(&repo_root, &["q8/*".to_owned()]);
+    assert!(
+        !torn.installed && torn.incomplete,
+        "an empty weight-bearing component makes the tier torn, not installed: {torn:?}"
+    );
+    assert!(
+        torn.missing_files
+            .iter()
+            .any(|file| file.starts_with("q8/text_encoder_2/")),
+        "missing_files must name text_encoder_2, got {:?}",
+        torn.missing_files
+    );
+
+    // Re-provisioning the component — the actual fix on the affected host — restores it to green.
+    std::fs::write(q8.join("text_encoder_2/config.json"), "{}").expect("config writes");
+    std::fs::write(q8.join("text_encoder_2/model.safetensors"), "weights").expect("weights write");
+    let repaired = crate::models::huggingface_cache_health(&repo_root, &["q8/*".to_owned()]);
+    assert!(
+        repaired.installed && !repaired.incomplete && repaired.missing_files.is_empty(),
+        "complete once text_encoder_2 is provisioned: {repaired:?}"
+    );
+}
+
+#[test]
 fn filtered_cache_health_reports_absent_filter_as_missing_not_incomplete() {
     // sc-9907: a filter whose files are ENTIRELY absent is cleanly missing, not torn. Only a
     // partially-present filter (some files there, some gone) counts as incomplete/repairable.


### PR DESCRIPTION
Closes the sc-13815 investigation: **the manifest allow-list is not the gap — the host cache was torn.**

## Finding

sc-13795 saw the `SceneWorks/flux1-dev-mlx` q8 tier load with an empty `text_encoder_2/`, so the PuLID render fell back to q4. The story asked whether this was (a) an allow-list gap or (b) partial host state. It is **(b)**.

| Check | Result |
|---|---|
| HF repo at the pinned revision | **Complete** — `q8/text_encoder_2/` has `config.json` (841 B) + `model.safetensors` (5,060,212,723 B) |
| `q8/*` glob recursion | **Recursive** — `glob::Pattern` uses `require_literal_separator: false`, so `q8/*` already selects `q8/text_encoder_2/model.safetensors`; verified empirically |
| Affected host cache today | **Complete**, byte-for-byte equal to HF — a re-provision resolved it |

So no manifest or provisioning change is warranted, and the download always had those weights in scope.

## Why this PR still carries code

The torn-tier case had **no test coverage**. Every existing quant-matrix fixture writes `model_index.json` as `{}` — which declares no components — so `diffusers_snapshot_health` has nothing to check and the tier-completeness augmentation in `huggingface_filtered_cache_health` never executes. The exact shape that bit us was untested.

This adds a fixture built from the real FluxPipeline `model_index.json` and pins both halves of the finding:

1. `q8/*` matches nested tier weights and does **not** leak across tiers — the allow-list is exonerated by assertion, not by argument.
2. A tier whose `text_encoder_2/` is empty reads `incomplete` and names the component (so the Fix button can repair it) rather than reporting a false green.
3. Provisioning the component returns it to installed — the actual host fix.

## Verification

- `cargo test -p sceneworks-rust-api` — **345 passed, 0 failed**, 2 ignored.
- `cargo fmt --all -- --check` clean; `cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings` clean.
- **Mutation-checked**: disabling the tier-completeness augmentation fails the test with `installed: true, incomplete: false` — precisely the false green that would let this reach a render. The test proves detection, not just execution.

Test-only change; no runtime behavior is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)