### PR TITLE
Deduplicate generation tier and style controls (sc-13630)

### DIFF
--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -123,7 +123,11 @@ import {
   PresetGuidanceStrip,
   PresetStackPreview,
   SavePresetPanel,
+  ModeTabs,
+  StyleAxisRow,
+  TierPickerField,
   useGenerationStudio,
+  useQuantTierPicker,
   useSavePreset,
 } from "./generationStudio.jsx";
 import { useAppContext } from "../context/AppContext.js";
@@ -146,7 +150,6 @@ import { ControlPanel } from "../components/ControlPanel.jsx";
 import { pidToggleVisible } from "../pidEligibility.js";
 import {
   allPossibleTiers,
-  defaultTierSelection,
   installedTiers,
   isBelowFloor,
   modelQualityFloor,
@@ -155,8 +158,7 @@ import {
 } from "../quantTier.js";
 import { suggestTier } from "../tierSuggestion.js";
 import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
-import { readLastTier, writeLastTier } from "../lastTierStore.js";
-import { readDefaultGenerationQuality } from "../generationQuality.js";
+import { readLastTier } from "../lastTierStore.js";
 import { PROMPT_REFINE_MODEL_ID, VISION_CAPTION_MODEL_ID, VISION_CAPTION_MODEL_REPO } from "../constants.js";
 import { parseResolution, pickClosestResolution } from "../resolutionMatch.js";
 import { fitsResolutionOptions } from "../resolutionMemory.js";
@@ -176,7 +178,6 @@ import {
   useUpscaleEngineFallback,
 } from "../upscaleEngines.js";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
-import { StylePicker } from "../components/StylePicker.jsx";
 import { StyledPromptPreview } from "../components/StyledPromptPreview.jsx";
 import { STYLE_GROUPS, styleHintForId, styleTextForId } from "../data/styleCatalog.js";
 import {
@@ -657,11 +658,6 @@ export function ImageStudio() {
   // so re-entering a model on this screen restores the tier you last generated with, in any
   // workspace and across app restarts. It seeds the picker as the top rung below a same-session pick
   // and above the model's base default (see the seed effect + `defaultTierSelection`).
-  const [quantTier, setQuantTier] = useState("");
-  // Brief "loading <tier>" hint shown right after a switch (reload-always): switching a heavy
-  // tier evicts + reloads on the worker, so we surface a transient loading note rather than
-  // implying an instant swap. Cleared on a short timer; purely cosmetic.
-  const [tierSwitching, setTierSwitching] = useState("");
   // PiD decoder toggle (epic 7840, sc-7851): off = the model's native VAE decode; on emits
   // `advanced.usePid: true`, routing decode through the optional PiD pixel-diffusion decoder
   // (decode + 2K/4K super-resolve, non-commercial output). Sticky pref, default off; the
@@ -977,6 +973,15 @@ export function ImageStudio() {
     () => suggestTier(selectedModel, unifiedMemoryGb),
     [selectedModel, unifiedMemoryGb],
   );
+  const { quantTier, tierSwitching, handleTierChange } = useQuantTierPicker({
+    screen: TIER_SCREEN,
+    model,
+    selectedModel,
+    availableTiers,
+    tierOptions,
+    autoTier,
+    useGenerationQuality: true,
+  });
   const possibleTiers = useMemo(
     () => allPossibleTiers(selectedModel, tierOptions),
     [selectedModel, tierOptions],
@@ -1391,46 +1396,6 @@ export function ImageStudio() {
   // survives restarts and is honored above the base default whenever that tier is still installed.
   // Keyed on `model` (not `selectedModel`) plus the installed-tier list so a catalog refresh that
   // newly installs a second tier re-derives the default without churning on every render.
-  const availableTiersKey = availableTiers.join(",");
-  useEffect(() => {
-    if (availableTiers.includes(quantTier)) {
-      return;
-    }
-    setQuantTier(
-      defaultTierSelection(selectedModel, readLastTier(TIER_SCREEN, model), {
-        ...tierOptions,
-        // Rung 3 (sc-10728): the app-wide default-generation-quality setting is the base default below
-        // the per-(screen,model) sticky. Read fresh here (like readLastTier) so a change made in Settings
-        // is picked up the next time this effect derives a default — no stale in-memory copy.
-        defaultQuality: readDefaultGenerationQuality(),
-        // When that setting is Auto (the default), the base is this capability-aware suggestion.
-        autoTier,
-      }) ?? "",
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [model, availableTiersKey, autoTier]);
-  // Switch the active quant tier (sc-8515): persist it as this (screen, model)'s last EXPLICIT tier
-  // (sc-10727 — sticky) and surface a brief "loading <tier>" note (reload-always — the worker evicts
-  // + reloads a heavy tier on the next generation; there is no co-residence). The note self-clears.
-  const tierSwitchTimer = useRef(null);
-  useEffect(() => () => clearTimeout(tierSwitchTimer.current), []);
-  const handleTierChange = useCallback(
-    (nextTier) => {
-      // Only an installed-and-complete tier can be selected — the disabled options in the dropdown are
-      // shown for discoverability, never as a pickable target. This is the belt behind the native
-      // `<option disabled>` (which already blocks selection) so no code path can strand the state on a
-      // tier that isn't in the cache.
-      if (nextTier === quantTier || !availableTiers.includes(nextTier)) {
-        return;
-      }
-      setQuantTier(nextTier);
-      writeLastTier(TIER_SCREEN, model, nextTier);
-      setTierSwitching(nextTier);
-      clearTimeout(tierSwitchTimer.current);
-      tierSwitchTimer.current = setTimeout(() => setTierSwitching(""), 1500);
-    },
-    [model, quantTier, availableTiers],
-  );
   const {
     availablePresets,
     selectedPreset,
@@ -2478,31 +2443,18 @@ export function ImageStudio() {
       <form className="studio-shell" onSubmit={submit}>
         <WorkPanel className="studio-work-panel">
           <div className="prompt-hero-top">
-            <div className="mode-tabs" role="tablist" aria-label="Image mode">
-              {[
+            <ModeTabs
+              label="Image mode"
+              options={[
                 ["text_to_image", "Text"],
                 ["edit_image", "Edit"],
                 ["character_image", "With character"],
-              ].map(([value, label]) => {
-                const macBlock = macModeTabBlock(value);
-                const active = mode === value;
-                return (
-                  <button
-                    className={active ? "mode-tab active" : "mode-tab"}
-                    key={value}
-                    role="tab"
-                    aria-selected={active}
-                    onClick={() => handleModeChange(value)}
-                    type="button"
-                    disabled={Boolean(macBlock)}
-                    title={macBlock ? macBlock.text : undefined}
-                  >
-                    {value === "text_to_image" ? <Icon.Sparkle size={13} /> : null}
-                    {label}
-                  </button>
-                );
-              })}
-            </div>
+              ]}
+              mode={mode}
+              onChange={handleModeChange}
+              blockFor={(value) => macModeTabBlock(value)}
+              leadingIcon={(value) => value === "text_to_image" ? <Icon.Sparkle size={13} /> : null}
+            />
             <button
               aria-pressed={batchMode}
               className={batchMode ? "batch-toggle active" : "batch-toggle"}
@@ -3224,53 +3176,19 @@ export function ImageStudio() {
                 composes the prompt (free-text) or merges into the caption (Ideogram, sc-13224); "None"
                 resets to pass-through. Hidden for booru-tag models, whose convention the catalog's prose
                 entries do not fit. NB: distinct from Krea's numeric "text style" (textStyleGain). */}
-            <div className="settings-bar-styles settings-bar-style-axis">
-              {styleAxisAvailable ? (
-                <div className="style-axis-field style-axis-catalog">
-                  <span className="settings-bar-label">Style</span>
-                  <StylePicker groups={STYLE_GROUPS} selectedId={styleId} onSelect={setStyleId} label="Style" />
-                </div>
-              ) : null}
-              <div className="style-axis-field style-axis-presets">
-                <span className="settings-bar-label">Style preset</span>
-                <div className="preset-chips">
-                  <button
-                    className={!selectedPreset ? "preset-chip active" : "preset-chip"}
-                    onClick={() => setSelectedPresetId(noPresetId)}
-                    type="button"
-                  >
-                    None
-                  </button>
-                  {availablePresets.map((preset) => (
-                    <button
-                      className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"}
-                      key={preset.id}
-                      onClick={() => setSelectedPresetId(preset.id)}
-                      type="button"
-                    >
-                      {preset.name ?? preset.id}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-            {availableGeneralPresets.length ? (
-              <div className="settings-bar-styles">
-                <span className="settings-bar-label">General</span>
-                <div className="preset-chips general-preset-chips">
-                  {availableGeneralPresets.map((preset) => (
-                    <button
-                      className={generalStackIds.includes(preset.id) ? "preset-chip active" : "preset-chip"}
-                      key={preset.id}
-                      onClick={() => toggleGeneralPreset(preset.id)}
-                      type="button"
-                    >
-                      {preset.name ?? preset.id}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            ) : null}
+            <StyleAxisRow
+              available={styleAxisAvailable}
+              groups={STYLE_GROUPS}
+              styleId={styleId}
+              onStyleChange={setStyleId}
+              selectedPreset={selectedPreset}
+              presets={availablePresets}
+              onPresetChange={setSelectedPresetId}
+              generalPresets={availableGeneralPresets}
+              generalStackIds={generalStackIds}
+              onToggleGeneral={toggleGeneralPreset}
+              noPresetValue={noPresetId}
+            />
           </div>
 
           {/* sc-13131: the EXACT composed prompt (Subject:/Style:, preserved sibling directives,
@@ -3459,31 +3377,21 @@ export function ImageStudio() {
                 </label>
               ) : null}
               {showTierPicker ? (
-                <label className="quant-tier-picker" title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation. Tiers you haven't downloaded are shown but disabled — install them from the Models page to enable.">
-                  Quant tier
-                  <select
-                    onChange={(event) => handleTierChange(event.target.value)}
-                    value={quantTier}
-                  >
-                    {tierPickerItems.map((item) => (
-                      <option key={item.tier} value={item.tier} disabled={item.disabled}>
-                        {item.label}
-                      </option>
-                    ))}
-                  </select>
-                  {tierSwitching ? (
-                    <span className="field-hint" role="status">
-                      Loading {tierLabel(tierSwitching)}…
-                    </span>
-                  ) : null}
-                  {tierBelowFloor ? (
+                <TierPickerField
+                  value={quantTier}
+                  onChange={handleTierChange}
+                  items={tierPickerItems}
+                  tierSwitching={tierSwitching}
+                  tierLabel={tierLabel}
+                  title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation. Tiers you haven't downloaded are shown but disabled — install them from the Models page to enable."
+                  warning={tierBelowFloor ? (
                     <span className="field-hint quant-tier-floor-note">
                       {tierLabel(quantTier)} is below the {tierLabel(qualityFloor)} recommended for{" "}
                       {selectedModel?.name ?? "this model"} — it can look washed or lose fine detail
                       here (quantization error is amplified under CFG). Your pick is honored.
                     </span>
                   ) : null}
-                </label>
+                />
               ) : null}
               {precisionToggle && !showTierPicker ? (
                 <label

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -12,7 +12,6 @@ import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
 import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
 import { StudioUpdateBadge, StudioUpdateNotice, updateOptionLabel } from "../components/StudioUpdateNotice.jsx";
 import { VideoUpscalePanel } from "./VideoUpscalePanel.jsx";
-import { StylePicker } from "../components/StylePicker.jsx";
 import { StyledPromptPreview } from "../components/StyledPromptPreview.jsx";
 import { STYLE_GROUPS, styleTextForId } from "../data/styleCatalog.js";
 import { composeStyledPrompt } from "../styleComposer.js";
@@ -51,7 +50,11 @@ import {
   PresetGuidanceStrip,
   PresetStackPreview,
   SavePresetPanel,
+  ModeTabs,
+  StyleAxisRow,
+  TierPickerField,
   useGenerationStudio,
+  useQuantTierPicker,
   useSavePreset,
 } from "./generationStudio.jsx";
 import { ReplacePersonPanel } from "./ReplacePersonPanel.jsx";
@@ -72,7 +75,6 @@ import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioS
 import { qualityChoices } from "../jobTypes.js";
 import {
   allPossibleTiers,
-  defaultTierSelection,
   installedTiers,
   quantizeTier,
   tierLabel,
@@ -84,7 +86,6 @@ import {
   recipeLoraSelection,
   recipeRequestedResolution,
 } from "../recipeFields.js";
-import { readLastTier, writeLastTier } from "../lastTierStore.js";
 import {
   SAMPLER_LABELS,
   SCHEDULER_LABELS,
@@ -192,8 +193,6 @@ export function VideoStudio() {
   const [quantization, setQuantization] = useState(saved.quantization ?? "auto");
   // MLX generation tier (sc-12165), separate from the torch/GGUF `quantization` state above.
   // The explicit pick is persisted per (video, model), outside the workspace settings snapshot.
-  const [quantTier, setQuantTier] = useState("");
-  const [tierSwitching, setTierSwitching] = useState("");
   // The model a replayed recipe asked for, when it isn't installed (sc-12324). Its settings still
   // restore; the mode-snap effect moves the picker to a model that serves the mode. Named rather
   // than silent so the swap doesn't read as the recipe's own choice.
@@ -432,57 +431,26 @@ export function VideoStudio() {
     () => mlxTierLane && possibleTiers.length > 1 && availableTiers.length > 0,
     [mlxTierLane, possibleTiers, availableTiers],
   );
+  // Seed from the per-(video, model) sticky, then the video-specific q4 base, clamped to installed.
+  // A model transition always re-seeds even when both models happen to expose the same tier list.
+  const {
+    quantTier,
+    setQuantTier,
+    tierSwitching,
+    handleTierChange,
+    skipNextReseed,
+  } = useQuantTierPicker({
+    screen: TIER_SCREEN,
+    model,
+    selectedModel,
+    availableTiers,
+    tierOptions,
+    reseedOnModelChange: true,
+  });
   const showTorchQuantization = !mlxTierLane && supportsQuantization;
   const selectedMlxQuantize =
     mlxTierLane && availableTiers.includes(quantTier) ? tierQuantize(quantTier) : null;
   const tierHasMemoryRisk = showTierPicker && ["q8", "bf16"].includes(quantTier);
-
-  // Seed from the per-(video, model) sticky, then the video-specific q4 base, clamped to installed.
-  // A model transition always re-seeds even when both models happen to expose the same tier list.
-  const availableTiersKey = availableTiers.join(",");
-  const quantTierModelRef = useRef(null);
-  // sc-12324: a recipe replay pins the tier its clip was generated at and usually sets the model
-  // too, which would otherwise re-seed the tier back to the default below. The tier is an
-  // aesthetic choice, so re-seeding would silently replay a different look. Armed only when the
-  // recipe actually changes the model — the one case where this effect is guaranteed to fire —
-  // so the one-shot is always consumed on the next commit and can never go stale.
-  const skipQuantTierReseed = useRef(false);
-  useEffect(() => {
-    const modelChanged = quantTierModelRef.current !== model;
-    quantTierModelRef.current = model;
-    if (skipQuantTierReseed.current) {
-      skipQuantTierReseed.current = false;
-      // Honor the recipe's tier only while the new model can actually serve it; otherwise fall
-      // through and re-seed rather than pinning a tier that isn't installed.
-      if (availableTiers.includes(quantTier)) {
-        return;
-      }
-    }
-    if (!modelChanged && availableTiers.includes(quantTier)) {
-      return;
-    }
-    setQuantTier(
-      defaultTierSelection(selectedModel, readLastTier(TIER_SCREEN, model), tierOptions) ?? "",
-    );
-    // `availableTiersKey` is the stable install-state dependency; the remaining values are read from
-    // the render that produced it, matching Image Studio's catalog-refresh seed behavior.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [model, availableTiersKey]);
-
-  const tierSwitchTimer = useRef(null);
-  useEffect(() => () => clearTimeout(tierSwitchTimer.current), []);
-  const handleTierChange = (nextTier) => {
-    // Only an installed-and-complete tier can be selected; the disabled options are shown for
-    // discoverability, never as a pickable target (belt behind the native `<option disabled>`).
-    if (nextTier === quantTier || !availableTiers.includes(nextTier)) {
-      return;
-    }
-    setQuantTier(nextTier);
-    writeLastTier(TIER_SCREEN, model, nextTier);
-    setTierSwitching(nextTier);
-    clearTimeout(tierSwitchTimer.current);
-    tierSwitchTimer.current = setTimeout(() => setTierSwitching(""), 1500);
-  };
   const samplerOptions = useMemo(
     () => samplerOptionsFromModel(selectedModel, activeBackend),
     [selectedModel, activeBackend],
@@ -780,7 +748,7 @@ export function VideoStudio() {
     const recipeTier = quantizeTier(rawSettings.mlxQuantize);
     if (recipeTier) {
       if (recipe.model && recipeModelAvailable && recipe.model !== model) {
-        skipQuantTierReseed.current = true;
+        skipNextReseed();
       }
       setQuantTier(recipeTier);
     }
@@ -1297,28 +1265,16 @@ export function VideoStudio() {
       <form className="studio-shell" onSubmit={submit}>
         <WorkPanel className="studio-work-panel">
           <div className="prompt-hero-top">
-            <div className="mode-tabs mode-control" role="tablist" aria-label="Video mode">
-              {modeOptions.map(([value, label]) => {
-                // Disabled only when no available model serves this mode on Mac — and never the
-                // active tab, so the user can always switch away (sc-5716).
-                const blocked = value !== mode && macModeTabBlocked(value);
-                const active = mode === value;
-                return (
-                  <button
-                    className={active ? "mode-tab active" : "mode-tab"}
-                    key={value}
-                    role="tab"
-                    aria-selected={active}
-                    onClick={() => setMode(value)}
-                    type="button"
-                    disabled={blocked}
-                    title={blocked ? "No installed model supports this mode on macOS." : undefined}
-                  >
-                    {label}
-                  </button>
-                );
-              })}
-            </div>
+            <ModeTabs
+              className="mode-tabs mode-control"
+              label="Video mode"
+              options={modeOptions}
+              mode={mode}
+              onChange={setMode}
+              blockFor={(value, active) => !active && macModeTabBlocked(value)
+                ? { text: "No installed model supports this mode on macOS." }
+                : null}
+            />
             <div className="prompt-hero-links">
               <button className="hero-link" onClick={() => setGuideOpen(true)} type="button">
                 <Icon.Book size={14} /> Prompt guide
@@ -1619,53 +1575,19 @@ export function VideoStudio() {
                 image-conditioned models and for booru-tag models), followed by the model's Style
                 presets — mirrors the Image Studio. The catalog wraps the outgoing prompt
                 (Subject:/Style:); "None" resets. */}
-            <div className="settings-bar-styles settings-bar-style-axis">
-              {styleAxisAvailable ? (
-                <div className="style-axis-field style-axis-catalog">
-                  <span className="settings-bar-label">Style</span>
-                  <StylePicker groups={STYLE_GROUPS} selectedId={styleId} onSelect={setStyleId} label="Style" />
-                </div>
-              ) : null}
-              <div className="style-axis-field style-axis-presets">
-                <span className="settings-bar-label">Style preset</span>
-                <div className="preset-chips">
-                  <button
-                    className={!selectedPreset ? "preset-chip active" : "preset-chip"}
-                    onClick={() => setSelectedPresetId(noPresetId)}
-                    type="button"
-                  >
-                    None
-                  </button>
-                  {availablePresets.map((preset) => (
-                    <button
-                      className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"}
-                      key={preset.id}
-                      onClick={() => setSelectedPresetId(preset.id)}
-                      type="button"
-                    >
-                      {preset.name ?? preset.id}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-            {availableGeneralPresets.length ? (
-              <div className="settings-bar-styles">
-                <span className="settings-bar-label">General</span>
-                <div className="preset-chips general-preset-chips">
-                  {availableGeneralPresets.map((preset) => (
-                    <button
-                      className={generalStackIds.includes(preset.id) ? "preset-chip active" : "preset-chip"}
-                      key={preset.id}
-                      onClick={() => toggleGeneralPreset(preset.id)}
-                      type="button"
-                    >
-                      {preset.name ?? preset.id}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            ) : null}
+            <StyleAxisRow
+              available={styleAxisAvailable}
+              groups={STYLE_GROUPS}
+              styleId={styleId}
+              onStyleChange={setStyleId}
+              selectedPreset={selectedPreset}
+              presets={availablePresets}
+              onPresetChange={setSelectedPresetId}
+              generalPresets={availableGeneralPresets}
+              generalStackIds={generalStackIds}
+              onToggleGeneral={toggleGeneralPreset}
+              noPresetValue={noPresetId}
+            />
           </div>
 
           {/* sc-13136: the EXACT composed prompt the run will send once a style is active — recomputed
@@ -1818,30 +1740,20 @@ export function VideoStudio() {
                 </>
               ) : null}
               {showTierPicker ? (
-                <label
-                  className="quant-tier-picker"
+                <TierPickerField
+                  value={quantTier}
+                  onChange={handleTierChange}
+                  items={tierPickerItems}
+                  tierSwitching={tierSwitching}
+                  tierLabel={tierLabel}
                   title="Switch which installed MLX quant tier generates. Higher precision uses more memory; switching a heavy tier reloads it before the next generation."
-                >
-                  Quant tier
-                  <select onChange={(event) => handleTierChange(event.target.value)} value={quantTier}>
-                    {tierPickerItems.map((item) => (
-                      <option key={item.tier} value={item.tier} disabled={item.disabled}>
-                        {item.label}
-                      </option>
-                    ))}
-                  </select>
-                  {tierSwitching ? (
-                    <span className="field-hint" role="status">
-                      Loading {tierLabel(tierSwitching)}…
-                    </span>
-                  ) : null}
-                  {tierHasMemoryRisk ? (
+                  warning={tierHasMemoryRisk ? (
                     <span className="field-hint quant-tier-memory-note">
                       Higher MLX video tiers may run out of memory on long or high-resolution clips.
                       Your pick is honored.
                     </span>
                   ) : null}
-                </label>
+                />
               ) : null}
               {showTorchQuantization ? (
                 <label>

--- a/apps/web/src/screens/generationStudio.jsx
+++ b/apps/web/src/screens/generationStudio.jsx
@@ -27,8 +27,160 @@ import {
 import { savePresetDialogValidation } from "../generationValidation.js";
 import { useValidation } from "../validation/useValidation.js";
 import { ValidationSummary } from "../validation/Validation.jsx";
+import { StylePicker } from "../components/StylePicker.jsx";
+import { defaultTierSelection } from "../quantTier.js";
+import { readLastTier, writeLastTier } from "../lastTierStore.js";
+import { readDefaultGenerationQuality } from "../generationQuality.js";
 
 const completedResultFallbackMs = 30000;
+
+export function useQuantTierPicker({
+  screen,
+  model,
+  selectedModel,
+  availableTiers,
+  tierOptions,
+  autoTier = null,
+  useGenerationQuality = false,
+  reseedOnModelChange = false,
+}) {
+  const [quantTier, setQuantTier] = useState("");
+  const [tierSwitching, setTierSwitching] = useState("");
+  const modelRef = useRef(null);
+  const skipReseedRef = useRef(false);
+  const availableTiersKey = availableTiers.join(",");
+
+  useEffect(() => {
+    const modelChanged = modelRef.current !== model;
+    modelRef.current = model;
+    if (skipReseedRef.current) {
+      skipReseedRef.current = false;
+      if (availableTiers.includes(quantTier)) return;
+    }
+    if ((!reseedOnModelChange || !modelChanged) && availableTiers.includes(quantTier)) return;
+    setQuantTier(
+      defaultTierSelection(selectedModel, readLastTier(screen, model), {
+        ...tierOptions,
+        ...(useGenerationQuality
+          ? { defaultQuality: readDefaultGenerationQuality(), autoTier }
+          : {}),
+      }) ?? "",
+    );
+    // Install-state is intentionally represented by the stable key; the other values belong
+    // to the render which produced it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model, availableTiersKey, autoTier]);
+
+  const timerRef = useRef(null);
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+  const handleTierChange = useCallback(
+    (nextTier) => {
+      if (nextTier === quantTier || !availableTiers.includes(nextTier)) return;
+      setQuantTier(nextTier);
+      writeLastTier(screen, model, nextTier);
+      setTierSwitching(nextTier);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setTierSwitching(""), 1500);
+    },
+    [availableTiers, model, quantTier, screen],
+  );
+
+  return {
+    quantTier,
+    setQuantTier,
+    tierSwitching,
+    handleTierChange,
+    skipNextReseed: () => {
+      skipReseedRef.current = true;
+    },
+  };
+}
+
+export function TierPickerField({ value, onChange, items, tierSwitching, tierLabel, title, warning }) {
+  return (
+    <label className="quant-tier-picker" title={title}>
+      Quant tier
+      <select onChange={(event) => onChange(event.target.value)} value={value}>
+        {items.map((item) => (
+          <option key={item.tier} value={item.tier} disabled={item.disabled}>
+            {item.label}
+          </option>
+        ))}
+      </select>
+      {tierSwitching ? (
+        <span className="field-hint" role="status">Loading {tierLabel(tierSwitching)}…</span>
+      ) : null}
+      {warning}
+    </label>
+  );
+}
+
+export function StyleAxisRow({
+  available,
+  groups,
+  styleId,
+  onStyleChange,
+  selectedPreset,
+  presets,
+  onPresetChange,
+  generalPresets,
+  generalStackIds,
+  onToggleGeneral,
+  noPresetValue,
+}) {
+  return (
+    <>
+      <div className="settings-bar-styles settings-bar-style-axis">
+        {available ? (
+          <div className="style-axis-field style-axis-catalog">
+            <span className="settings-bar-label">Style</span>
+            <StylePicker groups={groups} selectedId={styleId} onSelect={onStyleChange} label="Style" />
+          </div>
+        ) : null}
+        <div className="style-axis-field style-axis-presets">
+          <span className="settings-bar-label">Style preset</span>
+          <div className="preset-chips">
+            <button className={!selectedPreset ? "preset-chip active" : "preset-chip"} onClick={() => onPresetChange(noPresetValue)} type="button">None</button>
+            {presets.map((preset) => (
+              <button className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"} key={preset.id} onClick={() => onPresetChange(preset.id)} type="button">
+                {preset.name ?? preset.id}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      {generalPresets.length ? (
+        <div className="settings-bar-styles">
+          <span className="settings-bar-label">General</span>
+          <div className="preset-chips general-preset-chips">
+            {generalPresets.map((preset) => (
+              <button className={generalStackIds.includes(preset.id) ? "preset-chip active" : "preset-chip"} key={preset.id} onClick={() => onToggleGeneral(preset.id)} type="button">
+                {preset.name ?? preset.id}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+export function ModeTabs({ label, className = "mode-tabs", options, mode, onChange, blockFor, leadingIcon }) {
+  return (
+    <div className={className} role="tablist" aria-label={label}>
+      {options.map(([value, text]) => {
+        const active = mode === value;
+        const block = blockFor?.(value, active) ?? null;
+        return (
+          <button className={active ? "mode-tab active" : "mode-tab"} key={value} role="tab" aria-selected={active} onClick={() => onChange(value)} type="button" disabled={Boolean(block)} title={block?.text}>
+            {leadingIcon?.(value)}
+            {text}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 // Cmd/Ctrl+Enter submits the studio form from the prompt textarea.
 export function onPromptKeyDown(event) {

--- a/apps/web/src/screens/generationStudio.shared.test.jsx
+++ b/apps/web/src/screens/generationStudio.shared.test.jsx
@@ -1,0 +1,201 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mountRoot, unmountRoot } from "../testUtils/dom.js";
+import { ModeTabs, StyleAxisRow, TierPickerField, useQuantTierPicker } from "./generationStudio.jsx";
+import { readLastTier, writeLastTier } from "../lastTierStore.js";
+
+vi.mock("../lastTierStore.js", () => ({
+  readLastTier: vi.fn(() => null),
+  writeLastTier: vi.fn(),
+}));
+vi.mock("../generationQuality.js", () => ({
+  readDefaultGenerationQuality: vi.fn(() => "auto"),
+}));
+
+function modelWithTiers(id, installed = ["q4", "q8", "bf16"]) {
+  return {
+    id,
+    hasVariantMatrix: true,
+    variants: ["q4", "q8", "bf16"].map((variant) => ({
+      variant,
+      installState: installed.includes(variant) ? "installed" : "missing",
+    })),
+  };
+}
+
+function TierHarness({
+  model = "one",
+  availableTiers = ["q4", "q8"],
+  screen = "video",
+  reseedOnModelChange = false,
+  useGenerationQuality = false,
+  autoTier = null,
+}) {
+  const state = useQuantTierPicker({
+    screen,
+    model,
+    selectedModel: modelWithTiers(model, availableTiers),
+    availableTiers,
+    tierOptions: { defaultQuality: "q4" },
+    reseedOnModelChange,
+    useGenerationQuality,
+    autoTier,
+  });
+  return (
+    <div>
+      <output>{state.quantTier}|{state.tierSwitching}</output>
+      <button data-action="q8" onClick={() => state.handleTierChange("q8")}>q8</button>
+      <button data-action="invalid" onClick={() => state.handleTierChange("bf16")}>invalid</button>
+      <button
+        data-action="recipe-q8"
+        onClick={() => {
+          state.skipNextReseed();
+          state.setQuantTier("q8");
+        }}
+      >
+        recipe q8
+      </button>
+      <button
+        data-action="recipe-bf16"
+        onClick={() => {
+          state.skipNextReseed();
+          state.setQuantTier("bf16");
+        }}
+      >
+        recipe bf16
+      </button>
+    </div>
+  );
+}
+
+describe("shared generation-studio controls", () => {
+  let container;
+  let root;
+  beforeEach(() => {
+    vi.mocked(readLastTier).mockReset();
+    vi.mocked(readLastTier).mockReturnValue(null);
+    vi.mocked(writeLastTier).mockReset();
+    ({ container, root } = mountRoot());
+  });
+  afterEach(async () => {
+    vi.useRealTimers();
+    await unmountRoot(root, container);
+  });
+
+  it("keeps the tier switch hint for 1500ms and then clears it", async () => {
+    vi.useFakeTimers();
+    await act(async () => root.render(<TierHarness />));
+    await act(async () => container.querySelector('[data-action="q8"]').click());
+    expect(container.querySelector("output").textContent).toBe("q8|q8");
+    await act(async () => vi.advanceTimersByTime(1500));
+    expect(container.querySelector("output").textContent).toBe("q8|");
+  });
+
+  it("re-seeds Video A→B from B's sticky even when the installed tier list is identical", async () => {
+    vi.mocked(readLastTier).mockImplementation((_, model) => model === "B" ? "q8" : null);
+    await act(async () => root.render(<TierHarness model="A" reseedOnModelChange />));
+    expect(container.querySelector("output").textContent).toBe("q4|");
+    await act(async () => root.render(<TierHarness model="B" reseedOnModelChange />));
+    expect(container.querySelector("output").textContent).toBe("q8|");
+  });
+
+  it("preserves an installed recipe tier exactly once, then re-seeds the next model change", async () => {
+    vi.mocked(readLastTier).mockImplementation((_, model) => model === "C" ? "q4" : null);
+    await act(async () => root.render(<TierHarness model="A" reseedOnModelChange />));
+    await act(async () => container.querySelector('[data-action="recipe-q8"]').click());
+    await act(async () => root.render(<TierHarness model="B" reseedOnModelChange />));
+    expect(container.querySelector("output").textContent).toBe("q8|");
+    await act(async () => root.render(<TierHarness model="C" reseedOnModelChange />));
+    expect(container.querySelector("output").textContent).toBe("q4|");
+  });
+
+  it("falls through to the new model default when a recipe tier is unavailable", async () => {
+    await act(async () => root.render(<TierHarness model="A" reseedOnModelChange />));
+    await act(async () => container.querySelector('[data-action="recipe-bf16"]').click());
+    await act(async () => root.render(
+      <TierHarness model="B" availableTiers={["q4", "q8"]} reseedOnModelChange />,
+    ));
+    expect(container.querySelector("output").textContent).toBe("q4|");
+  });
+
+  it("keeps Image Auto capability-aware while Video retains its q4 base", async () => {
+    await act(async () => root.render(
+      <TierHarness
+        model="image"
+        availableTiers={["q4", "q8", "bf16"]}
+        screen="image"
+        useGenerationQuality
+        autoTier="bf16"
+      />,
+    ));
+    expect(container.querySelector("output").textContent).toBe("bf16|");
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    await act(async () => root.render(
+      <TierHarness model="video" availableTiers={["q4", "q8", "bf16"]} screen="video" />,
+    ));
+    expect(container.querySelector("output").textContent).toBe("q4|");
+  });
+
+  it("persists only valid manual selections and rejects unavailable tiers", async () => {
+    await act(async () => root.render(<TierHarness model="one" />));
+    await act(async () => container.querySelector('[data-action="invalid"]').click());
+    expect(container.querySelector("output").textContent).toBe("q4|");
+    expect(writeLastTier).not.toHaveBeenCalled();
+    await act(async () => container.querySelector('[data-action="q8"]').click());
+    expect(writeLastTier).toHaveBeenCalledWith("video", "one", "q8");
+  });
+
+  it("preserves disabled and active mode-tab semantics", async () => {
+    await act(async () => root.render(
+      <ModeTabs
+        label="Modes"
+        options={[["text", "Text"], ["edit", "Edit"]]}
+        mode="text"
+        onChange={() => {}}
+        blockFor={(_, active) => active ? null : { text: "Unavailable" }}
+      />,
+    ));
+    const [text, edit] = container.querySelectorAll('[role="tab"]');
+    expect(text.getAttribute("aria-selected")).toBe("true");
+    expect(edit.disabled).toBe(true);
+    expect(edit.title).toBe("Unavailable");
+  });
+
+  it("renders shared tier warnings and style/general preset chips", async () => {
+    await act(async () => root.render(
+      <TierPickerField
+        value="q8"
+        onChange={() => {}}
+        items={[{ tier: "q8", label: "Q8", disabled: false }]}
+        tierSwitching=""
+        tierLabel={(value) => value}
+        warning={<span>Memory warning</span>}
+      />,
+    ));
+    expect(container.textContent).toContain("Memory warning");
+    const onPresetChange = vi.fn();
+    const onToggleGeneral = vi.fn();
+    await act(async () => root.render(
+      <StyleAxisRow
+        available={false}
+        groups={[]}
+        styleId={null}
+        onStyleChange={() => {}}
+        selectedPreset={null}
+        presets={[{ id: "film", name: "Film" }]}
+        onPresetChange={onPresetChange}
+        generalPresets={[{ id: "sharp", name: "Sharp" }]}
+        generalStackIds={["sharp"]}
+        onToggleGeneral={onToggleGeneral}
+        noPresetValue="none"
+      />,
+    ));
+    const buttons = [...container.querySelectorAll("button")];
+    await act(async () => buttons.find((button) => button.textContent === "Film").click());
+    await act(async () => buttons.find((button) => button.textContent === "Sharp").click());
+    expect(onPresetChange).toHaveBeenCalledWith("film");
+    expect(onToggleGeneral).toHaveBeenCalledWith("sharp");
+    expect(buttons.find((button) => button.textContent === "Sharp").classList.contains("active")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extract shared useQuantTierPicker logic from Image and Video studios
- share TierPickerField, StyleAxisRow, and mode-tab rendering
- preserve Image auto/default-quality and Video q4/model-change/recipe-reseed differences
- cover sticky/clamp/timer/manual persistence and one-shot replay behavior

## Validation
- full web suite: 2341 tests
- focused review suites: 133 tests
- post-rebase shared hook suite: 8 tests
- ESLint: zero errors
- Vite production build
- git diff --check

Independent adversarial review: PASS (confidence 0.98).

Shortcut: sc-13630