### PR TITLE
Guard project-scoped hook responses (sc-13626)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -71,7 +71,7 @@ import {
 } from "./appHelpers.js";
 import {
   hasVisibleLocalFailureForView,
-  isCurrentAssetRefresh,
+  isCurrentProjectRequest,
   reconcileSelectedAssetId,
 } from "./appStateHelpers.js";
 
@@ -747,7 +747,7 @@ export function App() {
     updatePreset,
     duplicatePreset,
     deletePreset,
-  } = usePresets({ token, activeProject, setError });
+  } = usePresets({ token, activeProject, activeProjectRef, setError });
 
   const {
     savedVoices,
@@ -765,7 +765,7 @@ export function App() {
     updatePromptBatch,
     duplicatePromptBatch,
     deletePromptBatch,
-  } = usePromptBatches({ token, activeProject, setError });
+  } = usePromptBatches({ token, activeProject, activeProjectRef, setError });
 
   const {
     trainingDatasets,
@@ -791,7 +791,7 @@ export function App() {
     smartCropTrainingDataset,
     stripExifTrainingDataset,
     createTrainingJob,
-  } = useTraining({ token, activeProject, setError, setJobs });
+  } = useTraining({ token, activeProject, activeProjectRef, setError, setJobs });
 
   // sc-8811: useModelsAndLoras lists these two cross-cutting refresh orchestrators as
   // useCallback deps of deleteModel/deleteLora, which sit in appContextValue's
@@ -1404,7 +1404,7 @@ export function App() {
       // after the user switches away; committing then would clobber the new
       // project's assets with the old one's. Drop the stale response — mirrors
       // refreshTimelines' guard (useTimelines.js).
-      if (!isCurrentAssetRefresh(activeProjectRef.current?.id ?? null, projectId)) {
+      if (!isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId)) {
         return;
       }
       setAssets(items);

--- a/apps/web/src/appStateHelpers.js
+++ b/apps/web/src/appStateHelpers.js
@@ -23,6 +23,6 @@ export function reconcileSelectedAssetId(items, currentId) {
   return defaultAsset?.id ?? null;
 }
 
-export function isCurrentAssetRefresh(activeProjectId, requestedProjectId) {
+export function isCurrentProjectRequest(activeProjectId, requestedProjectId) {
   return activeProjectId === requestedProjectId;
 }

--- a/apps/web/src/appStateHelpers.test.js
+++ b/apps/web/src/appStateHelpers.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   hasVisibleLocalFailureForView,
-  isCurrentAssetRefresh,
+  isCurrentProjectRequest,
   reconcileSelectedAssetId,
 } from "./appStateHelpers.js";
 
@@ -56,13 +56,13 @@ describe("reconcileSelectedAssetId", () => {
   });
 });
 
