### PR TITLE
Audio Studio: add model-aware prompt guides and refinement [sc-14353]

### DIFF
--- a/apps/web/public/prompt-guides/acestep-v15-turbo.md
+++ b/apps/web/public/prompt-guides/acestep-v15-turbo.md
@@ -1,25 +1,74 @@
 # ACE-Step v1.5 XL Turbo Music Guide
 
-ACE-Step v1.5 XL Turbo is a **text-to-music** model — describe a piece and it composes and renders it. It powers the Audio Studio **Music** tab and also supports prompted audio editing of an existing clip.
+ACE-Step v1.5 XL Turbo is a **text-to-music** model. Audio Studio gives it two different text inputs: a **Music Description** (the prompt) for the recording’s overall sound, and optional **Lyrics** for the words and song timeline.
 
 ## Installation
 
 ACE-Step runs natively (Candle) on every platform. Install it once from the **Models** screen — it is about 11 GB and downloads into the shared Hugging Face cache from `ACE-Step/acestep-v15-xl-turbo-diffusers` (MIT). It ships its own Oobleck VAE, so there is no separately-licensed audio component.
 
-## Writing the prompt
+## Music Description
 
-- Describe genre, mood, instrumentation, and tempo: "dreamy lo-fi hip-hop, mellow Rhodes, vinyl crackle, 80 BPM".
-- Lyrics and prompts in 50+ languages are supported (English, Chinese, Japanese, Korean, French, German, Spanish, Italian, Portuguese, Russian, and more); the language tag is advisory.
-- The turbo checkpoint is guidance-distilled, so it runs fast at a low step count (the reference default is around 8) — no separate CFG scale to tune.
+Describe the whole recording in a compact paragraph. Useful dimensions are:
+
+- genre and style;
+- lead and supporting instruments;
+- mood and atmosphere;
+- vocal gender, character, and delivery when vocals are wanted;
+- tempo feel (or use the separate BPM control);
+- how verses, choruses, bridges, or instrumental passages change in energy;
+- production character, such as intimate live-room, raw demo, spacious cinematic, or polished modern mix.
+
+Example:
+
+> Bittersweet indie pop with intimate female lead vocals, shimmering clean electric guitars, warm melodic bass, restrained acoustic drums, and subtle analog synth pads. Reflective close-miked verses expand into wide, cathartic choruses, ending with layered harmonies and a fading guitar figure.
+
+**Refine my prompt** rewrites only this Music Description. It must return one description—not lyrics, field labels, BPM/key metadata, or commentary. Lyrics and all other controls remain unchanged until you edit them yourself.
+
+## Lyrics and song structure
+
+Lyrics are separate from the Music Description. Use section tags to describe the song’s timeline:
+
+```text
+[Intro]
+[Instrumental]
+
+[Verse 1]
+Cardboard boxes by the door
+Dust outlines across the floor
+
+[Chorus]
+I'm driving past the county line
+Leaving half my heart behind
+
+[Bridge]
+Maybe leaving doesn't mean
+Losing everything we've been
+
+[Outro]
+[Instrumental]
+```
+
+Useful tags include `[Intro]`, `[Verse 1]`, `[Pre-Chorus]`, `[Chorus]`, `[Bridge]`, `[Instrumental]`, and `[Outro]`. Keep each section’s lyric length realistic for the selected duration. Leave Lyrics empty for an instrumental track.
+
+## Audio Studio controls
+
+- **BPM**: optional whole-number tempo. Leave blank for automatic tempo.
+- **Key**: optional musical key such as `C minor` or `A Major`.
+- **Language**: select the language matching the lyrics. SceneWorks currently exposes English, Chinese, Japanese, Korean, French, German, Spanish, Italian, Portuguese, and Russian.
+- **Length**: target duration, up to 600 seconds.
+- **Steps**: advanced solver-step override; blank keeps the Turbo model’s default.
+
+Time signature is not a separate SceneWorks control. If meter matters, describe it in the Music Description (for example, “slow 6/8 ballad”).
+
+The Turbo checkpoint is guidance-distilled, so Audio Studio does not show unsupported CFG or negative-prompt controls.
 
 ## Editing existing audio
 
-ACE-Step can edit a source clip through three modes:
+Choose a Source track to enable the edit modes advertised by the installed model:
 
 - **Inpaint** — regenerate a bounded interior span fresh from the prompt.
 - **Repaint** — regenerate a span while conditioning on the surrounding audio for continuity.
-- **Extend** — continue the clip past its end, preserving the original.
+- **Extend** — continue the clip past its end; Length is the new total duration.
+- **Cover** — restyle the whole source using the Music Description.
 
-## Duration
-
-Output is 48 kHz stereo, up to **10 minutes**. Longer clips cost proportionally more time on CPU.
+For Inpaint/Repaint, set Region start/end in seconds. Edit strength is optional. Output is 48 kHz stereo.

--- a/apps/web/public/prompt-guides/chatterbox-tts.md
+++ b/apps/web/public/prompt-guides/chatterbox-tts.md
@@ -4,7 +4,7 @@ Chatterbox Clone-TTS (Resemble AI) renders a **full cloned-voice voiceover direc
 
 ## Installation
 
-The model runs natively (Candle) on every platform. Install it once from the **Models** screen — the T3 checkpoint, the S3Gen checkpoint, and the tokenizer download into the shared Hugging Face cache from `ResembleAI/chatterbox` (MIT). The speaker voice-encoder and the PerTh watermarker weights are small companion files the model resolves from the hub on first use.
+The model runs natively (Candle) on every platform. Install it once from the **Models** screen — the T3 checkpoint, S3Gen checkpoint, tokenizer, speaker voice encoder, and PerTh watermarker are provisioned as the model’s pinned downloads in the shared Hugging Face cache (`ResembleAI/chatterbox`, MIT).
 
 ## How it works
 
@@ -14,6 +14,8 @@ You provide two inputs:
 - **Reference voice** — a short library audio clip of the target voice. The model derives the speaker identity from it and uses it as the acoustic reference for the waveform, so one call produces the cloned voiceover.
 
 There is no separate base-voice or match-strength control: the clone is rendered end to end in the reference voice at 24 kHz mono, up to about 30 seconds per generation.
+
+**Refine my prompt** treats the prompt as a script. It preserves the words and meaning and makes only minimal punctuation or readability adjustments; it does not change the selected reference voice.
 
 ## Practical notes
 

