### PR TITLE
feat(docker): add combined RunPod GPU image

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,6 +82,8 @@ jobs:
           npm run check
           npm run check:compose
           npm run check:docker:rust-api:self-test
+          npm run check:docker:runpod
+          npm run check:docker:runpod:supervisor
       - name: Guard against NC model weights in a published artifact (sc-10526, epic 10512)
         # SceneWorks converts weights at install and pulls them at runtime — it never
         # redistributes them. Baking a Non-Commercial family's weights (Anima /

--- a/README.md
+++ b/README.md
@@ -242,6 +242,27 @@ docker build --secret id=inference_token,env=SCENEWORKS_INFERENCE_READ_TOKEN `
   --tag sceneworks-api-embed:local .
 ```
 
+For a one-image RunPod GPU deployment, build the `runpod` target instead. It
+contains the embedded-web API, candle CUDA worker, CPU utility worker, ffmpeg,
+and the native Model Manager downloader. PID 1 health-gates the worker on the
+loopback API and drains every process on SIGTERM; Compose is not used.
+
+```powershell
+docker build --secret id=inference_token,env=SCENEWORKS_INFERENCE_READ_TOKEN `
+  --file docker/rust.Dockerfile `
+  --target runpod `
+  --tag sceneworks-runpod:local .
+
+docker run --gpus all --publish 8010:8010 `
+  --env SCENEWORKS_ACCESS_TOKEN=choose-a-private-token `
+  --volume sceneworks-data:/sceneworks `
+  sceneworks-runpod:local
+```
+
+On RunPod, attach the pod's persistent volume at `/sceneworks` in place of the
+example named volume. Provider-specific volume layout and ownership hardening
+are handled separately; this image only defines the shared mount contract.
+
 Key knobs:
 
 - `SCENEWORKS_API_PORT` / `SCENEWORKS_WEB_PORT` — container/host ports for the API

