### PR TITLE
feat(web): Simple UI shell behind a sidebar Simple/Advanced switch

### DIFF
--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -23,6 +23,15 @@ pub(crate) struct UiPreferences {
     /// Last-used accent palette id (see `ACCENT_IDS`); absent until first set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     accent: Option<String>,
+    /// "Use Simple UI by default" (the Simple UI design handoff): whether the reduced-surface
+    /// Simple shell is the one the app opens on. Absent until first set, which the web reads as
+    /// OFF — an existing install keeps the full workspace it already has. Made durable through
+    /// this API for the same reason as theme/accent: the desktop shell's per-launch
+    /// `127.0.0.1:<port>` origin changes every launch, wiping origin-keyed `localStorage`.
+    /// A phone viewport forces the Simple shell regardless of this value; that rule is
+    /// client-side (it depends on the viewport, not on stored state).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    simple_ui: Option<bool>,
     /// App-wide default generation quality (`auto`|`bf16`|`q8`|`q4`); the baseline the
     /// per-model default tier derives from when no per-(screen,model) sticky pick exists
     /// (sc-10728). `auto` (epic 10721 R3) is the default: each model defaults to the
@@ -177,6 +186,13 @@ pub(crate) async fn set_ui_preferences(
         }
         if let Some(accent) = normalize_accent(payload.accent.as_deref()) {
             prefs.accent = Some(accent);
+        }
+        // Only touch the Simple-UI default when the payload actually carries it, so a
+        // theme/accent/quality-only PUT can't reset it (same partial-merge rule as the fields
+        // above). It is a plain bool, so there is nothing to normalize — an out-of-vocabulary
+        // value can't parse in the first place.
+        if let Some(simple_ui) = payload.simple_ui {
+            prefs.simple_ui = Some(simple_ui);
         }
         // Only touch the quality when the payload actually carries it, so a theme- or accent-only PUT
         // can't reset it. A present-but-invalid value coerces to `auto`. A deliberate quality PUT also

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -388,6 +388,68 @@ async fn ui_preferences_migrates_a_legacy_q8_to_auto_once() {
     );
 }
 
+/// Simple UI design handoff: "Use Simple UI by default" persists server-side for the same reason as
+/// theme/accent — the desktop shell's per-launch `127.0.0.1:<port>` origin wipes origin-keyed
+/// localStorage, so a user who opted into the Simple shell would be dropped back into the full
+/// workspace on every relaunch. Absent until first set (⇒ the web reads OFF and an existing install
+/// keeps the workspace it has), and the PUT merges like every other field.
+#[tokio::test]
+async fn ui_preferences_simple_ui_round_trips_and_merges() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir); // no token configured ⇒ PUT is open
+    let app = create_app(settings).expect("app creates");
+
+    // Fresh install: absent, so the web falls back to the full workspace.
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(prefs.get("simpleUi").is_none());
+
+    // Opting in persists and is echoed back.
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "simpleUi": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["simpleUi"], true);
+
+    // Survives a "relaunch".
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["simpleUi"], true);
+
+    // A partial PUT (theme only) MERGES — it must not silently drop the user back into the
+    // full workspace on their next launch.
+    let (status, _) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["simpleUi"], true);
+    assert_eq!(prefs["theme"], "dark");
+
+    // Opting back out persists too (a false must be stored, not treated as "unset").
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "simpleUi": false }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["simpleUi"], false);
+    let (status, prefs) = request(app, "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(prefs["simpleUi"], false);
+}
+
 /// epic 10721 R1: the per-(screen, model) tier sticky persists server-side so a user's studio pick
 /// survives a desktop relaunch (localStorage alone is wiped by the shell's per-launch origin). A PUT
 /// carrying the map replaces it wholesale (the web sends the full merged map); a PUT without it merges.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -55,6 +55,20 @@ import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
 import { appConfirm, ConfirmHost } from "./appConfirm.jsx";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
+// Simple UI (design handoff "Simple UI for creative studios") — an ALTERNATIVE shell that
+// renders instead of this workspace when the sidebar switch is on Simple. The workspace
+// below is unchanged apart from that switch in its footer.
+import { SimpleShell } from "./simple/SimpleShell.jsx";
+import { SimpleModeSwitch } from "./simple/SimpleModeSwitch.jsx";
+import { useViewportWidth } from "./simple/useContainerWidth.js";
+import {
+  ADVANCED_MODE,
+  SIMPLE_MODE,
+  readStoredSimpleDefault,
+  resolveUiMode,
+  uiModeLockedToSimple,
+  writeStoredSimpleDefault,
+} from "./simple/uiMode.js";
 import {
   buildLocalJobStack,
   isActiveWorker,
@@ -536,6 +550,29 @@ export function App() {
       body: JSON.stringify({ accent: next }),
     }).catch(() => {});
   };
+  // Simple UI (design handoff). `simpleUiDefault` is the persisted "Use Simple UI by
+  // default" preference — same durable contract as theme/accent (server copy in
+  // ui-preferences.json + a localStorage instant-paint cache), because the desktop
+  // shell's per-launch 127.0.0.1:<port> origin wipes origin-keyed localStorage.
+  // `uiModeOverride` is this session's sidebar pick, which wins over the preference;
+  // a phone viewport wins over both (the full workspace is unusable at that width).
+  const [simpleUiDefault, setSimpleUiDefault] = useState(readStoredSimpleDefault);
+  const [uiModeOverride, setUiModeOverride] = useState(null);
+  const viewportWidth = useViewportWidth();
+  const uiModeLocked = uiModeLockedToSimple(viewportWidth);
+  const uiMode = resolveUiMode({
+    simpleDefault: simpleUiDefault,
+    override: uiModeOverride,
+    width: viewportWidth,
+  });
+  const changeSimpleUiDefault = useCallback((next) => {
+    setSimpleUiDefault(next);
+    writeStoredSimpleDefault(next);
+    apiFetch("/api/v1/ui-preferences", "", {
+      method: "PUT",
+      body: JSON.stringify({ simpleUi: next }),
+    }).catch(() => {});
+  }, []);
   const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
@@ -1094,6 +1131,13 @@ export function App() {
         }
         if (isAccentId(prefs?.accent)) {
           setAccent(prefs.accent);
+        }
+        // "Use Simple UI by default" (design handoff). Seeded from the durable copy for
+        // the same reason as theme/accent; the localStorage cache only gives the first
+        // paint. A session override (the sidebar switch) still wins over it.
+        if (typeof prefs?.simpleUi === "boolean") {
+          setSimpleUiDefault(prefs.simpleUi);
+          writeStoredSimpleDefault(prefs.simpleUi);
         }
         // Re-prime the default-generation-quality cache from the durable server copy (sc-10728).
         // It isn't React state here — the studio reads it fresh from localStorage via
@@ -2257,6 +2301,17 @@ export function App() {
   // desktop — hold the studio/gate back briefly to avoid a flash.
   const setupGateLoading = isDesktopShell && setupCompleted === null;
   const showSetupWizard = isDesktopShell && setupCompleted === false && authenticated;
+  // The Simple shell replaces the workspace only once the app is actually usable. The
+  // first-run flows — the desktop setup wizard, the "create your first workspace" gate,
+  // and the remote-browser password band — stay on the existing shell that owns them, so
+  // Simple never renders studios whose Generate could only fail. Once past them the
+  // switch is live, and the Settings toggle + the sidebar switch both reach it.
+  const shellGated =
+    showSetupWizard ||
+    setupGateLoading ||
+    needsFirstProject ||
+    (access.authRequired && !isDesktopShell && !token);
+  const showSimpleShell = uiMode === SIMPLE_MODE && !shellGated;
 
   // sc-1651 Phase B: shared primitives screens read via useAppContext() instead of
   // drilled props. Screens build any screen-specific wrappers from these (e.g. a
@@ -2500,6 +2555,27 @@ export function App() {
     sendCharacterToImage, sendCharacterToVideo, sendPresetToStudio, openDatasetInLibrary, theme, changeTheme,
   ]);
 
+  // Simple UI (design handoff): an ALTERNATIVE shell rendered in place of the workspace
+  // below. It mounts INSIDE the same two providers, so its screens read the identical
+  // catalogs, job feed and actions — there is no second data layer, and switching back
+  // to Advanced lands on the same live state.
+  if (showSimpleShell) {
+    return (
+      <AppStaticContext.Provider value={appStaticValue}>
+        <AppLiveContext.Provider value={appLiveValue}>
+          <SimpleShell
+            accent={accent}
+            lockedToSimple={uiModeLocked}
+            onAccentChange={changeAccent}
+            onModeChange={setUiModeOverride}
+            onSimpleDefaultChange={changeSimpleUiDefault}
+            simpleDefault={simpleUiDefault}
+          />
+        </AppLiveContext.Provider>
+      </AppStaticContext.Provider>
+    );
+  }
+
   return (
     <AppStaticContext.Provider value={appStaticValue}>
     <AppLiveContext.Provider value={appLiveValue}>
@@ -2549,13 +2625,21 @@ export function App() {
           </div>
         ))}
 
