### PR TITLE
Enforce Text model capability in Image Studio (sc-13629)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -802,7 +802,8 @@ export function ImageStudio() {
   );
   const macGating = macGatingActive(macCapabilities);
   const imageModelServesMode = useCallback((item, value) => {
-    const caps = item?.capabilities ?? [];
+    const capabilitiesDeclared = Array.isArray(item?.capabilities);
+    const caps = capabilitiesDeclared ? item.capabilities : [];
     if (value === "edit_image") {
       return (
         (caps.includes("edit_image") || caps.includes("image_edit")) &&
@@ -819,7 +820,11 @@ export function ImageStudio() {
     // sourceless edit) and reference-only identity models (MLX-ineligible without a
     // reference → strand on "Waiting for an available worker"); both classes lack
     // text_to_image. Mirrors the per-capability gating the other three modes use.
-    return caps.includes("text_to_image");
+    // Older installed-model records predate the capability array and historically
+    // represented the Text workflow. Preserve that compatibility, while treating
+    // every explicit capability list — including [] — as authoritative (so
+    // unsupported, edit-only, and reference-only models can never leak into Text).
+    return !capabilitiesDeclared || caps.includes("text_to_image");
   }, [macCapabilities]);
   const modelsForMode = useCallback(
     (value) => macImageModels.filter((item) => imageModelServesMode(item, value)),
@@ -829,11 +834,12 @@ export function ImageStudio() {
     () => modelsForMode(mode),
     [mode, modelsForMode],
   );
-  const pickerModels = mode === "text_to_image" && availableModels.length === 0 ? macImageModels : availableModels;
+  const pickerModels = availableModels;
   // Model-availability gate (sc-5947): when the user has no mac-available image model at all,
   // show recommended image-model downloads instead of the studio. `ready` matches the picker
-  // (which falls back to all macImageModels for the text tab); offers come from the full catalog
-  // via imageModelUsable, recommended-first.
+  // across any of its modes; offers come from the full catalog via imageModelUsable,
+  // recommended-first. A mode with no compatible installed model stays inside the
+  // studio so the user can switch tabs, but renders an empty, actionable picker.
   const modelReady = macImageModels.length > 0;
   const modelOffers = useMemo(
     () => downloadOffersFor(models, imageModelUsable, macCapabilities),
@@ -851,7 +857,13 @@ export function ImageStudio() {
       setModel(pickerModels[0].id);
     }
   }, [pickerModels, model]);
-  const selectedModel = imageModels.find((item) => item.id === model);
+  // Resolve only through the current mode's capability-filtered set. A restored
+  // selection can be stale until the snap effect runs; it must never become the
+  // effective model for either rendering defaults or submitting a job.
+  const selectedModel = availableModels.find((item) => item.id === model);
+  const selectedModelServesMode = Boolean(selectedModel);
+  const modeLabel =
+    mode === "edit_image" ? "Edit" : mode === "character_image" ? "With character" : "Text";
   // Booru-convention prompt hint (sc-10760): non-null for danbooru-tag models (Anima, Illustrious)
   // that declare `ui.promptHint`; rendered under the prompt box with a link into the prompt guide.
   const promptHint = promptHintFor(selectedModel?.ui);
@@ -1992,6 +2004,13 @@ export function ImageStudio() {
     if (submitting) {
       return;
     }
+    // Defense in depth for Enter/programmatic submits and restored stale state.
+    // The disabled button is only an affordance; capability eligibility is the
+    // actual authorization to create a job.
+    if (!selectedModelServesMode) {
+      setSubmitError(`Install or select a model that supports ${modeLabel} generation.`);
+      return;
+    }
     if (dimensionsInvalid) {
       setSubmitError("Width and height must each be between 256 and 4096.");
       return;
@@ -2215,6 +2234,10 @@ export function ImageStudio() {
     if (batchRun?.submitting || !activeProject) {
       return;
     }
+    if (!selectedModelServesMode) {
+      setBatchError(`Install or select a model that supports ${modeLabel} generation.`);
+      return;
+    }
     const resolved = expandBatch(batchPrompts, batchVariables);
     if (!resolved.length) {
       return;
@@ -2428,11 +2451,13 @@ export function ImageStudio() {
   const generateValidity = useValidation(imageGenerateValidation, generateDraft, undefined);
   // `submitting` is a busy gate, not a rule. `batchTotal === 0` is a requirement (silent),
   // already folded into batchValidity — no need to repeat it here.
-  const batchRunDisabled = !batchValidity.ready || Boolean(batchRun?.submitting);
+  const batchRunDisabled =
+    !batchValidity.ready || !selectedModelServesMode || Boolean(batchRun?.submitting);
   // The two conditions whose message has its own home stay explicit gates: a structured
   // caption's field errors live in the builder, and a Mac block prints its own note.
   const generateDisabled =
     submitting ||
+    !selectedModelServesMode ||
     !generateValidity.ready ||
     (structuredActive && !captionValidation?.ok) ||
     Boolean(macActiveModeBlock);
@@ -3170,6 +3195,14 @@ export function ImageStudio() {
                     </option>
                   ))}
                 </select>
+                {!pickerModels.length ? (
+                  <span className="field-hint" role="status">
+                    No installed model supports {modeLabel} generation.{" "}
+                    <button onClick={() => setActiveView("Models")} type="button">
+                      Browse models
+                    </button>
+                  </span>
+                ) : null}
                 <StudioUpdateNotice item={selectedModel} onUpdate={createModelDownloadJob} />
               </label>
               <label className="settings-field settings-field-aspect">

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -813,6 +813,18 @@ describe("ImageStudio model picker capability gating", () => {
   };
   const EDIT_ONLY = { ...Z_IMAGE, id: "edit_only", name: "Edit Only", capabilities: ["edit_image", "image_to_image"] };
   const CHARACTER_ONLY = { ...Z_IMAGE, id: "character_only", name: "Character Only", capabilities: ["character_image"] };
+  const LEGACY_NO_CAPABILITIES = {
+    ...Z_IMAGE,
+    id: "legacy_model",
+    name: "Legacy Model",
+    capabilities: undefined,
+  };
+  const EXPLICITLY_UNSUPPORTED = {
+    ...Z_IMAGE,
+    id: "unsupported_model",
+    name: "Unsupported Model",
+    capabilities: [],
+  };
   const MAC_CAPS = {
     macGatingActive: true,
     platform: "darwin",
@@ -854,6 +866,94 @@ describe("ImageStudio model picker capability gating", () => {
     expect(options).toContain("variations_model"); // declares text_to_image
     expect(options).not.toContain("edit_only");
     expect(options).not.toContain("character_only");
+  });
+
+  it("keeps Text empty and actionable when only edit/reference models are installed", async () => {
+    const context = baseContext({ imageModels: [EDIT_ONLY, CHARACTER_ONLY] });
+    await render(context);
+
+    expect(modelOptionValues()).toEqual([]);
+    expect(container.textContent).toContain("No installed model supports Text generation.");
+    expect(
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Generate").disabled,
+    ).toBe(true);
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Browse models"),
+    );
+    expect(context.setActiveView).toHaveBeenCalledWith("Models");
+
+    // The empty Text picker must not strand the other valid modes.
+    await click(modeButton("Edit"));
+    await act(async () => {});
+    expect(modelOptionValues()).toEqual(["edit_only"]);
+    expect(field(container, "Model").value).toBe("edit_only");
+  });
+
+  it("accepts absent legacy capability metadata but rejects an explicit empty list", async () => {
+    await render(baseContext({
+      imageModels: [EXPLICITLY_UNSUPPORTED, LEGACY_NO_CAPABILITIES],
+    }));
+
+    expect(modelOptionValues()).toEqual(["legacy_model"]);
+    expect(modelOptionValues()).not.toContain("unsupported_model");
+  });
+
+  it("rejects a programmatic Generate submit with a stale mode-incompatible restored model", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({ mode: "text_to_image", model: "edit_only" }),
+    );
+    const context = baseContext({
+      createImageJob: vi.fn(),
+      imageModels: [EDIT_ONLY, CHARACTER_ONLY],
+    });
+    await render(context);
+
+    await act(async () => {
+      container.querySelector("form").dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(context.createImageJob).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "supports Text generation",
+    );
+  });
+
+  it("rejects a programmatic batch run with a stale mode-incompatible restored model", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        mode: "text_to_image",
+        model: "edit_only",
+        batchMode: true,
+        batchPromptsText: "first prompt\nsecond prompt",
+      }),
+    );
+    const context = baseContext({
+      createImageJob: vi.fn(),
+      imageModels: [EDIT_ONLY, CHARACTER_ONLY],
+    });
+    await render(context);
+
+    const runBatch = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("Run batch"),
+    );
+    expect(runBatch.disabled).toBe(true);
+
+    // Exercise the React handler itself, bypassing the browser's disabled-button
+    // suppression. runBatch must independently enforce eligibility.
+    const reactPropsKey = Object.keys(runBatch).find((key) => key.startsWith("__reactProps"));
+    await act(async () => {
+      await runBatch[reactPropsKey].onClick();
+    });
+
+    expect(context.createImageJob).not.toHaveBeenCalled();
+    expect(container.querySelector(".batch-warning[role='alert']")?.textContent).toContain(
+      "supports Text generation",
+    );
   });
 
   it("enables the Mac Edit tab when any available model supports edit mode (sc-5589)", async () => {


### PR DESCRIPTION
## Summary
- remove the unsafe Text-tab fallback to edit/reference-only models
- show an actionable empty picker and disable generation when no Text model is eligible
- defensively reject stale invalid Generate and batch invocations
- preserve compatibility only for legacy records without capability metadata; explicit arrays remain authoritative

## Validation
- focused ImageStudio: 73 tests
- full web suite: 2300 tests
- ESLint: zero errors
- Vite production build
- git diff --check

Independent adversarial review: PASS (confidence 0.99).

Shortcut: sc-13629