-describe("isCurrentAssetRefresh", () => {
+describe("isCurrentProjectRequest", () => {
   it("rejects a project response after the active project is cleared", () => {
-    expect(isCurrentAssetRefresh(null, "project-a")).toBe(false);
+    expect(isCurrentProjectRequest(null, "project-a")).toBe(false);
   });
 
   it("accepts only the exact currently active project", () => {
-    expect(isCurrentAssetRefresh("project-a", "project-a")).toBe(true);
-    expect(isCurrentAssetRefresh("project-b", "project-a")).toBe(false);
+    expect(isCurrentProjectRequest("project-a", "project-a")).toBe(true);
+    expect(isCurrentProjectRequest("project-b", "project-a")).toBe(false);
   });
 });

--- a/apps/web/src/hooks/staleProjectGuards.test.jsx
+++ b/apps/web/src/hooks/staleProjectGuards.test.jsx
@@ -1,0 +1,316 @@
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePresets } from "./usePresets.js";
+import { usePromptBatches } from "./usePromptBatches.js";
+import { useTraining } from "./useTraining.js";
+
+const pendingRequests = [];
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn(
+      (url, _token, options) =>
+        new Promise((resolve, reject) => {
+          pendingRequests.push({ url, options, resolve, reject });
+        }),
+    ),
+  };
+});
+
+function mountHook(hook, activeProjectRef, extraProps = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  let latest;
+
+  function Harness() {
+    latest = hook({
+      token: "token",
+      activeProject: activeProjectRef.current,
+      activeProjectRef,
+      setError: extraProps.setError ?? vi.fn(),
+      setJobs: vi.fn(),
+    });
+    return null;
+  }
+
+  act(() => root.render(<Harness />));
+  return {
+    get: () => latest,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+const CATALOG_CASES = [
+  {
+    name: "presets",
+    hook: usePresets,
+    refresh: "refreshPresets",
+    state: "presets",
+    create: "createPreset",
+    path: "/api/v1/recipe-presets",
+  },
+  {
+    name: "prompt batches",
+    hook: usePromptBatches,
+    refresh: "refreshPromptBatches",
+    state: "promptBatches",
+    create: "createPromptBatch",
+    path: "/api/v1/prompt-batches",
+  },
+];
+
+describe.each(CATALOG_CASES)(
+  "$name stale-project guards (sc-13626)",
+  ({ hook, refresh, state, create, path }) => {
+    let mounted;
+
+    afterEach(() => mounted?.unmount());
+
+    it("drops project A success and error commits after switching to B", async () => {
+      const activeProjectRef = { current: { id: "A" } };
+      const setError = vi.fn();
+      mounted = mountHook(hook, activeProjectRef, { setError });
+
+      let success;
+      act(() => {
+        success = mounted.get()[refresh]("A");
+      });
+      activeProjectRef.current = { id: "B" };
+      await act(async () => {
+        pendingRequests[0].resolve([{ id: "from-A" }]);
+        await success;
+      });
+
+      expect(mounted.get()[state]).toEqual([]);
+      expect(setError).not.toHaveBeenCalled();
+
+      activeProjectRef.current = { id: "A" };
+      let failure;
+      act(() => {
+        failure = mounted.get()[refresh]("A");
+      });
+      activeProjectRef.current = { id: "B" };
+      await act(async () => {
+        pendingRequests[1].reject(new Error("stale A failure"));
+        await failure;
+      });
+
+      expect(mounted.get()[state]).toEqual([]);
+      expect(setError).not.toHaveBeenCalled();
+    });
+
+    it("does not launch a project A post-mutation refetch after switching to B", async () => {
+      const activeProjectRef = { current: { id: "A" } };
+      mounted = mountHook(hook, activeProjectRef);
+
+      let mutation;
+      act(() => {
+        mutation = mounted.get()[create]({ scope: "project", name: "A item" });
+      });
+      expect(pendingRequests[0].url).toBe(`${path}?scope=project&projectId=A`);
+
+      activeProjectRef.current = { id: "B" };
+      await act(async () => {
+        pendingRequests[0].resolve({ id: "created-in-A" });
+        await mutation;
+      });
+
+      expect(pendingRequests).toHaveLength(1);
+    });
+
+    it("preserves global catalog refreshes across project changes", async () => {
+      const activeProjectRef = { current: { id: "A" } };
+      mounted = mountHook(hook, activeProjectRef);
+
+      let refreshGlobal;
+      act(() => {
+        refreshGlobal = mounted.get()[refresh](null);
+      });
+      expect(pendingRequests[0].url).toBe(path);
+
+      activeProjectRef.current = { id: "B" };
+      await act(async () => {
+        pendingRequests[0].resolve([{ id: "global" }]);
+        await refreshGlobal;
+      });
+
+      expect(mounted.get()[state]).toEqual([{ id: "global" }]);
+    });
+
+    it("refreshes the active project view after a global mutation", async () => {
+      const activeProjectRef = { current: { id: "A" } };
+      mounted = mountHook(hook, activeProjectRef);
+
+      let mutation;
+      act(() => {
+        mutation = mounted.get()[create]({ scope: "global", name: "global item" });
+      });
+      pendingRequests[0].resolve({ id: "global-created" });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(pendingRequests[1].url).toBe(`${path}?projectId=A`);
+      await act(async () => {
+        pendingRequests[1].resolve([{ id: "global-created" }]);
+        await mutation;
+      });
+      expect(mounted.get()[state]).toEqual([{ id: "global-created" }]);
+    });
+  },
+);
+
+describe("useTraining stale-project guards (sc-13626)", () => {
+  let mounted;
+
+  afterEach(() => mounted?.unmount());
+
+  it("keeps loading true when older same-project success resolves before the newest request", async () => {
+    const activeProjectRef = { current: { id: "A" } };
+    mounted = mountHook(useTraining, activeProjectRef);
+
+    let refreshA1;
+    let refreshA2;
+    act(() => {
+      refreshA1 = mounted.get().refreshTrainingDatasets("A");
+      refreshA2 = mounted.get().refreshTrainingDatasets("A");
+    });
+
+    await act(async () => {
+      pendingRequests[0].resolve([{ id: "older-A" }]);
+      await refreshA1;
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(true);
+    expect(mounted.get().trainingDatasets).toEqual([]);
+    expect(mounted.get().trainingDatasetsProjectId).toBeNull();
+
+    await act(async () => {
+      pendingRequests[1].resolve([{ id: "newest-A" }]);
+      await refreshA2;
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(false);
+    expect(mounted.get().trainingDatasets).toEqual([{ id: "newest-A" }]);
+    expect(mounted.get().trainingDatasetsProjectId).toBe("A");
+  });
+
+  it("does not let an older same-project error overwrite a newer success", async () => {
+    const activeProjectRef = { current: { id: "A" } };
+    mounted = mountHook(useTraining, activeProjectRef);
+
+    let refreshA1;
+    let refreshA2;
+    act(() => {
+      refreshA1 = mounted.get().refreshTrainingDatasets("A");
+      refreshA2 = mounted.get().refreshTrainingDatasets("A");
+    });
+
+    await act(async () => {
+      pendingRequests[1].resolve([{ id: "newest-A" }]);
+      await refreshA2;
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(false);
+    expect(mounted.get().trainingDatasets).toEqual([{ id: "newest-A" }]);
+    expect(mounted.get().trainingDatasetsProjectId).toBe("A");
+    expect(mounted.get().trainingDatasetsError).toBe("");
+
+    await act(async () => {
+      pendingRequests[0].reject(new Error("older A failed"));
+      await refreshA1;
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(false);
+    expect(mounted.get().trainingDatasets).toEqual([{ id: "newest-A" }]);
+    expect(mounted.get().trainingDatasetsProjectId).toBe("A");
+    expect(mounted.get().trainingDatasetsError).toBe("");
+  });
+
+  it("keeps project B loading and data authoritative when A resolves first", async () => {
+    const activeProjectRef = { current: { id: "A" } };
+    mounted = mountHook(useTraining, activeProjectRef);
+
+    let refreshA;
+    act(() => {
+      refreshA = mounted.get().refreshTrainingDatasets("A");
+    });
+
+    activeProjectRef.current = { id: "B" };
+    let refreshB;
+    act(() => {
+      refreshB = mounted.get().refreshTrainingDatasets("B");
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(true);
+
+    await act(async () => {
+      pendingRequests[0].resolve([{ id: "from-A" }]);
+      await refreshA;
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(true);
+    expect(mounted.get().trainingDatasets).toEqual([]);
+
+    await act(async () => {
+      pendingRequests[1].resolve([{ id: "from-B" }]);
+      await refreshB;
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(false);
+    expect(mounted.get().trainingDatasets).toEqual([{ id: "from-B" }]);
+    expect(mounted.get().trainingDatasetsProjectId).toBe("B");
+  });
+
+  it("keeps the A to null reset authoritative when A's request later rejects", async () => {
+    const activeProjectRef = { current: { id: "A" } };
+    mounted = mountHook(useTraining, activeProjectRef);
+
+    let staleRefresh;
+    act(() => {
+      staleRefresh = mounted.get().refreshTrainingDatasets("A");
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(true);
+
+    activeProjectRef.current = null;
+    await act(async () => {
+      await mounted.get().refreshTrainingDatasets(null);
+    });
+    expect(mounted.get().loadingTrainingDatasets).toBe(false);
+    expect(mounted.get().trainingDatasetsProjectId).toBeNull();
+    expect(mounted.get().trainingDatasetsError).toBe("");
+
+    await act(async () => {
+      pendingRequests[0].reject(new Error("stale A failure"));
+      await staleRefresh;
+    });
+
+    expect(mounted.get().loadingTrainingDatasets).toBe(false);
+    expect(mounted.get().trainingDatasets).toEqual([]);
+    expect(mounted.get().trainingDatasetsProjectId).toBeNull();
+    expect(mounted.get().trainingDatasetsError).toBe("");
+  });
+
+  it("does not launch a project A post-mutation refetch after switching to B", async () => {
+    const activeProjectRef = { current: { id: "A" } };
+    mounted = mountHook(useTraining, activeProjectRef);
+
+    let mutation;
+    act(() => {
+      mutation = mounted.get().updateTrainingDataset("dataset", { name: "updated" }, "A");
+    });
+    activeProjectRef.current = { id: "B" };
+    await act(async () => {
+      pendingRequests[0].resolve({ id: "dataset" });
+      await mutation;
+    });
+
+    expect(pendingRequests).toHaveLength(1);
+  });
+});
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  pendingRequests.length = 0;
+});

--- a/apps/web/src/hooks/usePresets.js
+++ b/apps/web/src/hooks/usePresets.js
@@ -1,13 +1,21 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
 
 // Owns the recipe-preset list plus its scoped refresh/create/update/duplicate/delete
 // mutations. Extracted from App.jsx (sc-1651). Behavior unchanged — token, the active
 // project, and error reporting are passed in. App's bulk refreshData still seeds the
 // list via the returned setPresets (same React setter identity), and the project-load
 // effect calls refreshCharacters/refreshPresets exactly as before.
-export function usePresets({ token, activeProject, setError }) {
+export function usePresets({ token, activeProject, activeProjectRef, setError }) {
   const [presets, setPresets] = useState([]);
+
+  const isCurrentPresetRequest = useCallback(
+    (projectId) =>
+      !projectId ||
+      isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId),
+    [activeProjectRef],
+  );
 
   // sc-4194: actions wrapped in useCallback so their identity is stable across
   // App's SSE-driven re-renders, enabling appContextValue to memoize.
@@ -16,16 +24,18 @@ export function usePresets({ token, activeProject, setError }) {
       try {
         const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
         const items = await apiFetch(`/api/v1/recipe-presets${query}`, token, { signal });
+        if (!isCurrentPresetRequest(projectId)) return [];
         setPresets(items);
         setError("");
         return items;
       } catch (err) {
         if (isAbortError(err)) return [];
+        if (!isCurrentPresetRequest(projectId)) return [];
         setError(err.message);
         return [];
       }
     },
-    [token, activeProject, setError],
+    [token, activeProject, isCurrentPresetRequest, setError],
   );
 
   const presetQuery = useCallback(
@@ -52,10 +62,16 @@ export function usePresets({ token, activeProject, setError }) {
         method: "POST",
         body: JSON.stringify(payload),
       });
-      await refreshPresets(activeProject?.id);
+      // Refresh the caller's current catalog view even when the mutation itself
+      // targets a global preset: a project view contains both global and project
+      // presets. Capture the id so a later project switch can suppress this refetch.
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentPresetRequest(projectId)) {
+        await refreshPresets(projectId);
+      }
       return created;
     },
-    [token, activeProject, presetQuery, refreshPresets],
+    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
   );
 
   const updatePreset = useCallback(
@@ -64,10 +80,13 @@ export function usePresets({ token, activeProject, setError }) {
         method: "PATCH",
         body: JSON.stringify(payload),
       });
-      await refreshPresets(activeProject?.id);
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentPresetRequest(projectId)) {
+        await refreshPresets(projectId);
+      }
       return updated;
     },
-    [token, activeProject, presetQuery, refreshPresets],
+    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
   );
 
   const duplicatePreset = useCallback(
@@ -76,10 +95,13 @@ export function usePresets({ token, activeProject, setError }) {
         method: "POST",
         body: JSON.stringify({}),
       });
-      await refreshPresets(activeProject?.id);
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentPresetRequest(projectId)) {
+        await refreshPresets(projectId);
+      }
       return duplicated;
     },
-    [token, activeProject, presetQuery, refreshPresets],
+    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
   );
 
   const deletePreset = useCallback(
@@ -87,10 +109,13 @@ export function usePresets({ token, activeProject, setError }) {
       const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
         method: "DELETE",
       });
-      await refreshPresets(activeProject?.id);
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentPresetRequest(projectId)) {
+        await refreshPresets(projectId);
+      }
       return archived;
     },
-    [token, activeProject, presetQuery, refreshPresets],
+    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
   );
 
   return {

--- a/apps/web/src/hooks/usePromptBatches.js
+++ b/apps/web/src/hooks/usePromptBatches.js
@@ -1,29 +1,39 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
 
 // Owns the prompt-batch list plus its scoped refresh/create/update/duplicate/delete
 // mutations (sc-9954, epic 9952). A direct sibling of usePresets — same scoping and
 // error handling — against the /api/v1/prompt-batches routes. Batches carry prompt
 // templates + variable definitions, not a generation recipe, so there is no
 // model/workflow filtering here.
-export function usePromptBatches({ token, activeProject, setError }) {
+export function usePromptBatches({ token, activeProject, activeProjectRef, setError }) {
   const [promptBatches, setPromptBatches] = useState([]);
+
+  const isCurrentBatchRequest = useCallback(
+    (projectId) =>
+      !projectId ||
+      isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId),
+    [activeProjectRef],
+  );
 
   const refreshPromptBatches = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
       try {
         const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
         const items = await apiFetch(`/api/v1/prompt-batches${query}`, token, { signal });
+        if (!isCurrentBatchRequest(projectId)) return [];
         setPromptBatches(items);
         setError("");
         return items;
       } catch (err) {
         if (isAbortError(err)) return [];
+        if (!isCurrentBatchRequest(projectId)) return [];
         setError(err.message);
         return [];
       }
     },
-    [token, activeProject, setError],
+    [token, activeProject, isCurrentBatchRequest, setError],
   );
 
   const batchQuery = useCallback(
@@ -50,10 +60,16 @@ export function usePromptBatches({ token, activeProject, setError }) {
         method: "POST",
         body: JSON.stringify(payload),
       });
-      await refreshPromptBatches(activeProject?.id);
+      // Refresh the caller's current catalog view even when the mutation itself
+      // targets a global batch: a project view contains both global and project
+      // batches. Capture the id so a later project switch can suppress this refetch.
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentBatchRequest(projectId)) {
+        await refreshPromptBatches(projectId);
+      }
       return created;
     },
-    [token, activeProject, batchQuery, refreshPromptBatches],
+    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
   );
 
   const updatePromptBatch = useCallback(
@@ -63,10 +79,13 @@ export function usePromptBatches({ token, activeProject, setError }) {
         token,
         { method: "PATCH", body: JSON.stringify(payload) },
       );
-      await refreshPromptBatches(activeProject?.id);
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentBatchRequest(projectId)) {
+        await refreshPromptBatches(projectId);
+      }
       return updated;
     },
