### PR TITLE
fix(worker): stabilize source URL resume test

### DIFF
--- a/crates/sceneworks-worker/src/tests/support_stubs.rs
+++ b/crates/sceneworks-worker/src/tests/support_stubs.rs
@@ -119,6 +119,10 @@ async fn spawn_binary_stub_with_options(
     let app = Router::new()
         .route("/api/v1/jobs/:job_id", get(job_stub))
         .route("/api/v1/jobs/:job_id/progress", post(progress_stub))
+        .route(
+            "/api/v1/workers/:worker_id/heartbeat",
+            post(heartbeat_stub),
+        )
         .route("/*path", get(binary_stub).head(binary_head_stub))
         .with_state(state);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -218,6 +222,12 @@ async fn progress_stub(
     axum::extract::Path(job_id): axum::extract::Path<String>,
 ) -> Response {
     Json(job_snapshot_json(&job_id, state.cancel_requested)).into_response()
+}
+
+async fn heartbeat_stub(
+    axum::extract::Path(worker_id): axum::extract::Path<String>,
+) -> Response {
+    Json(worker_snapshot_json(&worker_id)).into_response()
 }
 
 fn job_snapshot_json(job_id: &str, cancel_requested: bool) -> Value {


### PR DESCRIPTION
## Summary

- register the worker heartbeat endpoint in the shared binary/API test stub
- return the existing worker snapshot shape from heartbeat requests
- keep production download and Range-resume behavior unchanged

## Root cause

Under Windows CI contention, `source_url_resumes_after_a_midstream_network_error` can cross the five-second download progress interval. The downloader then legitimately posts a worker heartbeat, but the shared test API stub did not register that POST route, so Axum returned `405 Method Not Allowed` before the Range retry could complete.

## Impact

This removes a timing-dependent Windows Candle worker failure while preserving the production heartbeat and resumable-download behavior under test.

## Validation

- `cargo fmt --all -- --check`
- targeted source URL resume test with default features
- default worker library suite: 417 passed, 4 ignored
- targeted source URL resume test with `backend-candle`
- CI-parity Candle worker library suite: 822 passed, 40 ignored, finished in 5.75s
- `git diff --check`
