### PR TITLE
Route the candle FLUX.2 edit lane at the packed turnkey tier (sc-10222)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -601,13 +601,39 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
         false,
     ),
     // FLUX.2-klein-9B + the `_kv` / `_true_v2` weight variants share the candle `flux2_klein_9b` loader
-    // (sc-7459, a weights swap). **txt2img only** on candle: edit / KV-cache shapes defer to torch.
-    ModelCaps::new("flux2_klein_9b", true, true, false, false, false),
-    ModelCaps::new("flux2_klein_9b_kv", true, true, false, false, false),
+    // (sc-7459, a weights swap). The klein/dev `edit_image` shapes do NOT reach this gate — they are
+    // branched out to the bespoke candle `Flux2Edit` lane above (`flux2_edit_candle_eligible`), so these
+    // caps describe the txt2img surface only.
+    //
+    // sc-10222 (epic 9083): `candle_quant = true` for the two ids that actually ship the standard
+    // q4/q8/bf16 turnkey. Both are worker `STANDARD_TIER_MODELS` members whose manifests carry a
+    // MEASURED `candle.vramGbByTier` (klein 46.2/50.6/75.5, dev 44.0/70.7/128.0) — the worker has served
+    // those tiers on the candle txt2img lane since sc-9092, but this row still said `false`, so
+    // `image_request_candle_eligible`'s `!supports_quant && candle_request_wants_quant` arm bounced every
+    // explicit `advanced.mlxQuantize > 0` tier-select off the candle lane into the retired torch
+    // fallback — and FLUX.2-klein has NO torch path at all. Cruelly, dev's own fit-gate tells a 48 GB
+    // user to pick q4 (44.0) instead of the q8 default (70.7): the only tier that fits was the one tier
+    // that could not be routed. This is the identical "engine wired, router half missed" skew sc-9983
+    // (krea/ideogram/boogu) and sc-11020 (qwen_image) each closed; the diagnostic tell is exactly the one
+    // recorded there — a family in `STANDARD_TIER_MODELS` with a `candle.vramGbByTier` block that is not
+    // in `CANDLE_QUANT_MODELS`. NOT `candle_quant_lora`: neither advertises candle inference LoRA.
+    //
+    // The load `Quant` stays `None` on klein regardless (`DENSE_TE_TIER_MODELS` keeps its bf16 Qwen3 text
+    // encoder full-precision); `mlxQuantize` here is a turnkey tier-SELECT — which pre-quantized subdir
+    // `standard_tier_subdir` descends into — not an on-the-fly quantize.
+    ModelCaps::new("flux2_klein_9b", true, true, true, false, false),
+    ModelCaps::new("flux2_klein_9b_kv", true, true, true, false, false),
+    // `_true_v2` stays `candle_quant = false`: it is the wikeeyang community fine-tune, installed by
+    // convert-at-install from a single bf16 file into a FLAT `modelPath` dir. It ships no q4/q8/bf16
+    // tier matrix (one `downloads[]` entry, `mlx.quantize: 8` on-the-fly), so there is no tier for a
+    // pick to select — admitting one would only hand the dense converted tree to the legacy CPU-stage →
+    // quantize-onto-GPU path on a shape nothing has validated.
     ModelCaps::new("flux2_klein_9b_true_v2", true, true, false, false, false),
     // FLUX.2-dev (epic 5914 MLX / epic 6564 sc-7458 candle) — the guidance-distilled 32B flagship.
-    // A SEPARATE candle engine from klein (Mistral3 TE + 48/48/15360 DiT); Q4-quantized at load off-Mac.
-    ModelCaps::new("flux2_dev", true, true, false, false, false),
+    // A SEPARATE candle engine from klein (Mistral3 TE + 48/48/15360 DiT). Same sc-10222 tier-select
+    // flip as klein above; its `SceneWorks/flux2-dev-mlx` turnkey is where the epic's headline
+    // "packed Q4 load kills the ~105 GB dense CPU-staging peak" claim actually lands.
+    ModelCaps::new("flux2_dev", true, true, true, false, false),
     // SDXL family (sc-10767, epic 9083 full-catalog parity): the candle lane serves the packed q4/q8
     // MLX tiers end-to-end — packed UNet (sc-9416), packed dual-CLIP (sc-9527), and LoRA/LoKr fold on a
     // packed tier (sc-9528) — and `candle-gen-sdxl` now advertises `supported_quants: [Q4, Q8]`. So