-    [token, activeProject, batchQuery, refreshPromptBatches],
+    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
   );
 
   const duplicatePromptBatch = useCallback(
@@ -76,10 +95,13 @@ export function usePromptBatches({ token, activeProject, setError }) {
         token,
         { method: "POST", body: JSON.stringify({}) },
       );
-      await refreshPromptBatches(activeProject?.id);
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentBatchRequest(projectId)) {
+        await refreshPromptBatches(projectId);
+      }
       return duplicated;
     },
-    [token, activeProject, batchQuery, refreshPromptBatches],
+    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
   );
 
   const deletePromptBatch = useCallback(
@@ -89,10 +111,13 @@ export function usePromptBatches({ token, activeProject, setError }) {
         token,
         { method: "DELETE" },
       );
-      await refreshPromptBatches(activeProject?.id);
+      const projectId = activeProject?.id ?? null;
+      if (isCurrentBatchRequest(projectId)) {
+        await refreshPromptBatches(projectId);
+      }
       return archived;
     },
-    [token, activeProject, batchQuery, refreshPromptBatches],
+    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
   );
 
   return {

--- a/apps/web/src/hooks/useTraining.js
+++ b/apps/web/src/hooks/useTraining.js
@@ -1,5 +1,6 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
 import { upsertJobNewest } from "../sorters.js";
 
 // Owns the project's training-dataset state plus dataset CRUD, caption sidecar/job,
@@ -10,41 +11,60 @@ import { upsertJobNewest } from "../sorters.js";
 //
 // sc-4194: actions are wrapped in useCallback so their identity is stable across App's
 // SSE-driven re-renders, letting appContextValue memoize.
-export function useTraining({ token, activeProject, setError, setJobs }) {
+export function useTraining({ token, activeProject, activeProjectRef, setError, setJobs }) {
   const [trainingDatasets, setTrainingDatasets] = useState([]);
   const [trainingDatasetsProjectId, setTrainingDatasetsProjectId] = useState(null);
   const [loadingTrainingDatasets, setLoadingTrainingDatasets] = useState(false);
   const [trainingDatasetsError, setTrainingDatasetsError] = useState("");
+  const trainingRefreshIdRef = useRef(0);
+
+  const isCurrentTrainingRequest = useCallback(
+    (projectId) =>
+      isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId),
+    [activeProjectRef],
+  );
 
   const refreshTrainingDatasets = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
+      // Reject an already-stale explicit call without letting it supersede the
+      // current project's in-flight refresh. Accepted calls receive monotonically
+      // increasing ownership so an older request for the *same* project cannot
+      // overwrite a newer request or clear its loading state.
+      if (!isCurrentTrainingRequest(projectId)) return [];
+      const refreshId = ++trainingRefreshIdRef.current;
+      const ownsCurrentRefresh = () =>
+        refreshId === trainingRefreshIdRef.current &&
+        isCurrentTrainingRequest(projectId);
+
       if (!projectId) {
         setTrainingDatasets([]);
         setTrainingDatasetsProjectId(null);
         setTrainingDatasetsError("");
+        setLoadingTrainingDatasets(false);
         return [];
       }
       setLoadingTrainingDatasets(true);
       try {
         const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, { signal });
+        if (!ownsCurrentRefresh()) return [];
         setTrainingDatasets(items);
         setTrainingDatasetsProjectId(projectId);
         setTrainingDatasetsError("");
         return items;
       } catch (err) {
         if (isAbortError(err)) return [];
+        if (!ownsCurrentRefresh()) return [];
         setTrainingDatasets([]);
         setTrainingDatasetsProjectId(projectId);
         setTrainingDatasetsError(err.message);
         return [];
       } finally {
-        // A superseded load must not clear the loading flag the new load just set.
-        if (!signal?.aborted) {
+        if (!signal?.aborted && ownsCurrentRefresh()) {
           setLoadingTrainingDatasets(false);
         }
       }
     },
-    [token, activeProject],
+    [token, activeProject, isCurrentTrainingRequest],
   );
 
   const loadTrainingDataset = useCallback(
@@ -115,10 +135,12 @@ export function useTraining({ token, activeProject, setError, setJobs }) {
         method: "POST",
         body: JSON.stringify(payload),
       });