--- a/docker/runpod-entrypoint.sh
+++ b/docker/runpod-entrypoint.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -u
+
+api_bin="${SCENEWORKS_API_BIN:-/usr/local/bin/sceneworks-rust-api}"
+worker_bin="${SCENEWORKS_WORKER_BIN:-/usr/local/bin/sceneworks-rust-worker}"
+curl_bin="${SCENEWORKS_CURL_BIN:-curl}"
+api_port="${SCENEWORKS_API_PORT:-8010}"
+api_url="http://127.0.0.1:${api_port}"
+readiness_attempts="${SCENEWORKS_READINESS_MAX_ATTEMPTS:-120}"
+readiness_interval="${SCENEWORKS_READINESS_INTERVAL_SECONDS:-1}"
+shutdown_attempts="${SCENEWORKS_SHUTDOWN_GRACE_ATTEMPTS:-100}"
+shutdown_interval="${SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS:-0.1}"
+
+api_pid=""
+worker_pid=""
+shutting_down=0
+
+log() {
+  printf '[runpod] %s\n' "$*" >&2
+}
+
+is_running() {
+  local pid="$1"
+  local state
+  [[ -n "${pid}" ]] || return 1
+  if [[ "${OSTYPE:-}" == linux* && -r "/proc/${pid}/stat" ]]; then
+    # `kill -0` still succeeds for an exited-but-not-yet-waited zombie. Reading
+    # proc state keeps readiness/monitoring responsive and avoids burning the
+    # full shutdown grace period before reaping a child that already stopped.
+    read -r _ _ state _ <"/proc/${pid}/stat" || return 1
+    [[ "${state}" != "Z" ]]
+    return
+  fi
+  # Test/development shells without Linux procfs (not the production image).
+  kill -0 "${pid}" 2>/dev/null
+}
+
+reap_status() {
+  local pid="$1"
+  local status
+  set +e
+  wait "${pid}"
+  status=$?
+  set -e
+  printf '%s' "${status}"
+}
+
+stop_child() {
+  local pid="$1"
+  local label="$2"
+  local attempt
+
+  if [[ -z "${pid}" ]]; then
+    return
+  fi
+
+  if is_running "${pid}"; then
+    kill -TERM "${pid}" 2>/dev/null || true
+  fi
+
+  for ((attempt = 0; attempt < shutdown_attempts; attempt += 1)); do
+    if ! is_running "${pid}"; then
+      break
+    fi
+    sleep "${shutdown_interval}"
+  done
+
+  if is_running "${pid}"; then
+    log "${label} child ${pid} exceeded the shutdown grace period; sending SIGKILL"
+    kill -KILL "${pid}" 2>/dev/null || true
+  fi
+  wait "${pid}" 2>/dev/null || true
+}
+
+shutdown_children() {
+  if (( shutting_down )); then
+    return
+  fi
+  shutting_down=1
+  trap - TERM INT HUP
+
+  # Keep the API alive while the worker supervisor drains its children so their
+  # final Offline heartbeat succeeds instead of producing shutdown-only transport
+  # errors. Once every GPU/utility child is gone, stop and reap the API.
+  stop_child "${worker_pid}" "worker supervisor"
+  stop_child "${api_pid}" "API"
+}
+
+handle_signal() {
+  log "shutdown signal received"
+  shutdown_children
+  exit 0
+}
+
+trap handle_signal TERM INT HUP
+
+mkdir -p \
+  "${SCENEWORKS_DATA_DIR:-/sceneworks/data}/cache" \
+  "${SCENEWORKS_CONFIG_DIR:-/sceneworks/config}" \
+  "${HF_HOME:-/sceneworks/data/cache/huggingface}"
+
+log "starting embedded-web API on 0.0.0.0:${api_port}"
+"${api_bin}" &
+api_pid=$!
+
+ready=0
+for ((attempt = 1; attempt <= readiness_attempts; attempt += 1)); do
+  if ! is_running "${api_pid}"; then
+    status="$(reap_status "${api_pid}")"
+    api_pid=""
+    log "API exited before becoming healthy (status ${status})"
+    exit "${status}"
+  fi
+  if "${curl_bin}" -fsS "${api_url}/api/v1/health" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep "${readiness_interval}"
+done
+
+if (( ! ready )); then
+  log "API did not become healthy after ${readiness_attempts} attempts"
+  shutdown_children
+  exit 1
+fi
+
+log "API healthy; starting candle GPU and utility workers"
+# `auto` is important here: the worker supervisor creates one child for every
+# visible GPU plus a CPU-only child. child_environment() sets
+# SCENEWORKS_UTILITY_JOBS=0 for GPU children and =1 for the CPU child, which is
+# the capability-routing boundary this combined image relies on.
+SCENEWORKS_API_URL="${api_url}" \
+SCENEWORKS_GPU_ID=auto \
+"${worker_bin}" &
+worker_pid=$!
+
+while true; do
+  if ! is_running "${api_pid}"; then
+    status="$(reap_status "${api_pid}")"
+    api_pid=""
+    log "API exited (status ${status}); stopping worker"
+    shutdown_children
+    exit "${status}"
+  fi
+  if ! is_running "${worker_pid}"; then
+    status="$(reap_status "${worker_pid}")"
+    worker_pid=""
+    log "worker supervisor exited (status ${status}); stopping API"
+    shutdown_children
+    exit "${status}"
+  fi
+  sleep 0.2
+done

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -28,7 +28,7 @@ RUN npm run build --prefix apps/web \
 
 FROM rust:1-bookworm AS builder
 # Which workspace binary to build (sceneworks-rust-api | sceneworks-rust-worker).
-ARG BIN
+ARG BIN=sceneworks-rust-api
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml rustfmt.toml ./
@@ -271,3 +271,43 @@ ENV PATH="/opt/ort/bin:${PATH}"
 COPY --from=candle-builder /out/sceneworks-rust-worker /usr/local/bin/sceneworks-rust-worker
 
 CMD ["sceneworks-rust-worker"]
