### PR TITLE
fix(candle): route SenseNova-U1 to the dense bf16 tier + add a GPU smoke [sc-13817]

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -924,6 +924,37 @@ pub(crate) fn resolve_weights_dir(
             SANA_SPRINT_CANDLE_DIFFUSERS_REPO,
         ));
     }
+    // SenseNova-U1 off-Mac (candle, sc-13817): `candle-gen-sensenova` dense-loads a FLAT
+    // `*.safetensors` backbone (`f32_vb`) and HARD-REJECTS `spec.quantize` — it can consume ONLY the
+    // dense `bf16/` tier of the SceneWorks turnkey. But every sensenova entry flags
+    // `mlx.standardTierLayout: true`, so `standard_tier_subdir` below picks `preferred_tier`, which
+    // with no explicit `mlxQuantize` and no `mlx.minQualityTier` is the app-wide **q8** default — an
+    // MLX-PACKED tier the candle loader cannot read. Net: the candle sensenova lane handed the loader
+    // packed weights and could never render. Force the dense tier here (the Anima `(None, None)`
+    // dense-force precedent above, in tier-subdir form).
+    //
+    // Applies to the WHOLE family, not just the `_fast` ids sc-13817 was filed against: base and
+    // infographic share the same loader constraint and the same manifest flags, so they had the
+    // identical defect. The descriptor advertises `supported_quants: &[]`, so `resolve_quant` already
+    // yields `(None, None)` and no quant reaches the load — the DIRECTORY was the whole bug.
+    //
+    // Forcing the tier here cannot silently override a user's tier pick: every sensenova
+    // `ModelCaps` sets `candle_quant = false` (routing/catalog.rs), so a deliberate
+    // `advanced.mlxQuantize > 0` DEFERS off this lane rather than arriving here to be quietly
+    // rewritten to bf16 — the same contract the Anima dense-force relies on. This arm only handles
+    // the default-quant case the router does not strip.
+    //
+    // When no dense tier is installed this REJECTS with an actionable message rather than falling
+    // back to a packed tier: a fallback would only reach the loader's opaque "no .safetensors found"
+    // / packed-detect failure, and silently substituting a tier the engine cannot load is the
+    // stub-render class of bug (sc-13831). macOS never compiles this branch — mlx-gen-sensenova
+    // packed-loads every tier, so the MLX lane keeps the full q4/q8/bf16 matrix.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    if is_sensenova_model(&request.model) {
+        return snapshot
+            .map(|root| sensenova_candle_dense_tier(&root, &request.model))
+            .transpose();
+    }
     // Catalog-wide quant-matrix models (sc-8513, epic 8506) ship as SceneWorks pre-quantized
     // turnkeys with self-contained `q4/` (default) + `q8/` + `bf16/` subdirs (replacing any
     // install-time convert); point the engine at the chosen tier's subdir rather than the repo root.
@@ -933,6 +964,44 @@ pub(crate) fn resolve_weights_dir(
         return Ok(snapshot.map(|root| standard_tier_subdir(&root, request)));
     }
     Ok(snapshot)
+}
+
+/// The DENSE SenseNova-U1 tier the candle lane can actually load (sc-13817).
+///
+/// `candle-gen-sensenova`'s `f32_vb` mmaps the flat `*.safetensors` shards directly under the
+/// resolved dir, so a loadable tier is one holding real weight files — the MLX-packed `q4/`/`q8/`
+/// tiers are unreadable to it regardless of how complete they are. Prefers `bf16/`; accepts a flat
+/// snapshot root (a non-tiered dense install) as the fallback shape.
+///
+/// A tier dir that exists but holds only configs/tokenizer — the *torn* shape a partial download
+/// leaves, and exactly what this repo's `q8/` looks like on a half-provisioned host — does NOT count
+/// as present, so a torn dense tier is reported as missing rather than handed to the loader.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn sensenova_candle_dense_tier(root: &Path, model: &str) -> WorkerResult<PathBuf> {
+    let has_flat_weights = |dir: &Path| -> bool {
+        std::fs::read_dir(dir).is_ok_and(|entries| {
+            entries.flatten().any(|entry| {
+                let path = entry.path();
+                !sceneworks_core::lora_family::is_hidden_file(&path)
+                    && path
+                        .extension()
+                        .is_some_and(|ext| ext == "safetensors" || ext == "gguf")
+            })
+        })
+    };
+    let bf16 = root.join("bf16");
+    if has_flat_weights(&bf16) {
+        return Ok(bf16);
+    }
+    if has_flat_weights(root) {
+        return Ok(root.to_path_buf());
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "{model}: the candle SenseNova-U1 engine loads DENSE weights only, and no dense tier is \
+         installed at {}. Install the model's bf16 tier (the q4/q8 tiers are MLX-packed and cannot \
+         be loaded by this backend).",
+        root.display()
+    )))
 }
 
 /// Models that ship the standard SceneWorks quant-matrix turnkey layout: self-contained `q4/`
