### PR TITLE
Restore GPU job-type parity with backend (sc-13631)

### DIFF
--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -19,7 +19,12 @@ export const GPU_REQUIRED_JOB_TYPES = new Set([
   "video_upscale",
   "person_replace",
   "lora_train",
+  "control_training",
   "training_caption",
+  "dataset_analysis",
+  "dataset_upscale",
+  "dataset_face_analysis",
+  "face_likeness_compare",
 ]);
 
 // Utility job types that run on any worker (no GPU required).
@@ -28,7 +33,7 @@ export const NON_GPU_JOB_TYPES = new Set([
   "model_import",
   "model_convert",
   "lora_import",
-  "prompt_refine",
+  "lora_download",
 ]);
 
 // Terminal job statuses (no further progress expected).

--- a/apps/web/src/jobTypesParity.test.js
+++ b/apps/web/src/jobTypesParity.test.js
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { GPU_REQUIRED_JOB_TYPES, NON_GPU_JOB_TYPES } from "./jobTypes.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CORE_SRC = resolve(HERE, "../../../crates/sceneworks-core/src");
+const contracts = readFileSync(resolve(CORE_SRC, "contracts.rs"), "utf8");
+const jobsStore = readFileSync(resolve(CORE_SRC, "jobs_store.rs"), "utf8");
+
+function jobTypeNamesByVariant() {
+  const block = contracts.match(/pub enum JobType \{([\s\S]*?)\n\s{4}\}\n\}/)?.[1];
+  expect(block, "contracts.rs must contain the JobType string enum").toBeTruthy();
+  return new Map(
+    [...block.matchAll(/^\s*(\w+)\s*=>\s*"([^"]+)",/gm)].map(([, variant, name]) => [
+      variant,
+      name,
+    ]),
+  );
+}
+
+function backendGpuJobTypes() {
+  const body = jobsStore.match(
+    /fn job_requires_gpu\(job_type: &JobType\) -> bool \{([\s\S]*?)\n\}/,
+  )?.[1];
+  expect(body, "jobs_store.rs must contain job_requires_gpu").toBeTruthy();
+  const names = jobTypeNamesByVariant();
+  return new Set(
+    [...body.matchAll(/JobType::(\w+)/g)].map(([, variant]) => {
+      expect(names.has(variant), `JobType::${variant} must exist in contracts.rs`).toBe(true);
+      return names.get(variant);
+    }),
+  );
+}
+
+function backendNonGpuUtilityJobTypes() {
+  const block = jobsStore.match(
+    /pub const NON_GPU_JOB_TYPES: &\[&str\] = &\[([\s\S]*?)\n\];/,
+  )?.[1];
+  expect(block, "jobs_store.rs must contain NON_GPU_JOB_TYPES").toBeTruthy();
+  return new Set([...block.matchAll(/"([^"]+)"/g)].map(([, name]) => name));
+}
+
+describe("web ↔ backend job placement parity (sc-13631)", () => {
+  it("mirrors the backend GPU-required predicate", () => {
+    expect([...GPU_REQUIRED_JOB_TYPES].sort()).toEqual([...backendGpuJobTypes()].sort());
+  });
+
+  it("mirrors backend utility jobs that ignore GPU placement", () => {
+    expect([...NON_GPU_JOB_TYPES].sort()).toEqual(
+      [...backendNonGpuUtilityJobTypes()].sort(),
+    );
+  });
+
+  it("leaves capability-routed audio outside both placement overrides", () => {
+    expect(GPU_REQUIRED_JOB_TYPES.has("audio_generate")).toBe(false);
+    expect(NON_GPU_JOB_TYPES.has("audio_generate")).toBe(false);
+  });
+});

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -96,7 +96,12 @@ function jobWaitingMessage(job, workers, jobs) {
   if (job.requestedGpu && job.requestedGpu !== "auto") {
     return `Waiting for GPU ${job.requestedGpu} to claim the job.`;
   }
-  return NON_GPU_JOB_TYPES.has(job.type) ? "Waiting for a utility worker." : "Waiting for an available GPU worker.";
+  if (NON_GPU_JOB_TYPES.has(job.type)) {
+    return "Waiting for a utility worker.";
+  }
+  return GPU_REQUIRED_JOB_TYPES.has(job.type)
+    ? "Waiting for an available GPU worker."
+    : "Waiting for an available worker with the required capability.";
 }
 
 function workerStatusLine(worker) {


### PR DESCRIPTION
## Summary
- mirror every backend GPU-required job type in the web queue
- align utility types with the backend and keep capability-routed audio outside both override sets
- show a generic capability wait message for capability-routed jobs
- parse authoritative Rust definitions in a parity test so future drift fails CI

## Validation
- full web suite: 2299 tests
- focused parity and queue tests: 13 tests
- ESLint: zero errors
- Vite production build
- git diff --check

Independent adversarial review: PASS (confidence 0.96).

Shortcut: sc-13631