### PR TITLE
Honor layer transforms during document crop (sc-13628)

### DIFF
--- a/apps/web/src/imageLayers.js
+++ b/apps/web/src/imageLayers.js
@@ -268,3 +268,38 @@ export function compositeLayersToCanvas(ctx, layers, { visibleOnly = true } = {}
     ctx.restore();
   }
 }
+
+// Draw one layer into a document crop, baking its document-space transform into
+// the output bitmap. The crop's top-left becomes output (0, 0). Straighten is a
+// document-level rotation about the crop centre, matching the crop preview/apply
+// semantics while still composing with the layer's own translate/rotate/scale.
+//
+// Opacity, blend mode, and visibility deliberately remain layer metadata: each
+// layer is rasterized independently so the preserved stack composites exactly as
+// it did before the crop.
+export function drawLayerIntoCrop(ctx, layer, { x, y, width, height }, straighten = 0) {
+  if (!layer?.image) return;
+  const t = layer.transform ?? identityTransform();
+  ctx.save();
+  if (straighten) {
+    const cx = x + width / 2;
+    const cy = y + height / 2;
+    ctx.translate(width / 2, height / 2);
+    ctx.rotate((straighten * Math.PI) / 180);
+    ctx.translate(-cx, -cy);
+  } else {
+    ctx.translate(-x, -y);
+  }
+  ctx.translate(t.x || 0, t.y || 0);
+  if (t.rotation) ctx.rotate((t.rotation * Math.PI) / 180);
+  ctx.scale(t.scaleX ?? 1, t.scaleY ?? 1);
+  ctx.drawImage(layer.image, 0, 0);
+  ctx.restore();
+}
+
+// Install a crop result without losing layer identity or compositing metadata.
+// The transform is identity because drawLayerIntoCrop already baked it into the
+// replacement bitmap; retaining it would apply the move/scale/rotation twice.
+export function replaceLayerWithCroppedBitmap(layer, { image, objectUrl, blob }) {
+  return { ...layer, image, objectUrl, blob, transform: identityTransform() };
+}

--- a/apps/web/src/imageLayers.test.js
+++ b/apps/web/src/imageLayers.test.js
@@ -18,6 +18,8 @@ import {
   snapshotLayers,
   sameLayerStack,
   compositeLayersToCanvas,
+  drawLayerIntoCrop,
+  replaceLayerWithCroppedBitmap,
 } from "./imageLayers.js";
 
 // A minimal stand-in for a decoded bitmap — only naturalWidth/Height are read by
