### PR TITLE
Harden editor and library destructive actions (sc-13627)

### DIFF
--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -337,6 +337,75 @@ export function closeConfirmMessage({ dirty, aiOpPending }) {
   return null;
 }
 
+export async function consumeEditorLaunch({ launch, confirmDiscard, openAsset, clearLaunch }) {
+  if (!launch?.assetId || !(await confirmDiscard())) return false;
+  await openAsset(launch.assetId);
+  clearLaunch?.();
+  return true;
+}
+
+export function createEditorLaunchGuard() {
+  let activeId = null;
+  return {
+    async consume({ launch, isCurrent, confirmDiscard, openAsset, clearLaunch }) {
+      if (!launch?.assetId || activeId === launch.id) return false;
+      const launchId = launch.id;
+      activeId = launchId;
+      try {
+        if (!(await confirmDiscard()) || activeId !== launchId || !isCurrent(launchId)) return false;
+        await openAsset(launch.assetId);
+        if (activeId !== launchId || !isCurrent(launchId)) return false;
+        clearLaunch?.();
+        return true;
+      } finally {
+        if (activeId === launchId) activeId = null;
+      }
+    },
+  };
+}
+
+export function InlineLayerName({ layer, onRename }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(layer.name);
+
+  if (!editing) {
+    return (
+      <button
+        className="ie-layer-name"
+        onClick={(event) => {
+          event.stopPropagation();
+          setDraft(layer.name);
+          setEditing(true);
+        }}
+        title="Rename layer"
+        type="button"
+      >
+        {layer.name}
+      </button>
+    );
+  }
+
+  return (
+    <input
+      aria-label={`Rename ${layer.name}`}
+      autoFocus
+      className="ie-input ie-layer-name-input"
+      onBlur={() => {
+        const name = draft.trim();
+        if (name) onRename(layer.id, name);
+        setEditing(false);
+      }}
+      onChange={(event) => setDraft(event.target.value)}
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") event.currentTarget.blur();
+        if (event.key === "Escape") setEditing(false);
+      }}
+      value={draft}
+    />
+  );
+}
+
 // Which save-state indicator the top bar shows (sc-11968): the unsaved-edits pill while
 // `dirty`, the "Saved ✓" hint once a Save has landed and nothing has changed since, else
 // nothing. Pure so the badge logic is unit-testable without a mounted canvas.