+
+# --- Combined RunPod GPU runtime ---------------------------------------------
+# RunPod starts one image per pod, so this target packages the embedded-web API
+# and the candle/CUDA worker together. The PID-1 entrypoint starts the API, waits
+# for its loopback health endpoint, then starts the worker in `auto` mode. The
+# worker's existing supervisor discovers the visible NVIDIA GPU(s) and starts a
+# dedicated CPU utility child alongside the GPU child; those children advertise
+# disjoint capabilities, so generation cannot leak onto the utility lane and
+# downloads/imports/exports cannot occupy the GPU lane.
+#
+# Keep this runtime based on rust-worker-candle: it is the validated CUDA 12.9.1
+# + cuDNN 9 + onnxruntime-gpu image and already contains ffmpeg. Model Manager
+# downloads run through the worker's native in-process downloader; intentionally
+# do not install the retired Hugging Face CLI (sc-12227 / sc-12232).
+FROM rust-worker-candle AS runpod
+
+COPY --from=embed-builder /out/sceneworks-rust-api /usr/local/bin/sceneworks-rust-api
+COPY docker/runpod-entrypoint.sh /usr/local/bin/sceneworks-runpod-entrypoint
+RUN chmod 0755 /usr/local/bin/sceneworks-runpod-entrypoint
+
+ENV SCENEWORKS_API_HOST=0.0.0.0 \
+    SCENEWORKS_API_PORT=8010 \
+    SCENEWORKS_API_URL=http://127.0.0.1:8010 \
+    SCENEWORKS_DATA_DIR=/sceneworks/data \
+    SCENEWORKS_CONFIG_DIR=/sceneworks/config \
+    SCENEWORKS_JOBS_DB_PATH=/sceneworks/data/cache/jobs.db \
+    SCENEWORKS_CANDLE_REQUIRED=1 \
+    SCENEWORKS_CANDLE_UNSUPPORTED_MODE=enforce \
+    SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1 \
+    SCENEWORKS_WORKER_ID=runpod-worker-0 \
+    HF_HOME=/sceneworks/data/cache/huggingface \
+    HF_HUB_CACHE=/sceneworks/data/cache/huggingface/hub \
+    HUGGINGFACE_HUB_CACHE=/sceneworks/data/cache/huggingface/hub
+
+EXPOSE 8010
+VOLUME ["/sceneworks"]
+HEALTHCHECK --interval=20s --timeout=5s --retries=3 --start-period=10s \
+    CMD curl -fsS "http://127.0.0.1:${SCENEWORKS_API_PORT:-8010}/api/v1/health" >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/sceneworks-runpod-entrypoint"]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "hooks:install": "git config core.hooksPath scripts/git-hooks",
     "check:docker:rust-api:self-test": "node --test scripts/check-docker-api-runtime.test.mjs",
     "check:docker:rust-api": "node scripts/check-docker-api-runtime.mjs",
+    "check:docker:runpod": "node scripts/check-runpod-image.mjs",
+    "check:docker:runpod:supervisor": "bash scripts/check-runpod-supervisor.sh",
     "bump:inference": "node scripts/bump-inference.mjs",
     "bump:inference:self-test": "node scripts/bump-inference.mjs --self-test",
     "rust:fmt": "cargo fmt --all -- --check",

--- a/scripts/check-runpod-image.mjs
+++ b/scripts/check-runpod-image.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [dockerfile, entrypoint, gpuSource, engineSource, readme] = await Promise.all([
+  readFile("docker/rust.Dockerfile", "utf8"),
+  readFile("docker/runpod-entrypoint.sh", "utf8"),
+  readFile("crates/sceneworks-worker/src/gpu.rs", "utf8"),
+  readFile("crates/sceneworks-worker/src/engines.rs", "utf8"),
+  readFile("README.md", "utf8"),
+]);
+
+function stage(name) {
+  const header = new RegExp(`^FROM ([^\\r\\n]+) AS ${name}\\r?$`, "m").exec(dockerfile);
+  assert.ok(header, `missing Docker stage ${name}`);
+  const start = header.index + header[0].length;
+  const next = dockerfile.indexOf("\nFROM ", start);
+  return {
+    base: header[1],
+    body: dockerfile.slice(start, next === -1 ? undefined : next),
+  };
+}
+
+const candleRuntime = stage("rust-worker-candle");
+const runpod = stage("runpod");
+
+assert.equal(
+  candleRuntime.base,
+  "nvidia/cuda:12.9.1-runtime-ubuntu24.04",
+  "combined image must retain the validated CUDA 12.9.1 / Ubuntu 24.04 runtime",
+);
+assert.equal(runpod.base, "rust-worker-candle", "combined image must inherit candle runtime");
+
+for (const contract of [
+  "ffmpeg",
+  "COPY --from=candle-builder /out/sceneworks-rust-worker",
+  "onnxruntime-gpu==${ONNXRUNTIME_GPU_VERSION}",
+]) {
+  assert.ok(candleRuntime.body.includes(contract), `candle runtime is missing ${contract}`);
+}
+for (const contract of [
+  "COPY --from=embed-builder /out/sceneworks-rust-api",
+  "COPY docker/runpod-entrypoint.sh",
+  "SCENEWORKS_API_URL=http://127.0.0.1:8010",
+  "SCENEWORKS_CANDLE_REQUIRED=1",
+  'VOLUME ["/sceneworks"]',
+  "/api/v1/health",
+  'ENTRYPOINT ["/usr/local/bin/sceneworks-runpod-entrypoint"]',
+]) {
+  assert.ok(runpod.body.includes(contract), `runpod stage is missing ${contract}`);
+}
+
+assert.ok(
+  entrypoint.includes("SCENEWORKS_GPU_ID=auto"),
+  "entrypoint must use worker auto-supervision to create GPU and utility children",
+);
+assert.ok(
+  entrypoint.includes('SCENEWORKS_API_URL="${api_url}"'),
+  "worker must connect to the API over loopback",
+);
+assert.ok(
+  entrypoint.includes("shutdown_children"),
+  "entrypoint must own coordinated child shutdown",
+);
+
+for (const capability of [
+  "Cap::ImageGenerate",
+  "Cap::VideoGenerate",
+]) {
+  assert.ok(engineSource.includes(capability), `worker engine registry is missing ${capability}`);
+}
+for (const capability of [
+  "WorkerCapability::ModelDownload",
+  "WorkerCapability::ModelImport",
+  "WorkerCapability::LoraImport",
+  "WorkerCapability::TimelineExport",
+]) {
+  assert.ok(gpuSource.includes(capability), `worker source is missing ${capability}`);
+}
+
+assert.ok(
+  dockerfile.includes("native in-process") && dockerfile.includes("do not install the retired Hugging Face CLI"),
+  "combined image must document the native Model Manager download path",
+);
+assert.ok(
+  !/pip install[^\n]*huggingface[_-]hub/i.test(dockerfile),
+  "combined image must not reintroduce the retired Hugging Face CLI",
+);
+for (const contract of [
+  "--target runpod",
+  "--gpus all",
+  "--env SCENEWORKS_ACCESS_TOKEN=",
+  "--volume sceneworks-data:/sceneworks",
+]) {
+  assert.ok(readme.includes(contract), `RunPod deployment docs are missing ${contract}`);
+}
+
+console.log("SceneWorks combined RunPod image contract check passed.");

