### PR TITLE
chore(docker): build embed-web API image [sc-10363]

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,22 @@ GPU inference worker from target `rust-worker-candle`. The API sets
 `SCENEWORKS_CANDLE_REQUIRED=1`, so a job candle can't serve fails with a precise
 error instead of waiting forever.
 
+To build a production API image that serves the React SPA, static assets, and
+`/api/v1/*` from the same process and origin, use the opt-in `rust-api-embed`
+target. The plain `rust-api` target remains the non-embedded image used by
+Compose. The build needs a read token for the private inference dependency; this
+PowerShell example reuses the authenticated GitHub CLI token without writing it
+to disk:
+
+```powershell
+$env:SCENEWORKS_INFERENCE_READ_TOKEN = gh auth token
+docker build --secret id=inference_token,env=SCENEWORKS_INFERENCE_READ_TOKEN `
+  --file docker/rust.Dockerfile `
+  --target rust-api-embed `
+  --build-arg BIN=sceneworks-rust-api `
+  --tag sceneworks-api-embed:local .
+```
+
 Key knobs:
 
 - `SCENEWORKS_API_PORT` / `SCENEWORKS_WEB_PORT` — container/host ports for the API

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1607,6 +1607,14 @@ mod web_assets {
     #[folder = "../web/dist"]
     struct WebAssets;
 
+    #[cfg(test)]
+    pub(super) fn first_static_asset_path() -> String {
+        WebAssets::iter()
+            .find(|path| path.starts_with("assets/"))
+            .expect("production web bundle contains a static asset")
+            .into_owned()
+    }
+
     // The desktop shell navigates its privileged webview to this server, so the embedded
     // UI runs from this origin and its CSP must come from here (tauri.conf.json only
     // governs the bundled setup screen). Kept narrow: scripts only from this origin (the

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -478,9 +478,10 @@ async fn embedded_ui_root_is_reachable_with_access_token_set() {
     // With a token configured and no header, the embedded UI root and assets
     // must not be blocked by auth (404 here under default features since the
     // bundle isn't embedded; the point is it is NOT 401).
-    let (status, _) = request(app.clone(), "GET", "/", Value::Null).await;
+    let (status, _, _) = request_raw(app.clone(), "GET", "/", Body::empty(), &[]).await;
     assert_ne!(status, StatusCode::UNAUTHORIZED);
-    let (status, _) = request(app.clone(), "GET", "/assets/app.js", Value::Null).await;
+    let (status, _, _) =
+        request_raw(app.clone(), "GET", "/assets/app.js", Body::empty(), &[]).await;
     assert_ne!(status, StatusCode::UNAUTHORIZED);
     // API routes stay protected.
     let (status, _) = request(app, "GET", "/api/v1/jobs", Value::Null).await;

--- a/apps/rust-api/src/tests/embedded_web.rs
+++ b/apps/rust-api/src/tests/embedded_web.rs
@@ -1,0 +1,62 @@
+use super::support::*;
+use axum::http::header::{CONTENT_SECURITY_POLICY, CONTENT_TYPE};
+
+#[tokio::test]
+async fn embedded_spa_and_api_share_the_router() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (root_status, root_headers, root_body) =
+        request_raw(app.clone(), "GET", "/", Body::empty(), &[]).await;
+    assert_eq!(root_status, StatusCode::OK);
+    assert_eq!(
+        root_headers
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("text/html")
+    );
+    assert!(root_headers.contains_key(CONTENT_SECURITY_POLICY));
+    assert!(
+        String::from_utf8_lossy(&root_body).contains("<div id=\"root\">"),
+        "root serves the built React entrypoint"
+    );
+
+    let (fallback_status, fallback_headers, fallback_body) = request_raw(
+        app.clone(),
+        "GET",
+        "/projects/client-side-route",
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(fallback_status, StatusCode::OK);
+    assert_eq!(
+        fallback_headers
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("text/html; charset=utf-8")
+    );
+    assert_eq!(fallback_body, root_body, "SPA fallback returns index.html");
+
+    let asset_path = format!("/{}", crate::web_assets::first_static_asset_path());
+    let (asset_status, asset_headers, asset_body) =
+        request_raw(app.clone(), "GET", &asset_path, Body::empty(), &[]).await;
+    assert_eq!(asset_status, StatusCode::OK);
+    assert!(
+        asset_headers
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value != "text/html; charset=utf-8"),
+        "static asset keeps its own MIME type"
+    );
+    assert!(!asset_body.is_empty(), "static asset body is embedded");
+
+    let (health_status, health) = request(app.clone(), "GET", "/api/v1/health", Value::Null).await;
+    assert_eq!(health_status, StatusCode::OK);
+    assert_eq!(health["service"], "sceneworks-api");
+
+    let (missing_api_status, missing_api) =
+        request(app, "GET", "/api/v1/not-a-route", Value::Null).await;
+    assert_eq!(missing_api_status, StatusCode::NOT_FOUND);
+    assert_eq!(missing_api["detail"], "Not Found");
+}

--- a/apps/rust-api/src/tests/mod.rs
+++ b/apps/rust-api/src/tests/mod.rs
@@ -3,6 +3,8 @@
 
 mod auth;
 mod catalog;
+#[cfg(feature = "embed-web")]
+mod embedded_web;
 mod jobs;
 mod mcp;
 mod media;

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -7,7 +7,24 @@
 # Build a specific image with `--target` + `--build-arg BIN=…`; docker-compose
 # sets both per service:
 #   docker build -f docker/rust.Dockerfile --target rust-api   --build-arg BIN=sceneworks-rust-api   .
+#   docker build -f docker/rust.Dockerfile --target rust-api-embed --build-arg BIN=sceneworks-rust-api .
 #   docker build -f docker/rust.Dockerfile --target rust-worker --build-arg BIN=sceneworks-rust-worker .
+
+# Production SPA bundle for the opt-in rust-api-embed target. The plain rust-api
+# target has no dependency on this stage, so it neither installs Node packages nor
+# embeds web assets. The license corpus is imported directly by the production UI.
+FROM node:22-bookworm-slim AS web-builder
+WORKDIR /app
+COPY apps/web/package.json apps/web/package-lock.json ./apps/web/
+RUN --mount=type=cache,target=/root/.npm npm ci --prefix apps/web
+COPY apps/web ./apps/web
+COPY apps/desktop/licenses ./apps/desktop/licenses
+# Explicit empty (not unset): apps/web/src/api.js maps this to window.location.origin.
+ENV VITE_API_BASE_URL=""
+# Guard the built artifact, not just the Dockerfile environment declaration:
+# an unset value bakes the local-Vite fallback into the production bundle.
+RUN npm run build --prefix apps/web \
+    && ! grep -R -q "http://localhost:8000" apps/web/dist
 
 FROM rust:1-bookworm AS builder
 # Which workspace binary to build (sceneworks-rust-api | sceneworks-rust-worker).
@@ -75,6 +92,25 @@ RUN apt-get update \
 COPY --from=builder /out/sceneworks-rust-api /usr/local/bin/sceneworks-rust-api
 
 CMD ["sceneworks-rust-api"]
+
+# --- Rust API + embedded production web runtime ------------------------------
+# Start from the unchanged API builder, add only the Node-built dist tree that
+# rust-embed consumes, and rebuild the API with the opt-in feature. Deriving the
+# runtime from rust-api keeps its packages and command identical to the plain image.
+FROM builder AS embed-builder
+
+COPY --from=web-builder /app/apps/web/dist ./apps/web/dist
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --offline -p sceneworks-rust-api --release --features embed-web \
+    && mkdir -p /out \
+    && cp target/release/sceneworks-rust-api /out/sceneworks-rust-api
+
+FROM rust-api AS rust-api-embed
+
+COPY --from=embed-builder /out/sceneworks-rust-api /usr/local/bin/sceneworks-rust-api
 
 # --- Rust worker runtime ------------------------------------------------------
 FROM debian:bookworm-slim AS rust-worker

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -216,6 +216,59 @@ async function assertContains(relativePath, expected) {
   }
 }
 
