### PR TITLE
docs(sc-13637): make worker architecture matrix provably complete

### DIFF
--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -257,7 +257,8 @@ string_enum! {
         // sc-4816) — SceneWorks' first video upscaler. Native-MLX SeedVR2 one-step
         // super-resolution on the macOS Rust worker (zero-Python, epic 3482): decode
         // the source clip -> temporal-chunked 5D upscale -> re-encode + source-audio
-        // passthrough. GPU-required like generation; mac-only (no torch fallback).
+        // passthrough. GPU-required like generation; native MLX on Mac and
+        // candle/CUDA off-Mac (no torch fallback).
         VideoUpscale => "video_upscale",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
@@ -429,8 +430,8 @@ string_enum! {
         // construction. See jobs_store::job_requires_gpu / mac_rust_supported.
         ImageSegment => "image_segment",
         // Standalone VIDEO upscale (Video Studio, epic 4811 / sc-4816). Advertised by
-        // the macOS Rust/MLX worker (native SeedVR2, zero-Python); mac-only, no other
-        // backend. GPU-required. See jobs_store::worker_supports_job.
+        // the macOS Rust/MLX worker and the off-Mac candle/CUDA worker (native
+        // SeedVR2, zero-Python). GPU-required. See jobs_store::worker_supports_job.
         VideoUpscale => "video_upscale",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -755,10 +755,10 @@ pub(crate) fn upscale_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 }
 
 /// Whether a `video_upscale` job is MLX-eligible (epic 4811 / sc-4816). The only Mac engine is the
-/// native-MLX SeedVR2 upscaler (`mlx-gen-seedvr2`); there is no torch fallback (mac-only). A job with
-/// any other engine is refused by the mlx worker — though no other backend advertises `video_upscale`
-/// today, so an unsupported engine simply has nowhere to run (surfaced as unsupported, not silently
-/// dropped). Defaults to `seedvr2` when the payload omits the engine.
+/// native-MLX SeedVR2 upscaler (`mlx-gen-seedvr2`); there is no torch fallback. A job with any other
+/// engine is refused by the mlx worker. The off-Mac candle lane mirrors this predicate for its
+/// SeedVR2 provider, so both native GPU backends enforce the same contract boundary. Defaults to
+/// `seedvr2` when the payload omits the engine.
 pub(crate) fn video_upscale_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     if !matches!(job.job_type, JobType::VideoUpscale) {
         return false;

--- a/crates/sceneworks-worker/ARCHITECTURE.md
+++ b/crates/sceneworks-worker/ARCHITECTURE.md
@@ -18,13 +18,19 @@ new job kind does not get silently unsupported.
 - **Job kinds:** `crates/sceneworks-core/src/contracts.rs` → `enum JobType`
   (canonical; the `string_enum!` macro adds an `Unknown(String)` forward-compat
   variant, so the enum is the complete set of *known* kinds).
-- **Routing oracle:** `crates/sceneworks-core/src/jobs_store.rs` →
-  `mac_rust_supported` enumerates every kind's MLX/candle-eligibility decision.
-  It is a Rust `match` over every `JobType` variant with no wildcard for known
-  kinds, so the compiler guarantees exhaustiveness — **a new `JobType` will not
-  compile until it is added here.** That property is what makes the matrix below
-  provably complete.
+- **Capability gate:** `crates/sceneworks-core/src/jobs_store.rs` →
+  `required_capability` maps a job to the capability a worker must advertise
+  (including the person-preview and control-training exceptions).
+- **Routing oracles:** `crates/sceneworks-core/src/jobs_store/routing/gaps.rs` →
+  `mac_rust_supported` and `candle_supported`, backed by the eligibility
+  predicates in `routing/mlx.rs` and `routing/candle.rs`. Each oracle is a Rust
+  `match` over every known `JobType`, so adding a variant forces an explicit
+  routing decision.
 - **Dispatch site:** `crates/sceneworks-worker/src/lib.rs::run_utility_job`.
+- **Drift guard:** `crates/sceneworks-worker/src/architecture_tests.rs` extracts
+  the canonical `JobType` declarations and fails unless this matrix has exactly
+  one row for every known kind and `run_utility_job` has an explicit dispatch
+  arm for every variant.
 
 ## How a job reaches a worker
 
@@ -65,33 +71,43 @@ it to `0` to disable idle eviction.
 Legend: ✅ handled · ❌ never dispatched (explicit fail-arm) · ⚠️ handled but
 conditional/partial.
 
-| Job kind (`JobType`) | Native worker | Proof (file:line) |
+<!-- job-matrix:start -->
+| Job kind (`JobType`) | Native worker | Durable code anchors |
 |---|---|---|
-| `placeholder` | ✅ utility | rs `lib.rs:623` |
-| `image_generate` | ✅ MLX (Mac) / candle (Win), if eligible | rs `lib.rs:629`, gate `jobs_store.rs:4093` |
-| `image_edit` | ⚠️ MLX/candle-eligible edit models only | rs `lib.rs:637`, oracle `jobs_store.rs:2027` |
-| `image_vqa` | ⚠️ MLX, SenseNova-U1 only | rs `lib.rs:652`, oracle `2040` |
-| `image_interleave` | ⚠️ MLX, SenseNova-U1 only | rs `lib.rs:655`, oracle `2040` |
-| `image_detail` | ⚠️ MLX, SDXL/RealVisXL only | rs `lib.rs:643`, oracle `2029` |
-| `image_upscale` | ⚠️ MLX Real-ESRGAN/SeedVR2; **AuraSR dropped on Mac** | rs `lib.rs:752`, oracle `2099` |
-| `video_generate` | ⚠️ MLX/candle-eligible models | rs `lib.rs:669`, oracle `2047` |
-| `video_extend` | ⚠️ MLX, LTX IC-LoRA + Wan TI2V-5B only | rs `lib.rs:669`, oracle `2053` |
-| `video_bridge` | ⚠️ MLX, LTX IC-LoRA + Wan TI2V-5B only | rs `lib.rs:669`, oracle `2053` |
-| `person_replace` | ⚠️ MLX Wan-VACE/SCAIL-2 only | rs `lib.rs:682`, oracle `2066` |
-| `video_upscale` | ⚠️ **Mac-only**, MLX SeedVR2 | rs `lib.rs:761` (`cfg(macos)`), oracle `2116` |
-| `person_detect` | ✅ MLX/candle + CPU procedural preview | rs `lib.rs:726`, oracle `2079` |
-| `person_track` | ✅ MLX/candle + CPU procedural preview | rs `lib.rs:764`, oracle `2079` |
-| `pose_detect` | ✅ MLX RTMW (Mac) / candle (Win) | rs `lib.rs:734`, oracle `2084` |
-| `kps_extract` | ✅ MLX SCRFD (Mac) / candle (Win) | rs `lib.rs:742`, oracle `2090` |
-| `lora_train` | ⚠️ MLX/candle-native families only | rs `lib.rs:690`, oracle `2131` |
-| `training_caption` | ⚠️ MLX/candle JoyCaption only | rs `lib.rs:696`, oracle `2133` |
-| `prompt_refine` | ✅ MLX/candle TextLlm | rs `lib.rs:705`, oracle `2021` |
-| `model_download` | ✅ utility | rs `lib.rs:708`, oracle `2016` |
-| `model_import` | ✅ utility | rs `lib.rs:714`, oracle `2017` |
-| `model_convert` | ✅ utility | rs `lib.rs:717`, oracle `2129` |
-| `lora_import` | ✅ utility | rs `lib.rs:711`, oracle `2018` |
-| `frame_extract` | ✅ utility (FFmpeg) | rs `lib.rs:720`, oracle `2019` |
-| `timeline_export` | ✅ utility (FFmpeg MP4) | rs `lib.rs:723`, oracle `2020` |
+| `placeholder` | ✅ CPU utility | `run_utility_job` → `run_placeholder_job`; `cpu_gpu` |
+| `image_generate` | ⚠️ MLX / candle, eligible models and modes only | `run_utility_job` → `run_image_generate_job`; `job_is_mlx_eligible`; `image_job_is_candle_eligible` |
+| `image_edit` | ⚠️ MLX / candle, eligible edit models only | `run_utility_job` → `run_image_generate_job`; `job_is_mlx_eligible`; `image_job_is_candle_eligible` |
+| `image_vqa` | ⚠️ MLX / candle, SenseNova-U1 only | `run_utility_job` → `run_vqa_job`; `understanding_job_is_mlx_eligible` |
+| `image_interleave` | ⚠️ MLX / candle, SenseNova-U1 only | `run_utility_job` → `run_interleave_job`; `understanding_job_is_mlx_eligible` |
+| `video_generate` | ⚠️ MLX / candle, eligible models and modes only | `run_utility_job` → `run_video_generate_job`; `video_job_is_mlx_eligible`; `video_job_is_candle_eligible` |
+| `video_extend` | ⚠️ MLX LTX/Wan eligible paths; candle Wan-VACE eligible path | `run_utility_job` → `run_video_generate_job`; `video_job_is_mlx_eligible`; `video_job_is_candle_eligible` |
+| `video_bridge` | ⚠️ MLX LTX/Wan eligible paths; candle Wan-VACE eligible path | `run_utility_job` → `run_video_generate_job`; `video_job_is_mlx_eligible`; `video_job_is_candle_eligible` |
+| `person_detect` | ✅ MLX / candle model-backed; CPU procedural preview | `run_utility_job` → `run_person_detect_job`; `required_capability`; `mlx_gpu`; `with_candle_capabilities` |
+| `person_track` | ✅ MLX / candle model-backed; CPU procedural preview | `run_utility_job` → `run_person_track_job`; `required_capability`; `mlx_gpu`; `with_candle_capabilities` |
+| `person_replace` | ⚠️ MLX / candle, eligible Wan-VACE/SCAIL paths | `run_utility_job` → `run_video_generate_job`; `video_job_is_mlx_eligible`; `video_job_is_candle_eligible` |
+| `audio_generate` | ⚠️ native candle audio registry on Mac / CUDA when linked | `run_utility_job` → `run_audio_generate_job`; `inference_runtime::audio`; `mlx_gpu`; `with_candle_capabilities` |
+| `pose_detect` | ✅ MLX/CoreML on Mac / candle/CUDA off-Mac | `run_utility_job` → `run_pose_detect_job`; `mlx_gpu`; `with_candle_capabilities` |
+| `kps_extract` | ✅ MLX SCRFD on Mac / candle SCRFD off-Mac | `run_utility_job` → `run_kps_extract_job`; `mlx_gpu`; `with_candle_capabilities` |
+| `image_upscale` | ⚠️ MLX / candle Real-ESRGAN or SeedVR2; AuraSR dropped | `run_utility_job` → `run_image_upscale_job`; `upscale_job_is_mlx_eligible`; `upscale_job_is_candle_eligible` |
+| `image_detail` | ⚠️ MLX, SDXL/RealVisXL detail models only | `run_utility_job` → `run_image_detail_job`; `job_is_mlx_eligible`; `mlx_gpu` |
+| `image_segment` | ⚠️ Mac-only MLX SAM3 | `run_utility_job` → `run_image_segment_job`; `mlx_gpu`; `mac_rust_supported` |
+| `video_upscale` | ⚠️ MLX on Mac / candle off-Mac, SeedVR2 only | `run_utility_job` → `run_video_upscale_job`; `video_upscale_job_is_mlx_eligible`; `video_upscale_job_is_candle_eligible` |
+| `frame_extract` | ✅ CPU utility (FFmpeg) | `run_utility_job` → `run_frame_extract_job`; `cpu_gpu` |
+| `timeline_export` | ✅ CPU utility (FFmpeg MP4) | `run_utility_job` → `run_timeline_export_job`; `cpu_gpu` |
+| `model_download` | ✅ CPU utility | `run_utility_job` → `run_model_download_job`; `cpu_gpu` |
+| `model_import` | ✅ CPU utility | `run_utility_job` → `run_model_import_job`; `cpu_gpu` |
+| `model_convert` | ✅ CPU utility | `run_utility_job` → `run_model_convert_job`; `cpu_gpu` |
+| `lora_import` | ✅ CPU utility | `run_utility_job` → `run_lora_import_job`; `cpu_gpu` |
+| `lora_download` | ✅ CPU utility | `run_utility_job` → `run_lora_download_job`; `cpu_gpu` |
+| `lora_train` | ⚠️ MLX / candle, native trainable families only | `run_utility_job` → `run_lora_train_job`; `training_job_is_mlx_eligible`; `training_job_is_candle_eligible` |
+| `control_training` | ⚠️ candle ControlNet trainer only | `run_utility_job` → `run_control_training_job`; `required_capability`; `is_real_training_job`; `training_job_is_candle_eligible` |
+| `training_caption` | ⚠️ MLX / candle JoyCaption only | `run_utility_job` → `run_training_caption_job`; `caption_job_is_mlx_eligible` |
+| `dataset_analysis` | ⚠️ MLX CLIP lane when linked; no candle CLIP lane yet | `run_utility_job` → `run_dataset_analysis_job`; `mlx_gpu`; `mac_rust_supported` |
+| `dataset_upscale` | ✅ MLX/CoreML on Mac / candle/CUDA off-Mac | `run_utility_job` → `run_dataset_upscale_job`; `mlx_gpu`; `with_candle_capabilities` |
+| `dataset_face_analysis` | ✅ MLX face stack on Mac / candle face stack off-Mac | `run_utility_job` → `run_dataset_face_analysis_job`; `mlx_gpu`; `with_candle_capabilities` |
+| `face_likeness_compare` | ✅ MLX face stack on Mac / candle face stack off-Mac | `run_utility_job` → `run_face_likeness_compare_job`; `mlx_gpu`; `with_candle_capabilities` |
+| `prompt_refine` | ⚠️ native TextLlm provider when its registry lane is linked | `run_utility_job` → `run_prompt_refine_job`; `registry_capabilities`; `mac_rust_supported`; `candle_supported` |
+<!-- job-matrix:end -->
 
 **Not job kinds** (routing/readiness capabilities, not dispatchable rows):
 `person_detect_preview`, `person_track_preview` (Rust CPU procedural),
@@ -102,17 +118,18 @@ conditional/partial.
 ## Coverage notes
 
 - **Utility family (CPU, any platform):** `placeholder`, `model_download`,
-  `model_import`, `model_convert`, `lora_import`, `frame_extract`,
-  `timeline_export` — served by the Rust CPU utility worker.
-- **macOS-only:** `video_upscale` — native SeedVR2 has no lane off macOS
-  (`jobs_store.rs:2112`, `lib.rs:758`). Unsupported elsewhere by design.
+  `model_import`, `model_convert`, `lora_import`, `lora_download`,
+  `frame_extract`, `timeline_export` — served by the Rust CPU utility worker.
+- **Platform-specific:** `image_segment` is Mac-only MLX. `video_upscale` is
+  SeedVR2 on both native GPU lanes: MLX on Mac and candle/CUDA off-Mac.
 - **Generation kinds:** each ⚠️ row serves the MLX/candle-eligible subset of its
   model/payload shapes; a shape outside the native lane is refused (no torch
   fallback), so it stays queued rather than silently downgraded.
 
 ## Maintenance
 
-When adding a `JobType` variant, the compiler will force you to update
-`mac_rust_supported` in `jobs_store.rs`. Also update: the dispatch arm in
-`lib.rs::run_utility_job`, the capability mirrors in `contracts.rs`, and **this
-matrix**.
+When adding a `JobType` variant, the routing-oracle matches force an explicit
+backend decision. Also update the dispatch arm in `lib.rs::run_utility_job`, the
+capability mirrors in `contracts.rs`, and this matrix. The
+`architecture_matrix_covers_every_known_job_type_and_dispatch_arm` test guards
+the enum/dispatch/documentation boundary against silent drift.

--- a/crates/sceneworks-worker/src/architecture_tests.rs
+++ b/crates/sceneworks-worker/src/architecture_tests.rs
@@ -1,0 +1,210 @@
+//! Executable drift guards for `ARCHITECTURE.md`.
+//!
+//! The capability matrix is checked against source text rather than a second hand-maintained Rust
+//! list: adding a `JobType` or omitting an explicit worker dispatch must make this test fail until
+//! the documentation and dispatcher are reconciled.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+const CONTRACTS: &str = include_str!("../../sceneworks-core/src/contracts.rs");
+const WORKER: &str = include_str!("lib.rs");
+const ARCHITECTURE: &str = include_str!("../ARCHITECTURE.md");
+
+fn known_job_types() -> BTreeMap<String, String> {
+    let body = CONTRACTS
+        .split_once("pub enum JobType {")
+        .expect("contracts.rs must declare JobType")
+        .1
+        .split_once("\n    }")
+        .expect("JobType declaration must have a closing brace")
+        .0;
+
+    body.lines()
+        .filter_map(|line| {
+            let (variant, wire) = line.split_once("=>")?;
+            let wire = wire.trim().strip_prefix('"')?.split('"').next()?;
+            Some((variant.trim().to_owned(), wire.to_owned()))
+        })
+        .collect()
+}
+
+fn documented_job_types() -> Vec<String> {
+    let matrix = ARCHITECTURE
+        .split_once("<!-- job-matrix:start -->")
+        .expect("architecture must mark the job matrix start")
+        .1
+        .split_once("<!-- job-matrix:end -->")
+        .expect("architecture must mark the job matrix end")
+        .0;
+
+    matrix
+        .lines()
+        .filter_map(|line| {
+            let value = line.strip_prefix("| `")?;
+            Some(value.split('`').next()?.to_owned())
+        })
+        .collect()
+}
+
+/// Remove comments and literal contents before inspecting Rust syntax. This is intentionally small
+/// (the production source remains compiled by rustc), but it understands nested block comments and
+/// escaped quoted strings so a `JobType::Variant` mention outside code cannot satisfy the guard.
+fn code_without_comments_or_literals(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        match (bytes[index], bytes.get(index + 1).copied()) {
+            (b'/', Some(b'/')) => {
+                index += 2;
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            (b'/', Some(b'*')) => {
+                index += 2;
+                let mut depth = 1_u32;
+                while index < bytes.len() && depth > 0 {
+                    match (bytes[index], bytes.get(index + 1).copied()) {
+                        (b'/', Some(b'*')) => {
+                            depth += 1;
+                            index += 2;
+                        }
+                        (b'*', Some(b'/')) => {
+                            depth -= 1;
+                            index += 2;
+                        }
+                        _ => index += 1,
+                    }
+                }
+            }
+            (b'"', _) => {
+                output.push(b'"');
+                index += 1;
+                while index < bytes.len() {
+                    match bytes[index] {
+                        b'\\' => index += 2,
+                        b'"' => {
+                            output.push(b'"');
+                            index += 1;
+                            break;
+                        }
+                        _ => index += 1,
+                    }
+                }
+            }
+            (byte, _) => {
+                output.push(byte);
+                index += 1;
+            }
+        }
+    }
+
+    String::from_utf8(output).expect("Rust source outside comments and literals remains UTF-8")
+}
+
+/// Extract only `JobType` variants occurring in top-level patterns of
+/// `run_utility_job`'s `match job.job_type`. Mentions in comments, strings, helper calls, or arm
+/// bodies are deliberately ignored.
+fn explicit_dispatch_variants(source: &str) -> BTreeSet<String> {
+    let code = code_without_comments_or_literals(source);
+    let function = code
+        .split_once("async fn run_utility_job(")
+        .expect("worker must declare run_utility_job")
+        .1;
+    let match_body = function
+        .split_once("match job.job_type {")
+        .expect("run_utility_job must match job.job_type")
+        .1;
+
+    let bytes = match_body.as_bytes();
+    let mut variants = BTreeSet::new();
+    let mut arm_start = 0;
+    let mut braces = 0_u32;
+    let mut parentheses = 0_u32;
+    let mut brackets = 0_u32;
+    let mut index = 0;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'{' => braces += 1,
+            b'}' if braces == 0 => break,
+            b'}' => braces -= 1,
+            b'(' => parentheses += 1,
+            b')' => parentheses -= 1,
+            b'[' => brackets += 1,
+            b']' => brackets -= 1,
+            b'=' if bytes.get(index + 1) == Some(&b'>')
+                && braces == 0
+                && parentheses == 0
+                && brackets == 0 =>
+            {
+                let pattern = &match_body[arm_start..index];
+                let mut rest = pattern;
+                while let Some((_, after_prefix)) = rest.split_once("JobType::") {
+                    let variant: String = after_prefix
+                        .chars()
+                        .take_while(|character| {
+                            character.is_ascii_alphanumeric() || *character == '_'
+                        })
+                        .collect();
+                    if !variant.is_empty() {
+                        variants.insert(variant);
+                    }
+                    rest = after_prefix;
+                }
+                index += 1;
+            }
+            b',' if braces == 0 && parentheses == 0 && brackets == 0 => arm_start = index + 1,
+            _ => {}
+        }
+        index += 1;
+    }
+
+    variants
+}
+
+#[test]
+fn architecture_matrix_covers_every_known_job_type_and_dispatch_arm() {
+    let known = known_job_types();
+    let rows = documented_job_types();
+    let documented: BTreeSet<_> = rows.iter().cloned().collect();
+    let expected: BTreeSet<_> = known.values().cloned().collect();
+
+    assert_eq!(
+        rows.len(),
+        documented.len(),
+        "ARCHITECTURE.md has duplicate JobType rows"
+    );
+    assert_eq!(
+        documented, expected,
+        "ARCHITECTURE.md must have exactly one row for every known JobType"
+    );
+
+    let dispatched = explicit_dispatch_variants(WORKER);
+    let expected_variants: BTreeSet<_> = known.keys().cloned().collect();
+    assert_eq!(
+        dispatched, expected_variants,
+        "run_utility_job must have an explicit match arm for every known JobType"
+    );
+
+    assert!(
+        !ARCHITECTURE.contains("Proof (file:line)"),
+        "architecture anchors must name durable modules/functions, not line numbers"
+    );
+}
+
+#[test]
+fn dispatch_guard_rejects_removed_arm_even_when_a_comment_keeps_the_variant_name() {
+    let mutated = WORKER.replacen(
+        "JobType::PromptRefine =>",
+        "// JobType::PromptRefine => removed arm\n            _removed_prompt_refine =>",
+        1,
+    );
+    assert_ne!(mutated, WORKER, "mutation target must exist");
+    assert!(
+        !explicit_dispatch_variants(&mutated).contains("PromptRefine"),
+        "a comment containing JobType::PromptRefine must not masquerade as a dispatch arm"
+    );
+}

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -831,7 +831,8 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         // SeedVR2 video upscaling (epic 4811, sc-4816): native-MLX one-step super-resolution
         // (`mlx-gen-seedvr2`), served in-process by `video_jobs::run_video_upscale_job` —
         // SceneWorks' first video upscaler. Decodes the source clip, runs the temporal-chunked