--- a/scripts/check-runpod-supervisor.sh
+++ b/scripts/check-runpod-supervisor.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+entrypoint="${repo_root}/docker/runpod-entrypoint.sh"
+temp_root="$(mktemp -d)"
+trap 'rm -rf "${temp_root}"' EXIT
+
+fail() {
+  printf 'runpod supervisor self-test failed: %s\n' "$*" >&2
+  exit 1
+}
+
+wait_for_event() {
+  local event="$1"
+  local file="$2"
+  local attempt
+  for ((attempt = 0; attempt < 100; attempt += 1)); do
+    if [[ -f "${file}" ]] && grep -Fqx "${event}" "${file}"; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  fail "timed out waiting for '${event}' in ${file}"
+}
+
+cat >"${temp_root}/fake-api" <<'EOF'
+#!/usr/bin/env bash
+set -u
+printf 'api:start\n' >>"${SCENEWORKS_TEST_EVENTS}"
+trap 'printf "api:term\n" >>"${SCENEWORKS_TEST_EVENTS}"; exit 0' TERM INT HUP
+while true; do sleep 0.1; done
+EOF
+
+cat >"${temp_root}/fake-worker" <<'EOF'
+#!/usr/bin/env bash
+set -u
+printf 'worker:start:%s:%s\n' "${SCENEWORKS_API_URL}" "${SCENEWORKS_GPU_ID}" >>"${SCENEWORKS_TEST_EVENTS}"
+trap 'printf "worker:term\n" >>"${SCENEWORKS_TEST_EVENTS}"; exit 0' TERM INT HUP
+if [[ "${SCENEWORKS_TEST_WORKER_EXIT_CODE:-}" =~ ^[0-9]+$ ]]; then
+  sleep 0.1
+  exit "${SCENEWORKS_TEST_WORKER_EXIT_CODE}"
+fi
+while true; do sleep 0.1; done
+EOF
+
+cat >"${temp_root}/fake-curl" <<'EOF'
+#!/usr/bin/env bash
+set -u
+count=0
+if [[ -f "${SCENEWORKS_TEST_CURL_COUNT}" ]]; then
+  count="$(cat "${SCENEWORKS_TEST_CURL_COUNT}")"
+fi
+count=$((count + 1))
+printf '%s' "${count}" >"${SCENEWORKS_TEST_CURL_COUNT}"
+[[ "${SCENEWORKS_TEST_CURL_ALWAYS_FAIL:-0}" != "1" && "${count}" -ge 2 ]]
+EOF
+chmod +x "${temp_root}/fake-api" "${temp_root}/fake-worker" "${temp_root}/fake-curl"
+
+run_dir="${temp_root}/signal"
+mkdir -p "${run_dir}"
+events="${run_dir}/events"
+SCENEWORKS_TEST_EVENTS="${events}" \
+SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
+SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
+SCENEWORKS_DATA_DIR="${run_dir}/data" \
+SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+HF_HOME="${run_dir}/hf" \
+SCENEWORKS_READINESS_MAX_ATTEMPTS=5 \
+SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
+SCENEWORKS_SHUTDOWN_GRACE_ATTEMPTS=6 \
+SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
+bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
+supervisor_pid=$!
+wait_for_event "worker:start:http://127.0.0.1:8010:auto" "${events}"
+kill -TERM "${supervisor_pid}"
+wait "${supervisor_pid}"
+wait_for_event "api:term" "${events}"
+wait_for_event "worker:term" "${events}"
+[[ "$(cat "${run_dir}/curl-count")" -eq 2 ]] || fail "readiness did not retry exactly once"
+
+run_dir="${temp_root}/child-failure"
+mkdir -p "${run_dir}"
+events="${run_dir}/events"
+set +e
+SCENEWORKS_TEST_EVENTS="${events}" \
+SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
+SCENEWORKS_TEST_WORKER_EXIT_CODE=23 \
+SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
+SCENEWORKS_DATA_DIR="${run_dir}/data" \
+SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+HF_HOME="${run_dir}/hf" \
+SCENEWORKS_READINESS_MAX_ATTEMPTS=5 \
+SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
+SCENEWORKS_SHUTDOWN_GRACE_ATTEMPTS=6 \
+SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
+bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
+status=$?
+set -e
+[[ "${status}" -eq 23 ]] || fail "worker failure status was ${status}, expected 23"
+wait_for_event "api:term" "${events}"
+
+run_dir="${temp_root}/readiness-failure"
+mkdir -p "${run_dir}"
+events="${run_dir}/events"
+set +e
+SCENEWORKS_TEST_EVENTS="${events}" \
+SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
+SCENEWORKS_TEST_CURL_ALWAYS_FAIL=1 \
+SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
+SCENEWORKS_DATA_DIR="${run_dir}/data" \
+SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+HF_HOME="${run_dir}/hf" \
+SCENEWORKS_READINESS_MAX_ATTEMPTS=3 \
+SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
+SCENEWORKS_SHUTDOWN_GRACE_ATTEMPTS=6 \
+SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
+bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
+status=$?
+set -e
+[[ "${status}" -eq 1 ]] || fail "readiness failure status was ${status}, expected 1"
+wait_for_event "api:term" "${events}"
+if grep -q '^worker:start:' "${events}"; then
+  fail "worker started before API readiness"
+fi
+
+printf 'SceneWorks RunPod supervisor lifecycle self-test passed.\n'


