### PR TITLE
Stop volatile static app-context invalidation (sc-13633)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -427,7 +427,6 @@ export function App() {
     loadedAssetsProjectId === activeProject?.id ? storedSelectedAssetId : null;
   const [projectFilter, setProjectFilter] = useState("all");
   const [requestedGpu, setRequestedGpu] = useState("auto");
-  const [jobPrompt, setJobPrompt] = useState("Placeholder generation");
   const [latestGenerationSetId, setLatestGenerationSetId] = useState(null);
   const [previewAsset, setPreviewAsset] = useState(null);
   // The collection the fullscreen preview was launched from, as an ordered list
@@ -1492,7 +1491,7 @@ export function App() {
   }
 
   const createPlaceholderJob = useCallback(
-    async (event) => {
+    async (event, prompt) => {
       event.preventDefault();
       try {
         await apiFetch("/api/v1/jobs", token, {
@@ -1503,8 +1502,8 @@ export function App() {
             projectName: activeProject?.name ?? null,
             requestedGpu,
             payload: {
-              prompt: jobPrompt,
-              createdFrom: activeView,
+              prompt,
+              createdFrom: activeViewRef.current,
             },
           }),
         });
@@ -1514,7 +1513,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token, activeProject, requestedGpu, jobPrompt, activeView],
+    [token, activeProject, requestedGpu],
   );
 
   const createImageJob = useCallback(
@@ -2336,8 +2335,6 @@ export function App() {
     createInterleaveJob,
     // Queue screen (sc-1651 Phase B batch 2)
     createPlaceholderJob,
-    jobPrompt,
-    setJobPrompt,
     projectFilter,
     setProjectFilter,
     projects,
@@ -2476,7 +2473,7 @@ export function App() {
     assets, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobAction, clearCompletedJobs, cancelPendingJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
-    jobPrompt, setJobPrompt, projectFilter, setProjectFilter, projects,
+    projectFilter, setProjectFilter, projects,
     createVideoJob, createVideoUpscaleJob, createImageJob, createAudioJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, studioLaunch,
     editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,

--- a/apps/web/src/App.shell.test.jsx
+++ b/apps/web/src/App.shell.test.jsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, ErrorBoundary } from "./main.jsx";
 import { assetUrl } from "./components/assetMedia.jsx";
 import { SetupWizard } from "./screens/SetupWizard.jsx";
-import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
+import { AppStaticContext, AppLiveContext, useAppStatic } from "./context/AppContext.js";
 import { FakeEventSource, response, settle, navLabels, changeField } from "./main.testSupport.jsx";
 
 describe("SceneWorks app shell", () => {
@@ -463,6 +463,80 @@ describe("SceneWorks app shell", () => {
       const after = providedValues[providedValues.length - 1];
       expect(providedValues.length).toBeGreaterThan(countBefore); // the event really re-rendered App
       expect(after).toBe(before); // identity preserved → consumer tree memoization holds
+    } finally {
+      AppStaticContext.Provider = OriginalProvider;
+    }
+  });
+
+  it("keeps Queue prompt churn out of static context while submitting the latest prompt and view (sc-13633)", async () => {
+    const providedValues = [];
+    let staticConsumerRenders = 0;
+    const OriginalProvider = AppStaticContext.Provider;
+    const StaticConsumer = React.memo(function StaticConsumer() {
+      useAppStatic();
+      staticConsumerRenders += 1;
+      return null;
+    });
+    const staticConsumer = <StaticConsumer />;
+
+    AppStaticContext.Provider = function RecordingProvider({ value, children }) {
+      providedValues.push(value);
+      return (
+        <OriginalProvider value={value}>
+          {children}
+          {staticConsumer}
+        </OriginalProvider>
+      );
+    };
+    try {
+      root = createRoot(container);
+      await act(async () => {
+        root.render(<App />);
+      });
+      await settle();
+
+      const staticBeforeNavigation = providedValues.at(-1);
+      const createJobBeforeNavigation = staticBeforeNavigation.createPlaceholderJob;
+      const consumerRendersBeforeNavigation = staticConsumerRenders;
+
+      const queueButton = [...container.querySelectorAll("button")].find(
+        (button) => button.querySelector(".nav-label")?.textContent === "Queue",
+      );
+      await act(async () => {
+        queueButton.click();
+      });
+      await settle();
+
+      const staticAfterNavigation = providedValues.at(-1);
+      expect(staticAfterNavigation).toBe(staticBeforeNavigation);
+      expect(staticAfterNavigation.createPlaceholderJob).toBe(createJobBeforeNavigation);
+      expect(staticConsumerRenders).toBe(consumerRendersBeforeNavigation);
+
+      const promptInput = container.querySelector("#queue-job-prompt");
+      const providerRendersBeforeTyping = providedValues.length;
+      await changeField(promptInput, "Latest local Queue prompt");
+
+      // Prompt state belongs to QueueScreen: typing neither re-renders App's provider
+      // nor wakes an unrelated static-only consumer.
+      expect(providedValues.length).toBe(providerRendersBeforeTyping);
+      expect(staticConsumerRenders).toBe(consumerRendersBeforeNavigation);
+      expect(providedValues.at(-1).createPlaceholderJob).toBe(createJobBeforeNavigation);
+
+      const form = container.querySelector(".job-composer");
+      await act(async () => {
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      });
+      await settle();
+
+      const request = global.fetch.mock.calls.find(
+        ([url, options]) =>
+          new URL(url).pathname.endsWith("/jobs") && options?.method === "POST",
+      );
+      expect(request).toBeTruthy();
+      expect(JSON.parse(request[1].body).payload).toEqual({
+        prompt: "Latest local Queue prompt",
+        createdFrom: "Queue",
+      });
     } finally {
       AppStaticContext.Provider = OriginalProvider;
     }

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { terminalStatuses } from "../constants.js";
 import { GPU_REQUIRED_JOB_TYPES, NON_GPU_JOB_TYPES, pendingStatuses } from "../jobTypes.js";
@@ -189,6 +189,7 @@ function WorkerCard({ worker }) {
 }
 
 export function QueueScreen() {
+  const [jobPrompt, setJobPrompt] = useState("Placeholder generation");
   const {
     activeProject,
     assets = [],
@@ -200,17 +201,15 @@ export function QueueScreen() {
     gpuOptions,
     jobAction,
     jobs = filteredJobs,
-    jobPrompt,
     projectFilter,
     projects,
     requestedGpu,
-    setJobPrompt,
     setProjectFilter,
     setPreviewAsset,
     setRequestedGpu,
     visibleWorkers,
   } = useAppContext();
-  const createJob = createPlaceholderJob;
+  const createJob = (event) => createPlaceholderJob(event, jobPrompt);
   const workers = visibleWorkers;
   // Prefer the shared index from context (sc-2082); fall back for legacy
   // contexts that may not yet expose it (test harnesses, etc.).


### PR DESCRIPTION
## Summary
- move the Queue placeholder prompt into QueueScreen local state
- pass the current prompt explicitly when creating a placeholder job
- read active view through the stable ref so navigation does not recreate the callback
- remove prompt/view churn from AppStaticContext identity

## Validation
- focused App shell and queue tests: 24 tests
- full web suite: 2334 tests
- ESLint: zero errors
- Vite production build
- git diff --check

Independent adversarial review: PASS (confidence 0.96).

Shortcut: sc-13633