-      await refreshTrainingDatasets(projectId);
+      if (isCurrentTrainingRequest(projectId)) {
+        await refreshTrainingDatasets(projectId);
+      }
       return created;
     },
-    [token, activeProject, refreshTrainingDatasets],
+    [token, activeProject, isCurrentTrainingRequest, refreshTrainingDatasets],
   );
 
   const uploadTrainingDatasetItem = useCallback(
@@ -145,10 +167,12 @@ export function useTraining({ token, activeProject, setError, setJobs }) {
         method: "PATCH",
         body: JSON.stringify(payload),
       });
-      await refreshTrainingDatasets(projectId);
+      if (isCurrentTrainingRequest(projectId)) {
+        await refreshTrainingDatasets(projectId);
+      }
       return updated;
     },
-    [token, activeProject, refreshTrainingDatasets],
+    [token, activeProject, isCurrentTrainingRequest, refreshTrainingDatasets],
   );
 
   const batchRenameTrainingDataset = useCallback(
@@ -164,10 +188,12 @@ export function useTraining({ token, activeProject, setError, setJobs }) {
           body: JSON.stringify(payload),
         },
       );
-      await refreshTrainingDatasets(projectId);
+      if (isCurrentTrainingRequest(projectId)) {
+        await refreshTrainingDatasets(projectId);
+      }
       return updated;
     },