@@ -3045,7 +3114,11 @@ fn is_flux_model(model: &str) -> bool {
 
 /// The SenseNova-U1 SceneWorks ids (base + 8-step distill), both served by the unified
 /// `mlx-gen-sensenova` engine (sc-3900).
-#[cfg(target_os = "macos")]
+///
+/// sc-13817 widened the gate from macOS-only: the off-Mac candle lane needs the same id set to force
+/// its dense-tier resolution (`sensenova_candle_dense_tier`), because `candle-gen-sensenova` can read
+/// only the dense `bf16/` tier.
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn is_sensenova_model(model: &str) -> bool {
     matches!(
         model,
@@ -7551,6 +7624,86 @@ mod standard_tier_tests {
             anima_dense_split_files_dir(tmp2.path().to_path_buf()),
             tmp2.path().to_path_buf(),
             "falls back to the snapshot root when split_files/ is absent"
+        );
+    }
+
+    /// sc-13817: the candle SenseNova-U1 lane must land on the DENSE `bf16/` tier.
+    ///
+    /// This is the whole defect the story was filed for, stated as an assertion. Every sensenova
+    /// entry flags `mlx.standardTierLayout: true` and declares no `mlx.minQualityTier`, so
+    /// `standard_tier_subdir` resolves `preferred_tier(None, None, false)` = the app-wide **q8**
+    /// default — an MLX-packed tier. `candle-gen-sensenova` dense-loads a flat `*.safetensors`
+    /// backbone and hard-rejects `spec.quantize`, so it can read ONLY `bf16/`. Before the fix the
+    /// candle lane handed the loader packed weights and could never render.
+    ///
+    /// The fixture installs a COMPLETE q8 tier alongside bf16 precisely so a passing result cannot
+    /// be an accident of q8 being absent — the tier-completeness fallback would reach bf16 on its
+    /// own if q8 were torn, which is what masks this bug on a half-provisioned host.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn sensenova_candle_resolves_the_dense_bf16_tier_over_a_complete_packed_q8() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // A COMPLETE packed q8 tier (weights present) — the tier the default would otherwise pick.
+        std::fs::create_dir_all(root.join("q8")).unwrap();
+        std::fs::write(root.join("q8").join("model.safetensors"), "packed").unwrap();
+        std::fs::write(root.join("q8").join("config.json"), "{}").unwrap();
+        // The dense tier the candle loader can actually read.
+        std::fs::create_dir_all(root.join("bf16")).unwrap();
+        std::fs::write(root.join("bf16").join("model.safetensors"), "dense").unwrap();
+
+        for model in [
+            "sensenova_u1_8b",
+            "sensenova_u1_8b_fast",
+            "sensenova_u1_8b_infographic_v2",
+            "sensenova_u1_8b_infographic_v3",
+            "sensenova_u1_8b_infographic_v2_fast",
+            "sensenova_u1_8b_infographic_v3_fast",
+        ] {
+            assert_eq!(
+                sensenova_candle_dense_tier(root, model).unwrap(),
+                root.join("bf16"),
+                "{model} must resolve the dense bf16 tier, never the packed q8 the default prefers"
+            );
+        }
+    }
+
+    /// sc-13817: a flat (non-tiered) dense snapshot resolves as-is, and a snapshot with NO dense
+    /// weights REJECTS with an actionable message instead of falling back to a packed tier.
+    ///
+    /// Falling back would only reach the loader's opaque "no .safetensors found" / packed-detect
+    /// failure — and silently substituting a tier the engine cannot load is the stub-render class of
+    /// bug (sc-13831). A TORN dense tier (configs present, weights absent — exactly what a partial
+    /// download leaves) must count as missing, not as present.
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn sensenova_candle_rejects_when_no_dense_tier_is_installed() {
+        // Flat dense snapshot (no tier subdirs) → resolve the root itself.
+        let flat = tempfile::tempdir().unwrap();
+        std::fs::write(flat.path().join("model.safetensors"), "dense").unwrap();
+        assert_eq!(
+            sensenova_candle_dense_tier(flat.path(), "sensenova_u1_8b_fast").unwrap(),
+            flat.path().to_path_buf(),
+            "a flat dense install resolves as-is"
+        );
+
+        // Packed q4/q8 only, plus a TORN bf16 (configs but no weights) — nothing dense is loadable.
+        let packed = tempfile::tempdir().unwrap();
+        let root = packed.path();
+        for tier in ["q4", "q8"] {
+            std::fs::create_dir_all(root.join(tier)).unwrap();
+            std::fs::write(root.join(tier).join("model.safetensors"), "packed").unwrap();
+        }
+        std::fs::create_dir_all(root.join("bf16")).unwrap();
+        std::fs::write(root.join("bf16").join("config.json"), "{}").unwrap();
+        std::fs::write(root.join("bf16").join("tokenizer.json"), "{}").unwrap();
+
+        let error = sensenova_candle_dense_tier(root, "sensenova_u1_8b_fast")
+            .expect_err("a torn/absent dense tier must reject, not fall back to a packed tier");
+        let message = error.to_string();
+        assert!(
+            message.contains("bf16") && message.contains("DENSE"),
+            "the error must name the dense tier to install, got {message:?}"
         );
     }
 

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -6145,6 +6145,54 @@ fn isolate_hf_hub_cache_to(hub: &std::path::Path) -> EnvVars {
     ])
 }
 
