### PR TITLE
sc-10371: make RunPod storage network-volume friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ docker build --secret id=inference_token,env=SCENEWORKS_INFERENCE_READ_TOKEN `
 
 docker run --gpus all --publish 8010:8010 `
   --env SCENEWORKS_ACCESS_TOKEN=choose-a-private-token `
-  --volume sceneworks-data:/sceneworks `
+  --volume sceneworks-data:/workspace `
   sceneworks-runpod:local
 ```
 
@@ -267,9 +267,33 @@ override. The same token is passed to every candle GPU and CPU utility worker.
 Loopback-only binds remain available without a token for local development.
 Tokens are operator-provided and are never generated or written to logs.
 
-On RunPod, attach the pod's persistent volume at `/sceneworks` in place of the
-example named volume. Provider-specific volume layout and ownership hardening
-are handled separately; this image only defines the shared mount contract.
+On a RunPod pod, attach the network volume at its normal `/workspace` mount. The
+single `SCENEWORKS_VOLUME` base defaults there and gives the following layout:
+
+- `/workspace/data` stores generated assets, projects, imported models, and
+  other application data.
+- `/workspace/config` stores configuration and user manifests.
+- `/workspace/cache/huggingface` stores downloaded Hugging Face models.
+- `/tmp/sceneworks/cache/jobs.db` remains on the pod's local ephemeral disk.
+  Queue state is transient, and SQLite locking is unreliable on NFS-style
+  network volumes. Set `SCENEWORKS_JOBS_DB_PATH` explicitly to persist it only
+  when the mounted filesystem has SQLite-safe locking; concurrent access or
+  lock failures are then the operator's responsibility.
+
+Set `SCENEWORKS_VOLUME=/runpod-volume` for a serverless network-volume mount, or
+another absolute container path for a custom mount. Explicit
+`SCENEWORKS_DATA_DIR`, `SCENEWORKS_CONFIG_DIR`, `SCENEWORKS_JOBS_DB_PATH`,
+`HF_HOME`, `HF_HUB_CACHE`, and `HUGGINGFACE_HUB_CACHE` values take precedence
+over derived defaults.
+
+The image intentionally runs as root, matching RunPod's default volume owner.
+At startup it creates and write-probes only the exact managed directories; it
+does not recursively `chown` a potentially large model volume. This also handles
+directories carrying a different numeric UID on ordinary pod mounts. If an NFS
+export uses root-squash or ACLs that deny even a bounded write probe, startup
+fails before the API launches with the exact path and an actionable permissions
+error; fix the export/ACL or use writable per-path overrides. No existing data
+is removed.
 
 Key knobs:
 

--- a/docker/runpod-entrypoint.sh
+++ b/docker/runpod-entrypoint.sh
@@ -26,6 +26,47 @@ trim_whitespace() {
   printf '%s' "${value}"
 }
 