--- a/apps/web/public/prompt-guides/generic-audio.md
+++ b/apps/web/public/prompt-guides/generic-audio.md
@@ -1,0 +1,19 @@
+# Audio Prompt Guide
+
+Audio Studio uses the selected model’s capabilities to decide whether the prompt is a script, a music description, a sound-effect description, or cloned-voice copy.
+
+## Speech and Voice Clone
+
+Write the exact words you want spoken. Natural punctuation controls pauses and phrasing. The prompt refiner preserves the wording and makes only small punctuation or readability adjustments.
+
+## Music
+
+Use the Music Description for the overall sound: genre, instrumentation, mood, vocal character, tempo feel, section dynamics, and production style. Put sung words in the separate Lyrics field when the selected model provides one.
+
+## Sound FX
+
+Name the sound source, action, material, environment, distance, intensity, duration, and acoustic space. Prefer concrete audible details over a story about the sound.
+
+## Refinement behavior
+
+**Refine my prompt** rewrites only the currently visible prompt. It does not alter lyrics, model settings, source audio, voice selections, or other generation controls. The proposed rewrite is not applied until you choose **Apply**.

--- a/apps/web/public/prompt-guides/kokoro-82m.md
+++ b/apps/web/public/prompt-guides/kokoro-82m.md
@@ -17,6 +17,8 @@ Kokoro ships **28 English voices** — 20 American (`af_*` female, `am_*` male) 
 - Output is 24 kHz mono, up to about **30 seconds** per request. For longer passages, split into multiple clips.
 - An optional target duration nudges the pace (the model derives a speed factor, clamped to 0.5–2.0×).
 
+**Refine my prompt** treats the prompt as a script. It preserves the words and meaning and makes only minimal punctuation or readability adjustments; it does not turn the script into a description of a voice.
+
 ## Practical notes
 
 Kokoro is single-speaker per request — render each speaker separately for a dialogue. It is small and fast, so iterating on wording and voice is cheap.

--- a/apps/web/public/prompt-guides/moss-soundeffect-v2.md
+++ b/apps/web/public/prompt-guides/moss-soundeffect-v2.md
@@ -9,13 +9,19 @@ MOSS-SFX runs natively (Candle) on every platform. Install it once from the **Mo
 ## Writing the prompt
 
 - Describe the source and its character: "heavy rain on a tin roof", "a distant thunderclap", "footsteps on gravel".
+- Add audible context when it matters: action, material, distance, intensity, environment, and acoustic space.
 - Bilingual prompts (English / Chinese) are supported; the language is advisory, not a mode switch.
 - Guidance (CFG) sharpens adherence to the prompt; the reference default is around 4.0, and 1.0 turns guidance off.
-- A negative prompt steers the model away from unwanted qualities.
+
+Example:
+
+> A heavy wooden cellar door creaks open slowly, rusty hinges grinding, close perspective in a damp stone room with a short dark echo; no speech or music.
+
+**Refine my prompt** rewrites this sound description only. It does not change length, language, guidance, steps, or seed. Audio Studio does not expose a negative-prompt field for this model.
 
 ## Duration
 
-Output is 48 kHz mono, up to **30 seconds**, with 0.1-second-granular duration control. Ask for the length you need directly.
+Output is 48 kHz mono, up to **30 seconds**, with whole-second duration control. Ask for the length you need directly.
 
 ## Practical notes
 

--- a/apps/web/public/prompt-guides/moss-tts-realtime.md
+++ b/apps/web/public/prompt-guides/moss-tts-realtime.md
@@ -14,7 +14,7 @@ MOSS-TTS-Realtime runs natively (Candle) on every platform, on CPU / Accelerate.
 
 ## Streaming
 
-This is the studio's first streaming model. As the clip renders, the results card advances chunk by chunk and the first speech is produced long before the whole clip is done. The finished, fully-assembled clip is what lands in your library and plays back — streaming is about how quickly it starts, not a different result.
+As the clip renders, the results card advances chunk by chunk. The current browser player becomes audible after the fully assembled clip is saved; it does not yet play partial chunks while synthesis is still running.
 
 ## Duration
 
@@ -22,4 +22,6 @@ Output is 24 kHz mono. Ask for the length you need; longer scripts simply take l
 
 ## Practical notes
 
-Because synthesis is autoregressive (one block of speech tokens at a time), latency to the first chunk stays low even for a long script — you hear it start almost immediately, then it fills in.
+Because synthesis is autoregressive (one block of speech tokens at a time), worker progress can begin well before a long script is complete.
+
+**Refine my prompt** treats the input as a script. It preserves the words and meaning and makes only minimal punctuation or readability adjustments.

--- a/apps/web/public/prompt-guides/moss-ttsd-v05.md
+++ b/apps/web/public/prompt-guides/moss-ttsd-v05.md
@@ -14,6 +14,8 @@ MOSS-TTSD runs natively (Candle) on every platform, on CPU / Accelerate. Install
 - Use normal punctuation — periods and commas shape the pacing. 20 in-band languages are supported (Chinese, English, and 18 more); write each turn in the language you want spoken.
 - There is no fixed voice bank: the model assigns a distinct natural voice to each speaker label. For a specific cloned voice, use the **Voice Clone** tab instead.
 
+Each turn has its own **Refine my prompt** action. Refinement treats that turn as spoken script, preserves its words and meaning, and leaves every other turn and speaker selection unchanged until you choose **Apply**.
+
 ## Single voice vs. multi-speaker
 
 A plain single-voice Speech model (Kokoro, MOSS-TTS-Realtime) reads one prompt in one voice. MOSS-TTSD is the model to reach for when you want a *dialogue* — an interview, a two-person scene, a narrated exchange — rendered as one continuous clip with the turns already voiced apart.

--- a/apps/web/public/prompt-guides/openvoice-v2.md
+++ b/apps/web/public/prompt-guides/openvoice-v2.md
@@ -1,6 +1,6 @@
 # OpenVoice V2 Voice Conversion Guide
 
-OpenVoice V2 is a **tone-color voice-conversion** model. It takes source speech and a short reference clip of a target voice, then re-renders the source in the target's timbre while preserving the original content and prosody. It is one of the models behind the Audio Studio **VoiceClone** tab.
+OpenVoice V2 is the conversion backend for Audio Studio’s **Voice Clone** fallback. You type a script and select a target reference voice. SceneWorks first synthesizes the script with its base speech model, then OpenVoice transfers the reference clip’s timbre onto that speech.
 
 ## Installation
 
@@ -8,15 +8,16 @@ OpenVoice runs natively (Candle) on every platform. Install it once from the **M
 
 ## How it works
 
-This is a **prompt-free** transform — there is no text prompt. You provide two inputs:
+You provide two user-facing inputs:
 