-        {APP_VERSION ? (
-          <div className="sidebar-footer">
+        {/* Simple ⇄ Advanced switch (design handoff). The ONE addition this shell makes for
+            the Simple UI; the same component renders in the Simple sidebar footer, so the
+            control can never present differently between the two. */}
+        <div className="sidebar-footer">
+          <SimpleModeSwitch
+            locked={uiModeLocked}
+            mode={ADVANCED_MODE}
+            onChange={setUiModeOverride}
+          />
+          {APP_VERSION ? (
             <span className="app-version" title={`SceneWorks ${APP_VERSION}`}>
               v{APP_VERSION}
             </span>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </aside>
 
       <section className="workspace">

--- a/apps/web/src/App.simpleUi.test.jsx
+++ b/apps/web/src/App.simpleUi.test.jsx
@@ -1,0 +1,137 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+import { click } from "./testUtils/dom.js";
+
+// Simple UI ⇄ full workspace switching at the App level (design handoff).
+//
+// The constraint this suite pins: the EXISTING workspace is what an install opens on and
+// what it keeps rendering — the Simple UI only appears when the user asks for it (or on a
+// phone). A regression that flipped the default would swap every user's UI silently, so
+// the "unchanged by default" assertion is the first test here.
+
+function sidebarSwitchButtons() {
+  return [...document.body.querySelectorAll(".sidebar-footer .su-switch button")];
+}
+
+describe("App — Simple/Advanced shell switching", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    // Desktop-width viewport: the phone rule must not be what decides these cases.
+    window.innerWidth = 1440;
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
+      if (path.endsWith("/ui-preferences")) {
+        return Promise.resolve(response({}));
+      }
+      return Promise.resolve(response([]));
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  it("opens on the FULL workspace, unchanged, for an untouched install", async () => {
+    await renderApp();
+    expect(container.querySelector("main.app")).toBeTruthy();
+    expect(container.querySelector(".workspace")).toBeTruthy();
+    expect(container.querySelector(".su-root")).toBeNull();
+  });
+
+  it("adds the Simple/Advanced switch to the workspace sidebar, on Advanced", async () => {
+    await renderApp();
+    const [simple, advanced] = sidebarSwitchButtons();
+    expect(simple.textContent).toBe("Simple");
+    expect(advanced.textContent).toBe("Advanced");
+    expect(advanced.className).toContain("active");
+    expect(simple.className).not.toContain("active");
+  });
+
+  it("swaps to the Simple shell when the sidebar switch is set to Simple, and back", async () => {
+    await renderApp();
+    await click(sidebarSwitchButtons()[0]);
+
+    expect(container.querySelector(".su-root")).toBeTruthy();
+    expect(container.querySelector("main.app")).toBeNull();
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Image Studio");
+
+    // Back again through the Simple shell's own footer switch — same component.
+    const advanced = [...container.querySelectorAll(".su-nav-footer .su-switch button")].find(
+      (node) => node.textContent === "Advanced",
+    );
+    await click(advanced);
+    expect(container.querySelector("main.app")).toBeTruthy();
+    expect(container.querySelector(".su-root")).toBeNull();
+  });
+
+  it("opens on the Simple shell when the durable preference says so", async () => {
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
+      if (path.endsWith("/ui-preferences")) {
+        return Promise.resolve(response({ simpleUi: true }));
+      }
+      return Promise.resolve(response([]));
+    });
+
+    await renderApp();
+    expect(container.querySelector(".su-root")).toBeTruthy();
+    // …and the durable value is mirrored into the instant-paint cache for the next launch.
+    expect(window.localStorage.getItem("sceneworks-simple-ui-default")).toBe("true");
+  });
+
+  it("forces the Simple shell on a phone viewport and locks the switch", async () => {
+    window.innerWidth = 390;
+    await renderApp();
+    expect(container.querySelector(".su-root")).toBeTruthy();
+    const [simple, advanced] = [
+      ...container.querySelectorAll(".su-nav-footer .su-switch button"),
+    ];
+    expect(simple.disabled).toBe(true);
+    expect(advanced.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -91,5 +91,12 @@ export const Icon = {
   Trash: (p) => <I {...p} d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6M10 11v6M14 11v6" />,
   Save: (p) => <I {...p} d="M5 3h11l5 5v13H5zM8 21v-8h8v8M9 3v5h6" />,
   Close: (p) => <I {...p} d="M18 6L6 18M6 6l12 12" />,
+  // Added for the Simple UI shell (design handoff): the phone drawer trigger, the
+  // result-tile download affordance, the selected-option tick in a picker sheet, and
+  // the preview/warning banner. Additive — no existing render site changes.
+  Menu: (p) => <I {...p} d="M4 6h16M4 12h16M4 18h16" />,
+  Download: (p) => <I {...p} d="M12 3v11M8 10.5l4 4 4-4M4 19h16" />,
+  Check: (p) => <I {...p} d="M4 12.5L9 17.5 20 6.5" />,
+  Warning: (p) => <I {...p} d="M12 3l9.5 17H2.5zM12 9v5M12 17.5h.01" />,
 };
 

--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -80,6 +80,14 @@ export function buildImageJobRequest(state) {
     bf16Precision,
     showTierPicker,
     quantTier,
+    // sc-10733's "this tier is a DELIBERATE pick" marker. ImageStudio computes it (its
+    // sticky == the outgoing tier) and buildImageJobAdvanced turns it into
+    // `advanced.mlxQuantizeExplicit` — but this layer, extracted in sc-11219, never
+    // destructured or forwarded it, so the flag was computed and then silently dropped and
+    // `mlxQuantizeExplicit` never reached a payload. A deliberate sticky tier was therefore
+    // still capability-downtierable by the worker, which is exactly what the flag exists to
+    // prevent. Threaded through here so the marker survives to `advanced`.
+    tierExplicit,
     showPidToggle,
     usePid,
     pidTarget,
@@ -233,6 +241,7 @@ export function buildImageJobRequest(state) {
       bf16Precision,
       showTierPicker,
       quantTier,
+      tierExplicit,
       showPidToggle,
       usePid,
       pidTarget,

--- a/apps/web/src/imageJobRequest.test.js
+++ b/apps/web/src/imageJobRequest.test.js
@@ -100,6 +100,26 @@ describe("buildImageJobRequest", () => {
     expect(request.advanced.strength).toBe(0.42);
   });
 
+  // sc-10733's explicit-tier marker crosses THIS layer on its way to buildImageJobAdvanced.
+  // It was computed by ImageStudio and consumed by buildImageJobAdvanced, but never
+  // destructured or forwarded here — so `advanced.mlxQuantizeExplicit` never reached a
+  // payload and a deliberate sticky tier stayed silently downtierable by the worker.
+  it("forwards tierExplicit so a deliberate tier pick reaches advanced.mlxQuantizeExplicit", () => {
+    const explicit = buildImageJobRequest(
+      img2imgPidState({ quantTier: "q4", tierExplicit: true }),
+    );
+    expect(explicit.advanced.mlxQuantize).toBe(4);
+    expect(explicit.advanced.mlxQuantizeExplicit).toBe(true);
+  });
+
+  it("omits mlxQuantizeExplicit for a DERIVED tier, so the worker may still downtier it", () => {
+    const derived = buildImageJobRequest(
+      img2imgPidState({ quantTier: "q4", tierExplicit: false }),
+    );
+    expect(derived.advanced.mlxQuantize).toBe(4);
+    expect(derived.advanced.mlxQuantizeExplicit).toBeUndefined();
+  });
+
   it("emits advanced.pidTarget:'2k' when the PiD 2K tier is selected (dropped by the batch copy)", () => {
     const request = buildImageJobRequest(img2imgPidState());
     expect(request.advanced.usePid).toBe(true);

--- a/apps/web/src/modelEligibility.js
+++ b/apps/web/src/modelEligibility.js
@@ -37,7 +37,15 @@ const VOICE_CLONE_CONDITIONING = new Set(["referenceaudio", "voiceembedding"]);
 // when it declares the capability and, under active Mac gating, that feature is MLX-routed
 // for it (the macModelFeatureBlock calls are no-ops off Mac).
 export function imageModelServesMode(model, mode, caps) {
-  const capabilities = model?.capabilities ?? [];
+  // sc-13634 (#1780) taught ImageStudio's local copy that an ABSENT capability array is a
+  // legacy installed-model record which historically meant "Text". This mirror kept the old
+  // `?? []` reading, so the two authorities disagreed for exactly those records: the studio
+  // offered them in Text while anything reading this predicate (the screen gate, download
+  // offers, and the Simple Image Studio) treated them as serving nothing. An EXPLICIT list —
+  // including `[]` — stays authoritative in both, so an edit-only or reference-only model
+  // still can never leak into Text.
+  const capabilitiesDeclared = Array.isArray(model?.capabilities);
+  const capabilities = capabilitiesDeclared ? model.capabilities : [];
   if (mode === "edit_image") {
     return (
       (capabilities.includes("edit_image") || capabilities.includes("image_edit")) &&
@@ -50,7 +58,7 @@ export function imageModelServesMode(model, mode, caps) {
   if (mode === "style_variations") {
     return capabilities.includes("style_variations") && !macModelFeatureBlock(model, caps, "reference");
   }
-  return capabilities.includes("text_to_image");
+  return !capabilitiesDeclared || capabilities.includes("text_to_image");
 }
 
 // Usable on Image Studio: an image-type model that isn't Mac-blocked and serves ≥1 mode.

--- a/apps/web/src/modelEligibility.test.js
+++ b/apps/web/src/modelEligibility.test.js
@@ -10,6 +10,7 @@ import {
   generationModelsForType,
   downloadOffersFor,
   hasUsableModelFor,
+  imageModelServesMode,
   imageModelUsable,
   poseModelUsable,
   supportedControlModes,
@@ -26,6 +27,24 @@ describe("modelEligibility predicates", () => {
     expect(imageModelUsable({ type: "image", capabilities: ["edit_image"] }, caps)).toBe(true);
     expect(imageModelUsable({ type: "image", capabilities: [] }, caps)).toBe(false);
     expect(imageModelUsable({ type: "video", capabilities: ["text_to_image"] }, caps)).toBe(false);
+  });
+
+  // sc-13634 (#1780) made ImageStudio's picker treat an ABSENT capability array as a legacy
+  // record that served Text; this shared mirror had kept the old `?? []` reading, so the two
+  // disagreed for exactly those records. The distinction that matters is absent vs explicit:
+  // an explicit [] (or an edit-only list) must still never serve Text.
+  it("imageModelServesMode treats an ABSENT capability array as legacy Text, but not an explicit one", () => {
+    expect(imageModelServesMode({ type: "image" }, "text_to_image", caps)).toBe(true);
+    expect(imageModelUsable({ type: "image" }, caps)).toBe(true);
+
+    expect(imageModelServesMode({ type: "image", capabilities: [] }, "text_to_image", caps)).toBe(false);
+    expect(
+      imageModelServesMode({ type: "image", capabilities: ["edit_image"] }, "text_to_image", caps),
+    ).toBe(false);
+    // A legacy record still only serves Text — the other three modes need a real declaration.
+    expect(imageModelServesMode({ type: "image" }, "edit_image", caps)).toBe(false);
+    expect(imageModelServesMode({ type: "image" }, "character_image", caps)).toBe(false);
+    expect(imageModelServesMode({ type: "image" }, "style_variations", caps)).toBe(false);
   });
 
   it("videoModelUsable matches video models with a video capability", () => {

--- a/apps/web/src/simple/PromptGuideSheet.jsx
+++ b/apps/web/src/simple/PromptGuideSheet.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Icon } from "../components/Icons.jsx";
+import { SimpleSheet } from "./SimpleSheet.jsx";
+
+// Prompt guide (design handoff): four numbered tips plus a "Try" example, in the same
+// sheet/modal chrome as the pickers. Deliberately short and model-agnostic — the full
+// per-model Markdown guide (PromptGuideModal) stays in the advanced workspace.
+export const PROMPT_GUIDE_TIPS = [
+  {
+    title: "Lead with the subject",
+    body: "Say what it is first, then style, setting, lighting, and framing.",
+  },
+  {
+    title: "Be concrete",
+    body: "“Golden hour”, “35mm”, “low angle” beat vague adjectives like “beautiful”.",
+  },
+  {
+    title: "Name the look",
+    body:
+      "Add camera & lens for photographic; medium (watercolor, cel) for illustration — or pick a Style preset.",
+  },
+  {
+    title: "Describe what you want",
+    body: "Focus on the positive; keep negatives short and only for real problems.",
+  },
+];
+
+export const PROMPT_GUIDE_EXAMPLE =
+  "“A lone lighthouse on a rocky cliff at golden hour, dramatic storm clouds, wide cinematic shot, 35mm, warm rim light.”";
+
+export function PromptGuideSheet({ onClose, phone }) {
+  return (
+    <SimpleSheet labelId="su-guide-title" onClose={onClose} phone={phone}>
+      <div className="su-sheet-head">
+        <h2 className="su-sheet-title" id="su-guide-title">
+          Prompt guide
+        </h2>
+        <button aria-label="Close" className="su-icon-btn" onClick={onClose} type="button">
+          <Icon.Close size={15} />
+        </button>
+      </div>
+      <p className="su-guide-intro">
+        A few things that make a prompt land. Or tap <strong>Refine</strong> to auto-expand a short
+        idea.
+      </p>
+      <div className="su-guide-tips">
+        {PROMPT_GUIDE_TIPS.map((tip, index) => (
+          <div className="su-guide-tip" key={tip.title}>
+            <span aria-hidden="true" className="su-guide-num">
+              {index + 1}
+            </span>
+            <div>
+              <strong>{tip.title}</strong>
+              <p>{tip.body}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="su-guide-try">
+        <div className="su-guide-try-label">Try</div>
+        <p>{PROMPT_GUIDE_EXAMPLE}</p>
+      </div>
+    </SimpleSheet>
+  );
+}

--- a/apps/web/src/simple/SimpleAssets.jsx
+++ b/apps/web/src/simple/SimpleAssets.jsx
@@ -1,0 +1,131 @@
+import React, { useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { AssetThumbnail, assetCanRenderAsAudio, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { isLibraryAsset } from "../constants.js";
+import { foldUpscaledAssetVariants } from "../assetVariants.js";
+import { assetMatchesSearch } from "../screens/LibraryScreen.jsx";
+import { assetGridColumns } from "./breakpoint.js";
+import { useSimpleUi } from "./SimpleUiContext.js";
+
+// Simple Assets (design handoff): search + type pills + a responsive thumbnail grid.
+// Reuses the Library screen's own hygiene rules so the two views can't disagree about
+// what belongs in the library: the `isLibraryAsset` origin allow-list, the trashed /
+// rejected exclusions, the upscale-variant fold, and the shared free-text matcher.
+
+const FILTERS = [
+  { id: "all", label: "All" },
+  { id: "image", label: "Images" },
+  { id: "video", label: "Clips" },
+  { id: "audio", label: "Audio" },
+];
+
+export function SimpleAssets() {
+  const { assets = [] } = useAppContext();
+  const { breakpoint, openPreview } = useSimpleUi();
+  const [filter, setFilter] = useState("all");
+  const [query, setQuery] = useState("");
+
+  const visible = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const library = assets.filter(isLibraryAsset);
+    return foldUpscaledAssetVariants(
+      library.filter((asset) => {
+        if (asset.status?.trashed || asset.status?.rejected) {
+          return false;
+        }
+        if (filter !== "all" && !matchesFilter(asset, filter)) {
+          return false;
+        }
+        return assetMatchesSearch(asset, needle);
+      }),
+    );
+  }, [assets, filter, query]);
+
+  return (
+    <div className="su-screen su-screen--tight">
+      <div className="su-search">
+        <Icon.Search size={16} />
+        <input
+          aria-label="Search assets"
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search assets…"
+          type="search"
+          value={query}
+        />
+      </div>
+
+      <div className="su-filter-pills su-scroll" role="radiogroup" aria-label="Asset type">
+        {FILTERS.map((entry) => (
+          <button
+            aria-checked={filter === entry.id}
+            className={filter === entry.id ? "su-filter-pill active" : "su-filter-pill"}
+            key={entry.id}
+            onClick={() => setFilter(entry.id)}
+            role="radio"
+            type="button"
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+
+      {visible.length ? (
+        <div
+          className="su-asset-grid"
+          style={{ "--su-asset-cols": assetGridColumns(breakpoint) }}
+        >
+          {visible.map((asset) => (
+            <button
+              className="su-asset"
+              key={asset.id}
+              onClick={() => openPreview(asset)}
+              title={asset.displayName ?? asset.id}
+              type="button"
+            >
+              {assetCanRenderAsAudio(asset) ? (
+                <span className="su-asset-placeholder">
+                  <Icon.Audio size={20} />
+                </span>
+              ) : (
+                <AssetThumbnail asset={asset} />
+              )}
+              <span aria-hidden="true" className="su-asset-kind">
+                {assetCanRenderAsVideo(asset) ? (
+                  <Icon.Play size={11} />
+                ) : assetCanRenderAsAudio(asset) ? (
+                  <Icon.Audio size={11} />
+                ) : (
+                  <Icon.Image size={11} />
+                )}
+              </span>
+              {asset.status?.favorite ? (
+                <span aria-hidden="true" className="su-asset-fav">
+                  <Icon.Star filled size={14} />
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="su-empty">
+          {query.trim() || filter !== "all"
+            ? "Nothing matches that filter yet."
+            : "Nothing here yet — generate something in a studio and it lands in Assets."}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// "Clips" covers both generated videos and uploaded footage, mirroring how the Library
+// screen counts them (video + upload) rather than a bare `type === "video"` test.
+function matchesFilter(asset, filter) {
+  if (filter === "video") {
+    return assetCanRenderAsVideo(asset);
+  }
+  if (filter === "audio") {
+    return assetCanRenderAsAudio(asset);
+  }
+  return asset.type === "image";
+}

--- a/apps/web/src/simple/SimpleAudioStudio.jsx
+++ b/apps/web/src/simple/SimpleAudioStudio.jsx
@@ -1,0 +1,241 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { AssetMedia } from "../components/assetMedia.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { audioModelServesMode } from "../modelEligibility.js";
+import { resolveJobResultAssets } from "../jobResultAssets.js";
+import { buildSimpleAudioRequest } from "./simpleJobs.js";
+import { useSimpleUi } from "./SimpleUiContext.js";
+import { Chips, DownloadButton, SheetSelect, jobIsRunning, newestLocalJob } from "./studioParts.jsx";
+
+// Simple Audio Studio (design handoff). The design flags this studio as a PREVIEW —
+// "the models and controls will change as it lands" — and asks for the warning banner
+// to be kept, so it is rendered verbatim.
+//
+// Music / Speech / SFX are the three modes the design shows. Voice Clone (the fourth
+// mode the advanced studio serves) is deliberately not surfaced here.
+
+const MODES = [
+  { id: "music", label: "Music" },
+  { id: "speech", label: "Speech" },
+  { id: "sfx", label: "SFX" },
+];
+const DURATIONS = [4, 8, 15, 30];
+
+export function SimpleAudioStudio() {
+  const {
+    audioModels = [],
+    createAudioJob,
+    rememberLocalGenerationJob,
+    audioLocalJobs = [],
+    assets = [],
+    activeProject,
+  } = useAppContext();
+  const { toast } = useSimpleUi();
+
+  const [mode, setMode] = useState("music");
+  const [prompt, setPrompt] = useState("");
+  const [model, setModel] = useState("");
+  const [voice, setVoice] = useState("");
+  const [duration, setDuration] = useState(8);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Per-mode eligibility comes from the model's own `audio` sub-block, exactly as the
+  // advanced studio resolves it — never a hardcoded id list.
+  const models = useMemo(
+    () => audioModels.filter((entry) => audioModelServesMode(entry, mode)),
+    [audioModels, mode],
+  );
+  const selectedModel = useMemo(
+    () => models.find((entry) => entry.id === model) ?? null,
+    [models, model],
+  );
+
+  useEffect(() => {
+    if (models.length && !models.some((entry) => entry.id === model)) {
+      setModel(models[0].id);
+    }
+  }, [models, model]);
+
+  // The Speech voice bank the selected model declares. A streaming / multi-speaker TTS
+  // ships none, in which case the Voice row is simply absent (it speaks in its own voice).
+  const voices = useMemo(() => {
+    const declared = selectedModel?.audio?.voices;
+    return Array.isArray(declared) ? declared : [];
+  }, [selectedModel]);
+
+  useEffect(() => {
+    if (voices.length && !voices.some((entry) => voiceId(entry) === voice)) {
+      setVoice(voiceId(voices[0]));
+    }
+  }, [voices, voice]);
+
+  // Length is capped to the model's advertised `audio.maxDurationSecs` — never a hardcoded
+  // ceiling. A model that declares no cap synthesizes its own natural length, so the control
+  // is hidden and no target duration is sent (matching the advanced studio's `showDuration`).
+  const maxDuration = Number.isFinite(selectedModel?.audio?.maxDurationSecs)
+    ? selectedModel.audio.maxDurationSecs
+    : null;
+  const showDuration = maxDuration != null;
+  const durations = useMemo(() => {
+    if (maxDuration == null) {
+      return [];
+    }
+    const fits = DURATIONS.filter((value) => value <= maxDuration);
+    return fits.length ? fits : [maxDuration];
+  }, [maxDuration]);
+
+  useEffect(() => {
+    if (durations.length && !durations.includes(duration)) {
+      setDuration(durations[durations.length - 1]);
+    }
+  }, [durations, duration]);
+
+  const latestJob = newestLocalJob(audioLocalJobs);
+  const busy = submitting || jobIsRunning(latestJob);
+  const canGenerate = Boolean(prompt.trim()) && Boolean(model) && !busy;
+  const resultAssets = latestJob ? resolveJobResultAssets(latestJob, assets, { type: "audio" }) : [];
+
+  async function generate() {
+    if (!canGenerate) {
+      return;
+    }
+    if (!activeProject) {
+      toast("Create or open a workspace first");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const job = await createAudioJob(
+        buildSimpleAudioRequest({
+          model,
+          prompt,
+          mode,
+          voice: voices.length ? voice : "",
+          durationSecs: showDuration ? duration : null,
+        }),
+      );
+      if (job) {
+        rememberLocalGenerationJob?.("audio", job);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="su-screen">
+      <div className="su-segmented" role="tablist">
+        {MODES.map((entry) => (
+          <button
+            aria-selected={mode === entry.id}
+            className={mode === entry.id ? "active" : ""}
+            key={entry.id}
+            onClick={() => setMode(entry.id)}
+            role="tab"
+            type="button"
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="su-notice" role="note">
+        <Icon.Warning size={16} />
+        <span>Audio Studio is a preview — the models and controls will change as it lands.</span>
+      </div>
+
+      <div>
+        <label className="su-field-label" htmlFor="su-audio-prompt">
+          {mode === "speech" ? "Script" : "Prompt"}
+        </label>
+        <textarea
+          className="su-textarea su-textarea--short"
+          id="su-audio-prompt"
+          onChange={(event) => setPrompt(event.target.value)}
+          placeholder={mode === "speech" ? "What should it say…" : "Describe the audio…"}
+          style={{ marginTop: 6 }}
+          value={prompt}
+        />
+      </div>
+
+      <div className="su-settings-bar">
+        <SheetSelect
+          label="Model"
+          onSelect={setModel}
+          options={models.map((entry) => ({
+            value: entry.id,
+            label: entry.name ?? entry.id,
+            active: entry.id === model,
+          }))}
+          value={selectedModel?.name ?? selectedModel?.id ?? "No audio model installed"}
+        />
+        {mode === "speech" && voices.length ? (
+          <SheetSelect
+            label="Voice"
+            onSelect={setVoice}
+            options={voices.map((entry) => ({
+              value: voiceId(entry),
+              label: voiceLabel(entry),
+              active: voiceId(entry) === voice,
+            }))}
+            value={voiceLabel(voices.find((entry) => voiceId(entry) === voice)) ?? "—"}
+          />
+        ) : null}
+        {showDuration ? (
+          <Chips
+            label="Duration"
+            onChange={setDuration}
+            options={durations.map((value) => ({ value, label: `${value}s` }))}
+            value={duration}
+          />
+        ) : null}
+      </div>
+
+      <button
+        className={busy ? "su-generate busy" : "su-generate"}
+        disabled={!canGenerate}
+        onClick={generate}
+        type="button"
+      >
+        {busy ? <span aria-hidden="true" className="su-spinner" /> : null}
+        {busy ? "Generating…" : "Generate audio"}
+      </button>
+
+      {resultAssets.length ? (
+        <div className="su-audio-result">
+          <AssetMedia asset={resultAssets[0]} />
+          <DownloadButton asset={resultAssets[0]} className="su-icon-btn" />
+        </div>
+      ) : busy ? (
+        <div className="su-audio-result">
+          <span aria-hidden="true" className="su-spinner" />
+          <span className="su-card-note">Rendering audio…</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// A declared voice may be a plain id string or a record; accept both so a manifest that
+// grows the richer shape needs no change here.
+function voiceId(entry) {
+  return typeof entry === "string" ? entry : (entry?.id ?? "");
+}
+
+// The advanced studio labels a voice `item.label ?? item.id` and GROUPS the picker by
+// accent/gender. This flat list can't group, so the same two fields are appended to the
+// row instead — the picker stays as informative without a second grouping mechanism.
+export function voiceLabel(entry) {
+  if (!entry) {
+    return null;
+  }
+  if (typeof entry === "string") {
+    return entry;
+  }
+  const name = entry.label ?? entry.name ?? entry.id ?? "";
+  const qualifiers = [entry.accent, entry.gender]
+    .map((part) => (typeof part === "string" ? part.trim() : ""))
+    .filter(Boolean);
+  return qualifiers.length ? `${name} · ${qualifiers.join(" ")}` : name;
+}

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -1,0 +1,315 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { imageModelServesMode } from "../modelEligibility.js";
+import { fitsResolutionOptions } from "../resolutionMemory.js";
+import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
+import { resultGridColumns } from "./breakpoint.js";
+import { describeResolution, resolutionSummary } from "./aspect.js";
+import { buildSimpleImageRequest, resolveSimpleTier } from "./simpleJobs.js";
+import { useSimpleRefine } from "./useSimpleRefine.js";
+import { useSimpleUi } from "./SimpleUiContext.js";
+import {
+  Chips,
+  RefinePanel,
+  ReferenceTile,
+  SheetSelect,
+  StudioResults,
+  StyleStrip,
+  jobIsRunning,
+  newestLocalJob,
+} from "./studioParts.jsx";
+
+// Simple Image Studio (design handoff): mode tabs → prompt → tool tiles → settings bar →
+// style strip → Generate → results. Every control is backed by the real catalog and the
+// real job queue; the reduced surface is which knobs are SHOWN, not what gets submitted
+// (see simpleJobs.js — the payload goes through the same builder the full studio uses).
+
+const VARIATION_OPTIONS = [1, 2, 4, 6].map((n) => ({ value: n, label: String(n) }));
+const DEFAULT_RESOLUTIONS = ["1024x1024", "1344x768", "768x1344", "896x1152", "1152x896", "1216x832"];
+const TIER_SCREEN = "image";
+
+export function SimpleImageStudio() {
+  const {
+    imageModels = [],
+    macCapabilities,
+    createImageJob,
+    rememberLocalGenerationJob,
+    imageLocalJobs = [],
+    assets = [],
+    recentImageAssets = [],
+    visibleWorkers = [],
+    activeProject,
+  } = useAppContext();
+  const { breakpoint, openGuide, toast, referenceRequest, clearReferenceRequest } = useSimpleUi();
+  const unifiedMemoryGb = useUnifiedMemoryGb();
+  const refine = useSimpleRefine("image");
+
+  const [mode, setMode] = useState("text_to_image");
+  const [prompt, setPrompt] = useState("");
+  const [model, setModel] = useState("");
+  const [resolution, setResolution] = useState("");
+  const [variations, setVariations] = useState(1);
+  const [styleId, setStyleId] = useState(null);
+  const [referenceAssetId, setReferenceAssetId] = useState(null);
+  const [refineOpen, setRefineOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Models that serve the active tab, under the same capability + Mac-gating predicate
+  // the advanced studio uses — never a hardcoded list.
+  const models = useMemo(
+    () => imageModels.filter((entry) => imageModelServesMode(entry, mode, macCapabilities)),
+    [imageModels, mode, macCapabilities],
+  );
+  const selectedModel = useMemo(
+    () => models.find((entry) => entry.id === model) ?? null,
+    [models, model],
+  );
+
+  // Keep the selection valid as the tab (and therefore the eligible set) changes.
+  useEffect(() => {
+    if (!models.length) {
+      return;
+    }
+    if (!models.some((entry) => entry.id === model)) {
+      setModel(models[0].id);
+    }
+  }, [models, model]);
+
+  const resolutions = useMemo(() => {
+    const declared = selectedModel?.limits?.resolutions?.length
+      ? selectedModel.limits.resolutions
+      : DEFAULT_RESOLUTIONS;
+    const backend = macCapabilities?.macGatingActive ? "mlx" : "candle";
+    const gated = fitsResolutionOptions(selectedModel, declared, unifiedMemoryGb, { backend });
+    return gated.length ? gated : declared;
+  }, [selectedModel, macCapabilities, unifiedMemoryGb]);
+
+  useEffect(() => {
+    if (resolutions.length && !resolutions.includes(resolution)) {
+      setResolution(resolutions[0]);
+    }
+  }, [resolutions, resolution]);
+
+  // Resolved against the FULL catalog, not just the picker's recent-20 list: a reference
+  // routed in from the Assets preview ("Use as reference") can be any library asset.
+  const referenceAsset = useMemo(
+    () => assets.find((asset) => asset.id === referenceAssetId) ?? null,
+    [assets, referenceAssetId],
+  );
+
+  // "Use as reference" from an asset preview lands here. Keyed on the request token so a
+  // repeat pick of the SAME asset still re-arms after the user cleared it.
+  useEffect(() => {
+    if (!referenceRequest) {
+      return;
+    }
+    setReferenceAssetId(referenceRequest.id);
+    clearReferenceRequest();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [referenceRequest?.token]);
+
+  const latestJob = newestLocalJob(imageLocalJobs);
+  const busy = submitting || jobIsRunning(latestJob);
+  const needsSource = mode === "edit_image" && !referenceAssetId;
+  const canGenerate =
+    Boolean(prompt.trim()) && Boolean(model) && Boolean(resolution) && !busy && !needsSource;
+
+  async function generate() {
+    if (!canGenerate) {
+      return;
+    }
+    if (!activeProject) {
+      toast("Create or open a workspace first");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const tier = resolveSimpleTier(selectedModel, TIER_SCREEN, {
+        convRotEligible: workerAdvertises(visibleWorkers, "int8_convrot"),
+        nvfp4Eligible: workerAdvertises(visibleWorkers, "nvfp4"),
+        unifiedMemoryGb,
+      });
+      const request = buildSimpleImageRequest({
+        prompt: prompt.trim(),
+        mode,
+        model,
+        resolution,
+        count: variations,
+        styleId,
+        sourceAssetId: mode === "edit_image" ? referenceAssetId : null,
+        ...tier,
+      });
+      if (!request) {
+        toast("That resolution isn’t valid");
+        return;
+      }
+      const job = await createImageJob(request);
+      if (job) {
+        rememberLocalGenerationJob?.("image", job);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function runRefine() {
+    const rewritten = await refine.run({
+      prompt,
+      modelId: model,
+      guidePath: selectedModel?.ui?.promptGuide?.path ?? "/prompt-guides/generic-image.md",
+    });
+    if (rewritten) {
+      setPrompt(rewritten);
+      setRefineOpen(false);
+    }
+  }
+
+  const resolutionText = resolution ? resolutionSummary(resolution) : "—";
+
+  return (
+    <div className="su-screen">
+      <div className="su-tabs" role="tablist">
+        <button
+          aria-selected={mode === "text_to_image"}
+          className={mode === "text_to_image" ? "su-tab active" : "su-tab"}
+          onClick={() => setMode("text_to_image")}
+          role="tab"
+          type="button"
+        >
+          Text
+        </button>
+        <button
+          aria-selected={mode === "edit_image"}
+          className={mode === "edit_image" ? "su-tab active" : "su-tab"}
+          onClick={() => setMode("edit_image")}
+          role="tab"
+          type="button"
+        >
+          Edit
+        </button>
+      </div>
+
+      <div>
+        <div className="su-prompt-head">
+          <label className="su-field-label" htmlFor="su-image-prompt">
+            Prompt
+          </label>
+          <button className="su-pill-btn" onClick={openGuide} type="button">
+            <Icon.Book size={13} />
+            Prompt guide
+          </button>
+        </div>
+        <textarea
+          className="su-textarea"
+          id="su-image-prompt"
+          onChange={(event) => setPrompt(event.target.value)}
+          placeholder="Describe the image you want…"
+          value={prompt}
+        />
+        {refineOpen ? (
+          <RefinePanel
+            blurb="Rewrite this prompt with richer detail using the Anubis-8B refiner."
+            busy={refine.busy}
+            error={refine.error}
+            modelMissing={refine.modelMissing}
+            onDownloadModel={refine.downloadModel}
+            onRun={runRefine}
+          />
+        ) : null}
+      </div>
+
+      <div className="su-tiles">
+        <ReferenceTile
+          asset={referenceAsset}
+          assets={recentImageAssets}
+          hint={mode === "edit_image" ? "Required — tap to pick the image to edit" : "Tap to attach an image"}
+          label={mode === "edit_image" ? "Source image" : "Reference"}
+          onChange={setReferenceAssetId}
+          required={mode === "edit_image"}
+        />
+        <button
+          className={refineOpen ? "su-tile active" : "su-tile"}
+          onClick={() => {
+            refine.reset();
+            setRefineOpen((open) => !open);
+          }}
+          type="button"
+        >
+          <span className="su-tile-head">
+            <Icon.Sparkle size={15} />
+            Refine
+          </span>
+          <span className="su-tile-hint">AI-rewrite your prompt</span>
+        </button>
+      </div>
+
+      <div className="su-settings-bar">
+        <div className="su-settings-row">
+          <SheetSelect
+            label="Model"
+            onSelect={setModel}
+            options={models.map((entry) => ({
+              value: entry.id,
+              label: entry.name ?? entry.id,
+              active: entry.id === model,
+            }))}
+            value={selectedModel?.name ?? selectedModel?.id ?? "No image model installed"}
+          />
+          <SheetSelect
+            kind="grid"
+            label="Resolution"
+            onSelect={setResolution}
+            options={resolutions.map((option) => ({
+              value: option,
+              ...describeResolution(option),
+              active: option === resolution,
+            }))}
+            title="Size & aspect"
+            value={resolutionText}
+          />
+        </div>
+        <Chips label="Variations" onChange={setVariations} options={VARIATION_OPTIONS} value={variations} />
+      </div>
+
+      <StyleStrip onChange={setStyleId} value={styleId} />
+
+      <button
+        className={busy ? "su-generate busy" : "su-generate"}
+        disabled={!canGenerate}
+        onClick={generate}
+        type="button"
+      >
+        {busy ? <span aria-hidden="true" className="su-spinner" /> : null}
+        {busy ? "Generating…" : `Generate ${variations} image${variations > 1 ? "s" : ""}`}
+      </button>
+      {needsSource ? (
+        <p className="su-empty">Pick the image you want to edit to start a run.</p>
+      ) : null}
+
+      <StudioResults
+        assets={assets}
+        columns={resultGridColumns(variations, breakpoint)}
+        job={latestJob}
+        meta={
+          selectedModel
+            ? `${selectedModel.name ?? selectedModel.id} · ${describeResolution(resolution).sub}`
+            : null
+        }
+        pendingCount={variations}
+        type="image"
+      />
+    </div>
+  );
+}
+
+// Mirrors the advanced studios' candle-only tier gates: a tier is only offered when a
+// live worker advertises the capability, so an MLX/pre-Ada host never resolves one.
+export function workerAdvertises(workers, capability) {
+  return (workers ?? []).some(
+    (worker) =>
+      worker?.status !== "offline" &&
+      Array.isArray(worker?.capabilities) &&
+      worker.capabilities.includes(capability),
+  );
+}

--- a/apps/web/src/simple/SimpleLicenses.jsx
+++ b/apps/web/src/simple/SimpleLicenses.jsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from "react";
+import { bundledLicenses } from "../data/bundledLicenses.js";
+import { modelLicenseRows } from "./licenseTerms.js";
+
+// Simple Licenses (design handoff): the app's own licence card, then one row per
+// bundled MODEL licence with a commercial-use badge. Backed by the real corpus
+// (apps/desktop/licenses/manifest.json via data/bundledLicenses.js) — the same source
+// the advanced Licenses screen renders, which is also where the full licence TEXT lives.
+
+const APP_LICENSE = "AGPL-3.0-or-later · © 2026 Michael Trefry & contributors. Free and open source.";
+
+export function SimpleLicenses() {
+  const rows = useMemo(() => modelLicenseRows(bundledLicenses), []);
+
+  return (
+    <div className="su-screen su-screen--tight">
+      <div className="su-license-app">
+        <strong>SceneWorks</strong>
+        <p>{APP_LICENSE}</p>
+      </div>
+
+      <div className="su-group-title">Model licenses</div>
+
+      {rows.map((row) => (
+        <div className="su-license-row" key={row.id}>
+          <span className="su-row-text">
+            <span className="su-license-name">{row.name}</span>
+            <span className="su-license-terms">{row.license || "—"}</span>
+          </span>
+          <span
+            className={
+              row.badge.tone === "danger" ? "su-license-badge su-license-badge--danger" : "su-license-badge"
+            }
+          >
+            {row.badge.label}
+          </span>
+        </div>
+      ))}
+
+      <p className="su-empty">
+        Full licence text for every bundled component — including the tooling binaries — is under
+        Licenses in the Advanced workspace.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/simple/SimpleModeSwitch.jsx
+++ b/apps/web/src/simple/SimpleModeSwitch.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { ADVANCED_MODE, SIMPLE_MODE } from "./uiMode.js";
+import "./simple.css";
+
+// The Simple ⇄ Advanced segmented switch.
+//
+// ONE component renders in BOTH shells — the Simple sidebar footer and the full
+// workspace's `.sidebar-footer` — so the two can never present the control differently.
+// This is the only addition the Simple UI makes to the existing workspace; everything
+// else about that shell is untouched.
+//
+// On a phone the switch is LOCKED to Simple (the full workspace is unusable at that
+// width), so it renders disabled with a one-line reason rather than silently ignoring
+// the click.
+export function SimpleModeSwitch({ mode, onChange, locked = false, className = "" }) {
+  return (
+    <div className={className}>
+      <div aria-label="Interface mode" className="su-switch" role="radiogroup">
+        <button
+          aria-checked={mode === SIMPLE_MODE}
+          className={mode === SIMPLE_MODE ? "active" : ""}
+          disabled={locked}
+          onClick={() => onChange(SIMPLE_MODE)}
+          role="radio"
+          type="button"
+        >
+          Simple
+        </button>
+        <button
+          aria-checked={mode === ADVANCED_MODE}
+          className={mode === ADVANCED_MODE ? "active" : ""}
+          disabled={locked}
+          onClick={() => onChange(ADVANCED_MODE)}
+          role="radio"
+          type="button"
+        >
+          Advanced
+        </button>
+      </div>
+      {locked ? <p className="su-switch-note">Phones always use the Simple UI.</p> : null}
+    </div>
+  );
+}

--- a/apps/web/src/simple/SimpleModelManager.jsx
+++ b/apps/web/src/simple/SimpleModelManager.jsx
@@ -1,0 +1,160 @@
+import React, { useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { terminalStatuses } from "../constants.js";
+import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
+import { useSimpleUi } from "./SimpleUiContext.js";
+
+// Simple Model Manager (design handoff): a tabbed catalog (Image / Video / Utility /
+// LoRAs) of one-line rows — glyph, name, "size · needs N GB", and a right-aligned
+// Manage (installed) or Download (missing) action.
+//
+// "Manage" hands off to the full Models screen (openInAdvanced — which switches the SHELL
+// as well as the view, since pointing the workspace at a screen while Simple is rendering
+// would be inert): per-tier downloads, conversion, repair, import and delete are exactly
+// the surface Simple is meant to hide, and duplicating a reduced version of them here would
+// be a second place to get destructive actions wrong. Download enqueues the model's default
+// tier through the same createModelDownloadJob the advanced screen uses.
+
+const TABS = [
+  { id: "image", label: "Image" },
+  { id: "video", label: "Video" },
+  { id: "utility", label: "Utility" },
+  { id: "loras", label: "LoRAs" },
+];
+
+export function SimpleModelManager() {
+  const { models = [], loras = [], jobs = [], createModelDownloadJob, createLoraDownloadJob } =
+    useAppContext();
+  const { toast, openInAdvanced } = useSimpleUi();
+  const unifiedMemoryGb = useUnifiedMemoryGb();
+  const [tab, setTab] = useState("image");
+
+  const rows = useMemo(() => {
+    if (tab === "loras") {
+      return loras.map((lora) => ({
+        id: lora.id,
+        name: lora.name ?? lora.id,
+        meta: [sizeLabel(lora), lora.baseModel ?? lora.family].filter(Boolean).join(" · "),
+        installed: lora.installState === "installed",
+        entry: lora,
+        kind: "lora",
+      }));
+    }
+    // Audio models ride the Utility tab alongside upscalers/refiners: the design's four
+    // tabs predate the Audio Studio landing, and a model the user can't find is worse
+    // than one on a slightly broad tab.
+    const wanted = tab === "utility" ? (type) => type !== "image" && type !== "video" : (type) => type === tab;
+    return models
+      .filter((model) => wanted(model.type))
+      .map((model) => ({
+        id: model.id,
+        name: model.name ?? model.id,
+        meta: [sizeLabel(model), needsLabel(model)].filter(Boolean).join(" · "),
+        installed: model.installState === "installed",
+        entry: model,
+        kind: "model",
+      }));
+  }, [tab, models, loras]);
+
+  const activeDownloads = useMemo(
+    () =>
+      new Set(
+        jobs
+          .filter(
+            (job) =>
+              (job.type === "model_download" || job.type === "lora_download") &&
+              !terminalStatuses.has(job.status),
+          )
+          .map((job) => job.payload?.modelId ?? job.payload?.loraId)
+          .filter(Boolean),
+      ),
+    [jobs],
+  );
+
+  async function download(row) {
+    const enqueue = row.kind === "lora" ? createLoraDownloadJob : createModelDownloadJob;
+    if (typeof enqueue !== "function") {
+      return;
+    }
+    const job = await enqueue(row.entry);
+    toast(job ? `Downloading ${row.name}…` : `Could not start the ${row.name} download`);
+  }
+
+  return (
+    <div className="su-screen su-screen--tight">
+      <div className="su-tabs su-scroll" role="tablist">
+        {TABS.map((entry) => (
+          <button
+            aria-selected={tab === entry.id}
+            className={tab === entry.id ? "su-tab active" : "su-tab"}
+            key={entry.id}
+            onClick={() => setTab(entry.id)}
+            role="tab"
+            type="button"
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+
+      {rows.length ? (
+        rows.map((row) => {
+          const downloading = activeDownloads.has(row.id);
+          return (
+            <div className="su-row" key={row.id}>
+              <span aria-hidden="true" className="su-row-glyph">
+                <Icon.Model size={20} />
+              </span>
+              <span className="su-row-text">
+                <span className="su-row-title">{row.name}</span>
+                <span className="su-row-meta">{row.meta || "—"}</span>
+              </span>
+              {row.installed ? (
+                <button
+                  className="su-row-action"
+                  onClick={() => openInAdvanced("Models")}
+                  title="Opens the full Models screen (tiers, convert, repair, delete)"
+                  type="button"
+                >
+                  Manage
+                </button>
+              ) : (
+                <button
+                  className="su-row-action primary"
+                  disabled={downloading}
+                  onClick={() => download(row)}
+                  type="button"
+                >
+                  {downloading ? "Downloading…" : "Download"}
+                </button>
+              )}
+            </div>
+          );
+        })
+      ) : (
+        <p className="su-empty">No {TABS.find((entry) => entry.id === tab)?.label.toLowerCase()} entries in the catalog.</p>
+      )}
+
+      {unifiedMemoryGb ? (
+        <p className="su-empty">This machine reports {unifiedMemoryGb.toFixed(0)} GB of usable memory.</p>
+      ) : null}
+    </div>
+  );
+}
+
+// The catalog's own human-readable download size; `~` marks an estimate, exactly as the
+// advanced Models screen labels it.
+function sizeLabel(entry) {
+  if (!entry?.downloadSizeLabel) {
+    return null;
+  }
+  return entry.downloadSizeEstimated ? `~${entry.downloadSizeLabel}` : entry.downloadSizeLabel;
+}
+
+// The model's declared memory floor, when it has one (mlx.minMemoryGb — the blanket
+// floor for its heaviest tier). Absent for models that declare none.
+function needsLabel(model) {
+  const floor = model?.mlx?.minMemoryGb;
+  return Number.isFinite(floor) ? `needs ${floor} GB` : null;
+}

--- a/apps/web/src/simple/SimplePreview.jsx
+++ b/apps/web/src/simple/SimplePreview.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Icon } from "../components/Icons.jsx";
+import { AssetMedia, assetCanRenderAsAudio, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
+import { DownloadButton } from "./studioParts.jsx";
+
+// Full-screen asset preview (design handoff): large media over four actions — "Use as
+// reference" (primary), Favorite, Download, Delete (danger).
+//
+// Delete routes to `deleteAsset`, which moves the asset to the trash (recoverable in the
+// full workspace's Assets → Trashcan). The Simple UI deliberately has no permanent-purge
+// path: an irreversible delete is not a control this surface should own.
+export function SimplePreview({ asset, onClose, onUseAsReference, onToggleFavorite, onDelete }) {
+  const title = assetCanRenderAsVideo(asset) ? "Clip" : assetCanRenderAsAudio(asset) ? "Audio" : "Image";
+  const favorite = Boolean(asset.status?.favorite);
+  return (
+    <div aria-label={`${title} preview`} className="su-preview" role="dialog">
+      <div className="su-preview-head">
+        <button aria-label="Close preview" className="su-preview-close" onClick={onClose} type="button">
+          <Icon.Close size={18} />
+        </button>
+        <strong>{asset.displayName ?? title}</strong>
+      </div>
+      <div className="su-preview-stage">
+        <AssetMedia asset={asset} />
+      </div>
+      <div className="su-preview-actions">
+        {assetCanRenderAsAudio(asset) ? null : (
+          <button className="su-preview-primary" onClick={() => onUseAsReference(asset)} type="button">
+            <Icon.Image size={16} />
+            Use as reference
+          </button>
+        )}
+        <div className="su-preview-row">
+          <button onClick={() => onToggleFavorite(asset)} type="button">
+            <Icon.Star filled={favorite} size={15} />
+            {favorite ? "Favorited" : "Favorite"}
+          </button>
+          <DownloadButton asset={asset} className="" label="Download" />
+          <button className="danger" onClick={() => onDelete(asset)} type="button">
+            <Icon.Trash size={15} />
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/simple/SimpleQueue.jsx
+++ b/apps/web/src/simple/SimpleQueue.jsx
@@ -1,0 +1,131 @@
+import React, { useMemo } from "react";
+import { useAppContext } from "../context/AppContext.js";
+import { errorStatuses, terminalStatuses } from "../jobTypes.js";
+import { percent } from "../formatting.js";
+
+// Simple Queue (design handoff): three stat tiles (Running / Queued / Done) over a list
+// of job rows — status dot, title, sub-line, status badge, and a progress bar.
+//
+// Same live `jobs` feed the advanced Queue reads (SSE-updated through useJobEvents), so
+// the two views never disagree; what Simple drops is the per-worker resource panel and
+// the retry/cancel/clear controls, which stay in the full workspace.
+
+// Statuses the design's three buckets map onto. "Running" is anything a worker has
+// claimed and not finished; "Queued" is the pending band; "Done" is terminal-and-clean.
+export function bucketFor(job) {
+  if (terminalStatuses.has(job.status)) {
+    return errorStatuses.has(job.status) ? "failed" : "done";
+  }
+  return job.status === "queued" || job.status === "pending_caption" ? "queued" : "running";
+}
+
+const BADGE_LABEL = {
+  running: "Running",
+  queued: "Queued",
+  done: "Done",
+  failed: "Failed",
+};
+
+export function SimpleQueue() {
+  const { jobs = [] } = useAppContext();
+
+  const rows = useMemo(
+    () =>
+      jobs.map((job) => ({
+        id: job.id,
+        bucket: bucketFor(job),
+        title: jobTitle(job),
+        sub: jobSub(job),
+        progress: Number(job.progress),
+        status: job.status,
+      })),
+    [jobs],
+  );
+
+  const counts = useMemo(
+    () => ({
+      running: rows.filter((row) => row.bucket === "running").length,
+      queued: rows.filter((row) => row.bucket === "queued").length,
+      done: rows.filter((row) => row.bucket === "done").length,
+    }),
+    [rows],
+  );
+
+  return (
+    <div className="su-screen su-screen--tight">
+      <div className="su-stats">
+        <div className="su-stat su-stat--running">
+          <div className="su-stat-value">{counts.running}</div>
+          <div className="su-stat-label">Running</div>
+        </div>
+        <div className="su-stat">
+          <div className="su-stat-value">{counts.queued}</div>
+          <div className="su-stat-label">Queued</div>
+        </div>
+        <div className="su-stat su-stat--done">
+          <div className="su-stat-value">{counts.done}</div>
+          <div className="su-stat-label">Done</div>
+        </div>
+      </div>
+
+      {rows.length ? (
+        rows.map((row) => {
+          const showBar = row.bucket !== "queued";
+          const width = row.bucket === "done" ? "100%" : Number.isFinite(row.progress) ? percent(row.progress) : "0%";
+          return (
+            <div className="su-job" key={row.id}>
+              <div className="su-job-head">
+                <span aria-hidden="true" className={`su-dot su-dot--${row.bucket}`} />
+                <span className="su-job-text">
+                  <span className="su-job-title">{row.title}</span>
+                  <span className="su-job-sub">{row.sub}</span>
+                </span>
+                <span className={`su-job-badge su-job-badge--${row.bucket}`}>
+                  {row.bucket === "running" && Number.isFinite(row.progress) && row.progress > 0
+                    ? percent(row.progress)
+                    : BADGE_LABEL[row.bucket]}
+                </span>
+              </div>
+              {showBar ? (
+                <div className={row.bucket === "done" ? "su-bar su-bar--done" : "su-bar"}>
+                  <span style={{ width }} />
+                </div>
+              ) : null}
+            </div>
+          );
+        })
+      ) : (
+        <p className="su-empty">Nothing in the queue. Runs you start in a studio show up here.</p>
+      )}
+    </div>
+  );
+}
+
+// The job's headline: the model it runs, falling back to the job type. Mirrors what the
+// advanced Queue card leads with, minus the worker/GPU detail.
+function jobTitle(job) {
+  const model = job.payload?.modelName ?? job.payload?.model ?? job.payload?.modelId;
+  return model ? String(model) : formatType(job.type);
+}
+
+function jobSub(job) {
+  const parts = [formatType(job.type)];
+  const width = job.payload?.width;
+  const height = job.payload?.height;
+  if (width && height) {
+    parts.push(`${width}×${height}`);
+  }
+  const count = job.payload?.count;
+  if (Number.isFinite(count) && count > 1) {
+    parts.push(`${count} variations`);
+  }
+  const duration = job.payload?.duration ?? job.payload?.targetDurationSecs;
+  if (Number.isFinite(duration)) {
+    parts.push(`${duration}s`);
+  }
+  return parts.join(" · ");
+}
+
+function formatType(type) {
+  return String(type ?? "job").replaceAll("_", " ");
+}

--- a/apps/web/src/simple/SimpleSettings.jsx
+++ b/apps/web/src/simple/SimpleSettings.jsx
@@ -1,0 +1,273 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { apiFetch } from "../api.js";
+import { useAppContext } from "../context/AppContext.js";
+import { ACCENTS } from "../accents.js";
+import {
+  AUTO_GENERATION_QUALITY,
+  GENERATION_QUALITY_OPTIONS,
+  generationQualityLabel,
+  readDefaultGenerationQuality,
+  writeDefaultGenerationQuality,
+} from "../generationQuality.js";
+import { loadCredentials, saveCredential } from "../credentials.js";
+import { Chips } from "./studioParts.jsx";
+import { useSimpleUi } from "./SimpleUiContext.js";
+
+// Simple Settings (design handoff): Appearance (theme + accent), Generation (default
+// quality + the Simple-UI default), Service credentials, Device.
+//
+// Every control writes to the SAME durable store the advanced Settings screen uses —
+// theme/accent and the default quality through `PUT /api/v1/ui-preferences`, credentials
+// through the shared keychain/REST transport — so a change made here is the same change
+// made there. Nothing in this screen is Simple-only state.
+
+export function SimpleSettings({ accent, onAccentChange, simpleDefault, onSimpleDefaultChange, lockedToSimple }) {
+  const { theme, changeTheme, visibleWorkers = [], macCapabilities } = useAppContext();
+  const { toast } = useSimpleUi();
+  const [quality, setQuality] = useState(readDefaultGenerationQuality);
+  const [credentials, setCredentials] = useState([]);
+  const [host, setHost] = useState("");
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadCredentials()
+      .then((items) => {
+        if (!cancelled) {
+          setCredentials(items ?? []);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function changeQuality(next) {
+    const value = writeDefaultGenerationQuality(next);
+    setQuality(value);
+    // ui-preferences is a public route (like /health) and MERGES partial updates, so
+    // sending only this field can't disturb theme/accent — same contract as App.jsx.
+    apiFetch("/api/v1/ui-preferences", "", {
+      method: "PUT",
+      body: JSON.stringify({ defaultGenerationQuality: value }),
+    }).catch(() => {});
+    toast(`Default quality set to ${generationQualityLabel(value)}`);
+  }
+
+  async function addCredential() {
+    const trimmedHost = host.trim();
+    if (!trimmedHost || !token.trim() || saving) {
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await saveCredential({
+        host: trimmedHost,
+        label: trimmedHost,
+        scheme: "bearer",
+        token: token.trim(),
+      });
+      setCredentials(updated ?? credentials);
+      setHost("");
+      setToken("");
+      toast(`Credential saved for ${trimmedHost}`);
+    } catch (error) {
+      toast(String(error?.message ?? error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Engine / GPU are read off the live worker registry — the one signal available in
+  // every deployment (desktop, Docker, remote browser).
+  const device = useMemo(() => describeDevice(visibleWorkers, macCapabilities), [visibleWorkers, macCapabilities]);
+
+  return (
+    <div className="su-screen su-screen--loose">
+      <div className="su-group">
+        <div className="su-group-title">Appearance</div>
+        <div className="su-card su-card--split">
+          <span className="su-card-title">Theme</span>
+          <div className="su-theme-toggle" role="radiogroup" aria-label="Theme">
+            <button
+              aria-checked={theme === "light"}
+              className={theme === "light" ? "active" : ""}
+              onClick={() => changeTheme("light")}
+              role="radio"
+              type="button"
+            >
+              <Icon.Sun size={14} />
+              Light
+            </button>
+            <button
+              aria-checked={theme === "dark"}
+              className={theme === "dark" ? "active" : ""}
+              onClick={() => changeTheme("dark")}
+              role="radio"
+              type="button"
+            >
+              <Icon.Moon size={14} />
+              Dark
+            </button>
+          </div>
+        </div>
+        <div className="su-card">
+          <div className="su-card-title">Accent</div>
+          <div className="su-accents" role="radiogroup" aria-label="Accent">
+            {ACCENTS.map((entry) => (
+              <button
+                aria-checked={accent === entry.id}
+                aria-label={entry.name}
+                className={accent === entry.id ? "su-accent-swatch active" : "su-accent-swatch"}
+                key={entry.id}
+                onClick={() => onAccentChange(entry.id)}
+                role="radio"
+                style={{ background: entry.swatch }}
+                type="button"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="su-group">
+        <div className="su-group-title">Generation</div>
+        <div className="su-card">
+          <div className="su-card-title">Default quality</div>
+          {/* Auto leads the row: it is the app-wide default (the highest-fidelity tier that
+              fits this machine), and omitting it would strand a Simple user on a pinned tier
+              with no way back. The three explicit tiers are the design's.
+              SHORT labels (the tier keys) — the advanced Settings screen's descriptive ones
+              ("Auto (best that fits this Mac)") don't fit a 34px chip. The full wording rides
+              the title attribute, and the selected tier is spelled out underneath. */}
+          <Chips
+            ariaLabel="Default quality"
+            capped
+            onChange={changeQuality}
+            options={GENERATION_QUALITY_OPTIONS.map((value) => ({
+              value,
+              label: shortQualityLabel(value),
+              title: generationQualityLabel(value),
+            }))}
+            value={quality}
+          />
+          <div className="su-card-sub">{generationQualityLabel(quality)}</div>
+        </div>
+        <div className="su-card su-card--split">
+          <div>
+            <div className="su-card-title">Use Simple UI by default</div>
+            <div className="su-card-sub">
+              {lockedToSimple ? "Phones always use it." : "Phones always use it; the sidebar switch overrides it for this session."}
+            </div>
+          </div>
+          <button
+            aria-checked={simpleDefault}
+            aria-label="Use Simple UI by default"
+            className={simpleDefault ? "su-toggle on" : "su-toggle"}
+            onClick={() => onSimpleDefaultChange(!simpleDefault)}
+            role="switch"
+            type="button"
+          >
+            <span />
+          </button>
+        </div>
+      </div>
+
+      <div className="su-group">
+        <div className="su-group-title">Service credentials</div>
+        <div className="su-card">
+          <div className="su-card-body">
+            <p className="su-card-note">
+              Add a token for gated downloads (e.g. huggingface.co). Tokens are write-only — they are
+              never shown again after saving.
+            </p>
+            {credentials.length ? (
+              <p className="su-card-note">
+                Saved for {credentials.map((credential) => credential.host).join(", ")}.
+              </p>
+            ) : null}
+            <div className="su-inline-form">
+              <input
+                aria-label="Credential host"
+                className="su-input"
+                onChange={(event) => setHost(event.target.value)}
+                placeholder="huggingface.co"
+                value={host}
+              />
+            </div>
+            <div className="su-inline-form">
+              <input
+                aria-label="Access token"
+                className="su-input"
+                onChange={(event) => setToken(event.target.value)}
+                placeholder="Access token"
+                type="password"
+                value={token}
+              />
+              <button
+                className="su-accent-btn"
+                disabled={!host.trim() || !token.trim() || saving}
+                onClick={addCredential}
+                type="button"
+              >
+                {saving ? "Saving…" : "Add"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="su-group">
+        <div className="su-group-title">Device</div>
+        <div className="su-card">
+          <div className="su-card-body">
+            <div className="su-kv">
+              <span>Engine</span>
+              <span>{device.engine}</span>
+            </div>
+            <div className="su-kv">
+              <span>GPU</span>
+              <span>{device.gpu}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Chip-sized label for a quality value — the design's [bf16, Q8, Q4] plus Auto. Derived
+// from the value rather than a lookup table, so a tier added to the vocabulary still gets a
+// sensible chip; the full descriptive wording rides the chip's title and the line beneath.
+export function shortQualityLabel(value) {
+  if (value === AUTO_GENERATION_QUALITY) {
+    return "Auto";
+  }
+  // bf16 is written lower-case everywhere in the product; the quant tiers are upper-case.
+  return value === "bf16" ? "bf16" : String(value).toUpperCase();
+}
+
+// Engine + GPU summary from the live worker registry. An MLX worker means Apple Silicon
+// unified memory; anything else is the discrete-GPU (candle) lane. Unknown values read
+// "Detecting…" rather than a fabricated placeholder.
+export function describeDevice(workers, macCapabilities) {
+  const gpuWorkers = (workers ?? []).filter((worker) => worker?.gpuId && worker.gpuId !== "cpu");
+  const mlx = gpuWorkers.find((worker) => worker.gpuId === "mlx");
+  const primary = mlx ?? gpuWorkers[0] ?? null;
+  const engine = mlx
+    ? "MLX · Apple Silicon"
+    : primary
+      ? "Candle · discrete GPU"
+      : macCapabilities?.platform === "macos"
+        ? "MLX · Apple Silicon"
+        : "Detecting…";
+  if (!primary) {
+    return { engine, gpu: "No worker connected" };
+  }
+  const totalMb = Number(primary.utilization?.memoryTotalMb);
+  const memory = Number.isFinite(totalMb) && totalMb > 0 ? ` · ${(totalMb / 1024).toFixed(0)} GB` : "";
+  return { engine, gpu: `${primary.gpuName ?? `GPU ${primary.gpuId}`}${memory}` };
+}

--- a/apps/web/src/simple/SimpleSheet.jsx
+++ b/apps/web/src/simple/SimpleSheet.jsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useRef } from "react";
+import { Icon } from "../components/Icons.jsx";
+
+// The Simple UI's one picker/overlay chrome (design handoff): a bottom sheet on phone
+// (drag handle, ≤76% height, slide-up) and a centered 460px modal card on tablet/desktop
+// (fade+pop). Which one renders is pure CSS off the root's `data-bp`, so this component
+// is the same in both bands — only the handle is phone-only.
+//
+// Backdrop click and Escape both close, and focus moves into the panel on open so a
+// keyboard user isn't left behind on the trigger.
+export function SimpleSheet({ title, onClose, phone, children, labelId = "su-sheet-title" }) {
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    panelRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKey(event) {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <button aria-label="Close" className="su-overlay" onClick={onClose} type="button" />
+      <div
+        aria-labelledby={labelId}
+        aria-modal="true"
+        className="su-sheet su-scroll"
+        ref={panelRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        {phone ? <div aria-hidden="true" className="su-sheet-handle" /> : null}
+        {title ? (
+          <h2 className="su-sheet-title" id={labelId}>
+            {title}
+          </h2>
+        ) : null}
+        {children}
+      </div>
+    </>
+  );
+}
+
+// The picker body for a sheet descriptor. Three shapes, matching the design:
+//   list  — model / voice / reference pickers (a tick marks the current value)
+//   grid  — size & aspect (3-up tiles with a label + sub-label)
+//   pills — duration (wrapping pills)
+export function SimpleSheetOptions({ kind, options, onSelect }) {
+  if (kind === "grid") {
+    return (
+      <div className="su-option-grid">
+        {options.map((option) => (
+          <button
+            aria-pressed={Boolean(option.active)}
+            className={option.active ? "su-option-tile active" : "su-option-tile"}
+            key={option.value}
+            onClick={() => onSelect(option.value)}
+            type="button"
+          >
+            <strong>{option.label}</strong>
+            {option.sub ? <small>{option.sub}</small> : null}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  if (kind === "pills") {
+    return (
+      <div className="su-option-pills">
+        {options.map((option) => (
+          <button
+            aria-pressed={Boolean(option.active)}
+            className={option.active ? "su-filter-pill active" : "su-filter-pill"}
+            key={option.value}
+            onClick={() => onSelect(option.value)}
+            type="button"
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="su-option-list">
+      {options.map((option) => (
+        <button
+          aria-pressed={Boolean(option.active)}
+          className={option.active ? "su-option-row active" : "su-option-row"}
+          key={option.value}
+          onClick={() => onSelect(option.value)}
+          type="button"
+        >
+          {option.thumbnail ? <img alt="" src={option.thumbnail} /> : null}
+          <span>{option.label}</span>
+          {option.active ? <Icon.Check size={16} /> : null}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -1,0 +1,303 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { Logo } from "../components/Logo.jsx";
+import { ConfirmHost } from "../appConfirm.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { terminalStatuses } from "../constants.js";
+import { breakpointFor, contentMaxWidth } from "./breakpoint.js";
+import { ADVANCED_MODE } from "./uiMode.js";
+import { useContainerWidth } from "./useContainerWidth.js";
+import { SimpleUiContext } from "./SimpleUiContext.js";
+import { SimpleSheet, SimpleSheetOptions } from "./SimpleSheet.jsx";
+import { PromptGuideSheet } from "./PromptGuideSheet.jsx";
+import { SimplePreview } from "./SimplePreview.jsx";
+import { SimpleModeSwitch } from "./SimpleModeSwitch.jsx";
+import { SimpleImageStudio } from "./SimpleImageStudio.jsx";
+import { SimpleVideoStudio } from "./SimpleVideoStudio.jsx";
+import { SimpleAudioStudio } from "./SimpleAudioStudio.jsx";
+import { SimpleAssets } from "./SimpleAssets.jsx";
+import { SimpleModelManager } from "./SimpleModelManager.jsx";
+import { SimpleQueue } from "./SimpleQueue.jsx";
+import { SimpleSettings } from "./SimpleSettings.jsx";
+import { SimpleLicenses } from "./SimpleLicenses.jsx";
+import "./simple.css";
+
+// The Simple UI shell (design handoff "Simple UI for creative studios").
+//
+// One responsive layout with three container-measured bands: a phone gets a top bar with
+// a hamburger and an overlay drawer, tablet/desktop get a persistent 244px sidebar and a
+// centered content column (680px / 900px). The shell owns the four overlays every screen
+// shares — the picker sheet, the prompt guide, the asset preview and the toast — and
+// publishes them on SimpleUiContext so a screen never re-implements one.
+//
+// It renders INSIDE App's providers, so every screen reads the same live catalogs, job
+// feed and actions the full workspace does. There is no parallel data layer.
+
+export const SIMPLE_SCREENS = [
+  {
+    group: "Studios",
+    items: [
+      { id: "image", label: "Image", icon: Icon.Image, title: "Image Studio", sub: "Text & Edit" },
+      { id: "video", label: "Video", icon: Icon.Video, title: "Video Studio", sub: "Text & Image to Video" },
+      { id: "audio", label: "Audio", icon: Icon.Audio, title: "Audio Studio", sub: "Music · Speech · SFX" },
+      { id: "assets", label: "Assets", icon: Icon.Library, title: "Assets", sub: "Images, clips & audio" },
+    ],
+  },
+  {
+    group: "Manage",
+    items: [
+      { id: "models", label: "Model Manager", icon: Icon.Model, title: "Model Manager", sub: "Download & manage checkpoints" },
+      { id: "queue", label: "Queue", icon: Icon.Queue, title: "Queue", sub: "Running & recent jobs" },
+      { id: "settings", label: "Settings", icon: Icon.Sliders, title: "Settings", sub: "Appearance, generation & device" },
+      { id: "licenses", label: "Licenses", icon: Icon.Book, title: "Licenses", sub: "Software & model terms" },
+    ],
+  },
+];
+
+const SCREEN_BY_ID = new Map(SIMPLE_SCREENS.flatMap((group) => group.items).map((item) => [item.id, item]));
+
+const TOAST_MS = 1900;
+
+export function SimpleShell({
+  accent,
+  onAccentChange,
+  simpleDefault,
+  onSimpleDefaultChange,
+  onModeChange,
+  lockedToSimple,
+}) {
+  const {
+    jobs = [],
+    assets = [],
+    deleteAsset,
+    updateAssetStatus,
+    setSelectedAssetId,
+    setActiveView,
+  } = useAppContext();
+
+  const [rootRef, width] = useContainerWidth();
+  const breakpoint = breakpointFor(width);
+  const phone = breakpoint === "phone";
+
+  const [screen, setScreen] = useState("image");
+  const [drawer, setDrawer] = useState(false);
+  const [sheet, setSheet] = useState(null);
+  const [guideOpen, setGuideOpen] = useState(false);
+  const [preview, setPreview] = useState(null);
+  const [toastText, setToastText] = useState(null);
+  // The reference an asset preview hands to the Image Studio. Held here (not in the
+  // studio) so "Use as reference" works from Assets, which is a different screen.
+  const [referenceRequest, setReferenceRequest] = useState(null);
+  const toastTimer = useRef(null);
+
+  useEffect(() => () => clearTimeout(toastTimer.current), []);
+
+  const toast = useCallback((message) => {
+    setToastText(message);
+    clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToastText(null), TOAST_MS);
+  }, []);
+
+  // Navigating closes the drawer and every open overlay (design: "Screen switch clears
+  // any open sheet/preview").
+  const goTo = useCallback((next) => {
+    setScreen(next);
+    setDrawer(false);
+    setSheet(null);
+    setPreview(null);
+    setGuideOpen(false);
+  }, []);
+
+  // Hand off to a full-workspace screen: point the workspace at `view` AND flip the shell,
+  // because setting the view alone would do nothing visible from in here. Refuses (with a
+  // reason) when the viewport has Simple locked on, so a control can never look inert.
+  const openInAdvanced = useCallback(
+    (view) => {
+      if (lockedToSimple) {
+        toast("That opens in the Advanced workspace — switch on a larger screen.");
+        return false;
+      }
+      setActiveView?.(view);
+      onModeChange(ADVANCED_MODE);
+      return true;
+    },
+    [lockedToSimple, onModeChange, setActiveView, toast],
+  );
+
+  const ui = useMemo(
+    () => ({
+      breakpoint,
+      goTo,
+      openSheet: setSheet,
+      closeSheet: () => setSheet(null),
+      openGuide: () => setGuideOpen(true),
+      openPreview: setPreview,
+      openInAdvanced,
+      uiLocked: lockedToSimple,
+      toast,
+      referenceRequest,
+      clearReferenceRequest: () => setReferenceRequest(null),
+    }),
+    [breakpoint, goTo, toast, referenceRequest, openInAdvanced, lockedToSimple],
+  );
+
+  const active = SCREEN_BY_ID.get(screen) ?? SCREEN_BY_ID.get("image");
+  const queueCount = useMemo(
+    () => jobs.filter((job) => !terminalStatuses.has(job.status)).length,
+    [jobs],
+  );
+  // The preview may be showing an asset that has since been deleted/refreshed away;
+  // re-resolve it from the live catalog each render so its favorite state stays honest.
+  const previewAsset = useMemo(
+    () => (preview ? (assets.find((asset) => asset.id === preview.id) ?? preview) : null),
+    [preview, assets],
+  );
+
+  return (
+    <SimpleUiContext.Provider value={ui}>
+      <div
+        className="su-root"
+        data-bp={breakpoint}
+        ref={rootRef}
+        style={{ "--su-content-max": contentMaxWidth(breakpoint) }}
+      >
+        {!phone || drawer ? (
+          <nav aria-label="Primary" className="su-nav su-scroll">
+            <div className="su-brand">
+              <Logo size={30} />
+              <div>
+                <div className="su-brand-name">SceneWorks</div>
+                <div className="su-brand-sub">Simple</div>
+              </div>
+            </div>
+            {SIMPLE_SCREENS.map((group) => (
+              <React.Fragment key={group.group}>
+                <div className="su-nav-group-title">{group.group}</div>
+                <div
+                  className={
+                    group.group === "Studios" ? "su-nav-group su-nav-group--studios" : "su-nav-group"
+                  }
+                >
+                  {group.items.map((item) => {
+                    const IconComponent = item.icon;
+                    return (
+                      <button
+                        aria-current={screen === item.id ? "page" : undefined}
+                        className={screen === item.id ? "su-nav-item active" : "su-nav-item"}
+                        key={item.id}
+                        onClick={() => goTo(item.id)}
+                        type="button"
+                      >
+                        <IconComponent size={group.group === "Studios" ? 19 : 18} />
+                        <span className="su-nav-label">{item.label}</span>
+                        {item.id === "queue" && queueCount ? (
+                          <span className="su-nav-badge">{queueCount}</span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </React.Fragment>
+            ))}
+            <div className="su-nav-footer">
+              <SimpleModeSwitch locked={lockedToSimple} mode="simple" onChange={onModeChange} />
+            </div>
+          </nav>
+        ) : null}
+
+        {phone && drawer ? (
+          <button aria-label="Close menu" className="su-scrim" onClick={() => setDrawer(false)} type="button" />
+        ) : null}
+
+        <div className="su-main">
+          <header className="su-topbar">
+            {phone ? (
+              <button
+                aria-label="Open menu"
+                className="su-hamburger"
+                onClick={() => setDrawer(true)}
+                type="button"
+              >
+                <Icon.Menu size={21} />
+              </button>
+            ) : null}
+            <div className="su-topbar-title">
+              <strong>{active.title}</strong>
+              <span>{active.sub}</span>
+            </div>
+          </header>
+
+          <div className="su-body su-scroll">
+            <div className="su-content">
+              {screen === "image" ? <SimpleImageStudio /> : null}
+              {screen === "video" ? <SimpleVideoStudio /> : null}
+              {screen === "audio" ? <SimpleAudioStudio /> : null}
+              {screen === "assets" ? <SimpleAssets /> : null}
+              {screen === "models" ? <SimpleModelManager /> : null}
+              {screen === "queue" ? <SimpleQueue /> : null}
+              {screen === "settings" ? (
+                <SimpleSettings
+                  accent={accent}
+                  lockedToSimple={lockedToSimple}
+                  onAccentChange={onAccentChange}
+                  onSimpleDefaultChange={onSimpleDefaultChange}
+                  simpleDefault={simpleDefault}
+                />
+              ) : null}
+              {screen === "licenses" ? <SimpleLicenses /> : null}
+            </div>
+          </div>
+        </div>
+
+        {sheet ? (
+          <SimpleSheet onClose={() => setSheet(null)} phone={phone} title={sheet.title}>
+            <SimpleSheetOptions
+              kind={sheet.kind}
+              onSelect={(value) => {
+                sheet.onSelect(value);
+                setSheet(null);
+              }}
+              options={sheet.options}
+            />
+          </SimpleSheet>
+        ) : null}
+
+        {guideOpen ? <PromptGuideSheet onClose={() => setGuideOpen(false)} phone={phone} /> : null}
+
+        {previewAsset ? (
+          <SimplePreview
+            asset={previewAsset}
+            onClose={() => setPreview(null)}
+            onDelete={async (asset) => {
+              setPreview(null);
+              await deleteAsset(asset);
+              toast("Moved to trash");
+            }}
+            onToggleFavorite={(asset) => {
+              updateAssetStatus(asset, { favorite: !asset.status?.favorite });
+              toast(asset.status?.favorite ? "Removed from favorites" : "Added to favorites");
+            }}
+            onUseAsReference={(asset) => {
+              setSelectedAssetId?.(asset.id);
+              setReferenceRequest({ id: asset.id, token: asset.id + Date.now() });
+              setPreview(null);
+              setScreen("image");
+              toast("Added as reference in Image Studio");
+            }}
+          />
+        ) : null}
+
+        {toastText ? (
+          <div aria-live="polite" className="su-toast" role="status">
+            <span>{toastText}</span>
+          </div>
+        ) : null}
+
+        {/* Desktop-safe confirm host (sc-11968): appConfirm() resolves through a real React
+            dialog rather than window.confirm, which no-ops in the Tauri WebView. Mounted here
+            so a Simple-side action that awaits a confirm still works. */}
+        <ConfirmHost />
+      </div>
+    </SimpleUiContext.Provider>
+  );
+}

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -1,0 +1,255 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../context/AppContext.js";
+import { SimpleShell } from "./SimpleShell.jsx";
+import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+// The Simple shell mounts inside App's providers and reads everything through them, so a
+// single legacy <AppContext.Provider> is enough to drive it in isolation (see AppContext's
+// fallback contract). These tests cover the shell's own contract: navigation, the picker
+// sheet, the toast, and that a Generate goes through the real job-creation action with the
+// real payload — not a mock.
+
+const IMAGE_MODEL = {
+  id: "z_image",
+  name: "Z-Image",
+  type: "image",
+  capabilities: ["text_to_image", "edit_image"],
+  installState: "installed",
+  limits: { resolutions: ["1024x1024", "1344x768"] },
+};
+
+function baseContext(overrides = {}) {
+  return {
+    activeProject: { id: "project-1", name: "Default" },
+    assets: [],
+    recentImageAssets: [],
+    jobs: [],
+    imageModels: [IMAGE_MODEL],
+    videoModels: [],
+    audioModels: [],
+    models: [IMAGE_MODEL],
+    loras: [],
+    imageLocalJobs: [],
+    videoLocalJobs: [],
+    audioLocalJobs: [],
+    visibleWorkers: [],
+    macCapabilities: null,
+    theme: "light",
+    changeTheme: () => {},
+    createImageJob: vi.fn(async () => ({ id: "job-1" })),
+    createVideoJob: vi.fn(async () => null),
+    createAudioJob: vi.fn(async () => null),
+    createModelDownloadJob: vi.fn(async () => null),
+    createLoraDownloadJob: vi.fn(async () => null),
+    rememberLocalGenerationJob: vi.fn(),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    setSelectedAssetId: vi.fn(),
+    setActiveView: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderShell(root, context, props = {}) {
+  return act(async () => {
+    root.render(
+      <AppContext.Provider value={context}>
+        <SimpleShell
+          accent="teal"
+          lockedToSimple={false}
+          onAccentChange={() => {}}
+          onModeChange={() => {}}
+          onSimpleDefaultChange={() => {}}
+          simpleDefault
+          {...props}
+        />
+      </AppContext.Provider>,
+    );
+  });
+}
+
+function buttonWithText(container, text) {
+  return [...container.querySelectorAll("button")].find(
+    (node) => node.textContent.trim() === text,
+  );
+}
+
+describe("SimpleShell", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    // jsdom has no ResizeObserver; the shell's measurement hook degrades to the
+    // unmeasured (desktop) band, which is what these tests exercise.
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.restoreAllMocks();
+  });
+
+  it("opens on the Image Studio with the persistent sidebar", async () => {
+    await renderShell(root, baseContext());
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Image Studio");
+    expect(container.querySelector(".su-nav")).toBeTruthy();
+    // Desktop band ⇒ no hamburger.
+    expect(container.querySelector(".su-hamburger")).toBeNull();
+    // The Simple/Advanced switch lives in the sidebar footer.
+    expect(container.querySelector(".su-nav-footer .su-switch")).toBeTruthy();
+  });
+
+  it("navigates between screens from the sidebar", async () => {
+    await renderShell(root, baseContext());
+    await click(buttonWithText(container, "Queue"));
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Queue");
+    await click(buttonWithText(container, "Licenses"));
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Licenses");
+  });
+
+  it("shows the live queue count as a nav badge and drops it when nothing is pending", async () => {
+    await renderShell(
+      root,
+      baseContext({
+        jobs: [
+          { id: "a", type: "image_generate", status: "running" },
+          { id: "b", type: "image_generate", status: "queued" },
+          { id: "c", type: "image_generate", status: "completed" },
+        ],
+      }),
+    );
+    expect(container.querySelector(".su-nav-badge").textContent).toBe("2");
+
+    await renderShell(root, baseContext({ jobs: [{ id: "c", type: "image_generate", status: "completed" }] }));
+    expect(container.querySelector(".su-nav-badge")).toBeNull();
+  });
+
+  it("opens the resolution picker as a sheet and applies the pick", async () => {
+    await renderShell(root, baseContext());
+    const resolutionButton = [...container.querySelectorAll(".su-select")].find((node) =>
+      node.textContent.includes("1:1"),
+    );
+    expect(resolutionButton).toBeTruthy();
+    await click(resolutionButton);
+
+    const sheet = container.querySelector(".su-sheet");
+    expect(sheet).toBeTruthy();
+    expect(sheet.querySelector(".su-sheet-title").textContent).toBe("Size & aspect");
+
+    const wide = [...sheet.querySelectorAll(".su-option-tile")].find((node) =>
+      node.textContent.includes("16:9"),
+    );
+    await click(wide);
+    // Sheet closes and the trigger reflects the new value.
+    expect(container.querySelector(".su-sheet")).toBeNull();
+    expect(
+      [...container.querySelectorAll(".su-select")].some((node) => node.textContent.includes("16:9")),
+    ).toBe(true);
+  });
+
+  it("opens the prompt guide overlay and closes it again", async () => {
+    await renderShell(root, baseContext());
+    await click(buttonWithText(container, "Prompt guide"));
+    expect(container.textContent).toContain("Lead with the subject");
+    await click(container.querySelector(".su-sheet-head .su-icon-btn"));
+    expect(container.textContent).not.toContain("Lead with the subject");
+  });
+
+  it("submits a real image job through createImageJob and remembers it locally", async () => {
+    const context = baseContext();
+    await renderShell(root, context);
+
+    const textarea = container.querySelector("#su-image-prompt");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      ).set;
+      setter.call(textarea, "a lighthouse at golden hour");
+      textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+
+    await click(container.querySelector(".su-generate"));
+
+    expect(context.createImageJob).toHaveBeenCalledTimes(1);
+    const payload = context.createImageJob.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      mode: "text_to_image",
+      model: "z_image",
+      prompt: "a lighthouse at golden hour",
+      count: 1,
+      width: 1024,
+      height: 1024,
+    });
+    expect(context.rememberLocalGenerationJob).toHaveBeenCalledWith("image", { id: "job-1" });
+  });
+
+  it("refuses to submit with an empty prompt", async () => {
+    const context = baseContext();
+    await renderShell(root, context);
+    expect(container.querySelector(".su-generate").disabled).toBe(true);
+    await click(container.querySelector(".su-generate"));
+    expect(context.createImageJob).not.toHaveBeenCalled();
+  });
+
+  it("locks the mode switch and explains why when the viewport forces Simple", async () => {
+    await renderShell(root, baseContext(), { lockedToSimple: true });
+    const [simple, advanced] = container.querySelectorAll(".su-nav-footer .su-switch button");
+    expect(simple.disabled).toBe(true);
+    expect(advanced.disabled).toBe(true);
+    expect(container.textContent).toContain("Phones always use the Simple UI.");
+  });
+
+  // "Manage" points the WORKSPACE at its Models screen — which is invisible while the
+  // Simple shell is rendering. So it has to flip the shell too, or the button is inert.
+  it("hands 'Manage' off to the full Models screen AND switches shells", async () => {
+    const context = baseContext();
+    const onModeChange = vi.fn();
+    await renderShell(root, context, { onModeChange });
+    await click(buttonWithText(container, "Model Manager"));
+
+    const manage = buttonWithText(container, "Manage");
+    expect(manage).toBeTruthy();
+    await click(manage);
+
+    expect(context.setActiveView).toHaveBeenCalledWith("Models");
+    expect(onModeChange).toHaveBeenCalledWith("advanced");
+  });
+
+  it("refuses the hand-off with a reason when the viewport locks Simple on", async () => {
+    const context = baseContext();
+    const onModeChange = vi.fn();
+    await renderShell(root, context, { onModeChange, lockedToSimple: true });
+    await click(buttonWithText(container, "Model Manager"));
+    await click(buttonWithText(container, "Manage"));
+
+    expect(context.setActiveView).not.toHaveBeenCalled();
+    expect(onModeChange).not.toHaveBeenCalled();
+    expect(container.querySelector(".su-toast").textContent).toContain("Advanced workspace");
+  });
+
+  it("enqueues a real download for a model that isn't installed", async () => {
+    const context = baseContext({
+      models: [IMAGE_MODEL, { ...IMAGE_MODEL, id: "flux_dev", name: "FLUX.1 [dev]", installState: "missing" }],
+    });
+    await renderShell(root, context);
+    await click(buttonWithText(container, "Model Manager"));
+    await click(buttonWithText(container, "Download"));
+
+    expect(context.createModelDownloadJob).toHaveBeenCalledTimes(1);
+    expect(context.createModelDownloadJob.mock.calls[0][0].id).toBe("flux_dev");
+  });
+
+  it("reports the mode switch to the host app", async () => {
+    const onModeChange = vi.fn();
+    await renderShell(root, baseContext(), { onModeChange });
+    const advanced = [...container.querySelectorAll(".su-nav-footer .su-switch button")].find(
+      (node) => node.textContent === "Advanced",
+    );
+    await click(advanced);
+    expect(onModeChange).toHaveBeenCalledWith("advanced");
+  });
+});

--- a/apps/web/src/simple/SimpleUiContext.js
+++ b/apps/web/src/simple/SimpleUiContext.js
@@ -1,0 +1,28 @@
+import { createContext, useContext } from "react";
+
+// Shell services the Simple screens use: the measured layout band plus the four
+// shell-owned overlays (picker sheet, prompt guide, asset preview, toast) and
+// navigation. Kept as its own tiny context — separate from the app-wide
+// AppStaticContext/AppLiveContext — so a Simple screen reads shell chrome from
+// here and real app data from there, with no overlap.
+//
+// Shape:
+//   breakpoint  "phone" | "tablet" | "desktop"
+//   goTo(screenId)
+//   openSheet({ title, kind, options, onSelect })  — kind: "list" | "grid" | "pills"
+//   closeSheet()
+//   openGuide()
+//   openPreview(asset)
+//   toast(message)
+//   openInAdvanced(view) — hand off to a full-workspace screen (returns false, with an
+//                          explanatory toast, when the viewport has Simple locked on)
+//   uiLocked            — true when the viewport forces Simple
+export const SimpleUiContext = createContext(null);
+
+export function useSimpleUi() {
+  const value = useContext(SimpleUiContext);
+  if (!value) {
+    throw new Error("useSimpleUi must be used within the Simple UI shell");
+  }
+  return value;
+}

--- a/apps/web/src/simple/SimpleVideoStudio.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.jsx
@@ -1,0 +1,289 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { videoModelServesMode } from "../modelEligibility.js";
+import { buildSimpleVideoRequest } from "./simpleJobs.js";
+import { describeResolution, resolutionSummary } from "./aspect.js";
+import { useSimpleRefine } from "./useSimpleRefine.js";
+import { useSimpleUi } from "./SimpleUiContext.js";
+import {
+  Chips,
+  RefinePanel,
+  ReferenceTile,
+  SheetSelect,
+  StudioResults,
+  StyleStrip,
+  jobIsRunning,
+  newestLocalJob,
+} from "./studioParts.jsx";
+
+// Simple Video Studio (design handoff): the Image pattern with Duration in place of
+// Variations, one full-width reference-image tile, and a single 16:9 result.
+//
+// Only the two headline modes are exposed — Text → Video and Image → Video. The other
+// ten video modes the full studio offers (extend, bridge, replace-person, ads2v, …)
+// stay in the advanced workspace by design; this is the "reduced surface", and the
+// switch to Advanced is one click away in the sidebar.
+
+const DEFAULT_DURATIONS = [3, 5, 8, 10];
+const DEFAULT_RESOLUTIONS = ["1280x720", "720x1280", "720x720", "854x480"];
+
+export function SimpleVideoStudio() {
+  const {
+    videoModels = [],
+    macCapabilities,
+    createVideoJob,
+    rememberLocalGenerationJob,
+    videoLocalJobs = [],
+    assets = [],
+    recentImageAssets = [],
+    activeProject,
+  } = useAppContext();
+  const { openGuide, toast } = useSimpleUi();
+  const refine = useSimpleRefine("video");
+
+  const [mode, setMode] = useState("text_to_video");
+  const [prompt, setPrompt] = useState("");
+  const [model, setModel] = useState("");
+  const [resolution, setResolution] = useState("");
+  const [duration, setDuration] = useState(5);
+  const [styleId, setStyleId] = useState(null);
+  const [sourceAssetId, setSourceAssetId] = useState(null);
+  const [refineOpen, setRefineOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const models = useMemo(
+    () => videoModels.filter((entry) => videoModelServesMode(entry, mode, macCapabilities)),
+    [videoModels, mode, macCapabilities],
+  );
+  const selectedModel = useMemo(
+    () => models.find((entry) => entry.id === model) ?? null,
+    [models, model],
+  );
+
+  useEffect(() => {
+    if (models.length && !models.some((entry) => entry.id === model)) {
+      setModel(models[0].id);
+    }
+  }, [models, model]);
+
+  const resolutions = selectedModel?.limits?.resolutions?.length
+    ? selectedModel.limits.resolutions
+    : DEFAULT_RESOLUTIONS;
+  const durations = selectedModel?.limits?.durations?.length
+    ? selectedModel.limits.durations
+    : DEFAULT_DURATIONS;
+  // The model's own fps list leads; the studio does not expose fps, so the first
+  // declared value is used — the same one the advanced picker defaults to.
+  const fps = selectedModel?.limits?.fps?.[0] ?? selectedModel?.defaults?.fps ?? 25;
+
+  useEffect(() => {
+    if (resolutions.length && !resolutions.includes(resolution)) {
+      setResolution(resolutions[0]);
+    }
+  }, [resolutions, resolution]);
+
+  useEffect(() => {
+    if (durations.length && !durations.includes(duration)) {
+      setDuration(durations[0]);
+    }
+  }, [durations, duration]);
+
+  const sourceAsset = useMemo(
+    () => recentImageAssets.find((asset) => asset.id === sourceAssetId) ?? null,
+    [recentImageAssets, sourceAssetId],
+  );
+
+  const latestJob = newestLocalJob(videoLocalJobs);
+  const busy = submitting || jobIsRunning(latestJob);
+  const needsSource = mode === "image_to_video" && !sourceAssetId;
+  const canGenerate =
+    Boolean(prompt.trim()) && Boolean(model) && Boolean(resolution) && !busy && !needsSource;
+
+  async function generate() {
+    if (!canGenerate) {
+      return;
+    }
+    if (!activeProject) {
+      toast("Create or open a workspace first");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const request = buildSimpleVideoRequest({
+        prompt: prompt.trim(),
+        mode,
+        model,
+        resolution,
+        duration,
+        fps,
+        styleId,
+        sourceAssetId,
+      });
+      if (!request) {
+        toast("That resolution isn’t valid");
+        return;
+      }
+      const job = await createVideoJob(request);
+      if (job) {
+        rememberLocalGenerationJob?.("video", job);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function runRefine() {
+    const rewritten = await refine.run({
+      prompt,
+      modelId: model,
+      guidePath: selectedModel?.ui?.promptGuide?.path ?? "/prompt-guides/generic-video.md",
+    });
+    if (rewritten) {
+      setPrompt(rewritten);
+      setRefineOpen(false);
+    }
+  }
+
+  const resolutionText = resolution ? resolutionSummary(resolution) : "—";
+
+  return (
+    <div className="su-screen">
+      <div className="su-tabs" role="tablist">
+        <button
+          aria-selected={mode === "text_to_video"}
+          className={mode === "text_to_video" ? "su-tab active" : "su-tab"}
+          onClick={() => setMode("text_to_video")}
+          role="tab"
+          type="button"
+        >
+          Text&nbsp;→&nbsp;Video
+        </button>
+        <button
+          aria-selected={mode === "image_to_video"}
+          className={mode === "image_to_video" ? "su-tab active" : "su-tab"}
+          onClick={() => setMode("image_to_video")}
+          role="tab"
+          type="button"
+        >
+          Image&nbsp;→&nbsp;Video
+        </button>
+      </div>
+
+      <div>
+        <div className="su-prompt-head">
+          <label className="su-field-label" htmlFor="su-video-prompt">
+            Prompt
+          </label>
+          {/* Video keeps ONE full-width Reference tile (design), so Refine rides here as a
+              pill beside the guide rather than as a second tile. */}
+          <span className="su-pill-row">
+            <button
+              aria-expanded={refineOpen}
+              className={refineOpen ? "su-pill-btn active" : "su-pill-btn"}
+              onClick={() => {
+                refine.reset();
+                setRefineOpen((open) => !open);
+              }}
+              type="button"
+            >
+              <Icon.Sparkle size={13} />
+              Refine
+            </button>
+            <button className="su-pill-btn" onClick={openGuide} type="button">
+              <Icon.Book size={13} />
+              Prompt guide
+            </button>
+          </span>
+        </div>
+        <textarea
+          className="su-textarea su-textarea--short"
+          id="su-video-prompt"
+          onChange={(event) => setPrompt(event.target.value)}
+          placeholder="Describe the shot…"
+          value={prompt}
+        />
+        {refineOpen ? (
+          <RefinePanel
+            blurb="Expand this into a detailed motion description."
+            busy={refine.busy}
+            error={refine.error}
+            modelMissing={refine.modelMissing}
+            onDownloadModel={refine.downloadModel}
+            onRun={runRefine}
+          />
+        ) : null}
+      </div>
+
+      <div className="su-tiles su-tiles--single">
+        <ReferenceTile
+          asset={sourceAsset}
+          assets={recentImageAssets}
+          hint={mode === "image_to_video" ? "Required for Image → Video" : "Optional start frame"}
+          label="Reference image"
+          onChange={setSourceAssetId}
+          required={mode === "image_to_video"}
+        />
+      </div>
+
+      <div className="su-settings-bar">
+        <div className="su-settings-row">
+          <SheetSelect
+            label="Model"
+            onSelect={setModel}
+            options={models.map((entry) => ({
+              value: entry.id,
+              label: entry.name ?? entry.id,
+              active: entry.id === model,
+            }))}
+            value={selectedModel?.name ?? selectedModel?.id ?? "No video model installed"}
+          />
+          <SheetSelect
+            kind="grid"
+            label="Resolution"
+            onSelect={setResolution}
+            options={resolutions.map((option) => ({
+              value: option,
+              ...describeResolution(option),
+              active: option === resolution,
+            }))}
+            title="Size & aspect"
+            value={resolutionText}
+          />
+        </div>
+        <Chips
+          label="Duration"
+          onChange={setDuration}
+          options={durations.map((value) => ({ value, label: `${value}s` }))}
+          value={duration}
+        />
+      </div>
+
+      <StyleStrip onChange={setStyleId} value={styleId} />
+
+      <button
+        className={busy ? "su-generate busy" : "su-generate"}
+        disabled={!canGenerate}
+        onClick={generate}
+        type="button"
+      >
+        {busy ? <span aria-hidden="true" className="su-spinner" /> : null}
+        {busy ? "Rendering…" : "Generate video"}
+      </button>
+      {needsSource ? <p className="su-empty">Attach a start frame to render an Image → Video clip.</p> : null}
+
+      <StudioResults
+        assets={assets}
+        columns={1}
+        job={latestJob}
+        meta={
+          selectedModel
+            ? `${selectedModel.name ?? selectedModel.id} · ${duration}s · ${describeResolution(resolution).sub}`
+            : null
+        }
+        type="video"
+        wide
+      />
+    </div>
+  );
+}

--- a/apps/web/src/simple/aspect.js
+++ b/apps/web/src/simple/aspect.js
@@ -1,0 +1,87 @@
+// Aspect labels for the Simple UI's "Size & aspect" picker (design handoff).
+//
+// The design's picker leads each tile with a shape name ("16:9") and keeps the exact
+// pixels underneath ("1344×768"). The exact reduced ratio is NOT usable as that name:
+// the generation buckets models declare are latent-grid-aligned, not clean ratios —
+// 1344×768 reduces to 7:4, 1216×832 to 19:13, 896×1152 to 7:9. Those are correct and
+// meaningless.
+//
+// So the label is the NEAREST name from the curated list below, chosen by relative
+// difference, with the exact dimensions always shown beside it. That is what image tools
+// do, and it makes the label a shape cue rather than a measurement — the measurement is
+// the sub-label. It resolves 4 of the design's 6 sizes to exactly the names the mockup
+// shows; the other two (1152×896, 896×1152) land on 5:4 / 4:5, which are strictly closer
+// to those pixel counts than the mockup's 4:3 / 3:4.
+
+const NAMED_ASPECTS = [
+  [1, 1],
+  [5, 4],
+  [4, 5],
+  [4, 3],
+  [3, 4],
+  [3, 2],
+  [2, 3],
+  [16, 10],
+  [10, 16],
+  [16, 9],
+  [9, 16],
+  [21, 9],
+  [9, 21],
+];
+
+/**
+ * Split a "WIDTHxHEIGHT" string into numbers, or null when it isn't one.
+ * @param {string} resolution
+ */
+export function parseSize(resolution) {
+  const [width, height] = String(resolution ?? "")
+    .toLowerCase()
+    .split("x")
+    .map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+/**
+ * The nearest curated aspect name for a width/height, e.g. "16:9".
+ * @param {number} width
+ * @param {number} height
+ */
+export function nearestAspectName(width, height) {
+  const ratio = width / height;
+  let best = NAMED_ASPECTS[0];
+  let bestDelta = Infinity;
+  for (const [w, h] of NAMED_ASPECTS) {
+    // Relative difference, so a 21:9 candidate isn't penalized for its larger magnitude.
+    const delta = Math.abs(ratio - w / h) / (w / h);
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      best = [w, h];
+    }
+  }
+  return `${best[0]}:${best[1]}`;
+}
+
+/**
+ * The picker tile's two lines for a resolution string: `{ label, sub }`. An unparseable
+ * value degrades to the raw string with no sub-label rather than inventing a shape.
+ * @param {string} resolution
+ */
+export function describeResolution(resolution) {
+  const size = parseSize(resolution);
+  if (!size) {
+    return { label: String(resolution ?? ""), sub: "" };
+  }
+  return {
+    label: nearestAspectName(size.width, size.height),
+    sub: `${size.width}×${size.height}`,
+  };
+}
+
+/** The one-line form the settings-bar trigger shows: "16:9 · 1344×768". */
+export function resolutionSummary(resolution) {
+  const { label, sub } = describeResolution(resolution);
+  return sub ? `${label} · ${sub}` : label;
+}

--- a/apps/web/src/simple/aspect.test.js
+++ b/apps/web/src/simple/aspect.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { describeResolution, nearestAspectName, parseSize, resolutionSummary } from "./aspect.js";
+
+describe("parseSize", () => {
+  it("parses a WxH string and rejects anything else", () => {
+    expect(parseSize("1344x768")).toEqual({ width: 1344, height: 768 });
+    expect(parseSize("1024X1024")).toEqual({ width: 1024, height: 1024 });
+    expect(parseSize("1024")).toBeNull();
+    expect(parseSize("0x512")).toBeNull();
+    expect(parseSize("")).toBeNull();
+    expect(parseSize(null)).toBeNull();
+  });
+});
+
+describe("nearestAspectName", () => {
+  it("names the standard generation buckets", () => {
+    // The reason this isn't a gcd reduction: these buckets are latent-grid-aligned, so
+    // the exact ratios are 7:4, 7:9 and 19:13 — correct and useless as a shape cue.
+    expect(nearestAspectName(1024, 1024)).toBe("1:1");
+    expect(nearestAspectName(1344, 768)).toBe("16:9");
+    expect(nearestAspectName(768, 1344)).toBe("9:16");
+    expect(nearestAspectName(1216, 832)).toBe("3:2");
+    expect(nearestAspectName(1280, 720)).toBe("16:9");
+    expect(nearestAspectName(720, 1280)).toBe("9:16");
+    expect(nearestAspectName(854, 480)).toBe("16:9");
+  });
+
+  it("picks the CLOSEST name, not the conventional one, for the near-square buckets", () => {
+    // 1152×896 is 1.2857 — nearer 5:4 (1.25) than 4:3 (1.333). The exact pixels are
+    // always shown beside the label, so the closer name is the honest one.
+    expect(nearestAspectName(1152, 896)).toBe("5:4");
+    expect(nearestAspectName(896, 1152)).toBe("4:5");
+  });
+
+  it("handles wide and tall extremes", () => {
+    expect(nearestAspectName(2560, 1080)).toBe("21:9");
+    expect(nearestAspectName(1080, 2560)).toBe("9:21");
+  });
+});
+
+describe("describeResolution / resolutionSummary", () => {
+  it("pairs the shape name with the exact pixels", () => {
+    expect(describeResolution("1344x768")).toEqual({ label: "16:9", sub: "1344×768" });
+    expect(resolutionSummary("1344x768")).toBe("16:9 · 1344×768");
+  });
+
+  it("degrades to the raw string rather than inventing a shape", () => {
+    expect(describeResolution("weird")).toEqual({ label: "weird", sub: "" });
+    expect(resolutionSummary("weird")).toBe("weird");
+    expect(describeResolution(null)).toEqual({ label: "", sub: "" });
+  });
+});

--- a/apps/web/src/simple/breakpoint.js
+++ b/apps/web/src/simple/breakpoint.js
@@ -1,0 +1,83 @@
+// Simple UI responsive breakpoints (design handoff "Simple UI for creative studios").
+//
+// The Simple shell is ONE responsive layout driven by the width of its own mount —
+// not `window` — so it stays correct when embedded (the design showcase mounts the
+// same app inside desktop / tablet / phone frames). The three bands and the content
+// caps below are the design's; every consumer reads them from here so the layout, the
+// picker chrome (bottom sheet vs centered modal) and the phone-forces-Simple rule in
+// App.jsx can never drift apart.
+
+// Below this the shell is a phone: hamburger + overlay drawer + bottom sheets.
+export const PHONE_MAX_WIDTH = 680;
+// At or above this the shell gets the roomier desktop content cap.
+export const DESKTOP_MIN_WIDTH = 1024;
+
+// Content-column caps. Phone content is full-bleed (no cap).
+export const TABLET_CONTENT_MAX = 680;
+export const DESKTOP_CONTENT_MAX = 900;
+
+/**
+ * The layout band for a measured container width.
+ * An unknown (null/0) width resolves to "desktop" — the shell renders with a
+ * persistent sidebar until the first ResizeObserver callback lands, which is the
+ * non-jarring default for the overwhelmingly common case (a desktop window).
+ * @param {number|null|undefined} width
+ * @returns {"phone"|"tablet"|"desktop"}
+ */
+export function breakpointFor(width) {
+  if (!Number.isFinite(width) || width <= 0) {
+    return "desktop";
+  }
+  if (width >= DESKTOP_MIN_WIDTH) {
+    return "desktop";
+  }
+  return width >= PHONE_MAX_WIDTH ? "tablet" : "phone";
+}
+
+/**
+ * True when a measured width is in the phone band. Shared by the shell layout and
+ * by App.jsx's "phones are always served the Simple UI" rule, so one number governs
+ * both. An unknown width is NOT a phone (never force Simple on a missing signal).
+ * @param {number|null|undefined} width
+ */
+export function isPhoneWidth(width) {
+  return Number.isFinite(width) && width > 0 && width < PHONE_MAX_WIDTH;
+}
+
+/**
+ * The `max-width` for the centered content column at a breakpoint ("none" on phone).
+ * @param {"phone"|"tablet"|"desktop"} breakpoint
+ */
+export function contentMaxWidth(breakpoint) {
+  if (breakpoint === "desktop") {
+    return `${DESKTOP_CONTENT_MAX}px`;
+  }
+  if (breakpoint === "tablet") {
+    return `${TABLET_CONTENT_MAX}px`;
+  }
+  return "none";
+}
+
+/**
+ * Asset-grid column count per band (design: 3 phone / 4 tablet / 6 desktop).
+ * @param {"phone"|"tablet"|"desktop"} breakpoint
+ */
+export function assetGridColumns(breakpoint) {
+  if (breakpoint === "desktop") {
+    return 6;
+  }
+  return breakpoint === "tablet" ? 4 : 3;
+}
+
+/**
+ * Result-grid column count for an image run: 1 column for a single variation,
+ * 3 columns for a 6-up run on desktop, otherwise 2 (design spec).
+ * @param {number} count
+ * @param {"phone"|"tablet"|"desktop"} breakpoint
+ */
+export function resultGridColumns(count, breakpoint) {
+  if (count <= 1) {
+    return 1;
+  }
+  return breakpoint === "desktop" && count >= 6 ? 3 : 2;
+}

--- a/apps/web/src/simple/breakpoint.test.js
+++ b/apps/web/src/simple/breakpoint.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESKTOP_MIN_WIDTH,
+  PHONE_MAX_WIDTH,
+  assetGridColumns,
+  breakpointFor,
+  contentMaxWidth,
+  isPhoneWidth,
+  resultGridColumns,
+} from "./breakpoint.js";
+
+describe("Simple UI breakpoints", () => {
+  it("splits the three bands on the design's boundaries", () => {
+    expect(breakpointFor(PHONE_MAX_WIDTH - 1)).toBe("phone");
+    expect(breakpointFor(PHONE_MAX_WIDTH)).toBe("tablet");
+    expect(breakpointFor(DESKTOP_MIN_WIDTH - 1)).toBe("tablet");
+    expect(breakpointFor(DESKTOP_MIN_WIDTH)).toBe("desktop");
+  });
+
+  it("resolves an unmeasured width to desktop rather than flashing the phone drawer", () => {
+    expect(breakpointFor(null)).toBe("desktop");
+    expect(breakpointFor(0)).toBe("desktop");
+    expect(breakpointFor(Number.NaN)).toBe("desktop");
+  });
+
+  it("agrees with isPhoneWidth, which App uses for the forced-Simple rule", () => {
+    expect(isPhoneWidth(PHONE_MAX_WIDTH - 1)).toBe(true);
+    expect(isPhoneWidth(PHONE_MAX_WIDTH)).toBe(false);
+    // Unknown width must NOT read as a phone — it would force a shell swap on no signal.
+    expect(isPhoneWidth(null)).toBe(false);
+    expect(isPhoneWidth(0)).toBe(false);
+  });
+
+  it("caps the content column per band", () => {
+    expect(contentMaxWidth("phone")).toBe("none");
+    expect(contentMaxWidth("tablet")).toBe("680px");
+    expect(contentMaxWidth("desktop")).toBe("900px");
+  });
+
+  it("sets asset-grid columns to 3 / 4 / 6", () => {
+    expect(assetGridColumns("phone")).toBe(3);
+    expect(assetGridColumns("tablet")).toBe(4);
+    expect(assetGridColumns("desktop")).toBe(6);
+  });
+
+  it("gives a single result its own column and only 6-up on desktop three", () => {
+    expect(resultGridColumns(1, "desktop")).toBe(1);
+    expect(resultGridColumns(2, "desktop")).toBe(2);
+    expect(resultGridColumns(4, "desktop")).toBe(2);
+    expect(resultGridColumns(6, "desktop")).toBe(3);
+    // A 6-up run on a narrower band stays 2 columns.
+    expect(resultGridColumns(6, "tablet")).toBe(2);
+    expect(resultGridColumns(6, "phone")).toBe(2);
+  });
+});

--- a/apps/web/src/simple/licenseTerms.js
+++ b/apps/web/src/simple/licenseTerms.js
@@ -1,0 +1,61 @@
+// Commercial-use badge for the Simple UI's Licenses screen (design handoff).
+//
+// The design shows one of two badges per model-licence row: "Commercial OK" (accent) or
+// "Non-commercial" (danger). The real corpus (`bundledLicenses`, derived from
+// apps/desktop/licenses/manifest.json) carries a free-text `license` string, not a flag —
+// so the badge is DERIVED here, in one pure place, rather than duplicated per render site.
+//
+// The rule is deliberately conservative and one-directional: a licence is treated as
+// non-commercial ONLY when it SAYS SO (the manifest names every restricted licence
+// explicitly — "FLUX.1 [dev] Non-Commercial License v1.1.1", "Ideogram Non-Commercial Model
+// Agreement", "CircleStone Labs Non-Commercial License v1.2", "Research / Non-Commercial
+// (CC-BY-NC-4.0 · …)", "Stable Video Diffusion Non-Commercial Community License"). Anything
+// else gets the permissive badge, which matches the design's own mapping (it badges the
+// Stability AI Community License as "Commercial OK").
+//
+// The badge is a NAVIGATION aid, not legal advice: several "Commercial OK" licences
+// (Stability Community, Krea 2 Community, LTX-2 Community, NVIDIA Open Model) carry
+// revenue thresholds or other conditions. The row keeps the full licence NAME next to the
+// badge, and the full text stays one tap away in the advanced Licenses screen.
+
+// Matches "non-commercial", "non commercial", "noncommercial" and the SPDX-style
+// "-NC-" / "NC-4.0" markers, case-insensitively.
+const NON_COMMERCIAL_PATTERN = /non[\s-]?commercial|\bnc-\d|-nc-|\bcc-by-nc\b/i;
+
+/**
+ * True when a licence string restricts commercial use.
+ * @param {string|null|undefined} license
+ */
+export function licenseIsNonCommercial(license) {
+  return NON_COMMERCIAL_PATTERN.test(String(license ?? ""));
+}
+
+/**
+ * The badge to render for a licence string.
+ * @param {string|null|undefined} license
+ * @returns {{ label: string, tone: "ok"|"danger" }}
+ */
+export function licenseBadge(license) {
+  return licenseIsNonCommercial(license)
+    ? { label: "Non-commercial", tone: "danger" }
+    : { label: "Commercial OK", tone: "ok" };
+}
+
+/**
+ * The model-licence rows the Simple Licenses screen lists: the bundled components that
+ * actually ship MODEL WEIGHTS (`models[]` non-empty), which is what the design's
+ * "MODEL LICENSES" group means. The binary components (FFmpeg, ONNX Runtime, the CUDA
+ * runtime) are tooling, not model terms, and stay out — they remain in the advanced
+ * Licenses screen, which lists the whole corpus with full text.
+ * @param {Array<object>} components - `bundledLicenses`.
+ */
+export function modelLicenseRows(components) {
+  return (components ?? [])
+    .filter((component) => Array.isArray(component?.models) && component.models.length > 0)
+    .map((component) => ({
+      id: component.id,
+      name: component.name,
+      license: component.license ?? "",
+      badge: licenseBadge(component.license),
+    }));
+}

--- a/apps/web/src/simple/licenseTerms.test.js
+++ b/apps/web/src/simple/licenseTerms.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { licenseBadge, licenseIsNonCommercial, modelLicenseRows } from "./licenseTerms.js";
+import { bundledLicenses } from "../data/bundledLicenses.js";
+
+describe("licenseIsNonCommercial", () => {
+  it("flags every restricted licence string the shipped corpus actually carries", () => {
+    // Pinned against the real strings in apps/desktop/licenses/manifest.json, so a
+    // rename upstream that this classifier stops matching fails here rather than
+    // silently badging a non-commercial model as "Commercial OK".
+    for (const license of [
+      "FLUX.1 [dev] Non-Commercial License v1.1.1",
+      "FLUX.2 [dev] Non-Commercial License",
+      "FLUX Non-Commercial License",
+      "Ideogram Non-Commercial Model Agreement",
+      "CircleStone Labs Non-Commercial License v1.2",
+      "Stable Video Diffusion Non-Commercial Community License",
+      "Research / Non-Commercial (CC-BY-NC-4.0 · Apple ML Research · MIT)",
+    ]) {
+      expect(licenseIsNonCommercial(license), license).toBe(true);
+    }
+  });
+
+  it("leaves permissive and conditional licences on the permissive badge", () => {
+    for (const license of [
+      "Apache-2.0",
+      "MIT",
+      "BSD-3-Clause",
+      "CreativeML Open RAIL++-M",
+      "Stability AI Community License",
+      "Krea 2 Community License",
+      "LTX-2 Community License",
+      "NVIDIA Open Model License",
+    ]) {
+      expect(licenseIsNonCommercial(license), license).toBe(false);
+    }
+  });
+
+  it("treats a missing licence string as unrestricted rather than throwing", () => {
+    expect(licenseIsNonCommercial(null)).toBe(false);
+    expect(licenseIsNonCommercial(undefined)).toBe(false);
+    expect(licenseIsNonCommercial("")).toBe(false);
+  });
+
+  it("maps to the design's two badges", () => {
+    expect(licenseBadge("MIT")).toEqual({ label: "Commercial OK", tone: "ok" });
+    expect(licenseBadge("FLUX Non-Commercial License")).toEqual({
+      label: "Non-commercial",
+      tone: "danger",
+    });
+  });
+});
+
+describe("modelLicenseRows", () => {
+  it("keeps only components that ship model weights", () => {
+    const rows = modelLicenseRows(bundledLicenses);
+    expect(rows.length).toBeGreaterThan(0);
+    // FFmpeg / ONNX Runtime / the CUDA runtime are tooling binaries with `models: []`.
+    expect(rows.some((row) => row.id === "ffmpeg")).toBe(false);
+    expect(rows.some((row) => row.id === "onnxruntime")).toBe(false);
+    // …and a real weights component IS present, with its badge resolved.
+    const zImage = rows.find((row) => row.name.includes("Z-Image"));
+    expect(zImage).toBeTruthy();
+    expect(zImage.badge.label).toBe("Commercial OK");
+  });
+
+  it("badges a restricted weights component as non-commercial", () => {
+    const rows = modelLicenseRows(bundledLicenses);
+    const fluxDev = rows.find((row) => row.name === "FLUX.1 [dev]");
+    expect(fluxDev).toBeTruthy();
+    expect(fluxDev.badge.label).toBe("Non-commercial");
+  });
+
+  it("tolerates an empty or absent corpus", () => {
+    expect(modelLicenseRows([])).toEqual([]);
+    expect(modelLicenseRows(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/simple/simple.css
+++ b/apps/web/src/simple/simple.css
@@ -1,0 +1,1947 @@
+/* ---------- Simple UI (design handoff "Simple UI for creative studios") ----------
+
+   A calmer, reduced-surface alternative shell that renders INSTEAD of the full
+   workspace when the Simple/Advanced switch is on Simple (and always on phones).
+
+   Everything here is namespaced under `.su-*` and scoped inside `.su-root`, so this
+   sheet cannot reach a single element of the existing workspace. Every colour, radius,
+   shadow and font is one of the tokens already defined in styles.css — no new palette.
+
+   Layout bands are driven by `data-bp` on the root, which the shell sets from the
+   width of its OWN mount (see useContainerWidth.js), not a media query — so the shell
+   is correct when embedded at less than viewport width. */
+
+.su-root {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+}
+
+.su-root *,
+.su-root *::before,
+.su-root *::after {
+  box-sizing: border-box;
+}
+
+.su-root button {
+  font-family: inherit;
+}
+
+@keyframes su-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes su-sheetup {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+@keyframes su-fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes su-drawin {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+@keyframes su-pop {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .su-root *,
+  .su-root *::before,
+  .su-root *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Thin scrollbars on every scrolling region, matching the prototype's `.scr`. */
+.su-scroll {
+  scrollbar-width: thin;
+}
+.su-scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.su-scroll::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--r-pill);
+}
+
+/* ---------- Navigation ---------- */
+
+.su-nav {
+  position: relative;
+  flex: 0 0 auto;
+  width: 244px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 14px 12px;
+  background: var(--bg-2);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  z-index: 5;
+}
+
+/* Phone: the sidebar becomes an overlay drawer above the scrim. */
+.su-root[data-bp="phone"] .su-nav {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 288px;
+  box-shadow: var(--shadow-lg);
+  z-index: 91;
+  animation: su-drawin var(--t-med) var(--ease-out);
+}
+
+.su-scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 90;
+  border: 0;
+  padding: 0;
+  background: rgba(15, 22, 34, 0.5);
+  animation: su-fadein 0.18s var(--ease-out);
+}
+
+.su-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 6px 16px;
+  flex: 0 0 auto;
+}
+
+.su-brand-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--wordmark-strong);
+}
+
+.su-brand-sub {
+  margin-top: -1px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.su-nav-group-title {
+  padding: 6px 10px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.su-nav-group-title + .su-nav-group-title,
+.su-nav-group + .su-nav-group-title {
+  padding-top: 16px;
+}
+
+.su-nav-group {
+  display: grid;
+  gap: 3px;
+}
+
+.su-nav-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  height: 42px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: none;
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease-out), color var(--t-fast) var(--ease-out);
+}
+
+.su-nav-group--studios .su-nav-item {
+  height: 44px;
+  font-size: 15px;
+}
+
+.su-nav-item:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.su-nav-item.active {
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+  box-shadow: var(--shadow-sm);
+}
+
+.su-nav-item.active::before {
+  content: "";
+  position: absolute;
+  left: -12px;
+  top: 9px;
+  bottom: 9px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--accent);
+}
+
+.su-nav-item svg {
+  flex: 0 0 auto;
+}
+
+.su-nav-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-nav-badge {
+  margin-left: auto;
+  padding: 2px 7px;
+  border-radius: var(--r-pill);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.su-nav-footer {
+  margin-top: auto;
+  padding: 12px 4px 4px;
+  border-top: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+/* ---------- Simple ⇄ Advanced switch (also rendered in the workspace sidebar) ---------- */
+
+.su-switch {
+  display: inline-flex;
+  width: 100%;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+}
+
+.su-switch button {
+  flex: 1;
+  padding: 7px;
+  border: 0;
+  border-radius: var(--r-xs);
+  background: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: center;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease-out), color var(--t-fast) var(--ease-out);
+}
+
+.su-switch button:hover:not(:disabled):not(.active) {
+  color: var(--text);
+}
+
+.su-switch button.active {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.su-switch button:disabled {
+  cursor: default;
+}
+
+.su-switch-note {
+  margin: 6px 2px 0;
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--text-faint);
+}
+
+/* The switch also lives in the FULL workspace's sidebar footer, which previously held
+   only the version string. These two rules are the whole footprint the Simple UI has in
+   the existing shell's styling: stack the version under the switch. */
+.sidebar-footer .su-switch {
+  background: var(--surface);
+}
+
+.sidebar-footer .app-version {
+  display: block;
+  margin-top: 8px;
+}
+
+/* ---------- Main column ---------- */
+
+.su-main {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.su-topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklch, var(--bg) 97%, transparent);
+  z-index: 4;
+}
+
+.su-hamburger {
+  width: 38px;
+  height: 38px;
+  margin-left: -6px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: none;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.su-hamburger:hover {
+  background: var(--surface-hover);
+}
+
+.su-topbar-title {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  flex: 1;
+  min-width: 0;
+}
+
+.su-topbar-title strong {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-topbar-title span {
+  font-size: 12.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.su-content {
+  width: 100%;
+  margin: 0 auto;
+  max-width: var(--su-content-max, none);
+}
+
+.su-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+
+.su-screen--tight {
+  gap: 11px;
+}
+
+.su-screen--loose {
+  gap: 16px;
+}
+
+/* ---------- Shared controls ---------- */
+
+.su-tabs {
+  display: flex;
+  gap: 22px;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+}
+
+.su-tab {
+  flex: 0 0 auto;
+  padding: 9px 2px;
+  margin-bottom: -1px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.su-tab.active {
+  border-bottom-color: var(--accent);
+  color: var(--text);
+  font-weight: 700;
+}
+
+.su-segmented {
+  display: flex;
+  gap: 2px;
+  max-width: 340px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+}
+
+.su-segmented button {
+  flex: 1;
+  padding: 8px;
+  border: 0;
+  border-radius: var(--r-xs);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.su-segmented button.active {
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+  box-shadow: var(--shadow-sm);
+}
+
+.su-field-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.su-section-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.su-prompt-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.su-pill-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.su-textarea {
+  width: 100%;
+  min-height: 104px;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.su-textarea--short {
+  min-height: 92px;
+}
+
+.su-textarea:focus-visible,
+.su-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.su-input {
+  height: var(--control-h);
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+}
+
+.su-inline-panel {
+  display: grid;
+  gap: 9px;
+  margin-top: 10px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.su-inline-panel p {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.su-inline-panel .su-error {
+  color: var(--danger);
+}
+
+.su-accent-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 38px;
+  padding: 0 15px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* Two distinct disabled states, deliberately not the same shade: BUSY keeps the button
+   reading as live work in progress (the design's 0.85), while NOT-YET-SUBMITTABLE has to
+   read as unavailable — at 0.85 an empty-prompt Generate looks clickable. */
+.su-accent-btn:disabled,
+.su-generate:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.su-accent-btn.busy:disabled,
+.su-generate.busy:disabled {
+  opacity: 0.85;
+}
+
+.su-tiles {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.su-tiles--single {
+  grid-template-columns: 1fr;
+}
+
+.su-pill-row {
+  display: inline-flex;
+  gap: 7px;
+}
+
+.su-pill-btn.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.su-tile {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  text-align: left;
+  cursor: pointer;
+}
+
+.su-tile.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.su-tile-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.su-tile-hint {
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.su-set-badge {
+  margin-left: auto;
+  padding: 1px 6px;
+  border: 1px solid var(--accent);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+  color: var(--accent);
+  font-size: 9.5px;
+  font-weight: 700;
+}
+
+.su-tile-ref {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.su-tile-ref img {
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: var(--r-xs);
+  object-fit: cover;
+}
+
+.su-tile-ref span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.su-settings-bar {
+  display: grid;
+  gap: 11px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.su-settings-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.su-root[data-bp="phone"] .su-settings-row {
+  grid-template-columns: 1fr;
+}
+
+.su-field {
+  display: grid;
+  gap: 5px;
+}
+
+.su-field > label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.su-select {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: var(--control-h);
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.su-select > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-select svg {
+  margin-left: auto;
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.su-select:disabled {
+  cursor: default;
+  color: var(--text-faint);
+}
+
+.su-chips {
+  display: flex;
+  gap: 6px;
+}
+
+.su-chip {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  place-items: center;
+  height: 34px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  /* Fixed height ⇒ a wrapping label would spill out of the chip and over whatever sits
+     below it. Chips carry short labels by design; anything longer truncates. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.su-chip.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.su-filter-pills {
+  display: flex;
+  gap: 7px;
+  overflow-x: auto;
+}
+
+.su-filter-pill {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 15px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.su-filter-pill.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+/* ---------- Style strip ---------- */
+
+.su-style-strip {
+  display: flex;
+  gap: 9px;
+  padding: 9px 0 2px;
+  overflow-x: auto;
+}
+
+.su-style {
+  flex: 0 0 auto;
+  width: 66px;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.su-style-thumb {
+  width: 66px;
+  height: 66px;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  color: var(--text-faint);
+  overflow: hidden;
+}
+
+.su-style-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.su-style.active .su-style-thumb {
+  border-color: var(--accent);
+}
+
+.su-style-name {
+  margin-top: 4px;
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-style.active .su-style-name {
+  color: var(--text);
+  font-weight: 700;
+}
+
+/* ---------- Generate + results ---------- */
+
+.su-generate {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  min-height: 54px;
+  border: 0;
+  border-radius: var(--r-md);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 15.5px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow:
+    0 1px 2px color-mix(in oklch, var(--accent) 40%, transparent),
+    0 8px 22px color-mix(in oklch, var(--accent) 28%, transparent);
+}
+
+.su-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: su-spin 0.7s linear infinite;
+}
+
+.su-spinner--sm {
+  width: 14px;
+  height: 14px;
+}
+
+.su-results-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 9px;
+}
+
+.su-results-head strong {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.su-results-head span {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+.su-results-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--su-result-cols, 2), minmax(0, 1fr));
+  gap: 10px;
+}
+
+.su-result {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.su-result--wide {
+  aspect-ratio: 16 / 9;
+}
+
+.su-result img,
+.su-result video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.su-result-open {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.su-result-open > span {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+.su-result-action {
+  position: absolute;
+  right: 7px;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  cursor: pointer;
+}
+
+.su-result-action--fav {
+  top: 7px;
+}
+
+.su-result-action--fav.on {
+  color: var(--warm);
+}
+
+.su-result-action--dl {
+  bottom: 7px;
+}
+
+.su-result-pending {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+.su-empty {
+  margin: 0;
+  padding: 18px 2px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.su-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 11px 13px;
+  border: 1px solid color-mix(in oklch, var(--warn) 40%, var(--border));
+  border-radius: var(--r-md);
+  background: var(--warn-soft);
+}
+
+.su-notice svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--warn);
+}
+
+.su-notice span {
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.su-notice--error {
+  border-color: color-mix(in oklch, var(--danger) 45%, var(--border));
+  background: var(--danger-soft);
+}
+
+.su-notice--error svg {
+  color: var(--danger);
+}
+
+/* ---------- Assets ---------- */
+
+.su-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  max-width: 420px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+}
+
+.su-search svg {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.su-search input {
+  flex: 1;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 14px;
+}
+
+.su-search input:focus-visible {
+  outline: none;
+}
+
+.su-asset-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--su-asset-cols, 3), minmax(0, 1fr));
+  gap: 8px;
+}
+
+.su-asset {
+  position: relative;
+  aspect-ratio: 1;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.su-asset img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.su-asset-kind {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-xs);
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+}
+
+.su-asset-fav {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  color: var(--warm);
+}
+
+.su-asset-placeholder {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  color: var(--text-faint);
+  background: repeating-linear-gradient(
+      45deg,
+      color-mix(in oklch, var(--accent) 18%, transparent) 0 5px,
+      transparent 5px 10px
+    ),
+    var(--surface-2);
+}
+
+/* ---------- Model Manager ---------- */
+
+.su-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.su-row-glyph {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-sm);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+/* These rows stack a title over a meta line. They are built from <span>s (they sit inside
+   a <button> in some places, where a <div> would be invalid), so the block display has to
+   come from CSS — without it both lines run together on one line. */
+.su-row-text {
+  display: block;
+  flex: 1;
+  min-width: 0;
+}
+
+.su-row-title {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-row-meta {
+  display: block;
+  margin-top: 1px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.su-row-action {
+  flex: 0 0 auto;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.su-row-action.primary {
+  border: 0;
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+.su-row-action:disabled {
+  cursor: default;
+  color: var(--text-faint);
+}
+
+/* ---------- Queue ---------- */
+
+.su-stats {
+  display: flex;
+  gap: 8px;
+}
+
+.su-stat {
+  flex: 1;
+  padding: 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  text-align: center;
+}
+
+.su-stat-value {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.su-stat--running .su-stat-value {
+  color: var(--accent-strong);
+}
+
+.su-stat--done .su-stat-value {
+  color: var(--success);
+}
+
+.su-stat-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.su-job {
+  display: grid;
+  gap: 9px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.su-job-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.su-dot {
+  width: 9px;
+  height: 9px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.su-dot--running {
+  background: var(--warm);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--warm) 22%, transparent);
+}
+
+.su-dot--done {
+  background: var(--success);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--success) 20%, transparent);
+}
+
+.su-dot--failed {
+  background: var(--danger);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--danger) 20%, transparent);
+}
+
+.su-job-text {
+  display: block;
+  flex: 1;
+  min-width: 0;
+}
+
+.su-job-title {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-job-sub {
+  display: block;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.su-job-badge {
+  margin-left: auto;
+  flex: 0 0 auto;
+  padding: 2px 9px;
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.su-job-badge--running {
+  background: color-mix(in oklch, var(--warm) 18%, var(--surface));
+  color: color-mix(in oklch, var(--warm) 70%, var(--text));
+}
+
+.su-job-badge--done {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.su-job-badge--failed {
+  background: var(--danger-soft);
+  color: color-mix(in oklch, var(--danger) 72%, var(--text));
+}
+
+.su-bar {
+  height: 6px;
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.su-bar > span {
+  display: block;
+  height: 100%;
+  border-radius: var(--r-pill);
+  background: var(--accent);
+  transition: width var(--t-med) var(--ease-out);
+}
+
+.su-bar--done > span {
+  background: var(--success);
+}
+
+/* ---------- Settings ---------- */
+
+.su-group {
+  display: grid;
+  gap: 10px;
+}
+
+.su-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.su-card {
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.su-card--split {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.su-card-title {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.su-card-sub {
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.su-card-body {
+  display: grid;
+  gap: 9px;
+}
+
+.su-card-note {
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.su-theme-toggle {
+  display: inline-flex;
+  gap: 2px;
+  flex: 0 0 auto;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+}
+
+.su-theme-toggle button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 0;
+  border-radius: var(--r-xs);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.su-theme-toggle button.active {
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+  box-shadow: var(--shadow-sm);
+}
+
+.su-accents {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 11px;
+  margin-top: 11px;
+}
+
+.su-accent-swatch {
+  width: 30px;
+  height: 30px;
+  border: 2px solid var(--border);
+  border-radius: 9px;
+  cursor: pointer;
+}
+
+.su-accent-swatch.active {
+  border-color: transparent;
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 35%, transparent);
+}
+
+.su-toggle {
+  position: relative;
+  width: 46px;
+  height: 27px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: var(--border-strong);
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease-out);
+}
+
+.su-toggle.on {
+  background: var(--accent);
+}
+
+.su-toggle > span {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 21px;
+  height: 21px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: var(--shadow-sm);
+  transition: left var(--t-fast) var(--ease-out);
+}
+
+.su-toggle.on > span {
+  left: 22px;
+}
+
+.su-toggle:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.su-kv {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.su-kv > span:first-child {
+  color: var(--text-muted);
+}
+
+.su-kv > span:last-child {
+  font-weight: 500;
+  text-align: right;
+}
+
+.su-inline-form {
+  display: flex;
+  gap: 8px;
+  max-width: 440px;
+}
+
+.su-inline-form .su-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.su-chips--capped {
+  max-width: 280px;
+}
+
+/* ---------- Licenses ---------- */
+
+.su-license-app {
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.su-license-app strong {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.su-license-app p {
+  margin: 3px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.su-license-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.su-license-name {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-license-terms {
+  display: block;
+  margin-top: 1px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.su-license-badge {
+  margin-left: auto;
+  flex: 0 0 auto;
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 10.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.su-license-badge--danger {
+  background: var(--danger-soft);
+  color: color-mix(in oklch, var(--danger) 72%, var(--text));
+}
+
+/* ---------- Sheet / modal ---------- */
+
+.su-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 70;
+  border: 0;
+  padding: 0;
+  background: rgba(15, 22, 34, 0.42);
+  animation: su-fadein 0.18s var(--ease-out);
+}
+
+.su-sheet {
+  position: absolute;
+  z-index: 71;
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+  overflow-y: auto;
+}
+
+.su-root[data-bp="phone"] .su-sheet {
+  inset: auto 0 0 0;
+  max-height: 76%;
+  padding: 8px 18px 26px;
+  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  animation: su-sheetup var(--t-med) var(--ease-out);
+}
+
+.su-root:not([data-bp="phone"]) .su-sheet {
+  top: 50%;
+  left: 50%;
+  width: 460px;
+  max-width: calc(100% - 48px);
+  max-height: 78%;
+  padding: 20px 22px 24px;
+  border-radius: 18px;
+  transform: translate(-50%, -50%);
+  animation: su-pop 0.2s var(--ease-out);
+}
+
+.su-sheet-handle {
+  width: 38px;
+  height: 4px;
+  margin: 0 auto 14px;
+  border-radius: var(--r-pill);
+  background: var(--border-strong);
+}
+
+.su-sheet-title {
+  margin: 0 0 14px;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.su-sheet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.su-sheet-head .su-sheet-title {
+  margin-bottom: 0;
+}
+
+.su-icon-btn {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.su-option-list {
+  display: grid;
+  gap: 4px;
+}
+
+.su-option-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 13px 12px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+
+.su-option-row:hover {
+  background: var(--surface-hover);
+}
+
+.su-option-row.active {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.su-option-row > span {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-option-row img {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  border-radius: var(--r-xs);
+  object-fit: cover;
+}
+
+.su-option-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.su-option-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 64px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.su-option-tile.active {
+  border: 2px solid var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.su-option-tile strong {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.su-option-tile small {
+  margin-top: 2px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+.su-option-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* ---------- Prompt guide ---------- */
+
+.su-guide-intro {
+  margin: 0 0 14px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.su-guide-intro strong {
+  color: var(--accent-strong);
+}
+
+.su-guide-tips {
+  display: grid;
+  gap: 12px;
+}
+
+.su-guide-tip {
+  display: flex;
+  gap: 11px;
+}
+
+.su-guide-num {
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.su-guide-tip strong {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.su-guide-tip p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.su-guide-try {
+  margin-top: 16px;
+  padding: 11px 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.su-guide-try-label {
+  margin-bottom: 4px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.su-guide-try p {
+  margin: 0;
+  font-size: 12.5px;
+  font-style: italic;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+/* ---------- Asset preview overlay ---------- */
+
+.su-preview {
+  position: absolute;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  animation: su-fadein 0.18s var(--ease-out);
+}
+
+.su-preview-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+  padding: 14px;
+}
+
+.su-preview-head strong {
+  font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-preview-close {
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.su-preview-stage {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  padding: 0 20px;
+}
+
+.su-preview-stage img,
+.su-preview-stage video {
+  max-width: min(560px, 100%);
+  max-height: 100%;
+  border-radius: var(--r-lg);
+  object-fit: contain;
+}
+
+.su-preview-stage audio {
+  width: min(560px, 100%);
+}
+
+.su-preview-actions {
+  flex: 0 0 auto;
+  display: grid;
+  gap: 10px;
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.su-preview-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 48px;
+  border: 0;
+  border-radius: var(--r-md);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 14.5px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.su-preview-row {
+  display: flex;
+  gap: 9px;
+}
+
+.su-preview-row button {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 42px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.su-preview-row button.danger {
+  border-color: color-mix(in oklch, var(--danger) 45%, var(--border));
+  background: var(--danger-soft);
+  color: color-mix(in oklch, var(--danger) 75%, var(--text));
+}
+
+/* ---------- Toast ---------- */
+
+.su-toast {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 26px;
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.su-toast > span {
+  padding: 11px 16px;
+  border-radius: var(--r-pill);
+  background: var(--ink);
+  color: #fff;
+  font-size: 12.5px;
+  font-weight: 500;
+  box-shadow: var(--shadow-lg);
+  animation: su-pop 0.2s var(--ease-out);
+}
+
+/* ---------- Audio result transport ---------- */
+
+.su-audio-result {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+.su-audio-result audio {
+  flex: 1;
+  min-width: 0;
+}

--- a/apps/web/src/simple/simpleJobs.js
+++ b/apps/web/src/simple/simpleJobs.js
@@ -1,0 +1,254 @@
+import { buildImageJobRequest } from "../imageJobRequest.js";
+import { composeStyledPrompt } from "../styleComposer.js";
+import { styleTextForId } from "../data/styleCatalog.js";
+import { defaultTierSelection, installedTiers } from "../quantTier.js";
+import { suggestTier } from "../tierSuggestion.js";
+import { readLastTier } from "../lastTierStore.js";
+import { readDefaultGenerationQuality } from "../generationQuality.js";
+
+// Job-request builders for the Simple UI (design handoff "Simple UI for creative studios").
+//
+// The Simple studios expose a REDUCED control surface, not a different generation
+// contract: a run submitted from Simple must be the same job the full workspace would
+// submit with those same visible settings, defaulted everywhere else. So the image
+// path delegates to the SAME pure `buildImageJobRequest` the advanced Image Studio (and
+// its batch run) uses — this module only supplies the neutral defaults for the knobs
+// Simple doesn't show. That way an advanced knob added later can't silently change
+// meaning here: it either keeps its omit-when-default rule (and Simple is unaffected)
+// or the shared builder's tests catch the drift.
+//
+// Video/audio have no extracted builder upstream (their payloads are assembled inline in
+// VideoStudio/AudioStudio), so those two are written out here against the same DTOs the
+// studios post — kept deliberately small and free of the mode-specific branches Simple
+// never reaches.
+
+// Quant tier is the ONE "advanced" knob Simple still has to resolve, because omitting it
+// would silently ignore the app-wide "Default quality" setting the Simple Settings screen
+// writes. This mirrors the advanced studios' seed effect exactly: the per-(screen,model)
+// sticky first, then the global quality setting, then the capability-aware Auto suggestion —
+// all clamped to what's actually installed.
+export function resolveSimpleTier(model, screen, options = {}) {
+  const { convRotEligible = false, nvfp4Eligible = false, unifiedMemoryGb = null } = options;
+  const tierOptions = { convRotEligible, nvfp4Eligible };
+  const available = installedTiers(model, tierOptions);
+  if (available.length === 0) {
+    return { quantTier: "", tierExplicit: false };
+  }
+  const sticky = readLastTier(screen, model?.id ?? "");
+  const quantTier =
+    defaultTierSelection(model, sticky, {
+      ...tierOptions,
+      defaultQuality: readDefaultGenerationQuality(),
+      autoTier: suggestTier(model, unifiedMemoryGb),
+    }) ?? "";
+  return {
+    quantTier,
+    // Only a DELIBERATE prior pick (the sticky) marks the tier explicit, so the worker's
+    // capability clamp may still downtier a derived default that doesn't fit (sc-10733).
+    tierExplicit: Boolean(quantTier) && sticky === quantTier,
+  };
+}
+
+// Neutral values for every advanced knob the Simple Image Studio does not render. Each one is
+// the value that makes `buildImageJobAdvanced`'s omit-when-default rule drop the key entirely,
+// so a Simple payload's `advanced` is exactly `{ resolution }` (+ styleId when a style is picked,
+// + mlxQuantize when a tier resolves) — byte-identical to an advanced run with untouched controls.
+const IMAGE_DEFAULTS = Object.freeze({
+  negativePrompt: "",
+  seed: "",
+  posePayload: [],
+  recipePresetId: null,
+  presetPromptResolvedClientSide: false,
+  characterId: null,
+  characterLookId: null,
+  multiReference: false,
+  editSecondPair: null,
+  controlPreprocessSourceId: null,
+  referenceAssetIds: [],
+  fitMode: "crop",
+  editInpaintCapable: false,
+  referenceAssetId: null,
+  supportsImg2img: false,
+  img2imgReferenceAssetId: null,
+  loras: [],
+  upscaleEnabled: false,
+  upscaleFactor: 2,
+  upscaleEngine: "",
+  upscaleSoftness: 0,
+  sampler: "default",
+  scheduler: "default",
+  schedulerShift: "",
+  stepsOverride: "",
+  guidanceOverride: "",
+  guidanceMethod: "cfg",
+  flashAttn: true,
+  promptEnhance: false,
+  enhancePrompt: false,
+  precisionToggle: false,
+  bf16Precision: false,
+  showTierPicker: false,
+  showPidToggle: false,
+  usePid: false,
+  pidTarget: "4k",
+  hideReferenceStrength: false,
+  ipAdapterScale: 0,
+  identityStructure: false,
+  controlnetScale: 0,
+  variationStrength: false,
+  trueCfgScale: 0,
+  img2imgStrength: 0,
+  supportsTextStyle: false,
+  textStyleGain: 1,
+  viewAngles: null,
+  viewAngle: "",
+  faceRestore: false,
+  controlActive: false,
+  activeControlMode: "pose",
+  controlPassthroughId: null,
+  effectiveControlScale: 0,
+  controlOverlayId: null,
+  multiPhaseActive: false,
+  phases: [],
+  sendStructured: false,
+  submitCaption: null,
+  submitBackend: null,
+  resolutionOverride: null,
+});
+
+/**
+ * Parse a "WIDTHxHEIGHT" resolution string into numbers. Returns null when unparseable
+ * so callers can refuse to submit rather than post a NaN geometry.
+ */
+export function parseResolutionPair(resolution) {
+  const [width, height] = String(resolution ?? "")
+    .toLowerCase()
+    .split("x")
+    .map((part) => Number.parseInt(part, 10));
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+/**
+ * The Image Studio job request for a Simple run.
+ * @param {object} input
+ * @param {string} input.prompt
+ * @param {"text_to_image"|"edit_image"} input.mode
+ * @param {string} input.model - catalog model id.
+ * @param {string} input.resolution - "WIDTHxHEIGHT".
+ * @param {number} input.count - variations.
+ * @param {string|null} input.styleId - Style Catalog group/sub-style id, or null for "None".
+ * @param {string|null} input.sourceAssetId - the edit source (edit_image only).
+ * @param {string} [input.quantTier] / @param {boolean} [input.tierExplicit] - from resolveSimpleTier.
+ * @returns {object|null} the payload for createImageJob, or null when the resolution is invalid.
+ */
+export function buildSimpleImageRequest({
+  prompt,
+  mode,
+  model,
+  resolution,
+  count,
+  styleId,
+  sourceAssetId,
+  quantTier = "",
+  tierExplicit = false,
+}) {
+  const size = parseResolutionPair(resolution);
+  if (!size) {
+    return null;
+  }
+  return buildImageJobRequest({
+    ...IMAGE_DEFAULTS,
+    promptToSend: prompt,
+    submitIntent: prompt,
+    resolution,
+    width: size.width,
+    height: size.height,
+    mode,
+    model,
+    count,
+    // The composer wants the style's free text; the id rides `advanced` so a Simple run
+    // replays into the advanced Style picker unchanged (sc-13132).
+    styleText: styleId ? styleTextForId(styleId) : null,
+    styleId: styleId || null,
+    sourceAssetId: sourceAssetId || null,
+    quantTier,
+    tierExplicit,
+  });
+}
+
+/**
+ * The Video Studio job request for a Simple run. Mirrors VideoStudio.submit()'s payload with
+ * every mode-specific channel Simple doesn't expose left at its empty default, so the DTO
+ * shape the API deserializes is unchanged.
+ */
+export function buildSimpleVideoRequest({
+  prompt,
+  mode,
+  model,
+  resolution,
+  duration,
+  fps,
+  styleId,
+  sourceAssetId,
+}) {
+  const size = parseResolutionPair(resolution);
+  if (!size) {
+    return null;
+  }
+  const styleText = styleId ? styleTextForId(styleId) : null;
+  const styleApplied = Boolean(styleText && styleText.trim());
+  return {
+    mode,
+    // The Style Catalog wrap is applied client-side, exactly as VideoStudio does (sc-13136);
+    // `presetPromptResolvedClientSide` then tells the server to skip its own fold.
+    prompt: styleApplied ? composeStyledPrompt({ styleText, userPrompt: prompt }) : prompt,
+    negativePrompt: "",
+    model,
+    duration: Number(duration),
+    fps: Number(fps),
+    width: size.width,
+    height: size.height,
+    quality: "balanced",
+    seed: null,
+    recipePresetId: null,
+    presetPromptResolvedClientSide: styleApplied || undefined,
+    characterId: null,
+    characterLookId: null,
+    sourceAssetId: mode === "image_to_video" ? sourceAssetId || null : null,
+    lastFrameAssetId: null,
+    sourceClipAssetId: null,
+    sourceClipAssetIds: [],
+    bridgeRightClipAssetId: null,
+    referenceAssetIds: [],
+    referenceClipAssetId: null,
+    personTrackId: null,
+    replacementMode: "face_only",
+    loras: [],
+    advanced: {
+      resolution,
+      ...(styleApplied ? { styleId, stylePrompt: prompt } : {}),
+    },
+  };
+}
+
+/**
+ * The Audio Studio job request for a Simple run. Mirrors AudioStudio.submit()'s base payload
+ * ({ model, prompt, language, targetDurationSecs, seed }) plus the single mode-specific field
+ * Simple surfaces — the Speech voice.
+ */
+export function buildSimpleAudioRequest({ model, prompt, mode, voice, durationSecs }) {
+  const target = Number(durationSecs);
+  const payload = {
+    model,
+    prompt: String(prompt ?? "").trim(),
+    // Omitted when the model declares no length cap, so it synthesizes its natural length.
+    targetDurationSecs: durationSecs != null && Number.isFinite(target) && target > 0 ? target : undefined,
+    seed: null,
+  };
+  if (mode === "speech" && voice) {
+    payload.voice = voice;
+  }
+  return payload;
+}

--- a/apps/web/src/simple/simpleJobs.test.js
+++ b/apps/web/src/simple/simpleJobs.test.js
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSimpleAudioRequest,
+  buildSimpleImageRequest,
+  buildSimpleVideoRequest,
+  parseResolutionPair,
+} from "./simpleJobs.js";
+import { buildImageJobRequest } from "../imageJobRequest.js";
+import { STYLE_GROUPS, styleTextForId } from "../data/styleCatalog.js";
+
+const STYLE_GROUP_ID = STYLE_GROUPS[0].id;
+
+describe("parseResolutionPair", () => {
+  it("parses a WxH string and rejects anything that isn't a positive pair", () => {
+    expect(parseResolutionPair("1344x768")).toEqual({ width: 1344, height: 768 });
+    expect(parseResolutionPair("1024X1024")).toEqual({ width: 1024, height: 1024 });
+    expect(parseResolutionPair("")).toBeNull();
+    expect(parseResolutionPair("1024")).toBeNull();
+    expect(parseResolutionPair("0x512")).toBeNull();
+    expect(parseResolutionPair("widexhigh")).toBeNull();
+    expect(parseResolutionPair(undefined)).toBeNull();
+  });
+});
+
+describe("buildSimpleImageRequest", () => {
+  const base = {
+    prompt: "a lighthouse at golden hour",
+    mode: "text_to_image",
+    model: "z_image",
+    resolution: "1344x768",
+    count: 4,
+    styleId: null,
+    sourceAssetId: null,
+  };
+
+  it("emits the geometry, count and mode the studio shows", () => {
+    const request = buildSimpleImageRequest(base);
+    expect(request.mode).toBe("text_to_image");
+    expect(request.model).toBe("z_image");
+    expect(request.prompt).toBe("a lighthouse at golden hour");
+    expect(request.count).toBe(4);
+    expect(request.width).toBe(1344);
+    expect(request.height).toBe(768);
+    expect(request.advanced.resolution).toBe("1344x768");
+  });
+
+  it("refuses an unparseable resolution instead of posting a NaN geometry", () => {
+    expect(buildSimpleImageRequest({ ...base, resolution: "not-a-size" })).toBeNull();
+  });
+
+  it("leaves `advanced` at just the resolution when no style and no tier are in play", () => {
+    // This is the load-bearing claim: every advanced knob Simple hides must hit its
+    // omit-when-default rule, so a Simple payload is byte-identical to an untouched
+    // advanced run. A new always-emitted key would fail here.
+    expect(Object.keys(buildSimpleImageRequest(base).advanced)).toEqual(["resolution"]);
+  });
+
+  it("is byte-identical to the advanced builder given the same visible settings", () => {
+    // Guards the reuse claim directly: if IMAGE_DEFAULTS ever drifts from what the
+    // advanced studio sends for an untouched control, this diverges.
+    const simple = buildSimpleImageRequest(base);
+    const advanced = buildImageJobRequest({
+      promptToSend: base.prompt,
+      submitIntent: base.prompt,
+      sendStructured: false,
+      submitCaption: null,
+      submitBackend: null,
+      resolutionOverride: null,
+      resolution: "1344x768",
+      mode: "text_to_image",
+      negativePrompt: "",
+      model: "z_image",
+      count: 4,
+      seed: "",
+      posePayload: [],
+      width: 1344,
+      height: 768,
+      recipePresetId: null,
+      presetPromptResolvedClientSide: false,
+      styleText: null,
+      styleId: null,
+      characterId: null,
+      characterLookId: null,
+      multiReference: false,
+      editSecondPair: null,
+      sourceAssetId: null,
+      controlPreprocessSourceId: null,
+      referenceAssetIds: [],
+      fitMode: "crop",
+      editInpaintCapable: false,
+      referenceAssetId: null,
+      supportsImg2img: false,
+      img2imgReferenceAssetId: null,
+      loras: [],
+      upscaleEnabled: false,
+      upscaleFactor: 2,
+      upscaleEngine: "",
+      upscaleSoftness: 0,
+      sampler: "default",
+      scheduler: "default",
+      schedulerShift: "",
+      stepsOverride: "",
+      guidanceOverride: "",
+      guidanceMethod: "cfg",
+      flashAttn: true,
+      promptEnhance: false,
+      enhancePrompt: false,
+      precisionToggle: false,
+      bf16Precision: false,
+      showTierPicker: false,
+      quantTier: "",
+      showPidToggle: false,
+      usePid: false,
+      pidTarget: "4k",
+      hideReferenceStrength: false,
+      ipAdapterScale: 0,
+      identityStructure: false,
+      controlnetScale: 0,
+      variationStrength: false,
+      trueCfgScale: 0,
+      img2imgStrength: 0,
+      supportsTextStyle: false,
+      textStyleGain: 1,
+      viewAngles: null,
+      viewAngle: "",
+      faceRestore: false,
+      controlActive: false,
+      activeControlMode: "pose",
+      controlPassthroughId: null,
+      effectiveControlScale: 0,
+      controlOverlayId: null,
+      multiPhaseActive: false,
+      phases: [],
+    });
+    expect(JSON.stringify(simple)).toBe(JSON.stringify(advanced));
+  });
+
+  it("composes a picked style into the prompt and records the id for replay", () => {
+    const request = buildSimpleImageRequest({ ...base, styleId: STYLE_GROUP_ID });
+    const styleText = styleTextForId(STYLE_GROUP_ID);
+    expect(styleText).toBeTruthy();
+    // The outgoing prompt is the COMPOSED string, not the raw one…
+    expect(request.prompt).not.toBe(base.prompt);
+    expect(request.prompt).toContain(styleText);
+    // …the client is authoritative, so the server must skip its own fold…
+    expect(request.presetPromptResolvedClientSide).toBe(true);
+    // …and both halves needed to replay into the advanced Style picker are recorded.
+    expect(request.advanced.styleId).toBe(STYLE_GROUP_ID);
+    expect(request.advanced.stylePrompt).toBe(base.prompt);
+  });
+
+  it("routes an edit run's source image through sourceAssetId", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      mode: "edit_image",
+      sourceAssetId: "asset-7",
+    });
+    expect(request.mode).toBe("edit_image");
+    expect(request.sourceAssetId).toBe("asset-7");
+    expect(request.fitMode).toBe("crop");
+  });
+
+  it("emits the resolved quant tier, and marks it explicit only for a deliberate pick", () => {
+    const derived = buildSimpleImageRequest({ ...base, quantTier: "q4", tierExplicit: false });
+    expect(derived.advanced.mlxQuantize).toBe(4);
+    expect(derived.advanced.mlxQuantizeExplicit).toBeUndefined();
+
+    const sticky = buildSimpleImageRequest({ ...base, quantTier: "q4", tierExplicit: true });
+    expect(sticky.advanced.mlxQuantizeExplicit).toBe(true);
+  });
+});
+
+describe("buildSimpleVideoRequest", () => {
+  const base = {
+    prompt: "slow drone push-in over a misty forest",
+    mode: "text_to_video",
+    model: "ltx_2_3",
+    resolution: "1280x720",
+    duration: 5,
+    fps: 25,
+    styleId: null,
+    sourceAssetId: null,
+  };
+
+  it("emits the geometry, duration and fps the studio shows", () => {
+    const request = buildSimpleVideoRequest(base);
+    expect(request).toMatchObject({
+      mode: "text_to_video",
+      model: "ltx_2_3",
+      duration: 5,
+      fps: 25,
+      width: 1280,
+      height: 720,
+      quality: "balanced",
+      seed: null,
+    });
+    expect(request.advanced.resolution).toBe("1280x720");
+  });
+
+  it("refuses an unparseable resolution", () => {
+    expect(buildSimpleVideoRequest({ ...base, resolution: "720" })).toBeNull();
+  });
+
+  it("only carries a source asset in image_to_video", () => {
+    expect(buildSimpleVideoRequest({ ...base, sourceAssetId: "asset-3" }).sourceAssetId).toBeNull();
+    expect(
+      buildSimpleVideoRequest({ ...base, mode: "image_to_video", sourceAssetId: "asset-3" })
+        .sourceAssetId,
+    ).toBe("asset-3");
+  });
+
+  it("wraps a picked style and records the raw prompt for replay", () => {
+    const request = buildSimpleVideoRequest({ ...base, styleId: STYLE_GROUP_ID });
+    expect(request.prompt).toContain(styleTextForId(STYLE_GROUP_ID));
+    expect(request.presetPromptResolvedClientSide).toBe(true);
+    expect(request.advanced.styleId).toBe(STYLE_GROUP_ID);
+    expect(request.advanced.stylePrompt).toBe(base.prompt);
+  });
+
+  it("leaves a styleless run's advanced payload at just the resolution", () => {
+    const request = buildSimpleVideoRequest(base);
+    expect(Object.keys(request.advanced)).toEqual(["resolution"]);
+    expect(request.presetPromptResolvedClientSide).toBeUndefined();
+  });
+});
+
+describe("buildSimpleAudioRequest", () => {
+  it("sends the base payload the audio route deserializes", () => {
+    expect(
+      buildSimpleAudioRequest({
+        model: "acestep_v15_turbo",
+        prompt: "  warm lo-fi beat  ",
+        mode: "music",
+        voice: "",
+        durationSecs: 8,
+      }),
+    ).toEqual({
+      model: "acestep_v15_turbo",
+      prompt: "warm lo-fi beat",
+      targetDurationSecs: 8,
+      seed: null,
+    });
+  });
+
+  it("carries a voice only in Speech", () => {
+    const speech = buildSimpleAudioRequest({
+      model: "kokoro_82m",
+      prompt: "hello",
+      mode: "speech",
+      voice: "af_heart",
+      durationSecs: 8,
+    });
+    expect(speech.voice).toBe("af_heart");
+    const music = buildSimpleAudioRequest({
+      model: "acestep_v15_turbo",
+      prompt: "hello",
+      mode: "music",
+      voice: "af_heart",
+      durationSecs: 8,
+    });
+    expect(music.voice).toBeUndefined();
+  });
+
+  it("omits the target duration when the model declares no length cap", () => {
+    const request = buildSimpleAudioRequest({
+      model: "moss_sfx_v2",
+      prompt: "thunder",
+      mode: "sfx",
+      voice: "",
+      durationSecs: null,
+    });
+    expect(request.targetDurationSecs).toBeUndefined();
+  });
+});

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -1,0 +1,299 @@
+import React, { useCallback, useRef, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { AssetThumbnail, assetUrl } from "../components/assetMedia.jsx";
+import { resolveJobResultAssets } from "../jobResultAssets.js";
+import { terminalStatuses } from "../constants.js";
+import { STYLE_GROUPS } from "../data/styleCatalog.js";
+import { useAppStatic } from "../context/AppContext.js";
+import { useSimpleUi } from "./SimpleUiContext.js";
+
+// Shared building blocks for the three Simple studios (design handoff). Each one is
+// the design's control re-expressed over the app's real data — no mock state.
+
+const STYLE_THUMB_BASE = "/style-thumbs";
+
+// Style strip: "None" plus the eight authored Style Catalog groups (the README's
+// "back this with the real styleCatalog groups"). Selecting a group stores the GROUP
+// id, which styleTextForId resolves to that group's overall description — the same
+// selection contract the advanced StylePicker uses, so a Simple run replays into the
+// advanced picker unchanged.
+export function StyleStrip({ value, onChange }) {
+  const options = [{ id: null, name: "None" }, ...STYLE_GROUPS.map((g) => ({ id: g.id, name: g.name }))];
+  return (
+    <div>
+      <span className="su-section-label">Style &amp; Presets</span>
+      <div className="su-style-strip su-scroll" role="radiogroup" aria-label="Style">
+        {options.map((option) => (
+          <StyleTile
+            active={(value ?? null) === option.id}
+            key={option.id ?? "none"}
+            name={option.name}
+            onSelect={() => onChange(option.id)}
+            styleId={option.id}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StyleTile({ active, name, onSelect, styleId }) {
+  // Thumbnails are generated locally (scripts/generate-style-thumbnails.mjs) and are
+  // git-ignored, so they may be absent at runtime — a 404 collapses to the neutral slot
+  // exactly as the advanced picker does, never a broken image.
+  const [failed, setFailed] = useState(false);
+  return (
+    <button
+      aria-checked={active}
+      className={active ? "su-style active" : "su-style"}
+      onClick={onSelect}
+      role="radio"
+      type="button"
+    >
+      <span className="su-style-thumb">
+        {styleId && !failed ? (
+          <img alt="" loading="lazy" onError={() => setFailed(true)} src={`${STYLE_THUMB_BASE}/${styleId}.png`} />
+        ) : null}
+      </span>
+      <span className="su-style-name">{name}</span>
+    </button>
+  );
+}
+
+// Reference / source-image tile. Armed state shows the design's "SET" badge plus a
+// thumbnail and the asset's display name; tapping an armed tile clears it, tapping an
+// empty one opens the picker sheet over the project's recent images.
+export function ReferenceTile({ label, hint, asset, assets, onChange, required = false }) {
+  const { openSheet, toast } = useSimpleUi();
+  const pick = useCallback(() => {
+    if (asset) {
+      onChange(null);
+      toast("Reference removed");
+      return;
+    }
+    if (!assets.length) {
+      toast("No images in this project yet");
+      return;
+    }
+    openSheet({
+      title: "Choose a reference",
+      kind: "list",
+      options: assets.map((item) => ({
+        value: item.id,
+        label: item.displayName ?? item.id,
+        thumbnail: assetUrl(item),
+      })),
+      onSelect: (id) => {
+        onChange(id);
+        toast("Reference attached");
+      },
+    });
+  }, [asset, assets, onChange, openSheet, toast]);
+
+  return (
+    <button className={asset ? "su-tile active" : "su-tile"} onClick={pick} type="button">
+      <span className="su-tile-head">
+        <Icon.Image size={15} />
+        {label}
+        {asset ? <span className="su-set-badge">SET</span> : null}
+      </span>
+      {asset ? (
+        <span className="su-tile-ref">
+          <AssetThumbnail asset={asset} />
+          <span>{asset.displayName ?? asset.id}</span>
+        </span>
+      ) : (
+        <span className="su-tile-hint">{hint ?? (required ? "Required — tap to attach" : "Tap to attach an image")}</span>
+      )}
+    </button>
+  );
+}
+
+// Inline refine panel (design): one "Rewrite prompt" button that replaces the prompt with
+// the Anubis-8B rewrite and closes. Unlike the advanced RefinePromptControl there is no
+// review step — that is the simplification the design asks for — but the failure paths it
+// owns are preserved: a missing refiner model offers its download instead of a raw error.
+export function RefinePanel({ blurb, busy, error, onRun, onDownloadModel, modelMissing }) {
+  return (
+    <div className="su-inline-panel">
+      <p>{blurb}</p>
+      {error ? (
+        <p className="su-error">{error}</p>
+      ) : null}
+      {modelMissing && onDownloadModel ? (
+        <button className="su-accent-btn" onClick={onDownloadModel} type="button">
+          Download refinement model
+        </button>
+      ) : (
+        <button
+          className={busy ? "su-accent-btn busy" : "su-accent-btn"}
+          disabled={busy}
+          onClick={onRun}
+          type="button"
+        >
+          {busy ? <span aria-hidden="true" className="su-spinner su-spinner--sm" /> : null}
+          {busy ? "Refining…" : "Rewrite prompt"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// A settings-bar select that opens the shared picker sheet.
+export function SheetSelect({ label, value, options, onSelect, title, kind = "list", disabled }) {
+  const { openSheet } = useSimpleUi();
+  return (
+    <div className="su-field">
+      <label htmlFor={undefined}>{label}</label>
+      <button
+        className="su-select"
+        disabled={disabled || options.length === 0}
+        onClick={() =>
+          openSheet({
+            title: title ?? label,
+            kind,
+            options,
+            onSelect,
+          })
+        }
+        type="button"
+      >
+        <span>{value}</span>
+        <Icon.ChevDown size={12} />
+      </button>
+    </div>
+  );
+}
+
+// `label` doubles as the visible field label and the group's accessible name. A caller
+// that already has a heading above the row (Settings' "Default quality" card) passes only
+// `ariaLabel`, so no empty <label> is emitted.
+export function Chips({ label, ariaLabel, options, value, onChange, capped = false }) {
+  return (
+    <div className="su-field">
+      {label ? <label>{label}</label> : null}
+      <div
+        aria-label={label || ariaLabel}
+        className={capped ? "su-chips su-chips--capped" : "su-chips"}
+        role="radiogroup"
+      >
+        {options.map((option) => (
+          <button
+            aria-checked={option.value === value}
+            className={option.value === value ? "su-chip active" : "su-chip"}
+            key={String(option.value)}
+            onClick={() => onChange(option.value)}
+            role="radio"
+            title={option.title}
+            type="button"
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// The newest run out of a studio's local job stack. The stack is ordered oldest→newest
+// (buildLocalJobStack), so the last entry is the run the Results block reflects.
+export function newestLocalJob(localJobs) {
+  return localJobs.length ? localJobs[localJobs.length - 1] : null;
+}
+
+export function jobIsRunning(job) {
+  return Boolean(job) && !terminalStatuses.has(job.status);
+}
+
+// Results block. Renders the newest run's outputs; while that run is still in flight it
+// renders one placeholder tile per expected output so the grid doesn't pop in.
+export function StudioResults({ job, assets, type, columns, meta, pendingCount = 1, wide = false }) {
+  const { toast, openPreview } = useSimpleUi();
+  const { updateAssetStatus } = useAppStatic();
+  const results = job ? resolveJobResultAssets(job, assets, { type }) : [];
+  const running = jobIsRunning(job);
+  if (!job || (!running && results.length === 0)) {
+    return null;
+  }
+  const tiles = results.length ? results : Array.from({ length: pendingCount }, () => null);
+  return (
+    <div>
+      <div className="su-results-head">
+        <strong>{results.length === 1 ? "Result" : "Results"}</strong>
+        {meta ? <span>{meta}</span> : null}
+      </div>
+      <div className="su-results-grid" style={{ "--su-result-cols": columns }}>
+        {tiles.map((asset, index) => (
+          <div
+            className={wide ? "su-result su-result--wide" : "su-result"}
+            key={asset?.id ?? `pending-${index}`}
+          >
+            {asset ? (
+              <>
+                <button
+                  aria-label="Open preview"
+                  className="su-result-open"
+                  onClick={() => openPreview(asset)}
+                  type="button"
+                >
+                  <AssetThumbnail asset={asset} />
+                </button>
+                <button
+                  aria-label={asset.status?.favorite ? "Remove from favorites" : "Add to favorites"}
+                  className={
+                    asset.status?.favorite ? "su-result-action su-result-action--fav on" : "su-result-action su-result-action--fav"
+                  }
+                  onClick={() => {
+                    updateAssetStatus(asset, { favorite: !asset.status?.favorite });
+                    toast(asset.status?.favorite ? "Removed from favorites" : "Added to favorites");
+                  }}
+                  type="button"
+                >
+                  <Icon.Star filled={Boolean(asset.status?.favorite)} size={14} />
+                </button>
+                <DownloadButton asset={asset} />
+              </>
+            ) : (
+              <span className="su-result-pending">
+                {running ? <span aria-hidden="true" className="su-spinner" /> : null}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Download uses a real anchor (the media URL already carries the auth ticket in
+// remote-auth mode, sc-8810) rather than a fetch — the browser owns the save dialog.
+export function DownloadButton({ asset, className = "su-result-action su-result-action--dl", label = null }) {
+  const anchorRef = useRef(null);
+  const { toast } = useSimpleUi();
+  return (
+    <>
+      <a
+        aria-hidden="true"
+        download={asset.displayName ?? ""}
+        href={assetUrl(asset)}
+        ref={anchorRef}
+        style={{ display: "none" }}
+        tabIndex={-1}
+      >
+        download
+      </a>
+      <button
+        aria-label="Download"
+        className={className}
+        onClick={() => {
+          anchorRef.current?.click();
+          toast("Downloading…");
+        }}
+        type="button"
+      >
+        <Icon.Download size={label ? 15 : 14} />
+        {label}
+      </button>
+    </>
+  );
+}

--- a/apps/web/src/simple/uiMode.js
+++ b/apps/web/src/simple/uiMode.js
@@ -1,0 +1,77 @@
+import { isPhoneWidth } from "./breakpoint.js";
+
+// Simple ⇄ Advanced UI mode (design handoff "Simple UI for creative studios").
+//
+// The Simple UI is an ALTERNATIVE shell, not a replacement: the full workspace is
+// untouched and the sidebar switch flips between them. Three inputs decide which
+// shell renders, in this precedence:
+//
+//   1. phone viewport  — always Simple (the full workspace is unusable at that width;
+//                        the design's "Phones always use it"). Not overridable, so the
+//                        sidebar switch is rendered disabled there.
+//   2. session override — the user clicked Simple/Advanced in the sidebar this session.
+//   3. stored default   — the "Use Simple UI by default" toggle in Settings.
+//
+// The stored default is OFF by default: an existing install keeps the workspace it
+// already has, and opting into Simple is a deliberate choice (either the switch or the
+// Settings toggle). Persistence mirrors theme/accent — a durable server copy in
+// ui-preferences.json plus a localStorage instant-paint cache — because on the desktop
+// shell the UI's 127.0.0.1:<port> origin changes every launch and wipes localStorage.
+
+export const SIMPLE_MODE = "simple";
+export const ADVANCED_MODE = "advanced";
+
+const STORAGE_KEY = "sceneworks-simple-ui-default";
+
+/**
+ * The persisted "Use Simple UI by default" preference. `false` when unset or when
+ * localStorage is unavailable, so an untouched install lands on the full workspace.
+ */
+export function readStoredSimpleDefault() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/** Cache the preference for the next instant paint. Silently no-ops when unavailable. */
+export function writeStoredSimpleDefault(value) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "true" : "false");
+  } catch {
+    // private mode / quota — the durable server copy still carries it.
+  }
+}
+
+/**
+ * Resolve the shell to render.
+ * @param {object} input
+ * @param {boolean} input.simpleDefault - persisted "Use Simple UI by default".
+ * @param {"simple"|"advanced"|null} input.override - this session's sidebar pick.
+ * @param {number|null} input.width - measured viewport width (null ⇒ unknown).
+ * @returns {"simple"|"advanced"}
+ */
+export function resolveUiMode({ simpleDefault, override, width }) {
+  if (isPhoneWidth(width)) {
+    return SIMPLE_MODE;
+  }
+  if (override === SIMPLE_MODE || override === ADVANCED_MODE) {
+    return override;
+  }
+  return simpleDefault ? SIMPLE_MODE : ADVANCED_MODE;
+}
+
+/**
+ * True when the viewport itself is forcing Simple, so the switch must present as
+ * locked rather than silently ignoring a click.
+ */
+export function uiModeLockedToSimple(width) {
+  return isPhoneWidth(width);
+}

--- a/apps/web/src/simple/uiMode.test.js
+++ b/apps/web/src/simple/uiMode.test.js
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  ADVANCED_MODE,
+  SIMPLE_MODE,
+  readStoredSimpleDefault,
+  resolveUiMode,
+  uiModeLockedToSimple,
+  writeStoredSimpleDefault,
+} from "./uiMode.js";
+import { PHONE_MAX_WIDTH } from "./breakpoint.js";
+
+describe("uiMode — which shell renders", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("keeps the full workspace for an untouched install", () => {
+    // The whole point of the switch: an existing user's UI does not change under them.
+    expect(readStoredSimpleDefault()).toBe(false);
+    expect(resolveUiMode({ simpleDefault: false, override: null, width: 1440 })).toBe(ADVANCED_MODE);
+  });
+
+  it("honors the stored default once the user opts in", () => {
+    writeStoredSimpleDefault(true);
+    expect(readStoredSimpleDefault()).toBe(true);
+    expect(resolveUiMode({ simpleDefault: true, override: null, width: 1440 })).toBe(SIMPLE_MODE);
+  });
+
+  it("lets a session override win over the stored default in BOTH directions", () => {
+    expect(resolveUiMode({ simpleDefault: false, override: SIMPLE_MODE, width: 1440 })).toBe(SIMPLE_MODE);
+    expect(resolveUiMode({ simpleDefault: true, override: ADVANCED_MODE, width: 1440 })).toBe(ADVANCED_MODE);
+  });
+
+  it("forces Simple on a phone even against an explicit Advanced override", () => {
+    const phone = PHONE_MAX_WIDTH - 1;
+    expect(resolveUiMode({ simpleDefault: false, override: ADVANCED_MODE, width: phone })).toBe(SIMPLE_MODE);
+    expect(uiModeLockedToSimple(phone)).toBe(true);
+  });
+
+  it("does not force Simple at the phone boundary or on an unknown width", () => {
+    // The boundary is exclusive — PHONE_MAX_WIDTH itself is the tablet band.
+    expect(uiModeLockedToSimple(PHONE_MAX_WIDTH)).toBe(false);
+    expect(resolveUiMode({ simpleDefault: false, override: null, width: PHONE_MAX_WIDTH })).toBe(ADVANCED_MODE);
+    // An unmeasured viewport must never silently swap the user's shell.
+    expect(uiModeLockedToSimple(null)).toBe(false);
+    expect(resolveUiMode({ simpleDefault: false, override: null, width: null })).toBe(ADVANCED_MODE);
+  });
+
+  it("ignores an unrecognized override rather than treating it as Simple", () => {
+    expect(resolveUiMode({ simpleDefault: false, override: "sImPlE", width: 1440 })).toBe(ADVANCED_MODE);
+    expect(resolveUiMode({ simpleDefault: true, override: "nonsense", width: 1440 })).toBe(SIMPLE_MODE);
+  });
+
+  it("round-trips the stored default through localStorage", () => {
+    writeStoredSimpleDefault(true);
+    expect(window.localStorage.getItem("sceneworks-simple-ui-default")).toBe("true");
+    writeStoredSimpleDefault(false);
+    expect(readStoredSimpleDefault()).toBe(false);
+  });
+});

--- a/apps/web/src/simple/useContainerWidth.js
+++ b/apps/web/src/simple/useContainerWidth.js
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Measure an element's own width (design handoff: "measure the mount, not `window` — it
+// must work embedded"). Returns `[ref, width]`; `width` is null until the first
+// observation lands, which `breakpointFor` resolves to the desktop band.
+//
+// The 4px dead-band mirrors the prototype: a sub-pixel scrollbar/zoom jitter must not
+// re-render the whole shell, and the three breakpoints are hundreds of pixels apart so a
+// 4px hysteresis can never straddle one.
+const WIDTH_EPSILON = 4;
+
+export function useContainerWidth() {
+  const [width, setWidth] = useState(null);
+  const observerRef = useRef(null);
+  const widthRef = useRef(null);
+
+  const ref = useCallback((element) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!element || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const next = Math.round(entries[0]?.contentRect?.width ?? 0);
+      if (!next) {
+        return;
+      }
+      if (widthRef.current !== null && Math.abs(next - widthRef.current) <= WIDTH_EPSILON) {
+        return;
+      }
+      widthRef.current = next;
+      setWidth(next);
+    });
+    observer.observe(element);
+    observerRef.current = observer;
+  }, []);
+
+  useEffect(
+    () => () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    },
+    [],
+  );
+
+  return [ref, width];
+}
+
+// Viewport width for the app-level "phones are always served the Simple UI" rule.
+// This one IS window-scoped on purpose: which SHELL to render is a property of the
+// device the app is running on, not of a container inside it. The shell's own layout
+// still measures its mount (useContainerWidth above), so an embedded Simple UI lays
+// itself out correctly regardless of what this reports.
+export function useViewportWidth() {
+  const [width, setWidth] = useState(() =>
+    typeof window === "undefined" ? null : window.innerWidth,
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+    const onResize = () => setWidth(window.innerWidth);
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return width;
+}

--- a/apps/web/src/simple/useSimpleRefine.js
+++ b/apps/web/src/simple/useSimpleRefine.js
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAppStatic } from "../context/AppContext.js";
+import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
+
+// The Simple studios' prompt refine (design handoff: "Wire to the Anubis-8B refiner").
+//
+// Same worker job the advanced RefinePromptControl runs — including the best-effort
+// fetch of the selected model's prompt guide, which is what gives the rewrite its
+// model-specific context — but the review step is dropped: the rewrite replaces the
+// prompt and the panel closes, per the design. The one advanced behavior that is NOT
+// dropped is the missing-model path: the refiner is a downloadable catalog model, so
+// when it isn't installed we surface its download rather than a raw worker error.
+
+function isModelMissing(refineModel, message) {
+  if (refineModel?.installState) {
+    return refineModel.installState === "missing";
+  }
+  return /not cached|not installed|snapshot is not/i.test(message ?? "");
+}
+
+export function useSimpleRefine(workflow) {
+  const { refinePrompt, models = [], createModelDownloadJob } = useAppStatic();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const controllerRef = useRef(null);
+
+  const refineModel = useMemo(
+    () => models.find((entry) => entry.id === PROMPT_REFINE_MODEL_ID) ?? null,
+    [models],
+  );
+
+  useEffect(
+    () => () => {
+      controllerRef.current?.abort();
+    },
+    [],
+  );
+
+  // Resolves to the rewritten prompt, or null when it failed (the reason is in `error`).
+  const run = useCallback(
+    async ({ prompt, modelId, guidePath }) => {
+      const trimmed = String(prompt ?? "").trim();
+      if (!trimmed || typeof refinePrompt !== "function" || busy) {
+        return null;
+      }
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      const { signal } = controller;
+      setBusy(true);
+      setError("");
+      try {
+        let guide = "";
+        if (guidePath) {
+          try {
+            const response = await fetch(guidePath, { signal });
+            if (response.ok) {
+              guide = await response.text();
+            }
+          } catch (err) {
+            if (err?.name === "AbortError") {
+              return null;
+            }
+            guide = "";
+          }
+        }
+        const refined = await refinePrompt({ prompt: trimmed, modelId, workflow, guide, signal });
+        return signal.aborted ? null : refined;
+      } catch (err) {
+        if (err?.name === "AbortError") {
+          return null;
+        }
+        setError(err?.message || "Prompt refinement failed.");
+        return null;
+      } finally {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+        }
+        setBusy(false);
+      }
+    },
+    [busy, refinePrompt, workflow],
+  );
+
+  const downloadModel = useCallback(async () => {
+    if (!refineModel || typeof createModelDownloadJob !== "function") {
+      return;
+    }
+    const job = await createModelDownloadJob(refineModel);
+    if (job) {
+      setError("Downloading the refinement model — track it in the Queue, then try again.");
+    }
+  }, [createModelDownloadJob, refineModel]);
+
+  return {
+    busy,
+    error,
+    run,
+    reset: () => setError(""),
+    downloadModel: refineModel ? downloadModel : null,
+    modelMissing: Boolean(error) && isModelMissing(refineModel, error),
+  };
+}


### PR DESCRIPTION
Implements the **"Simple UI for creative studios"** design handoff: a calmer, reduced-surface alternative to the full workspace — mobile-first but fully responsive — covering four studios (Image, Video, Audio, Assets) plus the four manage screens (Model Manager, Queue, Settings, Licenses).

It is an **alternative shell, not a replacement.** Everything new lives in `apps/web/src/simple/`. The existing workspace is untouched apart from the Simple/Advanced switch added to its sidebar footer — that plus a render branch is the *entire* footprint in the old UI (**+92 lines in `App.jsx`, no existing markup changed**). One shared `SimpleModeSwitch` renders in *both* sidebars so the control can't present differently between them.

## No second data layer

`SimpleShell` mounts **inside** App's existing `AppStaticContext`/`AppLiveContext` providers, so every screen reads the same catalogs, the same SSE job feed and the same actions the full studios use:

- Model pickers go through the shared `modelEligibility` predicates; resolutions through the model's declared `limits` + the memory gate; styles through the real 8-group Style Catalog and its generated thumbnails; refine through the real Anubis-8B job.
- **Image runs are built by the same pure `buildImageJobRequest` the advanced studio and its batch run use.** `simpleJobs.js` only supplies neutral defaults for the knobs Simple hides, and a test pins the two payloads **byte-identical** for the same visible settings — so the reduced surface can never drift into a different generation contract.
- Assets reuses `LibraryScreen`'s own hygiene rules; Settings writes the same `ui-preferences.json`; Licenses renders the real `bundledLicenses`.

## Which shell renders (`uiMode.js`)

| | |
|---|---|
| 1. phone viewport | always Simple — the switch renders **locked**, with a reason |
| 2. session override | the sidebar switch |
| 3. stored default | "Use Simple UI by default" in Settings |

**That default is OFF.** The mockup shows it on, but defaulting every existing install into Simple *is* changing your UI. Phones are force-Simple as designed; everything else opts in deliberately. It persists like theme/accent — a durable `simpleUi` field in `ui-preferences.json` plus a localStorage instant-paint cache — because the desktop shell's per-launch `127.0.0.1:<port>` origin wipes origin-keyed localStorage.

Simple also stays **out of the first-run flows** (setup wizard, first-workspace gate, remote password band), which keep the existing shell that owns them — so it never renders a Generate that could only fail.

## Deviations from the mockup — each flagged in-code

- **Style strip** uses the real catalog group names (per the handoff README's own instruction) rather than the mockup's labels.
- **Quality chips gain `Auto`** — the app's actual default. Omitting it would strand a Simple user on a pinned tier with no way back.
- **Credentials form gains a token field.** The prototype had only a host input, which would have shipped a non-functional control.
- **Aspect labels are nearest-named** (`1152x896` -> `5:4`, not the mockup's `4:3`). The generation buckets are latent-grid-aligned, so the exact reduction is `7:9`/`19:13` — correct and meaningless. The exact pixels sit directly beneath the label.

## Two bug fixes worth reviewing separately

**1. `tierExplicit` was silently dropped (commit 1).** It's computed in `ImageStudio` and consumed by `buildImageJobAdvanced`, but `imageJobRequest.js` — extracted in sc-11219 — never destructured or forwarded it. So `advanced.mlxQuantizeExplicit` has **never** reached a payload, and a *deliberate* sticky tier pick stayed silently downtierable by the worker — exactly what sc-10733 added the flag to prevent. Two lines + regression tests. **This changes advanced-path payloads for users with a sticky tier**; happy to split it out if you'd rather land it alone.

**2. The shared image-model mirror drifted from #1780 (commit 3).** `modelEligibility.imageModelServesMode` is documented as mirroring ImageStudio's predicate. #1780 taught the studio's local copy that an *absent* capability array is a legacy record meaning "Text"; this shared copy kept the old `?? []` reading. The two authorities disagreed for exactly those records — the studio offered them in Text while the screen gate, the download offers and the Simple picker treated them as serving nothing. Only the absent-array case changes; an **explicit** list stays authoritative in both (including `[]`, whose existing assertion is unchanged and still passes).

Also adds four additive glyphs to the shared `Icon` set (Menu, Download, Check, Warning) with no existing render site changed.

## Verification

- **2407 web tests pass** (171 files; 62 new), **0 lint errors**
- `cargo fmt --all --check` clean; `cargo check` clean; **8 Rust `ui_preferences` tests pass**, including the new `simpleUi` round-trip/merge/partial-PUT case
- Driven in a browser against a **real API on a scratch data dir** with the live 79-model catalog — **re-run after merging `main`**: advanced UI renders unchanged, both switch directions round-trip, all eight screens, the modal picker, dark theme + accent swap, and the phone drawer at 375px. No console errors.
- Three bugs found and fixed during that pass: title/meta spans collapsing onto one line, quality-chip labels overflowing their 34px chips, and the disabled Generate button reading as enabled.

`main` is merged in, so CI builds a merge commit that has actually been verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