+async function assertEmbeddedApiDockerTarget() {
+  const dockerfilePath = "docker/rust.Dockerfile";
+  const body = await readFile(path.join(root, dockerfilePath), "utf8");
+  const stage = (name) => {
+    const match = new RegExp(`^FROM [^\\r\\n]+ AS ${name}\\r?$`, "m").exec(body);
+    if (!match) return undefined;
+    const start = match.index + match[0].length;
+    const next = body.indexOf("\nFROM ", start);
+    return body.slice(start, next === -1 ? undefined : next);
+  };
+
+  const plainBuilder = stage("builder");
+  const webBuilder = stage("web-builder");
+  const embedBuilder = stage("embed-builder");
+  const embedRuntime = stage("rust-api-embed");
+  if (!plainBuilder || !webBuilder || !embedBuilder || !embedRuntime) {
+    throw new Error(
+      `${dockerfilePath} must define builder, web-builder, embed-builder, and rust-api-embed stages`,
+    );
+  }
+  if (plainBuilder.includes("embed-web")) {
+    throw new Error(`${dockerfilePath} plain builder must remain free of the embed-web feature`);
+  }
+  for (const command of [
+    "npm ci --prefix apps/web",
+    'ENV VITE_API_BASE_URL=""',
+    "npm run build --prefix apps/web",
+    "! grep -R -q \"http://localhost:8000\" apps/web/dist",
+    "COPY apps/desktop/licenses ./apps/desktop/licenses",
+  ]) {
+    if (!webBuilder.includes(command)) {
+      throw new Error(
+        `${dockerfilePath} web-builder is missing required build contract: ${command}`,
+      );
+    }
+  }
+  if (!embedBuilder.includes("COPY --from=web-builder /app/apps/web/dist ./apps/web/dist")) {
+    throw new Error(
+      `${dockerfilePath} embed-builder must copy the production SPA into the Rust build tree`,
+    );
+  }
+  if (!embedBuilder.includes("--features embed-web")) {
+    throw new Error(
+      `${dockerfilePath} embed-builder must compile sceneworks-rust-api with embed-web`,
+    );
+  }
+  if (!/^FROM rust-api AS rust-api-embed$/m.test(body)) {
+    throw new Error(
+      `${dockerfilePath} rust-api-embed must inherit the unchanged rust-api runtime`,
+    );
+  }
+}
+
 function stripJsoncComments(body) {
   let result = "";
   let inString = false;
@@ -536,6 +589,7 @@ await assertContains(".env.example", "SCENEWORKS_INFERENCE_READ_TOKEN=");
 await assertContains("docker/rust.Dockerfile", "sceneworks-rust-api");
 await assertContains("docker/rust.Dockerfile", "type=secret,id=inference_token,required=true");
 await assertContains("docker/rust.Dockerfile", "cargo build --offline");
+await assertEmbeddedApiDockerTarget();
 await assertContains(".cargo/config.toml", "git-fetch-with-cli = true");
 for (const workflowPath of inferenceCargoWorkflows) {
   await assertContains(workflowPath, "SCENEWORKS_INFERENCE_READ_TOKEN");


### PR DESCRIPTION
## Summary
- add an opt-in Node build stage and `rust-api-embed` Docker target that embeds `apps/web/dist`
- build the SPA for `window.location.origin` and reject artifacts that bake the local Vite `localhost:8000` fallback
- cover root/static/deep-link/API routing, preserve the plain API target, and document the local build command

## Acceptance criteria
- [x] `/`, hashed static assets, and SPA deep-link fallback are served by the embedded API image
- [x] browser API resolution and `/api/v1/*` stay on the image's origin and process
- [x] plain `rust-api` remains non-embedded and builds without the Node stage
- [x] local `rust-api-embed` build command is documented

## Validation
- `npm run check`
- `npm ci --prefix apps/web && npm run build --prefix apps/web`
- `cargo fmt --all -- --check`
- `cargo clippy -p sceneworks-rust-api --all-targets --features embed-web -- -D warnings`
- `cargo test -p sceneworks-rust-api --features embed-web` (347 passed, 2 ignored real-ComfyUI smokes)
- Docker build: `rust-api-embed`
- Docker build: plain `rust-api` (stage graph omitted Node web builder)
- live embedded-container smoke: root 200, app asset 200, deep link 200, health API same process; served app bundle uses `window.location.origin` and excludes `http://localhost:8000`
- live plain-container smoke: root 404, health API available

Shortcut: [sc-10363](https://app.shortcut.com/trefry/story/10363)