@@ -808,6 +877,18 @@ export function ImageEditor() {
   const [status, setStatus] = useState({ loading: false, error: "" });
   const [pickerOpen, setPickerOpen] = useState(false);
   const [view, setView] = useState({ scale: 1, x: 0, y: 0 });
+  const launchAttemptRef = useRef(null);
+  const launchGuardRef = useRef(null);
+  if (!launchGuardRef.current) launchGuardRef.current = createEditorLaunchGuard();
+  const editorLaunchRef = useRef(editorLaunch);
+  editorLaunchRef.current = editorLaunch;
+  const editorMountedRef = useRef(true);
+  useEffect(() => {
+    editorMountedRef.current = true;
+    return () => {
+      editorMountedRef.current = false;
+    };
+  }, []);
 
   // Redesign shell UI state (epic 10243). `layout` picks one of four panel
   // arrangements (accordion default) and persists to localStorage; `accCollapsed`
@@ -1574,18 +1655,25 @@ export function ImageEditor() {
   // sc-8730: consume the App-level Image Editor launch channel. When something outside
   // the editor (currently the FullscreenPreview "Edit" button via sendAssetToImageEditor)
   // routes an asset here, App switches activeView to "ImageEditor" and stashes
-  // { id, assetId } in editorLaunch. Keyed on the launch id so it fires once per launch
-  // (relaunching the same asset gets a fresh id) and never on unrelated re-renders.
-  // Entering via the nav with no launch leaves editorLaunch null → no auto-open. We clear
-  // the launch after consuming it so navigating away and back doesn't re-open a stale asset.
+  // { id, assetId } in editorLaunch. A dirty editor confirms before replacement. Cancelling
+  // leaves the launch pending; changing the dirty state re-arms it, while the attempt/in-flight
+  // refs prevent ordinary re-renders or the accepted open's own state updates from duplicating
+  // the prompt/load. Entering via the nav with no launch leaves editorLaunch null. We clear
+  // only after the accepted open has finished handling the asset.
   useEffect(() => {
-    if (!editorLaunch?.assetId) {
-      return;
-    }
-    openAsset(editorLaunch.assetId);
-    clearEditorLaunch?.();
+    if (!editorLaunch?.assetId) return;
+    const attemptKey = `${editorLaunch.id}:${dirty}`;
+    if (launchAttemptRef.current === attemptKey) return;
+    launchAttemptRef.current = attemptKey;
+    launchGuardRef.current.consume({
+      launch: editorLaunch,
+      isCurrent: (id) => editorMountedRef.current && editorLaunchRef.current?.id === id,
+      confirmDiscard: confirmDiscardEdits,
+      openAsset,
+      clearLaunch: clearEditorLaunch,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorLaunch?.id]);
+  }, [editorLaunch?.id, dirty]);
 
   const openFile = useCallback(
     (file) => {
@@ -3783,16 +3871,7 @@ export function ImageEditor() {
                     ) : (
                       <span className="ie-layer-thumb" />
                     )}
-                    <span
-                      className="ie-layer-name"
-                      onDoubleClick={() => {
-                        const name = window.prompt("Rename layer", layer.name)?.trim();
-                        if (name) renameLayer(layer.id, name);
-                      }}
-                      title="Double-click to rename"
-                    >
-                      {layer.name}
-                    </span>
+                    <InlineLayerName layer={layer} onRename={renameLayer} />
                     {layer.blendMode && layer.blendMode !== "source-over" ? (
                       <span className="ie-layer-blend">
                         {(BLEND_MODES.find((mode) => mode.value === layer.blendMode)?.label ?? layer.blendMode).slice(0, 4)}

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -85,6 +85,9 @@ import {
   leaveGuardArming,
   closeConfirmMessage,
   saveStatusIndicator,
+  consumeEditorLaunch,
+  createEditorLaunchGuard,
+  InlineLayerName,
 } from "./ImageEditor.jsx";
 import { verifyCaption, serializeCaption, ELEMENT_KEY_ORDER_OBJ } from "../ideogramCaption.js";
 
@@ -297,8 +300,9 @@ describe("ImageEditor scaffold", () => {
       expect(fetchSpy.mock.calls[0][0]).toContain(
         "/api/v1/projects/project_1/files/assets/images/launched.png",
       );
-      // The launch is consumed exactly once so returning to the editor won't re-open it.
-      expect(clearEditorLaunch).toHaveBeenCalledTimes(1);
+      // Clearing is deliberately deferred until image decoding/open handling completes.
+      // The ordering and cancellation behavior is pinned by the helper test below.
+      expect(clearEditorLaunch).not.toHaveBeenCalled();
     });
 
     it("ignores a launch whose asset isn't a renderable image in the project", async () => {
@@ -315,6 +319,113 @@ describe("ImageEditor scaffold", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(clearEditorLaunch).toHaveBeenCalledTimes(1);
     });
+
+    it("keeps a launch pending when discard is cancelled and only clears after opening", async () => {
+      const openAsset = vi.fn(async () => {});
+      const clearLaunch = vi.fn();
+      const launch = { id: "launch-dirty", assetId: IMAGE_ASSET.id };
+
+      expect(
+        await consumeEditorLaunch({
+          launch,
+          confirmDiscard: vi.fn(async () => false),
+          openAsset,
+          clearLaunch,
+        }),
+      ).toBe(false);
+      expect(openAsset).not.toHaveBeenCalled();
+      expect(clearLaunch).not.toHaveBeenCalled();
+
+      expect(
+        await consumeEditorLaunch({
+          launch,
+          confirmDiscard: vi.fn(async () => true),
+          openAsset,
+          clearLaunch,
+        }),
+      ).toBe(true);
+      expect(openAsset).toHaveBeenCalledWith(IMAGE_ASSET.id);
+      expect(clearLaunch).toHaveBeenCalledTimes(1);
+      expect(openAsset.mock.invocationCallOrder[0]).toBeLessThan(clearLaunch.mock.invocationCallOrder[0]);
+    });
+
+    it("serializes dirty transitions and ignores a stale launch replaced during confirmation", async () => {
+      let resolveFirst;
+      const firstConfirm = new Promise((resolve) => {
+        resolveFirst = resolve;
+      });
+      const guard = createEditorLaunchGuard();
+      let currentId = "launch-old";
+      const confirmDiscard = vi.fn(() => firstConfirm);
+      const openAsset = vi.fn(async () => {});
+      const clearLaunch = vi.fn();
+      const oldLaunch = { id: "launch-old", assetId: "asset-old" };
+
+      const oldAttempt = guard.consume({
+        launch: oldLaunch,
+        isCurrent: (id) => currentId === id,
+        confirmDiscard,
+        openAsset,
+        clearLaunch,
+      });
+      // A dirty-state rerender for the same launch must not raise a second prompt.
+      await guard.consume({
+        launch: oldLaunch,
+        isCurrent: (id) => currentId === id,
+        confirmDiscard,
+        openAsset,
+        clearLaunch,
+      });
+      expect(confirmDiscard).toHaveBeenCalledTimes(1);
+
+      currentId = "launch-new";
+      const newAttempt = guard.consume({
+        launch: { id: "launch-new", assetId: "asset-new" },
+        isCurrent: (id) => currentId === id,
+        confirmDiscard: vi.fn(async () => true),
+        openAsset,
+        clearLaunch,
+      });
+      await newAttempt;
+      resolveFirst(true);
+      await oldAttempt;
+
+      expect(openAsset).toHaveBeenCalledTimes(1);
+      expect(openAsset).toHaveBeenCalledWith("asset-new");
+      expect(clearLaunch).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("inline layer rename", () => {
+  it("uses a keyboard-accessible inline field, commits Enter, and cancels Escape", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onRename = vi.fn();
+    const layer = { id: "layer-1", name: "Background" };
+
+    await act(async () => root.render(<InlineLayerName layer={layer} onRename={onRename} />));
+    const button = container.querySelector('button[title="Rename layer"]');
+    await act(async () => button.click());
+    let input = container.querySelector('input[aria-label="Rename Background"]');
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+      setter.call(input, "  Plate  ");
+      input.dispatchEvent(new window.Event("input", { bubbles: true }));
+      input.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    expect(onRename).toHaveBeenCalledWith("layer-1", "Plate");
+
+    await act(async () => container.querySelector('button[title="Rename layer"]').click());
+    input = container.querySelector('input[aria-label="Rename Background"]');
+    await act(async () =>
+      input.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Escape", bubbles: true })),
+    );
+    expect(onRename).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+    container.remove();
   });
 });
 

--- a/apps/web/src/screens/KeyPointLibraryScreen.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.jsx
@@ -41,7 +41,7 @@ function presetSourceUrl(preset) {
 
 // --- Library tab ------------------------------------------------------------
 
-function PresetCard({ preset, onDelete }) {
+function PresetCard({ preset, onDelete, deleting }) {
   return (
     <div className="keypoint-card">
       <div className="keypoint-card-figure">
@@ -60,15 +60,15 @@ function PresetCard({ preset, onDelete }) {
         </span>
       </div>
       {!preset.builtin && onDelete ? (
-        <button className="link-button danger" onClick={() => onDelete(preset)} type="button">
-          Delete
+        <button className="link-button danger" disabled={deleting} onClick={() => onDelete(preset)} type="button">
+          {deleting ? "Deleting…" : "Delete"}
         </button>
       ) : null}
     </div>
   );
 }
 
-function KeypointLibraryPanel({ hidden, presets, loading, error, onDelete }) {
+function KeypointLibraryPanel({ hidden, presets, loading, error, onDelete, deletingPresetId }) {
   const builtins = presets.filter((preset) => preset.builtin);
   const custom = presets.filter((preset) => !preset.builtin);
   return (
@@ -95,7 +95,12 @@ function KeypointLibraryPanel({ hidden, presets, loading, error, onDelete }) {
             {custom.length ? (
               <div className="keypoint-grid">
                 {custom.map((preset) => (
-                  <PresetCard key={preset.id} preset={preset} onDelete={onDelete} />
+                  <PresetCard
+                    deleting={Boolean(deletingPresetId)}
+                    key={preset.id}
+                    preset={preset}
+                    onDelete={onDelete}
+                  />
                 ))}
               </div>
             ) : (
@@ -372,6 +377,7 @@ function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoa
   const [editingId, setEditingId] = useState(null);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
+  const deletePendingRef = useRef(false);
 
   const presetById = useMemo(() => Object.fromEntries(presets.map((preset) => [preset.id, preset])), [presets]);
 
@@ -453,6 +459,33 @@ function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoa
     });
   }, [name, orderedIds, editingId, token, wrap, resetBuilder]);
 
+  const deleteCollection = useCallback(
+    async (collection) => {
+      if (deletePendingRef.current) return;
+      deletePendingRef.current = true;
+      setBusy(true);
+      setError("");
+      try {
+        const ok = await appConfirm({
+          title: "Delete keypoint collection?",
+          message: `Delete “${collection.name}”? This cannot be undone.`,
+          confirmLabel: "Delete",
+          cancelLabel: "Keep collection",
+          tone: "danger",
+        });
+        if (!ok) return;
+        await deleteKeypointCollection(token, collection.id);
+        onChanged?.();
+      } catch (err) {
+        setError(String(err?.message ?? err));
+      } finally {
+        deletePendingRef.current = false;
+        setBusy(false);
+      }
+    },
+    [token, onChanged],
+  );
+
   return (
     <div aria-labelledby="keypoint-tab-collections" hidden={hidden} id="keypoint-panel-collections" role="tabpanel">
       <div className="keypoint-collections">
@@ -493,7 +526,7 @@ function KeypointCollectionsPanel({ hidden, presets, collections, collectionsLoa
                         <button
                           className="link-button danger"
                           disabled={busy}
-                          onClick={() => wrap(() => deleteKeypointCollection(token, collection.id))}
+                          onClick={() => deleteCollection(collection)}
                           type="button"
                         >
                           Delete
@@ -626,6 +659,9 @@ async function postExtractJob(token, requestedGpu, sourcePath) {
 
 export function KeyPointLibraryScreen() {
   const [activeTab, setActiveTab] = useState("library");
+  const [deleteError, setDeleteError] = useState("");
+  const [deletingPresetId, setDeletingPresetId] = useState(null);
+  const deletePendingRef = useRef(false);
   const { token } = useAppStatic();
   const { presets, loading: presetsLoading, error: presetsError, reload: reloadPresets } = useKeypointPresets();
   const {
@@ -636,9 +672,28 @@ export function KeyPointLibraryScreen() {
 
   const deletePreset = useCallback(
     async (preset) => {
-      await deleteKeypointPreset(token, preset.id);
-      await reloadPresets();
-      await reloadCollections();
+      if (deletePendingRef.current) return;
+      deletePendingRef.current = true;
+      setDeletingPresetId(preset.id);
+      setDeleteError("");
+      try {
+        const ok = await appConfirm({
+          title: "Delete keypoint preset?",
+          message: `Delete “${preset.name}”? Collections that use it may also be affected.`,
+          confirmLabel: "Delete",
+          cancelLabel: "Keep preset",
+          tone: "danger",
+        });
+        if (!ok) return;
+        await deleteKeypointPreset(token, preset.id);
+        await reloadPresets();
+        await reloadCollections();
+      } catch (err) {
+        setDeleteError(String(err?.message ?? err));
+      } finally {
+        deletePendingRef.current = false;
+        setDeletingPresetId(null);
+      }
     },
     [token, reloadPresets, reloadCollections],
   );
@@ -668,8 +723,9 @@ export function KeyPointLibraryScreen() {
         hidden={activeTab !== "library"}
         presets={presets}
         loading={presetsLoading}
-        error={presetsError}
+        error={deleteError || presetsError}
         onDelete={deletePreset}
+        deletingPresetId={deletingPresetId}
       />
       <KeypointCapturePanel
         hidden={activeTab !== "capture"}

--- a/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
+++ b/apps/web/src/screens/KeyPointLibraryScreen.test.jsx
@@ -6,6 +6,7 @@ import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
 const apiCalls = [];
 let presets = [];
 let collections = [];
+let mutationFailure = null;
 
 // Desktop-safe confirm (sc-11971): mocked so the explicit discard / cancel guards are
 // deterministic and observable. Defaults to "confirm"; tests flip it to "cancel".
@@ -19,6 +20,7 @@ vi.mock("../api.js", async (importOriginal) => {
     apiFetch: vi.fn(async (path, _token, options = {}) => {
       const method = options.method ?? "GET";
       apiCalls.push({ path, method, body: options.body });
+      if (mutationFailure && method !== "GET") throw mutationFailure;
       if (method === "GET" && path === "/api/v1/keypoints/presets") return presets;
       if (method === "GET" && path === "/api/v1/keypoints/collections") return collections;
       if (method === "POST" && path === "/api/v1/keypoints/sources") {
@@ -65,6 +67,13 @@ async function setInputValue(input, value) {
 }
 const byText = (text, selector = "button") =>
   [...document.querySelectorAll(selector)].find((el) => el.textContent.includes(text));
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 function makeContext(overrides = {}) {
   return { token: "test-token", requestedGpu: "auto", jobs: [], ...overrides };
@@ -79,6 +88,7 @@ describe("KeyPointLibraryScreen", () => {
     apiCalls.length = 0;
     presets = [];
     collections = [];
+    mutationFailure = null;
     appConfirmMock.mockClear();
     appConfirmMock.mockResolvedValue(true);
     window.URL.createObjectURL = () => "blob:test";
@@ -142,18 +152,56 @@ describe("KeyPointLibraryScreen", () => {
     expect(image).toBeTruthy();
   });
 
-  it("protects built-ins (no delete) and deletes a user preset against the reserved project", async () => {
+  it("protects built-ins and danger-confirms a user preset delete", async () => {
     presets = [builtinPreset(), customPreset()];
     await render();
     const deletes = [...document.body.querySelectorAll("button")].filter((b) => b.textContent.trim() === "Delete");
     // Only the one custom preset is deletable; the built-in has no delete control.
     expect(deletes).toHaveLength(1);
     await click(deletes[0]);
+    expect(appConfirmMock).toHaveBeenCalledWith(expect.objectContaining({ tone: "danger" }));
     expect(
       apiCalls.some(
         (c) => c.method === "DELETE" && c.path === "/api/v1/projects/project_global_keypoints/assets/asset_k1",
       ),
     ).toBe(true);
+  });
+
+  it("keeps a preset when delete is cancelled and surfaces delete failures", async () => {
+    presets = [customPreset()];
+    await render();
+    appConfirmMock.mockResolvedValueOnce(false);
+    await click(exactBtn("Delete"));
+    expect(apiCalls.some((call) => call.method === "DELETE")).toBe(false);
+
+    appConfirmMock.mockResolvedValueOnce(true);
+    mutationFailure = new Error("preset delete failed");
+    await click(exactBtn("Delete"));
+    expect(document.body.querySelector("#keypoint-panel-library .inline-warning").textContent).toContain(
+      "preset delete failed",
+    );
+  });
+
+  it("serializes preset delete confirmation and mutation across rapid clicks", async () => {
+    presets = [customPreset(), customPreset({ id: "asset_k2", name: "Other" })];
+    await render();
+    const confirmation = deferred();
+    appConfirmMock.mockReturnValueOnce(confirmation.promise);
+    const deletes = [...document.body.querySelectorAll("button")].filter((button) =>
+      button.textContent.includes("Delete"),
+    );
+
+    await act(async () => {
+      deletes[0].click();
+      deletes[0].click();
+      deletes[1].click();
+    });
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect([...document.body.querySelectorAll(".keypoint-card button")].every((button) => button.disabled)).toBe(true);
+    await act(async () => confirmation.resolve(true));
+    await act(async () => {});
+
+    expect(apiCalls.filter((call) => call.method === "DELETE")).toHaveLength(1);
   });
 
   it("captures a preset: upload → extract → preview → save", async () => {
@@ -296,6 +344,54 @@ describe("KeyPointLibraryScreen", () => {
     expect(
       apiCalls.some((c) => c.method === "PUT" && c.path === "/api/v1/keypoints/collections/col_user/default"),
     ).toBe(true);
+  });
+
+  it("danger-confirms collection deletion, honors cancel, and surfaces failures", async () => {
+    presets = [builtinPreset()];
+    collections = [
+      { id: "col_user", name: "My Set", orderedPresetIds: ["builtin_front"], isDefault: false },
+    ];
+    await render();
+    await click(document.body.querySelector("#keypoint-tab-collections"));
+
+    appConfirmMock.mockResolvedValueOnce(false);
+    await click(exactBtn("Delete"));
+    expect(apiCalls.some((call) => call.method === "DELETE")).toBe(false);
+
+    appConfirmMock.mockResolvedValueOnce(true);
+    mutationFailure = new Error("collection delete failed");
+    await click(exactBtn("Delete"));
+    expect(appConfirmMock).toHaveBeenLastCalledWith(expect.objectContaining({ tone: "danger" }));
+    expect(document.body.querySelector("#keypoint-panel-collections .inline-warning").textContent).toContain(
+      "collection delete failed",
+    );
+  });
+
+  it("serializes collection delete confirmation across rapid clicks", async () => {
+    presets = [builtinPreset()];
+    collections = [
+      { id: "col_one", name: "One", orderedPresetIds: ["builtin_front"], isDefault: false },
+      { id: "col_two", name: "Two", orderedPresetIds: ["builtin_front"], isDefault: false },
+    ];
+    await render();
+    await click(document.body.querySelector("#keypoint-tab-collections"));
+    const confirmation = deferred();
+    appConfirmMock.mockReturnValueOnce(confirmation.promise);
+    const deletes = [...document.body.querySelectorAll("#keypoint-panel-collections button")].filter(
+      (button) => button.textContent.trim() === "Delete",
+    );
+
+    await act(async () => {
+      deletes[0].click();
+      deletes[0].click();
+      deletes[1].click();
+    });
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(deletes.every((button) => button.disabled)).toBe(true);
+    await act(async () => confirmation.resolve(true));
+    await act(async () => {});
+
+    expect(apiCalls.filter((call) => call.method === "DELETE")).toHaveLength(1);
   });
 
   it("flags a completed capture as unsaved and prompts NO confirm to reach review (sc-11971)", async () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -9301,7 +9301,23 @@ details[open] > summary.lora-scope-group-heading::before,
 .ie-layer-vis:hover { background: var(--ie-surface2); color: var(--ie-text); }
 .ie-layer-vis .ie-vis-off { opacity: 0.38; }
 .ie-layer-thumb { width: 36px; height: 30px; border-radius: var(--r-xs); border: 1px solid var(--ie-border); flex: 0 0 auto; object-fit: cover; }
-.ie-layer-name { flex: 1; font-size: 12.5px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ie-layer-name {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: text;
+}
+.ie-layer-name-input { flex: 1; min-width: 0; height: 26px; padding: 3px 6px; }
 .ie-layer-blend { font: 500 10.5px var(--ie-mono); color: var(--ie-faint); text-transform: uppercase; }
 .ie-layer-op { margin-top: 9px; display: flex; align-items: center; gap: 10px; }
 .ie-layer-op .ie-range { flex: 1; }


### PR DESCRIPTION
## Summary
- confirm unsaved-editor discard before external asset launches and guard replacement races
- replace desktop-inert layer rename prompt with an accessible inline editor
- add danger confirmations, error surfacing, and concurrency guards to keypoint preset and collection deletes

## Validation
- full web suite: 2303 tests
- focused review suite: 115 tests
- changed-file ESLint
- Vite production build
- git diff --check

Independent adversarial review: PASS (confidence 0.98).

Shortcut: sc-13627