@@ -1351,6 +1377,12 @@ mod tests {
         // the candle txt2img lane, so a tier-select stays on candle; no candle inference LoRA on base
         // qwen. (sc-9983 flipped this for krea/ideogram/boogu but missed qwen.)
         "qwen_image",
+        // sc-10222: FLUX.2-klein 9B/`_kv` + FLUX.2-dev — the same missed router half, for the last
+        // `STANDARD_TIER_MODELS` families still carrying it. `_true_v2` is deliberately absent (a flat
+        // convert-at-install dir with no tier matrix); see the caps rows for the full reasoning.
+        "flux2_klein_9b",
+        "flux2_klein_9b_kv",
+        "flux2_dev",
     ];
 
     // sc-9983: Krea moved to CANDLE_QUANT_LORA_MODELS (BOTH). sc-10676: Anima is the LoRA-only candle

--- a/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
@@ -857,6 +857,58 @@ fn qwen_image_quant_tier_select_stays_on_candle() {
 }
 
 #[test]
+fn flux2_turnkey_quant_tier_select_stays_on_candle() {
+    // sc-10222 (epic 9083): the LAST families carrying the "engine wired, router half missed" skew
+    // (sc-9983 krea/ideogram/boogu, sc-11020 qwen). `flux2_klein_9b`/`_kv`/`flux2_dev` are worker
+    // `STANDARD_TIER_MODELS` members whose `SceneWorks/flux2-*-mlx` turnkeys ship q4/q8/bf16 packed
+    // subdirs, resolved by `standard_tier_subdir` and MEASURED in the manifest `candle.vramGbByTier`
+    // — but `candle_quant` was `false`, so an explicit tier-select enforce-failed `candle_unsupported`
+    // at routing before ever reaching the worker. FLUX.2-klein has no torch path at all, and dev's own
+    // fit-gate asks a 48 GB user for q4 (44.0 GB) over the q8 default (70.7) — the only tier that fits
+    // was the one tier that could not be routed.
+    for model in ["flux2_klein_9b", "flux2_klein_9b_kv", "flux2_dev"] {
+        for bits in [4, 8] {
+            assert!(
+                image_request_candle_eligible(
+                    model,
+                    &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": bits } }))
+                ),
+                "{model} Q{bits} tier-select should stay on candle (sc-10222)"
+            );
+        }
+        // An explicit bf16 pick (<= 0) and a plain job were always eligible — unchanged.
+        for advanced in [json!({ "mlxQuantize": 0 }), json!({ "steps": 28 })] {
+            assert!(
+                image_request_candle_eligible(
+                    model,
+                    &object(json!({ "prompt": "x", "advanced": advanced }))
+                ),
+                "{model} dense/plain shape must stay candle-eligible"
+            );
+        }
+        // No candle inference LoRA on any FLUX.2 id — a LoRA still defers to torch.
+        assert!(
+            !image_request_candle_eligible(
+                model,
+                &object(json!({ "loras": [{ "name": "x", "path": "/x.safetensors" }] }))
+            ),
+            "{model} LoRA must still defer (quant and LoRA are decoupled caps)"
+        );
+    }
+    // `_true_v2` is deliberately NOT flipped: the wikeeyang fine-tune installs by convert-at-install
+    // into a FLAT `modelPath` dir with no q4/q8/bf16 tier matrix, so there is no tier for a pick to
+    // select. Its plain txt2img stays candle-eligible; only the tier-select defers.
+    assert!(image_request_candle_eligible(
+        "flux2_klein_9b_true_v2",
+        &object(json!({ "prompt": "x" }))
+    ));
+    assert!(!image_request_candle_eligible(
+        "flux2_klein_9b_true_v2",
+        &object(json!({ "prompt": "x", "advanced": { "mlxQuantize": 4 } }))
+    ));
+}
+
+#[test]
 fn sdxl_family_quant_and_lora_stay_on_candle() {
     // sc-10767 (epic 9083): the SDXL family advertises Q4/Q8 packed tiers (candle-gen sc-9416/9527)
     // AND inference LoRA/LoKr on a packed tier (sc-9528), so a quant tier-select AND a LoRA both

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -237,11 +237,10 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // the chosen tier's subdir via the shared `resolve_weights_dir` → `standard_tier_subdir`
     // (sc-9092 retired the old candle dense-BFL load for the generic lane). It must match the
     // manifest `downloads[].repo`; the pre-rehost gated `black-forest-labs/FLUX.2-dev` default
-    // made `model_repo` probe the wrong HF-cache dir. NOTE: the bespoke off-Mac candle *edit*
-    // lane in `flux2_edit_candle.rs` still keys its own dense-BFL default for both flux2 klein
-    // and dev, which no longer matches the re-hosted packed turnkey the catalog downloads — a
-    // separate off-Mac gap that needs candle-hardware verification, tracked as sc-10222 (epic
-    // 9083 gap #3), not touched here.
+    // made `model_repo` probe the wrong HF-cache dir. sc-10222 (epic 9083 gap #3) retired the
+    // last holdout: the bespoke off-Mac candle *edit* lane (`flux2_edit_candle.rs`) kept its own
+    // dense-BFL constants and now delegates to the same shared `resolve_weights_dir`, so THIS
+    // row is the single source of truth for the klein and dev base repo on every lane.
     ModelRow {
         sceneworks_id: "flux2_dev",
         engine_id: "flux2_dev",

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -28,11 +28,6 @@ const FLUX2_EDIT_CANDLE_DEV_GUIDANCE: f32 = 4.0;
 /// The adapter/engine id recorded on candle FLUX.2 edit assets + telemetry (distinct from the txt2img
 /// `candle_flux2` lane). Shared by klein + dev edit (the dev variant is the same edit surface).
 const FLUX2_EDIT_CANDLE_ENGINE: &str = "candle_flux2_edit";
-/// Default FLUX.2-klein base repo when the manifest omits `repo`.
-const FLUX2_EDIT_CANDLE_DEFAULT_REPO: &str = "black-forest-labs/FLUX.2-klein-9B";
-/// Default FLUX.2-dev base repo (the 32B flagship; sc-7460/7736). The candle lane loads the dense
-/// diffusers snapshot and Q4-quantizes it at load (no install-time packed convert off-Mac).
-const FLUX2_EDIT_CANDLE_DEV_REPO: &str = "black-forest-labs/FLUX.2-dev";
 /// Cap on references fed to a single FLUX.2 edit (the multi-image picker, sc-6211): the dev edit is
 /// activation-bound, so cap at the engine's validated native fan-out. This deliberately differs from
 /// the MLX `MAX_EDIT_REFERENCES` (4): that bound is set by the 96 GB Apple-Silicon unified-memory
@@ -63,43 +58,46 @@ fn flux2_edit_candle_mode(request: &ImageRequest) -> bool {
     request.mode == "edit_image" && non_empty(&request.source_asset_id)
 }
 
-/// Resolve the FLUX.2 base snapshot: an explicit `modelPath` dir (advanced or manifest) wins, else the
-/// HF cache snapshot for the manifest `repo` (default per family — klein vs dev). `None` means the base
-/// is not present locally, so the job is not candle-runnable. Mirrors `resolve_sdxl_edit_candle_base`.
+/// Resolve the FLUX.2 base snapshot through the **shared** [`resolve_weights_dir`] — the same resolver
+/// the candle txt2img lane uses (sc-10222, epic 9083 gap #3).
+///
+/// This lane used to key its own `black-forest-labs/FLUX.2-{klein-9B,dev}` dense-BFL constants. The
+/// sc-9092 sweep that retired the ad-hoc candle repo resolvers into `standard_tier_subdir` covered
+/// ideogram/boogu/krea/lens + the generic txt2img lane but missed this bespoke edit lane, so it kept
+/// probing the pre-rehost gated repos. The catalog's `downloads[]` pull ONLY the re-hosted
+/// `SceneWorks/flux2-*-mlx` packed q4/q8/bf16 turnkeys (sc-8711 / sc-8513) — there is no dense-BFL
+/// download on any platform — so off-Mac the probe found nothing, `resolve_flux2_edit_candle_base`
+/// returned `None`, and every FLUX.2 edit job silently failed the candle-eligibility check.
+///
+/// Delegating fixes it end to end: `resolve_weights_dir` takes the `modelPath` override first (the
+/// `flux2_klein_9b_true_v2` convert-at-install seam, unchanged), then the engines.rs `default_repo`
+/// (the SceneWorks turnkey — one source of truth, so a future re-host can't drift this lane again),
+/// then descends into the request's tier via `standard_tier_subdir` for the `STANDARD_TIER_MODELS`
+/// members (`flux2_klein_9b`, `flux2_dev`).
+///
+/// **No engine change was needed.** `Flux2Edit::load{,_dev}` builds its TE + DiT through the shared
+/// `Pipeline::load_te_and_dit`, whose every projection is a `QLinear::linear_detect` — it packed-detects
+/// a `.scales` sibling per tensor independently of the load `Quant`, and degrades to dense when there
+/// is none. That is the identical code path the candle FLUX.2 **txt2img** lane has been loading these
+/// turnkeys through since sc-9092; only the DIRECTORY handed to it was wrong. `None` still means the
+/// base is not present locally, so the job is not candle-runnable. Mirrors `krea_edit_candle_available`
+/// (the newer candle edit lane, already on the shared resolver).
 fn resolve_flux2_edit_candle_base(
     request: &ImageRequest,
     settings: &Settings,
 ) -> WorkerResult<Option<PathBuf>> {
-    if let Some(path) = request
-        .advanced
-        .get("modelPath")
-        .or_else(|| request.model_manifest_entry.get("modelPath"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-    {
-        return resolve_app_managed_model_dir(settings, &path, "FLUX.2 edit modelPath").map(Some);
-    }
-    let repo = flux2_edit_candle_repo(request);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, &repo))
+    resolve_weights_dir(request, settings)
 }
 
-/// The FLUX.2 base repo for this request: manifest `repo` else the per-family default (dev vs klein).
+/// The FLUX.2 base repo recorded on the asset telemetry: the shared manifest-`repo`-else-`default_repo`
+/// resolution ([`model_repo`]), so the recipe names the turnkey the load actually read rather than this
+/// lane's own constant (sc-10222). Falls back to the model id for an id outside the engine table (only
+/// reachable from a test payload — `is_flux2_edit_candle_model` gates the lane to three known ids).
 fn flux2_edit_candle_repo(request: &ImageRequest) -> String {
-    let default = if is_flux2_edit_candle_dev(&request.model) {
-        FLUX2_EDIT_CANDLE_DEV_REPO
-    } else {
-        FLUX2_EDIT_CANDLE_DEFAULT_REPO
-    };
-    request
-        .model_manifest_entry
-        .get("repo")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(default)
-        .to_owned()
+    match mlx_model(&request.model) {
+        Some(model) => model_repo(request, &model),
+        None => request.model.clone(),
+    }
 }
 
 /// True when this is a candle-eligible FLUX.2 edit job (a klein/dev `edit_image` job with a source)
@@ -246,10 +244,19 @@ async fn generate_candle_flux2_edit_stream(
         pid_effective_dims(request.width, request.height, use_pid, pid_output_tier(request));
     let references = load_flux2_edit_references(request, project_path, settings, width, height)?;
 
-    // dev (32B) loads Q4 (manifest `mlx.quantize: 4` → `resolve_quant`); klein loads dense. The dev
-    // edit is activation-bound — multi-reference adds latent tokens to the DiT stream — but the candle
-    // engine query-row-chunks its joint attention (sc-6217/sc-7523), so a device OOM surfaces as a load/
-    // generate error rather than silently corrupting; no Mac-style unified-memory pre-guard applies here.
+    // Since sc-10222 `flux2_base` is the RESOLVED tier subdir (`q4/`/`q8/`/`bf16/`), so the tier the
+    // load reads is chosen by the DIRECTORY, not by this `Quant` — every projection packed-detects its
+    // `.scales` sibling. dev still resolves a `Quant` (it is the value `resolve_quant` records on the
+    // recipe, and it drives the dense CPU-stage → quantize-onto-GPU fallback when the resolved dir is a
+    // dense/`modelPath` tree rather than a packed turnkey). klein keeps a hardcoded `(None, None)`: it is
+    // a DENSE-TE turnkey (`DENSE_TE_TIER_MODELS`) whose bf16 Qwen3 text encoder must never be
+    // re-quantized — `resolve_quant`'s `is_dense_te_tier` carve-out returns exactly this for
+    // `flux2_klein_9b`, and the hardcode additionally keeps `_true_v2` (a convert-at-install dense dir,
+    // NOT in that list) on the dense load it has always used.
+    //
+    // The dev edit is activation-bound — multi-reference adds latent tokens to the DiT stream — but the
+    // candle engine query-row-chunks its joint attention (sc-6217/sc-7523), so a device OOM surfaces as a
+    // load/generate error rather than silently corrupting; no Mac-style unified-memory pre-guard applies.
     let (quant, quant_bits) = if is_dev {
         resolve_quant(request, Some(&flux2_base))
     } else {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -6193,6 +6193,105 @@ fn sensenova_weights_resolution_routes_the_candle_lane_to_the_dense_tier() {
     );
 }
 
+/// sc-10222 (epic 9083 gap #3) — the candle FLUX.2 **edit** lane resolves the re-hosted packed turnkey.
+///
+/// The lane used to key its own `black-forest-labs/FLUX.2-{klein-9B,dev}` dense-BFL constants, missed by
+/// the sc-9092 sweep that retired the other ad-hoc candle repo resolvers. The catalog's `downloads[]`
+/// pull ONLY the `SceneWorks/flux2-*-mlx` q4/q8/bf16 turnkeys (sc-8711 / sc-8513) — there is no
+/// dense-BFL download on any platform — so the probe found nothing, `resolve_flux2_edit_candle_base`
+/// returned `None`, and `flux2_edit_candle_available` reported the job not candle-runnable. Off-Mac that
+/// is fatal for klein, which has no torch path at all.
+///
+/// The hub is seeded with ONLY what the catalog actually downloads (no BFL snapshot anywhere), so a
+/// regression to any bespoke constant makes this fail rather than silently pass off a stale cache. The
+/// per-tier assertions additionally prove the lane goes through `standard_tier_subdir` — the whole point
+/// of the fix, since `Flux2Edit`'s `QLinear::linear_detect` picks its precision from the DIRECTORY.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn flux2_edit_candle_base_resolves_the_packed_turnkey_tier() {
+    let root = tempfile::tempdir().unwrap();
+    let hub = root.path().join("hub");
+    std::fs::create_dir_all(&hub).unwrap();
+    let _hf = isolate_hf_hub_cache_to(&hub);
+    let mut settings = Settings::from_env();
+    settings.data_dir = root.path().to_path_buf();
+    settings.backend_candle_enabled = true;
+
+    // (model id, the engines.rs `default_repo` turnkey the catalog downloads).
+    for (model, cache_dir) in [
+        ("flux2_klein_9b", "models--SceneWorks--flux2-klein-9b-mlx"),
+        ("flux2_dev", "models--SceneWorks--flux2-dev-mlx"),
+    ] {
+        let snapshot = hub.join(cache_dir).join("snapshots").join("installed");
+        for tier in ["q4", "q8", "bf16"] {
+            let path = snapshot
+                .join(tier)
+                .join("transformer")
+                .join("diffusion_pytorch_model.safetensors");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"weights").unwrap();
+        }
+        // An edit payload with NO manifest `repo`, so the resolution runs through the shared
+        // `mlx_model` → engines.rs `default_repo` — the exact seam the bespoke constants shadowed.
+        let edit = |advanced: serde_json::Value| {
+            request(json!({
+                "projectId": "p", "model": model, "prompt": "make it snow",
+                "mode": "edit_image", "sourceAssetId": "asset_1", "count": 1,
+                "advanced": advanced
+            }))
+        };
+
+        // No explicit tier → the app-wide q8 default, clamped to what is installed.
+        assert_eq!(
+            resolve_flux2_edit_candle_base(&edit(json!({})), &settings).unwrap(),
+            Some(snapshot.join("q8")),
+            "{model} edit must resolve the packed turnkey's q8 tier (sc-10222)"
+        );
+        // An explicit tier pick is honored — the edit lane A/Bs tiers like the txt2img lane.
+        for (bits, tier) in [(4, "q4"), (8, "q8"), (0, "bf16")] {
+            assert_eq!(
+                resolve_flux2_edit_candle_base(&edit(json!({ "mlxQuantize": bits })), &settings)
+                    .unwrap(),
+                Some(snapshot.join(tier)),
+                "{model} edit with mlxQuantize {bits} must resolve the {tier} tier"
+            );
+        }
+        // The whole point: the job is now candle-runnable off-Mac.
+        assert!(
+            flux2_edit_candle_available(&edit(json!({})), &settings),
+            "{model} edit must be candle-available once the turnkey is installed (sc-10222)"
+        );
+        // The recipe names the turnkey the load actually read, not a dense-BFL constant.
+        assert!(
+            flux2_edit_candle_repo(&edit(json!({}))).starts_with("SceneWorks/flux2-"),
+            "{model} edit telemetry must record the re-hosted turnkey repo"
+        );
+    }
+}
+
+/// sc-10222 — with NO FLUX.2 snapshot installed the edit lane still reports "not runnable" rather than
+/// handing the engine a path that does not exist. Guards the `None` half of the delegation: the shared
+/// `resolve_weights_dir` must not manufacture a directory for an unfetched repo.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn flux2_edit_candle_base_is_absent_without_the_turnkey() {
+    let dir = tempfile::tempdir().unwrap();
+    let _hf = isolate_hf_hub_cache_to(dir.path());
+    let mut settings = Settings::from_env();
+    settings.data_dir = dir.path().to_path_buf();
+    settings.backend_candle_enabled = true;
+
+    let edit = request(json!({
+        "projectId": "p", "model": "flux2_klein_9b", "prompt": "make it snow",
+        "mode": "edit_image", "sourceAssetId": "asset_1", "count": 1
+    }));
+    assert_eq!(
+        resolve_flux2_edit_candle_base(&edit, &settings).unwrap(),
+        None
+    );
+    assert!(!flux2_edit_candle_available(&edit, &settings));
+}
+
 // sc-11171 (F-008): a strict-pose job on a WIRED candle pose family (e.g. `z_image_turbo`) whose control
 // base snapshot is NOT installed must route to the loud `PoseControlBaseMissing` reject, NOT fall through
 // to the plain candle txt2img lane (which would silently render an unconditioned image and drop the