-- **Source audio** — the speech whose words and delivery you want to keep.
-- **Target reference** — a few seconds of the voice whose timbre you want to apply.
+- **Script** — the exact words to speak.
+- **Reference voice** — a few clean seconds of the target voice.
 
-The converter extracts the target's tone color and transfers it onto the source. Output is 22.05 kHz; it does not resample, so keep the studio's output rate at the model's native rate.
+SceneWorks creates the source speech internally; there is no source-audio picker in this flow. The converter extracts the target’s tone color and transfers it to that generated speech. Output is 22.05 kHz.
+
+**Refine my prompt** treats the prompt as a script: it preserves the words and meaning, making only minimal punctuation or readability adjustments. It does not describe the target voice or change the selected reference.
 
 ## Practical notes
 
 - A clean, dry reference clip gives the best timbre transfer.
-- A strength control adjusts how strongly the target timbre is applied.
-- Because content and prosody come from the source, record the performance you want first, then convert the voice.
+- Match strength controls how strongly the reference timbre is applied.

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -797,6 +797,10 @@ export const fallbackModels = [
       label: "Kokoro 82M",
       description:
         "Kokoro-82M text-to-speech (StyleTTS2 lineage) — the recommended Speech model. English voices (American + British), 24 kHz mono, up to ~30 s per clip. Candle-native on every platform. Apache-2.0.",
+      promptGuide: {
+        title: "Kokoro 82M Speech Guide",
+        path: "/prompt-guides/kokoro-82m.md",
+      },
     },
   },
   {
@@ -818,6 +822,10 @@ export const fallbackModels = [
       label: "MOSS-TTS-Realtime (Streaming)",
       description:
         "MOSS-TTS-Realtime-1.7B streaming text-to-speech — streams speech in incremental chunks as it renders, so the first audio arrives before the clip finishes. 24 kHz mono, English + Chinese. Candle-native on every platform. Apache-2.0.",
+      promptGuide: {
+        title: "MOSS-TTS-Realtime Guide",
+        path: "/prompt-guides/moss-tts-realtime.md",
+      },
     },
   },
   {
@@ -842,6 +850,10 @@ export const fallbackModels = [
       label: "MOSS-TTSD v0.5 (Multi-Speaker)",
       description:
         "MOSS-TTSD-v0.5 multi-speaker / long-form dialogue text-to-speech — give it a segmented script (up to two speakers, [S1]/[S2]) and it renders the whole dialogue in one clip, each turn in its own voice. 24 kHz mono, 20 in-band languages. Candle-native on every platform. Apache-2.0.",
+      promptGuide: {
+        title: "MOSS-TTSD Multi-Speaker Guide",
+        path: "/prompt-guides/moss-ttsd-v05.md",
+      },
     },
   },
   {
@@ -860,6 +872,10 @@ export const fallbackModels = [
       label: "MOSS SoundEffect v2",
       description:
         "MOSS-SoundEffect v2.0 text-to-audio flow-matching model for sound effects and ambience. 48 kHz mono, up to 30 s. Candle-native on every platform. Apache-2.0.",
+      promptGuide: {
+        title: "MOSS SoundEffect v2 Guide",
+        path: "/prompt-guides/moss-soundeffect-v2.md",
+      },
     },
   },
   {
@@ -881,6 +897,10 @@ export const fallbackModels = [
       label: "ACE-Step v1.5 XL Turbo",
       description:
         "ACE-Step v1.5 XL Turbo text-to-music model. 48 kHz stereo, up to 10 minutes, with prompted audio editing (inpaint / repaint / extend). Candle-native on every platform. MIT.",
+      promptGuide: {
+        title: "ACE-Step v1.5 XL Turbo Music Guide",
+        path: "/prompt-guides/acestep-v15-turbo.md",
+      },
     },
   },
   {
@@ -898,6 +918,10 @@ export const fallbackModels = [
       label: "OpenVoice V2",
       description:
         "OpenVoice V2 tone-color voice conversion — transfers a target voice's timbre onto source speech from a short reference clip. 22.05 kHz output. Candle-native on every platform. MIT.",
+      promptGuide: {
+        title: "OpenVoice V2 Voice Conversion Guide",
+        path: "/prompt-guides/openvoice-v2.md",
+      },
     },
   },
   {
@@ -919,6 +943,10 @@ export const fallbackModels = [
       label: "Chatterbox Clone-TTS",
       description:
         "Chatterbox (Resemble AI) native cloned-voice TTS — renders a full cloned-voice WAV directly from your script plus a short reference clip in a single step (no separate base-TTS/conversion pass). 24 kHz mono, up to 30 s. Candle-native on every platform. MIT.",
+      promptGuide: {
+        title: "Chatterbox Clone-TTS Guide",
+        path: "/prompt-guides/chatterbox-tts.md",
+      },
     },
   },
   {
@@ -935,6 +963,10 @@ export const fallbackModels = [
       label: "Chatterbox Voice Encoder",
       description:
         "Chatterbox (Resemble AI) speaker voice encoder — maps a few seconds of reference audio to a voice-identity embedding for cloned-voice conditioning. Candle-native on every platform. MIT.",
+      promptGuide: {
+        title: "Chatterbox Voice Encoder Guide",
+        path: "/prompt-guides/chatterbox-ve.md",
+      },
     },
   },
 ];

--- a/apps/web/src/constants.test.js
+++ b/apps/web/src/constants.test.js
@@ -37,3 +37,24 @@ describe("fallbackModels SD3.5 surfacing (sc-7873)", () => {
     expect(medium.defaults.guidanceScale).toBe(4.5);
   });
 });
