### PR TITLE
Pin Boogu and Ideogram on-demand tier fetches

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -752,6 +752,74 @@ fn requested_receipt_variant(request: &ImageRequest) -> Option<String> {
 ))]
 const IDEOGRAM_BF16_REPO: &str = "SceneWorks/ideogram-4";
 
+/// Exact snapshots used by the on-demand non-default tier fetches.  The API replaces a submitted
+/// `modelManifestEntry` with its resolved builtin/user manifest entry before enqueueing, so a repo
+/// different from the engine default is an intentional configured override.  First-party turnkeys
+/// never follow a mutable ref; configured override repos retain `main` because SceneWorks cannot know
+/// their release commit in advance.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const BOOGU_MLX_TURNKEY_REVISION: &str = "a459e614d408bfdf57089c32cc3da706f5a017de";
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+const IDEOGRAM_MLX_TURNKEY_REVISION: &str = "a3095855b8819dc0d6b067cb1354aaa7da189ff8";
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn turnkey_tier_revision<'a>(
+    repo: &str,
+    default_repo: &str,
+    default_revision: &'a str,
+) -> &'a str {
+    if repo == default_repo {
+        default_revision
+    } else {
+        "main"
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn pinned_turnkey_snapshot_for_request(
+    data_dir: &Path,
+    request: &ImageRequest,
+    repo: &str,
+    default_repo: &str,
+    revision: &str,
+) -> Option<PathBuf> {
+    if repo != default_repo {
+        return None;
+    }
+    let root =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(data_dir, repo, revision)?;
+    let selected = match request.model.as_str() {
+        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => {
+            boogu_model_subdir(&root, request)
+        }
+        "ideogram_4" | "ideogram_4_turbo" => ideogram_model_subdir(&root, request),
+        _ => return None,
+    };
+    let complete = if request.model.starts_with("boogu_") {
+        selected
+            .join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file()
+            || selected
+                .join("transformer/diffusion_pytorch_model.safetensors.index.json")
+                .is_file()
+    } else {
+        selected.join("transformer/model.safetensors").is_file()
+    };
+    complete.then_some(root)
+}
+
 /// The whole-repo `Efficient-Large-Model/Sana_1600M_1024px_diffusers` HF snapshot the candle SANA
 /// lane loads (sc-11780, epic 8485). The `candle-gen-sana` pipeline reads the diffusers-layout tree
 /// (`transformer/` + `vae/` + `text_encoder/`) directly, so the off-Mac lane resolves this repo's
@@ -812,13 +880,34 @@ pub(crate) fn resolve_weights_dir(
         Some(&request.model),
         receipt_variant.as_deref(),
     );
-    let snapshot = receipt_snapshot
-        .clone()
+    let pinned_turnkey_snapshot = match request.model.as_str() {
+        "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => {
+            pinned_turnkey_snapshot_for_request(
+                &settings.data_dir,
+                request,
+                &repo,
+                model.default_repo(),
+                BOOGU_MLX_TURNKEY_REVISION,
+            )
+        }
+        "ideogram_4" | "ideogram_4_turbo" => pinned_turnkey_snapshot_for_request(
+            &settings.data_dir,
+            request,
+            &repo,
+            model.default_repo(),
+            IDEOGRAM_MLX_TURNKEY_REVISION,
+        ),
+        _ => None,
+    };
+    let has_pinned_turnkey_snapshot = pinned_turnkey_snapshot.is_some();
+    let snapshot = pinned_turnkey_snapshot
+        .or_else(|| receipt_snapshot.clone())
         .or_else(|| huggingface_snapshot_dir(&settings.data_dir, &repo));
     // A tier receipt already resolves to the exact self-contained tier directory.  Returning it
     // before the family pickers prevents a second `q4/q8/bf16` descent and, more importantly, keeps
     // all load inputs on the receipt side of the all-receipt-or-all-current boundary.
-    if receipt_snapshot
+    if !has_pinned_turnkey_snapshot
+        && receipt_snapshot
         .as_deref()
         .and_then(tier_key_from_resolved_dir)
         .is_some()
@@ -2012,19 +2101,33 @@ async fn ensure_boogu_tier_present(
     let Some(model) = mlx_model(&request.model) else {
         return Ok(());
     };
-    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, &model_repo(request, &model))
-    else {
+    let repo = model_repo(request, &model);
+    let root = if repo == model.default_repo() {
+        crate::model_jobs::huggingface_pinned_snapshot_dir(
+            &settings.data_dir,
+            &repo,
+            BOOGU_MLX_TURNKEY_REVISION,
+        )
+    } else {
+        huggingface_snapshot_dir(&settings.data_dir, &repo)
+    };
+    let repo_is_installed = root.is_some()
+        || (repo == model.default_repo()
+            && huggingface_snapshot_dir(&settings.data_dir, &repo).is_some());
+    if !repo_is_installed {
         // Turnkey not downloaded at all → leave it to the load path's "weights not found" error.
         return Ok(());
-    };
-    let tier_dir = root.join(&tier);
+    }
+    let tier_dir = root.as_ref().map(|root| root.join(&tier));
     // Present already (packed single-file q4 OR sharded-dense bf16 `.index.json`) → no fetch.