+/// sc-13817 — **the wiring half** of the candle SenseNova dense-force.
+///
+/// The unit tests next to `sensenova_candle_dense_tier` prove the resolver picks bf16; this proves
+/// `resolve_weights_dir` actually ROUTES sensenova through it. Without that branch the request falls
+/// to `standard_tier_subdir` (every sensenova entry flags `mlx.standardTierLayout: true`), which with
+/// no explicit `mlxQuantize` and no `minQualityTier` resolves the app-wide **q8** default — an
+/// MLX-packed tier `candle-gen-sensenova` cannot read, since it dense-mmaps a flat `*.safetensors`
+/// backbone and hard-rejects `spec.quantize`.
+///
+/// Both tiers are seeded COMPLETE so the result cannot be an accident of the packed tier being
+/// absent — a torn q8 would fall through to bf16 on its own, which is exactly what masks this bug on
+/// a half-provisioned host (the dev box that filed the story had a weightless q8).
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn sensenova_weights_resolution_routes_the_candle_lane_to_the_dense_tier() {
+    let root = tempfile::tempdir().unwrap();
+    let hub = root.path().join("hub");
+    std::fs::create_dir_all(&hub).unwrap();
+    let _hf = isolate_hf_hub_cache_to(&hub);
+    let snapshot = hub
+        .join("models--SceneWorks--sensenova-u1-8b-fast-mlx")
+        .join("snapshots")
+        .join("installed-revision");
+    // A COMPLETE packed q8 (what the default would pick) AND the dense bf16 tier.
+    for file in ["q8/model.safetensors", "bf16/model.safetensors"] {
+        let path = snapshot.join(file);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"weights").unwrap();
+    }
+    let mut settings = Settings::from_env();
+    settings.data_dir = root.path().to_path_buf();
+
+    let req = request(json!({
+        "projectId": "p",
+        "model": "sensenova_u1_8b_fast",
+        "modelManifestEntry": {
+            "repo": "SceneWorks/sensenova-u1-8b-fast-mlx",
+            "mlx": { "standardTierLayout": true, "quantize": 4 }
+        }
+    }));
+
+    assert_eq!(
+        resolve_weights_dir(&req, &settings).unwrap(),
+        Some(snapshot.join("bf16")),
+        "the candle sensenova lane must resolve the DENSE bf16 tier, not the packed q8 default"
+    );
+}
+
 // sc-11171 (F-008): a strict-pose job on a WIRED candle pose family (e.g. `z_image_turbo`) whose control
 // base snapshot is NOT installed must route to the loud `PoseControlBaseMissing` reject, NOT fall through
 // to the plain candle txt2img lane (which would silently render an unconditioned image and drop the

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -259,6 +259,13 @@ mod flux2_dev_gpu_smoke;
 // the evidence that unblocks flipping `macOnly: false` / `candle_routed = true` (sc-10625).
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod anima_gpu_smoke;
+// Real-weight GPU smoke for the candle SenseNova-U1 8B lane (sc-13817, epic 13678). Test-only +
+// candle-only; drives `crate::inference_runtime::load("sensenova_u1_8b{,_fast}")` against the DENSE
+// bf16 turnkey tier. SenseNova was the one candle image family with no GPU smoke — and its lane had
+// never worked, because the tier resolver handed the dense-only loader an MLX-packed q8 tier. This is
+// the hardware evidence for the sc-13817 dense-force fix.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod sensenova_gpu_smoke;
 // Real-weight GPU smoke for the candle SANA 1600M lane (epic 8485, sc-11780). Test-only + candle-only;
 // drives the WORKER's `resolve_weights_dir("sana_1600m")` (the diffusers-snapshot-root resolution) +
 // `gen_core::load("sana_1600m")` against the whole `Efficient-Large-Model/Sana_1600M_1024px_diffusers`