+
+describe("fallbackModels audio prompt-guide parity (sc-14353)", () => {
+  it("gives every selectable built-in audio fallback its model-specific guide", () => {
+    const expected = {
+      kokoro_82m: "/prompt-guides/kokoro-82m.md",
+      moss_tts_realtime: "/prompt-guides/moss-tts-realtime.md",
+      moss_ttsd_v05: "/prompt-guides/moss-ttsd-v05.md",
+      moss_sfx_v2: "/prompt-guides/moss-soundeffect-v2.md",
+      acestep_v15_turbo: "/prompt-guides/acestep-v15-turbo.md",
+      openvoice_v2: "/prompt-guides/openvoice-v2.md",
+      chatterbox_tts: "/prompt-guides/chatterbox-tts.md",
+      chatterbox_ve: "/prompt-guides/chatterbox-ve.md",
+    };
+
+    for (const [id, path] of Object.entries(expected)) {
+      const model = fallbackModels.find((entry) => entry.id === id);
+      expect(model, `${id} must be present in fallbackModels`).toBeTruthy();
+      expect(model.ui?.promptGuide?.path).toBe(path);
+    }
+  });
+});

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -14,6 +14,9 @@ import {
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
 import { jobAudioResultAssets } from "../jobResultAssets.js";
 import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
+import { RefinePromptControl } from "../components/RefinePromptControl.jsx";
+import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 
 // SceneWorks Audio Studio — the navigable shell (epic 13400, C0 / sc-13407). This screen mirrors
 // the canonical studio shell (VideoStudio.jsx): page-frame > WorkPanel + .mode-tabs + AdvancedSection
@@ -180,6 +183,21 @@ function groupVoicesByGenderAccent(voices) {
   return groups;
 }
 
+const GENERIC_AUDIO_PROMPT_GUIDE = Object.freeze({
+  title: "Audio Prompt Guide",
+  path: "/prompt-guides/generic-audio.md",
+});
+
+function usablePromptGuide(guide) {
+  return (
+    guide &&
+    typeof guide.title === "string" &&
+    guide.title.trim() &&
+    typeof guide.path === "string" &&
+    guide.path.trim()
+  );
+}
+
 export function AudioStudio() {
   const {
     activeProject,
@@ -190,6 +208,7 @@ export function AudioStudio() {
     audioLocalJobs = [],
     jobAction,
     createAudioJob,
+    refinePrompt,
     createModelDownloadJob,
     rememberLocalGenerationJob,
     setActiveView,
@@ -253,6 +272,7 @@ export function AudioStudio() {
   const [registeringVoice, setRegisteringVoice] = useState(false);
   const [savedVoiceNotice, setSavedVoiceNotice] = useState(null);
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
+  const [guideOpen, setGuideOpen] = useState(false);
   // Guards a Speech run in flight so a second submit (double-click / ⌘↵) can't double-enqueue
   // (mirrors VideoStudio's `submitting`). Cleared in submit's finally.
   const [submitting, setSubmitting] = useState(false);
@@ -274,12 +294,17 @@ export function AudioStudio() {
       .filter(isVoiceCloneConverter)
       .sort((a, b) => Number(isNativeCloneGenerator(b)) - Number(isNativeCloneGenerator(a)));
   };
-  const selectedModel = audioModels.find((item) => item.id === model) ?? audioModels[0] ?? null;
+  const modeModels = modelsForMode(mode);
+  // Resolve only against models that can actually generate in this mode. A reduced catalog may
+  // contain audio utility components (for example Chatterbox-VE) that must never become a prompt
+  // target merely because there is no compatible generator to put in the picker.
+  const selectedModel =
+    modeModels.find((item) => item.id === model) ?? modeModels[0] ?? null;
 
-  // Model-availability gate: `ready` follows the picker (audioModels is live-catalog-then-fallback in
-  // App.jsx — empty only once the catalog has loaded with no installed audio model). Offers come from
-  // the full catalog via audioModelUsable, recommended-first.
-  const modelReady = audioModels.length > 0;
+  // Model-availability gate: an installed audio utility alone is not enough; at least one model must
+  // serve a real Audio Studio generation mode. Offers still come from the full catalog so the user
+  // can install a compatible generator.
+  const modelReady = AUDIO_MODES.some((value) => modelsForMode(value).length > 0);
   const modelOffers = useMemo(
     () => downloadOffersFor(models, audioModelUsable, macCapabilities),
     [models, macCapabilities],
@@ -288,6 +313,18 @@ export function AudioStudio() {
     () => (jobs ?? []).filter((job) => job.type === "model_download"),
     [jobs],
   );
+  // Same local refinement model used by Image / Video Studio. The shared control owns the
+  // missing-model download affordance; Audio Studio only resolves the catalog entry.
+  const refineModel = useMemo(
+    () => models.find((entry) => entry.id === PROMPT_REFINE_MODEL_ID),
+    [models],
+  );
+  // Built-ins declare a model-specific guide. Keep third-party / legacy entries useful with an
+  // audio-aware fallback instead of silently hiding the guide and refinement surfaces.
+  const declaredPromptGuide = selectedModel?.ui?.promptGuide;
+  const promptGuide = usablePromptGuide(declaredPromptGuide)
+    ? declaredPromptGuide
+    : GENERIC_AUDIO_PROMPT_GUIDE;
 
   // The selected model's audio capabilities — the single source every field below reads from. Never
   // hardcoded: an absent sub-block simply hides the dependent control.
@@ -452,20 +489,23 @@ export function AudioStudio() {
   const canGenerate =
     WIRED_MODES.has(mode) &&
     modelReady &&
-    Boolean(model) &&
+    Boolean(selectedModel) &&
     contentReady &&
     referenceReady &&
     !submitting;
 
-  // Snap the model to one that serves the active mode (mirrors VideoStudio). A no-op when the current
-  // model already serves the mode, or when nothing serves it (a reduced catalog).
+  // Snap a reduced catalog to its first usable mode, then snap the model state to the resolved
+  // generator for that mode. This keeps prompt-free audio utilities out of the picker/refiner path.
   useEffect(() => {
-    if (modelServesMode(selectedModel, mode)) {
+    if (!modeModels.length) {
+      const fallbackMode = AUDIO_MODES.find((value) => modelsForMode(value).length > 0);
+      if (fallbackMode && fallbackMode !== mode) {
+        setMode(fallbackMode);
+      }
       return;
     }
-    const fallback = modelsForMode(mode)[0];
-    if (fallback && fallback.id !== model) {
-      setModel(fallback.id);
+    if (selectedModel && selectedModel.id !== model) {
+      setModel(selectedModel.id);
     }
     // modelServesMode / modelsForMode close over audioModels, captured below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -586,7 +626,7 @@ export function AudioStudio() {
       // language-casing seam (en-US → en-us) is handled server-side. Language is omitted when unset so
       // the model derives its own default. Mirrors how VideoStudio builds createVideoJob's payload.
       const payload = {
-        model,
+        model: selectedModel.id,
         prompt: prompt.trim(),
         language: language || undefined,
         targetDurationSecs: clampedDuration,
@@ -672,9 +712,9 @@ export function AudioStudio() {
     }
   }
 
-  // The model list the picker offers: those that serve the active mode, falling back to the full
-  // available list if none do (a reduced catalog) so the picker is never empty.
-  const pickerModels = modelsForMode(mode).length ? modelsForMode(mode) : audioModels;
+  // The picker must contain only models that can generate in the active mode. Utility-only or
+  // incompatible reduced catalogs are handled by the availability gate / mode snap above.
+  const pickerModels = modeModels;
 
   return (
     <ModelAvailabilityGate
@@ -714,6 +754,11 @@ export function AudioStudio() {
                   );
                 })}
               </div>
+              <div className="prompt-hero-links">
+                <button className="hero-link" onClick={() => setGuideOpen(true)} type="button">
+                  <Icon.Book size={14} /> Prompt guide
+                </button>
+              </div>
             </div>
 
             <div className="prompt-input-row">
@@ -744,14 +789,29 @@ export function AudioStudio() {
                           </option>
                         ))}
                       </select>
-                      <textarea
-                        aria-label={`Segment ${index + 1} text`}
-                        className="script-segment-text"
-                        onChange={(event) => updateSegment(index, { text: event.target.value })}
-                        placeholder="What this speaker says…"
-                        rows={2}
-                        value={segment.text ?? ""}
-                      />
+                      <div className="script-segment-content">
+                        <textarea
+                          aria-label={`Segment ${index + 1} text`}
+                          className="script-segment-text"
+                          onChange={(event) => updateSegment(index, { text: event.target.value })}
+                          placeholder="What this speaker says…"
+                          rows={2}
+                          value={segment.text ?? ""}
+                        />
+                        <RefinePromptControl
+                          key={`${mode}:${selectedModel?.id}:${script.length}:${index}`}
+                          guidePath={promptGuide.path}
+                          modelId={selectedModel?.id}
+                          onApply={(refined) => updateSegment(index, { text: refined })}
+                          prompt={segment.text}
+                          refinePrompt={refinePrompt}
+                          refineModel={refineModel}
+                          onDownloadRefineModel={
+                            refineModel ? () => createModelDownloadJob(refineModel) : undefined
+                          }
+                          workflow="audio"
+                        />
+                      </div>
                       <button
                         aria-label={`Remove segment ${index + 1}`}
                         className="script-segment-remove"
@@ -793,13 +853,34 @@ export function AudioStudio() {
               </button>
             </div>
 
+            {/* Multi-speaker turns own one refiner apiece inside their structured editor above. Plain
+                prompt modes share this single control. Key by mode + resolved model so switching either
+                aborts an in-flight request and cannot surface a stale rewrite from the previous guide. */}
+            {!showMultiSpeaker && selectedModel ? (
+              <RefinePromptControl
+                key={`${mode}:${selectedModel.id}`}
+                guidePath={promptGuide.path}
+                modelId={selectedModel.id}
+                onApply={setPrompt}
+                prompt={prompt}
+                refinePrompt={refinePrompt}
+                refineModel={refineModel}
+                onDownloadRefineModel={
+                  refineModel ? () => createModelDownloadJob(refineModel) : undefined
+                }
+                workflow="audio"
+              />
+            ) : null}
+
             <div className="settings-bar">
               <div className="settings-bar-row">
                 <label className="settings-field settings-field-model">
                   Model
-                  <select onChange={(event) => setModel(event.target.value)} value={model}>
-                    {/* Models gated on the selected tab: only those that serve the active mode,
-                        falling back to the full list so the picker is never empty. */}
+                  <select
+                    onChange={(event) => setModel(event.target.value)}
+                    value={selectedModel?.id ?? ""}
+                  >
+                    {/* Models gated on the selected tab: only real generators that serve this mode. */}
                     {pickerModels.map((item) => (
                       <option key={item.id} value={item.id}>
                         {item.name ?? item.ui?.label ?? item.id}
@@ -1244,6 +1325,13 @@ export function AudioStudio() {
             </section>
           </div>
         </form>
+        {guideOpen ? (
+          <PromptGuideModal
+            guide={promptGuide}
+            modelName={selectedModel?.name}
+            onClose={() => setGuideOpen(false)}
+          />
+        ) : null}
       </section>
     </ModelAvailabilityGate>
   );

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -13,6 +13,7 @@ vi.mock("../api.js", async (importOriginal) => {
 import { AppContext } from "../context/AppContext.js";
 import { AudioStudio } from "./AudioStudio.jsx";
 import { KEEP_ALIVE_VIEWS, navSections, viewTitles } from "../App.jsx";
+import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
 
 // Fixture audio models mirroring the seeded `type:"audio"` catalog entries (constants.js). Each
 // carries only the `audio` sub-block the eligibility predicates + UI read — voices (speech),
@@ -32,7 +33,10 @@ const KOKORO = {
     sampleRates: [24000],
     maxDurationSecs: 30,
   },
-  ui: { label: "Kokoro 82M" },
+  ui: {
+    label: "Kokoro 82M",
+    promptGuide: { title: "Kokoro Speech Guide", path: "/prompt-guides/kokoro-82m.md" },
+  },
 };
 
 const MOSS = {
@@ -40,7 +44,10 @@ const MOSS = {
   name: "MOSS SoundEffect v2 (SFX)",
   type: "audio",
   audio: { languages: ["en", "zh"], sampleRates: [48000], maxDurationSecs: 30 },
-  ui: { label: "MOSS SoundEffect v2" },
+  ui: {
+    label: "MOSS SoundEffect v2",
+    promptGuide: { title: "MOSS SoundEffect Guide", path: "/prompt-guides/moss-soundeffect-v2.md" },
+  },
 };
 
 const ACESTEP = {
@@ -54,7 +61,10 @@ const ACESTEP = {
     editModes: ["inpaint", "repaint", "extend", "cover"],
     conditioning: ["AudioEdit"],
   },
-  ui: { label: "ACE-Step v1.5 XL Turbo" },
+  ui: {
+    label: "ACE-Step v1.5 XL Turbo",
+    promptGuide: { title: "ACE-Step Music Guide", path: "/prompt-guides/acestep-v15-turbo.md" },
+  },
 };
 
 const OPENVOICE = {
@@ -62,7 +72,10 @@ const OPENVOICE = {
   name: "OpenVoice V2 (Voice Conversion)",
   type: "audio",
   audio: { sampleRates: [22050], conditioning: ["ReferenceAudio"] },
-  ui: { label: "OpenVoice V2" },
+  ui: {
+    label: "OpenVoice V2",
+    promptGuide: { title: "OpenVoice Guide", path: "/prompt-guides/openvoice-v2.md" },
+  },
 };
 
 // Native clone-TTS generator (sc-13412): ReferenceAudio + VoiceEmbedding marks it as a single-call clone
@@ -78,7 +91,10 @@ const CHATTERBOX_TTS = {
     maxDurationSecs: 30,
     conditioning: ["VoiceEmbedding", "ReferenceAudio"],
   },
-  ui: { label: "Chatterbox Clone-TTS" },
+  ui: {
+    label: "Chatterbox Clone-TTS",
+    promptGuide: { title: "Chatterbox Guide", path: "/prompt-guides/chatterbox-tts.md" },
+  },
 };
 
 // Streaming TTS (sc-13675): NO voice bank — serves Speech via audio.supportsStreaming. Kept OUT of
@@ -93,7 +109,10 @@ const MOSS_TTS_REALTIME = {
     maxDurationSecs: 2400,
     supportsStreaming: true,
   },
-  ui: { label: "MOSS-TTS-Realtime (Streaming)" },
+  ui: {
+    label: "MOSS-TTS-Realtime (Streaming)",
+    promptGuide: { title: "MOSS Realtime Guide", path: "/prompt-guides/moss-tts-realtime.md" },
+  },
 };
 
 // Multi-speaker dialogue TTS (sc-13676): NO voice bank — serves Speech via audio.supportsMultiSpeaker
@@ -110,7 +129,10 @@ const MOSS_TTSD = {
     supportsMultiSpeaker: true,
     maxSpeakers: 2,
   },
-  ui: { label: "MOSS-TTSD v0.5 (Multi-Speaker)" },
+  ui: {
+    label: "MOSS-TTSD v0.5 (Multi-Speaker)",
+    promptGuide: { title: "MOSS Multi-Speaker Guide", path: "/prompt-guides/moss-ttsd-v05.md" },
+  },
 };
 
 const ALL_AUDIO = [KOKORO, MOSS, ACESTEP, OPENVOICE];
@@ -142,6 +164,23 @@ const fieldByLabelStart = (container, label) =>
   [...container.querySelectorAll(".settings-bar label")].find((el) =>
     el.textContent.trim().startsWith(label),
   );
+const setTextareaValue = async (el, value) => {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    ).set;
+    setter.call(el, value);
+    el.dispatchEvent(new window.Event("input", { bubbles: true }));
+  });
+};
+const settle = async () => {
+  await act(async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve();
+    }
+  });
+};
 
 describe("AudioStudio shell (sc-13407)", () => {
   let container;
@@ -280,6 +319,27 @@ describe("AudioStudio shell (sc-13407)", () => {
     expect(options).not.toContain("chatterbox_ve");
   });
 
+  it("does not treat a prompt-free voice encoder as a generator in a reduced catalog", async () => {
+    const chatterbox = {
+      id: "chatterbox_ve",
+      name: "Chatterbox Voice Encoder",
+      type: "audio",
+      audio: { conditioning: ["VoiceEmbedding"] },
+      ui: {
+        label: "Chatterbox Voice Encoder",
+        promptGuide: {
+          title: "Chatterbox Voice Encoder Guide",
+          path: "/prompt-guides/chatterbox-ve.md",
+        },
+      },
+    };
+    await render(baseContext({ audioModels: [chatterbox], models: [chatterbox] }));
+
+    expect(container.querySelector(".model-availability-gate")).toBeTruthy();
+    expect(container.querySelector(".audio-studio")).toBeNull();
+    expect(buttonWithText(container, "Refine my prompt")).toBeUndefined();
+  });
+
   it("renders the studio body when an audio model is installed (gate open)", async () => {
     await render(baseContext());
     expect(container.querySelector(".audio-studio")).toBeTruthy();
@@ -293,6 +353,227 @@ describe("AudioStudio shell (sc-13407)", () => {
     expect(container.querySelector(".model-availability-gate")).toBeTruthy();
     expect(container.querySelector(".audio-studio")).toBeNull();
     expect(container.textContent).toContain("Audio Studio needs an audio model");
+  });
+});
+
+describe("AudioStudio prompt guides and refinement (sc-14353)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.restoreAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <AudioStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("opens the selected model's guide and switches from Kokoro to ACE-Step without stale content", async () => {
+    const fetchGuide = vi.spyOn(globalThis, "fetch").mockImplementation(async (path) => ({
+      ok: true,
+      text: async () => `Guide for ${path}`,
+    }));
+    await render(baseContext());
+
+    await click(buttonWithText(container, "Prompt guide"));
+    await settle();
+    expect(fetchGuide).toHaveBeenLastCalledWith("/prompt-guides/kokoro-82m.md");
+    expect(document.querySelector("#prompt-guide-title").textContent).toBe("Kokoro Speech Guide");
+
+    await click(buttonWithText(document, "Close"));
+    await click(modeTab(container, "Music"));
+    await click(buttonWithText(container, "Prompt guide"));
+    await settle();
+    expect(fetchGuide).toHaveBeenLastCalledWith("/prompt-guides/acestep-v15-turbo.md");
+    expect(document.querySelector("#prompt-guide-title").textContent).toBe("ACE-Step Music Guide");
+  });
+
+  it("refines an ACE-Step music description with the audio workflow and applies only after review", async () => {
+    const fetchGuide = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => "# ACE-Step guide\n\nRefine only the Music Description.",
+    });
+    const refinePrompt = vi.fn(async () => "Dreamy synth-pop with warm analog pads and a rising final chorus.");
+    await render(
+      baseContext({
+        refinePrompt,
+        models: [
+          ...ALL_AUDIO,
+          { id: PROMPT_REFINE_MODEL_ID, name: "Prompt Refiner", installState: "installed" },
+        ],
+      }),
+    );
+
+    await click(modeTab(container, "Music"));
+    const promptInput = container.querySelector('textarea[aria-label="Prompt"]');
+    await setTextareaValue(promptInput, "dreamy pop");
+    await click(buttonWithText(container, "Refine my prompt"));
+    await settle();
+
+    expect(fetchGuide).toHaveBeenCalledWith(
+      "/prompt-guides/acestep-v15-turbo.md",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(refinePrompt).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "dreamy pop",
+      modelId: "acestep_v15_turbo",
+      workflow: "audio",
+      guide: "# ACE-Step guide\n\nRefine only the Music Description.",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(promptInput.value).toBe("dreamy pop");
+
+    await click(buttonWithText(container, "Keep original"));
+    expect(promptInput.value).toBe("dreamy pop");
+
+    await click(buttonWithText(container, "Refine my prompt"));
+    await settle();
+    await click(buttonWithText(container, "Apply"));
+    expect(promptInput.value).toBe(
+      "Dreamy synth-pop with warm analog pads and a rising final chorus.",
+    );
+  });
+
+  it("uses the generic audio guide for a third-party model without usable guide metadata", async () => {
+    const thirdParty = {
+      ...MOSS,
+      id: "third_party_sfx",
+      name: "Third-party SFX",
+      ui: {
+        label: "Third-party SFX",
+        promptGuide: { title: " ", path: "" },
+      },
+    };
+    const fetchGuide = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => "# Generic audio guide",
+    });
+    await render(baseContext({ audioModels: [thirdParty], models: [thirdParty] }));
+
+    await click(modeTab(container, "Sound FX"));
+    await click(buttonWithText(container, "Prompt guide"));
+    await settle();
+    expect(fetchGuide).toHaveBeenLastCalledWith("/prompt-guides/generic-audio.md");
+    expect(document.querySelector("#prompt-guide-title").textContent).toBe("Audio Prompt Guide");
+  });
+
+  it("aborts an in-flight refinement when the mode/model changes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => "# Speech guide",
+    });
+    let refineSignal;
+    const refinePrompt = vi.fn(({ signal }) => {
+      refineSignal = signal;
+      return new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      });
+    });
+    await render(baseContext({ refinePrompt }));
+    await setTextareaValue(container.querySelector('textarea[aria-label="Prompt"]'), "Read this aloud.");
+    await click(buttonWithText(container, "Refine my prompt"));
+    await settle();
+    expect(refineSignal.aborted).toBe(false);
+
+    await click(modeTab(container, "Music"));
+    await settle();
+    expect(refineSignal.aborted).toBe(true);
+    expect(container.querySelector(".refine-review")).toBeNull();
+    expect(container.querySelector(".refine-error")).toBeNull();
+  });
+
+  it("reuses the missing-refiner download affordance inside Audio Studio", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true, text: async () => "# Guide" });
+    const refinePrompt = vi.fn(async () => {
+      throw new Error("prompt-refine model snapshot is not cached.");
+    });
+    const createModelDownloadJob = vi.fn(async () => ({ id: "download-refiner" }));
+    await render(
+      baseContext({
+        refinePrompt,
+        createModelDownloadJob,
+        models: [
+          ...ALL_AUDIO,
+          { id: PROMPT_REFINE_MODEL_ID, name: "Prompt Refiner", installState: "missing" },
+        ],
+      }),
+    );
+    await setTextareaValue(container.querySelector('textarea[aria-label="Prompt"]'), "Read this.");
+    await click(buttonWithText(container, "Refine my prompt"));
+    await settle();
+
+    await click(buttonWithText(container, "Download refinement model"));
+    await settle();
+    expect(createModelDownloadJob).toHaveBeenCalledWith(expect.objectContaining({
+      id: PROMPT_REFINE_MODEL_ID,
+    }));
+    expect(container.querySelector(".refine-missing-model").textContent).toContain("Downloading");
+  });
+
+  it("guides and non-destructively refines each multi-speaker script turn", async () => {
+    const fetchGuide = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => "# Multi-speaker guide",
+    });
+    const refinePrompt = vi.fn(async () => "Hello there, and welcome.");
+    await render(
+      baseContext({
+        audioModels: [MOSS_TTSD],
+        models: [
+          MOSS_TTSD,
+          { id: PROMPT_REFINE_MODEL_ID, name: "Prompt Refiner", installState: "installed" },
+        ],
+        refinePrompt,
+      }),
+    );
+    expect(container.querySelector('[data-testid="multi-speaker-script"]')).toBeTruthy();
+
+    await click(buttonWithText(container, "Prompt guide"));
+    await settle();
+    expect(fetchGuide).toHaveBeenLastCalledWith("/prompt-guides/moss-ttsd-v05.md");
+    expect(document.querySelector("#prompt-guide-title").textContent).toBe(
+      "MOSS Multi-Speaker Guide",
+    );
+    await click(buttonWithText(document, "Close"));
+
+    const firstTurn = container.querySelector('textarea[aria-label="Segment 1 text"]');
+    const secondTurn = container.querySelector('textarea[aria-label="Segment 2 text"]');
+    await setTextareaValue(firstTurn, "hello there and welcome");
+    await setTextareaValue(secondTurn, "Keep my second turn.");
+    const refineButtons = [...container.querySelectorAll("button")].filter((button) =>
+      button.textContent.includes("Refine my prompt"),
+    );
+    expect(refineButtons).toHaveLength(2);
+    await click(refineButtons[0]);
+    await settle();
+
+    expect(refinePrompt).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "hello there and welcome",
+      modelId: "moss_ttsd_v05",
+      workflow: "audio",
+      guide: "# Multi-speaker guide",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(firstTurn.value).toBe("hello there and welcome");
+    expect(secondTurn.value).toBe("Keep my second turn.");
+
+    await click(buttonWithText(container, "Apply"));
+    expect(firstTurn.value).toBe("Hello there, and welcome.");
+    expect(secondTurn.value).toBe("Keep my second turn.");
   });
 });
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2323,6 +2323,12 @@ label {
   min-width: 108px;
 }
 