-    if tier_dir
-        .join("transformer/diffusion_pytorch_model.safetensors")
-        .is_file()
-        || tier_dir
-            .join("transformer/diffusion_pytorch_model.safetensors.index.json")
+    if tier_dir.as_ref().is_some_and(|tier_dir| {
+        tier_dir
+            .join("transformer/diffusion_pytorch_model.safetensors")
             .is_file()
+            || tier_dir
+                .join("transformer/diffusion_pytorch_model.safetensors.index.json")
+                .is_file()
+    })
     {
         return Ok(());
     }
@@ -2034,14 +2137,9 @@ async fn ensure_boogu_tier_present(
         format!("{tier}/mllm/*"),
         format!("{tier}/vae/*"),
     ];
-    crate::model_jobs::ensure_hf_files_cached(
-        api,
-        settings,
-        job,
-        &model_repo(request, &model),
-        "main",
-        &files,
-    )
+    let revision =
+        turnkey_tier_revision(&repo, model.default_repo(), BOOGU_MLX_TURNKEY_REVISION);
+    crate::model_jobs::ensure_hf_files_cached(api, settings, job, &repo, revision, &files)
     .await
     .map(|_| ())
 }
@@ -2080,28 +2178,36 @@ async fn ensure_ideogram_tier_present(
     let Some(model) = mlx_model(&request.model) else {
         return Ok(());
     };
-    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, &model_repo(request, &model))
-    else {
+    let repo = model_repo(request, &model);
+    let root = if repo == model.default_repo() {
+        crate::model_jobs::huggingface_pinned_snapshot_dir(
+            &settings.data_dir,
+            &repo,
+            IDEOGRAM_MLX_TURNKEY_REVISION,
+        )
+    } else {
+        huggingface_snapshot_dir(&settings.data_dir, &repo)
+    };
+    let repo_is_installed = root.is_some()
+        || (repo == model.default_repo()
+            && huggingface_snapshot_dir(&settings.data_dir, &repo).is_some());
+    if !repo_is_installed {
         // Turnkey not downloaded at all → leave it to the load path's "weights not found" error.
         return Ok(());
-    };
+    }
     // Present already (the packed single-file transformer) → no fetch.
-    if root
-        .join(tier)
-        .join("transformer/model.safetensors")
-        .is_file()
+    if root.as_ref().is_some_and(|root| {
+        root.join(tier)
+            .join("transformer/model.safetensors")
+            .is_file()
+    })
     {
         return Ok(());
     }
     let files = vec![format!("{tier}/*")];
-    crate::model_jobs::ensure_hf_files_cached(
-        api,
-        settings,
-        job,
-        &model_repo(request, &model),
-        "main",
-        &files,
-    )
+    let revision =
+        turnkey_tier_revision(&repo, model.default_repo(), IDEOGRAM_MLX_TURNKEY_REVISION);
+    crate::model_jobs::ensure_hf_files_cached(api, settings, job, &repo, revision, &files)
     .await
     .map(|_| ())
 }

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -10352,6 +10352,143 @@ fn instantid_revisions_are_pinned_commits_not_main() {
     assert_eq!(instantid_revision("some/override-repo"), "main");
 }
 