### PR DESCRIPTION
Closes [sc-10222](https://app.shortcut.com/trefry/story/10222) (epic 9083 gap #3).

## The bug

The bespoke off-Mac candle FLUX.2 **edit** lane (`image_jobs/flux2_edit_candle.rs`) still keyed its own pre-rehost dense-BFL constants:

```rust
const FLUX2_EDIT_CANDLE_DEFAULT_REPO: &str = "black-forest-labs/FLUX.2-klein-9B";
const FLUX2_EDIT_CANDLE_DEV_REPO: &str = "black-forest-labs/FLUX.2-dev";
```

The sc-9092 sweep that retired the ad-hoc candle repo resolvers into the shared `standard_tier_subdir` path covered ideogram/boogu/krea/lens + the generic txt2img lane, but not this one.

The catalog's `downloads[]` pull **only** the re-hosted `SceneWorks/flux2-*-mlx` packed q4/q8/bf16 turnkeys (sc-8711 / sc-8513) — there is no dense-BFL download on any platform. So off-Mac the probe found nothing, `resolve_flux2_edit_candle_base` returned `None`, and every FLUX.2 edit job failed the candle-eligibility check. **FLUX.2-klein has no torch path at all**, so off-Mac that lane was simply dead.

## Fix — path (2), no engine change needed

The story left open whether the engine could packed-load the turnkey or needed a dense diffusers tree. It can, and already does:

`Flux2Edit::load{,_dev}` builds its TE + DiT through the shared `Pipeline::load_te_and_dit`, and **every** projection in `transformer.rs` / `text_encoder.rs` is a `QLinear::linear_detect` — it packed-detects a `.scales` sibling per tensor independently of the load `Quant`, and degrades to dense per-tensor when there is none. That is the identical code path the candle FLUX.2 **txt2img** lane has loaded these same turnkeys through since sc-9092; only the DIRECTORY handed to it was wrong.

So the lane now delegates to the shared `resolve_weights_dir`, which:
1. takes the `modelPath` override first — the `flux2_klein_9b_true_v2` convert-at-install seam, unchanged;
2. else resolves the engines.rs `default_repo` (the SceneWorks turnkey — one source of truth, so a future re-host cannot drift this lane again);
3. else descends into the request's tier via `standard_tier_subdir` for the `STANDARD_TIER_MODELS` members.

This is the shape `krea_edit_candle_available` (the newer candle edit lane) already uses.

## Also: the router half

While verifying the lane boundary I found the classically-missed step 2b still open for FLUX.2 — the same skew sc-9983 (krea/ideogram/boogu) and sc-11020 (qwen_image) each closed.

`flux2_klein_9b`, `_kv` and `flux2_dev` are worker `STANDARD_TIER_MODELS` members whose manifests carry **measured** `candle.vramGbByTier` blocks (klein 46.2/50.6/75.5, dev 44.0/70.7/128.0), but `IMAGE_MODEL_CAPS` still said `candle_quant = false` — so `image_request_candle_eligible`'s `!supports_quant && candle_request_wants_quant` arm bounced every explicit `advanced.mlxQuantize > 0` tier-select off the candle lane into the retired torch fallback.

The diagnostic tell is exactly the one recorded on the prior two: a family in `STANDARD_TIER_MODELS` with a `candle.vramGbByTier` block that is not in `CANDLE_QUANT_MODELS`. Cruelly, dev's own fit-gate asks a 48 GB user to pick q4 (44.0 GB) instead of the q8 default (70.7) — the only tier that fits was the one tier that could not be routed.

`flux2_klein_9b_true_v2` deliberately stays `false`: the wikeeyang fine-tune installs by convert-at-install into a flat `modelPath` dir with no tier matrix, so there is no tier for a pick to select.

## Verification

- `cargo test -p sceneworks-core --lib` — 563 pass (whole `--lib`, not just `routing::` — the candle-routing tests live in `jobs_store::candle_routing_tests`).
- `cargo check -p sceneworks-worker --features backend-candle --tests` — clean (the exact `candle-worker` CI job, which `parity` is blind to).
- New worker tests pass on that candle build: per-tier resolution (q8 default / explicit q4 / q8 / bf16), `flux2_edit_candle_available`, the telemetry repo, and the absent-turnkey `None` half. The hub fixture seeds **only** what the catalog downloads — no BFL snapshot anywhere — so a regression to any bespoke constant fails rather than passing off a stale cache.

Not GPU-validated: the resolution change is directory-only and the engine path it feeds is the one the txt2img lane already runs on these tiers. A real in-app edit A/B across tiers is [sc-9096](https://app.shortcut.com/trefry/story/9096), the epic finale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)