### PR TITLE
fix(runpod): require token before public bind (sc-10365)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,14 @@ docker run --gpus all --publish 8010:8010 `
   sceneworks-runpod:local
 ```
 
+The combined image binds publicly by default and therefore requires a non-blank
+`SCENEWORKS_ACCESS_TOKEN` before it starts either the API or workers. A missing or
+whitespace-only token fails immediately with an actionable error, even if
+`SCENEWORKS_ALLOW_OPEN_BIND` is injected; this image never enables that legacy
+override. The same token is passed to every candle GPU and CPU utility worker.
+Loopback-only binds remain available without a token for local development.
+Tokens are operator-provided and are never generated or written to logs.
+
 On RunPod, attach the pod's persistent volume at `/sceneworks` in place of the
 example named volume. Provider-specific volume layout and ownership hardening
 are handled separately; this image only defines the shared mount contract.

--- a/crates/sceneworks-worker/src/supervisor.rs
+++ b/crates/sceneworks-worker/src/supervisor.rs
@@ -314,7 +314,7 @@ pub(crate) async fn terminate_child(child: &mut Child) {
     let _ = child.start_kill();
 }
 
-pub(crate) fn start_child_worker(_settings: &Settings, spec: &WorkerSpec) -> WorkerResult<Child> {
+pub(crate) fn start_child_worker(settings: &Settings, spec: &WorkerSpec) -> WorkerResult<Child> {
     let executable = std::env::current_exe()?;
     emit_event_value(
         Level::INFO,
@@ -325,7 +325,11 @@ pub(crate) fn start_child_worker(_settings: &Settings, spec: &WorkerSpec) -> Wor
         }),
     );
     let mut command = Command::new(executable);
-    command.envs(child_environment(spec));
+    // Make the auth contract explicit for every supervised GPU/utility child.
+    // Do not rely on ambient inheritance: first remove any raw parent value,
+    // then add the trimmed, nonblank value Settings accepted (if configured).
+    command.env_remove("SCENEWORKS_ACCESS_TOKEN");
+    command.envs(child_environment(settings, spec));
     // Windows graceful-shutdown channel (sc-11184 / F-014). Windows has no per-child
     // SIGTERM, so give the child a supervisor-held stdin pipe: closing the write end in
     // `terminate_child` delivers EOF, which the child's `shutdown_signal()` selects on
@@ -385,11 +389,17 @@ async fn report_worker_terminated(
     }
 }
 