+/// The Boogu/Ideogram on-demand tier fetches pin first-party turnkeys while preserving the established
+/// control-lane convention for explicitly configured override repos.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn turnkey_tier_fetch_revisions_pin_defaults_and_allow_explicit_overrides() {
+    assert_pinned_revision("BOOGU_MLX_TURNKEY_REVISION", BOOGU_MLX_TURNKEY_REVISION);
+    assert_pinned_revision(
+        "IDEOGRAM_MLX_TURNKEY_REVISION",
+        IDEOGRAM_MLX_TURNKEY_REVISION,
+    );
+
+    let boogu = mlx_model("boogu_image").expect("Boogu engine");
+    assert_eq!(boogu.default_repo(), "SceneWorks/boogu-image-mlx");
+    assert_eq!(
+        turnkey_tier_revision(
+            boogu.default_repo(),
+            boogu.default_repo(),
+            BOOGU_MLX_TURNKEY_REVISION,
+        ),
+        BOOGU_MLX_TURNKEY_REVISION
+    );
+
+    let ideogram = mlx_model("ideogram_4").expect("Ideogram engine");
+    assert_eq!(ideogram.default_repo(), "SceneWorks/ideogram-4-mlx");
+    assert_eq!(
+        turnkey_tier_revision(
+            ideogram.default_repo(),
+            ideogram.default_repo(),
+            IDEOGRAM_MLX_TURNKEY_REVISION,
+        ),
+        IDEOGRAM_MLX_TURNKEY_REVISION
+    );
+
+    assert_eq!(
+        turnkey_tier_revision(
+            "example/custom-boogu",
+            boogu.default_repo(),
+            BOOGU_MLX_TURNKEY_REVISION,
+        ),
+        "main"
+    );
+    assert_eq!(
+        turnkey_tier_revision(
+            "example/custom-ideogram",
+            ideogram.default_repo(),
+            IDEOGRAM_MLX_TURNKEY_REVISION,
+        ),
+        "main"
+    );
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn turnkey_resolution_prefers_pinned_tier_over_stale_main_but_override_uses_main() {
+    let root = tempfile::tempdir().unwrap();
+    let hub = root.path().join("hub");
+    std::fs::create_dir_all(&hub).unwrap();
+    let _hf = isolate_hf_hub_cache_to(&hub);
+    let mut settings = Settings::from_env();
+    settings.data_dir = root.path().to_path_buf();
+
+    for (repo, revision, relative) in [
+        (
+            "SceneWorks/boogu-image-mlx",
+            BOOGU_MLX_TURNKEY_REVISION,
+            "base-q4/transformer/diffusion_pytorch_model.safetensors",
+        ),
+        (
+            "SceneWorks/ideogram-4-mlx",
+            IDEOGRAM_MLX_TURNKEY_REVISION,
+            "q8/transformer/model.safetensors",
+        ),
+    ] {
+        let cache = hub.join(format!("models--{}", repo.replace('/', "--")));
+        std::fs::create_dir_all(cache.join("refs")).unwrap();
+        std::fs::write(cache.join("refs/main"), "stale-main").unwrap();
+        for (snapshot, contents) in [("stale-main", b"A".as_slice()), (revision, b"B".as_slice())] {
+            let file = cache.join("snapshots").join(snapshot).join(relative);
+            std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+            std::fs::write(file, contents).unwrap();
+        }
+    }
+
+    let boogu = request(json!({
+        "projectId": "p", "model": "boogu_image",
+        "advanced": {"mlxQuantize": 4},
+        "modelManifestEntry": {"repo": "SceneWorks/boogu-image-mlx"}
+    }));
+    assert_eq!(
+        resolve_weights_dir(&boogu, &settings).unwrap(),
+        Some(
+            hub.join("models--SceneWorks--boogu-image-mlx/snapshots")
+                .join(BOOGU_MLX_TURNKEY_REVISION)
+                .join("base-q4")
+        )
+    );
+
+    let ideogram = request(json!({
+        "projectId": "p", "model": "ideogram_4",
+        "advanced": {"mlxQuantize": 8},
+        "modelManifestEntry": {"repo": "SceneWorks/ideogram-4-mlx"}
+    }));
+    assert_eq!(
+        resolve_weights_dir(&ideogram, &settings).unwrap(),
+        Some(
+            hub.join("models--SceneWorks--ideogram-4-mlx/snapshots")
+                .join(IDEOGRAM_MLX_TURNKEY_REVISION)
+                .join("q8")
+        )
+    );
+
+    let override_repo = "example/custom-boogu";
+    let override_cache = hub.join("models--example--custom-boogu");
+    std::fs::create_dir_all(override_cache.join("refs")).unwrap();
+    std::fs::write(override_cache.join("refs/main"), "override-main").unwrap();
+    let override_file = override_cache
+        .join("snapshots/override-main/base-q4/transformer")
+        .join("diffusion_pytorch_model.safetensors");
+    std::fs::create_dir_all(override_file.parent().unwrap()).unwrap();
+    std::fs::write(override_file, b"override").unwrap();
+    let override_request = request(json!({
+        "projectId": "p", "model": "boogu_image",
+        "advanced": {"mlxQuantize": 4},
+        "modelManifestEntry": {"repo": override_repo}
+    }));
+    assert_eq!(
+        resolve_weights_dir(&override_request, &settings).unwrap(),
+        Some(override_cache.join("snapshots/override-main/base-q4"))
+    );
+}
+
 /// The MLX-only strict-control pins (`flux1_control.rs` / `flux2.rs`) + the MLX Qwen distill-LoRA pin
 /// (`qwen.rs`). These files are `#[cfg(target_os = "macos")]`-gated `include!`s.
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- pin first-party Boogu and Ideogram turnkey tier fetches to exact Hugging Face commits
- preserve mutable `main` only for resolved non-default user/import repo overrides
- add deterministic default, override, and revision-format coverage

Shortcut: sc-13620

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p sceneworks-worker turnkey_tier_fetch_revisions_pin_defaults_and_allow_explicit_overrides --features backend-candle`
- `cargo test -p sceneworks-worker revisions_are_pinned --features backend-candle`
- `cargo check --locked -p sceneworks-worker --features backend-candle`