+.script-segment-content {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
 .script-segment-text {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -2338,6 +2344,11 @@ label {
   outline: none;
   border-color: var(--accent);
   box-shadow: var(--shadow-glow);
+}
+
+.script-segment-content .refine-button {
+  padding-block: 4px;
+  font-size: 12px;
 }
 
 .script-segment-remove {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -9215,6 +9215,10 @@
             {
               "label": "ACE-Step v1.5 XL Turbo (Hugging Face)",
               "url": "https://huggingface.co/ACE-Step/acestep-v15-xl-turbo-diffusers"
+            },
+            {
+              "label": "ACE-Step 1.5 Musician's Guide",
+              "url": "https://github.com/ace-step/ACE-Step-1.5/blob/main/docs/en/ace_step_musicians_guide.md"
             }
           ]
         }

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -11,7 +11,7 @@
 //!
 //! The `TextLlm` contract is generic (`system` + `prompt` + sampling → text), so the
 //! prompt-refinement PRODUCT logic that lived in `prompt_refine.py` moves here caller-side: the
-//! rewrite rules + image/video medium switch + guide assembly (`build_refine_system_prompt`, into the
+//! rewrite rules + image/video/audio medium switch + guide assembly (`build_refine_system_prompt`, into the
 //! request `system`) and the reasoning-block / code-fence / surrounding-quote cleanup
 //! (`clean_refine_output`, over the model reply). Sampling matches the Python path (temperature 0.7,
 //! top_p 0.9, max_new_tokens 512), as does the empty-output → error behavior and the `{originalPrompt,
@@ -194,15 +194,16 @@ const PROGRESS_POST_INTERVAL: Duration = Duration::from_millis(250);
 // macOS + candle builds.
 // ----------------------------------------------------------------------------------------------
 
-/// The base rewrite rules with the `{medium}` placeholders filled (`image` / `video`). Verbatim port
-/// of the Python `_BASE_RULES.format(medium=…)`.
+/// The base rewrite rules with the `{medium}` placeholders filled (`image` / `video` / `audio`).
+/// Image-only photographic guidance is attached only to the image medium; audio adds protection for
+/// script/lyric text so a generic rewrite cannot silently change words intended to be spoken or sung.
 #[cfg(any(
     test,
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn base_rules(medium: &str) -> String {
-    [
+    let mut rules = vec![
         format!("You are a prompt rewriter for a generative {medium} model."),
         format!(
             "Rewrite the user's input into a single, precise {medium} prompt that follows the \
@@ -223,27 +224,42 @@ fn base_rules(medium: &str) -> String {
             .to_owned(),
         "- Follow the guide's recommended structure, phrasing, and what-to-avoid guidance."
             .to_owned(),
-        // sc-13881 (epic 13879): a refined PHOTOGRAPHIC prompt must keep the concrete camera/lens/
-        // film-stock specifications the user wrote — they carry real visual meaning to modern image
-        // models (Krea, for one, honors "Kodak Portra"). The refiner used to strip the whole trailing
-        // comma-list when trimming for concision, taking the camera/lens specs with the empty praise —
-        // a net-negative edit. Trim ONLY the empty praise; preserve the specifications.
-        "- Keep concrete photographic specifications the user wrote — camera body, lens and focal \
-         length, film stock, and aperture (e.g. \"85mm f/1.4\", \"Kodak Portra 400\", \"shot on a \
-         50mm lens\"). These carry real visual meaning; do not drop them when trimming."
-            .to_owned(),
-        "- When trimming for concision, remove ONLY empty praise that adds no visual information \
-         (\"masterpiece\", \"stunning\", \"premium\", \"gorgeous\", \"award-winning\", \
-         \"ultra-detailed\"), never the concrete camera, lens, film-stock, or lighting details."
-            .to_owned(),
         "- Match the user's language: if their prompt is not in English, respond in the same \
          language."
             .to_owned(),
         "- Do not wrap the output in quotes, markdown, JSON, or code fences unless those are part \
          of the described scene."
             .to_owned(),
-    ]
-    .join("\n")
+    ];
+    if medium.eq_ignore_ascii_case("image") {
+        // sc-13881 (epic 13879): a refined PHOTOGRAPHIC prompt must keep concrete camera/lens/
+        // film-stock specifications. Trim ONLY empty praise; preserve real visual specifications.
+        rules.extend([
+            "- Keep concrete photographic specifications the user wrote — camera body, lens and focal \
+             length, film stock, and aperture (e.g. \"85mm f/1.4\", \"Kodak Portra 400\", \"shot on a \
+             50mm lens\"). These carry real visual meaning; do not drop them when trimming."
+                .to_owned(),
+            "- When trimming for concision, remove ONLY empty praise that adds no visual information \
+             (\"masterpiece\", \"stunning\", \"premium\", \"gorgeous\", \"award-winning\", \
+             \"ultra-detailed\"), never the concrete camera, lens, film-stock, or lighting details."
+                .to_owned(),
+        ]);
+    } else if medium.eq_ignore_ascii_case("audio") {
+        rules.extend([
+            "- Treat the selected model guide as authoritative about whether the input is an audio \
+             description, a script, or lyrics."
+                .to_owned(),
+            "- If the input is a script or lyrics intended to be spoken or sung, preserve its words, \
+             meaning, section labels, and speaker labels. Make only minimal punctuation or formatting \
+             edits unless the guide explicitly asks for another transformation."
+                .to_owned(),
+            "- If the input describes music or sound, prefer concrete audible attributes such as \
+             instrumentation or sound source, performance, rhythm or pacing, space, dynamics, and \
+             production character. Do not add visual or camera terminology."
+                .to_owned(),
+        ]);
+    }
+    rules.join("\n")
 }
 
 /// Build the `system` message for the refiner: the rewrite rules (medium chosen from the workflow)
@@ -254,13 +270,10 @@ fn base_rules(medium: &str) -> String {
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 fn build_refine_system_prompt(guide: Option<&str>, workflow: Option<&str>) -> String {
-    let medium = if workflow
-        .map(|w| w.trim().eq_ignore_ascii_case("video"))
-        .unwrap_or(false)
-    {
-        "video"
-    } else {
-        "image"
+    let medium = match workflow.map(str::trim) {
+        Some(value) if value.eq_ignore_ascii_case("video") => "video",
+        Some(value) if value.eq_ignore_ascii_case("audio") => "audio",
+        _ => "image",
     };
     let rules = base_rules(medium);
     let guide = guide.unwrap_or("").trim();
@@ -1487,6 +1500,21 @@ mod tests {
         let video = build_refine_system_prompt(None, Some("video"));
         assert!(video.contains("generative video model"));
         assert!(!video.contains("# Model prompt guide"));
+
+        let audio = build_refine_system_prompt(
+            Some("# ACE-Step Guide\n\nRefine only the music description."),
+            Some("audio"),
+        );
+        assert!(audio.contains("generative audio model"));
+        assert!(audio.contains("ACE-Step Guide"));
+        assert!(
+            audio.contains("script or lyrics"),
+            "audio rules protect text intended to be spoken or sung"
+        );
+        assert!(
+            !audio.contains("camera body"),
+            "audio refinement must not inherit image-only camera guidance"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add model-aware Prompt guide and review-before-apply Refine my prompt parity to Audio Studio
- pass the selected audio model, model guide, current editable prompt/script turn, and `workflow: "audio"` through the shared refinement path
- add safe generic fallback metadata and per-model audio guide coverage, including an ACE-Step 1.5 caption/lyrics guide grounded in SceneWorks controls
- keep prompt-free audio utilities out of reduced-catalog generator/refiner paths
- teach the native worker audio-specific refinement rules so scripts and lyrics are protected and image camera/lens guidance is not inherited

## Validation

- `npm --prefix apps/web test -- --run` — 173 files / 2,465 tests passed
- focused Audio Studio/constants suite — 59 tests passed
- Image/Video guide/refiner parity suites — 119 tests passed
- `npm --prefix apps/web run lint` — 0 errors (68 pre-existing warnings)
- `npm --prefix apps/web run build`
- `npm run check`
- `npm run check:compose`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — all non-hardware tests passed; the sandbox-isolated Metal guard passed separately with GPU access
- `cargo build`
- `npm run rust:check:candle` — Linux/Candle worker and sidecar typechecked with test targets under `-D warnings`
- interactive browser verification in light/dark themes for ACE-Step and MOSS-TTSD per-turn refinement; no console errors
- independent adversarial review: PASS

The Docker-only `rust:check:neither` reproduction could not run locally because Docker Desktop was not running; CI is the source of truth for that lane.

Shortcut: https://app.shortcut.com/trefry/story/14353
