### PR TITLE
fix(worker): preflight video upscale and external Wan loads (sc-13621)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "libc",
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -471,7 +471,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -552,7 +552,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -565,7 +565,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -814,7 +814,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "image",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -945,7 +945,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1076,7 +1076,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "cudaforge",
 ]
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3838,10 +3838,12 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
+ "memmap2",
  "pmetal-mlx-rs",
  "pmetal-mlx-sys",
+ "safetensors 0.4.5",
  "sceneworks-gen-core",
  "serde_json",
  "thiserror 2.0.18",
@@ -3851,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3863,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3876,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -3889,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -3928,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -3941,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -3951,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3960,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -3969,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3982,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -3994,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4006,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4018,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4027,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4039,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4053,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4066,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4077,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4088,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4099,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4110,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4121,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4130,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4139,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4149,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4160,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4174,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4187,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4197,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4208,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4218,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4231,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4255,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "core-llm",
  "half",
@@ -4567,7 +4569,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5797,7 +5799,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -5807,7 +5809,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -5818,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -5922,7 +5924,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5979,7 +5981,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6096,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b83b51da6ff5a6b9750a414730cf71ed7ac5269b#b83b51da6ff5a6b9750a414730cf71ed7ac5269b"
+source = "git+https://github.com/SceneWorks/inference?rev=ba44fdf95219c0c8e05888caf1e6aa00fa61cac9#ba44fdf95219c0c8e05888caf1e6aa00fa61cac9"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",
@@ -7323,7 +7325,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8480,7 +8482,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "ba44fdf95219c0c8e05888caf1e6aa00fa61cac9" }

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -28,7 +28,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "ba44fdf95219c0c8e05888caf1e6aa00fa61cac9" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -72,13 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b" }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "ba44fdf95219c0c8e05888caf1e6aa00fa61cac9" }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "b83b51da6ff5a6b9750a414730cf71ed7ac5269b", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "ba44fdf95219c0c8e05888caf1e6aa00fa61cac9", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -3149,6 +3149,16 @@ pub(crate) async fn run_ffmpeg(
     args: Vec<String>,
     context: Option<FfmpegContext<'_>>,
 ) -> WorkerResult<()> {
+    run_ffmpeg_capture_stderr(args, context).await.map(|_| ())
+}
+
+/// Run FFmpeg with the shared heartbeat/cancellation lifecycle and return its stderr on success.
+/// Most callers use [`run_ffmpeg`]; media probes need FFmpeg's progress/stream metadata without
+/// introducing an `ffprobe` dependency (the desktop bundle ships only FFmpeg).
+pub(crate) async fn run_ffmpeg_capture_stderr(
+    args: Vec<String>,
+    context: Option<FfmpegContext<'_>>,
+) -> WorkerResult<String> {
     let Some((program, arguments)) = args.split_first() else {
         return Err(WorkerError::InvalidPayload(
             "FFmpeg command is empty.".to_owned(),
@@ -3218,10 +3228,10 @@ pub(crate) async fn run_ffmpeg(
     let stderr = stderr_task
         .await
         .map_err(|error| task_join_error("ffmpeg stderr reader task", error))?;
-    if status.success() {
-        return Ok(());
-    }
     let stderr = String::from_utf8_lossy(&stderr);
+    if status.success() {
+        return Ok(stderr.into_owned());
+    }
     let bounded = bounded_tail(&stderr, 10, 2000);
     if bounded.trim().is_empty() {
         Err(WorkerError::Engine(

--- a/crates/sceneworks-worker/src/video_jobs.rs
+++ b/crates/sceneworks-worker/src/video_jobs.rs
@@ -1574,6 +1574,24 @@ pub(crate) fn seedvr2_estimated_output_bytes(frame_count: u64, out_w: u64, out_h
     frame_count.saturating_mul(per_frame)
 }
 
+/// Peak scratch footprint while SeedVR2 is streaming: the native-resolution source PNG sequence and
+/// the upscaled output sequence coexist until the final encode. Both use a raw-RGB upper bound.
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn seedvr2_estimated_scratch_bytes(
+    frame_count: u64,
+    src_w: u64,
+    src_h: u64,
+    out_w: u64,
+    out_h: u64,
+) -> u64 {
+    seedvr2_estimated_output_bytes(frame_count, src_w, src_h)
+        .saturating_add(seedvr2_estimated_output_bytes(frame_count, out_w, out_h))
+}
+
 /// Bytes currently AVAILABLE on the volume backing `path`, best-effort and portable with NO new crate
 /// dependency: macOS + Linux run POSIX `df -k -P <path>` and read the 4th column (available 1K
 /// blocks); Windows (candle lane) uses `fs2::available_space` (a safe wrapper over the Win32
@@ -1628,6 +1646,7 @@ pub(crate) fn available_disk_bytes(path: &Path) -> Option<u64> {
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
+#[allow(dead_code)] // retained as the output-only regression seam for sc-9646/sc-13585 tests
 pub(crate) fn check_seedvr2_output_disk(
     scratch_dir: &Path,
     frame_count: u64,
@@ -1653,6 +1672,43 @@ pub(crate) fn check_seedvr2_output_disk(
              {out_w}×{out_h} would write ~{needed:.1} GB of PNG frames to the scratch volume, over \
              the ~{budget:.1} GB usable of ~{available:.1} GB free. Trim the clip to about \
              {max_frames} frames (or fewer), lower the target resolution, or free up disk space.",
+            needed = needed as f64 / GIB,
+            budget = budget as f64 / GIB,
+            available = available as f64 / GIB,
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn check_seedvr2_scratch_disk(
+    scratch_dir: &Path,
+    frame_count: u64,
+    src_w: u64,
+    src_h: u64,
+    out_w: u64,
+    out_h: u64,
+) -> WorkerResult<()> {
+    if frame_count == 0 || src_w == 0 || src_h == 0 || out_w == 0 || out_h == 0 {
+        return Ok(());
+    }
+    let Some(available) = available_disk_bytes(scratch_dir) else {
+        return Ok(());
+    };
+    let needed = seedvr2_estimated_scratch_bytes(frame_count, src_w, src_h, out_w, out_h);
+    let budget = ((available as f64) * SEEDVR2_DISK_OUTPUT_FRACTION) as u64;
+    if needed > budget {
+        const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+        let per_frame = seedvr2_estimated_scratch_bytes(1, src_w, src_h, out_w, out_h).max(1);
+        let max_frames = budget / per_frame;
+        return Err(WorkerError::InvalidPayload(format!(
+            "Not enough disk space to upscale this clip: {frame_count} source frames at \
+             {src_w}×{src_h} plus {frame_count} output frames at {out_w}×{out_h} need ~{needed:.1} GB \
+             of PNG scratch, over the ~{budget:.1} GB usable of ~{available:.1} GB free. Trim the clip \
+             to about {max_frames} frames (or fewer), lower the target resolution, or free disk space.",
             needed = needed as f64 / GIB,
             budget = budget as f64 / GIB,
             available = available as f64 / GIB,
@@ -1902,6 +1958,90 @@ async fn decode_seedvr2_source_to_disk(
     Ok(paths)
 }
 
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Seedvr2SourceProbe {
+    frame_count: u64,
+    width: u32,
+    height: u32,
+}
+
+/// Parse FFmpeg's mapped output-stream geometry and final `frame=` counter. The output stream is
+/// authoritative because FFmpeg applies input rotation metadata before the null mux (and before our
+/// PNG decode), so the first/input `Video:` line can report the opposite orientation. Kept pure so
+/// the admission plan is tested without real media. We intentionally ignore encoder/status tokens
+/// outside sane dimensions.
+#[cfg(any(
+    test,
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn parse_seedvr2_source_probe(stderr: &str) -> Option<Seedvr2SourceProbe> {
+    let frame_count = stderr.rmatch_indices("frame=").find_map(|(idx, _)| {
+        stderr[idx + 6..]
+            .trim_start()
+            .split(|c: char| !c.is_ascii_digit())
+            .next()
+            .filter(|digits| !digits.is_empty())
+            .and_then(|digits| digits.parse::<u64>().ok())
+    })?;
+    let video_line = stderr.lines().rev().find(|line| line.contains("Video:"))?;
+    let (width, height) = video_line
+        .split(|c: char| c.is_whitespace() || c == ',')
+        .find_map(|token| {
+            let token = token.trim_matches(|c: char| !c.is_ascii_digit() && c != 'x');
+            let (w, h) = token.split_once('x')?;
+            let (w, h) = (w.parse::<u32>().ok()?, h.parse::<u32>().ok()?);
+            (w > 0 && h > 0 && w <= 65_535 && h <= 65_535).then_some((w, h))
+        })?;
+    (frame_count > 0).then_some(Seedvr2SourceProbe {
+        frame_count,
+        width,
+        height,
+    })
+}
+
+/// Decode-free, VFR-safe source probe using the bundled FFmpeg null mux. The shared runner preserves
+/// the normal heartbeat/cancellation lifecycle while FFmpeg walks the source.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+async fn probe_seedvr2_source(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
+    source: &Path,
+) -> WorkerResult<Seedvr2SourceProbe> {
+    let ctx = FfmpegContext::new(api, settings, job_id, SEEDVR2_CANCEL_MESSAGE);
+    let stderr = crate::media_jobs::run_ffmpeg_capture_stderr(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-hide_banner".to_owned(),
+            "-i".to_owned(),
+            source.to_string_lossy().into_owned(),
+            "-map".to_owned(),
+            "0:v:0".to_owned(),
+            "-f".to_owned(),
+            "null".to_owned(),
+            "-".to_owned(),
+        ],
+        Some(ctx),
+    )
+    .await?;
+    parse_seedvr2_source_probe(&stderr).ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Could not determine the source video's frame count and dimensions before upscale."
+                .to_owned(),
+        )
+    })
+}
+
 /// Load the temporal window `paths[start .. start+len]` (clamped to the sequence end) into engine
 /// [`Image`]s on demand (sc-9595). Real frames only — the engine's `preprocess_chunk` pads a partial
 /// trailing window with last-frame repeats internally, matching the whole-clip path. Runs the blocking
@@ -2120,38 +2260,59 @@ async fn run_seedvr2_stream(
     weights_dir: PathBuf,
 ) -> WorkerResult<Seedvr2Stream> {
     let seed = req.seed.unwrap_or(0);
-    // Decode the whole source to numbered PNGs on disk (RAM-free), then peek the first frame's dims.
+    // Probe BEFORE creating either PNG sequence. The source and output sequences coexist at peak, so
+    // admission must account for both before the first source frame can consume scratch.
+    let probe = probe_seedvr2_source(api, settings, &job.id, source_path).await?;
+    let (target_w, target_h) = match (req.target_width, req.target_height) {
+        (Some(w), Some(h)) if w > 0 && h > 0 => (w, h),
+        _ => (
+            probe.width.saturating_mul(factor),
+            probe.height.saturating_mul(factor),
+        ),
+    };
+    let target_w = snap_seedvr2_dim(target_w);
+    let target_h = snap_seedvr2_dim(target_h);
+    {
+        let guard_dir = out_frames_dir
+            .parent()
+            .unwrap_or(out_frames_dir)
+            .to_path_buf();
+        let p = probe;
+        tokio::task::spawn_blocking(move || {
+            check_seedvr2_scratch_disk(
+                &guard_dir,
+                p.frame_count,
+                u64::from(p.width),
+                u64::from(p.height),
+                u64::from(target_w),
+                u64::from(target_h),
+            )
+        })
+        .await
+        .map_err(|error| task_join_error("seedvr2 disk preflight", error))??;
+    }
+
+    // Only an admitted job may materialize the native-resolution source PNG sequence.
     let paths =
         decode_seedvr2_source_to_disk(api, settings, &job.id, source_path, src_frames_dir).await?;
     let n = paths.len();
+    if n as u64 != probe.frame_count {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Source video changed while preparing upscale (probed {} frames, decoded {n}). Retry the job.",
+            probe.frame_count
+        )));
+    }
     let first = load_seedvr2_window(&paths, 0, 1).await?;
     let src_w = first[0].width;
     let src_h = first[0].height;
     drop(first);
-
-    // Resolve + snap the target output resolution (identical to the whole-clip path).
-    let (target_w, target_h) = match (req.target_width, req.target_height) {
-        (Some(w), Some(h)) if w > 0 && h > 0 => (w, h),
-        _ => (src_w.saturating_mul(factor), src_h.saturating_mul(factor)),
-    };
-    let target_w = snap_seedvr2_dim(target_w);
-    let target_h = snap_seedvr2_dim(target_h);
+    if (src_w, src_h) != (probe.width, probe.height) {
+        return Err(WorkerError::InvalidPayload(
+            "Source video dimensions changed while preparing upscale. Retry the job.".to_owned(),
+        ));
+    }
 
     tokio::fs::create_dir_all(out_frames_dir).await?;
-
-    // Disk-space preflight (sc-9646): sc-9595 streams the whole upscaled PNG sequence to this scratch
-    // dir before the final encode, so a long / high-res clip can write many GB with no bound (the
-    // removed sc-8829 host-RAM cap previously bounded the whole operation). Fail loud HERE — before the
-    // first window's decode + GPU work — when the estimated output footprint would exceed a generous
-    // fraction of the scratch volume's free space, so we don't fill the disk mid-run. Probed on a
-    // blocking thread (it shells out) but cheap and one-shot.
-    {
-        let guard_dir = out_frames_dir.to_path_buf();
-        let (frames, gw, gh) = (n as u64, u64::from(target_w), u64::from(target_h));
-        tokio::task::spawn_blocking(move || check_seedvr2_output_disk(&guard_dir, frames, gw, gh))
-            .await
-            .map_err(|error| task_join_error("seedvr2 disk preflight", error))??;
-    }
 
     // Plan the worker windows over the REAL frame count with the engine's own planner: a valid chunk
     // length + `DEFAULT_OVERLAP` cross-fade, so the worker-window seam handling matches the engine's
@@ -4524,8 +4685,14 @@ async fn generate_video_using(
                 Some((high, low, te, vae, snapshot, i2v)) => {
                     crate::generator_cache::with_uncached_generator(
                         move || {
-                            runtime_cuda::providers::wan::wan14b::load_from_comfyui_experts(
-                                high, low, te, vae, snapshot, i2v,
+                            runtime_cuda::providers::wan::wan14b::load_from_comfyui_experts_with_offload(
+                                high,
+                                low,
+                                te,
+                                vae,
+                                snapshot,
+                                i2v,
+                                OffloadPolicy::Sequential,
                             )
                             .map_err(|error| {
                                 crate::classify_engine_error("video load failed", error)
@@ -5915,6 +6082,55 @@ struct ComfyuiWanPaths {
     snapshot_dir: PathBuf,
 }
 
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn comfyui_wan_admission_bytes(paths: &ComfyuiWanPaths) -> u64 {
+    let file_bytes = |path: &Path| path.metadata().map(|m| m.len()).unwrap_or(0);
+    file_bytes(&paths.high)
+        .saturating_add(file_bytes(&paths.low))
+        .saturating_add(match &paths.te {
+            Some(path) => file_bytes(path),
+            None => {
+                crate::mlx_fit_gate::sum_safetensors_bytes(&paths.snapshot_dir.join("text_encoder"))
+            }
+        })
+        .saturating_add(match &paths.vae {
+            Some(path) => file_bytes(path),
+            None => crate::mlx_fit_gate::sum_safetensors_bytes(&paths.snapshot_dir.join("vae")),
+        })
+}
+
+/// Conservative admission for external ComfyUI A14B. These user-supplied experts have no builtin
+/// manifest tier/measurement, so the only authoritative pre-load signal is their actual file set.
+/// Sequential expert swapping is explicit at the load seam below, but a 24–32 GB card must not admit
+/// a pair whose on-disk weights alone already exceed its live budget.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn comfyui_wan_vram_preflight(
+    paths: ComfyuiWanPaths,
+    gpu_id: &str,
+    budget: Option<crate::vram_gate::VramBudget>,
+) -> WorkerResult<ComfyuiWanPaths> {
+    let Some(budget) = budget else {
+        return Ok(paths);
+    };
+    let bytes = comfyui_wan_admission_bytes(&paths);
+    if bytes == 0 {
+        return Ok(paths);
+    }
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    const CUDA_HEADROOM_GB: f64 = 2.0;
+    let needed = bytes as f64 / GIB + CUDA_HEADROOM_GB;
+    if budget.free_gb + f64::EPSILON < needed {
+        return Err(WorkerError::InvalidPayload(format!(
+            "ComfyUI Wan2.2 A14B needs at least ~{} GB of VRAM admission budget for its supplied \
+             experts and supporting weights, but GPU {gpu_id} has ~{} GB available. Use smaller \
+             quantized ComfyUI experts, close other GPU workloads, or run on a larger GPU.",
+            needed.ceil() as u64,
+            budget.free_gb.round() as u64,
+        )));
+    }
+    Ok(paths)
+}
+
 /// Peek a safetensors header (8-byte length + JSON) and return the `patch_embedding.weight`
 /// in-channels (`shape[1]`) — the T2V(16)/I2V(36) discriminator. `None` on any read/parse miss.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
@@ -6053,6 +6269,12 @@ async fn generate_candle_wan_comfyui(
                 .to_owned(),
         )
     })?;
+    // Admission happens before `generate_video` reaches the uncached external-expert load.
+    let paths = comfyui_wan_vram_preflight(
+        paths,
+        &settings.gpu_id,
+        candle_video_vram_budget(settings).await,
+    )?;
     let input = VideoGenInput {
         engine_id: WAN_COMFYUI_T2V_ENGINE,
         // The snapshot tier supplies the tokenizer (and the metrics `model_dir`, and the UMT5 TE / VAE
@@ -6071,6 +6293,7 @@ async fn generate_candle_wan_comfyui(
         guidance: None,
         seed: resolve_video_seed(request) as u64,
         conditioning: Vec::new(),
+        offload_policy: candle_wan_offload_policy(WAN_COMFYUI_T2V_ENGINE),
         comfyui: Some(ComfyuiWanExperts {
             high_file: paths.high,
             low_file: paths.low,
@@ -11245,6 +11468,106 @@ mod tests {
 
     fn request(value: Value) -> VideoRequest {
         VideoRequest::from_payload(&value.as_object().cloned().unwrap())
+    }
+
+    #[test]
+    fn seedvr2_probe_and_scratch_plan_cover_both_sequences_before_decode() {
+        let stderr = r#"
+          Stream #0:0: Video: h264 (High), yuv420p, 1920x1080, 30 fps
+        frame=  347 fps=0.0 q=-0.0 Lsize=N/A time=00:00:11.56
+        "#;
+        assert_eq!(
+            parse_seedvr2_source_probe(stderr),
+            Some(Seedvr2SourceProbe {
+                frame_count: 347,
+                width: 1920,
+                height: 1080,
+            })
+        );
+        let source = seedvr2_estimated_output_bytes(347, 1920, 1080);
+        let output = seedvr2_estimated_output_bytes(347, 3840, 2160);
+        assert_eq!(
+            seedvr2_estimated_scratch_bytes(347, 1920, 1080, 3840, 2160),
+            source + output,
+            "the pre-decode plan must reserve the coexisting native and upscaled PNG sequences"
+        );
+    }
+
+    #[test]
+    fn seedvr2_probe_uses_effective_output_geometry_after_rotation() {
+        let stderr = r#"
+          Stream #0:0: Video: h264 (High), yuv420p, 1920x1080, 30 fps
+        Output #0, null, to 'pipe:':
+          Stream #0:0: Video: wrapped_avframe, yuv420p, 1080x1920, 30 fps
+        frame=  347 fps=0.0 q=-0.0 Lsize=N/A time=00:00:11.56
+        "#;
+        assert_eq!(
+            parse_seedvr2_source_probe(stderr),
+            Some(Seedvr2SourceProbe {
+                frame_count: 347,
+                width: 1080,
+                height: 1920,
+            }),
+            "rotation metadata must use the effective mapped geometry produced by the PNG decode"
+        );
+    }
+
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    #[test]
+    fn comfyui_wan_a14b_gate_rejects_32gb_and_admits_large_card() {
+        let root = std::env::temp_dir().join(format!(
+            "sc13621_comfy_wan_gate_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let high = root.join("high.safetensors");
+        let low = root.join("low.safetensors");
+        std::fs::File::create(&high)
+            .unwrap()
+            .set_len(20 * 1024 * 1024 * 1024)
+            .unwrap();
+        std::fs::File::create(&low)
+            .unwrap()
+            .set_len(20 * 1024 * 1024 * 1024)
+            .unwrap();
+        let make_paths = || ComfyuiWanPaths {
+            high: high.clone(),
+            low: low.clone(),
+            te: None,
+            vae: None,
+            snapshot_dir: root.clone(),
+        };
+        assert!(
+            comfyui_wan_vram_preflight(
+                make_paths(),
+                "0",
+                Some(crate::vram_gate::VramBudget {
+                    free_gb: 32.0,
+                    total_gb: 32.0,
+                }),
+            )
+            .is_err(),
+            "a 32 GB card must not reach the external A14B load"
+        );
+        assert!(
+            comfyui_wan_vram_preflight(
+                make_paths(),
+                "0",
+                Some(crate::vram_gate::VramBudget {
+                    free_gb: 96.0,
+                    total_gb: 96.0,
+                }),
+            )
+            .is_ok(),
+            "larger-card behavior remains admitted"
+        );
+        assert_eq!(
+            candle_wan_offload_policy(WAN_COMFYUI_T2V_ENGINE),
+            OffloadPolicy::Sequential
+        );
+        std::fs::remove_dir_all(&root).ok();
     }
 
     /// sc-13585: on Windows the free-space probe was inert — the old code matched an `fsutil` output


### PR DESCRIPTION
## Summary
- probe SeedVR2 source geometry and frame count before writing scratch PNGs
- gate combined source + output scratch usage before decode
- add conservative VRAM admission and explicit sequential offload for external ComfyUI Wan A14B

## Validation
- cargo fmt --all -- --check
- focused SeedVR2 production-plan regression
- cargo check --locked -p sceneworks-worker
- cargo check --locked -p sceneworks-worker --target x86_64-unknown-linux-gnu --no-default-features
- Candle/CUDA regression requires CI because local nvcc is unavailable

Shortcut: sc-13621