### PR TITLE
fix(web): send the Simple UI's Text-mode reference image

### DIFF
--- a/apps/web/src/simple/SimpleAudioStudio.jsx
+++ b/apps/web/src/simple/SimpleAudioStudio.jsx
@@ -9,9 +9,8 @@ import { useSimpleUi } from "./SimpleUiContext.js";
 import {
   Chips,
   DownloadButton,
-  JobFailureNotice,
   SheetSelect,
-  jobFailure,
+  StudioRunStatus,
   jobIsRunning,
   newestLocalJob,
 } from "./studioParts.jsx";
@@ -210,17 +209,13 @@ export function SimpleAudioStudio() {
         {busy ? "Generating…" : "Generate audio"}
       </button>
 
-      {jobFailure(latestJob) && !resultAssets.length ? (
-        <JobFailureNotice failure={jobFailure(latestJob)} />
-      ) : resultAssets.length ? (
+      {/* Live run strip: progress + Cancel + the outcome, right under Generate. */}
+      <StudioRunStatus job={latestJob} />
+
+      {resultAssets.length ? (
         <div className="su-audio-result">
           <AssetMedia asset={resultAssets[0]} />
           <DownloadButton asset={resultAssets[0]} className="su-icon-btn" />
-        </div>
-      ) : busy ? (
-        <div className="su-audio-result">
-          <span aria-hidden="true" className="su-spinner" />
-          <span className="su-card-note">Rendering audio…</span>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/simple/SimpleAudioStudio.jsx
+++ b/apps/web/src/simple/SimpleAudioStudio.jsx
@@ -6,7 +6,15 @@ import { audioModelServesMode } from "../modelEligibility.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 import { buildSimpleAudioRequest } from "./simpleJobs.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
-import { Chips, DownloadButton, SheetSelect, jobIsRunning, newestLocalJob } from "./studioParts.jsx";
+import {
+  Chips,
+  DownloadButton,
+  JobFailureNotice,
+  SheetSelect,
+  jobFailure,
+  jobIsRunning,
+  newestLocalJob,
+} from "./studioParts.jsx";
 
 // Simple Audio Studio (design handoff). The design flags this studio as a PREVIEW —
 // "the models and controls will change as it lands" — and asks for the warning banner
@@ -202,7 +210,9 @@ export function SimpleAudioStudio() {
         {busy ? "Generating…" : "Generate audio"}
       </button>
 
-      {resultAssets.length ? (
+      {jobFailure(latestJob) && !resultAssets.length ? (
+        <JobFailureNotice failure={jobFailure(latestJob)} />
+      ) : resultAssets.length ? (
         <div className="su-audio-result">
           <AssetMedia asset={resultAssets[0]} />
           <DownloadButton asset={resultAssets[0]} className="su-icon-btn" />

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -16,6 +16,7 @@ import {
   ReferenceTile,
   SheetSelect,
   StudioResults,
+  StudioRunStatus,
   StyleStrip,
   jobIsRunning,
   newestLocalJob,
@@ -360,6 +361,9 @@ export function SimpleImageStudio() {
           </span>
         </div>
       ) : null}
+
+      {/* Live run strip: progress + Cancel + the outcome, right under Generate. */}
+      <StudioRunStatus job={latestJob} />
 
       <StudioResults
         assets={assets}

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { imageModelServesMode } from "../modelEligibility.js";
+import { findModelEditLora, loraIsInstalled } from "../presetUtils.js";
 import { fitsResolutionOptions } from "../resolutionMemory.js";
 import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
 import { resultGridColumns } from "./breakpoint.js";
@@ -39,6 +40,8 @@ export function SimpleImageStudio() {
     assets = [],
     recentImageAssets = [],
     visibleWorkers = [],
+    loras = [],
+    createLoraDownloadJob,
     activeProject,
   } = useAppContext();
   const { breakpoint, openGuide, toast, referenceRequest, clearReferenceRequest } = useSimpleUi();
@@ -116,11 +119,36 @@ export function SimpleImageStudio() {
   const supportsImg2img = Boolean(selectedModel?.ui?.img2img);
   const referenceUsable = mode === "edit_image" || supportsImg2img;
 
+  // Krea-style managed image-edit LoRA (epic 10871, sc-11069): Krea 2's edit lane requires an
+  // `image_edit`-role LoRA and fails the job without one. Like the advanced studio we MANAGE it
+  // rather than exposing a picker — auto-applied when installed, surfaced as a one-click download
+  // when not. Null for edit models that need none (Qwen-Image-Edit, FLUX.2), so this is inert
+  // for them.
+  const editLora = useMemo(
+    () => (mode === "edit_image" ? findModelEditLora(loras, selectedModel) : null),
+    [mode, loras, selectedModel],
+  );
+  const editLoraInstalled = loraIsInstalled(editLora);
+  const editLoraMissing = Boolean(editLora) && !editLoraInstalled;
+  const [editLoraRequested, setEditLoraRequested] = useState(false);
+  useEffect(() => {
+    if (!editLoraMissing) {
+      setEditLoraRequested(false);
+    }
+  }, [editLoraMissing]);
+
   const latestJob = newestLocalJob(imageLocalJobs);
   const busy = submitting || jobIsRunning(latestJob);
   const needsSource = mode === "edit_image" && !referenceAssetId;
   const canGenerate =
-    Boolean(prompt.trim()) && Boolean(model) && Boolean(resolution) && !busy && !needsSource;
+    Boolean(prompt.trim()) &&
+    Boolean(model) &&
+    Boolean(resolution) &&
+    !busy &&
+    !needsSource &&
+    // A required edit LoRA that isn't downloaded blocks the run HERE rather than letting the
+    // worker reject it — the job would fail with an error the studio never surfaces.
+    !editLoraMissing;
 
   async function generate() {
     if (!canGenerate) {
@@ -149,6 +177,8 @@ export function SimpleImageStudio() {
         referenceAssetId,
         supportsImg2img,
         img2imgStrength: referenceStrengthFor(selectedModel),
+        // Auto-applied in edit mode; the worker's edit lane rejects the run without it.
+        editLora: editLoraInstalled ? editLora : null,
         ...tier,
       });
       if (!request) {
@@ -303,6 +333,32 @@ export function SimpleImageStudio() {
       </button>
       {needsSource ? (
         <p className="su-empty">Pick the image you want to edit to start a run.</p>
+      ) : null}
+      {/* The managed edit LoRA isn't downloaded yet. The worker would reject the run outright
+          ("the source-image conditioning is inert"), so offer the one-click fetch instead of
+          letting the user discover it as a failed job. */}
+      {editLoraMissing ? (
+        <div className="su-notice" role="status">
+          <Icon.Warning size={16} />
+          <span>
+            {selectedModel?.name ?? "This model"} needs the {editLora.name ?? "image-edit"} LoRA to
+            edit.{" "}
+            {editLoraRequested ? (
+              "Downloading — track it in the Queue, then generate again."
+            ) : (
+              <button
+                className="su-link"
+                onClick={() => {
+                  setEditLoraRequested(true);
+                  createLoraDownloadJob?.(editLora);
+                }}
+                type="button"
+              >
+                Download it
+              </button>
+            )}
+          </span>
+        </div>
       ) : null}
 
       <StudioResults

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -7,6 +7,7 @@ import { fitsResolutionOptions } from "../resolutionMemory.js";
 import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
 import { resultGridColumns } from "./breakpoint.js";
 import { describeResolution, resolutionSummary } from "./aspect.js";
+import { preferredResolution } from "./modelDefaults.js";
 import { buildSimpleImageRequest, referenceStrengthFor, resolveSimpleTier } from "./simpleJobs.js";
 import { useSimpleRefine } from "./useSimpleRefine.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
@@ -89,11 +90,22 @@ export function SimpleImageStudio() {
     return gated.length ? gated : declared;
   }, [selectedModel, macCapabilities, unifiedMemoryGb]);
 
+  // Seed from the model's DECLARED default, not `limits.resolutions[0]` — for 16 shipped
+  // image models those differ (z_image declares 1024², its list leads with 768²), so [0]
+  // would silently start a Simple run at a lower resolution than the same model in the full
+  // workspace.
   useEffect(() => {
-    if (resolutions.length && !resolutions.includes(resolution)) {
-      setResolution(resolutions[0]);
+    // Guard on a RESOLVED model (mirrors ImageStudio's sc-11962 guard). Before the catalog
+    // lands, `resolutions` is the generic fallback list — seeding from it seeds 1024², and
+    // because almost every model also allows 1024² the value then STICKS and the model's own
+    // declared default is never applied. The guard is what makes the seed above actually bite.
+    if (!selectedModel) {
+      return;
     }
-  }, [resolutions, resolution]);
+    if (resolutions.length && !resolutions.includes(resolution)) {
+      setResolution(preferredResolution(selectedModel, resolutions));
+    }
+  }, [resolutions, resolution, selectedModel]);
 
   // Resolved against the FULL catalog, not just the picker's recent-20 list: a reference
   // routed in from the Assets preview ("Use as reference") can be any library asset.

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -6,7 +6,7 @@ import { fitsResolutionOptions } from "../resolutionMemory.js";
 import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
 import { resultGridColumns } from "./breakpoint.js";
 import { describeResolution, resolutionSummary } from "./aspect.js";
-import { buildSimpleImageRequest, resolveSimpleTier } from "./simpleJobs.js";
+import { buildSimpleImageRequest, referenceStrengthFor, resolveSimpleTier } from "./simpleJobs.js";
 import { useSimpleRefine } from "./useSimpleRefine.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
 import {
@@ -109,6 +109,13 @@ export function SimpleImageStudio() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [referenceRequest?.token]);
 
+  // Reference-guided generation on the TEXT tab is a per-model capability (`ui.img2img`):
+  // Z-Image, Krea 2, SD3.5, SANA, Ideogram 4 and Boogu declare it, most models don't. On a
+  // model without it the tile stays visible (the design's 2-up tile grid) but disabled and
+  // says why, rather than accepting a reference the payload would then drop.
+  const supportsImg2img = Boolean(selectedModel?.ui?.img2img);
+  const referenceUsable = mode === "edit_image" || supportsImg2img;
+
   const latestJob = newestLocalJob(imageLocalJobs);
   const busy = submitting || jobIsRunning(latestJob);
   const needsSource = mode === "edit_image" && !referenceAssetId;
@@ -137,7 +144,11 @@ export function SimpleImageStudio() {
         resolution,
         count: variations,
         styleId,
-        sourceAssetId: mode === "edit_image" ? referenceAssetId : null,
+        // One armed reference; simpleJobs routes it by mode (edit source vs img2img
+        // reference + advanced.strength) and drops it when the model can't use it.
+        referenceAssetId,
+        supportsImg2img,
+        img2imgStrength: referenceStrengthFor(selectedModel),
         ...tier,
       });
       if (!request) {
@@ -223,7 +234,14 @@ export function SimpleImageStudio() {
         <ReferenceTile
           asset={referenceAsset}
           assets={recentImageAssets}
-          hint={mode === "edit_image" ? "Required — tap to pick the image to edit" : "Tap to attach an image"}
+          disabled={!referenceUsable}
+          hint={
+            !referenceUsable
+              ? `${selectedModel?.name ?? "This model"} can’t use a reference image — switch model to use one.`
+              : mode === "edit_image"
+                ? "Required — tap to pick the image to edit"
+                : "Tap to attach an image"
+          }
           label={mode === "edit_image" ? "Source image" : "Reference"}
           onChange={setReferenceAssetId}
           required={mode === "edit_image"}

--- a/apps/web/src/simple/SimpleJobCard.jsx
+++ b/apps/web/src/simple/SimpleJobCard.jsx
@@ -90,9 +90,12 @@ function formatType(type) {
 /**
  * @param {object} props
  * @param {object} props.job
- * @param {(job: object) => any} [props.onCancel] - omitted ⇒ no Cancel button.
+ * @param {(job: object) => any} [props.onCancel] - omitted ⇒ no Cancel button. Only ever
+ *   offered while the job is non-terminal.
+ * @param {(job: object) => any} [props.onDismiss] - omitted ⇒ no Dismiss button. Only ever
+ *   offered once the job IS terminal, so the two actions never both appear.
  */
-export function SimpleJobCard({ job, onCancel }) {
+export function SimpleJobCard({ job, onCancel, onDismiss }) {
   // Local, so the button reports immediately: the job's status only flips once the
   // server responds and the SSE tick lands, which is long enough to look unresponsive.
   const [canceling, setCanceling] = useState(false);
@@ -135,6 +138,17 @@ export function SimpleJobCard({ job, onCancel }) {
           >
             <Icon.Close size={14} />
             {canceling ? "Canceling…" : "Cancel"}
+          </button>
+        ) : null}
+        {!cancelable && onDismiss ? (
+          <button
+            className="su-job-cancel"
+            onClick={() => onDismiss(job)}
+            title="Dismiss this message"
+            type="button"
+          >
+            <Icon.Close size={14} />
+            Dismiss
           </button>
         ) : null}
       </div>

--- a/apps/web/src/simple/SimpleJobCard.jsx
+++ b/apps/web/src/simple/SimpleJobCard.jsx
@@ -1,0 +1,144 @@
+import React, { useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { errorStatuses, pendingStatuses, terminalStatuses } from "../jobTypes.js";
+import { percent } from "../formatting.js";
+
+// The Simple UI's one job card. Rendered in TWO places from this single definition:
+//   - the Queue screen, as the list rows
+//   - each studio, directly under Generate, for that studio's newest run
+// so a run's progress and its Cancel are in front of the user where they started it,
+// not only on a screen they'd have to navigate to.
+//
+// Before this, Simple had no way to cancel a run at all and no progress readout
+// anywhere — a submitted job was a spinner with no end and no exit.
+
+// The three error statuses share one bucket (colour + placement) but NOT one label —
+// a job the user canceled must not read as "Failed".
+const STATUS_LABEL = {
+  canceled: "Canceled",
+  interrupted: "Interrupted",
+};
+
+const BUCKET_LABEL = {
+  running: "Running",
+  queued: "Queued",
+  done: "Done",
+  failed: "Failed",
+};
+
+/**
+ * Which of the four visual buckets a job belongs to.
+ * @param {object} job
+ * @returns {"running"|"queued"|"done"|"failed"}
+ */
+export function bucketFor(job) {
+  if (terminalStatuses.has(job.status)) {
+    return errorStatuses.has(job.status) ? "failed" : "done";
+  }
+  return pendingStatuses.has(job.status) ? "queued" : "running";
+}
+
+export function badgeLabelFor(bucket, status) {
+  return STATUS_LABEL[status] ?? BUCKET_LABEL[bucket];
+}
+
+/** A job can be canceled while it has not reached a terminal state. */
+export function jobIsCancelable(job) {
+  return Boolean(job) && !terminalStatuses.has(job.status);
+}
+
+// The job's headline: the model it runs, falling back to the job type — what the
+// advanced Queue card leads with, minus the worker/GPU detail.
+export function jobTitle(job) {
+  const model = job.payload?.modelName ?? job.payload?.model ?? job.payload?.modelId;
+  return model ? String(model) : formatType(job.type);
+}
+
+export function jobSub(job) {
+  const parts = [formatType(job.type)];
+  const { width, height, count } = job.payload ?? {};
+  if (width && height) {
+    parts.push(`${width}×${height}`);
+  }
+  if (Number.isFinite(count) && count > 1) {
+    parts.push(`${count} variations`);
+  }
+  const duration = job.payload?.duration ?? job.payload?.targetDurationSecs;
+  if (Number.isFinite(duration)) {
+    parts.push(`${duration}s`);
+  }
+  return parts.join(" · ");
+}
+
+function formatType(type) {
+  return String(type ?? "job").replaceAll("_", " ");
+}
+
+/**
+ * @param {object} props
+ * @param {object} props.job
+ * @param {(job: object) => any} [props.onCancel] - omitted ⇒ no Cancel button.
+ */
+export function SimpleJobCard({ job, onCancel }) {
+  // Local, so the button reports immediately: the job's status only flips once the
+  // server responds and the SSE tick lands, which is long enough to look unresponsive.
+  const [canceling, setCanceling] = useState(false);
+  const bucket = bucketFor(job);
+  const progress = Number(job.progress);
+  const hasProgress = Number.isFinite(progress) && progress > 0;
+  const cancelable = jobIsCancelable(job);
+  const error = errorStatuses.has(job.status) ? String(job.error ?? job.message ?? "").trim() : "";
+  // A running job with no progress reading yet gets an indeterminate bar rather than a
+  // 0% one, so "working" is distinguishable from "stuck at zero" (mirrors the advanced
+  // WorkerProgressCard).
+  const indeterminate = bucket === "running" && !hasProgress;
+  const showBar = bucket !== "queued" && !error;
+
+  return (
+    <div className="su-job">
+      <div className="su-job-head">
+        <span aria-hidden="true" className={`su-dot su-dot--${bucket}`} />
+        <span className="su-job-text">
+          <span className="su-job-title">{jobTitle(job)}</span>
+          <span className="su-job-sub">{jobSub(job)}</span>
+        </span>
+        <span className={`su-job-badge su-job-badge--${bucket}`}>
+          {bucket === "running" && hasProgress ? percent(progress) : badgeLabelFor(bucket, job.status)}
+        </span>
+        {cancelable && onCancel ? (
+          <button
+            className="su-job-cancel"
+            disabled={canceling}
+            onClick={async () => {
+              setCanceling(true);
+              try {
+                await onCancel(job);
+              } finally {
+                setCanceling(false);
+              }
+            }}
+            title="Cancel this run"
+            type="button"
+          >
+            <Icon.Close size={14} />
+            {canceling ? "Canceling…" : "Cancel"}
+          </button>
+        ) : null}
+      </div>
+      {error ? <p className="su-job-error">{error}</p> : null}
+      {showBar ? (
+        <div
+          className={[
+            "su-bar",
+            bucket === "done" ? "su-bar--done" : "",
+            indeterminate ? "su-bar--indeterminate" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          <span style={indeterminate ? undefined : { width: bucket === "done" ? "100%" : percent(progress) }} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/simple/SimpleJobCard.jsx
+++ b/apps/web/src/simple/SimpleJobCard.jsx
@@ -47,6 +47,19 @@ export function jobIsCancelable(job) {
   return Boolean(job) && !terminalStatuses.has(job.status);
 }
 
+// Whether a studio should stop showing this run's card. The QUEUE always keeps every row —
+// that is its job — but a studio is a workspace, not a history, so a finished run should not
+// sit between the Generate button and the results.
+//
+// Two outcomes clear themselves and two do not:
+//   completed → the results grid below IS the outcome; a "Done" row is redundant chrome.
+//   canceled  → the user did it deliberately, so they already know.
+//   failed / interrupted → the card is the ONLY place the worker's reason is shown in a
+//     studio. Dismissing it would put us back to a run that silently produced nothing.
+export function jobClearsFromStudio(job) {
+  return job?.status === "completed" || job?.status === "canceled";
+}
+
 // The job's headline: the model it runs, falling back to the job type — what the
 // advanced Queue card leads with, minus the worker/GPU detail.
 export function jobTitle(job) {

--- a/apps/web/src/simple/SimpleQueue.jsx
+++ b/apps/web/src/simple/SimpleQueue.jsx
@@ -1,69 +1,36 @@
 import React, { useMemo } from "react";
 import { useAppContext } from "../context/AppContext.js";
-import { errorStatuses, terminalStatuses } from "../jobTypes.js";
-import { percent } from "../formatting.js";
+import { SimpleJobCard, bucketFor } from "./SimpleJobCard.jsx";
+import { useSimpleUi } from "./SimpleUiContext.js";
 
 // Simple Queue (design handoff): three stat tiles (Running / Queued / Done) over a list
-// of job rows — status dot, title, sub-line, status badge, and a progress bar.
+// of job rows. The rows are the shared SimpleJobCard, the same component the studios
+// render under their Generate button — so progress, the failure reason and Cancel behave
+// identically wherever a run is shown.
 //
 // Same live `jobs` feed the advanced Queue reads (SSE-updated through useJobEvents), so
 // the two views never disagree; what Simple drops is the per-worker resource panel and
-// the retry/cancel/clear controls, which stay in the full workspace.
-
-// Statuses the design's three buckets map onto. "Running" is anything a worker has
-// claimed and not finished; "Queued" is the pending band; "Done" is terminal-and-clean.
-export function bucketFor(job) {
-  if (terminalStatuses.has(job.status)) {
-    return errorStatuses.has(job.status) ? "failed" : "done";
-  }
-  return job.status === "queued" || job.status === "pending_caption" ? "queued" : "running";
-}
-
-const BADGE_LABEL = {
-  running: "Running",
-  queued: "Queued",
-  done: "Done",
-  failed: "Failed",
-};
-
-// The three error statuses share one bucket (colour + placement) but NOT one label — a job the
-// user canceled must not read as "Failed".
-const STATUS_LABEL = {
-  canceled: "Canceled",
-  interrupted: "Interrupted",
-};
-
-export function badgeLabelFor(bucket, status) {
-  return STATUS_LABEL[status] ?? BADGE_LABEL[bucket];
-}
+// the retry/clear controls, which stay in the full workspace.
 
 export function SimpleQueue() {
-  const { jobs = [] } = useAppContext();
+  const { jobs = [], jobAction } = useAppContext();
+  const { toast } = useSimpleUi();
 
-  const rows = useMemo(
-    () =>
-      jobs.map((job) => ({
-        id: job.id,
-        bucket: bucketFor(job),
-        title: jobTitle(job),
-        sub: jobSub(job),
-        progress: Number(job.progress),
-        status: job.status,
-        // The worker's reason, shown on the row. Without it a failed run read as a bare
-        // "Failed" badge and the actual message — often actionable — was only in the Logs.
-        error: errorStatuses.has(job.status) ? String(job.error ?? job.message ?? "").trim() : "",
-      })),
-    [jobs],
-  );
+  const counts = useMemo(() => {
+    const tally = { running: 0, queued: 0, done: 0 };
+    for (const job of jobs) {
+      const bucket = bucketFor(job);
+      if (bucket in tally) {
+        tally[bucket] += 1;
+      }
+    }
+    return tally;
+  }, [jobs]);
 
-  const counts = useMemo(
-    () => ({
-      running: rows.filter((row) => row.bucket === "running").length,
-      queued: rows.filter((row) => row.bucket === "queued").length,
-      done: rows.filter((row) => row.bucket === "done").length,
-    }),
-    [rows],
-  );
+  async function cancel(job) {
+    await jobAction?.(job, "cancel");
+    toast("Run canceled");
+  }
 
   return (
     <div className="su-screen su-screen--tight">
@@ -82,65 +49,11 @@ export function SimpleQueue() {
         </div>
       </div>
 
-      {rows.length ? (
-        rows.map((row) => {
-          const showBar = row.bucket !== "queued";
-          const width = row.bucket === "done" ? "100%" : Number.isFinite(row.progress) ? percent(row.progress) : "0%";
-          return (
-            <div className="su-job" key={row.id}>
-              <div className="su-job-head">
-                <span aria-hidden="true" className={`su-dot su-dot--${row.bucket}`} />
-                <span className="su-job-text">
-                  <span className="su-job-title">{row.title}</span>
-                  <span className="su-job-sub">{row.sub}</span>
-                </span>
-                <span className={`su-job-badge su-job-badge--${row.bucket}`}>
-                  {row.bucket === "running" && Number.isFinite(row.progress) && row.progress > 0
-                    ? percent(row.progress)
-                    : badgeLabelFor(row.bucket, row.status)}
-                </span>
-              </div>
-              {row.error ? <p className="su-job-error">{row.error}</p> : null}
-              {showBar && !row.error ? (
-                <div className={row.bucket === "done" ? "su-bar su-bar--done" : "su-bar"}>
-                  <span style={{ width }} />
-                </div>
-              ) : null}
-            </div>
-          );
-        })
+      {jobs.length ? (
+        jobs.map((job) => <SimpleJobCard job={job} key={job.id} onCancel={cancel} />)
       ) : (
         <p className="su-empty">Nothing in the queue. Runs you start in a studio show up here.</p>
       )}
     </div>
   );
-}
-
-// The job's headline: the model it runs, falling back to the job type. Mirrors what the
-// advanced Queue card leads with, minus the worker/GPU detail.
-function jobTitle(job) {
-  const model = job.payload?.modelName ?? job.payload?.model ?? job.payload?.modelId;
-  return model ? String(model) : formatType(job.type);
-}
-
-function jobSub(job) {
-  const parts = [formatType(job.type)];
-  const width = job.payload?.width;
-  const height = job.payload?.height;
-  if (width && height) {
-    parts.push(`${width}×${height}`);
-  }
-  const count = job.payload?.count;
-  if (Number.isFinite(count) && count > 1) {
-    parts.push(`${count} variations`);
-  }
-  const duration = job.payload?.duration ?? job.payload?.targetDurationSecs;
-  if (Number.isFinite(duration)) {
-    parts.push(`${duration}s`);
-  }
-  return parts.join(" · ");
-}
-
-function formatType(type) {
-  return String(type ?? "job").replaceAll("_", " ");
 }

--- a/apps/web/src/simple/SimpleQueue.jsx
+++ b/apps/web/src/simple/SimpleQueue.jsx
@@ -26,6 +26,17 @@ const BADGE_LABEL = {
   failed: "Failed",
 };
 
+// The three error statuses share one bucket (colour + placement) but NOT one label — a job the
+// user canceled must not read as "Failed".
+const STATUS_LABEL = {
+  canceled: "Canceled",
+  interrupted: "Interrupted",
+};
+
+export function badgeLabelFor(bucket, status) {
+  return STATUS_LABEL[status] ?? BADGE_LABEL[bucket];
+}
+
 export function SimpleQueue() {
   const { jobs = [] } = useAppContext();
 
@@ -38,6 +49,9 @@ export function SimpleQueue() {
         sub: jobSub(job),
         progress: Number(job.progress),
         status: job.status,
+        // The worker's reason, shown on the row. Without it a failed run read as a bare
+        // "Failed" badge and the actual message — often actionable — was only in the Logs.
+        error: errorStatuses.has(job.status) ? String(job.error ?? job.message ?? "").trim() : "",
       })),
     [jobs],
   );
@@ -83,10 +97,11 @@ export function SimpleQueue() {
                 <span className={`su-job-badge su-job-badge--${row.bucket}`}>
                   {row.bucket === "running" && Number.isFinite(row.progress) && row.progress > 0
                     ? percent(row.progress)
-                    : BADGE_LABEL[row.bucket]}
+                    : badgeLabelFor(row.bucket, row.status)}
                 </span>
               </div>
-              {showBar ? (
+              {row.error ? <p className="su-job-error">{row.error}</p> : null}
+              {showBar && !row.error ? (
                 <div className={row.bucket === "done" ? "su-bar su-bar--done" : "su-bar"}>
                   <span style={{ width }} />
                 </div>

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -88,6 +88,14 @@ export function SimpleShell({
   // The reference an asset preview hands to the Image Studio. Held here (not in the
   // studio) so "Use as reference" works from Assets, which is a different screen.
   const [referenceRequest, setReferenceRequest] = useState(null);
+  // Failed runs the user has dismissed from a studio. Held HERE rather than in the studio
+  // because the studios unmount on navigation — studio-local state would resurrect a
+  // dismissed failure the moment the user came back to the tab. Session-scoped by design:
+  // the Queue keeps the row permanently, so nothing is actually lost.
+  const [dismissedJobIds, setDismissedJobIds] = useState(() => new Set());
+  const dismissJob = useCallback((id) => {
+    setDismissedJobIds((current) => new Set(current).add(id));
+  }, []);
   const toastTimer = useRef(null);
 
   useEffect(() => () => clearTimeout(toastTimer.current), []);
@@ -137,8 +145,10 @@ export function SimpleShell({
       toast,
       referenceRequest,
       clearReferenceRequest: () => setReferenceRequest(null),
+      dismissedJobIds,
+      dismissJob,
     }),
-    [breakpoint, goTo, toast, referenceRequest, openInAdvanced, lockedToSimple],
+    [breakpoint, goTo, toast, referenceRequest, openInAdvanced, lockedToSimple, dismissedJobIds, dismissJob],
   );
 
   const active = SCREEN_BY_ID.get(screen) ?? SCREEN_BY_ID.get("image");

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -498,6 +498,38 @@ describe("SimpleShell", () => {
     expect(container.querySelector(".su-job-badge").textContent).toBe("Running");
   });
 
+  // The audit's headline finding, pinned end-to-end: the studio must SEED from the model's
+  // declared default, not the first allowed value. z_image declares 1024² while its limits
+  // list leads with 768², so the wrong seed silently downgraded every Simple run of it.
+  it("seeds the resolution from the model's declared default, not limits[0]", async () => {
+    // Rendered as the FIRST model this shell ever sees. A prior render would leave a
+    // still-valid resolution in state, which correctly sticks (switching model keeps a
+    // selection the new model also allows — same as the advanced studio) and would mask
+    // what the seed actually chose. That stickiness is exactly why a click-through in the
+    // browser missed this bug.
+    // Declared default, first-allowed, and the 1024² fallback are three DISTINCT values here,
+    // so this can only pass by actually reading `defaults.resolution`. (A model declaring
+    // 1024² — which every mismatching shipped model happens to do — would pass even with the
+    // bug, because the fallback lands on the same answer.)
+    const leadsLow = {
+      ...IMAGE_MODEL,
+      defaults: { resolution: "1344x768" },
+      limits: { resolutions: ["768x768", "1024x1024", "1344x768"] },
+    };
+    const lowContext = baseContext({ imageModels: [leadsLow], models: [leadsLow] });
+    await renderShell(root, lowContext);
+
+    expect(
+      [...container.querySelectorAll(".su-select")].some((n) => n.textContent.includes("1344×768")),
+    ).toBe(true);
+
+    await typePrompt(container, "a lighthouse");
+    await click(container.querySelector(".su-generate"));
+    const payload = lowContext.createImageJob.mock.calls[0][0];
+    expect(payload.width).toBe(1344);
+    expect(payload.height).toBe(768);
+  });
+
   it("refuses to submit with an empty prompt", async () => {
     const context = baseContext();
     await renderShell(root, context);

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -414,10 +414,45 @@ describe("SimpleShell", () => {
   });
 
   it("offers no Cancel once a run is terminal", async () => {
-    const done = { ...RUNNING_JOB, status: "completed", progress: 1 };
-    await renderShell(root, baseContext({ jobs: [done], imageLocalJobs: [done] }));
+    const failed = { ...RUNNING_JOB, status: "failed", error: "out of memory" };
+    await renderShell(root, baseContext({ jobs: [failed], imageLocalJobs: [failed] }));
+    expect(container.querySelector(".su-job")).toBeTruthy();
     expect(buttonWithText(container, "Cancel")).toBeUndefined();
   });
+
+  // The four terminal states are NOT interchangeable in a studio, which is exactly the
+  // assumption worth pinning per-status rather than as one "terminal" case.
+  //   completed → the results grid below IS the outcome
+  //   canceled  → the user did it deliberately
+  //   failed / interrupted → the card is the studio's ONLY carrier of the worker's reason
+  const STUDIO_CARD_BY_STATUS = [
+    ["completed", false],
+    ["canceled", false],
+    ["failed", true],
+    ["interrupted", true],
+  ];
+
+  for (const [status, stays] of STUDIO_CARD_BY_STATUS) {
+    it(`${stays ? "keeps" : "clears"} the studio run card for a ${status} run`, async () => {
+      const job = { ...RUNNING_JOB, status, progress: 1, error: "out of memory" };
+      await renderShell(root, baseContext({ jobs: [job], imageLocalJobs: [job] }));
+      expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Image Studio");
+      if (stays) {
+        expect(container.querySelector(".su-job")).toBeTruthy();
+        expect(container.querySelector(".su-job-error").textContent).toBe("out of memory");
+      } else {
+        expect(container.querySelector(".su-job")).toBeNull();
+      }
+    });
+
+    it(`always keeps the Queue row for a ${status} run`, async () => {
+      const job = { ...RUNNING_JOB, status, progress: 1, error: "out of memory" };
+      await renderShell(root, baseContext({ jobs: [job] }));
+      await click(navButton(container, "Queue"));
+      // The Queue is a history — it keeps every row regardless of outcome.
+      expect(container.querySelector(".su-job")).toBeTruthy();
+    });
+  }
 
   it("sweeps an indeterminate bar for a claimed run with no percentage yet", async () => {
     const noProgress = { ...RUNNING_JOB, progress: 0 };

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -53,6 +53,7 @@ function baseContext(overrides = {}) {
     createAudioJob: vi.fn(async () => null),
     createModelDownloadJob: vi.fn(async () => null),
     createLoraDownloadJob: vi.fn(async () => null),
+    jobAction: vi.fn(async () => {}),
     rememberLocalGenerationJob: vi.fn(),
     refinePrompt: vi.fn(),
     deleteAsset: vi.fn(),
@@ -84,6 +85,14 @@ function renderShell(root, context, props = {}) {
 function buttonWithText(container, text) {
   return [...container.querySelectorAll("button")].find(
     (node) => node.textContent.trim() === text,
+  );
+}
+
+// Nav items carry a count badge ("Queue1" when one job is pending), so they can't be
+// matched by exact text.
+function navButton(container, label) {
+  return [...container.querySelectorAll(".su-nav-item")].find((node) =>
+    node.textContent.startsWith(label),
   );
 }
 
@@ -127,9 +136,9 @@ describe("SimpleShell", () => {
 
   it("navigates between screens from the sidebar", async () => {
     await renderShell(root, baseContext());
-    await click(buttonWithText(container, "Queue"));
+    await click(navButton(container, "Queue"));
     expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Queue");
-    await click(buttonWithText(container, "Licenses"));
+    await click(navButton(container, "Licenses"));
     expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Licenses");
   });
 
@@ -330,8 +339,10 @@ describe("SimpleShell", () => {
     const context = baseContext({ jobs: [failed], imageLocalJobs: [failed] });
     await renderShell(root, context);
 
-    expect(container.textContent).toContain("Failed.");
-    expect(container.textContent).toContain("Krea 2 edit requires the Krea 2 Identity Edit LoRA.");
+    expect(container.querySelector(".su-job-error").textContent).toBe(
+      "Krea 2 edit requires the Krea 2 Identity Edit LoRA.",
+    );
+    expect(container.querySelector(".su-job-badge").textContent).toBe("Failed");
   });
 
   it("shows the failure reason on the Queue row too", async () => {
@@ -343,7 +354,7 @@ describe("SimpleShell", () => {
       payload: { model: "z_image" },
     };
     await renderShell(root, baseContext({ jobs: [failed] }));
-    await click(buttonWithText(container, "Queue"));
+    await click(navButton(container, "Queue"));
 
     expect(container.querySelector(".su-job-error").textContent).toBe(
       "no worker supports image_generate",
@@ -360,8 +371,60 @@ describe("SimpleShell", () => {
       payload: { model: "z_image" },
     };
     await renderShell(root, baseContext({ jobs: [canceled] }));
-    await click(buttonWithText(container, "Queue"));
+    await click(navButton(container, "Queue"));
     expect(container.querySelector(".su-job-badge").textContent).toBe("Canceled");
+  });
+
+  // Simple had NO way to cancel a run and no progress readout anywhere — a submitted job
+  // was a spinner with no end and no exit. The run strip under Generate is the same card
+  // the Queue lists, so both surfaces get progress + Cancel from one component.
+  const RUNNING_JOB = {
+    id: "job-run",
+    type: "image_generate",
+    status: "running",
+    progress: 0.42,
+    payload: { model: "z_image", width: 1024, height: 1024 },
+  };
+
+  it("shows progress and a Cancel for the running job under Generate", async () => {
+    const context = baseContext({ jobs: [RUNNING_JOB], imageLocalJobs: [RUNNING_JOB] });
+    await renderShell(root, context);
+
+    // The strip renders in the STUDIO, not only on the Queue screen.
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Image Studio");
+    expect(container.querySelector(".su-job-badge").textContent).toBe("42%");
+    expect(container.querySelector(".su-bar > span").style.width).toBe("42%");
+
+    await click(buttonWithText(container, "Cancel"));
+    expect(context.jobAction).toHaveBeenCalledTimes(1);
+    expect(context.jobAction.mock.calls[0][0].id).toBe("job-run");
+    expect(context.jobAction.mock.calls[0][1]).toBe("cancel");
+  });
+
+  it("offers Cancel on the Queue screen too", async () => {
+    const context = baseContext({ jobs: [RUNNING_JOB] });
+    await renderShell(root, context);
+    await click(navButton(container, "Queue"));
+
+    await click(buttonWithText(container, "Cancel"));
+    expect(context.jobAction).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "job-run" }),
+      "cancel",
+    );
+  });
+
+  it("offers no Cancel once a run is terminal", async () => {
+    const done = { ...RUNNING_JOB, status: "completed", progress: 1 };
+    await renderShell(root, baseContext({ jobs: [done], imageLocalJobs: [done] }));
+    expect(buttonWithText(container, "Cancel")).toBeUndefined();
+  });
+
+  it("sweeps an indeterminate bar for a claimed run with no percentage yet", async () => {
+    const noProgress = { ...RUNNING_JOB, progress: 0 };
+    await renderShell(root, baseContext({ jobs: [noProgress], imageLocalJobs: [noProgress] }));
+    // A 0%-wide bar reads as "stuck"; the sweeping variant reads as "working".
+    expect(container.querySelector(".su-bar").className).toContain("su-bar--indeterminate");
+    expect(container.querySelector(".su-job-badge").textContent).toBe("Running");
   });
 
   it("refuses to submit with an empty prompt", async () => {
@@ -386,7 +449,7 @@ describe("SimpleShell", () => {
     const context = baseContext();
     const onModeChange = vi.fn();
     await renderShell(root, context, { onModeChange });
-    await click(buttonWithText(container, "Model Manager"));
+    await click(navButton(container, "Model Manager"));
 
     const manage = buttonWithText(container, "Manage");
     expect(manage).toBeTruthy();
@@ -400,7 +463,7 @@ describe("SimpleShell", () => {
     const context = baseContext();
     const onModeChange = vi.fn();
     await renderShell(root, context, { onModeChange, lockedToSimple: true });
-    await click(buttonWithText(container, "Model Manager"));
+    await click(navButton(container, "Model Manager"));
     await click(buttonWithText(container, "Manage"));
 
     expect(context.setActiveView).not.toHaveBeenCalled();
@@ -413,7 +476,7 @@ describe("SimpleShell", () => {
       models: [IMAGE_MODEL, { ...IMAGE_MODEL, id: "flux_dev", name: "FLUX.1 [dev]", installState: "missing" }],
     });
     await renderShell(root, context);
-    await click(buttonWithText(container, "Model Manager"));
+    await click(navButton(container, "Model Manager"));
     await click(buttonWithText(container, "Download"));
 
     expect(context.createModelDownloadJob).toHaveBeenCalledTimes(1);

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -445,6 +445,14 @@ describe("SimpleShell", () => {
       }
     });
 
+    it(`offers ${stays ? "a Dismiss" : "no Dismiss"} on the studio card for a ${status} run`, async () => {
+      const job = { ...RUNNING_JOB, status, progress: 1, error: "out of memory" };
+      await renderShell(root, baseContext({ jobs: [job], imageLocalJobs: [job] }));
+      // Cancel and Dismiss are mutually exclusive — a terminal run can only be dismissed.
+      expect(buttonWithText(container, "Cancel")).toBeUndefined();
+      expect(Boolean(buttonWithText(container, "Dismiss"))).toBe(stays);
+    });
+
     it(`always keeps the Queue row for a ${status} run`, async () => {
       const job = { ...RUNNING_JOB, status, progress: 1, error: "out of memory" };
       await renderShell(root, baseContext({ jobs: [job] }));
@@ -453,6 +461,34 @@ describe("SimpleShell", () => {
       expect(container.querySelector(".su-job")).toBeTruthy();
     });
   }
+
+  it("dismisses a failed run's card from the studio without touching the Queue", async () => {
+    const failed = { ...RUNNING_JOB, status: "failed", error: "out of memory" };
+    await renderShell(root, baseContext({ jobs: [failed], imageLocalJobs: [failed] }));
+
+    expect(container.querySelector(".su-job")).toBeTruthy();
+    await click(buttonWithText(container, "Dismiss"));
+    expect(container.querySelector(".su-job")).toBeNull();
+
+    // The Queue is the history — dismissing in a studio must not remove it there.
+    await click(navButton(container, "Queue"));
+    expect(container.querySelector(".su-job")).toBeTruthy();
+    expect(container.querySelector(".su-job-error").textContent).toBe("out of memory");
+  });
+
+  // The studios unmount on navigation, so a studio-local dismissal flag would resurrect the
+  // card on the way back. This is why the dismissed set lives on the shell.
+  it("keeps a dismissal after navigating away and back", async () => {
+    const failed = { ...RUNNING_JOB, status: "failed", error: "out of memory" };
+    await renderShell(root, baseContext({ jobs: [failed], imageLocalJobs: [failed] }));
+
+    await click(buttonWithText(container, "Dismiss"));
+    await click(navButton(container, "Queue"));
+    await click(navButton(container, "Image"));
+
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Image Studio");
+    expect(container.querySelector(".su-job")).toBeNull();
+  });
 
   it("sweeps an indeterminate bar for a claimed run with no percentage yet", async () => {
     const noProgress = { ...RUNNING_JOB, progress: 0 };

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -257,6 +257,113 @@ describe("SimpleShell", () => {
     expect(tile.textContent).toContain("SDXL can’t use a reference image");
   });
 
+  // A Krea 2 edit run failed in the worker because Simple sent `loras: []`, and then the
+  // failure was invisible: the studio rendered nothing and the reason was only in Logs.
+  const KREA = {
+    ...IMAGE_MODEL,
+    id: "krea_2_turbo",
+    name: "Krea 2 Turbo",
+    family: "krea_2",
+  };
+  const KREA_LORA = {
+    id: "krea2_identity_edit",
+    name: "Krea 2 Identity Edit",
+    conditioningRole: "image_edit",
+    installState: "installed",
+    compatibility: { families: ["krea_2"] },
+    families: ["krea_2"],
+  };
+
+  it("auto-applies the managed edit LoRA on a Krea 2 edit run", async () => {
+    const context = baseContext({
+      imageModels: [KREA],
+      models: [KREA],
+      loras: [KREA_LORA],
+      assets: [REFERENCE_ASSET],
+      recentImageAssets: [REFERENCE_ASSET],
+    });
+    await renderShell(root, context);
+
+    await click(buttonWithText(container, "Edit"));
+    await typePrompt(container, "make it dusk");
+    await click([...container.querySelectorAll(".su-tile")].find((n) => n.textContent.includes("Source image")));
+    await click(
+      [...container.querySelectorAll(".su-option-row")].find((n) => n.textContent.includes("cliff_ref.png")),
+    );
+    await click(container.querySelector(".su-generate"));
+
+    const payload = context.createImageJob.mock.calls[0][0];
+    expect(payload.mode).toBe("edit_image");
+    expect(payload.sourceAssetId).toBe("asset-9");
+    expect(payload.loras.map((l) => l.id)).toEqual(["krea2_identity_edit"]);
+    expect(payload.loras[0].conditioningRole).toBe("image_edit");
+  });
+
+  it("blocks the run and offers the download when the edit LoRA isn't installed", async () => {
+    const context = baseContext({
+      imageModels: [KREA],
+      models: [KREA],
+      loras: [{ ...KREA_LORA, installState: "missing" }],
+      assets: [REFERENCE_ASSET],
+      recentImageAssets: [REFERENCE_ASSET],
+    });
+    await renderShell(root, context);
+    await click(buttonWithText(container, "Edit"));
+    await typePrompt(container, "make it dusk");
+
+    expect(container.textContent).toContain("needs the Krea 2 Identity Edit LoRA");
+    expect(container.querySelector(".su-generate").disabled).toBe(true);
+
+    await click(buttonWithText(container, "Download it"));
+    expect(context.createLoraDownloadJob).toHaveBeenCalledTimes(1);
+    expect(context.createLoraDownloadJob.mock.calls[0][0].id).toBe("krea2_identity_edit");
+  });
+
+  it("surfaces a failed run's reason in the studio instead of rendering nothing", async () => {
+    const failed = {
+      id: "job-x",
+      type: "image_generate",
+      status: "failed",
+      error: "Krea 2 edit requires the Krea 2 Identity Edit LoRA.",
+      payload: {},
+    };
+    const context = baseContext({ jobs: [failed], imageLocalJobs: [failed] });
+    await renderShell(root, context);
+
+    expect(container.textContent).toContain("Failed.");
+    expect(container.textContent).toContain("Krea 2 edit requires the Krea 2 Identity Edit LoRA.");
+  });
+
+  it("shows the failure reason on the Queue row too", async () => {
+    const failed = {
+      id: "job-x",
+      type: "image_generate",
+      status: "failed",
+      error: "no worker supports image_generate",
+      payload: { model: "z_image" },
+    };
+    await renderShell(root, baseContext({ jobs: [failed] }));
+    await click(buttonWithText(container, "Queue"));
+
+    expect(container.querySelector(".su-job-error").textContent).toBe(
+      "no worker supports image_generate",
+    );
+    expect(container.querySelector(".su-job-badge").textContent).toBe("Failed");
+  });
+
+  it("badges a canceled job as Canceled, not Failed", async () => {
+    const canceled = {
+      id: "job-c",
+      type: "image_generate",
+      status: "canceled",
+      error: "Canceled before a worker started.",
+      payload: { model: "z_image" },
+    };
+    await renderShell(root, baseContext({ jobs: [canceled] }));
+    await click(buttonWithText(container, "Queue"));
+    expect(container.querySelector(".su-job-badge").textContent).toBe("Canceled");
+  });
+
   it("refuses to submit with an empty prompt", async () => {
     const context = baseContext();
     await renderShell(root, context);

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -17,6 +17,17 @@ const IMAGE_MODEL = {
   capabilities: ["text_to_image", "edit_image"],
   installState: "installed",
   limits: { resolutions: ["1024x1024", "1344x768"] },
+  // Z-Image declares reference-guided generation in the real catalog, with this exact
+  // strength config — so the Text tab's Reference tile is live for it.
+  ui: { img2img: true, img2imgStrength: { default: 0.5, min: 0, max: 1, step: 0.05 } },
+};
+
+const REFERENCE_ASSET = {
+  id: "asset-9",
+  type: "image",
+  projectId: "project-1",
+  displayName: "cliff_ref.png",
+  url: "/media/cliff_ref.png",
 };
 
 function baseContext(overrides = {}) {
@@ -74,6 +85,18 @@ function buttonWithText(container, text) {
   return [...container.querySelectorAll("button")].find(
     (node) => node.textContent.trim() === text,
   );
+}
+
+async function typePrompt(container, value) {
+  const textarea = container.querySelector("#su-image-prompt");
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    ).set;
+    setter.call(textarea, value);
+    textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+  });
 }
 
 describe("SimpleShell", () => {
@@ -185,6 +208,53 @@ describe("SimpleShell", () => {
       height: 1024,
     });
     expect(context.rememberLocalGenerationJob).toHaveBeenCalledWith("image", { id: "job-1" });
+  });
+
+  // Regression for a shipped bug: the Reference tile armed, showed SET + a thumbnail and
+  // toasted "Reference attached", but the id was routed to `sourceAssetId` — which
+  // buildImageJobRequest discards outside edit mode — so the run silently ignored it. This
+  // drives the REAL tile through the REAL picker sheet, which is what the payload-only
+  // tests could not catch.
+  it("attaches a Text-mode reference through the tile and sends it with a strength", async () => {
+    const context = baseContext({ assets: [REFERENCE_ASSET], recentImageAssets: [REFERENCE_ASSET] });
+    await renderShell(root, context);
+
+    await typePrompt(container, "a lighthouse");
+    await click(buttonWithText(container, "ReferenceTap to attach an image"));
+
+    // The picker sheet lists the project's images; choose the one asset.
+    const row = [...container.querySelectorAll(".su-option-row")].find((node) =>
+      node.textContent.includes("cliff_ref.png"),
+    );
+    expect(row).toBeTruthy();
+    await click(row);
+
+    // Armed: the tile reports SET rather than the empty hint.
+    expect(container.querySelector(".su-set-badge")).toBeTruthy();
+
+    await click(container.querySelector(".su-generate"));
+
+    const payload = context.createImageJob.mock.calls[0][0];
+    expect(payload.referenceAssetId).toBe("asset-9");
+    expect(payload.advanced.strength).toBe(0.5);
+    expect(payload.sourceAssetId).toBeNull();
+  });
+
+  it("disables the Reference tile, with a reason, on a model that can't use one", async () => {
+    const plainModel = { ...IMAGE_MODEL, id: "sdxl", name: "SDXL", ui: undefined };
+    const context = baseContext({
+      imageModels: [plainModel],
+      models: [plainModel],
+      assets: [REFERENCE_ASSET],
+      recentImageAssets: [REFERENCE_ASSET],
+    });
+    await renderShell(root, context);
+
+    const tile = [...container.querySelectorAll(".su-tile")].find((node) =>
+      node.textContent.includes("Reference"),
+    );
+    expect(tile.disabled).toBe(true);
+    expect(tile.textContent).toContain("SDXL can’t use a reference image");
   });
 
   it("refuses to submit with an empty prompt", async () => {

--- a/apps/web/src/simple/SimpleUiContext.js
+++ b/apps/web/src/simple/SimpleUiContext.js
@@ -17,6 +17,9 @@ import { createContext, useContext } from "react";
 //   openInAdvanced(view) — hand off to a full-workspace screen (returns false, with an
 //                          explanatory toast, when the viewport has Simple locked on)
 //   uiLocked            — true when the viewport forces Simple
+//   dismissedJobIds     — Set of failed-run ids the user has dismissed from a studio.
+//                         Shell-held, because the studios unmount on navigation.
+//   dismissJob(id)
 export const SimpleUiContext = createContext(null);
 
 export function useSimpleUi() {

--- a/apps/web/src/simple/SimpleVideoStudio.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.jsx
@@ -4,6 +4,7 @@ import { useAppContext } from "../context/AppContext.js";
 import { videoModelServesMode } from "../modelEligibility.js";
 import { buildSimpleVideoRequest } from "./simpleJobs.js";
 import { describeResolution, resolutionSummary } from "./aspect.js";
+import { preferredDuration, preferredVideoResolution } from "./modelDefaults.js";
 import { useSimpleRefine } from "./useSimpleRefine.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
 import {
@@ -74,21 +75,33 @@ export function SimpleVideoStudio() {
   const durations = selectedModel?.limits?.durations?.length
     ? selectedModel.limits.durations
     : DEFAULT_DURATIONS;
-  // The model's own fps list leads; the studio does not expose fps, so the first
-  // declared value is used — the same one the advanced picker defaults to.
-  const fps = selectedModel?.limits?.fps?.[0] ?? selectedModel?.defaults?.fps ?? 25;
 
+  // Both seeds read the model's DECLARED default rather than `limits.*[0]`, which is only
+  // the first ALLOWED value. For nearly every shipped video model they differ — LTX-2.3
+  // declares 6s but lists 4s first; Wan 2.2 A14B declares 1280×720 but lists 832×480 first —
+  // so [0] silently started a Simple run shorter and smaller than the same model in the full
+  // workspace.
+  // Both effects guard on a RESOLVED model (mirrors ImageStudio's sc-11962 guard): before the
+  // catalog lands these lists are the generic fallbacks, and seeding from them locks in a
+  // value the model also happens to allow — after which the model's own declared default is
+  // never applied.
   useEffect(() => {
+    if (!selectedModel) {
+      return;
+    }
     if (resolutions.length && !resolutions.includes(resolution)) {
-      setResolution(resolutions[0]);
+      setResolution(preferredVideoResolution(selectedModel, resolutions));
     }
-  }, [resolutions, resolution]);
+  }, [resolutions, resolution, selectedModel]);
 
   useEffect(() => {
-    if (durations.length && !durations.includes(duration)) {
-      setDuration(durations[0]);
+    if (!selectedModel) {
+      return;
     }
-  }, [durations, duration]);
+    if (durations.length && !durations.includes(duration)) {
+      setDuration(preferredDuration(selectedModel, durations));
+    }
+  }, [durations, duration, selectedModel]);
 
   const sourceAsset = useMemo(
     () => recentImageAssets.find((asset) => asset.id === sourceAssetId) ?? null,
@@ -117,7 +130,6 @@ export function SimpleVideoStudio() {
         model,
         resolution,
         duration,
-        fps,
         styleId,
         sourceAssetId,
       });

--- a/apps/web/src/simple/SimpleVideoStudio.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.jsx
@@ -12,6 +12,7 @@ import {
   ReferenceTile,
   SheetSelect,
   StudioResults,
+  StudioRunStatus,
   StyleStrip,
   jobIsRunning,
   newestLocalJob,
@@ -271,6 +272,9 @@ export function SimpleVideoStudio() {
         {busy ? "Rendering…" : "Generate video"}
       </button>
       {needsSource ? <p className="su-empty">Attach a start frame to render an Image → Video clip.</p> : null}
+
+      {/* Live run strip: progress + Cancel + the outcome, right under Generate. */}
+      <StudioRunStatus job={latestJob} />
 
       <StudioResults
         assets={assets}

--- a/apps/web/src/simple/modelDefaults.js
+++ b/apps/web/src/simple/modelDefaults.js
@@ -1,0 +1,57 @@
+// Resolving a model's DECLARED default for a control the Simple UI shows.
+//
+// The trap this exists to close: `limits.<thing>[0]` is the first ALLOWED value, not the
+// model's chosen default, and for most shipped models the two differ:
+//
+//   z_image        limits.resolutions[0] 768x768   vs  defaults.resolution 1024x1024
+//   wan_2_2_t2v    limits.resolutions[0] 832x480   vs  defaults.resolution 1280x720
+//   ltx_2_3        limits.durations[0]   4s        vs  defaults.duration   6s
+//   wan_2_2        limits.fps[0]         16        vs  defaults.fps        24
+//
+// Picking `[0]` therefore silently downgrades a Simple run relative to the same model in the
+// full workspace — a lower resolution, a shorter clip, a frame rate the model never chose
+// (Wan 2.2 at 16 fps instead of 24 plays 33% slow). The advanced studios all read
+// `defaults.*` (ImageStudio's `preferredResolution`, VideoStudio's duration/fps/resolution
+// seeds); this module is the one place Simple does the same.
+
+/**
+ * The value a control should start on: the model's declared default when it is actually
+ * offered, else the first entry of `preferences` that is offered, else the first option.
+ *
+ * @param {*} declared - the model's `defaults.<field>`.
+ * @param {Array} options - the values the picker offers (already memory-gated).
+ * @param {Array} [preferences] - ordered fallbacks to try before giving up on `options[0]`.
+ */
+export function preferredOption(declared, options, preferences = []) {
+  const list = Array.isArray(options) ? options : [];
+  if (list.length === 0) {
+    return undefined;
+  }
+  if (declared !== undefined && declared !== null && list.includes(declared)) {
+    return declared;
+  }
+  for (const preference of preferences) {
+    if (list.includes(preference)) {
+      return preference;
+    }
+  }
+  return list[0];
+}
+
+// The Image Studio's resolution default. Mirrors ImageStudio's `preferredResolution`
+// exactly, including its 1024² second choice — so a Simple run and an untouched advanced
+// run of the same model start on the same geometry.
+export function preferredResolution(model, options) {
+  return preferredOption(model?.defaults?.resolution, options, ["1024x1024"]);
+}
+
+// The Video Studio's resolution default. No 1024² second choice — video geometry is
+// model-specific and the advanced studio seeds straight from `defaults.resolution`.
+export function preferredVideoResolution(model, options) {
+  return preferredOption(model?.defaults?.resolution, options);
+}
+
+// The Video Studio's clip-length default.
+export function preferredDuration(model, options) {
+  return preferredOption(model?.defaults?.duration, options);
+}

--- a/apps/web/src/simple/modelDefaults.test.js
+++ b/apps/web/src/simple/modelDefaults.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  preferredDuration,
+  preferredOption,
+  preferredResolution,
+  preferredVideoResolution,
+} from "./modelDefaults.js";
+
+// These pin the exact trap the audit found: `limits.<thing>[0]` is the first ALLOWED value,
+// not the model's chosen default, and for most shipped models the two differ. The fixtures
+// below are the REAL declared values from config/manifests/builtin.models.jsonc, so a
+// manifest change that invalidates the assumption shows up here.
+
+describe("preferredOption", () => {
+  it("takes the declared default when it is offered", () => {
+    expect(preferredOption("1024x1024", ["768x768", "1024x1024"])).toBe("1024x1024");
+  });
+
+  it("falls through the preference list when the declared default isn't offered", () => {
+    expect(preferredOption("2048x2048", ["768x768", "1024x1024"], ["1024x1024"])).toBe("1024x1024");
+  });
+
+  it("falls back to the first option when nothing else matches", () => {
+    expect(preferredOption("2048x2048", ["768x768", "640x640"], ["1024x1024"])).toBe("768x768");
+    expect(preferredOption(undefined, ["768x768"])).toBe("768x768");
+    expect(preferredOption(null, ["768x768"])).toBe("768x768");
+  });
+
+  it("is undefined for an empty option list rather than throwing", () => {
+    expect(preferredOption("1024x1024", [])).toBeUndefined();
+    expect(preferredOption("1024x1024", undefined)).toBeUndefined();
+  });
+
+  it("treats a declared 0 as a real value, not as unset", () => {
+    // Guards the `!declared` shape of this check — 0 is a legitimate declared default.
+    expect(preferredOption(0, [3, 0, 5])).toBe(0);
+  });
+});
+
+describe("preferredResolution (image)", () => {
+  // z_image: declares 1024x1024, but its limits list LEADS with 768x768.
+  const Z_IMAGE = { defaults: { resolution: "1024x1024" } };
+  const Z_IMAGE_OPTIONS = ["768x768", "1024x1024", "1280x720", "720x1280"];
+
+  it("starts on the model's declared default, not the first allowed value", () => {
+    expect(preferredResolution(Z_IMAGE, Z_IMAGE_OPTIONS)).toBe("1024x1024");
+    expect(preferredResolution(Z_IMAGE, Z_IMAGE_OPTIONS)).not.toBe(Z_IMAGE_OPTIONS[0]);
+  });
+
+  // The z_image case above CANNOT tell the declared-default branch from the 1024² fallback:
+  // every mismatching image model in the shipped catalog happens to declare 1024², so both
+  // paths give the same answer and the assertion passes for the wrong reason. This case
+  // separates them — declared, first-allowed and the 1024² fallback are three distinct
+  // values, so only reading `defaults.resolution` produces 1344x768.
+  it("prefers the declared default OVER the 1024² fallback (discriminating case)", () => {
+    const model = { defaults: { resolution: "1344x768" } };
+    const options = ["768x768", "1024x1024", "1344x768"];
+    expect(preferredResolution(model, options)).toBe("1344x768");
+  });
+
+  it("prefers 1024² over the first entry when the declared default is gated out", () => {
+    // Mirrors ImageStudio's own preferredResolution, including this second choice.
+    expect(preferredResolution({ defaults: { resolution: "1536x1536" } }, Z_IMAGE_OPTIONS)).toBe(
+      "1024x1024",
+    );
+  });
+
+  it("falls back to the first option for a model declaring nothing", () => {
+    expect(preferredResolution({}, ["832x1216", "1024x1024"])).toBe("1024x1024");
+    expect(preferredResolution({}, ["832x1216", "640x640"])).toBe("832x1216");
+  });
+});
+
+describe("preferredVideoResolution / preferredDuration", () => {
+  // wan_2_2_t2v_14b: declares 1280x720 + 5s, but lists 832x480 and 3s first.
+  const WAN_A14B = { defaults: { resolution: "1280x720", duration: 5 } };
+
+  it("starts video geometry on the declared default", () => {
+    const options = ["832x480", "1280x720", "720x1280"];
+    expect(preferredVideoResolution(WAN_A14B, options)).toBe("1280x720");
+    expect(preferredVideoResolution(WAN_A14B, options)).not.toBe(options[0]);
+  });
+
+  it("starts clip length on the declared default", () => {
+    const options = [3, 5, 8, 10];
+    expect(preferredDuration(WAN_A14B, options)).toBe(5);
+    expect(preferredDuration(WAN_A14B, options)).not.toBe(options[0]);
+  });
+
+  // ltx_2_3: declares 6s, lists 4s first.
+  it("handles LTX's 6s default against a list leading with 4s", () => {
+    expect(preferredDuration({ defaults: { duration: 6 } }, [4, 6, 8, 10])).toBe(6);
+  });
+
+  it("does NOT apply the image 1024² preference to video", () => {
+    // Video geometry is model-specific; a 1024² second choice would be meaningless.
+    expect(
+      preferredVideoResolution({ defaults: { resolution: "9999x9999" } }, ["832x480", "1024x1024"]),
+    ).toBe("832x480");
+  });
+
+  it("falls back to the first allowed value when the model declares none", () => {
+    expect(preferredDuration({}, [3, 5])).toBe(3);
+    expect(preferredVideoResolution({}, ["832x480"])).toBe("832x480");
+  });
+});

--- a/apps/web/src/simple/simple.css
+++ b/apps/web/src/simple/simple.css
@@ -1004,6 +1004,18 @@
   color: var(--text-muted);
 }
 
+/* An inline action inside a notice — reads as a link, not a second button. */
+.su-link {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--accent-strong);
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .su-notice--error {
   border-color: color-mix(in oklch, var(--danger) 45%, var(--border));
   background: var(--danger-soft);
@@ -1297,6 +1309,14 @@
 .su-job-badge--failed {
   background: var(--danger-soft);
   color: color-mix(in oklch, var(--danger) 72%, var(--text));
+}
+
+.su-job-error {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: color-mix(in oklch, var(--danger) 72%, var(--text));
+  overflow-wrap: anywhere;
 }
 
 .su-bar {

--- a/apps/web/src/simple/simple.css
+++ b/apps/web/src/simple/simple.css
@@ -1311,6 +1311,33 @@
   color: color-mix(in oklch, var(--danger) 72%, var(--text));
 }
 
+.su-job-cancel {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease-out), color var(--t-fast) var(--ease-out);
+}
+
+.su-job-cancel:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--danger) 45%, var(--border));
+  color: color-mix(in oklch, var(--danger) 75%, var(--text));
+}
+
+.su-job-cancel:disabled {
+  cursor: default;
+}
+
 .su-job-error {
   margin: 0;
   font-size: 11.5px;
@@ -1336,6 +1363,23 @@
 
 .su-bar--done > span {
   background: var(--success);
+}
+
+/* A claimed run that hasn't reported a percentage yet. A 0%-wide bar would be
+   indistinguishable from "stuck", so it sweeps instead. */
+.su-bar--indeterminate > span {
+  width: 40%;
+  transition: none;
+  animation: su-sweep 1.1s var(--ease-out) infinite;
+}
+
+@keyframes su-sweep {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(250%);
+  }
 }
 
 /* ---------- Settings ---------- */

--- a/apps/web/src/simple/simpleJobs.js
+++ b/apps/web/src/simple/simpleJobs.js
@@ -239,7 +239,6 @@ export function buildSimpleVideoRequest({
   model,
   resolution,
   duration,
-  fps,
   styleId,
   sourceAssetId,
 }) {
@@ -257,7 +256,11 @@ export function buildSimpleVideoRequest({
     negativePrompt: "",
     model,
     duration: Number(duration),
-    fps: Number(fps),
+    // fps is deliberately OMITTED. Simple exposes no frame-rate control, and the route
+    // resolves an absent fps from the model's declared `defaults.fps` (sc-12347) — which is
+    // exactly what the advanced studio sends when its fps picker is untouched. Sending a
+    // value we invented instead is what the DTO's own comment calls out as harmful: a blanket
+    // rate "is not a value any model chose", and it makes `limits.fps` unenforceable.
     width: size.width,
     height: size.height,
     quality: "balanced",

--- a/apps/web/src/simple/simpleJobs.js
+++ b/apps/web/src/simple/simpleJobs.js
@@ -1,5 +1,6 @@
 import { buildImageJobRequest } from "../imageJobRequest.js";
 import { composeStyledPrompt } from "../styleComposer.js";
+import { serializeLora } from "../presetUtils.js";
 import { styleTextForId } from "../data/styleCatalog.js";
 import { defaultTierSelection, installedTiers } from "../quantTier.js";
 import { suggestTier } from "../tierSuggestion.js";
@@ -168,6 +169,8 @@ export function referenceStrengthFor(model) {
  * @param {string|null} input.referenceAssetId - the armed reference, whichever mode is active.
  * @param {boolean} [input.supportsImg2img] - the selected model's `ui.img2img` flag.
  * @param {number} [input.img2imgStrength] - from referenceStrengthFor(selectedModel).
+ * @param {object|null} [input.editLora] - the model's managed `image_edit`-role LoRA catalog entry
+ *   (findModelEditLora), auto-applied in edit mode. Null for models needing none.
  * @param {string} [input.quantTier] / @param {boolean} [input.tierExplicit] - from resolveSimpleTier.
  * @returns {object|null} the payload for createImageJob, or null when the resolution is invalid.
  */
@@ -181,6 +184,7 @@ export function buildSimpleImageRequest({
   referenceAssetId,
   supportsImg2img = false,
   img2imgStrength = DEFAULT_IMG2IMG_STRENGTH,
+  editLora = null,
   quantTier = "",
   tierExplicit = false,
 }) {
@@ -193,8 +197,16 @@ export function buildSimpleImageRequest({
   // what makes buildImageJobAdvanced emit `advanced.strength`, so claiming it for a model
   // without the capability would send a knob the engine has no use for.
   const img2imgActive = !editing && supportsImg2img && Boolean(referenceAssetId);
+  // Krea-style managed image-edit LoRA (epic 10871, sc-11069). Krea 2's edit lane REJECTS a run
+  // without an `image_edit`-role LoRA — "without it the source-image conditioning is inert" — so
+  // an edit payload that omits it fails in the worker, not the UI. The advanced studio already
+  // manages this for the user rather than exposing it in the LoRA picker, which is exactly the
+  // Simple behavior; it just has to actually be applied. `serializeLora` round-trips
+  // `conditioningRole`, which is what the worker's role check reads.
+  const loras = editing && editLora ? [serializeLora(editLora)] : [];
   return buildImageJobRequest({
     ...IMAGE_DEFAULTS,
+    loras,
     sourceAssetId: editing ? referenceAssetId || null : null,
     supportsImg2img: img2imgActive,
     img2imgReferenceAssetId: img2imgActive ? referenceAssetId : null,

--- a/apps/web/src/simple/simpleJobs.js
+++ b/apps/web/src/simple/simpleJobs.js
@@ -130,8 +130,34 @@ export function parseResolutionPair(resolution) {
   return { width, height };
 }
 
+// The reference strength used when an img2img-capable model has a reference attached but
+// the surface shows no slider — which is every Simple run. The model declares its own
+// default under `ui.img2imgStrength.default` (every img2img entry in the shipped catalog
+// declares 0.5, the same value the advanced slider initializes to); this constant is only
+// the fallback for an entry that declares the `ui.img2img` flag but no strength config.
+export const DEFAULT_IMG2IMG_STRENGTH = 0.5;
+
+/**
+ * The reference strength a Simple run should send for `model`. Reads the model's declared
+ * default so a catalog entry that tunes it is honored without a code change here.
+ */
+export function referenceStrengthFor(model) {
+  const declared = model?.ui?.img2imgStrength?.default;
+  return Number.isFinite(declared) ? declared : DEFAULT_IMG2IMG_STRENGTH;
+}
+
 /**
  * The Image Studio job request for a Simple run.
+ *
+ * The single armed reference is routed by MODE, because the two modes condition on an
+ * image in completely different ways:
+ *   - edit_image      → `sourceAssetId`: the image being edited. No strength exists on this
+ *                       path; the model's edit pipeline owns it.
+ *   - text_to_image   → `img2imgReferenceAssetId` + `advanced.strength`, but ONLY on a model
+ *                       that declares `ui.img2img`. buildImageJobRequest drops a
+ *                       text-mode `sourceAssetId` on the floor, so routing it there would
+ *                       silently ignore the user's reference.
+ *
  * @param {object} input
  * @param {string} input.prompt
  * @param {"text_to_image"|"edit_image"} input.mode
@@ -139,7 +165,9 @@ export function parseResolutionPair(resolution) {
  * @param {string} input.resolution - "WIDTHxHEIGHT".
  * @param {number} input.count - variations.
  * @param {string|null} input.styleId - Style Catalog group/sub-style id, or null for "None".
- * @param {string|null} input.sourceAssetId - the edit source (edit_image only).
+ * @param {string|null} input.referenceAssetId - the armed reference, whichever mode is active.
+ * @param {boolean} [input.supportsImg2img] - the selected model's `ui.img2img` flag.
+ * @param {number} [input.img2imgStrength] - from referenceStrengthFor(selectedModel).
  * @param {string} [input.quantTier] / @param {boolean} [input.tierExplicit] - from resolveSimpleTier.
  * @returns {object|null} the payload for createImageJob, or null when the resolution is invalid.
  */
@@ -150,7 +178,9 @@ export function buildSimpleImageRequest({
   resolution,
   count,
   styleId,
-  sourceAssetId,
+  referenceAssetId,
+  supportsImg2img = false,
+  img2imgStrength = DEFAULT_IMG2IMG_STRENGTH,
   quantTier = "",
   tierExplicit = false,
 }) {
@@ -158,8 +188,17 @@ export function buildSimpleImageRequest({
   if (!size) {
     return null;
   }
+  const editing = mode === "edit_image";
+  // Only claim img2img on the text path AND on a model that advertises it — the flag is
+  // what makes buildImageJobAdvanced emit `advanced.strength`, so claiming it for a model
+  // without the capability would send a knob the engine has no use for.
+  const img2imgActive = !editing && supportsImg2img && Boolean(referenceAssetId);
   return buildImageJobRequest({
     ...IMAGE_DEFAULTS,
+    sourceAssetId: editing ? referenceAssetId || null : null,
+    supportsImg2img: img2imgActive,
+    img2imgReferenceAssetId: img2imgActive ? referenceAssetId : null,
+    img2imgStrength,
     promptToSend: prompt,
     submitIntent: prompt,
     resolution,
@@ -172,7 +211,6 @@ export function buildSimpleImageRequest({
     // replays into the advanced Style picker unchanged (sc-13132).
     styleText: styleId ? styleTextForId(styleId) : null,
     styleId: styleId || null,
-    sourceAssetId: sourceAssetId || null,
     quantTier,
     tierExplicit,
   });

--- a/apps/web/src/simple/simpleJobs.test.js
+++ b/apps/web/src/simple/simpleJobs.test.js
@@ -204,6 +204,45 @@ describe("buildSimpleImageRequest", () => {
     expect(request.advanced.strength).toBeUndefined();
   });
 
+  // Krea 2's edit lane REJECTS a run whose payload carries no `image_edit`-role LoRA
+  // ("without it the source-image conditioning is inert"). Simple sent `loras: []`
+  // unconditionally, so every Krea 2 edit failed in the worker.
+  const KREA_EDIT_LORA = {
+    id: "krea2_identity_edit",
+    name: "Krea 2 Identity Edit",
+    conditioningRole: "image_edit",
+    installState: "installed",
+  };
+
+  it("auto-applies the model's managed edit LoRA on an edit run", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      mode: "edit_image",
+      referenceAssetId: "asset-7",
+      editLora: KREA_EDIT_LORA,
+    });
+    expect(request.loras).toHaveLength(1);
+    expect(request.loras[0].id).toBe("krea2_identity_edit");
+    // The ROLE is what the worker's edit-lane check reads — a serialized entry that lost it
+    // fails exactly as an absent LoRA would.
+    expect(request.loras[0].conditioningRole).toBe("image_edit");
+  });
+
+  it("does not attach the edit LoRA to a TEXT run", () => {
+    const request = buildSimpleImageRequest({ ...base, editLora: KREA_EDIT_LORA });
+    expect(request.loras).toEqual([]);
+  });
+
+  it("sends no LoRAs for an edit model that needs none", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      mode: "edit_image",
+      referenceAssetId: "asset-7",
+      editLora: null,
+    });
+    expect(request.loras).toEqual([]);
+  });
+
   it("emits no img2img fields at all when nothing is armed", () => {
     const request = buildSimpleImageRequest({ ...base, supportsImg2img: true });
     expect(request.referenceAssetId).toBeNull();

--- a/apps/web/src/simple/simpleJobs.test.js
+++ b/apps/web/src/simple/simpleJobs.test.js
@@ -288,24 +288,30 @@ describe("buildSimpleVideoRequest", () => {
     model: "ltx_2_3",
     resolution: "1280x720",
     duration: 5,
-    fps: 25,
     styleId: null,
     sourceAssetId: null,
   };
 
-  it("emits the geometry, duration and fps the studio shows", () => {
+  it("emits the geometry and duration the studio shows", () => {
     const request = buildSimpleVideoRequest(base);
     expect(request).toMatchObject({
       mode: "text_to_video",
       model: "ltx_2_3",
       duration: 5,
-      fps: 25,
       width: 1280,
       height: 720,
       quality: "balanced",
       seed: null,
     });
     expect(request.advanced.resolution).toBe("1280x720");
+  });
+
+  // Simple exposes no frame-rate control, and the route resolves an absent fps from the
+  // model's declared `defaults.fps` (sc-12347). Sending an invented rate is what the DTO
+  // calls out as harmful — Wan 2.2 declares 24 but lists 16 first, so a `limits.fps[0]`
+  // guess rendered it 33% slow.
+  it("omits fps entirely so the route resolves the model's declared rate", () => {
+    expect("fps" in buildSimpleVideoRequest(base)).toBe(false);
   });
 
   it("refuses an unparseable resolution", () => {

--- a/apps/web/src/simple/simpleJobs.test.js
+++ b/apps/web/src/simple/simpleJobs.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_IMG2IMG_STRENGTH,
   buildSimpleAudioRequest,
   buildSimpleImageRequest,
   buildSimpleVideoRequest,
   parseResolutionPair,
+  referenceStrengthFor,
 } from "./simpleJobs.js";
 import { buildImageJobRequest } from "../imageJobRequest.js";
 import { STYLE_GROUPS, styleTextForId } from "../data/styleCatalog.js";
@@ -30,7 +32,7 @@ describe("buildSimpleImageRequest", () => {
     resolution: "1344x768",
     count: 4,
     styleId: null,
-    sourceAssetId: null,
+    referenceAssetId: null,
   };
 
   it("emits the geometry, count and mode the studio shows", () => {
@@ -153,11 +155,59 @@ describe("buildSimpleImageRequest", () => {
     const request = buildSimpleImageRequest({
       ...base,
       mode: "edit_image",
-      sourceAssetId: "asset-7",
+      referenceAssetId: "asset-7",
     });
     expect(request.mode).toBe("edit_image");
     expect(request.sourceAssetId).toBe("asset-7");
     expect(request.fitMode).toBe("crop");
+    // The edit path has no strength knob — the model's edit pipeline owns the conditioning.
+    expect(request.advanced.strength).toBeUndefined();
+    expect(request.referenceAssetId).toBeNull();
+  });
+
+  // The bug this suite missed on the first pass: a TEXT-mode reference was routed to
+  // `sourceAssetId`, which buildImageJobRequest drops for non-edit modes — so the tile
+  // armed, badged and toasted, and then nothing was sent. The reference has to ride the
+  // img2img channel, which is also what makes `advanced.strength` appear.
+  it("routes a TEXT-mode reference through img2img and sends the model's strength", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      referenceAssetId: "asset-9",
+      supportsImg2img: true,
+      img2imgStrength: 0.5,
+    });
+    expect(request.referenceAssetId).toBe("asset-9");
+    expect(request.advanced.strength).toBe(0.5);
+    // Never as the edit source — that field is edit-mode-only and would be discarded.
+    expect(request.sourceAssetId).toBeNull();
+  });
+
+  it("honors a model-declared reference strength over the fallback", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      referenceAssetId: "asset-9",
+      supportsImg2img: true,
+      img2imgStrength: 0.35,
+    });
+    expect(request.advanced.strength).toBe(0.35);
+  });
+
+  it("drops a TEXT-mode reference on a model that can't do img2img", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      referenceAssetId: "asset-9",
+      supportsImg2img: false,
+    });
+    expect(request.referenceAssetId).toBeNull();
+    expect(request.sourceAssetId).toBeNull();
+    // No strength for a reference that isn't being sent.
+    expect(request.advanced.strength).toBeUndefined();
+  });
+
+  it("emits no img2img fields at all when nothing is armed", () => {
+    const request = buildSimpleImageRequest({ ...base, supportsImg2img: true });
+    expect(request.referenceAssetId).toBeNull();
+    expect(request.advanced.strength).toBeUndefined();
   });
 
   it("emits the resolved quant tier, and marks it explicit only for a deliberate pick", () => {
@@ -167,6 +217,28 @@ describe("buildSimpleImageRequest", () => {
 
     const sticky = buildSimpleImageRequest({ ...base, quantTier: "q4", tierExplicit: true });
     expect(sticky.advanced.mlxQuantizeExplicit).toBe(true);
+  });
+});
+
+describe("referenceStrengthFor", () => {
+  it("reads the model's declared default so a tuned catalog entry is honored", () => {
+    expect(referenceStrengthFor({ ui: { img2imgStrength: { default: 0.35 } } })).toBe(0.35);
+    // 0 is a legitimate strength and must not be treated as "unset".
+    expect(referenceStrengthFor({ ui: { img2imgStrength: { default: 0 } } })).toBe(0);
+  });
+
+  it("falls back when the entry declares img2img but no strength config", () => {
+    expect(referenceStrengthFor({ ui: { img2img: true } })).toBe(DEFAULT_IMG2IMG_STRENGTH);
+    expect(referenceStrengthFor(null)).toBe(DEFAULT_IMG2IMG_STRENGTH);
+    expect(referenceStrengthFor({ ui: { img2imgStrength: { default: "half" } } })).toBe(
+      DEFAULT_IMG2IMG_STRENGTH,
+    );
+  });
+
+  it("matches what every img2img entry in the shipped catalog declares", () => {
+    // Pins the fallback to the catalog's actual value, so a manifest sweep that changed it
+    // wouldn't leave this constant silently disagreeing with every model.
+    expect(DEFAULT_IMG2IMG_STRENGTH).toBe(0.5);
   });
 });
 

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -3,6 +3,7 @@ import { Icon } from "../components/Icons.jsx";
 import { AssetThumbnail, assetUrl } from "../components/assetMedia.jsx";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 import { terminalStatuses } from "../constants.js";
+import { errorStatuses } from "../jobTypes.js";
 import { STYLE_GROUPS } from "../data/styleCatalog.js";
 import { useAppStatic } from "../context/AppContext.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
@@ -212,6 +213,36 @@ export function jobIsRunning(job) {
   return Boolean(job) && !terminalStatuses.has(job.status);
 }
 
+// A run that ended badly, and the reason. The worker's message is the useful part — it is
+// frequently ACTIONABLE ("Select it in the LoRA picker", "needs N GB") — so it is surfaced
+// verbatim rather than replaced with a generic failure string.
+export function jobFailure(job) {
+  if (!job || !errorStatuses.has(job.status)) {
+    return null;
+  }
+  const detail = job.error ?? job.message ?? "";
+  const label = job.status === "canceled" ? "Canceled" : job.status === "interrupted" ? "Interrupted" : "Failed";
+  return { label, detail: String(detail).trim() };
+}
+
+// The shared failure notice. Rendered in the studios' results zone so a job that dies in the
+// worker is visible where the user is looking — before this, a failed Simple run showed
+// NOTHING at all and the reason was only in the Logs screen.
+export function JobFailureNotice({ failure }) {
+  if (!failure) {
+    return null;
+  }
+  return (
+    <div className="su-notice su-notice--error" role="alert">
+      <Icon.Warning size={16} />
+      <span>
+        <strong>{failure.label}.</strong>
+        {failure.detail ? ` ${failure.detail}` : " The worker gave no reason — check Logs in the Advanced workspace."}
+      </span>
+    </div>
+  );
+}
+
 // Results block. Renders the newest run's outputs; while that run is still in flight it
 // renders one placeholder tile per expected output so the grid doesn't pop in.
 export function StudioResults({ job, assets, type, columns, meta, pendingCount = 1, wide = false }) {
@@ -219,6 +250,12 @@ export function StudioResults({ job, assets, type, columns, meta, pendingCount =
   const { updateAssetStatus } = useAppStatic();
   const results = job ? resolveJobResultAssets(job, assets, { type }) : [];
   const running = jobIsRunning(job);
+  const failure = jobFailure(job);
+  // A failed run produces no assets, so the old "no results ⇒ render nothing" guard swallowed
+  // the failure entirely. Show the reason instead.
+  if (failure && results.length === 0) {
+    return <JobFailureNotice failure={failure} />;
+  }
   if (!job || (!running && results.length === 0)) {
     return null;
   }

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -3,9 +3,9 @@ import { Icon } from "../components/Icons.jsx";
 import { AssetThumbnail, assetUrl } from "../components/assetMedia.jsx";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 import { terminalStatuses } from "../constants.js";
-import { errorStatuses } from "../jobTypes.js";
 import { STYLE_GROUPS } from "../data/styleCatalog.js";
 import { useAppStatic } from "../context/AppContext.js";
+import { SimpleJobCard } from "./SimpleJobCard.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
 
 // Shared building blocks for the three Simple studios (design handoff). Each one is
@@ -213,33 +213,28 @@ export function jobIsRunning(job) {
   return Boolean(job) && !terminalStatuses.has(job.status);
 }
 
-// A run that ended badly, and the reason. The worker's message is the useful part — it is
-// frequently ACTIONABLE ("Select it in the LoRA picker", "needs N GB") — so it is surfaced
-// verbatim rather than replaced with a generic failure string.
-export function jobFailure(job) {
-  if (!job || !errorStatuses.has(job.status)) {
-    return null;
-  }
-  const detail = job.error ?? job.message ?? "";
-  const label = job.status === "canceled" ? "Canceled" : job.status === "interrupted" ? "Interrupted" : "Failed";
-  return { label, detail: String(detail).trim() };
-}
 
-// The shared failure notice. Rendered in the studios' results zone so a job that dies in the
-// worker is visible where the user is looking — before this, a failed Simple run showed
-// NOTHING at all and the reason was only in the Logs screen.
-export function JobFailureNotice({ failure }) {
-  if (!failure) {
+// The studio's live run strip: the SAME job card the Queue screen lists, rendered directly
+// under Generate. That is where the user's attention already is, so progress and Cancel are
+// in front of them instead of one navigation away — and because it is one component, the two
+// surfaces cannot drift.
+//
+// It stays mounted after the run ends so the outcome (Done / the failure reason) is readable
+// where the run was started; the results grid renders below it.
+export function StudioRunStatus({ job }) {
+  const { toast } = useSimpleUi();
+  const { jobAction } = useAppStatic();
+  if (!job) {
     return null;
   }
   return (
-    <div className="su-notice su-notice--error" role="alert">
-      <Icon.Warning size={16} />
-      <span>
-        <strong>{failure.label}.</strong>
-        {failure.detail ? ` ${failure.detail}` : " The worker gave no reason — check Logs in the Advanced workspace."}
-      </span>
-    </div>
+    <SimpleJobCard
+      job={job}
+      onCancel={async (target) => {
+        await jobAction?.(target, "cancel");
+        toast("Run canceled");
+      }}
+    />
   );
 }
 
@@ -250,12 +245,8 @@ export function StudioResults({ job, assets, type, columns, meta, pendingCount =
   const { updateAssetStatus } = useAppStatic();
   const results = job ? resolveJobResultAssets(job, assets, { type }) : [];
   const running = jobIsRunning(job);
-  const failure = jobFailure(job);
-  // A failed run produces no assets, so the old "no results ⇒ render nothing" guard swallowed
-  // the failure entirely. Show the reason instead.
-  if (failure && results.length === 0) {
-    return <JobFailureNotice failure={failure} />;
-  }
+  // Failure/outcome reporting lives in StudioRunStatus (the run strip above this), so this
+  // block is purely the output grid — a failed run simply has none.
   if (!job || (!running && results.length === 0)) {
     return null;
   }

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -221,11 +221,12 @@ export function jobIsRunning(job) {
 //
 // Unlike the Queue (which keeps every row), a studio clears the card once the run resolves
 // cleanly — see `jobClearsFromStudio`. A FAILED run keeps its card, because that card is the
-// only place a studio shows the worker's reason.
+// only place a studio shows the worker's reason — but the user can Dismiss it once read,
+// rather than being left staring at it. Dismissal is studio-local: the Queue row survives.
 export function StudioRunStatus({ job }) {
-  const { toast } = useSimpleUi();
+  const { toast, dismissedJobIds, dismissJob } = useSimpleUi();
   const { jobAction } = useAppStatic();
-  if (!job || jobClearsFromStudio(job)) {
+  if (!job || jobClearsFromStudio(job) || dismissedJobIds?.has(job.id)) {
     return null;
   }
   return (
@@ -235,6 +236,7 @@ export function StudioRunStatus({ job }) {
         await jobAction?.(target, "cancel");
         toast("Run canceled");
       }}
+      onDismiss={(target) => dismissJob(target.id)}
     />
   );
 }

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -5,7 +5,7 @@ import { resolveJobResultAssets } from "../jobResultAssets.js";
 import { terminalStatuses } from "../constants.js";
 import { STYLE_GROUPS } from "../data/styleCatalog.js";
 import { useAppStatic } from "../context/AppContext.js";
-import { SimpleJobCard } from "./SimpleJobCard.jsx";
+import { SimpleJobCard, jobClearsFromStudio } from "./SimpleJobCard.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
 
 // Shared building blocks for the three Simple studios (design handoff). Each one is
@@ -219,12 +219,13 @@ export function jobIsRunning(job) {
 // in front of them instead of one navigation away — and because it is one component, the two
 // surfaces cannot drift.
 //
-// It stays mounted after the run ends so the outcome (Done / the failure reason) is readable
-// where the run was started; the results grid renders below it.
+// Unlike the Queue (which keeps every row), a studio clears the card once the run resolves
+// cleanly — see `jobClearsFromStudio`. A FAILED run keeps its card, because that card is the
+// only place a studio shows the worker's reason.
 export function StudioRunStatus({ job }) {
   const { toast } = useSimpleUi();
   const { jobAction } = useAppStatic();
-  if (!job) {
+  if (!job || jobClearsFromStudio(job)) {
     return null;
   }
   return (

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -63,7 +63,7 @@ function StyleTile({ active, name, onSelect, styleId }) {
 // Reference / source-image tile. Armed state shows the design's "SET" badge plus a
 // thumbnail and the asset's display name; tapping an armed tile clears it, tapping an
 // empty one opens the picker sheet over the project's recent images.
-export function ReferenceTile({ label, hint, asset, assets, onChange, required = false }) {
+export function ReferenceTile({ label, hint, asset, assets, onChange, required = false, disabled = false }) {
   const { openSheet, toast } = useSimpleUi();
   const pick = useCallback(() => {
     if (asset) {
@@ -91,13 +91,20 @@ export function ReferenceTile({ label, hint, asset, assets, onChange, required =
   }, [asset, assets, onChange, openSheet, toast]);
 
   return (
-    <button className={asset ? "su-tile active" : "su-tile"} onClick={pick} type="button">
+    <button
+      className={asset && !disabled ? "su-tile active" : "su-tile"}
+      disabled={disabled}
+      onClick={pick}
+      type="button"
+    >
       <span className="su-tile-head">
         <Icon.Image size={15} />
         {label}
-        {asset ? <span className="su-set-badge">SET</span> : null}
+        {asset && !disabled ? <span className="su-set-badge">SET</span> : null}
       </span>
-      {asset ? (
+      {/* A disabled tile shows its REASON, never the armed thumbnail — an armed reference the
+          model can't consume must not read as active. */}
+      {asset && !disabled ? (
         <span className="su-tile-ref">
           <AssetThumbnail asset={asset} />
           <span>{asset.displayName ?? asset.id}</span>


### PR DESCRIPTION
Follow-up to #1791. The Simple Image Studio's **Reference tile silently did nothing on the Text tab.**

It armed, showed the `SET` badge and a thumbnail, and toasted "Reference attached" — then the id was routed to `sourceAssetId`, which `buildImageJobRequest` discards for any non-edit mode. So the run ignored the reference entirely. And because `IMAGE_DEFAULTS` hardcoded `supportsImg2img: false`, no `advanced.strength` was emitted either. The worst failure mode for a control: it looked like it worked.

## The routing

The single armed reference is now routed by **mode**, in `simpleJobs.js`:

| mode | channel | strength |
|---|---|---|
| `edit_image` | `sourceAssetId` — the image being edited | none; the model's edit pipeline owns the conditioning |
| `text_to_image` | `img2imgReferenceAssetId` + `supportsImg2img` | `advanced.strength` |

Text-mode reference-guided generation is a per-model capability (`ui.img2img`). **13 catalog entries declare it** — Z-Image ×2, Krea 2 ×2, SD3.5 ×3, SANA ×2, Ideogram 4 ×2, Boogu ×2 — all with `ui.img2imgStrength.default: 0.5`.

Simple shows no strength slider, so `referenceStrengthFor` reads the model's **own declared default** (falling back to 0.5). A catalog entry that tunes it is honored with no code change here.

On a model *without* the capability the tile stays visible — keeping the design's 2-up tile grid — but renders **disabled and names the reason**, and an armed-but-unusable reference drops its `SET` badge and thumbnail so it can't read as active.

## Why #1791's tests missed this

Worth recording, because both gaps were mine:

- the byte-identical payload test only covered the **styleless, referenceless** path, so it never exercised the reference at all
- the browser pass ran against a **scratch data dir with no assets**, so there was nothing to attach and the tile was never armed

Added: a shell-level test that drives the **real tile through the real picker sheet** and asserts the resulting payload, plus payload tests for both modes, the unsupported-model drop, the "nothing armed" case, and the strength resolution.

**Verified by mutation** — reintroducing the old routing reds 3 of them, including the shell test, so they genuinely discriminate rather than asserting a default.

## Verification

- **2415 web tests pass** (172 files, 9 new), **0 lint errors**; re-run after merging `main` (3 commits behind at push time)
- **Confirmed on the wire** against a live API with a real uploaded asset, intercepting the actual `POST /image/jobs` body:

```json
{ "model": "z_image", "mode": "text_to_image",
  "referenceAssetId": "asset_8e45f0cd…", "sourceAssetId": null,
  "advanced": { "resolution": "1024x1024", "mlxQuantize": 8, "strength": 0.5 } }
```

- Also confirmed in-browser: selecting Anima 2B (no `ui.img2img`) disables the tile with "Anima 2B can't use a reference image — switch model to use one."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
