### PR TITLE
Harden authenticated and concurrent downloads (sc-13616)

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -84,21 +84,8 @@ fn download_stall_timeout() -> Option<Duration> {
     (seconds > 0).then(|| Duration::from_secs(seconds))
 }
 
-// The cross-process download lock (F-098 / sc-8900) is only reachable from
-// `ensure_cached_file_verified`, which is gated to the macOS MLX runtime and the
-// off-Mac candle InstantID lane; gate the whole apparatus the same way so the bare
-// (non-macOS, non-candle) lib build — which still compiles `download_source_url` —
-// doesn't drag in an unused `fs2` import or dead lock helpers.
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
 use download_lock::DownloadLock;
 
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
 mod download_lock {
     use super::{task_join_error, WorkerError, WorkerResult};
     use fs2::FileExt as _;
@@ -586,6 +573,55 @@ pub(crate) struct DownloadContext<'a> {
 
 const AUTO_RESUME_ATTEMPTS: usize = 1;
 
+struct DownloadResumeState {
+    network_attempts_remaining: usize,
+    stall_timeout: Option<Duration>,
+    stall_resumes_without_progress: u32,
+    last_stall_bytes: u64,
+}
+
+impl DownloadResumeState {
+    fn new(allow_network_resume: bool) -> Self {
+        Self {
+            network_attempts_remaining: usize::from(allow_network_resume) * AUTO_RESUME_ATTEMPTS,
+            stall_timeout: download_stall_timeout(),
+            stall_resumes_without_progress: 0,
+            last_stall_bytes: 0,
+        }
+    }
+
+    fn take_network_resume(&mut self) -> bool {
+        if self.network_attempts_remaining == 0 {
+            false
+        } else {
+            self.network_attempts_remaining -= 1;
+            true
+        }
+    }
+
+    fn record_stall(&mut self, label: &str, on_disk: u64) -> WorkerResult<()> {
+        if on_disk > self.last_stall_bytes {
+            self.stall_resumes_without_progress = 0;
+        } else {
+            self.stall_resumes_without_progress += 1;
+        }
+        self.last_stall_bytes = on_disk;
+        if self.stall_resumes_without_progress >= MAX_STALL_RESUMES_WITHOUT_PROGRESS {
+            let timeout_secs = self.stall_timeout.map_or(0, |timeout| timeout.as_secs());
+            return Err(WorkerError::Io(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "{label} download stalled: no forward progress for \
+                     {MAX_STALL_RESUMES_WITHOUT_PROGRESS} consecutive {timeout_secs}s windows \
+                     (stuck at {}). The source appears hung; try again.",
+                    format_bytes_with_exact(on_disk),
+                ),
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// Download a single file to `dest` (resumable via HTTP Range), rejecting a truncated
 /// response (size mismatch) and, when `expected_sha256` is provided, a corrupt one
 /// (content-digest mismatch). On a digest mismatch the file is removed so a corrupt
@@ -698,19 +734,12 @@ async fn download_file_inner(
             progress.discard_started_bytes(removed_bytes);
         }
     }
-    let mut resume_attempts_remaining = if context.fresh_download {
-        0
-    } else {
-        AUTO_RESUME_ATTEMPTS
-    };
+    let mut resume = DownloadResumeState::new(!context.fresh_download);
     // Forward-progress watchdog (independent of the network-error resume budget above):
     // a hung-but-alive stream is abort-and-resumed as often as it keeps advancing, and
     // only a source wedged at the same offset for MAX_STALL_RESUMES_WITHOUT_PROGRESS
     // consecutive windows gives up. `last_stall_bytes` starts at 0 so the FIRST stall
     // never counts as no-progress (any partial file already beats it).
-    let stall_timeout = download_stall_timeout();
-    let mut stall_resumes_without_progress = 0_u32;
-    let mut last_stall_bytes = 0_u64;
     loop {
         let existing_bytes = existing_download_bytes(dest, expected_size).await?;
         if expected_size.is_some_and(|size| existing_bytes == size) {
@@ -736,7 +765,7 @@ async fn download_file_inner(
         }
         let appending = existing_bytes > 0 && status == StatusCode::PARTIAL_CONTENT;
         if existing_bytes > 0 && !appending {
-            progress.discard_started_bytes(existing_bytes);
+            progress.reset_to_on_disk(0);
         }
         let mut response = response;
         let mut output = if appending {
@@ -777,7 +806,7 @@ async fn download_file_inner(
                     report_download_progress(context, progress).await?;
                     // A live-but-hung stream (bytes trickling in under HTTP_READ_TIMEOUT
                     // yet never advancing) is caught here and abort-and-resumed below.
-                    if stall_timeout
+                    if resume.stall_timeout
                         .is_some_and(|timeout| progress.is_stalled(timeout, DOWNLOAD_STALL_MIN_PROGRESS))
                     {
                         stalled = true;
@@ -792,24 +821,7 @@ async fn download_file_inner(
             // advances the on-disk count, keep going; only a source stuck at the same
             // offset for consecutive windows is fatal.
             let on_disk = existing_download_bytes(dest, expected_size).await?;
-            if on_disk > last_stall_bytes {
-                stall_resumes_without_progress = 0;
-            } else {
-                stall_resumes_without_progress += 1;
-            }
-            last_stall_bytes = on_disk;
-            if stall_resumes_without_progress >= MAX_STALL_RESUMES_WITHOUT_PROGRESS {
-                let timeout_secs = stall_timeout.map_or(0, |timeout| timeout.as_secs());
-                return Err(WorkerError::Io(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    format!(
-                        "{label} download stalled: no forward progress for \
-                         {MAX_STALL_RESUMES_WITHOUT_PROGRESS} consecutive {timeout_secs}s windows \
-                         (stuck at {}). The source appears hung; try again.",
-                        format_bytes_with_exact(on_disk),
-                    ),
-                )));
-            }
+            resume.record_stall(label, on_disk)?;
             continue;
         }
         if let Some(error) = transfer_error {
@@ -818,8 +830,7 @@ async fn download_file_inner(
                 if written == expected {
                     return Ok(());
                 }
-                if written < expected && resume_attempts_remaining > 0 {
-                    resume_attempts_remaining -= 1;
+                if written < expected && resume.take_network_resume() {
                     continue;
                 }
             }
@@ -835,8 +846,7 @@ async fn download_file_inner(
             if written == expected {
                 return Ok(());
             }
-            if written < expected && resume_attempts_remaining > 0 {
-                resume_attempts_remaining -= 1;
+            if written < expected && resume.take_network_resume() {
                 continue;
             }
             if written > expected {
@@ -900,6 +910,7 @@ pub(crate) async fn download_snapshot(
         if let Some(parent) = target_path.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
+        let _lock = DownloadLock::acquire_async(&target_path).await?;
         download_file(
             context,
             &file.download_url,
@@ -955,10 +966,12 @@ pub(crate) async fn download_snapshot_into_cache(
             .map(|value| normalize_etag(&value))
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| blob_fallback_name(&file.path));
+        let blob_path = blobs_dir.join(&etag);
+        let _lock = DownloadLock::acquire_async(&blob_path).await?;
         download_file(
             context,
             &file.download_url,
-            &blobs_dir.join(&etag),
+            &blob_path,
             file.size,
             // The blob is named by its etag (= the LFS sha256), and the tree API
             // reports the same digest as `lfs.oid`; verify the content against it.
@@ -1159,108 +1172,169 @@ pub(crate) async fn download_source_url(
     };
 
     let client = source_url_client_for_request(context.settings, &request_url).await?;
-    let total_bytes = lora_source_content_length(&client, &request_url, bearer).await?;
+    let total_bytes = lora_source_content_length(&client, &request_url, bearer)
+        .await
+        .map_err(|error| redact_source_url_error("sourceUrl HEAD failed", error))?;
     if total_bytes.is_some_and(|total| total > max_bytes) {
         return Err(WorkerError::InvalidPayload(format!(
             "{source_label} sourceUrl exceeds the {} limit",
             format_bytes(max_bytes)
         )));
     }
-    let existing_bytes = existing_download_bytes(&target_path, total_bytes).await?;
-    if total_bytes.is_some_and(|total| total > 0 && existing_bytes == total) {
+    let started_bytes = existing_download_bytes(&target_path, total_bytes).await?;
+    if total_bytes.is_some_and(|total| total > 0 && started_bytes == total) {
         return Ok(());
-    }
-    let range_header = (existing_bytes > 0).then(|| format!("bytes={existing_bytes}-"));
-    let mut response = send_source_url_with_redirects(
-        context.settings,
-        &request_url,
-        &client,
-        bearer,
-        range_header.as_deref(),
-    )
-    .await?;
-    if response.status() == StatusCode::RANGE_NOT_SATISFIABLE {
-        let range_total = response
-            .headers()
-            .get(header::CONTENT_RANGE)
-            .and_then(|value| value.to_str().ok())
-            .and_then(content_range_total);
-        if total_bytes
-            .or(range_total)
-            .is_some_and(|total| total > 0 && existing_bytes == total)
-        {
-            return Ok(());
-        }
-    }
-    response = response.error_for_status()?;
-    let appending = existing_bytes > 0 && response.status() == StatusCode::PARTIAL_CONTENT;
-    let expected_bytes = total_bytes.or_else(|| {
-        response.content_length().map(|remaining| {
-            if appending {
-                existing_bytes + remaining
-            } else {
-                remaining
-            }
-        })
-    });
-    if expected_bytes.is_some_and(|total| total > max_bytes) {
-        return Err(WorkerError::InvalidPayload(format!(
-            "{source_label} sourceUrl exceeds the {} limit",
-            format_bytes(max_bytes)
-        )));
     }
     let mut progress = DownloadProgress::new(
         source_url,
-        if appending { existing_bytes } else { 0 },
-        expected_bytes,
+        started_bytes,
+        total_bytes,
         progress_report_interval(context.settings),
     );
-    let mut output = if appending {
-        tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&target_path)
-            .await?
-    } else {
-        tokio::fs::File::create(&target_path).await?
-    };
-    let mut interval = tokio::time::interval(progress.report_interval());
-    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    interval.tick().await;
+    let mut resume = DownloadResumeState::new(!context.fresh_download);
     loop {
-        tokio::select! {
-            chunk = response.chunk() => {
-                let Some(chunk) = chunk? else {
-                    break;
-                };
-                // No per-chunk cancel poll here (sc-8806): a GET per received HTTP
-                // chunk turned a multi-GB download into tens of thousands of API
-                // round-trips and serialized the transfer on them. The interval arm
-                // below heartbeats + cancel-checks every report tick, exactly like
-                // `download_file_inner`, so cancel latency is the tick interval.
-                output.write_all(&chunk).await?;
-                progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
-                if progress.downloaded_bytes() > max_bytes {
-                    return Err(WorkerError::InvalidPayload(format!(
-                        "{source_label} sourceUrl exceeds the {} limit",
-                        format_bytes(max_bytes)
-                    )));
-                }
-            }
-            _ = interval.tick() => {
-                report_download_progress(context, &progress).await?;
+        let existing_bytes = existing_download_bytes(&target_path, total_bytes).await?;
+        let range_header = (existing_bytes > 0).then(|| format!("bytes={existing_bytes}-"));
+        let response = send_source_url_with_redirects(
+            context.settings,
+            &request_url,
+            &client,
+            bearer,
+            range_header.as_deref(),
+        )
+        .await;
+        let mut response = match response {
+            Ok(response) => response,
+            Err(_error) if resume.take_network_resume() => continue,
+            Err(error) => return Err(redact_source_url_error("sourceUrl GET failed", error)),
+        };
+        if response.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+            let range_total = response
+                .headers()
+                .get(header::CONTENT_RANGE)
+                .and_then(|value| value.to_str().ok())
+                .and_then(content_range_total);
+            if total_bytes
+                .or(range_total)
+                .is_some_and(|total| total > 0 && existing_bytes == total)
+            {
+                return Ok(());
             }
         }
+        response = response
+            .error_for_status()
+            .map_err(|error| redact_reqwest_source_url_error("sourceUrl GET failed", error))?;
+        let appending = existing_bytes > 0 && response.status() == StatusCode::PARTIAL_CONTENT;
+        if existing_bytes > 0 && !appending {
+            progress.reset_to_on_disk(0);
+        }
+        let expected_bytes = total_bytes.or_else(|| {
+            response.content_length().map(|remaining| {
+                if appending {
+                    existing_bytes + remaining
+                } else {
+                    remaining
+                }
+            })
+        });
+        if expected_bytes.is_some_and(|total| total > max_bytes) {
+            return Err(WorkerError::InvalidPayload(format!(
+                "{source_label} sourceUrl exceeds the {} limit",
+                format_bytes(max_bytes)
+            )));
+        }
+        let mut output = if appending {
+            tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&target_path)
+                .await?
+        } else {
+            tokio::fs::File::create(&target_path).await?
+        };
+        let mut interval = tokio::time::interval(progress.report_interval());
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        interval.tick().await;
+        progress.reset_stall_clock();
+        let mut transfer_error = None;
+        let mut stalled = false;
+        loop {
+            tokio::select! {
+                chunk = response.chunk() => {
+                    match chunk {
+                        Ok(Some(chunk)) => {
+                            output.write_all(&chunk).await?;
+                            progress.record_transferred(u64::try_from(chunk.len()).unwrap_or(u64::MAX));
+                            if progress.downloaded_bytes() > max_bytes {
+                                return Err(WorkerError::InvalidPayload(format!(
+                                    "{source_label} sourceUrl exceeds the {} limit",
+                                    format_bytes(max_bytes)
+                                )));
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(error) => {
+                            transfer_error = Some(error);
+                            break;
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    report_download_progress(context, &progress).await?;
+                    if resume.stall_timeout.is_some_and(|timeout| {
+                        progress.is_stalled(timeout, DOWNLOAD_STALL_MIN_PROGRESS)
+                    }) {
+                        stalled = true;
+                        break;
+                    }
+                }
+            }
+        }
+        output.flush().await?;
+        if stalled {
+            let on_disk = existing_download_bytes(&target_path, total_bytes).await?;
+            resume.record_stall(&format!("{source_label} sourceUrl"), on_disk)?;
+            continue;
+        }
+        if let Some(error) = transfer_error {
+            if resume.take_network_resume() {
+                continue;
+            }
+            return Err(redact_reqwest_source_url_error(
+                "sourceUrl body failed",
+                error,
+            ));
+        }
+        if let Some(expected) = expected_bytes {
+            let written = tokio::fs::metadata(&target_path).await?.len();
+            if written == expected {
+                return Ok(());
+            }
+            if written < expected && resume.take_network_resume() {
+                continue;
+            }
+            if written > expected {
+                let _ = tokio::fs::remove_file(&target_path).await;
+            }
+            return Err(WorkerError::InvalidPayload(download_size_mismatch_message(
+                &format!("{source_label} sourceUrl"),
+                written,
+                expected,
+            )));
+        }
+        return Ok(());
     }
-    output.flush().await?;
-    if expected_bytes.is_some_and(|expected| progress.downloaded_bytes() != expected) {
-        return Err(WorkerError::InvalidPayload(download_size_mismatch_message(
-            &format!("{source_label} sourceUrl"),
-            progress.downloaded_bytes(),
-            expected_bytes.unwrap_or_default(),
-        )));
+}
+
+fn redact_reqwest_source_url_error(context: &str, error: reqwest::Error) -> WorkerError {
+    WorkerError::InvalidPayload(format!("{context}: {}", error.without_url()))
+}
+
+fn redact_source_url_error(context: &str, error: WorkerError) -> WorkerError {
+    match error {
+        WorkerError::Http(error) => redact_reqwest_source_url_error(context, error),
+        other => other,
     }
-    Ok(())
 }
 
 /// Maximum redirect hops to follow on an authenticated source-URL download.
@@ -1547,6 +1621,17 @@ impl<'a> DownloadProgress<'a> {
 
     fn discard_started_bytes(&mut self, bytes: u64) {
         self.started_bytes = self.started_bytes.saturating_sub(bytes);
+    }
+
+    /// Reconcile progress with the bytes that still exist after an HTTP server ignores
+    /// a Range request and the destination is restarted with a full `200` response.
+    /// Bytes transferred on an abandoned attempt must not count toward limits,
+    /// progress, or the next stall window.
+    fn reset_to_on_disk(&mut self, bytes: u64) {
+        self.started_bytes = bytes;
+        self.transferred_bytes = 0;
+        self.stall_checkpoint_bytes = bytes;
+        self.stall_checkpoint_at = Instant::now();
     }
 
     fn report_interval(&self) -> Duration {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -39,7 +39,7 @@ use tempfile::tempdir;
 use super::api_client::ApiClient;
 use super::downloads::{
     build_source_url_client, credential_for_host, download_lora_source_url,
-    download_progress_payload, download_snapshot_into_cache, normalize_sha256,
+    download_progress_payload, download_snapshot_into_cache, download_source_url, normalize_sha256,
     report_download_progress, DownloadContext, DownloadProgress, HuggingFaceSnapshot, SnapshotFile,
 };
 #[cfg(target_os = "macos")]

--- a/crates/sceneworks-worker/src/tests/credentials_and_source_url.rs
+++ b/crates/sceneworks-worker/src/tests/credentials_and_source_url.rs
@@ -66,6 +66,218 @@ fn worker_credentials_env_overrides_file_per_host() {
 }
 
 #[tokio::test]
+async fn source_url_query_token_is_redacted_from_status_errors() {
+    let app = Router::new().route(
+        "/download/style.safetensors",
+        get(|| async { AxumStatusCode::INTERNAL_SERVER_ERROR })
+            .head(|| async { AxumStatusCode::INTERNAL_SERVER_ERROR }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+
+    let temp = tempdir().expect("tempdir creates");
+    let api_base = spawn_binary_stub(b"ignored".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = api_base;
+    settings.allow_private_lora_urls = true;
+    settings.credentials = vec![WorkerCredential {
+        host: "127.0.0.1".to_owned(),
+        token: "super-secret-query-token".to_owned(),
+        scheme: CredentialScheme::Query,
+    }];
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let error = download_lora_source_url(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        },
+        &format!("http://{address}/download/style.safetensors"),
+        &temp.path().join("redaction-target"),
+    )
+    .await
+    .expect_err("500 response is surfaced");
+    let message = error.to_string();
+    assert!(message.contains("sourceUrl"));
+    assert!(!message.contains("super-secret-query-token"));
+    assert!(!message.contains("token="));
+}
+
+#[tokio::test]
+async fn source_url_resumes_an_existing_partial_file_with_range() {
+    let bytes = b"complete-source-url-weights".to_vec();
+    let download_base = spawn_binary_stub(bytes.clone()).await;
+    let temp = tempdir().expect("tempdir creates");
+    let api_base = spawn_binary_stub(b"ignored".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = api_base;
+    settings.allow_private_lora_urls = true;
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let target_dir = temp.path().join("resume-target");
+    tokio::fs::create_dir_all(&target_dir).await.unwrap();
+    tokio::fs::write(
+        target_dir.join("style.safetensors"),
+        &bytes[..bytes.len() / 2],
+    )
+    .await
+    .unwrap();
+
+    download_lora_source_url(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        },
+        &format!("{download_base}/style.safetensors"),
+        &target_dir,
+    )
+    .await
+    .expect("partial source URL download resumes");
+
+    assert_eq!(
+        tokio::fs::read(target_dir.join("style.safetensors"))
+            .await
+            .unwrap(),
+        bytes
+    );
+}
+
+#[derive(Clone)]
+struct InterruptedSourceState {
+    bytes: Vec<u8>,
+    gets: Arc<AtomicUsize>,
+    ranges: Arc<AtomicUsize>,
+}
+
+#[tokio::test]
+async fn source_url_resumes_after_a_midstream_network_error() {
+    let bytes = b"midstream-interruption-must-resume".to_vec();
+    let state = InterruptedSourceState {
+        bytes: bytes.clone(),
+        gets: Arc::new(AtomicUsize::new(0)),
+        ranges: Arc::new(AtomicUsize::new(0)),
+    };
+    let gets = state.gets.clone();
+    let ranges = state.ranges.clone();
+    let app = Router::new()
+        .route(
+            "/style.safetensors",
+            get(interrupted_source).head(interrupted_source),
+        )
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("listener binds");
+    let address = listener.local_addr().expect("listener has address");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("stub serves");
+    });
+
+    let temp = tempdir().expect("tempdir creates");
+    let api_base = spawn_binary_stub(b"ignored".to_vec()).await;
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    settings.api_url = api_base;
+    settings.allow_private_lora_urls = true;
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+    let target_dir = temp.path().join("interrupted-target");
+    download_source_url(
+        &DownloadContext {
+            api: &api,
+            client: &client,
+            settings: &settings,
+            job_id: "job-1",
+            cancel_message: "canceled",
+            fresh_download: false,
+        },
+        &format!("http://{address}/style.safetensors"),
+        &target_dir,
+        "LoRA",
+        bytes.len() as u64,
+    )
+    .await
+    .expect("midstream transport failure resumes with Range");
+
+    assert_eq!(gets.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        ranges.load(Ordering::SeqCst),
+        1,
+        "retry must carry a Range from the bytes written before disconnect"
+    );
+    assert_eq!(
+        tokio::fs::read(target_dir.join("style.safetensors"))
+            .await
+            .unwrap(),
+        bytes
+    );
+}
+
+async fn interrupted_source(
+    State(state): State<InterruptedSourceState>,
+    method: axum::http::Method,
+    headers: HeaderMap,
+) -> Response {
+    let total = state.bytes.len();
+    if method == axum::http::Method::HEAD {
+        let mut response = Response::new(Body::empty());
+        response.headers_mut().insert(
+            axum::http::header::CONTENT_LENGTH,
+            axum::http::HeaderValue::from_str(&total.to_string()).unwrap(),
+        );
+        return response;
+    }
+    let attempt = state.gets.fetch_add(1, Ordering::SeqCst);
+    if headers
+        .get(axum::http::header::RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("bytes="))
+        .and_then(|value| value.strip_suffix('-'))
+        .and_then(|value| value.parse::<usize>().ok())
+        .is_some()
+    {
+        state.ranges.fetch_add(1, Ordering::SeqCst);
+        // Adversarial CDN behavior: ignore the valid Range and restart with a full 200.
+        return state.bytes.into_response();
+    }
+    if attempt > 0 {
+        return state.bytes.into_response();
+    }
+    let midpoint = total / 2;
+    let first = futures_util::stream::once(async move {
+        Ok::<_, std::io::Error>(axum::body::Bytes::copy_from_slice(
+            &state.bytes[..midpoint],
+        ))
+    });
+    let failure = futures_util::stream::once(async {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        Err::<axum::body::Bytes, _>(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "intentional test disconnect",
+        ))
+    });
+    let stream = futures_util::StreamExt::chain(first, failure);
+    let mut response = Response::new(Body::from_stream(stream));
+    response.headers_mut().insert(
+        axum::http::header::CONTENT_LENGTH,
+        axum::http::HeaderValue::from_str(&total.to_string()).unwrap(),
+    );
+    response
+}
+
+#[tokio::test]
 async fn source_url_follows_redirect_and_strips_auth_across_hosts() {
     let temp = tempdir().expect("tempdir creates");
     // The download host (127.0.0.1) requires a bearer token, then 302-redirects to


### PR DESCRIPTION
## Summary
- redact query credentials from all surfaced source-URL HTTP errors
- give source-URL downloads bounded midstream/error/stall Range resume semantics
- reset accounting correctly when a server ignores Range and restarts with 200
- lock each snapshot target/blob across worker processes before writing

## Validation
- full worker library: 975 passed, 176 ignored, 0 failed
- source URL, transport restart, snapshot, lock, and watchdog regressions
- Linux x86_64 no-default-features check
- rustfmt and git diff --check

Independent adversarial review: PASS (confidence 0.97).

Shortcut: sc-13616