-    [token, activeProject, refreshTrainingDatasets],
+    [token, activeProject, isCurrentTrainingRequest, refreshTrainingDatasets],
   );
 
   const writeTrainingDatasetCaptionSidecars = useCallback(
@@ -183,10 +209,12 @@ export function useTraining({ token, activeProject, setError, setJobs }) {
           body: JSON.stringify(payload),
         },
       );
-      await refreshTrainingDatasets(projectId);
+      if (isCurrentTrainingRequest(projectId)) {
+        await refreshTrainingDatasets(projectId);
+      }
       return result;
     },
-    [token, activeProject, refreshTrainingDatasets],
+    [token, activeProject, isCurrentTrainingRequest, refreshTrainingDatasets],
   );
 
   const createTrainingDatasetCaptionJob = useCallback(


### PR DESCRIPTION
## Summary
- reject stale preset, prompt-batch, and training-dataset responses after project changes
- guard success, error, identity, loading, and post-mutation refetch commits
- use monotonic request ownership for overlapping same-project training refreshes
- preserve global preset and prompt-batch catalog behavior

## Validation
- full web suite before rebase: 2316 tests
- post-rebase focused deferred-race suite: 19 tests
- production build
- ESLint: zero errors
- git diff --check

Independent adversarial review: PASS (confidence 0.99).

Shortcut: sc-13626