@@ -37,6 +39,92 @@ describe("blend modes (sc-6120)", () => {
     // Every entry has a non-empty token + label, and tokens are unique.
     expect(BLEND_MODES.every((m) => m.value && m.label)).toBe(true);
     expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe("transform-aware layer crop (sc-13628)", () => {
+  const recordingCropCtx = () => {
+    const calls = [];
+    return {
+      calls,
+      save: () => calls.push(["save"]),
+      restore: () => calls.push(["restore"]),
+      translate: (x, y) => calls.push(["translate", x, y]),
+      rotate: (angle) => calls.push(["rotate", angle]),
+      scale: (x, y) => calls.push(["scale", x, y]),
+      drawImage: (...args) => calls.push(["drawImage", ...args]),
+    };
+  };
+
+  it("translates the crop origin before baking move, rotation, and scale", () => {
+    const image = fakeImage();
+    const layer = liveLayer("moved", {
+      image,
+      opacity: 0.4,
+      blendMode: "multiply",
+      transform: { x: 30, y: -8, rotation: 90, scaleX: 2, scaleY: 0.5 },
+    });
+    const ctx = recordingCropCtx();
+
+    drawLayerIntoCrop(ctx, layer, { x: 12, y: 7, width: 60, height: 40 });
+
+    expect(ctx.calls).toEqual([
+      ["save"],
+      ["translate", -12, -7],
+      ["translate", 30, -8],
+      ["rotate", Math.PI / 2],
+      ["scale", 2, 0.5],
+      ["drawImage", image, 0, 0],
+      ["restore"],
+    ]);
+    // Compositing properties are intentionally preserved outside the baked pixels.
+    expect(layer).toMatchObject({ opacity: 0.4, blendMode: "multiply", visible: true });
+  });
+
+  it("combines straighten about the crop centre with the layer transform", () => {
+    const image = fakeImage();
+    const layer = liveLayer("rotated", {
+      image,
+      transform: { x: 9, y: 11, rotation: -15, scaleX: 1.25, scaleY: 0.75 },
+    });
+    const ctx = recordingCropCtx();
+
+    drawLayerIntoCrop(ctx, layer, { x: 20, y: 30, width: 80, height: 60 }, 10);
+
+    expect(ctx.calls).toEqual([
+      ["save"],
+      ["translate", 40, 30],
+      ["rotate", (10 * Math.PI) / 180],
+      ["translate", -60, -60],
+      ["translate", 9, 11],
+      ["rotate", (-15 * Math.PI) / 180],
+      ["scale", 1.25, 0.75],
+      ["drawImage", image, 0, 0],
+      ["restore"],
+    ]);
+  });
+
+  it("preserves stack metadata while normalizing the baked transform", () => {
+    const original = liveLayer("hidden-top", {
+      name: "Foreground",
+      visible: false,
+      opacity: 0.35,
+      blendMode: "screen",
+      transform: { x: 12, y: 4, rotation: 22, scaleX: 0.8, scaleY: 1.4 },
+    });
+    const replacement = { image: fakeImage(40, 30), objectUrl: "blob:crop", blob: { cropped: true } };
+
+    const cropped = replaceLayerWithCroppedBitmap(original, replacement);
+
+    expect(cropped).toMatchObject({
+      id: "hidden-top",
+      name: "Foreground",
+      visible: false,
+      opacity: 0.35,
+      blendMode: "screen",
+      ...replacement,
+      transform: identityTransform(),
+    });
   });
 });
 

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -28,12 +28,14 @@ import {
   addLayer,
   compositeLayersToCanvas,
   createLayer,
+  drawLayerIntoCrop,
   duplicateLayer,
   identityTransform,
   layerById,
   moveLayer,
   removeLayer,
   replaceLayerBitmap,
+  replaceLayerWithCroppedBitmap,
   sameLayerStack,
   setActiveLayer,
   setLayerProps,
@@ -1897,9 +1899,9 @@ export function ImageEditor() {
     const sy = clamp(Math.round(cropRect.y), 0, working.height - 1);
     const sw = clamp(Math.round(cropRect.width), 1, working.width - sx);
     const sh = clamp(Math.round(cropRect.height), 1, working.height - sy);
-    // Document-level crop (sc-6119): crop EVERY layer's bitmap to the rect and set the
-    // doc dims — the stack is preserved. Layers are doc-aligned in this slice; per-layer
-    // transforms (and transform-aware crop) arrive with sc-6120.
+    // Crop every layer in document space. Per-layer transforms are baked into the
+    // new bitmap so the result matches the visible composition; layer compositing
+    // metadata remains intact and the baked transform is reset below.
     let cropped;
     try {
       cropped = await Promise.all(
@@ -1908,18 +1910,7 @@ export function ImageEditor() {
           canvas.width = sw;
           canvas.height = sh;
           const ctx = canvas.getContext("2d");
-          if (straighten) {
-            // Straighten (sc-10255): rotate the layer by `straighten°` about the crop-rect
-            // centre, then take the axis-aligned sw×sh window — a rotate-then-crop. Corners
-            // that rotate past the source edge come through transparent (inset your crop).
-            const cx = sx + sw / 2;
-            const cy = sy + sh / 2;
-            ctx.translate(sw / 2, sh / 2);
-            ctx.rotate((straighten * Math.PI) / 180);
-            ctx.drawImage(layer.image, -cx, -cy);
-          } else {
-            ctx.drawImage(layer.image, sx, sy, sw, sh, 0, 0, sw, sh);
-          }
+          drawLayerIntoCrop(ctx, layer, { x: sx, y: sy, width: sw, height: sh }, straighten);
           const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
           if (!blob) throw new Error("Could not encode the crop.");
           const { image, objectUrl } = await blobToImage(blob);
@@ -1942,7 +1933,7 @@ export function ImageEditor() {
       height: sh,
       layers: prev.layers.map((layer) => {
         const c = byId.get(layer.id);
-        return c ? { ...layer, image: c.image, objectUrl: c.objectUrl, blob: c.blob } : layer;
+        return c ? replaceLayerWithCroppedBitmap(layer, c) : layer;
       }),
     }));
     oldLayers.forEach((layer) => layer.objectUrl && URL.revokeObjectURL(layer.objectUrl));


### PR DESCRIPTION
## Summary
- rasterize each layer through the shared translate/rotate/scale transform semantics before cropping
- compose straighten around the crop center
- bake transformed pixels and reset layer transforms to prevent double application
- preserve layer metadata, provenance, undo, and blob lifecycle

## Validation
- focused editor/image-layer tests: 118 tests; review subset 20 tests
- full web suite: 2313 tests
- ESLint: zero errors
- Vite production build
- git diff --check

Independent adversarial review: PASS (confidence 0.98).

Shortcut: sc-13628