-        // 5D upscale, re-encodes, and passes the source audio through. Mac-only (no torch path).
+        // 5D upscale, re-encodes, and passes the source audio through. The off-Mac
+        // twin is advertised by `with_candle_capabilities` (there is no torch path).
         WorkerCapability::VideoUpscale,
         // Real, model-backed person detection + tracking (epic 3482, sc-3488 /
         // sc-3633/3634/3709): the native-MLX YOLO11 detector + SORT/ByteTrack tracker +

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1596,6 +1596,9 @@ mod test_env;
 #[cfg(test)]
 mod manifest_pins;
 
+#[cfg(test)]
+mod architecture_tests;
+
 // Pinned-snapshot provisioning helpers + the install-layout smokes (sc-13797/sc-13810). Compiled on
 // EVERY platform — the download/layout code is platform-agnostic; only the live-network smoke inside
 // carries `#[cfg(target_os = "macos")]` for lane confinement.


### PR DESCRIPTION
## Summary
- enumerate all 33 canonical job kinds in the worker architecture matrix
- replace stale numeric line references with durable module/function anchors
- correct video_upscale to document both MLX/macOS and Candle/off-Mac SeedVR2 lanes
- correct stale source comments about capability/routing ownership
- add an executable enum/document/dispatch drift guard that parses actual top-level match arms

## Validation
- architecture tests: 2 passed, including a comment-preserving removed-arm mutation
- worker Linux no-default check passed
- formatting and diff checks passed
- independent adversarial re-review: PASS, no findings, confidence 0.99

Shortcut: https://app.shortcut.com/trefry/story/13637