### PR TITLE
Audio Studio redesign — take grid, play deck, Simple UI + Assets audio (epic 14361)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -998,6 +998,18 @@ export function App() {
         .slice(0, 20),
     [assets, activeProject?.id],
   );
+  // The audio twin of recentImage/recentVideoAssets (epic 14361): the Audio Studio's results
+  // zone groups this session's runs AND the project's recent clips, so "Latest audio" is
+  // populated on a fresh launch instead of empty until you generate something.
+  const recentAudioAssets = useMemo(
+    () =>
+      assets
+        .filter((asset) => asset.type === "audio" && (!activeProject?.id || asset.projectId === activeProject.id))
+        .slice()
+        .sort(sortNewest)
+        .slice(0, 20),
+    [assets, activeProject?.id],
+  );
   const imageLocalJobs = useMemo(
     () => buildLocalJobStack(localGenerationJobIds.image, jobs, activeProject?.id, isImageGenerationJob),
     [activeProject?.id, jobs, localGenerationJobIds.image],
@@ -2406,6 +2418,7 @@ export function App() {
     latestVideoAssets,
     recentImageAssets,
     recentVideoAssets,
+    recentAudioAssets,
     studioLaunch,
     // sc-8730: Image Editor launch channel + the two Edit paths. sendAssetToImageEditor
     // routes to the editor canvas (FullscreenPreview Edit button); sendAssetToImageEdit
@@ -2530,7 +2543,7 @@ export function App() {
     jobAction, clearCompletedJobs, cancelPendingJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
     projectFilter, setProjectFilter, projects,
     createVideoJob, createVideoUpscaleJob, createImageJob, createAudioJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
-    recentVideoAssets, studioLaunch,
+    recentVideoAssets, recentAudioAssets, studioLaunch,
     editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,
     rememberLocalGenerationJob, personTracks, createPersonDetectionJob,
     createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, audioModels, models, macCapabilities,

--- a/apps/web/src/audioTakes.js
+++ b/apps/web/src/audioTakes.js
@@ -1,0 +1,244 @@
+import { terminalStatuses } from "./jobTypes.js";
+import { jobAudioResultAssets } from "./jobResultAssets.js";
+
+// Shared, pure derivations behind the Audio Studio redesign (epic 14361). The take grid,
+// the play deck and the Simple UI surfaces all read a run's mode, model, settings chips and
+// relative time from these — so the Advanced screen and the Simple screen can't disagree
+// about what a run was.
+//
+// Everything here is DERIVED, never stored: a "run" is a job in the audio local-job lane,
+// its takes are the assets that job produced, and the header chips are read off the job's
+// own submitted `payload`. No new API surface.
+
+export const AUDIO_MODE_LABELS = Object.freeze({
+  speech: "Speech",
+  sfx: "Sound FX",
+  music: "Music",
+  voiceclone: "Voice Clone",
+});
+
+// m:ss clock for every transport read-out. Clamps NaN/negative to 0:00.
+export function formatClock(seconds) {
+  const total = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+// Coarse relative time for a run header ("just now" / "2 min ago" / "3 h ago" / "2 d ago").
+// Deliberately coarse: the header is a glance surface, not a log.
+export function formatRelativeTime(timestamp, nowMs = Date.now()) {
+  const then = Date.parse(timestamp ?? "");
+  if (!Number.isFinite(then)) {
+    return "";
+  }
+  const seconds = Math.max(0, Math.floor((nowMs - then) / 1000));
+  if (seconds < 45) {
+    return "just now";
+  }
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} min ago`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return `${hours} h ago`;
+  }
+  return `${Math.round(hours / 24)} d ago`;
+}
+
+// Which audio mode produced a run. The audio job DTO carries no `mode` field — the mode is
+// a STUDIO concept, not a request one — so it is inferred from the knobs the run actually
+// submitted, in the order that makes each one unambiguous:
+//   reference clip ⇒ Voice Clone · music sub-block or an edit band ⇒ Music ·
+//   a voice / dialogue script ⇒ Speech · otherwise the residual text→audio generator ⇒ SFX.
+// The selected model's advertised capabilities break the remaining ties (a bare Speech run
+// with no voice picked still reads as Speech because its model ships a voice bank).
+export function audioJobMode(job, model = null) {
+  const payload = job?.payload ?? {};
+  if (payload.referenceAudioAssetId) {
+    return "voiceclone";
+  }
+  if (payload.bpm != null || payload.musicalKey || payload.lyrics != null || payload.editMode) {
+    return "music";
+  }
+  if (payload.voice || (Array.isArray(payload.script) && payload.script.length > 0)) {
+    return "speech";
+  }
+  const audio = model?.audio && typeof model.audio === "object" ? model.audio : null;
+  if (audio) {
+    if (Array.isArray(audio.editModes) && audio.editModes.length > 0) {
+      return "music";
+    }
+    if (
+      (Array.isArray(audio.voices) && audio.voices.length > 0) ||
+      audio.supportsMultiSpeaker
+    ) {
+      return "speech";
+    }
+  }
+  return "sfx";
+}
+
+// The run's own parameters, as the short mono chips the group header shows. Read straight
+// off the submitted payload so a chip can never claim a setting the run didn't carry.
+export function audioRunChips(job) {
+  const payload = job?.payload ?? {};
+  const chips = [];
+  if (payload.voice) {
+    chips.push(String(payload.voice));
+  }
+  if (payload.language) {
+    chips.push(String(payload.language));
+  }
+  if (payload.bpm != null && payload.bpm !== "") {
+    chips.push(`${payload.bpm} BPM`);
+  }
+  if (payload.musicalKey) {
+    chips.push(String(payload.musicalKey));
+  }
+  if (payload.editMode) {
+    chips.push(String(payload.editMode));
+  }
+  const duration = Number(payload.targetDurationSecs);
+  if (Number.isFinite(duration) && duration > 0) {
+    chips.push(`${Math.round(duration)} s`);
+  }
+  if (payload.seed !== null && payload.seed !== undefined && payload.seed !== "") {
+    chips.push(`seed ${payload.seed}`);
+  }
+  return chips;
+}
+
+// Display name for the model a run used: the catalog's label when the model is still
+// installed, else the raw id the payload recorded (a run whose model was since removed
+// still names what produced it).
+export function audioRunModelName(job, models = []) {
+  const id = job?.payload?.model ?? "";
+  const match = (models ?? []).find((item) => item?.id === id);
+  return match?.name ?? match?.ui?.label ?? id;
+}
+
+// True while a run is still producing — the in-flight strip's gate.
+export function audioJobIsRunning(job) {
+  return Boolean(job) && !terminalStatuses.has(job.status);
+}
+
+// The run stack the results zone renders: one group per job in the audio local-job lane,
+// newest first, each carrying its resolved takes. In-flight and failed runs are included
+// (with no takes yet) so the caller can pin them above the completed groups.
+export function audioRunGroups(jobs, assets, models = []) {
+  return (Array.isArray(jobs) ? jobs : []).map((job) => {
+    const takes = jobAudioResultAssets(job, assets);
+    const model = (models ?? []).find((item) => item?.id === job?.payload?.model) ?? null;
+    const mode = audioJobMode(job, model);
+    return {
+      job,
+      id: job.id,
+      mode,
+      modeLabel: AUDIO_MODE_LABELS[mode] ?? mode,
+      modelName: audioRunModelName(job, models),
+      chips: audioRunChips(job),
+      takes,
+      running: audioJobIsRunning(job),
+      createdAt: job.createdAt ?? job.startedAt ?? null,
+      replayable: Boolean(job.payload),
+    };
+  });
+}
+
+// A run reconstructed from an asset's own REPLAY RECORD (`recipe` + `normalizedSettings`,
+// written by project_store) rather than from a live job. This is what populates "Latest
+// audio" on a fresh launch: the local-job lane only holds the runs THIS session enqueued, so
+// without it the surface is empty until you generate something — which is not what the
+// design's "last N clips in this project" head describes.
+//
+// The replay record is deliberately narrower than a job payload (it keeps voice / language /
+// requested length / seed, not the music sub-block), so an asset-derived group shows the
+// chips the asset actually recorded and no more.
+function assetRunPayload(asset) {
+  const recipe = asset?.recipe ?? {};
+  const settings = recipe.normalizedSettings ?? {};
+  const payload = { model: recipe.model ?? "" };
+  if (typeof recipe.prompt === "string" && recipe.prompt.trim()) {
+    payload.prompt = recipe.prompt.trim();
+  }
+  if (settings.voice) {
+    payload.voice = settings.voice;
+  }
+  if (settings.language) {
+    payload.language = settings.language;
+  }
+  if (settings.targetDurationSecs != null) {
+    payload.targetDurationSecs = settings.targetDurationSecs;
+  }
+  if (recipe.seed != null) {
+    payload.seed = recipe.seed;
+  }
+  if (recipe.mode === "voice_clone") {
+    // Enough for audioJobMode to classify it; a replay needs the reference clip the user
+    // re-picks, so the group offers no Run again (see `replayable` below).
+    payload.referenceAudioAssetId = asset?.lineage?.sourceAssetId ?? "";
+  }
+  return payload;
+}
+
+// Project-recent clips as run groups, newest first, skipping any asset a live job group
+// already covers. One group per generation set (the run identity the asset records).
+export function audioAssetRunGroups(assets, models = [], coveredAssetIds = new Set()) {
+  const groups = [];
+  const byRun = new Map();
+  for (const asset of Array.isArray(assets) ? assets : []) {
+    if (!asset || asset.type !== "audio" || coveredAssetIds.has(asset.id)) {
+      continue;
+    }
+    const key = asset.generationSetId ?? `asset:${asset.id}`;
+    const existing = byRun.get(key);
+    if (existing) {
+      existing.takes.push(asset);
+      continue;
+    }
+    const payload = assetRunPayload(asset);
+    const job = { id: `run:${key}`, status: "completed", createdAt: asset.createdAt ?? null, payload };
+    const model = (models ?? []).find((item) => item?.id === payload.model) ?? null;
+    const mode = audioJobMode(job, model);
+    const group = {
+      job,
+      id: job.id,
+      mode,
+      modeLabel: AUDIO_MODE_LABELS[mode] ?? mode,
+      modelName: audioRunModelName(job, models),
+      chips: audioRunChips(job),
+      takes: [asset],
+      running: false,
+      createdAt: asset.createdAt ?? null,
+      // A voice clone can't be replayed without re-picking its reference clip, and a run
+      // whose model is gone can't be replayed at all — so those groups hide "Run again"
+      // rather than offering a button that would fail.
+      replayable: mode !== "voiceclone" && Boolean(model),
+    };
+    byRun.set(key, group);
+    groups.push(group);
+  }
+  // The groups themselves arrive newest-first (the recent-assets order), but the takes INSIDE
+  // a run are numbered "Take 1..N" in the order the run produced them — so sort each run's
+  // takes oldest-first or Take 1 would label the last clip rendered.
+  for (const group of groups) {
+    group.takes.sort((a, b) => Date.parse(a.createdAt ?? 0) - Date.parse(b.createdAt ?? 0));
+  }
+  return groups;
+}
+
+// Expected take count for an in-flight run — what the worker declared, when it has. Absent
+// ⇒ the strip simply omits the "N takes" clause rather than guessing.
+export function audioExpectedTakes(job) {
+  const declared = Number(job?.result?.expectedCount);
+  return Number.isFinite(declared) && declared > 0 ? declared : null;
+}
+
+// The line a take card / deck shows as its title: the prompt the run submitted, falling
+// back to the asset's own display name for an imported or legacy clip.
+export function audioTakeTitle(job, asset) {
+  const prompt = typeof job?.payload?.prompt === "string" ? job.payload.prompt.trim() : "";
+  return prompt || asset?.displayName || "Untitled clip";
+}

--- a/apps/web/src/audioTakes.test.js
+++ b/apps/web/src/audioTakes.test.js
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  audioExpectedTakes,
+  audioJobMode,
+  audioRunChips,
+  audioRunGroups,
+  audioRunModelName,
+  audioTakeTitle,
+  formatClock,
+  formatRelativeTime,
+} from "./audioTakes.js";
+
+// Run grouping + header derivations for the Audio Studio redesign (epic 14361 / sc-14364).
+// Everything here is derived from the job's OWN payload and the live asset catalog — these
+// pin that a header can never claim a setting the run didn't carry.
+
+const KOKORO = { id: "kokoro_82m", name: "Kokoro 82M", audio: { voices: [{ id: "af_heart" }] } };
+const ACESTEP = { id: "acestep", name: "ACE-Step Turbo", audio: { editModes: ["extend"] } };
+const MOSS = { id: "moss_sfx", name: "MOSS SoundEffect", audio: { languages: ["en"] } };
+
+describe("formatClock", () => {
+  it("renders m:ss and clamps junk to 0:00", () => {
+    expect(formatClock(0)).toBe("0:00");
+    expect(formatClock(9.7)).toBe("0:09");
+    expect(formatClock(125)).toBe("2:05");
+    expect(formatClock(Number.NaN)).toBe("0:00");
+    expect(formatClock(-4)).toBe("0:00");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  const now = Date.parse("2026-07-24T12:00:00Z");
+  it("steps from 'just now' up to days", () => {
+    expect(formatRelativeTime("2026-07-24T11:59:50Z", now)).toBe("just now");
+    expect(formatRelativeTime("2026-07-24T11:58:00Z", now)).toBe("2 min ago");
+    expect(formatRelativeTime("2026-07-24T09:00:00Z", now)).toBe("3 h ago");
+    expect(formatRelativeTime("2026-07-22T12:00:00Z", now)).toBe("2 d ago");
+  });
+
+  it("is empty for a missing or unparseable timestamp", () => {
+    expect(formatRelativeTime(null, now)).toBe("");
+    expect(formatRelativeTime("not a date", now)).toBe("");
+  });
+});
+
+describe("audioJobMode", () => {
+  it("reads Voice Clone off the reference clip, ahead of every other signal", () => {
+    const job = { payload: { referenceAudioAssetId: "asset-1", voice: "af_heart", bpm: 120 } };
+    expect(audioJobMode(job, KOKORO)).toBe("voiceclone");
+  });
+
+  it("reads Music off the music sub-block or an edit band", () => {
+    expect(audioJobMode({ payload: { bpm: 128 } })).toBe("music");
+    expect(audioJobMode({ payload: { musicalKey: "C minor" } })).toBe("music");
+    expect(audioJobMode({ payload: { editMode: "extend" } })).toBe("music");
+  });
+
+  it("reads Speech off a voice or a dialogue script", () => {
+    expect(audioJobMode({ payload: { voice: "af_heart" } })).toBe("speech");
+    expect(audioJobMode({ payload: { script: [{ text: "hi" }] } })).toBe("speech");
+  });
+
+  it("falls back to the model's advertised capabilities when the payload is bare", () => {
+    // A bare prompt-only run: the model's own capability block breaks the tie.
+    expect(audioJobMode({ payload: { prompt: "a door slam" } }, KOKORO)).toBe("speech");
+    expect(audioJobMode({ payload: { prompt: "a piano loop" } }, ACESTEP)).toBe("music");
+    expect(audioJobMode({ payload: { prompt: "a door slam" } }, MOSS)).toBe("sfx");
+    // No model at all ⇒ the residual text→audio generator.
+    expect(audioJobMode({ payload: { prompt: "a door slam" } }, null)).toBe("sfx");
+  });
+});
+
+describe("audioRunChips", () => {
+  it("lists only the settings the run actually submitted", () => {
+    expect(
+      audioRunChips({
+        payload: { voice: "af_heart", language: "en-US", targetDurationSecs: 12, seed: 4821 },
+      }),
+    ).toEqual(["af_heart", "en-US", "12 s", "seed 4821"]);
+  });
+
+  it("carries the music sub-block and omits cleared knobs", () => {
+    expect(audioRunChips({ payload: { bpm: 128, musicalKey: "C minor", seed: null } })).toEqual([
+      "128 BPM",
+      "C minor",
+    ]);
+  });
+
+  it("keeps seed 0 — a real, reproducible seed, not an empty value", () => {
+    expect(audioRunChips({ payload: { seed: 0 } })).toEqual(["seed 0"]);
+  });
+
+  it("is empty for a run with no recorded payload", () => {
+    expect(audioRunChips({})).toEqual([]);
+  });
+});
+
+describe("audioRunModelName", () => {
+  it("prefers the catalog label and falls back to the recorded id", () => {
+    expect(audioRunModelName({ payload: { model: "kokoro_82m" } }, [KOKORO])).toBe("Kokoro 82M");
+    // The model was uninstalled since the run — the header still names what produced it.
+    expect(audioRunModelName({ payload: { model: "kokoro_82m" } }, [])).toBe("kokoro_82m");
+  });
+});
+
+describe("audioRunGroups", () => {
+  const assets = [
+    { id: "a1", type: "audio", displayName: "Take 1" },
+    { id: "a2", type: "audio", displayName: "Take 2" },
+  ];
+  const jobs = [
+    {
+      id: "job-running",
+      status: "running",
+      createdAt: "2026-07-24T12:00:00Z",
+      payload: { model: "acestep", bpm: 128 },
+      result: { expectedCount: 3 },
+    },
+    {
+      id: "job-done",
+      status: "completed",
+      createdAt: "2026-07-24T11:00:00Z",
+      payload: { model: "kokoro_82m", voice: "af_heart" },
+      result: { assetIds: ["a1", "a2"] },
+    },
+  ];
+
+  it("resolves one group per run, in lane order, with its takes and header facts", () => {
+    const groups = audioRunGroups(jobs, assets, [KOKORO, ACESTEP]);
+    expect(groups.map((group) => group.id)).toEqual(["job-running", "job-done"]);
+
+    expect(groups[0].running).toBe(true);
+    expect(groups[0].mode).toBe("music");
+    expect(groups[0].modeLabel).toBe("Music");
+    expect(groups[0].modelName).toBe("ACE-Step Turbo");
+    expect(groups[0].takes).toEqual([]);
+
+    expect(groups[1].running).toBe(false);
+    expect(groups[1].mode).toBe("speech");
+    expect(groups[1].takes.map((asset) => asset.id)).toEqual(["a1", "a2"]);
+    expect(groups[1].chips).toEqual(["af_heart"]);
+    expect(groups[1].createdAt).toBe("2026-07-24T11:00:00Z");
+  });
+
+  it("is empty for an empty lane", () => {
+    expect(audioRunGroups([], assets, [])).toEqual([]);
+  });
+});
+
+describe("audioExpectedTakes", () => {
+  it("reports only a declared, positive count", () => {
+    expect(audioExpectedTakes({ result: { expectedCount: 3 } })).toBe(3);
+    expect(audioExpectedTakes({ result: { expectedCount: 0 } })).toBeNull();
+    expect(audioExpectedTakes({})).toBeNull();
+  });
+});
+
+describe("audioTakeTitle", () => {
+  it("prefers the run's prompt, falling back to the asset's display name", () => {
+    expect(audioTakeTitle({ payload: { prompt: "  rain at the door  " } }, { displayName: "x" })).toBe(
+      "rain at the door",
+    );
+    expect(audioTakeTitle({ payload: { prompt: "   " } }, { displayName: "Imported clip" })).toBe(
+      "Imported clip",
+    );
+    expect(audioTakeTitle(null, {})).toBe("Untitled clip");
+  });
+});

--- a/apps/web/src/audioWaveform.js
+++ b/apps/web/src/audioWaveform.js
@@ -1,0 +1,214 @@
+import { useEffect, useState } from "react";
+import { assetCanRenderAsAudio, assetUrl } from "./components/assetMedia.jsx";
+
+// Waveform peaks for the Audio Studio redesign (epic 14361 / sc-14362).
+//
+// Every audio surface in the redesign — the take card, the play-deck stage, the Simple
+// take grid and the Simple Assets tile/viewer — draws the clip as a bar waveform. The
+// peaks are DERIVED FROM THE RENDERED AUDIO, client-side: the clip is fetched once and
+// decoded through the Web Audio API, then downsampled to a fixed-resolution peak array
+// that every surface shares. (The design bundle ships a `waveforms.json` of synthetic
+// paths; those are mock stand-ins and deliberately do NOT ship.)
+//
+// Degradation is total and silent: no AudioContext (jsdom, an old webview), no fetch, a
+// 404 on a purged clip or an undecodable codec all resolve to `null`, and the renderer
+// draws a flat idle bar row. A failure is remembered so a broken asset is never re-fetched
+// on every re-render.
+
+// Peak resolution the decoder caches at. Each surface resamples DOWN from this to its own
+// bar count, so one decode serves the 22-bar Assets tile and the 96-bar deck stage alike.
+export const PEAK_RESOLUTION = 160;
+
+// Downsample raw PCM samples to `bars` normalized 0..1 peaks — the max absolute amplitude
+// in each window, scaled so the loudest bar is 1. A silent clip yields all-zero peaks
+// (drawn as the minimum bar), never NaN.
+export function peaksFromSamples(samples, bars = PEAK_RESOLUTION) {
+  const count = Math.max(1, Math.floor(bars));
+  const out = new Array(count).fill(0);
+  const total = samples?.length ?? 0;
+  if (total === 0) {
+    return out;
+  }
+  const window = total / count;
+  let loudest = 0;
+  for (let bar = 0; bar < count; bar += 1) {
+    const start = Math.floor(bar * window);
+    const end = Math.min(total, Math.max(start + 1, Math.floor((bar + 1) * window)));
+    let peak = 0;
+    for (let index = start; index < end; index += 1) {
+      const value = Math.abs(samples[index]);
+      if (value > peak) {
+        peak = value;
+      }
+    }
+    out[bar] = peak;
+    if (peak > loudest) {
+      loudest = peak;
+    }
+  }
+  if (loudest > 0) {
+    for (let bar = 0; bar < count; bar += 1) {
+      out[bar] /= loudest;
+    }
+  }
+  return out;
+}
+
+// Resample a cached peak array to `bars` entries (max within each window), so one decode
+// drives every bar count in the UI.
+export function resamplePeaks(peaks, bars) {
+  const source = Array.isArray(peaks) ? peaks : [];
+  const count = Math.max(1, Math.floor(bars));
+  if (source.length === 0) {
+    return new Array(count).fill(0);
+  }
+  if (source.length === count) {
+    return source;
+  }
+  const out = new Array(count).fill(0);
+  const window = source.length / count;
+  for (let bar = 0; bar < count; bar += 1) {
+    const start = Math.floor(bar * window);
+    const end = Math.min(source.length, Math.max(start + 1, Math.floor((bar + 1) * window)));
+    let peak = 0;
+    for (let index = start; index < end; index += 1) {
+      if (source[index] > peak) {
+        peak = source[index];
+      }
+    }
+    out[bar] = peak;
+  }
+  return out;
+}
+
+// The intrinsic width of a waveform drawn with `bars` bars at `pitch` spacing. The SVG is
+// stretched to its cell with preserveAspectRatio="none", so this is a viewBox unit, not a
+// CSS pixel count.
+export function waveformWidth(bars, pitch = 5, inset = 3) {
+  return inset * 2 + Math.max(0, Math.floor(bars) - 1) * pitch;
+}
+
+// ONE `<path>` `d` of vertical strokes — the design's bar waveform, drawn as a single path
+// with round caps rather than one element per bar. Bars are centred on the mid-line and
+// floored at `minBar` so silence still reads as a waveform rather than a gap.
+export function waveformPath(peaks, options = {}) {
+  const { bars = PEAK_RESOLUTION, height = 56, pitch = 5, inset = 3, minBar = 0.06 } = options;
+  const values = resamplePeaks(peaks, bars);
+  const mid = height / 2;
+  const room = Math.max(1, mid - inset);
+  let path = "";
+  for (let bar = 0; bar < values.length; bar += 1) {
+    const magnitude = Math.max(minBar, Math.min(1, Number(values[bar]) || 0));
+    const half = magnitude * room;
+    const x = inset + bar * pitch;
+    path += `M${x} ${(mid - half).toFixed(1)}V${(mid + half).toFixed(1)}`;
+  }
+  return path;
+}
+
+// A flat idle bar row — what a surface draws before the decode lands, and permanently when
+// there is nothing to decode against (no AudioContext, a purged clip, an odd codec).
+export function idlePeaks(bars = PEAK_RESOLUTION) {
+  return new Array(Math.max(1, Math.floor(bars))).fill(0);
+}
+
+// Decoded peaks, keyed by asset id: one decode per clip per session, shared by every
+// surface. `failedAssetIds` is the never-retry set — a clip whose file is gone would
+// otherwise re-fetch on every render.
+const peakCache = new Map();
+const inflightDecodes = new Map();
+const failedAssetIds = new Set();
+
+// Test seam: drop the module-level caches so a suite can exercise a fresh decode.
+export function resetAudioPeakCache() {
+  peakCache.clear();
+  inflightDecodes.clear();
+  failedAssetIds.clear();
+}
+
+function audioContextCtor() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.AudioContext ?? window.webkitAudioContext ?? null;
+}
+
+async function decodeAssetPeaks(asset) {
+  const Ctx = audioContextCtor();
+  const url = assetUrl(asset);
+  if (!Ctx || !url || typeof fetch !== "function") {
+    return null;
+  }
+  const response = await fetch(url);
+  if (!response.ok) {
+    return null;
+  }
+  const bytes = await response.arrayBuffer();
+  const context = new Ctx();
+  try {
+    const decoded = await context.decodeAudioData(bytes);
+    return peaksFromSamples(decoded.getChannelData(0), PEAK_RESOLUTION);
+  } finally {
+    // The context exists only to decode; closing it releases the (limited) hardware slot.
+    context.close?.();
+  }
+}
+
+// Peaks for an audio asset, or `null` until they land / forever when they can't. Safe to
+// call for any asset — a non-audio one never decodes.
+export function useAudioPeaks(asset) {
+  const assetId = asset?.id ?? null;
+  const playable = Boolean(asset) && assetCanRenderAsAudio(asset);
+  const [peaks, setPeaks] = useState(() => (assetId ? (peakCache.get(assetId) ?? null) : null));
+
+  useEffect(() => {
+    if (!playable || !assetId) {
+      setPeaks(null);
+      return undefined;
+    }
+    const cached = peakCache.get(assetId);
+    if (cached) {
+      setPeaks(cached);
+      return undefined;
+    }
+    setPeaks(null);
+    if (failedAssetIds.has(assetId)) {
+      return undefined;
+    }
+    let live = true;
+    let pending = inflightDecodes.get(assetId);
+    if (!pending) {
+      // A second mount of the same clip joins this promise rather than starting a competing
+      // fetch. The decode is deliberately NOT aborted on unmount: it is shared, so cancelling
+      // it for one subscriber would poison the result for the others, and the payload is a
+      // single short clip that lands in the cache for the rest of the session either way.
+      pending = decodeAssetPeaks(asset).then(
+        (result) => {
+          inflightDecodes.delete(assetId);
+          if (result) {
+            peakCache.set(assetId, result);
+          } else {
+            failedAssetIds.add(assetId);
+          }
+          return result;
+        },
+        () => {
+          inflightDecodes.delete(assetId);
+          failedAssetIds.add(assetId);
+          return null;
+        },
+      );
+      inflightDecodes.set(assetId, pending);
+    }
+    pending.then((result) => {
+      if (live && result) {
+        setPeaks(result);
+      }
+    });
+    return () => {
+      live = false;
+    };
+  }, [assetId, playable, asset]);
+
+  return peaks;
+}

--- a/apps/web/src/audioWaveform.test.js
+++ b/apps/web/src/audioWaveform.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  PEAK_RESOLUTION,
+  idlePeaks,
+  peaksFromSamples,
+  resamplePeaks,
+  waveformPath,
+  waveformWidth,
+} from "./audioWaveform.js";
+
+// Waveform peaks seam (epic 14361 / sc-14362). The peaks are derived from the REAL clip, so
+// the pure halves — downsampling, resampling and the path builder — are what these pin.
+
+describe("peaksFromSamples", () => {
+  it("downsamples to the requested bar count and normalizes the loudest bar to 1", () => {
+    // Four windows, each with a different absolute peak; the max must scale to exactly 1.
+    const samples = new Float32Array([0.1, 0.05, 0.4, 0.2, -0.8, 0.3, 0.2, 0.05]);
+    const peaks = peaksFromSamples(samples, 4);
+    expect(peaks).toHaveLength(4);
+    expect(peaks.map((value) => Number(value.toFixed(3)))).toEqual([0.125, 0.5, 1, 0.25]);
+  });
+
+  it("uses the ABSOLUTE amplitude, so a negative-only window is not silent", () => {
+    // Discriminating: a signed mean (or an unsigned max on raw values) would report ~0 here.
+    const peaks = peaksFromSamples(new Float32Array([-0.5, -0.5, 0.25, 0.25]), 2);
+    expect(peaks).toEqual([1, 0.5]);
+  });
+
+  it("returns zeros — never NaN — for silence or an empty buffer", () => {
+    expect(peaksFromSamples(new Float32Array([0, 0, 0, 0]), 2)).toEqual([0, 0]);
+    expect(peaksFromSamples(new Float32Array([]), 3)).toEqual([0, 0, 0]);
+  });
+});
+
+describe("resamplePeaks", () => {
+  it("takes the max within each window when narrowing", () => {
+    expect(resamplePeaks([0.1, 0.9, 0.3, 0.2], 2)).toEqual([0.9, 0.3]);
+  });
+
+  it("passes an already-matching array through untouched", () => {
+    const peaks = [0.2, 0.4];
+    expect(resamplePeaks(peaks, 2)).toBe(peaks);
+  });
+
+  it("pads a missing decode to the requested length", () => {
+    expect(resamplePeaks(null, 3)).toEqual([0, 0, 0]);
+  });
+});
+
+describe("waveformPath", () => {
+  it("emits ONE path of vertical strokes at the bar pitch, centred on the mid-line", () => {
+    const path = waveformPath([1, 0.5], { bars: 2, height: 40, pitch: 5, inset: 3, minBar: 0 });
+    // Room is (height/2 - inset) = 17: a full bar spans 3..37, a half bar 11.5..28.5.
+    expect(path).toBe("M3 3.0V37.0M8 11.5V28.5");
+  });
+
+  it("floors silence at minBar so a quiet clip still reads as a waveform", () => {
+    const path = waveformPath([0], { bars: 1, height: 40, inset: 3, minBar: 0.1 });
+    expect(path).toBe("M3 18.3V21.7");
+  });
+
+  it("clamps an out-of-range peak rather than overflowing the box", () => {
+    expect(waveformPath([9], { bars: 1, height: 40, inset: 3 })).toBe("M3 3.0V37.0");
+  });
+
+  it("widths the viewBox from the bar count and pitch", () => {
+    expect(waveformWidth(4, 5, 3)).toBe(21);
+    expect(waveformWidth(1, 5, 3)).toBe(6);
+  });
+});
+
+describe("idlePeaks", () => {
+  it("is a flat row at the surface's own resolution", () => {
+    expect(idlePeaks(4)).toEqual([0, 0, 0, 0]);
+    expect(idlePeaks()).toHaveLength(PEAK_RESOLUTION);
+  });
+});

--- a/apps/web/src/components/AdvancedSection.jsx
+++ b/apps/web/src/components/AdvancedSection.jsx
@@ -12,19 +12,28 @@ import { Icon } from "./Icons.jsx";
 //
 // Controlled via `open` / `onToggle`; presentational only. `actions` (e.g. "Reset
 // to model defaults") sit to the left of the caret and keep their own handlers.
+//
+// `leading` is optional non-interactive content pinned to the START of the header row,
+// pushing the "Advanced" trigger and its caret to the right (epic 14361: the Audio Studio
+// settings bar shares this row with the selected model's capability hint). It is outside the
+// toggle button on purpose — the row's click target stays the trigger itself.
 export function AdvancedSection({
   open,
   onToggle,
   label = "Advanced",
   hint,
   actions,
+  leading,
   className,
   children,
 }) {
-  const rootClass = ["advanced-section", open ? "open" : "", className].filter(Boolean).join(" ");
+  const rootClass = ["advanced-section", open ? "open" : "", leading ? "advanced-section--leading" : "", className]
+    .filter(Boolean)
+    .join(" ");
   return (
     <section className={rootClass}>
       <div className="advanced-section-head">
+        {leading ? <div className="advanced-section-leading">{leading}</div> : null}
         <button
           aria-expanded={Boolean(open)}
           className="advanced-section-toggle"

--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { actionStatuses, terminalStatuses } from "../jobTypes.js";
 import { formatSeconds, liveElapsedSeconds, percent } from "../formatting.js";
+// m:ss transport clock — shared with the Audio Studio's take deck (epic 14361) so both
+// transports read the same way.
+import { formatClock } from "../audioTakes.js";
 import { useAppLive } from "../context/AppContext.js";
 import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { deriveWorkerHardware, findWorkerForJob, liveMeters } from "../workers.js";
@@ -388,14 +391,6 @@ function VideoThumbnail({ assets, onThumbnailClick }) {
 export function audioAssetDurationSeconds(asset) {
   const declared = Number(asset?.file?.duration);
   return Number.isFinite(declared) && declared > 0 ? declared : 0;
-}
-
-// m:ss clock for the transport read-out. Clamps NaN/negative to 0:00.
-function formatClock(seconds) {
-  const total = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
-  const mins = Math.floor(total / 60);
-  const secs = total % 60;
-  return `${mins}:${String(secs).padStart(2, "0")}`;
 }
 
 const PlayGlyph = (

--- a/apps/web/src/components/audioTakeParts.jsx
+++ b/apps/web/src/components/audioTakeParts.jsx
@@ -1,0 +1,313 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "./Icons.jsx";
+import { AssetMedia, assetUrl } from "./assetMedia.jsx";
+import { audioAssetDurationSeconds } from "./WorkerProgressCard.jsx";
+import { idlePeaks, useAudioPeaks, waveformPath, waveformWidth } from "../audioWaveform.js";
+import { formatClock } from "../audioTakes.js";
+
+// Shared audio-take primitives for the Audio Studio redesign (epic 14361).
+//
+// Two pieces, used verbatim by the Advanced studio, the Simple studio and the Simple
+// Assets viewer so the three surfaces can't drift:
+//   • AudioWaveform — the bar waveform, its played band and its playhead (optionally
+//     seekable), drawn from peaks decoded off the real clip (audioWaveform.js).
+//   • useAudioTakePlayer — the transport. ONE <audio> element per surface, ref-driven with
+//     native controls off, exactly the way WorkerProgressCard's AudioTransport already
+//     works: `onLoadedMetadata` corrects the declared duration and `timeupdate` — not a
+//     timer — drives `currentTime`. Loading a different take pauses the previous one, so
+//     only one clip ever plays at a time.
+
+// Bar counts per surface size. Fewer bars on a small cell keeps the pitch readable rather
+// than smearing 160 hairlines into a block.
+export const WAVEFORM_BARS = Object.freeze({ tile: 26, card: 44, deck: 96, stage: 120 });
+
+// Glyph size per button size, so the triangle stays optically centred at 22px and at 56px.
+const PLAY_GLYPH_SIZE = Object.freeze({ xs: 11, sm: 13, md: 15, lg: 19, xl: 22 });
+
+/**
+ * The clip's waveform: a single round-capped bar path, the played band and the playhead.
+ * Stretches to its cell (`preserveAspectRatio="none"`), so the caller owns the box.
+ * Passing `onSeek` makes the surface clickable — x-offset maps to a 0..1 fraction.
+ */
+export function AudioWaveform({
+  asset,
+  bars = WAVEFORM_BARS.card,
+  height = 56,
+  progress = 0,
+  onSeek = null,
+  className = "",
+  label = "Waveform",
+}) {
+  const decoded = useAudioPeaks(asset);
+  const peaks = decoded ?? idlePeaks(bars);
+  const path = useMemo(() => waveformPath(peaks, { bars, height }), [peaks, bars, height]);
+  const width = waveformWidth(bars);
+  const played = Math.max(0, Math.min(1, Number(progress) || 0));
+
+  const seek = (event) => {
+    if (!onSeek) {
+      return;
+    }
+    const box = event.currentTarget.getBoundingClientRect();
+    if (!box.width) {
+      return;
+    }
+    onSeek(Math.max(0, Math.min(1, (event.clientX - box.left) / box.width)));
+  };
+
+  const classes = ["audio-wave", decoded ? "" : "audio-wave--idle", className].filter(Boolean).join(" ");
+  const body = (
+    <>
+      <svg
+        aria-hidden="true"
+        className="audio-wave__svg"
+        focusable="false"
+        preserveAspectRatio="none"
+        viewBox={`0 0 ${width} ${height}`}
+      >
+        <path d={path} />
+      </svg>
+      {played > 0 ? (
+        <span aria-hidden="true" className="audio-wave__played" style={{ width: `${played * 100}%` }} />
+      ) : null}
+    </>
+  );
+  if (!onSeek) {
+    return (
+      <span aria-label={label} className={classes} role="img">
+        {body}
+      </span>
+    );
+  }
+  return (
+    <button aria-label={`Seek ${label.toLowerCase()}`} className={classes} onClick={seek} type="button">
+      {body}
+    </button>
+  );
+}
+
+/**
+ * The now-playing transport shared by every audio surface.
+ *
+ * Returns the loaded take's id (null = nothing loaded, so no deck), live playback state and
+ * the actions the deck / cards call. `mediaProps` + `audioRef` are spread onto ONE
+ * <AssetMedia> the surface renders (see LoadedAudioElement below).
+ */
+export function useAudioTakePlayer() {
+  const audioRef = useRef(null);
+  const [loadedTakeId, setLoadedTakeId] = useState(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [loop, setLoop] = useState(false);
+  // Set when a NEW take is loaded, so playback starts once the element has swapped src —
+  // calling play() before React commits the new source would play the old clip.
+  const autoPlay = useRef(false);
+
+  const play = useCallback(() => {
+    const el = audioRef.current;
+    // play() may reject (autoplay policy) or be unimplemented (jsdom); the onPlay/onPause
+    // events keep state authoritative in a real browser.
+    try {
+      const played = el?.play?.();
+      if (played && typeof played.catch === "function") {
+        played.catch(() => setIsPlaying(false));
+      }
+    } catch {
+      /* ignore — state falls back to the media events */
+    }
+    setIsPlaying(true);
+  }, []);
+
+  const pause = useCallback(() => {
+    audioRef.current?.pause?.();
+    setIsPlaying(false);
+  }, []);
+
+  useEffect(() => {
+    if (!loadedTakeId || !autoPlay.current) {
+      return;
+    }
+    autoPlay.current = false;
+    play();
+  }, [loadedTakeId, play]);
+
+  // Play a take. The same take toggles pause/resume; a different one loads from 0:00 and
+  // plays, which pauses the previous clip (there is only ever one element).
+  const toggleTake = useCallback(
+    (asset) => {
+      if (!asset?.id) {
+        return;
+      }
+      if (asset.id === loadedTakeId) {
+        if (isPlaying) {
+          pause();
+        } else {
+          play();
+        }
+        return;
+      }
+      pause();
+      autoPlay.current = true;
+      setCurrentTime(0);
+      setDuration(audioAssetDurationSeconds(asset));
+      setLoadedTakeId(asset.id);
+    },
+    [loadedTakeId, isPlaying, pause, play],
+  );
+
+  const unload = useCallback(() => {
+    pause();
+    autoPlay.current = false;
+    setLoadedTakeId(null);
+    setCurrentTime(0);
+    setDuration(0);
+  }, [pause]);
+
+  const seekTo = useCallback((seconds) => {
+    const el = audioRef.current;
+    const next = Math.max(0, Number(seconds) || 0);
+    setCurrentTime(next);
+    if (el) {
+      el.currentTime = next;
+    }
+  }, []);
+
+  const seekFraction = useCallback(
+    (fraction) => {
+      if (duration > 0) {
+        seekTo(fraction * duration);
+      }
+    },
+    [duration, seekTo],
+  );
+
+  const skip = useCallback(
+    (delta) => {
+      const limit = duration > 0 ? duration : currentTime;
+      seekTo(Math.min(limit, currentTime + delta));
+    },
+    [currentTime, duration, seekTo],
+  );
+
+  const mediaProps = useMemo(
+    () => ({
+      controls: false,
+      loop,
+      onLoadedMetadata: (event) => {
+        const real = Number(event.currentTarget?.duration);
+        if (Number.isFinite(real) && real > 0) {
+          setDuration(real);
+        }
+      },
+      onTimeUpdate: (event) => setCurrentTime(Number(event.currentTarget?.currentTime) || 0),
+      onPlay: () => setIsPlaying(true),
+      onPause: () => setIsPlaying(false),
+      onEnded: () => {
+        setIsPlaying(false);
+        setCurrentTime(0);
+      },
+    }),
+    [loop],
+  );
+
+  const progress = duration > 0 ? Math.min(1, currentTime / duration) : 0;
+
+  return {
+    audioRef,
+    mediaProps,
+    loadedTakeId,
+    isPlaying,
+    currentTime,
+    duration,
+    progress,
+    loop,
+    toggleLoop: () => setLoop((value) => !value),
+    toggleTake,
+    unload,
+    seekFraction,
+    skip,
+  };
+}
+
+/**
+ * The single <audio> element a surface renders for its loaded take. Native controls are
+ * off — the deck's own transport drives it through the player's ref.
+ */
+export function LoadedAudioElement({ asset, player, className = "audio-deck__el" }) {
+  if (!asset || !assetUrl(asset)) {
+    return null;
+  }
+  return (
+    <AssetMedia
+      asset={asset}
+      className={className}
+      ref={player.audioRef}
+      {...player.mediaProps}
+    />
+  );
+}
+
+/**
+ * Round accent play/pause button — the take card's 32px overlay, the deck's 46px hero and
+ * the Simple/Assets sizes are all this button with a size modifier.
+ */
+export function AudioPlayButton({ playing, onClick, size = "md", label = null, className = "" }) {
+  const classes = ["audio-play-btn", `audio-play-btn--${size}`, className].filter(Boolean).join(" ");
+  const glyph = PLAY_GLYPH_SIZE[size] ?? PLAY_GLYPH_SIZE.md;
+  return (
+    <button
+      aria-label={label ?? (playing ? "Pause" : "Play")}
+      aria-pressed={playing}
+      className={classes}
+      onClick={onClick}
+      type="button"
+    >
+      {playing ? <Icon.Pause size={glyph} /> : <Icon.Play size={glyph} />}
+    </button>
+  );
+}
+
+/** The mono `m:ss / m:ss` clock every transport shows. */
+export function AudioClock({ current, total, className = "audio-clock" }) {
+  return (
+    <span className={className}>
+      <strong>{formatClock(current)}</strong>
+      <span aria-hidden="true"> / </span>
+      <span className="audio-clock__total">{formatClock(total)}</span>
+    </span>
+  );
+}
+
+/**
+ * Download control shared by the deck and the take card. A real anchor click (the media URL
+ * already carries the auth ticket in remote-auth mode, sc-8810) rather than a fetch, so the
+ * browser owns the save dialog — same mechanism the Simple UI's DownloadButton uses.
+ */
+export function AudioDownloadButton({ asset, className = "", label = null, iconSize = 14 }) {
+  const anchorRef = useRef(null);
+  return (
+    <>
+      <a
+        aria-hidden="true"
+        download={asset?.displayName ?? ""}
+        href={assetUrl(asset)}
+        ref={anchorRef}
+        style={{ display: "none" }}
+        tabIndex={-1}
+      >
+        download
+      </a>
+      <button
+        aria-label="Download"
+        className={className}
+        onClick={() => anchorRef.current?.click()}
+        title="Download"
+        type="button"
+      >
+        <Icon.Download size={iconSize} />
+        {label}
+      </button>
+    </>
+  );
+}

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -9,7 +9,17 @@ export { terminalStatuses, actionStatuses } from "./jobTypes.js";
 // else — Character Studio outputs (`character_studio`), Pose/Key Point library assets
 // (`pose_library` / `keypoint_library`), and any future origin — stays out by default.
 // Origins are assigned by the backend (`crates/sceneworks-core/src/asset_index.rs`).
-export const LIBRARY_ORIGINS = new Set(["image_studio", "video_studio", "document_studio", "upload"]);
+// `audio_studio` (epic 13400) was never added here when the Audio Studio landed, so every
+// generated clip was filtered out of BOTH asset libraries — the Advanced Library screen and
+// the Simple Assets grid, whose "Audio" filter pill could therefore never match anything.
+// Audio is studio-generated media like the other three, so it belongs (epic 14361).
+export const LIBRARY_ORIGINS = new Set([
+  "image_studio",
+  "video_studio",
+  "audio_studio",
+  "document_studio",
+  "upload",
+]);
 
 // True when an asset belongs in the Main Asset Library. A missing origin is treated as
 // eligible: the normalized API always stamps one, so only legacy/non-normalized records

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -2,8 +2,9 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { AdvancedSection } from "../components/AdvancedSection.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
-import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
+import { useAudioTakePlayer } from "../components/audioTakeParts.jsx";
+import { AudioResults } from "./audioResults.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import {
   AUDIO_MODES,
@@ -12,7 +13,6 @@ import {
   downloadOffersFor,
 } from "../modelEligibility.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
-import { jobAudioResultAssets } from "../jobResultAssets.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
 
 // SceneWorks Audio Studio — the navigable shell (epic 13400, C0 / sc-13407). This screen mirrors
@@ -188,13 +188,17 @@ export function AudioStudio() {
     models = [],
     jobs = [],
     audioLocalJobs = [],
+    recentAudioAssets = [],
     jobAction,
     createAudioJob,
     createModelDownloadJob,
     rememberLocalGenerationJob,
     setActiveView,
-    setPreviewAsset,
     macCapabilities,
+    // Take-card actions (epic 14361): the four things you can do to a clip you just heard.
+    updateAssetStatus,
+    deleteAsset,
+    sendAssetToVideo,
     savedVoices = [],
     createSavedVoice,
     deleteSavedVoice,
@@ -545,20 +549,43 @@ export function AudioStudio() {
     audioModels.length > 0,
   );
 
-  // A human-readable capability summary (sample rate + max length) so the capability-driven nature of
-  // the settings is visible at a glance and survives a model switch. Cheap enough to build inline.
+  // A human-readable capability summary so the capability-driven nature of the settings is visible
+  // at a glance and survives a model switch. Every clause is READ off the model's own audio block —
+  // voice bank size, language count, output rate, length cap — and a clause a model doesn't
+  // advertise is simply absent (epic 14361: the hint now owns the settings bar's footer row, so it
+  // carries the whole capability picture rather than just the rate). Cheap enough to build inline.
   const capabilitySummary = [
+    voices.length ? `${voices.length} ${voices.length === 1 ? "voice" : "voices"}` : null,
+    languages.length ? `${languages.length} ${languages.length === 1 ? "language" : "languages"}` : null,
     sampleRates.length
       ? sampleRates.map((rate) => `${Math.round(Number(rate) / 100) / 10} kHz`).join(" / ")
       : null,
-    maxDurationSecs != null ? `up to ${maxDurationSecs}s` : null,
+    maxDurationSecs != null ? `max ${maxDurationSecs} s` : null,
+    showStreaming ? "streaming" : null,
   ]
     .filter(Boolean)
     .join(" · ");
 
   const onOpenQueue = () => setActiveView("Queue");
   const onCancelJob = (job) => jobAction?.(job, "cancel");
-  const onPreview = (asset, scope) => setPreviewAsset?.(asset, scope);
+
+  // The results zone's now-playing transport (epic 14361). One player per screen, so loading
+  // a take always pauses the previous one.
+  const player = useAudioTakePlayer();
+
+  // "Run again" re-submits the run's OWN stored payload verbatim — the request the job
+  // recorded, not the current control values (which may have moved on since). A new run
+  // lands at the top of the stack with its own in-flight strip.
+  async function runAgain(job) {
+    const payload = job?.payload;
+    if (!payload) {
+      return;
+    }
+    const next = await createAudioJob?.(payload);
+    if (next) {
+      rememberLocalGenerationJob?.("audio", next);
+    }
+  }
 
   async function submit(event) {
     event.preventDefault();
@@ -787,13 +814,29 @@ export function AudioStudio() {
                   form's onSubmit. Disabled — never a silent no-op — until a run can proceed: empty
                   content (prompt or multi-speaker script), no installed model, a non-Speech tab, or a
                   run already in flight all block it. */}
-              <button className="prompt-cta" type="submit" disabled={!canGenerate}>
-                <Icon.Sparkle size={14} />
-                Generate
-              </button>
+              {/* The CTA and the shortcut hint that used to live in the results head — the hint
+                  belongs with the action it describes (epic 14361, screen 2a). */}
+              <div className="prompt-cta-stack">
+                <button className="prompt-cta" type="submit" disabled={!canGenerate}>
+                  <Icon.Sparkle size={14} />
+                  Generate
+                </button>
+                <span className="kbd-hint">
+                  <kbd>⌘</kbd>
+                  <kbd>↵</kbd>
+                  to generate
+                </span>
+              </div>
             </div>
 
-            <div className="settings-bar">
+            {/* Settings bar (epic 14361 / sc-14363). The row is a FIXED 4-column grid — Model ·
+                Voice · Language · Length — with `align-items: end`, and the model's capability
+                hint has moved out of the Model label onto its own full-width footer row (shared
+                with the Advanced trigger). Under the old flex row that hint lived inside the
+                Model label, so `align-items: flex-end` pushed the MODEL caption ~24px above its
+                neighbours and the field overflowed them. Mode-dependent extra fields keep their
+                capability gating and simply become cells in the same grid. */}
+            <div className="settings-bar audio-settings-bar">
               <div className="settings-bar-row">
                 <label className="settings-field settings-field-model">
                   Model
@@ -806,11 +849,6 @@ export function AudioStudio() {
                       </option>
                     ))}
                   </select>
-                  {capabilitySummary ? (
-                    <span className="field-hint" role="note">
-                      {capabilitySummary}
-                    </span>
-                  ) : null}
                 </label>
 
                 {/* Speech: the voice bank the selected model ships (audio.voices), grouped into
@@ -1110,8 +1148,20 @@ export function AudioStudio() {
               </div>
             ) : null}
 
+            {/* The Advanced disclosure doubles as the settings bar's footer row (screen 2a): the
+                selected model's capability hint sits at its start, the trigger + caret at its end,
+                and the panel opens contiguously beneath — one bordered row rather than a hint
+                stranded inside the Model field. */}
             <AdvancedSection
+              className="audio-advanced-section"
               hint="cleared values → model default"
+              leading={
+                capabilitySummary ? (
+                  <span className="field-hint audio-capability-hint" role="note">
+                    {capabilitySummary}
+                  </span>
+                ) : null
+              }
               onToggle={() => setAdvancedOpen((value) => !value)}
               open={advancedOpen}
             >
@@ -1192,56 +1242,42 @@ export function AudioStudio() {
             </AdvancedSection>
           </WorkPanel>
 
+          {/* Results zone (epic 14361 / sc-14364) — run-grouped waveform take cards, a slim
+              in-flight strip and the docked play deck. The full WorkerProgressCard is no longer
+              this surface's vocabulary; it stays in the Queue screen (and here only for a FAILED
+              run, which needs its error + Retry actions). */}
           <div className="studio-results">
-            <section className="review-panel">
-              <div className="review-panel-head">
-                <div className="review-panel-head-title">
-                  <h2>Latest audio</h2>
-                  {/* Streaming reveal (sc-13675): shown ONLY when the selected model advertises
-                      audio.supportsStreaming. It signals that the clip renders incrementally — the
-                      worker posts per-chunk progress, so the WorkerProgressCard below advances THROUGH
-                      the stream as chunks arrive, and the first audio is produced before the full clip
-                      finishes. Capability-driven, never a hardcoded id; hidden for every one-shot mode. */}
-                  {showStreaming ? (
-                    <span
-                      className="streaming-badge"
-                      data-testid="audio-streaming-badge"
-                      title="This model streams audio incrementally — the first audio arrives before the full clip finishes rendering."
-                    >
-                      Streams incrementally
-                    </span>
-                  ) : null}
-                </div>
-                <span className="kbd-hint">
-                  <kbd>⌘</kbd>
-                  <kbd>↵</kbd>
-                  to generate
-                </span>
-              </div>
-              {/* Results zone — empty in C0. Once C1 enqueues audio jobs (via
-                  rememberLocalGenerationJob('audio', job)) they surface here through the shared
-                  audio-player card (A5 / sc-13405); nothing else in the shell changes. */}
-              {audioLocalJobs.length ? (
-                <div className="worker-progress-card-stack local-job-stack">
-                  {audioLocalJobs.map((job) => {
-                    const jobAssets = jobAudioResultAssets(job, assets);
-                    return (
-                      <WorkerProgressCard
-                        key={job.id}
-                        job={job}
-                        thumbnailsVariant="audio-player"
-                        thumbnailAssets={jobAssets}
-                        onThumbnailClick={(asset) => onPreview(asset, jobAssets)}
-                        onCancel={onCancelJob}
-                        onOpenQueue={onOpenQueue}
-                      />
-                    );
-                  })}
-                </div>
-              ) : (
-                <div className="empty-panel">No audio yet</div>
-              )}
-            </section>
+            <AudioResults
+              assets={assets}
+              jobs={audioLocalJobs}
+              models={audioModels}
+              recentAssets={recentAudioAssets}
+              onCancelJob={onCancelJob}
+              onDiscard={(asset) => deleteAsset?.(asset)}
+              onFavorite={(asset) =>
+                updateAssetStatus?.(asset, { favorite: !asset.status?.favorite })
+              }
+              onOpenQueue={onOpenQueue}
+              onRunAgain={runAgain}
+              onSeeAll={() => setActiveView("Library")}
+              onSendToVideo={(asset) => sendAssetToVideo?.(asset)}
+              player={player}
+              streamingBadge={
+                /* Streaming reveal (sc-13675): shown ONLY when the selected model advertises
+                   audio.supportsStreaming — the clip renders incrementally, so the in-flight strip
+                   advances THROUGH the stream as chunks arrive and the first audio is produced
+                   before the full clip finishes. Capability-driven, never a hardcoded id. */
+                showStreaming ? (
+                  <span
+                    className="streaming-badge"
+                    data-testid="audio-streaming-badge"
+                    title="This model streams audio incrementally — the first audio arrives before the full clip finishes rendering."
+                  >
+                    Streams incrementally
+                  </span>
+                ) : null
+              }
+            />
           </div>
         </form>
       </section>

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -133,6 +133,54 @@ function baseContext(overrides = {}) {
   };
 }
 
+// A completed Speech run and its two takes (epic 14361 / sc-14364). The payload is what the
+// studio actually posts, so the run header's chips and "Run again" are exercised against a
+// real request rather than an invented shape.
+const SPEECH_RUN_PAYLOAD = Object.freeze({
+  model: "kokoro_82m",
+  prompt: "She paused at the door, listening to the rain gather in the gutters.",
+  voice: "af_heart",
+  language: "en-US",
+  targetDurationSecs: 12,
+  seed: 4821,
+});
+
+const SPEECH_TAKES = [
+  {
+    id: "audio-asset-1",
+    type: "audio",
+    projectId: "project_1",
+    displayName: "Take 1",
+    file: { path: "assets/audios/genset_x/kokoro_take_1.wav", mimeType: "audio/wav", duration: 12 },
+  },
+  {
+    id: "audio-asset-2",
+    type: "audio",
+    projectId: "project_1",
+    displayName: "Take 2",
+    file: { path: "assets/audios/genset_x/kokoro_take_2.wav", mimeType: "audio/wav", duration: 11 },
+  },
+];
+
+const COMPLETED_SPEECH_JOB = {
+  id: "audio-job-done",
+  type: "audio_generate",
+  status: "completed",
+  createdAt: "2026-07-24T12:00:00Z",
+  payload: SPEECH_RUN_PAYLOAD,
+  result: { assetIds: ["audio-asset-1", "audio-asset-2"], expectedCount: 2 },
+};
+
+function takesContext(overrides = {}) {
+  return baseContext({
+    assets: SPEECH_TAKES,
+    audioLocalJobs: [COMPLETED_SPEECH_JOB],
+    createAudioJob: vi.fn(async () => null),
+    rememberLocalGenerationJob: vi.fn(),
+    ...overrides,
+  });
+}
+
 const buttonWithText = (root, text) =>
   [...root.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
 const modeTabs = (container) => container.querySelector(".mode-control");
@@ -475,24 +523,114 @@ describe("AudioStudio Speech generation (sc-13408)", () => {
     ]);
   });
 
-  it("renders an audio-player results card for a completed audio job in the lane", async () => {
-    const audioAsset = {
-      id: "audio-asset-1",
-      type: "audio",
-      projectId: "project_1",
-      displayName: "The walking skeleton is alive.",
-      file: { path: "assets/audios/genset_x/2026-07-19_kokoro_walking.wav", mimeType: "audio/wav" },
-    };
-    const completedJob = {
-      id: "audio-job-done",
-      type: "audio_generate",
-      status: "completed",
-      result: { assetIds: ["audio-asset-1"], expectedCount: 1 },
-    };
+  it("groups a completed run into take cards instead of a worker card (sc-14364)", async () => {
+    await render(takesContext());
+
+    const results = container.querySelector(".studio-results");
+    // The full worker card is the QUEUE's vocabulary now — a completed run never renders one here.
+    expect(results.querySelector(".worker-progress-card")).toBeNull();
+    expect(results.querySelector('[data-testid="audio-run-group"]')).toBeTruthy();
+    expect(results.querySelectorAll('[data-testid="audio-take-card"]').length).toBe(2);
+    expect(results.textContent).not.toContain("No audio yet");
+    // The run header reads its chips off the job's OWN payload, never the live controls.
+    const head = results.querySelector(".audio-run__head");
+    expect([...head.querySelectorAll(".audio-run__chip")].map((el) => el.textContent)).toEqual([
+      "af_heart",
+      "en-US",
+      "12 s",
+      "seed 4821",
+    ]);
+    expect(head.textContent).toContain("Kokoro 82M (Speech)");
+    // Nothing is loaded, so there is no deck and no <audio> element yet.
+    expect(results.querySelector('[data-testid="audio-play-deck"]')).toBeNull();
+  });
+
+  it("playing a take mounts the deck on that clip and the × unloads it (sc-14364)", async () => {
+    await render(takesContext());
+    const results = container.querySelector(".studio-results");
+
+    await click(results.querySelector('[aria-label="Play take 2"]'));
+
+    const deck = results.querySelector('[data-testid="audio-play-deck"]');
+    expect(deck).toBeTruthy();
+    // The deck drives a REAL <audio> element pointed at the take that was played.
+    const audioEl = deck.querySelector("audio");
+    expect(audioEl.getAttribute("src")).toContain("kokoro_take_2.wav");
+    expect(deck.textContent).toContain("Take 2");
+    // …and that take's card carries the loaded ring, the first one does not.
+    const cards = [...results.querySelectorAll('[data-testid="audio-take-card"]')];
+    expect(cards[0].className).not.toContain("is-loaded");
+    expect(cards[1].className).toContain("is-loaded");
+
+    await click(deck.querySelector('[aria-label="Close player"]'));
+    expect(results.querySelector('[data-testid="audio-play-deck"]')).toBeNull();
+    expect(
+      [...results.querySelectorAll('[data-testid="audio-take-card"]')].some((card) =>
+        card.className.includes("is-loaded"),
+      ),
+    ).toBe(false);
+  });
+
+  it("Run again re-submits the run's OWN stored payload, not the current controls (sc-14364)", async () => {
+    const createAudioJob = vi.fn(async () => ({ id: "audio-job-2" }));
+    const rememberLocalGenerationJob = vi.fn();
+    await render(takesContext({ createAudioJob, rememberLocalGenerationJob }));
+
+    await click(buttonWithText(container.querySelector(".audio-run__head"), "Run again"));
+
+    expect(createAudioJob).toHaveBeenCalledTimes(1);
+    expect(createAudioJob.mock.calls[0][0]).toEqual(SPEECH_RUN_PAYLOAD);
+    expect(rememberLocalGenerationJob).toHaveBeenCalledWith("audio", { id: "audio-job-2" });
+  });
+
+  it("renders a running run as the slim in-flight strip, not the full worker card (sc-14364)", async () => {
+    const jobAction = vi.fn();
     await render(
       baseContext({
-        assets: [audioAsset],
-        audioLocalJobs: [completedJob],
+        audioLocalJobs: [
+          {
+            id: "audio-job-running",
+            type: "audio_generate",
+            status: "running",
+            progress: 0.44,
+            message: "chunk 4 of 9",
+            payload: { ...SPEECH_RUN_PAYLOAD },
+            result: { expectedCount: 3 },
+          },
+        ],
+        jobAction,
+        createAudioJob: vi.fn(),
+        rememberLocalGenerationJob: vi.fn(),
+      }),
+    );
+
+    const results = container.querySelector(".studio-results");
+    const strip = results.querySelector('[data-testid="audio-inflight-strip"]');
+    expect(strip).toBeTruthy();
+    expect(strip.textContent).toContain("Speech · Kokoro 82M (Speech) · 3 takes");
+    expect(strip.textContent).toContain("chunk 4 of 9");
+    // `job.progress` is a 0..1 fraction, not a percentage — the strip must not render "44%"
+    // for 0.44 (nor 4400% for 44).
+    expect(strip.querySelector(".progress-track span").style.width).toBe("44%");
+    // The GPU meters / job id / attempt counter stay in the Queue.
+    expect(results.querySelector(".worker-progress-card")).toBeNull();
+
+    await click(buttonWithText(strip, "Cancel"));
+    expect(jobAction).toHaveBeenCalledWith(expect.objectContaining({ id: "audio-job-running" }), "cancel");
+  });
+
+  it("keeps the full worker card for a FAILED run so its error and retries stay reachable", async () => {
+    await render(
+      baseContext({
+        audioLocalJobs: [
+          {
+            id: "audio-job-failed",
+            type: "audio_generate",
+            status: "failed",
+            error: "the vocoder gave up",
+            payload: { ...SPEECH_RUN_PAYLOAD },
+          },
+        ],
         createAudioJob: vi.fn(),
         rememberLocalGenerationJob: vi.fn(),
       }),
@@ -500,13 +638,7 @@ describe("AudioStudio Speech generation (sc-13408)", () => {
 
     const results = container.querySelector(".studio-results");
     expect(results.querySelector(".worker-progress-card")).toBeTruthy();
-    // The completed clip surfaces through the shared audio-player card with a real <audio> src.
-    const audioEl = results.querySelector("audio");
-    expect(audioEl).toBeTruthy();
-    expect(audioEl.getAttribute("src")).toContain(
-      "assets/audios/genset_x/2026-07-19_kokoro_walking.wav",
-    );
-    expect(results.textContent).not.toContain("No audio yet");
+    expect(results.textContent).toContain("the vocoder gave up");
   });
 
   it("Voice Clone needs a reference before Generate is enabled (sc-13411)", async () => {

--- a/apps/web/src/screens/audioResults.jsx
+++ b/apps/web/src/screens/audioResults.jsx
@@ -1,0 +1,426 @@
+import React, { useMemo } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { WorkerProgressCard, audioAssetDurationSeconds } from "../components/WorkerProgressCard.jsx";
+import {
+  AudioClock,
+  AudioDownloadButton,
+  AudioPlayButton,
+  AudioWaveform,
+  LoadedAudioElement,
+  WAVEFORM_BARS,
+} from "../components/audioTakeParts.jsx";
+import {
+  audioAssetRunGroups,
+  audioExpectedTakes,
+  audioRunGroups,
+  audioTakeTitle,
+  formatClock,
+  formatRelativeTime,
+} from "../audioTakes.js";
+import { terminalStatuses } from "../jobTypes.js";
+// `job.progress` is a 0..1 fraction (the same value WorkerProgressCard renders); `percent`
+// is the one place that conversion lives.
+import { percent } from "../formatting.js";
+
+// Audio Studio results zone (epic 14361 / sc-14364) — the "Latest audio" surface.
+//
+// It replaces a stack of queue-worker cards with a CREATIVE surface: a slim in-flight strip
+// pinned at the top, run-grouped waveform take cards in the same .review-grid geometry the
+// Image and Video studios use, and a now-playing play deck docked above the runs while a
+// take is loaded. The FULL WorkerProgressCard — job id, GPU meters, attempt counter,
+// hardware pills — deliberately stays in the Queue screen; the only place it still appears
+// here is a FAILED run, which keeps its existing card treatment (and its Retry actions).
+//
+// Everything is derived: a run IS a job in the audio local-job lane, its takes are the
+// assets that job produced, and the header chips are read off the job's own payload
+// (audioTakes.js). No new API surface, no stored grouping.
+
+// The head's count clause. Written as the design words it, from the takes actually resolved.
+function clipCountLabel(count) {
+  return `last ${count} ${count === 1 ? "clip" : "clips"} in this project`;
+}
+
+function ModeChip({ mode, label, extra = null, className = "" }) {
+  return (
+    <span className={`audio-mode-chip audio-mode-chip--${mode} ${className}`.trim()}>
+      {label}
+      {extra ? <span className="audio-mode-chip__extra">{extra}</span> : null}
+    </span>
+  );
+}
+
+/**
+ * One running audio run, pinned above the run groups. A trimmed progress row — status chip,
+ * title, message, a 6px track and Cancel / Queue — rather than the full worker card.
+ */
+export function AudioInflightStrip({ run, onCancel, onOpenQueue }) {
+  const { job } = run;
+  const takes = audioExpectedTakes(job);
+  const numeric = Number(job.progress);
+  const hasProgress = Number.isFinite(numeric) && numeric > 0;
+  const title = [run.modeLabel, run.modelName, takes ? `${takes} takes` : null]
+    .filter(Boolean)
+    .join(" · ");
+  const message = job.message ?? "";
+  return (
+    <div className="audio-inflight" data-testid="audio-inflight-strip">
+      <span className="audio-inflight__status">{job.cancelRequested ? "Canceling" : "Rendering"}</span>
+      <div className="audio-inflight__body">
+        <div className="audio-inflight__titles">
+          <strong className="audio-inflight__title">{title}</strong>
+          {message ? <span className="audio-inflight__message">{message}</span> : null}
+        </div>
+        <div className="progress-track audio-inflight__track" aria-label="Run progress">
+          <span style={{ width: hasProgress ? percent(Math.min(1, numeric)) : "0%" }} />
+        </div>
+      </div>
+      <div className="audio-inflight__actions">
+        {onCancel ? (
+          <button
+            className="secondary-action"
+            disabled={job.cancelRequested}
+            onClick={() => onCancel(job)}
+            type="button"
+          >
+            {job.cancelRequested ? "Canceling…" : "Cancel"}
+          </button>
+        ) : null}
+        {onOpenQueue ? (
+          <button className="audio-link" onClick={() => onOpenQueue(job)} type="button">
+            Queue
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** A single take: waveform thumbnail, prompt excerpt, meta and the four asset actions. */
+export function AudioTakeCard({
+  run,
+  asset,
+  index,
+  loaded,
+  playing,
+  progress,
+  onToggle,
+  onFavorite,
+  onSendToVideo,
+  onDiscard,
+}) {
+  const duration = audioAssetDurationSeconds(asset);
+  const favorite = Boolean(asset.status?.favorite);
+  return (
+    <article className={loaded ? "audio-take is-loaded" : "audio-take"} data-testid="audio-take-card">
+      <div className="audio-take__wave">
+        <AudioWaveform
+          asset={asset}
+          bars={WAVEFORM_BARS.card}
+          height={118}
+          label={`Take ${index + 1}`}
+          progress={loaded ? progress : 0}
+        />
+        <span className="audio-take__badge">Take {index + 1}</span>
+        <AudioPlayButton
+          className="audio-take__play"
+          label={`${playing && loaded ? "Pause" : "Play"} take ${index + 1}`}
+          onClick={() => onToggle(asset)}
+          playing={loaded && playing}
+          size="md"
+        />
+        <span className="audio-take__duration">{formatClock(duration)}</span>
+      </div>
+      <p className="audio-take__prompt">{audioTakeTitle(run.job, asset)}</p>
+      <div className="audio-take__meta">
+        <span>
+          {run.modeLabel} · {run.modelName}
+        </span>
+        <span className="audio-take__meta-duration">{formatClock(duration)}</span>
+      </div>
+      <div className="audio-take__actions">
+        <button
+          aria-label={favorite ? "Remove from favorites" : "Add to favorites"}
+          aria-pressed={favorite}
+          className={favorite ? "audio-icon-btn is-on" : "audio-icon-btn"}
+          onClick={() => onFavorite?.(asset)}
+          title="Favorite"
+          type="button"
+        >
+          <Icon.Star filled={favorite} size={14} />
+        </button>
+        <AudioDownloadButton asset={asset} className="audio-icon-btn" />
+        <button
+          aria-label="Send to Video Editor"
+          className="audio-icon-btn"
+          onClick={() => onSendToVideo?.(asset)}
+          title="Send to Video Editor"
+          type="button"
+        >
+          <Icon.Editor size={14} />
+        </button>
+        <button
+          aria-label="Discard take"
+          className="audio-icon-btn audio-icon-btn--danger"
+          onClick={() => onDiscard?.(asset)}
+          title="Discard"
+          type="button"
+        >
+          <Icon.Trash size={14} />
+        </button>
+      </div>
+    </article>
+  );
+}
+
+/** One generation run: the header (mode / model / settings chips / time / Run again) + its takes. */
+export function AudioRunGroup({
+  run,
+  loadedTakeId,
+  playing,
+  progress,
+  onToggle,
+  onRunAgain,
+  onFavorite,
+  onSendToVideo,
+  onDiscard,
+}) {
+  return (
+    <section className="audio-run" data-testid="audio-run-group">
+      <header className="audio-run__head">
+        <ModeChip label={run.modeLabel} mode={run.mode} />
+        <strong className="audio-run__model">{run.modelName}</strong>
+        <div className="audio-run__chips">
+          {run.chips.map((chip) => (
+            <span className="audio-run__chip" key={chip}>
+              {chip}
+            </span>
+          ))}
+        </div>
+        <span aria-hidden="true" className="audio-run__rule" />
+        {run.createdAt ? <span className="audio-run__time">{formatRelativeTime(run.createdAt)}</span> : null}
+        {onRunAgain && run.replayable ? (
+          <button className="audio-link" onClick={() => onRunAgain(run.job)} type="button">
+            <Icon.Refresh size={13} />
+            Run again
+          </button>
+        ) : null}
+      </header>
+      <div className="audio-take-grid">
+        {run.takes.map((asset, index) => (
+          <AudioTakeCard
+            asset={asset}
+            index={index}
+            key={asset.id}
+            loaded={asset.id === loadedTakeId}
+            onDiscard={onDiscard}
+            onFavorite={onFavorite}
+            onSendToVideo={onSendToVideo}
+            onToggle={onToggle}
+            playing={playing}
+            progress={progress}
+            run={run}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The now-playing deck: head + waveform stage + transport. Rendered ONLY while a take is
+ * loaded, docked directly above the first run group. Drives the one real <audio> element.
+ */
+export function AudioPlayDeck({ run, asset, takeIndex, player, onRunAgain, onSendToVideo }) {
+  const duration = player.duration > 0 ? player.duration : audioAssetDurationSeconds(asset);
+  const meta = [run?.modelName, ...(run?.chips ?? [])].filter(Boolean).join(" · ");
+  return (
+    <section className="audio-deck" data-testid="audio-play-deck">
+      <LoadedAudioElement asset={asset} player={player} />
+      <header className="audio-deck__head">
+        <ModeChip
+          extra={takeIndex >= 0 ? `Take ${takeIndex + 1}` : null}
+          label={run?.modeLabel ?? "Audio"}
+          mode={run?.mode ?? "speech"}
+        />
+        <strong className="audio-deck__title" title={audioTakeTitle(run?.job, asset)}>
+          {audioTakeTitle(run?.job, asset)}
+        </strong>
+        <div className="audio-deck__head-actions">
+          <AudioDownloadButton asset={asset} className="secondary-action" iconSize={15} label="Download" />
+          {onSendToVideo ? (
+            <button className="secondary-action" onClick={() => onSendToVideo(asset)} type="button">
+              <Icon.Editor size={15} />
+              Send to Video Editor
+            </button>
+          ) : null}
+          {onRunAgain && run?.job && run?.replayable ? (
+            <button className="secondary-action audio-deck__again" onClick={() => onRunAgain(run.job)} type="button">
+              <Icon.Refresh size={15} />
+              Run again
+            </button>
+          ) : null}
+          <button
+            aria-label="Close player"
+            className="secondary-action audio-deck__close"
+            onClick={player.unload}
+            title="Close player"
+            type="button"
+          >
+            <Icon.Close size={15} />
+          </button>
+        </div>
+      </header>
+
+      <div className="audio-deck__stage">
+        <AudioWaveform
+          asset={asset}
+          bars={WAVEFORM_BARS.deck}
+          height={140}
+          label="Clip"
+          onSeek={player.seekFraction}
+          progress={player.progress}
+        />
+        <div className="audio-deck__ticks">
+          <span>0:00</span>
+          <span>{formatClock(duration)}</span>
+        </div>
+      </div>
+
+      <div className="audio-deck__transport">
+        <button
+          aria-label="Back 5 seconds"
+          className="audio-round-btn"
+          onClick={() => player.skip(-5)}
+          type="button"
+        >
+          <Icon.ArrowLeft size={15} />
+        </button>
+        <AudioPlayButton onClick={() => player.toggleTake(asset)} playing={player.isPlaying} size="xl" />
+        <button
+          aria-label="Forward 5 seconds"
+          className="audio-round-btn"
+          onClick={() => player.skip(5)}
+          type="button"
+        >
+          <Icon.ArrowRight size={15} />
+        </button>
+        <button
+          aria-label="Loop"
+          aria-pressed={player.loop}
+          className={player.loop ? "audio-round-btn is-on" : "audio-round-btn"}
+          onClick={player.toggleLoop}
+          type="button"
+        >
+          <Icon.Refresh size={15} />
+        </button>
+        <AudioClock current={player.currentTime} total={duration} />
+        {meta ? <span className="audio-deck__meta">{meta}</span> : null}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The whole "Latest audio" zone.
+ *
+ * `player` is the surface's single useAudioTakePlayer instance — the deck and every take
+ * card read their loaded/playing state from it, so only one clip plays at a time.
+ */
+export function AudioResults({
+  jobs,
+  assets,
+  recentAssets = [],
+  models,
+  player,
+  streamingBadge = null,
+  onCancelJob,
+  onOpenQueue,
+  onSeeAll,
+  onRunAgain,
+  onFavorite,
+  onSendToVideo,
+  onDiscard,
+}) {
+  // This session's runs (the local-job lane) own the takes they produced; the project's
+  // recent clips fill in behind them, reconstructed from each asset's own replay record, so
+  // the surface is populated on a fresh launch rather than empty until you generate.
+  const runs = useMemo(() => {
+    const jobRuns = audioRunGroups(jobs, assets, models);
+    const covered = new Set(jobRuns.flatMap((run) => run.takes.map((asset) => asset.id)));
+    return [...jobRuns, ...audioAssetRunGroups(recentAssets, models, covered)];
+  }, [jobs, assets, recentAssets, models]);
+
+  const inflight = runs.filter((run) => run.running);
+  // A failed run has no takes to show, so it keeps the full worker card — the surface where
+  // the error, the attempt count and Retry live.
+  const failed = runs.filter((run) => !run.running && run.takes.length === 0 && terminalStatuses.has(run.job.status));
+  const completed = runs.filter((run) => !run.running && run.takes.length > 0);
+  const takeCount = completed.reduce((total, run) => total + run.takes.length, 0);
+
+  const loaded = useMemo(() => {
+    if (!player.loadedTakeId) {
+      return null;
+    }
+    for (const run of runs) {
+      const index = run.takes.findIndex((asset) => asset.id === player.loadedTakeId);
+      if (index >= 0) {
+        return { run, asset: run.takes[index], index };
+      }
+    }
+    return null;
+  }, [runs, player.loadedTakeId]);
+
+  return (
+    <section className="review-panel audio-results">
+      <div className="review-panel-head">
+        <div className="review-panel-head-title">
+          <h2>Latest audio</h2>
+          {takeCount ? <span className="audio-results__count">{clipCountLabel(takeCount)}</span> : null}
+          {streamingBadge}
+        </div>
+        {onSeeAll ? (
+          <button className="audio-link audio-results__all" onClick={onSeeAll} type="button">
+            See all in Assets
+            <Icon.ArrowRight size={14} />
+          </button>
+        ) : null}
+      </div>
+
+      {inflight.map((run) => (
+        <AudioInflightStrip key={run.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} run={run} />
+      ))}
+
+      {failed.map((run) => (
+        <WorkerProgressCard job={run.job} key={run.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
+      ))}
+
+      {loaded ? (
+        <AudioPlayDeck
+          asset={loaded.asset}
+          onRunAgain={onRunAgain}
+          onSendToVideo={onSendToVideo}
+          player={player}
+          run={loaded.run}
+          takeIndex={loaded.index}
+        />
+      ) : null}
+
+      {completed.map((run) => (
+        <AudioRunGroup
+          key={run.id}
+          loadedTakeId={player.loadedTakeId}
+          onDiscard={onDiscard}
+          onFavorite={onFavorite}
+          onRunAgain={onRunAgain}
+          onSendToVideo={onSendToVideo}
+          onToggle={player.toggleTake}
+          playing={player.isPlaying}
+          progress={player.progress}
+          run={run}
+        />
+      ))}
+
+      {runs.length === 0 ? <div className="empty-panel">No audio yet</div> : null}
+    </section>
+  );
+}

--- a/apps/web/src/simple/SimpleAssets.jsx
+++ b/apps/web/src/simple/SimpleAssets.jsx
@@ -6,6 +6,7 @@ import { isLibraryAsset } from "../constants.js";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
 import { assetMatchesSearch } from "../screens/LibraryScreen.jsx";
 import { assetGridColumns } from "./breakpoint.js";
+import { SimpleAudioTile } from "./simpleAudioParts.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
 
 // Simple Assets (design handoff): search + type pills + a responsive thumbnail grid.
@@ -22,7 +23,7 @@ const FILTERS = [
 
 export function SimpleAssets() {
   const { assets = [] } = useAppContext();
-  const { breakpoint, openPreview } = useSimpleUi();
+  const { breakpoint, openPreview, loadedTakeId } = useSimpleUi();
   const [filter, setFilter] = useState("all");
   const [query, setQuery] = useState("");
 
@@ -75,37 +76,40 @@ export function SimpleAssets() {
           className="su-asset-grid"
           style={{ "--su-asset-cols": assetGridColumns(breakpoint) }}
         >
-          {visible.map((asset) => (
-            <button
-              className="su-asset"
-              key={asset.id}
-              onClick={() => openPreview(asset)}
-              title={asset.displayName ?? asset.id}
-              type="button"
-            >
-              {assetCanRenderAsAudio(asset) ? (
-                <span className="su-asset-placeholder">
-                  <Icon.Audio size={20} />
-                </span>
-              ) : (
+          {visible.map((asset) =>
+            /* Audio used to render a blank hatched placeholder. It now draws its waveform
+               INSIDE the same square cell (epic 14361 / sc-14366), so a row of mixed assets
+               keeps its rhythm — with its own play button, which opens the viewer already
+               playing while the cell body opens it paused. */
+            assetCanRenderAsAudio(asset) ? (
+              <SimpleAudioTile
+                asset={asset}
+                key={asset.id}
+                loaded={asset.id === loadedTakeId}
+                onOpen={(target) => openPreview(target)}
+                onToggle={(target) => openPreview(target, { play: true })}
+                phone={breakpoint === "phone"}
+              />
+            ) : (
+              <button
+                className="su-asset"
+                key={asset.id}
+                onClick={() => openPreview(asset)}
+                title={asset.displayName ?? asset.id}
+                type="button"
+              >
                 <AssetThumbnail asset={asset} />
-              )}
-              <span aria-hidden="true" className="su-asset-kind">
-                {assetCanRenderAsVideo(asset) ? (
-                  <Icon.Play size={11} />
-                ) : assetCanRenderAsAudio(asset) ? (
-                  <Icon.Audio size={11} />
-                ) : (
-                  <Icon.Image size={11} />
-                )}
-              </span>
-              {asset.status?.favorite ? (
-                <span aria-hidden="true" className="su-asset-fav">
-                  <Icon.Star filled size={14} />
+                <span aria-hidden="true" className="su-asset-kind">
+                  {assetCanRenderAsVideo(asset) ? <Icon.Play size={11} /> : <Icon.Image size={11} />}
                 </span>
-              ) : null}
-            </button>
-          ))}
+                {asset.status?.favorite ? (
+                  <span aria-hidden="true" className="su-asset-fav">
+                    <Icon.Star filled size={14} />
+                  </span>
+                ) : null}
+              </button>
+            ),
+          )}
         </div>
       ) : (
         <p className="su-empty">

--- a/apps/web/src/simple/SimpleAudioStudio.jsx
+++ b/apps/web/src/simple/SimpleAudioStudio.jsx
@@ -1,26 +1,22 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Icon } from "../components/Icons.jsx";
-import { AssetMedia } from "../components/assetMedia.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { audioModelServesMode } from "../modelEligibility.js";
-import { resolveJobResultAssets } from "../jobResultAssets.js";
+import { audioAssetRunGroups, audioRunGroups } from "../audioTakes.js";
+import { useAudioTakePlayer } from "../components/audioTakeParts.jsx";
 import { buildSimpleAudioRequest } from "./simpleJobs.js";
+import { SimpleAudioDeck, SimpleTakeCard, takeGridColumns } from "./simpleAudioParts.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
-import {
-  Chips,
-  DownloadButton,
-  SheetSelect,
-  StudioRunStatus,
-  jobIsRunning,
-  newestLocalJob,
-} from "./studioParts.jsx";
+import { Chips, SheetSelect, StudioRunStatus, jobIsRunning, newestLocalJob } from "./studioParts.jsx";
 
-// Simple Audio Studio (design handoff). The design flags this studio as a PREVIEW —
-// "the models and controls will change as it lands" — and asks for the warning banner
-// to be kept, so it is rendered verbatim.
+// Simple Audio Studio (design handoff → Audio Studio redesign, epic 14361 / sc-14365).
 //
 // Music / Speech / SFX are the three modes the design shows. Voice Clone (the fourth
 // mode the advanced studio serves) is deliberately not surfaced here.
+//
+// The mode control is the `.su-tabs` underline tab set the Image and Video studios use, and
+// the results zone is the same take grid + play deck the Advanced studio grew — sized off
+// the MEASURED band (breakpointFor via the shell's `breakpoint`), never a media query. The
+// old "this studio is a preview" notice is gone: the studio ships.
 
 const MODES = [
   { id: "music", label: "Music" },
@@ -35,10 +31,13 @@ export function SimpleAudioStudio() {
     createAudioJob,
     rememberLocalGenerationJob,
     audioLocalJobs = [],
+    recentAudioAssets = [],
     assets = [],
     activeProject,
   } = useAppContext();
-  const { toast } = useSimpleUi();
+  const { toast, breakpoint } = useSimpleUi();
+  // One transport for the screen, so loading a take always pauses the previous one.
+  const player = useAudioTakePlayer();
 
   const [mode, setMode] = useState("music");
   const [prompt, setPrompt] = useState("");
@@ -101,7 +100,30 @@ export function SimpleAudioStudio() {
   const latestJob = newestLocalJob(audioLocalJobs);
   const busy = submitting || jobIsRunning(latestJob);
   const canGenerate = Boolean(prompt.trim()) && Boolean(model) && !busy;
-  const resultAssets = latestJob ? resolveJobResultAssets(latestJob, assets, { type: "audio" }) : [];
+
+  // Every take this project's audio runs have produced, newest run first — the same derived
+  // grouping the Advanced studio reads, flattened into one grid (Simple shows takes, not runs).
+  const runs = useMemo(() => {
+    const jobRuns = audioRunGroups(audioLocalJobs, assets, audioModels);
+    const covered = new Set(jobRuns.flatMap((run) => run.takes.map((asset) => asset.id)));
+    return [...jobRuns, ...audioAssetRunGroups(recentAudioAssets, audioModels, covered)];
+  }, [audioLocalJobs, assets, recentAudioAssets, audioModels]);
+  const takes = useMemo(
+    () => runs.flatMap((run) => run.takes.map((asset, index) => ({ run, asset, index }))),
+    [runs],
+  );
+  const loaded = takes.find((take) => take.asset.id === player.loadedTakeId) ?? null;
+
+  // "Run again" re-submits the run's OWN recorded payload, not the current controls.
+  async function runAgain(job) {
+    if (!job?.payload) {
+      return;
+    }
+    const next = await createAudioJob(job.payload);
+    if (next) {
+      rememberLocalGenerationJob?.("audio", next);
+    }
+  }
 
   async function generate() {
     if (!canGenerate) {
@@ -132,11 +154,11 @@ export function SimpleAudioStudio() {
 
   return (
     <div className="su-screen">
-      <div className="su-segmented" role="tablist">
+      <div className="su-tabs" role="tablist">
         {MODES.map((entry) => (
           <button
             aria-selected={mode === entry.id}
-            className={mode === entry.id ? "active" : ""}
+            className={mode === entry.id ? "su-tab active" : "su-tab"}
             key={entry.id}
             onClick={() => setMode(entry.id)}
             role="tab"
@@ -145,11 +167,6 @@ export function SimpleAudioStudio() {
             {entry.label}
           </button>
         ))}
-      </div>
-
-      <div className="su-notice" role="note">
-        <Icon.Warning size={16} />
-        <span>Audio Studio is a preview — the models and controls will change as it lands.</span>
       </div>
 
       <div>
@@ -212,10 +229,39 @@ export function SimpleAudioStudio() {
       {/* Live run strip: progress + Cancel + the outcome, right under Generate. */}
       <StudioRunStatus job={latestJob} />
 
-      {resultAssets.length ? (
-        <div className="su-audio-result">
-          <AssetMedia asset={resultAssets[0]} />
-          <DownloadButton asset={resultAssets[0]} className="su-icon-btn" />
+      {takes.length ? (
+        <div>
+          <div className="su-results-head">
+            <strong>Latest audio</strong>
+            <span>
+              {takes.length} {takes.length === 1 ? "clip" : "clips"}
+            </span>
+          </div>
+          {loaded ? (
+            <SimpleAudioDeck
+              asset={loaded.asset}
+              breakpoint={breakpoint}
+              onRunAgain={runAgain}
+              player={player}
+              run={loaded.run}
+              takeIndex={loaded.index}
+            />
+          ) : null}
+          <div className="su-take-grid" style={{ "--su-take-cols": takeGridColumns(breakpoint) }}>
+            {takes.map(({ run, asset, index }) => (
+              <SimpleTakeCard
+                asset={asset}
+                index={index}
+                key={asset.id}
+                loaded={asset.id === player.loadedTakeId}
+                onToggle={player.toggleTake}
+                phone={breakpoint === "phone"}
+                playing={player.isPlaying}
+                progress={player.progress}
+                run={run}
+              />
+            ))}
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/simple/SimplePreview.jsx
+++ b/apps/web/src/simple/SimplePreview.jsx
@@ -1,17 +1,60 @@
-import React from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { AssetMedia, assetCanRenderAsAudio, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
+import { useAudioTakePlayer } from "../components/audioTakeParts.jsx";
+import { audioAssetRunGroups, formatRelativeTime } from "../audioTakes.js";
+import { useAppContext } from "../context/AppContext.js";
+import { SimpleAudioViewer } from "./simpleAudioParts.jsx";
 import { DownloadButton } from "./studioParts.jsx";
 
 // Full-screen asset preview (design handoff): large media over four actions — "Use as
 // reference" (primary), Favorite, Download, Delete (danger).
 //
+// For an AUDIO asset the stage is the play deck (epic 14361 / sc-14366) rather than a bare
+// <audio> element: waveform panel, played band, transport and clock, plus "Send to Video
+// Editor" — on desktop at the transport's right edge, on phone in the primary slot that
+// "Use as reference" leaves empty (it stays hidden for audio, as before).
+//
 // Delete routes to `deleteAsset`, which moves the asset to the trash (recoverable in the
 // full workspace's Assets → Trashcan). The Simple UI deliberately has no permanent-purge
 // path: an irreversible delete is not a control this surface should own.
-export function SimplePreview({ asset, onClose, onUseAsReference, onToggleFavorite, onDelete }) {
-  const title = assetCanRenderAsVideo(asset) ? "Clip" : assetCanRenderAsAudio(asset) ? "Audio" : "Image";
+export function SimplePreview({
+  asset,
+  onClose,
+  onUseAsReference,
+  onToggleFavorite,
+  onDelete,
+  onSendToVideo,
+  audioAutoPlay = false,
+  breakpoint = "desktop",
+}) {
+  const { audioModels = [] } = useAppContext();
+  const audio = assetCanRenderAsAudio(asset);
+  const title = assetCanRenderAsVideo(asset) ? "Clip" : audio ? "Audio" : "Image";
   const favorite = Boolean(asset.status?.favorite);
+  const phone = breakpoint === "phone";
+  const player = useAudioTakePlayer();
+
+  // The clip's own run, reconstructed from its replay record — the same derivation the studios
+  // use, so the viewer's mode chip and model name can't disagree with the take grid's.
+  const run = useMemo(
+    () => (audio ? (audioAssetRunGroups([asset], audioModels)[0] ?? null) : null),
+    [audio, asset, audioModels],
+  );
+
+  // The tile's play button opens the viewer already playing; opening the tile itself just
+  // loads the clip. Guarded so a re-render can't restart playback the user paused.
+  const started = useRef(false);
+  useEffect(() => {
+    if (!audio || started.current) {
+      return;
+    }
+    started.current = true;
+    if (audioAutoPlay) {
+      player.toggleTake(asset);
+    }
+  }, [audio, audioAutoPlay, asset, player]);
+
   return (
     <div aria-label={`${title} preview`} className="su-preview" role="dialog">
       <div className="su-preview-head">
@@ -20,11 +63,29 @@ export function SimplePreview({ asset, onClose, onUseAsReference, onToggleFavori
         </button>
         <strong>{asset.displayName ?? title}</strong>
       </div>
-      <div className="su-preview-stage">
-        <AssetMedia asset={asset} />
+      <div className={audio ? "su-preview-stage su-preview-stage--audio" : "su-preview-stage"}>
+        {audio ? (
+          <SimpleAudioViewer
+            asset={asset}
+            breakpoint={breakpoint}
+            meta={audioMetaLine(asset, run)}
+            onSendToVideo={onSendToVideo}
+            player={player}
+            run={run}
+          />
+        ) : (
+          <AssetMedia asset={asset} />
+        )}
       </div>
       <div className="su-preview-actions">
-        {assetCanRenderAsAudio(asset) ? null : (
+        {audio ? (
+          phone && onSendToVideo ? (
+            <button className="su-preview-primary" onClick={() => onSendToVideo(asset)} type="button">
+              <Icon.Editor size={16} />
+              Send to Video Editor
+            </button>
+          ) : null
+        ) : (
           <button className="su-preview-primary" onClick={() => onUseAsReference(asset)} type="button">
             <Icon.Image size={16} />
             Use as reference
@@ -44,4 +105,30 @@ export function SimplePreview({ asset, onClose, onUseAsReference, onToggleFavori
       </div>
     </div>
   );
+}
+
+// The viewer's meta line — model · voice · language · rate/channels · age. Every clause is
+// read off the asset's OWN recorded recipe and measured file block (project_store's audio
+// asset record), so a clip that recorded none simply shows fewer clauses. The model is shown
+// by its catalog LABEL when it's still installed (the recipe records the id), falling back to
+// the recorded id so a clip from an uninstalled model still names what produced it.
+function audioMetaLine(asset, run) {
+  const settings = asset?.recipe?.normalizedSettings ?? {};
+  const rate = Number(asset?.file?.sampleRate);
+  const channels = Number(asset?.file?.channels);
+  const format = [
+    Number.isFinite(rate) && rate > 0 ? `${Math.round(rate / 100) / 10} kHz` : null,
+    channels === 1 ? "mono" : channels === 2 ? "stereo" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return [
+    run?.modelName || asset?.recipe?.model || null,
+    settings.voice ?? null,
+    settings.language ?? null,
+    format || null,
+    formatRelativeTime(asset?.createdAt) || null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -3,6 +3,7 @@ import { Icon } from "../components/Icons.jsx";
 import { Logo } from "../components/Logo.jsx";
 import { ConfirmHost } from "../appConfirm.jsx";
 import { useAppContext } from "../context/AppContext.js";
+import { assetCanRenderAsAudio } from "../components/assetMedia.jsx";
 import { terminalStatuses } from "../constants.js";
 import { breakpointFor, contentMaxWidth } from "./breakpoint.js";
 import { ADVANCED_MODE } from "./uiMode.js";
@@ -73,6 +74,7 @@ export function SimpleShell({
     updateAssetStatus,
     setSelectedAssetId,
     setActiveView,
+    sendAssetToVideo,
   } = useAppContext();
 
   const [rootRef, width] = useContainerWidth();
@@ -84,6 +86,12 @@ export function SimpleShell({
   const [sheet, setSheet] = useState(null);
   const [guideOpen, setGuideOpen] = useState(false);
   const [preview, setPreview] = useState(null);
+  // Which audio asset the Assets viewer holds (epic 14361 / sc-14366). It lives HERE, beside
+  // `preview`, so the grid and the viewer agree on which clip is loaded — the grid rings the
+  // loaded tile while the viewer IS that clip's play deck. Only the ID is shell state: the
+  // transport itself lives in the viewer, so a `timeupdate` can't re-render every screen.
+  const [loadedTakeId, setLoadedTakeId] = useState(null);
+  const [audioAutoPlay, setAudioAutoPlay] = useState(false);
   const [toastText, setToastText] = useState(null);
   // The reference an asset preview hands to the Image Studio. Held here (not in the
   // studio) so "Use as reference" works from Assets, which is a different screen.
@@ -99,6 +107,22 @@ export function SimpleShell({
   const toastTimer = useRef(null);
 
   useEffect(() => () => clearTimeout(toastTimer.current), []);
+
+  // Opening an asset. An audio asset also becomes the loaded take, so the grid rings it and
+  // the viewer opens on its deck; `play` (the tile's play button) starts it immediately.
+  const openPreview = useCallback((asset, options = {}) => {
+    if (!asset) {
+      setPreview(null);
+      return;
+    }
+    if (assetCanRenderAsAudio(asset)) {
+      setLoadedTakeId(asset.id);
+      setAudioAutoPlay(Boolean(options.play));
+    } else {
+      setAudioAutoPlay(false);
+    }
+    setPreview(asset);
+  }, []);
 
   const toast = useCallback((message) => {
     setToastText(message);
@@ -139,7 +163,8 @@ export function SimpleShell({
       openSheet: setSheet,
       closeSheet: () => setSheet(null),
       openGuide: () => setGuideOpen(true),
-      openPreview: setPreview,
+      openPreview,
+      loadedTakeId,
       openInAdvanced,
       uiLocked: lockedToSimple,
       toast,
@@ -148,7 +173,18 @@ export function SimpleShell({
       dismissedJobIds,
       dismissJob,
     }),
-    [breakpoint, goTo, toast, referenceRequest, openInAdvanced, lockedToSimple, dismissedJobIds, dismissJob],
+    [
+      breakpoint,
+      goTo,
+      toast,
+      referenceRequest,
+      openInAdvanced,
+      lockedToSimple,
+      dismissedJobIds,
+      dismissJob,
+      openPreview,
+      loadedTakeId,
+    ],
   );
 
   const active = SCREEN_BY_ID.get(screen) ?? SCREEN_BY_ID.get("image");
@@ -277,7 +313,18 @@ export function SimpleShell({
         {previewAsset ? (
           <SimplePreview
             asset={previewAsset}
+            audioAutoPlay={audioAutoPlay}
+            breakpoint={breakpoint}
             onClose={() => setPreview(null)}
+            onSendToVideo={
+              sendAssetToVideo
+                ? (asset) => {
+                    if (openInAdvanced("Video")) {
+                      sendAssetToVideo(asset);
+                    }
+                  }
+                : null
+            }
             onDelete={async (asset) => {
               setPreview(null);
               await deleteAsset(asset);

--- a/apps/web/src/simple/SimpleUiContext.js
+++ b/apps/web/src/simple/SimpleUiContext.js
@@ -12,7 +12,10 @@ import { createContext, useContext } from "react";
 //   openSheet({ title, kind, options, onSelect })  — kind: "list" | "grid" | "pills"
 //   closeSheet()
 //   openGuide()
-//   openPreview(asset)
+//   openPreview(asset, { play })  — `play: true` opens an audio asset already playing
+//   loadedTakeId        — the audio asset the preview last loaded, so the Assets grid can
+//                         ring it (epic 14361). Only the id: the transport lives in the
+//                         viewer, so playback ticks don't re-render every screen.
 //   toast(message)
 //   openInAdvanced(view) — hand off to a full-workspace screen (returns false, with an
 //                          explanatory toast, when the viewport has Simple locked on)

--- a/apps/web/src/simple/simple.css
+++ b/apps/web/src/simple/simple.css
@@ -423,35 +423,6 @@
   font-weight: 700;
 }
 
-.su-segmented {
-  display: flex;
-  gap: 2px;
-  max-width: 340px;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  background: var(--bg-2);
-}
-
-.su-segmented button {
-  flex: 1;
-  padding: 8px;
-  border: 0;
-  border-radius: var(--r-xs);
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 12.5px;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.su-segmented button.active {
-  background: var(--surface);
-  color: var(--text);
-  font-weight: 700;
-  box-shadow: var(--shadow-sm);
-}
-
 .su-field-label {
   font-size: 12px;
   font-weight: 600;
@@ -1993,19 +1964,321 @@
   animation: su-pop 0.2s var(--ease-out);
 }
 
-/* ---------- Audio result transport ---------- */
+/* ---------- Audio: take grid, play deck, Assets tile + viewer (epic 14361) ---------- */
+/* Sizes step off the MEASURED band (the shell's `breakpoint`), never a media query, so the
+   screens stay correct when the shell is embedded in a narrow frame. Every grid/flex
+   container below carries minmax(0, 1fr) / min-width: 0 — without it the no-wrap transport
+   rows make their column max-content and the deck overflows at phone width. */
 
-.su-audio-result {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px;
+.su-take-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--su-take-cols, 2), minmax(0, 1fr));
+  gap: 10px;
+}
+
+.su-take {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 8px;
   border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  transition: border-color var(--t-fast);
+}
+
+.su-take.is-loaded {
+  border-color: var(--accent);
+}
+
+.su-take__wave {
+  position: relative;
+  height: 88px;
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  overflow: hidden;
+}
+
+.su-take__play {
+  position: absolute;
+  left: 6px;
+  bottom: 6px;
+}
+
+.su-take__duration {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  padding: 1px 5px;
+  border-radius: var(--r-xs);
+  background: color-mix(in oklch, var(--bg-2) 82%, transparent);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  pointer-events: none;
+}
+
+.su-take__title {
+  font-size: 12.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-take__meta {
+  font-size: 11px;
+  color: var(--text-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The studio's play deck. */
+.su-deck {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 13px;
+  border: 1px solid var(--border-strong);
   border-radius: var(--r-md);
   background: var(--surface);
 }
 
-.su-audio-result audio {
-  flex: 1;
+.su-deck__el {
+  display: none;
+}
+
+.su-deck__head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
   min-width: 0;
+}
+
+.su-deck__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-deck__close {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-xs);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.su-deck__stage {
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  overflow: hidden;
+}
+
+.su-deck__transport {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.su-deck__play--phone {
+  width: 48px;
+  height: 48px;
+}
+
+.su-deck__meta {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-deck__meta--phone {
+  flex: none;
+}
+
+.su-deck__actions {
+  display: inline-flex;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.su-deck__action,
+.su-deck__wide-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.su-deck__action {
+  height: 32px;
+  padding: 0 11px;
+}
+
+/* Phone: Download / Run again leave the transport row for a full-width pair under the clock. */
+.su-deck__wide-action {
+  flex: 1;
+  height: 42px;
+}
+
+.su-deck__actions--phone {
+  display: flex;
+  gap: 9px;
+}
+
+/* Assets grid: the audio cell. Same square as an image cell, split into waveform + bar. */
+.su-asset--audio {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  background: var(--bg-2);
+  transition: border-color var(--t-fast);
+  border: 1px solid transparent;
+}
+
+.su-asset--audio.is-loaded {
+  border-color: var(--accent);
+}
+
+/* The cell body is the open target; the play button sits above it in z-order. */
+.su-asset-open {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.su-asset-open__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.su-asset-audio__wave {
+  display: grid;
+  align-items: center;
+  min-height: 0;
+  padding: 0 7px;
+  pointer-events: none;
+}
+
+.su-asset-audio__bar {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 6px 7px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.su-asset-audio__name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--text);
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-asset-audio__time {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+
+/* Assets viewer: the deck at full size, replacing the bare <audio> stage. */
+.su-preview-stage--audio {
+  align-items: center;
+  padding: 0 16px;
+}
+
+.su-audio-viewer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
+  width: min(680px, 100%);
+}
+
+.su-audio-viewer__meta {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.su-audio-viewer__meta-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-audio-viewer__panel {
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--bg-2);
+}
+
+.su-audio-viewer__transport {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.su-audio-viewer__transport .audio-play-btn--xl {
+  width: 56px;
+  height: 56px;
+}
+
+.su-audio-viewer__clock {
+  font-size: 15px;
+}
+
+.su-audio-viewer__send {
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
+.su-root[data-bp="phone"] .su-audio-viewer {
+  width: 100%;
 }

--- a/apps/web/src/simple/simpleAudioParts.jsx
+++ b/apps/web/src/simple/simpleAudioParts.jsx
@@ -1,0 +1,228 @@
+import React from "react";
+import { Icon } from "../components/Icons.jsx";
+import { audioAssetDurationSeconds } from "../components/WorkerProgressCard.jsx";
+import {
+  AudioClock,
+  AudioDownloadButton,
+  AudioPlayButton,
+  AudioWaveform,
+  LoadedAudioElement,
+  WAVEFORM_BARS,
+} from "../components/audioTakeParts.jsx";
+import { audioTakeTitle, formatClock } from "../audioTakes.js";
+
+// Simple UI audio parts (epic 14361 / sc-14365, sc-14366) — the take grid, the deck and the
+// Assets viewer stage, in Simple's own vocabulary.
+//
+// Same behavior as the Advanced surfaces (one <audio>, one loaded take, played band + clock
+// off `timeupdate`), sized off the MEASURED container band rather than a media query, so the
+// screens stay correct when the shell is embedded in a narrow frame.
+
+// Stage waveform height and play-button size per band — the design's three steps.
+const DECK_WAVE_HEIGHT = Object.freeze({ desktop: 84, tablet: 72, phone: 58 });
+const VIEWER_WAVE_HEIGHT = Object.freeze({ desktop: 150, tablet: 132, phone: 104 });
+
+/** Take-grid column count per band (3 desktop / 2 tablet / 1 phone). */
+export function takeGridColumns(breakpoint) {
+  if (breakpoint === "desktop") {
+    return 3;
+  }
+  return breakpoint === "tablet" ? 2 : 1;
+}
+
+/** One take in the Simple results grid. */
+export function SimpleTakeCard({ run, asset, index, loaded, playing, progress, onToggle, phone }) {
+  const duration = audioAssetDurationSeconds(asset);
+  return (
+    <div className={loaded ? "su-take is-loaded" : "su-take"} data-testid="su-take-card">
+      <div className="su-take__wave">
+        <AudioWaveform
+          asset={asset}
+          bars={WAVEFORM_BARS.card}
+          height={88}
+          label={`Take ${index + 1}`}
+          progress={loaded ? progress : 0}
+        />
+        <AudioPlayButton
+          className="su-take__play"
+          label={`${loaded && playing ? "Pause" : "Play"} take ${index + 1}`}
+          onClick={() => onToggle(asset)}
+          playing={loaded && playing}
+          size={phone ? "lg" : "sm"}
+        />
+        <span className="su-take__duration">{formatClock(duration)}</span>
+      </div>
+      <strong className="su-take__title">
+        Take {index + 1} · {audioTakeTitle(run?.job, asset)}
+      </strong>
+      <span className="su-take__meta">
+        {run?.modeLabel} · {run?.modelName}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The Simple studio's play deck: the same head / stage / transport stack as the Advanced
+ * deck at reduced sizes. On phone the Download / Run again pair moves out of the transport
+ * row into full-width buttons under the clock, so the no-wrap row can't overflow.
+ */
+export function SimpleAudioDeck({ run, asset, takeIndex, player, breakpoint, onRunAgain }) {
+  const phone = breakpoint === "phone";
+  const duration = player.duration > 0 ? player.duration : audioAssetDurationSeconds(asset);
+  const meta = [run?.modelName, ...(run?.chips ?? [])].filter(Boolean).join(" · ");
+  const actions = (
+    <>
+      <AudioDownloadButton
+        asset={asset}
+        className={phone ? "su-deck__wide-action" : "su-deck__action"}
+        iconSize={15}
+        label="Download"
+      />
+      {onRunAgain && run?.job ? (
+        <button
+          className={phone ? "su-deck__wide-action" : "su-deck__action"}
+          onClick={() => onRunAgain(run.job)}
+          type="button"
+        >
+          <Icon.Refresh size={15} />
+          Run again
+        </button>
+      ) : null}
+    </>
+  );
+  return (
+    <div className="su-deck" data-testid="su-audio-deck">
+      <LoadedAudioElement asset={asset} player={player} className="su-deck__el" />
+      <div className="su-deck__head">
+        <span className={`audio-mode-chip audio-mode-chip--${run?.mode ?? "speech"}`}>
+          {run?.modeLabel ?? "Audio"}
+          {takeIndex >= 0 ? <span className="audio-mode-chip__extra">Take {takeIndex + 1}</span> : null}
+        </span>
+        <strong className="su-deck__title">{audioTakeTitle(run?.job, asset)}</strong>
+        <button aria-label="Close player" className="su-deck__close" onClick={player.unload} type="button">
+          <Icon.Close size={16} />
+        </button>
+      </div>
+      <div className="su-deck__stage">
+        <AudioWaveform
+          asset={asset}
+          bars={WAVEFORM_BARS.deck}
+          height={DECK_WAVE_HEIGHT[breakpoint] ?? DECK_WAVE_HEIGHT.desktop}
+          label="Clip"
+          onSeek={player.seekFraction}
+          progress={player.progress}
+        />
+      </div>
+      <div className="su-deck__transport">
+        {/* 44px desktop/tablet, 48px phone — the phone step is a touch-target bump, not a
+            different control, so it rides a modifier rather than a second size. */}
+        <AudioPlayButton
+          className={phone ? "su-deck__play su-deck__play--phone" : "su-deck__play"}
+          onClick={() => player.toggleTake(asset)}
+          playing={player.isPlaying}
+          size="lg"
+        />
+        <AudioClock current={player.currentTime} total={duration} />
+        {phone ? null : <span className="su-deck__meta">{meta}</span>}
+        {phone ? null : <div className="su-deck__actions">{actions}</div>}
+      </div>
+      {phone ? (
+        <>
+          <span className="su-deck__meta su-deck__meta--phone">{meta}</span>
+          <div className="su-preview-row su-deck__actions--phone">{actions}</div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The Simple Assets viewer stage for an audio asset — the deck at full size, replacing the
+ * bare <audio> the overlay used to render. The viewer's own Favorite / Download / Delete row
+ * stays in SimplePreview; only the stage lives here.
+ */
+export function SimpleAudioViewer({ asset, player, breakpoint, meta, run, onSendToVideo }) {
+  const phone = breakpoint === "phone";
+  const duration = player.duration > 0 ? player.duration : audioAssetDurationSeconds(asset);
+  const loaded = player.loadedTakeId === asset.id;
+  return (
+    <div className="su-audio-viewer" data-testid="su-audio-viewer">
+      <LoadedAudioElement asset={asset} player={player} className="su-deck__el" />
+      {run || meta ? (
+        <div className="su-audio-viewer__meta">
+          {run ? (
+            <span className={`audio-mode-chip audio-mode-chip--${run.mode}`}>{run.modeLabel}</span>
+          ) : null}
+          {meta ? <span className="su-audio-viewer__meta-text">{meta}</span> : null}
+        </div>
+      ) : null}
+      <div className="su-audio-viewer__panel">
+        <AudioWaveform
+          asset={asset}
+          bars={WAVEFORM_BARS.stage}
+          height={VIEWER_WAVE_HEIGHT[breakpoint] ?? VIEWER_WAVE_HEIGHT.desktop}
+          label="Clip"
+          onSeek={player.seekFraction}
+          progress={loaded ? player.progress : 0}
+        />
+      </div>
+      <div className="su-audio-viewer__transport">
+        <AudioPlayButton
+          onClick={() => player.toggleTake(asset)}
+          playing={loaded && player.isPlaying}
+          size="xl"
+        />
+        <AudioClock className="audio-clock su-audio-viewer__clock" current={loaded ? player.currentTime : 0} total={duration} />
+        {!phone && onSendToVideo ? (
+          <button className="secondary-action su-audio-viewer__send" onClick={() => onSendToVideo(asset)} type="button">
+            <Icon.Editor size={15} />
+            Send to Video Editor
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The Assets grid cell for an audio asset: a waveform over a bottom bar carrying the play
+ * button, the display name and the duration — inside the same square cell images and clips
+ * use, so the grid keeps its rhythm.
+ *
+ * The cell carries no transport of its own: in Assets the DECK IS THE VIEWER, so the play
+ * button opens the viewer already playing (`onToggle`) while the cell body opens it paused
+ * (`onOpen`). `loaded` just rings the clip the viewer last held.
+ */
+export function SimpleAudioTile({ asset, loaded, onOpen, onToggle, phone }) {
+  const duration = audioAssetDurationSeconds(asset);
+  const name = asset.displayName ?? asset.id;
+  return (
+    <div className={loaded ? "su-asset su-asset--audio is-loaded" : "su-asset su-asset--audio"}>
+      <button
+        className="su-asset-open"
+        onClick={() => onOpen(asset)}
+        title={name}
+        type="button"
+      >
+        <span className="su-asset-open__label">{name}</span>
+      </button>
+      <span className="su-asset-audio__wave">
+        <AudioWaveform asset={asset} bars={WAVEFORM_BARS.tile} height={phone ? 38 : 42} label={name} />
+      </span>
+      <span className="su-asset-audio__bar">
+        <AudioPlayButton label={`Play ${name}`} onClick={() => onToggle(asset)} playing={false} size="xs" />
+        {phone ? null : <span className="su-asset-audio__name">{name}</span>}
+        <span className="su-asset-audio__time">{formatClock(duration)}</span>
+      </span>
+      <span aria-hidden="true" className="su-asset-kind">
+        <Icon.Audio size={11} />
+      </span>
+      {asset.status?.favorite ? (
+        <span aria-hidden="true" className="su-asset-fav">
+          <Icon.Star filled size={14} />
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15162,3 +15162,598 @@ textarea[aria-invalid="true"]:focus {
 .multiphase-cfg-hint {
   margin-top: 2px;
 }
+
+/* ══ Audio Studio redesign — take grid, run groups and the play deck (epic 14361) ═══════
+   The results zone stopped being a job monitor: runs group into waveform take cards on the
+   same .review-grid geometry the Image/Video studios use, with a now-playing deck docked
+   above them. Presentation only — every value is a token, so light theme and all six accent
+   palettes keep working, and nothing here hardcodes a resolved oklch literal. */
+
+/* ---------- Work panel: settings bar as a fixed 4-column grid (sc-14363) ---------- */
+/* Scoped to the Audio Studio so the Image/Video studios' flex settings rows are untouched.
+   Model · Voice · Length are the fixed columns; every capability-gated extra field (Language,
+   BPM, Key, region start/end, edit strength) simply becomes another cell. */
+.audio-settings-bar .settings-bar-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 14px;
+  align-items: end;
+}
+
+.audio-settings-bar .settings-field {
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .audio-settings-bar .settings-bar-row {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* The capability hint owns the start of the Advanced disclosure's header row — the settings
+   bar's footer — instead of sitting inside the Model label where it displaced the caption. */
+.advanced-section-leading {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.advanced-section--leading .advanced-section-toggle {
+  flex: 0 0 auto;
+}
+
+.audio-capability-hint {
+  margin-top: 0;
+  font-size: 12px;
+  color: var(--text-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The ⌘↵ hint moved from the results head to sit under the Generate CTA. */
+.prompt-cta-stack {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  justify-items: center;
+  gap: 6px;
+}
+
+.prompt-cta-stack .prompt-cta {
+  width: 100%;
+}
+
+/* ---------- Waveform primitive ---------- */
+.audio-wave {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  overflow: hidden;
+}
+
+button.audio-wave {
+  cursor: pointer;
+}
+
+.audio-wave__svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  stroke: color-mix(in oklch, var(--accent) 55%, var(--bg-2));
+  stroke-width: 2.6;
+  stroke-linecap: round;
+  fill: none;
+}
+
+.audio-wave--idle .audio-wave__svg {
+  stroke: color-mix(in oklch, var(--accent) 26%, var(--bg-2));
+}
+
+/* The played band + its playhead. Width is currentTime / duration; the transition matches
+   .progress-track span so the two progress surfaces move at the same rate. */
+.audio-wave__played {
+  position: absolute;
+  inset: 0 auto 0 0;
+  pointer-events: none;
+  background: color-mix(in oklch, var(--accent) 20%, transparent);
+  border-right: 2px solid var(--accent-strong);
+  transition: width 180ms ease;
+}
+
+/* ---------- Transport controls ---------- */
+.audio-play-btn {
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: var(--accent);
+  color: var(--accent-fg);
+  cursor: pointer;
+  transition: background var(--t-fast);
+}
+
+.audio-play-btn:hover {
+  background: var(--accent-strong);
+}
+
+.audio-play-btn--xs { width: 22px; height: 22px; }
+.audio-play-btn--sm { width: 28px; height: 28px; }
+.audio-play-btn--md { width: 32px; height: 32px; }
+.audio-play-btn--lg { width: 44px; height: 44px; }
+
+.audio-play-btn--xl {
+  width: 46px;
+  height: 46px;
+  box-shadow: 0 8px 22px color-mix(in oklch, var(--accent) 30%, transparent);
+}
+
+.audio-round-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: border-color var(--t-fast), color var(--t-fast);
+}
+
+.audio-round-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.audio-round-btn.is-on {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.audio-clock {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+
+.audio-clock strong {
+  font-weight: 500;
+  color: var(--text);
+}
+
+/* Accent text link used by "See all in Assets", "Run again" and the strip's Queue link. */
+.audio-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--accent-strong);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.audio-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Mode chip ---------- */
+.audio-mode-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex: 0 0 auto;
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.audio-mode-chip__extra {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  opacity: 0.85;
+}
+
+.audio-mode-chip--music {
+  background: color-mix(in oklch, var(--warm) 22%, var(--surface));
+  color: var(--warm);
+}
+
+.audio-mode-chip--sfx {
+  background: color-mix(in oklch, var(--success) 20%, var(--surface));
+  color: var(--success);
+}
+
+.audio-mode-chip--voiceclone {
+  background: color-mix(in oklch, var(--accent) 16%, var(--surface));
+  color: var(--accent-strong);
+}
+
+/* ---------- Results zone ---------- */
+.audio-results {
+  min-width: 0;
+}
+
+.audio-results__count {
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.audio-results__all {
+  align-self: center;
+}
+
+/* In-flight strip — the trimmed progress row that replaces the full worker card here. */
+.audio-inflight {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.audio-inflight__status {
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.audio-inflight__body {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.audio-inflight__titles {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.audio-inflight__title {
+  font-size: 13.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.audio-inflight__message {
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-inflight__track {
+  height: 6px;
+}
+
+.audio-inflight__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.audio-inflight .secondary-action {
+  height: 30px;
+}
+
+/* Run group — header row then the take grid. */
+.audio-run {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.audio-run__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.audio-run__model {
+  font-size: 13.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.audio-run__chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.audio-run__chip {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-xs);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.audio-run__rule {
+  flex: 1 1 20px;
+  min-width: 12px;
+  height: 1px;
+  background: var(--border);
+}
+
+.audio-run__time {
+  font-size: 12px;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+
+.audio-take-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: var(--gap-3);
+}
+
+/* Take card — .review-card geometry with a waveform well instead of a poster frame. */
+.audio-take {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  min-width: 0;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+
+.audio-take.is-loaded {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 20%, transparent);
+}
+
+.audio-take__wave {
+  position: relative;
+  height: 118px;
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  overflow: hidden;
+}
+
+.audio-take__badge,
+.audio-take__duration {
+  position: absolute;
+  padding: 2px 6px;
+  border-radius: var(--r-xs);
+  background: color-mix(in oklch, var(--bg-2) 82%, transparent);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  pointer-events: none;
+}
+
+.audio-take__badge {
+  top: 7px;
+  left: 7px;
+}
+
+.audio-take__duration {
+  right: 7px;
+  bottom: 7px;
+  font-size: 11px;
+}
+
+.audio-take__play {
+  position: absolute;
+  left: 7px;
+  bottom: 7px;
+}
+
+.audio-take__prompt {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.audio-take__meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--text-faint);
+  min-width: 0;
+}
+
+.audio-take__meta span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-take__meta-duration {
+  font-family: var(--font-mono);
+  flex: 0 0 auto;
+}
+
+.audio-take__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.audio-icon-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-xs);
+  background: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+
+.audio-icon-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.audio-icon-btn.is-on {
+  color: var(--accent-strong);
+}
+
+.audio-icon-btn--danger:hover {
+  color: var(--danger);
+}
+
+/* ---------- Play deck ---------- */
+/* The explicit minmax(0, 1fr) matters: without it the no-wrap transport row makes the grid
+   column max-content and the deck overflows narrow containers. */
+.audio-deck {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-lg);
+  background: var(--bg-2);
+}
+
+.audio-deck__el {
+  display: none;
+}
+
+.audio-deck__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.audio-deck__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 14.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-deck__head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.audio-deck__head-actions .secondary-action {
+  height: 32px;
+}
+
+.audio-deck__again {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.audio-deck__close {
+  width: 32px;
+  padding: 0;
+  justify-content: center;
+}
+
+.audio-deck__stage {
+  padding: 14px 16px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg);
+}
+
+.audio-deck__stage .audio-wave {
+  height: 140px;
+}
+
+.audio-deck__ticks {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  padding-top: 7px;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+
+.audio-deck__transport {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.audio-deck__meta {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: right;
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .audio-deck__head {
+    flex-wrap: wrap;
+  }
+
+  .audio-deck__transport {
+    flex-wrap: wrap;
+  }
+
+  .audio-deck__meta {
+    flex-basis: 100%;
+    text-align: left;
+  }
+}


### PR DESCRIPTION
Implements the design handoff in `design/Audio Studio redesign directions.zip`
(`design_handoff_audio_studio/README.md` + screenshots `2a` / `3a` / `4a`).
Epic [sc-14361](https://app.shortcut.com/trefry/epic/14361), stories
[sc-14362](https://app.shortcut.com/trefry/story/14362) ·
[sc-14363](https://app.shortcut.com/trefry/story/14363) ·
[sc-14364](https://app.shortcut.com/trefry/story/14364) ·
[sc-14365](https://app.shortcut.com/trefry/story/14365) ·
[sc-14366](https://app.shortcut.com/trefry/story/14366) ·
[sc-14367](https://app.shortcut.com/trefry/story/14367).

## What changes

The Audio Studio's "Latest audio" zone rendered nothing but queue-worker cards, so a
creative surface read like a job monitor. It is now a creative surface.

**Advanced studio (screen 2a)**
- A slim **in-flight strip** per running run — status chip, title, message, a 6px progress
  track, Cancel + a Queue link. The full `WorkerProgressCard` (job id, GPU meters, attempt
  counter, hardware pills) stays in the Queue screen; it survives here only for a FAILED
  run, which still needs its error and retries.
- **Run groups**, newest first: mode chip, model, the run's own settings chips, relative
  time, and a **Run again** that re-submits the run's OWN recorded payload — not the
  current control values.
- **Take cards** on `.review-grid` geometry: waveform well with a Take N chip, round accent
  play/pause, played band + playhead, prompt excerpt, meta, and the favourite / download /
  send-to-timeline / discard actions.
- The **play deck**, docked above the runs while a take is loaded: head, waveform stage with
  a tick row, and the transport (skip / play / loop / clock / meta). Clicking the stage
  seeks. Only one clip plays at a time.
- **Settings-bar alignment fix**: `.settings-bar-row` was a flex row with
  `align-items: flex-end` whose Model field carried the capability hint — pushing the MODEL
  caption ~24px above its neighbours and overflowing them. Now a fixed `2fr 1fr 1fr 1fr`
  grid, with the hint moved onto the Advanced disclosure's header row via a new generic
  `leading` slot on the shared `AdvancedSection` (rather than forking the "one canonical
  Advanced disclosure" component). Every capability-gated field keeps its gate.

**Simple UI (screens 3a / 4a)**
- Audio's mode control becomes the `.su-tabs` underline tabs Image and Video already use;
  the "this studio is a preview" notice is gone.
- The same deck + take grid, sized off the **measured band** (3/2/1 columns; stage waveform
  84/72/58px; 44px play, 48px on phone). On phone the deck's Download / Run again leave the
  transport row for a full-width pair under the clock.
- Simple Assets: an audio asset rendered a blank hatched placeholder and opened a bare
  `<audio>`. It now draws its waveform inside the same square cell, and the viewer stage is
  the deck at full size (mode chip, meta line, 56px transport, Send to Video Editor).

**Waveforms** are derived from the rendered clip client-side (fetch + Web Audio
`decodeAudioData`), downsampled and cached per asset so one decode serves every surface. No
`AudioContext`, a purged file or an undecodable codec all degrade to a flat idle bar row and
are never retried. The bundle's `waveforms.json` is a synthetic mock stand-in and does not
ship.

## Three bugs found along the way

1. **`audio_studio` was never added to `LIBRARY_ORIGINS`** when the Audio Studio landed
   (epic 13400). Every generated clip was filtered out of BOTH asset libraries — the
   Advanced Library screen and the Simple Assets grid, whose "Audio" filter pill had
   therefore never matched anything. Screen 4a was literally unreachable until this was
   fixed. Verified in the running app: 0 → 6 assets.
2. **`job.progress` is a 0..1 fraction, not a percentage.** The first cut of the in-flight
   strip rendered `4400%` for a 44%-complete run. Now routed through `formatting.percent`,
   the same helper `WorkerProgressCard` uses. Caught by looking at the running app — the
   unit test written alongside it had encoded the same wrong convention, and now pins
   `0.44 → "44%"`.
3. **`audioLocalJobs` only holds the CURRENT session's runs**, so "Latest audio" was empty
   on every fresh launch — contradicting the design's own "last N clips in this project"
   head. Added `recentAudioAssets` (the audio twin of `recentImage/recentVideoAssets`), and
   runs the lane doesn't hold are reconstructed from each asset's `recipe` replay record.

## Known limits (documented on the stories, not hidden)

- **An audio job produces exactly one asset today** (`audio_streaming_result` hardcodes
  `expectedCount: 1`), so a run group is single-take in practice. The grid is the right
  shape and forward-compatible; the mock's "3 takes" is design fiction.
- The asset replay record (`recipe.normalizedSettings`) keeps voice / language / requested
  length / seed but **not** the music sub-block, so an asset-derived Music run shows no
  BPM/key chip. Widening it is a backend change, deliberately not made here.
- A voice clone (needs its reference re-picked) and a run whose model is uninstalled can't
  be replayed, so those groups hide Run again rather than offering a button that would fail.
- The **Advanced** Library screen still renders audio as a bare tile — outside the handoff's
  scope, but newly visible now that audio assets reach it. Filed as
  [sc-14391](https://app.shortcut.com/trefry/story/14391).

## Verification

- Full web suite green: **2488 passed / 175 files**. `eslint src`: 0 errors (69 pre-existing
  warnings, none in the new files).
- New tests: 11 in `audioWaveform.test.js`, 16 in `audioTakes.test.js`, 5 in
  `AudioStudio.test.jsx` (run grouping + absence of the worker card, deck mount/ring on play
  and unmount on ×, Run again re-submitting the stored payload, the in-flight strip, the
  failed-run worker card). The one existing test that asserted the old worker-card results
  zone was replaced, not deleted.
- Driven in the running app against a local mock API with real WAVs: playback, seeking, the
  played band and clock, the accent ring following the loaded take — at 1400px and 430px, in
  **both light and dark themes**. Every new CSS value is a token or a `color-mix` over one;
  no resolved oklch literals, so the six accent palettes keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