--- a/crates/sceneworks-worker/src/sensenova_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/sensenova_gpu_smoke.rs
@@ -1,0 +1,219 @@
+//! Local real-weight GPU smoke for the candle **SenseNova-U1 8B** worker lane (sc-13817, epic 13678).
+//! `#[ignore]`d — run by hand on the RTX PRO 6000. It drives the real candle SenseNova engine via
+//! `crate::inference_runtime::load("sensenova_u1_8b{,_fast}")` with a `LoadSpec` pointed at the tier
+//! `resolve_weights_dir` resolves — the exact runtime seam `generate_candle_stream` uses, minus the
+//! API/job plumbing.
+//!
+//! **Why this smoke exists.** Every other candle image family (anima / flux2_dev / sana / sdxl) has a
+//! GPU smoke; SenseNova had none, so its candle lane had never been executed on hardware. It had
+//! also never *worked*: the loader (`candle-gen-sensenova`) dense-loads a flat `*.safetensors`
+//! backbone via `f32_vb` and hard-rejects `spec.quantize`, but every sensenova catalog entry flags
+//! `mlx.standardTierLayout: true` with no `mlx.minQualityTier`, so `standard_tier_subdir` resolved
+//! the app-wide **q8** default — an MLX-packed tier the engine cannot read. sc-13817 forces the lane
+//! onto the dense `bf16/` tier; this smoke is the hardware evidence for that fix.
+//!
+//! **The tier is the point.** `SENSENOVA_DIR` must be the **dense bf16** tier dir (a flat
+//! `model.safetensors` + `tokenizer.json`, plus `distill_merged.json` on the `_fast` turnkey). The
+//! smoke asserts that shape up front rather than letting a packed q4/q8 dir reach the loader and fail
+//! with an opaque tensor-name error — pointing this at a packed tier is a *setup* mistake and should
+//! say so.
+//!
+//! Note the dense tier is ~35 GB of bf16 and `f32_vb` mmaps it as **F32**, so expect roughly double
+//! that resident on the device. This is a 96 GB-class-card smoke.
+//!
+//! Build with `CUDA_COMPUTE_CAP=120` (native Blackwell sm_120).
+//!
+//! Setup (PowerShell):
+//! ```text
+//! $env:SENSENOVA_DIR="E:\huggingface\hub\models--SceneWorks--sensenova-u1-8b-fast-mlx\snapshots\<hash>\bf16"
+//! $env:SENSENOVA_OUT_DIR="D:\sceneworks-sensenova-validate"
+//! # optional: SENSENOVA_VARIANT=base|fast  SENSENOVA_W=1024 SENSENOVA_H=1024
+//! #           SENSENOVA_STEPS=..  SENSENOVA_GUIDANCE=..  SENSENOVA_SEED=42  SENSENOVA_PROMPT="..."
+//! cargo test -p sceneworks-worker --no-default-features --features backend-candle --release \
+//!   sensenova_candle_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, WeightsSource};
+
+use super::smoke_support::{env_or, image_std, save_png, DEGENERATE_STD_FLOOR_DEFAULT};
+
+/// Resolve the SenseNova variant → engine id + its shipped defaults (steps/guidance).
+///
+/// `fast` is the 8-step distilled turnkey (CFG-free, guidance 1.0 — the distill LoRA is pre-merged
+/// into the tier); `base` is the undistilled 50-step model at guidance 4.0. Both match the catalog
+/// `defaults` for the corresponding manifest entry.
+fn resolve_variant(raw: &str) -> (&'static str, u32, f32) {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "base" => ("sensenova_u1_8b", 50, 4.0),
+        "fast" => ("sensenova_u1_8b_fast", 8, 1.0),
+        other => panic!("SENSENOVA_VARIANT must be base|fast, got {other:?}"),
+    }
+}
+
+/// Whether `dir` holds a flat dense backbone — the shape `candle-gen-sensenova`'s `f32_vb` mmaps
+/// (`*.safetensors` directly under the tier dir, no `transformer/` component tree).
+///
+/// A packed MLX `q4/`/`q8/` tier also carries `*.safetensors`, so this is a *shape* check, not a
+/// precision check; the caller pairs it with the `bf16` path hint in its failure message. A tier
+/// holding only configs/tokenizer (the torn shape a partial download leaves) fails it.
+fn has_flat_safetensors(dir: &Path) -> bool {
+    std::fs::read_dir(dir).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            let path = entry.path();
+            !sceneworks_core::lora_family::is_hidden_file(&path)
+                && path.extension().is_some_and(|ext| ext == "safetensors")
+        })
+    })
+}
+
+fn env_path(key: &str) -> PathBuf {
+    // Trim: a cmd `set VAR=value && ...` keeps the trailing space before `&&`
+    // (reference_candle_build_toolchain_win — cost two build cycles on sc-9994).
+    PathBuf::from(
+        std::env::var(key)
+            .unwrap_or_else(|_| panic!("set ${key}"))
+            .trim(),
+    )
+}
+
+#[cfg(test)]
+mod variant_tests {
+    use super::{has_flat_safetensors, resolve_variant};
+
+    #[test]
+    fn resolve_variant_maps_the_two_ids_with_their_shipped_defaults() {
+        // The distilled turnkey is 8-step CFG-free; the base model is 50-step at guidance 4.0.
+        assert_eq!(resolve_variant("base"), ("sensenova_u1_8b", 50, 4.0));
+        assert_eq!(resolve_variant(" FAST ").0, "sensenova_u1_8b_fast");
+        assert_eq!(resolve_variant("fast").1, 8);
+        assert_eq!(resolve_variant("fast").2, 1.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "SENSENOVA_VARIANT must be base|fast")]
+    fn resolve_variant_rejects_unknown() {
+        let _ = resolve_variant("turbo");
+    }
+
+    #[test]
+    fn flat_safetensors_probe_rejects_a_config_only_tier() {
+        // The torn shape a partial download leaves — configs present, weights absent. Handing this to
+        // the loader produces an opaque "no .safetensors found"; the smoke must catch it as setup.
+        let torn = tempfile::tempdir().unwrap();
+        std::fs::write(torn.path().join("config.json"), "{}").unwrap();
+        std::fs::write(torn.path().join("tokenizer.json"), "{}").unwrap();
+        assert!(!has_flat_safetensors(torn.path()));
+
+        let dense = tempfile::tempdir().unwrap();
+        std::fs::write(dense.path().join("model.safetensors"), "weights").unwrap();
+        assert!(has_flat_safetensors(dense.path()));
+    }
+}
+
+#[test]
+#[ignore = "real-weight GPU smoke; needs the DENSE bf16 SenseNova-U1 tier (~35GB) + a CUDA device (cap=120)"]
+fn sensenova_candle_gpu_smoke() {
+    let weights_dir = env_path("SENSENOVA_DIR");
+    let (variant_raw, _) = (env_or("SENSENOVA_VARIANT", "fast"), ());
+    let (engine_id, default_steps, default_guidance) = resolve_variant(&variant_raw);
+
+    // The tier is the whole point of sc-13817 — fail loudly on a packed/torn dir rather than letting
+    // it reach the loader as an opaque tensor error.
+    assert!(
+        has_flat_safetensors(&weights_dir),
+        "SENSENOVA_DIR must be the DENSE bf16 tier (a flat model.safetensors), got no .safetensors \
+         in {}. The q4/q8 tiers are MLX-packed and unreadable by the candle engine.",
+        weights_dir.display()
+    );
+    assert!(
+        weights_dir.join("tokenizer.json").is_file(),
+        "SENSENOVA_DIR must hold tokenizer.json (a self-contained SenseNova-U1 tier): {}",
+        weights_dir.display()
+    );
+    if engine_id == "sensenova_u1_8b_fast" {
+        // The `_fast` turnkey bakes the 8-step distill LoRA into its weights and ships this marker;
+        // without it the loader would try to resolve+merge a distill LoRA that the tier does not ship
+        // (the sc-13787 marker-skip is what makes the pre-merged tier loadable at all).
+        assert!(
+            weights_dir.join("distill_merged.json").is_file(),
+            "the _fast tier must ship distill_merged.json (pre-merged 8-step distill, sc-8775/sc-13787): {}",
+            weights_dir.display()
+        );
+    }
+
+    let out_dir = PathBuf::from(env_or("SENSENOVA_OUT_DIR", "/tmp/sensenova_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let steps: u32 = env_or("SENSENOVA_STEPS", &default_steps.to_string())
+        .parse()
+        .expect("SENSENOVA_STEPS");
+    let w: u32 = env_or("SENSENOVA_W", "1024").parse().expect("SENSENOVA_W");
+    let h: u32 = env_or("SENSENOVA_H", "1024").parse().expect("SENSENOVA_H");
+    let guidance: f32 = env_or("SENSENOVA_GUIDANCE", &default_guidance.to_string())
+        .parse()
+        .expect("SENSENOVA_GUIDANCE");
+    let seed: u64 = env_or("SENSENOVA_SEED", "42")
+        .parse()
+        .expect("SENSENOVA_SEED");
+    let prompt = env_or(
+        "SENSENOVA_PROMPT",
+        "a red vintage bicycle leaning against a weathered brick wall, golden hour light, sharp focus",
+    );
+
+    // Same seam as `generate_candle_stream`: a registry load of the candle sensenova engine with a
+    // DENSE `LoadSpec` (no `.with_quant(..)` — the descriptor advertises `supported_quants: &[]` and
+    // the engine hard-rejects a quantize request, so the worker resolves `(None, None)`).
+    println!(
+        "[smoke] loading {engine_id} (dense) from {} ...",
+        weights_dir.display()
+    );
+    let spec = LoadSpec::new(WeightsSource::Dir(weights_dir.clone()));
+    let generator = crate::inference_runtime::load(engine_id, &spec)
+        .unwrap_or_else(|error| panic!("load candle {engine_id} provider: {error}"));
+
+    let req = GenerationRequest {
+        prompt: prompt.clone(),
+        width: w,
+        height: h,
+        count: 1,
+        seed: Some(seed),
+        steps: Some(steps),
+        guidance: Some(guidance),
+        ..Default::default()
+    };
+    println!("[smoke] rendering {w}x{h} @ {steps} steps, guidance {guidance} ...");
+    let mut last = String::new();
+    let output = generator
+        .generate(&req, &mut |p| {
+            let s = format!("{p:?}");
+            if s != last {
+                println!("[progress] {s}");
+                last = s;
+            }
+        })
+        .unwrap_or_else(|error| panic!("{engine_id} generate: {error}"));
+    let image = match output {
+        GenerationOutput::Images(mut images) => images.pop().expect("engine returned no image"),
+        other => panic!("expected Images output, got {other:?}"),
+    };
+
+    let std = image_std(&image);
+    let png = out_dir.join(format!("sensenova_{variant_raw}_{steps}step_{w}x{h}.png"));
+    save_png(&image, &png);
+    println!(
+        "[smoke] {engine_id} {}x{} std {:.2} -> {}",
+        image.width,
+        image.height,
+        std,
+        png.display()
+    );
+    assert_eq!((image.width, image.height), (w, h));
+    assert!(
+        std > DEGENERATE_STD_FLOOR_DEFAULT,
+        "{engine_id} render looks degenerate (std {std:.2}) — possible NaN / all-black decode \
+         (check CUDA_COMPUTE_CAP=120 and that SENSENOVA_DIR is the DENSE bf16 tier)"
+    );
+    println!("[smoke] DONE: {engine_id} dense render coherent at {steps} steps");
+}


### PR DESCRIPTION
The candle SenseNova-U1 lane could never render. This makes it reachable and gives it the hardware smoke every other candle image family already had.

## Root cause

`candle-gen-sensenova` dense-mmaps a flat `*.safetensors` backbone (`f32_vb`, `DType::F32`) and hard-rejects `spec.quantize` — it can consume **only** the dense `bf16/` tier. But every sensenova catalog entry flags `mlx.standardTierLayout: true` and declares no `mlx.minQualityTier`, so `standard_tier_subdir` resolved `preferred_tier(None, None, false)` — the app-wide **q8** default — and handed the loader an MLX-packed tier it cannot read.

**This corrects the story's premise.** sc-13817 supposed sensenova was *outside* the standard tier descent ("not in `STANDARD_TIER_MODELS`, no `standardTierLayout` flag, so it is unclear that `resolve_weights_dir` even lands candle on a dense subdir"). It is not in the const registry, but it *does* carry the manifest flag — so the resolution was fully defined, and defined wrongly. The other half of the premise also resolved cleanly: the descriptor advertises `supported_quants: &[]`, so `resolve_quant` already yielded `(None, None)` and no quant ever reached the load. **The directory was the entire bug.**

## The fix

Forces the dense tier, following the Anima `(None, None)` dense-force precedent in tier-subdir form.

- **Whole family, not just `_fast`.** Base and infographic share the loader constraint and the manifest flags, so they had the identical defect; fixing only the ids named in the story would have left the rest broken.
- **Cannot silently override a user's tier pick.** Every sensenova `ModelCaps` sets `candle_quant = false`, so an explicit `advanced.mlxQuantize > 0` defers off this lane rather than arriving here to be quietly rewritten to bf16 — the same contract the Anima dense-force relies on. This branch only handles the default-quant case the router does not strip.
- **Rejects rather than falling back.** With no dense tier installed it returns an actionable "install the bf16 tier" error. Falling back to a packed tier would only reach the loader's opaque `no .safetensors found`, and silently substituting a tier the engine cannot load is the stub-render class of bug (sc-13831). A *torn* dense tier (configs present, weights absent) counts as missing, not present.

## The GPU smoke

Every other candle image family (anima / flux2_dev / sana / sdxl) has one; sensenova had none, so this lane had never been executed on hardware. `sensenova_gpu_smoke.rs` mirrors those, and asserts the dense-tier shape up front so aiming it at a packed tier reports a *setup* mistake instead of an opaque tensor-name failure.

## Verification

| Config | Result |
|---|---|
| candle (`--no-default-features --features backend-candle`) | **802 passed / 0 failed**; clippy `--all-targets -D warnings` exit 0 |
| default features | **402 passed / 0 failed** |
| `cargo fmt --all -- --check` | clean |

**Mutation-checked.** Disabling the new branch makes the wiring test resolve `…/q8` instead of `…/bf16` — it reproduces the exact reported defect, so the test proves the routing rather than merely executing it.

The fixture seeds a **complete** packed q8 alongside bf16 deliberately: a torn q8 falls through to bf16 on its own, which is precisely what masks this bug on a half-provisioned host (the box that filed the story had a weightless q8 tier — configs only, zero weights).

🤖 Generated with [Claude Code](https://claude.com/claude-code)