+require_absolute_path() {
+  local label="$1"
+  local path="$2"
+  local non_slashes
+  case "${path}" in
+    /*) ;;
+    *)
+      log "${label} must be an absolute container path (got '${path}')"
+      return 1
+      ;;
+  esac
+  non_slashes="${path//\//}"
+  if [[ -z "${non_slashes}" ]]; then
+    log "${label} must name a managed subdirectory, not the filesystem root"
+    return 1
+  fi
+  case "${path}" in
+    */./* | */. | */../* | */..)
+      log "${label} must not contain '.' or '..' path segments (got '${path}')"
+      return 1
+      ;;
+  esac
+}
+
+ensure_writable_dir() {
+  local label="$1"
+  local dir="$2"
+  local probe
+
+  require_absolute_path "${label}" "${dir}" || return 1
+  if ! mkdir -p -- "${dir}"; then
+    log "cannot create ${label} at '${dir}'. The RunPod volume must be writable by the container root user."
+    return 1
+  fi
+  if ! probe="$(mktemp "${dir}/.sceneworks-write-test.XXXXXX")"; then
+    log "${label} at '${dir}' is not writable. This image runs as root and does not recursively chown network volumes; fix the mount's export/ACL permissions or choose a writable per-path override."
+    return 1
+  fi
+  rm -f -- "${probe}"
+}
+
 effective_api_host() {
   local host
   if [[ -v SCENEWORKS_API_HOST ]]; then
@@ -136,10 +177,54 @@ if ! is_loopback_host "${api_host}" && [[ -z "${access_token_trimmed}" ]]; then
 fi
 unset access_token_trimmed
 
-mkdir -p \
-  "${SCENEWORKS_DATA_DIR:-/sceneworks/data}/cache" \
-  "${SCENEWORKS_CONFIG_DIR:-/sceneworks/config}" \
-  "${HF_HOME:-/sceneworks/data/cache/huggingface}"
+# RunPod mounts a pod network volume at /workspace by default. Resolve every
+# durable default from that one base at runtime so changing SCENEWORKS_VOLUME is
+# enough; explicit per-path settings always win. Keep SQLite off NFS-style
+# storage unless the operator deliberately overrides SCENEWORKS_JOBS_DB_PATH.
+SCENEWORKS_VOLUME="${SCENEWORKS_VOLUME:-/workspace}"
+SCENEWORKS_DATA_DIR="${SCENEWORKS_DATA_DIR:-${SCENEWORKS_VOLUME}/data}"
+SCENEWORKS_CONFIG_DIR="${SCENEWORKS_CONFIG_DIR:-${SCENEWORKS_VOLUME}/config}"
+SCENEWORKS_JOBS_DB_PATH="${SCENEWORKS_JOBS_DB_PATH:-/tmp/sceneworks/cache/jobs.db}"
+HF_HOME="${HF_HOME:-${SCENEWORKS_VOLUME}/cache/huggingface}"
+
+# Preserve the resolver's documented cache-variable precedence. In particular,
+# an explicit legacy HUGGINGFACE_HUB_CACHE must not be shadowed by a generated
+# HF_HUB_CACHE value.
+if [[ -n "${HF_HUB_CACHE:-}" ]]; then
+  effective_hf_hub_cache="${HF_HUB_CACHE}"
+elif [[ -n "${HUGGINGFACE_HUB_CACHE:-}" ]]; then
+  effective_hf_hub_cache="${HUGGINGFACE_HUB_CACHE}"
+else
+  HF_HUB_CACHE="${HF_HOME}/hub"
+  HUGGINGFACE_HUB_CACHE="${HF_HUB_CACHE}"
+  effective_hf_hub_cache="${HF_HUB_CACHE}"
+fi
+
+export SCENEWORKS_VOLUME SCENEWORKS_DATA_DIR SCENEWORKS_CONFIG_DIR
+export SCENEWORKS_JOBS_DB_PATH HF_HOME HF_HUB_CACHE HUGGINGFACE_HUB_CACHE
+
+jobs_db_parent="${SCENEWORKS_JOBS_DB_PATH%/*}"
+if [[ -z "${jobs_db_parent}" && "${SCENEWORKS_JOBS_DB_PATH}" == /* ]]; then
+  jobs_db_parent="/"
+fi
+[[ "${jobs_db_parent}" != "${SCENEWORKS_JOBS_DB_PATH}" ]] || jobs_db_parent="."
+
+# The runtime is intentionally root so a newly attached root-owned volume and a
+# directory owned by a different numeric UID both work without a recursive
+# ownership walk over multi-gigabyte model caches. Restrict startup work to the
+# exact managed directories and verify writes before launching either child.
+require_absolute_path "SCENEWORKS_VOLUME" "${SCENEWORKS_VOLUME}" || exit 1
+require_absolute_path "SceneWorks data directory" "${SCENEWORKS_DATA_DIR}" || exit 1
+require_absolute_path "SceneWorks config directory" "${SCENEWORKS_CONFIG_DIR}" || exit 1
+require_absolute_path "Hugging Face home" "${HF_HOME}" || exit 1
+require_absolute_path "Hugging Face hub cache" "${effective_hf_hub_cache}" || exit 1
+require_absolute_path "jobs.db parent directory" "${jobs_db_parent}" || exit 1
+ensure_writable_dir "SceneWorks data directory" "${SCENEWORKS_DATA_DIR}" || exit 1
+ensure_writable_dir "SceneWorks config directory" "${SCENEWORKS_CONFIG_DIR}" || exit 1
+ensure_writable_dir "Hugging Face home" "${HF_HOME}" || exit 1
+ensure_writable_dir "Hugging Face hub cache" "${effective_hf_hub_cache}" || exit 1
+ensure_writable_dir "jobs.db parent directory" "${jobs_db_parent}" || exit 1
+unset effective_hf_hub_cache jobs_db_parent
 
 log "starting embedded-web API on ${api_host}:${api_port}"
 "${api_bin}" &

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -294,19 +294,15 @@ RUN chmod 0755 /usr/local/bin/sceneworks-runpod-entrypoint
 ENV SCENEWORKS_API_HOST=0.0.0.0 \
     SCENEWORKS_API_PORT=8010 \
     SCENEWORKS_API_URL=http://127.0.0.1:8010 \
-    SCENEWORKS_DATA_DIR=/sceneworks/data \
-    SCENEWORKS_CONFIG_DIR=/sceneworks/config \
-    SCENEWORKS_JOBS_DB_PATH=/sceneworks/data/cache/jobs.db \
+    SCENEWORKS_VOLUME=/workspace \
+    SCENEWORKS_JOBS_DB_PATH=/tmp/sceneworks/cache/jobs.db \
     SCENEWORKS_CANDLE_REQUIRED=1 \
     SCENEWORKS_CANDLE_UNSUPPORTED_MODE=enforce \
     SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1 \
-    SCENEWORKS_WORKER_ID=runpod-worker-0 \
-    HF_HOME=/sceneworks/data/cache/huggingface \
-    HF_HUB_CACHE=/sceneworks/data/cache/huggingface/hub \
-    HUGGINGFACE_HUB_CACHE=/sceneworks/data/cache/huggingface/hub
+    SCENEWORKS_WORKER_ID=runpod-worker-0
 
 EXPOSE 8010
-VOLUME ["/sceneworks"]
+VOLUME ["/workspace"]
 HEALTHCHECK --interval=20s --timeout=5s --retries=3 --start-period=10s \
     CMD curl -fsS "http://127.0.0.1:${SCENEWORKS_API_PORT:-8010}/api/v1/health" >/dev/null || exit 1
 

--- a/scripts/check-runpod-image.mjs
+++ b/scripts/check-runpod-image.mjs
@@ -42,8 +42,10 @@ for (const contract of [
   "COPY --from=embed-builder /out/sceneworks-rust-api",
   "COPY docker/runpod-entrypoint.sh",
   "SCENEWORKS_API_URL=http://127.0.0.1:8010",
+  "SCENEWORKS_VOLUME=/workspace",
+  "SCENEWORKS_JOBS_DB_PATH=/tmp/sceneworks/cache/jobs.db",
   "SCENEWORKS_CANDLE_REQUIRED=1",
-  'VOLUME ["/sceneworks"]',
+  'VOLUME ["/workspace"]',
   "/api/v1/health",
   'ENTRYPOINT ["/usr/local/bin/sceneworks-runpod-entrypoint"]',
 ]) {
@@ -111,7 +113,9 @@ for (const contract of [
   "--target runpod",
   "--gpus all",
   "--env SCENEWORKS_ACCESS_TOKEN=",
-  "--volume sceneworks-data:/sceneworks",
+  "--volume sceneworks-data:/workspace",
+  "SCENEWORKS_VOLUME=/runpod-volume",
+  "/tmp/sceneworks/cache/jobs.db",
 ]) {
   assert.ok(readme.includes(contract), `RunPod deployment docs are missing ${contract}`);
 }

--- a/scripts/check-runpod-supervisor.sh
+++ b/scripts/check-runpod-supervisor.sh
@@ -43,6 +43,20 @@ elif [[ -n "${SCENEWORKS_ACCESS_TOKEN:-}" ]]; then
 else
   printf 'api:token:absent\n' >>"${SCENEWORKS_TEST_EVENTS}"
 fi
+if [[ "${SCENEWORKS_TEST_RECORD_PATHS:-0}" == "1" ]]; then
+  printf 'api:paths:%s|%s|%s|%s|%s|%s\n' \
+    "${SCENEWORKS_VOLUME}" \
+    "${SCENEWORKS_DATA_DIR}" \
+    "${SCENEWORKS_CONFIG_DIR}" \
+    "${SCENEWORKS_JOBS_DB_PATH}" \
+    "${HF_HOME}" \
+    "${HF_HUB_CACHE:-${HUGGINGFACE_HUB_CACHE:-}}" \
+    >>"${SCENEWORKS_TEST_EVENTS}"
+  printf 'api:hf-env:%s|%s\n' \
+    "${HF_HUB_CACHE-<unset>}" \
+    "${HUGGINGFACE_HUB_CACHE-<unset>}" \
+    >>"${SCENEWORKS_TEST_EVENTS}"
+fi
 printf 'api:start\n' >>"${SCENEWORKS_TEST_EVENTS}"
 trap 'printf "api:term\n" >>"${SCENEWORKS_TEST_EVENTS}"; exit 0' TERM INT HUP
 while true; do sleep 0.1; done
@@ -140,6 +154,205 @@ assert_public_bind_rejected "public-v4-blank" "0.0.0.0" $' \t '
 assert_public_bind_rejected "public-v4-override" "0.0.0.0" "unset" "1"
 assert_public_bind_rejected "public-v6-bare" "::" "unset"
 assert_public_bind_rejected "public-v6-bracketed" "[::]" "unset"
+
+assert_storage_rejected() {
+  local label="$1"
+  shift
+  local run_dir="${temp_root}/${label}"
+  local status
+  mkdir -p "${run_dir}"
+
+  set +e
+  env -u SCENEWORKS_DATA_DIR \
+    -u SCENEWORKS_CONFIG_DIR \
+    -u SCENEWORKS_JOBS_DB_PATH \
+    -u HF_HOME \
+    -u HF_HUB_CACHE \
+    -u HUGGINGFACE_HUB_CACHE \
+    SCENEWORKS_API_HOST=127.0.0.1 \
+    SCENEWORKS_ACCESS_TOKEN= \
+    SCENEWORKS_TEST_EVENTS="${run_dir}/events" \
+    SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+    SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+    "$@" \
+    bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
+  status=$?
+  set -e
+
+  [[ "${status}" -eq 1 ]] || fail "${label} status was ${status}, expected 1"
+  [[ ! -e "${run_dir}/events" ]] || fail "${label} started a child with invalid storage paths"
+  grep -Fq "must " "${run_dir}/stderr" || fail "${label} lacked an actionable path error"
+}
+
+# Empty settings use their safe derived defaults, but relative container paths
+# and a jobs database whose parent is filesystem root are rejected before any
+# process starts.
+assert_storage_rejected "relative-volume" SCENEWORKS_VOLUME=relative
+assert_storage_rejected "slash-only-root-volume" SCENEWORKS_VOLUME=//
+assert_storage_rejected "dot-segment-volume" SCENEWORKS_VOLUME=/workspace/..
+assert_storage_rejected \
+  "relative-data-override" \
+  SCENEWORKS_VOLUME="${temp_root}/valid-base" \
+  SCENEWORKS_DATA_DIR=relative-data
+assert_storage_rejected \
+  "root-alias-data-override" \
+  SCENEWORKS_VOLUME="${temp_root}/valid-base" \
+  SCENEWORKS_DATA_DIR=/tmp/..
+assert_storage_rejected \
+  "root-jobs-parent" \
+  SCENEWORKS_VOLUME="${temp_root}/valid-base" \
+  SCENEWORKS_JOBS_DB_PATH=/jobs.db
+assert_storage_rejected \
+  "dot-segment-jobs-parent" \
+  SCENEWORKS_VOLUME="${temp_root}/valid-base" \
+  SCENEWORKS_JOBS_DB_PATH=/tmp/../jobs.db
+
+# A missing token must also fail before the new single-volume defaults create
+# anything. Do not let the security preflight regress behind storage setup.
+run_dir="${temp_root}/public-volume-no-side-effects"
+mkdir -p "${run_dir}"
+set +e
+env -u SCENEWORKS_ACCESS_TOKEN \
+  -u SCENEWORKS_DATA_DIR \
+  -u SCENEWORKS_CONFIG_DIR \
+  -u SCENEWORKS_JOBS_DB_PATH \
+  -u HF_HOME \
+  -u HF_HUB_CACHE \
+  -u HUGGINGFACE_HUB_CACHE \
+  SCENEWORKS_API_HOST=0.0.0.0 \
+  SCENEWORKS_VOLUME="${run_dir}/volume" \
+  SCENEWORKS_TEST_EVENTS="${run_dir}/events" \
+  SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+  SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+  bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
+status=$?
+set -e
+[[ "${status}" -eq 1 ]] || fail "public volume preflight status was ${status}, expected 1"
+[[ ! -e "${run_dir}/events" ]] || fail "public volume preflight started a child"
+[[ ! -e "${run_dir}/volume" ]] || fail "public volume preflight touched the volume"
+
+# One base must derive every durable default, while the jobs database stays on
+# the explicitly selected ephemeral path. The persisted marker proves startup
+# never replaces or clears a reused mount.
+run_dir="${temp_root}/volume-layout"
+mkdir -p "${run_dir}/volume"
+printf 'keep-me\n' >"${run_dir}/volume/existing-model-marker"
+events="${run_dir}/events"
+env -u SCENEWORKS_DATA_DIR \
+  -u SCENEWORKS_CONFIG_DIR \
+  -u HF_HOME \
+  -u HF_HUB_CACHE \
+  -u HUGGINGFACE_HUB_CACHE \
+  SCENEWORKS_DATA_DIR= \
+  SCENEWORKS_CONFIG_DIR= \
+  HF_HOME= \
+  HF_HUB_CACHE= \
+  HUGGINGFACE_HUB_CACHE= \
+  SCENEWORKS_TEST_EVENTS="${events}" \
+  SCENEWORKS_TEST_RECORD_PATHS=1 \
+  SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
+  SCENEWORKS_API_HOST=127.0.0.1 \
+  SCENEWORKS_ACCESS_TOKEN= \
+  SCENEWORKS_VOLUME="${run_dir}/volume" \
+  SCENEWORKS_JOBS_DB_PATH="${run_dir}/ephemeral/jobs.db" \
+  SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+  SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+  SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
+  SCENEWORKS_READINESS_MAX_ATTEMPTS=5 \
+  SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
+  SCENEWORKS_SHUTDOWN_GRACE_ATTEMPTS=6 \
+  SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
+  bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
+supervisor_pid=$!
+wait_for_event \
+  "api:paths:${run_dir}/volume|${run_dir}/volume/data|${run_dir}/volume/config|${run_dir}/ephemeral/jobs.db|${run_dir}/volume/cache/huggingface|${run_dir}/volume/cache/huggingface/hub" \
+  "${events}"
+wait_for_event \
+  "api:hf-env:${run_dir}/volume/cache/huggingface/hub|${run_dir}/volume/cache/huggingface/hub" \
+  "${events}"
+wait_for_event "worker:start:http://127.0.0.1:8010:auto" "${events}"
+kill -TERM "${supervisor_pid}"
+wait "${supervisor_pid}"
+[[ -f "${run_dir}/volume/existing-model-marker" ]] ||
+  fail "startup removed existing persistent-volume data"
+[[ -d "${run_dir}/volume/data" ]] || fail "derived data directory was not created"
+[[ -d "${run_dir}/volume/config" ]] || fail "derived config directory was not created"
+[[ -d "${run_dir}/volume/cache/huggingface/hub" ]] ||
+  fail "derived Hugging Face cache was not created"
+[[ ! -e "${run_dir}/volume/tmp" ]] || fail "ephemeral jobs data landed on persistent volume"
+if find "${run_dir}" -name '.sceneworks-write-test.*' -print -quit | grep -q .; then
+  fail "startup left a write-probe artifact behind"
+fi
+
+# Explicit paths beat the base independently. Also exercise the legacy HF cache
+# override without allowing a generated HF_HUB_CACHE to shadow it.
+run_dir="${temp_root}/volume-overrides"
+mkdir -p "${run_dir}"
+events="${run_dir}/events"
+env -u HF_HUB_CACHE \
+  SCENEWORKS_TEST_EVENTS="${events}" \
+  SCENEWORKS_TEST_RECORD_PATHS=1 \
+  SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
+  SCENEWORKS_API_HOST=127.0.0.1 \
+  SCENEWORKS_ACCESS_TOKEN= \
+  SCENEWORKS_VOLUME= \
+  SCENEWORKS_DATA_DIR="${run_dir}/custom-data" \
+  SCENEWORKS_CONFIG_DIR="${run_dir}/custom-config" \
+  SCENEWORKS_JOBS_DB_PATH="${run_dir}/custom-runtime/jobs.db" \
+  HF_HOME="${run_dir}/custom-hf-home" \
+  HUGGINGFACE_HUB_CACHE="${run_dir}/legacy-hub-cache" \
+  SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+  SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+  SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
+  SCENEWORKS_READINESS_MAX_ATTEMPTS=5 \
+  SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
+  SCENEWORKS_SHUTDOWN_GRACE_ATTEMPTS=6 \
+  SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
+  bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
+supervisor_pid=$!
+wait_for_event \
+  "api:paths:/workspace|${run_dir}/custom-data|${run_dir}/custom-config|${run_dir}/custom-runtime/jobs.db|${run_dir}/custom-hf-home|${run_dir}/legacy-hub-cache" \
+  "${events}"
+wait_for_event "api:hf-env:<unset>|${run_dir}/legacy-hub-cache" "${events}"
+wait_for_event "worker:start:http://127.0.0.1:8010:auto" "${events}"
+kill -TERM "${supervisor_pid}"
+wait "${supervisor_pid}"
+
+# When both hub-cache spellings are explicit, HF_HUB_CACHE remains the effective
+# high-priority value and neither operator setting is rewritten.
+run_dir="${temp_root}/hf-both-overrides"
+mkdir -p "${run_dir}"
+events="${run_dir}/events"
+SCENEWORKS_TEST_EVENTS="${events}" \
+SCENEWORKS_TEST_RECORD_PATHS=1 \
+SCENEWORKS_TEST_CURL_COUNT="${run_dir}/curl-count" \
+SCENEWORKS_API_HOST=127.0.0.1 \
+SCENEWORKS_ACCESS_TOKEN= \
+SCENEWORKS_VOLUME="${run_dir}/volume" \
+SCENEWORKS_DATA_DIR="${run_dir}/data" \
+SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+SCENEWORKS_JOBS_DB_PATH="${run_dir}/runtime/jobs.db" \
+HF_HOME="${run_dir}/hf-home" \
+HF_HUB_CACHE="${run_dir}/priority-hub-cache" \
+HUGGINGFACE_HUB_CACHE="${run_dir}/legacy-hub-cache" \
+SCENEWORKS_API_BIN="${temp_root}/fake-api" \
+SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
+SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
+SCENEWORKS_READINESS_MAX_ATTEMPTS=5 \
+SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
+SCENEWORKS_SHUTDOWN_GRACE_ATTEMPTS=6 \
+SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
+bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
+supervisor_pid=$!
+wait_for_event \
+  "api:paths:${run_dir}/volume|${run_dir}/data|${run_dir}/config|${run_dir}/runtime/jobs.db|${run_dir}/hf-home|${run_dir}/priority-hub-cache" \
+  "${events}"
+wait_for_event \
+  "api:hf-env:${run_dir}/priority-hub-cache|${run_dir}/legacy-hub-cache" \
+  "${events}"
+wait_for_event "worker:start:http://127.0.0.1:8010:auto" "${events}"
+kill -TERM "${supervisor_pid}"
+wait "${supervisor_pid}"
 
 run_dir="${temp_root}/signal"
 mkdir -p "${run_dir}"


### PR DESCRIPTION
## Summary
- derive RunPod data, config, and Hugging Face cache paths from one `SCENEWORKS_VOLUME` base (default `/workspace`) while preserving every explicit per-path override
- keep `jobs.db` on local ephemeral storage by default and document the SQLite/NFS override risk
- validate and write-probe only exact managed directories, reject relative/root-alias paths before side effects, and avoid recursive volume chown
- expand deterministic lifecycle coverage for auth ordering, persistence, override/HF precedence, path safety, and probe cleanup

## Validation
- independent adversarial review: PASS (high confidence)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`; `cargo build`
- web lint (0 errors), 2,406 Vitest tests, production build
- 52 Python unit tests; 12 contract parity tests
- scaffold, Compose, RunPod image, and expanded supervisor contracts
- built `runpod` target; live healthy root-owned + UID-4242/mode-0700 mounts
- same named volume reused across fresh containers: assets/models/config/HF markers persisted; local marker did not; jobs DB stayed under `/tmp`
- read-only mount failed pre-child with exact actionable path; public no-token guard remained before path validation

The host FFmpeg e2e lane had its known unrelated 240-resolution fixture failure (4 other e2e tests passed); CI intentionally does not provision ffmpeg and skips that fixture.

Shortcut: sc-10371