### PR TITLE
Fix project-switch state hygiene (sc-13625)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -69,6 +69,11 @@ import {
   readStoredAccent,
   readStoredTheme,
 } from "./appHelpers.js";
+import {
+  hasVisibleLocalFailureForView,
+  isCurrentAssetRefresh,
+  reconcileSelectedAssetId,
+} from "./appStateHelpers.js";
 
 // Desktop (Tauri) shell detection (unified helper, epic 4484 story 6). The first-run
 // setup wizard is desktop-only; web/Docker (and a remote LAN browser) keep the
@@ -410,8 +415,16 @@ export function App() {
   const [trainingPresets, setTrainingPresets] = useState({ schemaVersion: 1, presets: [] });
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
   const [trainingPresetsError, setTrainingPresetsError] = useState("");
-  const [assets, setAssets] = useState([]);
-  const [selectedAssetId, setSelectedAssetId] = useState(null);
+  const [loadedAssets, setAssets] = useState([]);
+  const [loadedAssetsProjectId, setLoadedAssetsProjectId] = useState(null);
+  const [storedSelectedAssetId, setSelectedAssetId] = useState(null);
+  // Scope project data during render, not in a passive effect. On A → B (or A
+  // → no project), B's first render therefore cannot observe A's assets or raw
+  // selection while B's catalog request is still pending.
+  const assets =
+    loadedAssetsProjectId === activeProject?.id ? loadedAssets : [];
+  const selectedAssetId =
+    loadedAssetsProjectId === activeProject?.id ? storedSelectedAssetId : null;
   const [projectFilter, setProjectFilter] = useState("all");
   const [requestedGpu, setRequestedGpu] = useState("auto");
   const [jobPrompt, setJobPrompt] = useState("Placeholder generation");
@@ -1236,6 +1249,7 @@ export function App() {
   useEffect(() => {
     if (!activeProject || !ready) {
       setAssets([]);
+      setLoadedAssetsProjectId(null);
       setCharacters([]);
       setSavedVoices([]);
       setPersonTracks([]);
@@ -1273,18 +1287,11 @@ export function App() {
   // useCallback is both stable and always current — the `stableRefreshData` ref-delegation
   // pattern used elsewhere in this file, expressed inline here since the whole body is refs.
   const hasVisibleLocalFailure = useCallback((job) => {
-    const active = activeViewRef.current;
-    const localIds = localGenerationJobIdsRef.current;
-    if (active === "Image" && localIds.image.includes(job.id)) {
-      return true;
-    }
-    if (active === "Video" && localIds.video.includes(job.id)) {
-      return true;
-    }
-    if (active === "Document" && localIds.document.includes(job.id)) {
-      return true;
-    }
-    return active === "Models" && job.type === "model_download";
+    return hasVisibleLocalFailureForView(
+      activeViewRef.current,
+      localGenerationJobIdsRef.current,
+      job,
+    );
   }, []);
 
   // Live job/worker/queue SSE stream, extracted to a hook (sc-9750). The handlers reach
@@ -1397,12 +1404,12 @@ export function App() {
       // after the user switches away; committing then would clobber the new
       // project's assets with the old one's. Drop the stale response — mirrors
       // refreshTimelines' guard (useTimelines.js).
-      if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
+      if (!isCurrentAssetRefresh(activeProjectRef.current?.id ?? null, projectId)) {
         return;
       }
       setAssets(items);
-      const defaultAsset = items.find((asset) => !asset.status?.trashed && !asset.status?.rejected) ?? items[0] ?? null;
-      setSelectedAssetId((current) => current ?? defaultAsset?.id ?? null);
+      setLoadedAssetsProjectId(projectId);
+      setSelectedAssetId((current) => reconcileSelectedAssetId(items, current));
       setError("");
     } catch (err) {
       if (isAbortError(err)) return;

--- a/apps/web/src/App.projectAssetBoundary.test.jsx
+++ b/apps/web/src/App.projectAssetBoundary.test.jsx
@@ -1,0 +1,124 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStatic } from "./context/AppContext.js";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+
+const { projectAssetRenderHistory } = vi.hoisted(() => ({
+  projectAssetRenderHistory: [],
+}));
+
+vi.mock("./screens/VideoStudio.jsx", () => ({
+  VideoStudio() {
+    const { activeProject, assets, selectedAssetId } = useAppStatic();
+    projectAssetRenderHistory.push({
+      projectId: activeProject?.id ?? null,
+      assetIds: assets.map((asset) => asset.id),
+      selectedAssetId,
+    });
+    return (
+      <output data-testid="project-asset-probe">
+        {JSON.stringify({
+          assetIds: assets.map((asset) => asset.id),
+          selectedAssetId,
+        })}
+      </output>
+    );
+  },
+}));
+
+import { App } from "./main.jsx";
+
+describe("project asset render boundary", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    projectAssetRenderHistory.length = 0;
+
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(
+          response([
+            { id: "project-a", name: "Project A" },
+            { id: "project-b", name: "Project B" },
+          ]),
+        );
+      }
+      if (path.endsWith("/projects/project-a/assets")) {
+        return Promise.resolve(
+          response([{ id: "asset-a", type: "image", displayName: "Asset A", status: {} }]),
+        );
+      }
+      if (path.endsWith("/projects/project-b/assets")) {
+        // Keep B's catalog pending so this test observes its very first render.
+        return new Promise(() => {});
+      }
+      return Promise.resolve(response([]));
+    });
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("never exposes project A assets or raw selection to project B while B loads", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    await act(async () => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Video")
+        ?.click();
+    });
+    await settle();
+
+    const probe = () =>
+      JSON.parse(document.body.querySelector("[data-testid='project-asset-probe']").textContent);
+    expect(probe()).toEqual({ assetIds: ["asset-a"], selectedAssetId: "asset-a" });
+
+    await act(async () => {
+      document.body.querySelector(".project-pill")?.click();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll(".project-menu-item")]
+        .find((item) => item.textContent.includes("Project B"))
+        ?.click();
+    });
+
+    expect(probe()).toEqual({ assetIds: [], selectedAssetId: null });
+    const projectBRenders = projectAssetRenderHistory.filter(
+      (snapshot) => snapshot.projectId === "project-b",
+    );
+    expect(projectBRenders.length).toBeGreaterThan(0);
+    expect(projectBRenders).toEqual(
+      projectBRenders.map(() => ({
+        projectId: "project-b",
+        assetIds: [],
+        selectedAssetId: null,
+      })),
+    );
+  });
+});