### PR DESCRIPTION
## Summary

- add a single `runpod` image target that inherits the CUDA 12.9.1 candle runtime and packages the embedded-web API plus candle worker
- supervise API readiness and the worker auto-topology over `127.0.0.1:8010`, with worker-first graceful shutdown
- preserve ffmpeg and native in-process Model Manager downloads without restoring the retired HF CLI
- document the one-image run command and add CI contract/lifecycle regressions

## Acceptance criteria

- **Single image/run:** `docker run --gpus all` with one `/sceneworks` volume and `SCENEWORKS_ACCESS_TOKEN` started the API, GPU workers, and CPU utility worker.
- **Routing:** live registrations advertised `image_generate`/`video_generate` on candle GPU workers and download/import/export capabilities on the CPU worker.
- **Health/shutdown:** `/api/v1/health` returned `ok`; the embedded UI returned 200; Docker stop drained workers before API and exited 0 in under one second.
- **Runtime tools/downloads:** ffmpeg 6.1.1 was present; the utility worker advertised the native model/lora download capabilities; no HF CLI was installed.

## Validation

- `npm run check`
- `npm run check:compose`
- `npm run check:docker:runpod`
- `bash scripts/check-runpod-supervisor.sh`
- `cargo fmt --all -- --check`
- combined `docker build --target runpod` from current `origin/main`
- live Docker Desktop GPU smoke: health, embedded UI, 2 candle GPU registrations, 1 CPU utility registration, ffmpeg, NVIDIA visibility, process tree, and clean stop
- independent adversarial review: PASS (high confidence; no issues or gaps)

Shortcut: https://app.shortcut.com/trefry/story/10364