-pub(crate) fn child_environment(spec: &WorkerSpec) -> BTreeMap<String, String> {
+pub(crate) fn child_environment(
+    settings: &Settings,
+    spec: &WorkerSpec,
+) -> BTreeMap<String, String> {
     let mut env = BTreeMap::new();
     env.insert("SCENEWORKS_WORKER_CHILD".to_owned(), "1".to_owned());
     env.insert("SCENEWORKS_WORKER_ID".to_owned(), spec.worker_id.clone());
     env.insert("SCENEWORKS_GPU_ID".to_owned(), spec.gpu_id.clone());
+    if let Some(access_token) = &settings.access_token {
+        env.insert("SCENEWORKS_ACCESS_TOKEN".to_owned(), access_token.clone());
+    }
     if spec.gpu_id == "cpu" {
         env.insert("CUDA_VISIBLE_DEVICES".to_owned(), String::new());
         env.insert("SCENEWORKS_UTILITY_JOBS".to_owned(), "1".to_owned());

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -110,19 +110,39 @@ fn auto_worker_ids_and_child_environment_match_python_supervisor() {
         ["0", "1", "cpu"]
     );
 
-    let gpu_env = child_environment(&WorkerSpec {
+    let mut settings = test_settings("http://127.0.0.1".to_owned(), None);
+    // Derive a process-local opaque value rather than committing a reusable
+    // credential fixture. The assertion never prints or logs its contents.
+    settings.access_token = Some(format!("{}-{}", env!("CARGO_PKG_NAME"), std::process::id()));
+
+    let gpu_env = child_environment(&settings, &WorkerSpec {
         worker_id: "worker-gpu-auto-1".to_owned(),
         gpu_id: "1".to_owned(),
     });
     assert_eq!(gpu_env["SCENEWORKS_UTILITY_JOBS"], "0");
     assert_eq!(gpu_env["CUDA_VISIBLE_DEVICES"], "1");
+    assert_eq!(
+        gpu_env.get("SCENEWORKS_ACCESS_TOKEN"),
+        settings.access_token.as_ref()
+    );
 
-    let cpu_env = child_environment(&WorkerSpec {
+    let cpu_env = child_environment(&settings, &WorkerSpec {
         worker_id: "worker-gpu-auto-cpu".to_owned(),
         gpu_id: "cpu".to_owned(),
     });
     assert_eq!(cpu_env["SCENEWORKS_UTILITY_JOBS"], "1");
     assert_eq!(cpu_env["CUDA_VISIBLE_DEVICES"], "");
+    assert_eq!(
+        cpu_env.get("SCENEWORKS_ACCESS_TOKEN"),
+        settings.access_token.as_ref()
+    );
+
+    settings.access_token = None;
+    let no_token_env = child_environment(&settings, &WorkerSpec {
+        worker_id: "worker-gpu-auto-cpu".to_owned(),
+        gpu_id: "cpu".to_owned(),
+    });
+    assert!(!no_token_env.contains_key("SCENEWORKS_ACCESS_TOKEN"));
 }
 
 #[test]

--- a/docker/runpod-entrypoint.sh
+++ b/docker/runpod-entrypoint.sh
@@ -19,6 +19,34 @@ log() {
   printf '[runpod] %s\n' "$*" >&2
 }
 
+trim_whitespace() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+effective_api_host() {
+  local host
+  if [[ -v SCENEWORKS_API_HOST ]]; then
+    host="$(trim_whitespace "${SCENEWORKS_API_HOST}")"
+    # Match the API's env_string fallback for an explicitly blank value.
+    [[ -n "${host}" ]] || host="127.0.0.1"
+  else
+    # The combined image's Dockerfile sets this value. Keeping the same fallback
+    # here makes direct entrypoint tests exercise the production posture.
+    host="0.0.0.0"
+  fi
+  printf '%s' "${host}"
+}
+
+is_loopback_host() {
+  case "$1" in
+    127.* | "::1" | "[::1]") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_running() {
   local pid="$1"
   local state
@@ -94,12 +122,26 @@ handle_signal() {
 
 trap handle_signal TERM INT HUP
 
+# This is a combined-image contract, not merely a late API-server safeguard:
+# fail before creating directories or starting any process when the configured
+# bind is network-reachable and the token is missing/blank. The legacy API
+# override is deliberately removed from every child so an injected value cannot
+# bypass this image's secure-by-default posture.
+api_host="$(effective_api_host)"
+access_token_trimmed="$(trim_whitespace "${SCENEWORKS_ACCESS_TOKEN:-}")"
+unset SCENEWORKS_ALLOW_OPEN_BIND
+if ! is_loopback_host "${api_host}" && [[ -z "${access_token_trimmed}" ]]; then
+  log "refusing network bind ${api_host}:${api_port}: SCENEWORKS_ACCESS_TOKEN is required by the combined RunPod image. Set a non-blank SCENEWORKS_ACCESS_TOKEN or bind to a loopback address; SCENEWORKS_ALLOW_OPEN_BIND cannot override this requirement."
+  exit 1
+fi
+unset access_token_trimmed
+
 mkdir -p \
   "${SCENEWORKS_DATA_DIR:-/sceneworks/data}/cache" \
   "${SCENEWORKS_CONFIG_DIR:-/sceneworks/config}" \
   "${HF_HOME:-/sceneworks/data/cache/huggingface}"
 
-log "starting embedded-web API on 0.0.0.0:${api_port}"
+log "starting embedded-web API on ${api_host}:${api_port}"
 "${api_bin}" &
 api_pid=$!
 
@@ -131,6 +173,7 @@ log "API healthy; starting candle GPU and utility workers"
 # the capability-routing boundary this combined image relies on.
 SCENEWORKS_API_URL="${api_url}" \
 SCENEWORKS_GPU_ID=auto \
+SCENEWORKS_ACCESS_TOKEN="${SCENEWORKS_ACCESS_TOKEN:-}" \
 "${worker_bin}" &
 worker_pid=$!
 

--- a/scripts/check-runpod-image.mjs
+++ b/scripts/check-runpod-image.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const [dockerfile, entrypoint, gpuSource, engineSource, readme] = await Promise.all([
+const [dockerfile, entrypoint, supervisor, gpuSource, engineSource, readme] = await Promise.all([
   readFile("docker/rust.Dockerfile", "utf8"),
   readFile("docker/runpod-entrypoint.sh", "utf8"),
+  readFile("crates/sceneworks-worker/src/supervisor.rs", "utf8"),
   readFile("crates/sceneworks-worker/src/gpu.rs", "utf8"),
   readFile("crates/sceneworks-worker/src/engines.rs", "utf8"),
   readFile("README.md", "utf8"),
@@ -58,8 +59,29 @@ assert.ok(
   "worker must connect to the API over loopback",
 );
 assert.ok(
+  entrypoint.includes('SCENEWORKS_ACCESS_TOKEN="${SCENEWORKS_ACCESS_TOKEN:-}"'),
+  "entrypoint must explicitly propagate the access token to the worker supervisor",
+);
+assert.ok(
+  entrypoint.includes("unset SCENEWORKS_ALLOW_OPEN_BIND"),
+  "entrypoint must remove the legacy unauthenticated-bind override",
+);
+assert.ok(
+  entrypoint.includes("is_loopback_host") && entrypoint.includes("access_token_trimmed"),
+  "entrypoint must reject a network bind before startup when the token is blank",
+);
+assert.ok(
   entrypoint.includes("shutdown_children"),
   "entrypoint must own coordinated child shutdown",
+);
+assert.ok(
+  supervisor.includes('command.env_remove("SCENEWORKS_ACCESS_TOKEN")') &&
+    supervisor.includes('"SCENEWORKS_ACCESS_TOKEN".to_owned()'),
+  "worker supervisor must explicitly propagate the parsed token to GPU and utility children",
+);
+assert.ok(
+  !dockerfile.includes("SCENEWORKS_ALLOW_OPEN_BIND"),
+  "combined image Dockerfile must never configure the unauthenticated-bind override",
 );
 
 for (const capability of [

--- a/scripts/check-runpod-supervisor.sh
+++ b/scripts/check-runpod-supervisor.sh
@@ -27,6 +27,22 @@ wait_for_event() {
 cat >"${temp_root}/fake-api" <<'EOF'
 #!/usr/bin/env bash
 set -u
+if [[ -v SCENEWORKS_ALLOW_OPEN_BIND ]]; then
+  printf 'api:override:present\n' >>"${SCENEWORKS_TEST_EVENTS}"
+  exit 91
+fi
+if [[ -n "${SCENEWORKS_TEST_EXPECTED_TOKEN:-}" ]]; then
+  if [[ "${SCENEWORKS_ACCESS_TOKEN:-}" != "${SCENEWORKS_TEST_EXPECTED_TOKEN}" ]]; then
+    printf 'api:token:mismatch\n' >>"${SCENEWORKS_TEST_EVENTS}"
+    exit 92
+  fi
+  printf 'api:token:present\n' >>"${SCENEWORKS_TEST_EVENTS}"
+elif [[ -n "${SCENEWORKS_ACCESS_TOKEN:-}" ]]; then
+  printf 'api:token:unexpected\n' >>"${SCENEWORKS_TEST_EVENTS}"
+  exit 93
+else
+  printf 'api:token:absent\n' >>"${SCENEWORKS_TEST_EVENTS}"
+fi
 printf 'api:start\n' >>"${SCENEWORKS_TEST_EVENTS}"
 trap 'printf "api:term\n" >>"${SCENEWORKS_TEST_EVENTS}"; exit 0' TERM INT HUP
 while true; do sleep 0.1; done
@@ -35,6 +51,22 @@ EOF
 cat >"${temp_root}/fake-worker" <<'EOF'
 #!/usr/bin/env bash
 set -u
+if [[ -v SCENEWORKS_ALLOW_OPEN_BIND ]]; then
+  printf 'worker:override:present\n' >>"${SCENEWORKS_TEST_EVENTS}"
+  exit 91
+fi
+if [[ -n "${SCENEWORKS_TEST_EXPECTED_TOKEN:-}" ]]; then
+  if [[ "${SCENEWORKS_ACCESS_TOKEN:-}" != "${SCENEWORKS_TEST_EXPECTED_TOKEN}" ]]; then
+    printf 'worker:token:mismatch\n' >>"${SCENEWORKS_TEST_EVENTS}"
+    exit 92
+  fi
+  printf 'worker:token:present\n' >>"${SCENEWORKS_TEST_EVENTS}"
+elif [[ -n "${SCENEWORKS_ACCESS_TOKEN:-}" ]]; then
+  printf 'worker:token:unexpected\n' >>"${SCENEWORKS_TEST_EVENTS}"
+  exit 93
+else
+  printf 'worker:token:absent\n' >>"${SCENEWORKS_TEST_EVENTS}"
+fi
 printf 'worker:start:%s:%s\n' "${SCENEWORKS_API_URL}" "${SCENEWORKS_GPU_ID}" >>"${SCENEWORKS_TEST_EVENTS}"
 trap 'printf "worker:term\n" >>"${SCENEWORKS_TEST_EVENTS}"; exit 0' TERM INT HUP
 if [[ "${SCENEWORKS_TEST_WORKER_EXIT_CODE:-}" =~ ^[0-9]+$ ]]; then
@@ -57,11 +89,68 @@ printf '%s' "${count}" >"${SCENEWORKS_TEST_CURL_COUNT}"
 EOF
 chmod +x "${temp_root}/fake-api" "${temp_root}/fake-worker" "${temp_root}/fake-curl"
 
+assert_public_bind_rejected() {
+  local label="$1"
+  local host="$2"
+  local token_mode="$3"
+  local override="${4:-}"
+  local run_dir="${temp_root}/${label}"
+  local status
+  mkdir -p "${run_dir}"
+
+  set +e
+  if [[ "${token_mode}" == "unset" ]]; then
+    env -u SCENEWORKS_ACCESS_TOKEN \
+      SCENEWORKS_API_HOST="${host}" \
+      SCENEWORKS_ALLOW_OPEN_BIND="${override}" \
+      SCENEWORKS_TEST_EVENTS="${run_dir}/events" \
+      SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+      SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+      SCENEWORKS_DATA_DIR="${run_dir}/data" \
+      SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+      HF_HOME="${run_dir}/hf" \
+      bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
+  else
+    SCENEWORKS_API_HOST="${host}" \
+    SCENEWORKS_ACCESS_TOKEN="${token_mode}" \
+    SCENEWORKS_ALLOW_OPEN_BIND="${override}" \
+    SCENEWORKS_TEST_EVENTS="${run_dir}/events" \
+    SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+    SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+    SCENEWORKS_DATA_DIR="${run_dir}/data" \
+    SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+    HF_HOME="${run_dir}/hf" \
+    bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
+  fi
+  status=$?
+  set -e
+
+  [[ "${status}" -eq 1 ]] || fail "${label} status was ${status}, expected 1"
+  [[ ! -e "${run_dir}/events" ]] || fail "${label} started a child before auth preflight"
+  [[ ! -d "${run_dir}/data" ]] || fail "${label} created data before auth preflight"
+  grep -Fq "SCENEWORKS_ACCESS_TOKEN is required" "${run_dir}/stderr" ||
+    fail "${label} did not return an actionable token error"
+}
+
+# Fail closed before any child/process/filesystem side effect for every public
+# wildcard spelling supported by the API. A whitespace-only value is missing,
+# and the legacy override cannot bypass the combined-image contract.
+assert_public_bind_rejected "public-v4-missing" "0.0.0.0" "unset"
+assert_public_bind_rejected "public-v4-blank" "0.0.0.0" $' \t '
+assert_public_bind_rejected "public-v4-override" "0.0.0.0" "unset" "1"
+assert_public_bind_rejected "public-v6-bare" "::" "unset"
+assert_public_bind_rejected "public-v6-bracketed" "[::]" "unset"
+
 run_dir="${temp_root}/signal"
 mkdir -p "${run_dir}"
 events="${run_dir}/events"
+test_access_token="runpod-self-test-$PPID-$RANDOM"
 SCENEWORKS_TEST_EVENTS="${events}" \
 SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
+SCENEWORKS_TEST_EXPECTED_TOKEN="${test_access_token}" \
+SCENEWORKS_API_HOST=0.0.0.0 \
+SCENEWORKS_ACCESS_TOKEN="${test_access_token}" \
+SCENEWORKS_ALLOW_OPEN_BIND=1 \
 SCENEWORKS_API_BIN="${temp_root}/fake-api" \
 SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
 SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
@@ -75,11 +164,17 @@ SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
 bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
 supervisor_pid=$!
 wait_for_event "worker:start:http://127.0.0.1:8010:auto" "${events}"
+wait_for_event "api:token:present" "${events}"
+wait_for_event "worker:token:present" "${events}"
 kill -TERM "${supervisor_pid}"
 wait "${supervisor_pid}"
 wait_for_event "api:term" "${events}"
 wait_for_event "worker:term" "${events}"
 [[ "$(cat "${run_dir}/curl-count")" -eq 2 ]] || fail "readiness did not retry exactly once"
+if grep -Fq -- "${test_access_token}" "${run_dir}/stdout" "${run_dir}/stderr"; then
+  fail "access token was written to supervisor output"
+fi
+unset test_access_token
 
 run_dir="${temp_root}/child-failure"
 mkdir -p "${run_dir}"
@@ -88,6 +183,8 @@ set +e
 SCENEWORKS_TEST_EVENTS="${events}" \
 SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
 SCENEWORKS_TEST_WORKER_EXIT_CODE=23 \
+SCENEWORKS_API_HOST=127.0.0.2 \
+SCENEWORKS_ACCESS_TOKEN= \
 SCENEWORKS_API_BIN="${temp_root}/fake-api" \
 SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
 SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
@@ -103,6 +200,8 @@ status=$?
 set -e
 [[ "${status}" -eq 23 ]] || fail "worker failure status was ${status}, expected 23"
 wait_for_event "api:term" "${events}"
+wait_for_event "api:token:absent" "${events}"
+wait_for_event "worker:token:absent" "${events}"
 
 run_dir="${temp_root}/readiness-failure"
 mkdir -p "${run_dir}"
@@ -111,6 +210,8 @@ set +e
 SCENEWORKS_TEST_EVENTS="${events}" \
 SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
 SCENEWORKS_TEST_CURL_ALWAYS_FAIL=1 \
+SCENEWORKS_API_HOST="[::1]" \
+SCENEWORKS_ACCESS_TOKEN= \
 SCENEWORKS_API_BIN="${temp_root}/fake-api" \
 SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
 SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \


### PR DESCRIPTION
## Summary
- fail before side effects when the combined RunPod image uses any non-loopback bind without a nonblank access token
- remove `SCENEWORKS_ALLOW_OPEN_BIND` from child environments so an injected legacy override cannot bypass the image contract
- explicitly propagate the parsed token to every supervised candle GPU and CPU utility child without logging it
- document the secure-by-default RunPod contract and extend deterministic image/supervisor regressions

## Acceptance criteria
- **No token + public bind:** deterministic and live production-image checks cover missing and whitespace-only values on IPv4/IPv6 wildcards; startup exits 1 with actionable text before directories or children exist.
- **Authenticated SPA/API/workers:** live embedded SPA returned 200, `/api/v1/auth/verify` accepted the valid in-memory token, protected calls returned 200, and GPU-shaped plus utility-shaped registration probes both succeeded without auth rejection. Rust tests prove the same parsed token is installed in both real child environment maps.
- **Negative auth:** live protected route returned 401 for missing and invalid tokens, 200 for the valid token.
- **No open-bind override:** Dockerfile contract forbids the variable, entrypoint unsets injected values, and live injected-override/no-token startup still failed closed.
- Tokens were generated only in memory for live validation and never appeared in logs or committed fixtures.

## Validation
- `npm run check`
- `npm run check:compose`
- `npm run check:docker:rust-api:self-test`
- `npm run check:docker:runpod`
- `bash scripts/check-runpod-supervisor.sh`
- `npm run check:nc-weights`
- `npm run check:license-coverage`
- web lint; 2,345 tests; production build
- Python unit: 52 passed; parity: 12 passed
- Rust workspace fmt, clippy `-D warnings`, test, build (API 345 passed/2 ignored; worker 407 passed/4 hardware smokes ignored)
- VS2022/CUDA 12.9 candle worker clippy all-targets + rust-api backend-candle check
- combined `runpod` target image build + deterministic live security/auth/registration matrix
- independent adversarial review: PASS (high confidence), no findings

Local FFmpeg e2e: 4 passed; the host-only timeline-export fixture failed because its existing `resolution: 240` request returns 400 when local ffmpeg is present. CI intentionally does not install ffmpeg and skips that unrelated fixture; no timeline/export code is changed here.

Shortcut: https://app.shortcut.com/trefry/story/10365