--- a/apps/web/src/appStateHelpers.js
+++ b/apps/web/src/appStateHelpers.js
@@ -1,0 +1,28 @@
+export function hasVisibleLocalFailureForView(activeView, localJobIds, job) {
+  if (activeView === "Image" && localJobIds.image.includes(job.id)) {
+    return true;
+  }
+  if (activeView === "Video" && localJobIds.video.includes(job.id)) {
+    return true;
+  }
+  if (activeView === "Audio" && localJobIds.audio.includes(job.id)) {
+    return true;
+  }
+  if (activeView === "Document" && localJobIds.document.includes(job.id)) {
+    return true;
+  }
+  return activeView === "Models" && job.type === "model_download";
+}
+
+export function reconcileSelectedAssetId(items, currentId) {
+  if (currentId && items.some((asset) => asset.id === currentId)) {
+    return currentId;
+  }
+  const defaultAsset =
+    items.find((asset) => !asset.status?.trashed && !asset.status?.rejected) ?? items[0] ?? null;
+  return defaultAsset?.id ?? null;
+}
+
+export function isCurrentAssetRefresh(activeProjectId, requestedProjectId) {
+  return activeProjectId === requestedProjectId;
+}

--- a/apps/web/src/appStateHelpers.test.js
+++ b/apps/web/src/appStateHelpers.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasVisibleLocalFailureForView,
+  isCurrentAssetRefresh,
+  reconcileSelectedAssetId,
+} from "./appStateHelpers.js";
+
+describe("hasVisibleLocalFailureForView", () => {
+  const localJobIds = {
+    image: ["image-local"],
+    video: ["video-local"],
+    audio: ["audio-local"],
+    document: ["document-local"],
+  };
+
+  it("treats a locally launched Audio job as visible while Audio Studio is active", () => {
+    expect(
+      hasVisibleLocalFailureForView("Audio", localJobIds, {
+        id: "audio-local",
+        type: "audio_generate",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress the global notice for an Audio job outside Audio Studio", () => {
+    expect(
+      hasVisibleLocalFailureForView("Assets", localJobIds, {
+        id: "audio-local",
+        type: "audio_generate",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("reconcileSelectedAssetId", () => {
+  const items = [
+    { id: "available", status: {} },
+    { id: "trashed", status: { trashed: true } },
+  ];
+
+  it("retains a selection only while that id exists in the fetched project catalog", () => {
+    expect(reconcileSelectedAssetId(items, "available")).toBe("available");
+    expect(reconcileSelectedAssetId(items, "other-project")).toBe("available");
+  });
+
+  it("preserves the initial default selection and all-rejected fallback behavior", () => {
+    expect(reconcileSelectedAssetId(items, null)).toBe("available");
+    expect(
+      reconcileSelectedAssetId(
+        [{ id: "rejected", status: { rejected: true } }],
+        null,
+      ),
+    ).toBe("rejected");
+    expect(reconcileSelectedAssetId([], "gone")).toBeNull();
+  });
+});
+
+describe("isCurrentAssetRefresh", () => {
+  it("rejects a project response after the active project is cleared", () => {
+    expect(isCurrentAssetRefresh(null, "project-a")).toBe(false);
+  });
+
+  it("accepts only the exact currently active project", () => {
+    expect(isCurrentAssetRefresh("project-a", "project-a")).toBe(true);
+    expect(isCurrentAssetRefresh("project-b", "project-a")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- suppress duplicate global failure notices for Audio Studio local jobs
- scope asset catalogs and raw selection to the active project at render time
- reject stale asset refreshes across project changes, including a switch to no project
- reconcile stale selected asset IDs against each fetched catalog

## Validation
- full web suite: 160 files, 2303 tests
- ESLint quiet mode
- Vite production build
- git diff --check

Independent adversarial review: PASS (confidence 0.99).

Shortcut: sc-13625