### PR TITLE
Surface repair for a torn tier even behind a complete sibling (sc-14431)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -2239,18 +2239,24 @@ fn install_state_for(
             if model_has_variant_matrix(model) {
                 let variants = model_variant_states(model, data_dir);
                 let any_installed = variants.iter().any(|variant| variant.installed);
-                // Only a torn tier (some-but-not-all files present) with no complete sibling is a real
-                // repair candidate; a validly absent tier is "missing", not "incomplete".
+                // A TORN tier — some of its files present but not all — is a genuine repair candidate:
+                // it will fail to load, and re-downloading that tier fixes it. A never-fetched tier is
+                // `missing` (`cache_incomplete == false` — nothing on disk to be torn), NOT torn, so it
+                // never enters this find. That distinction is what makes it safe to surface repair even
+                // when a complete sibling exists: sc-9907 (a clean single-tier install must not read
+                // "incomplete + Fix" just because its OTHER tiers were never downloaded) is preserved by
+                // `torn` excluding missing tiers, WITHOUT also suppressing a genuinely half-downloaded
+                // sibling (sc-14431 — the old `!any_installed &&` guard hid a torn q8 behind a complete
+                // q4, so chroma/sdxl/qwen/wan/lens all reported `repairAvailable: false` over a torn tier).
                 let torn = variants
                     .iter()
                     .find(|variant| variant.cache_incomplete && !variant.installed);
-                let incomplete = !any_installed && torn.is_some();
-                let missing = if any_installed {
-                    Vec::new()
-                } else {
-                    torn.map(|variant| variant.missing_required_files.clone())
-                        .unwrap_or_default()
-                };
+                let incomplete = torn.is_some();
+                // Report the torn tier's missing files so the model-level repair knows what to re-fetch,
+                // even though a sibling tier is complete (`any_installed`).
+                let missing = torn
+                    .map(|variant| variant.missing_required_files.clone())
+                    .unwrap_or_default();
                 (any_installed, incomplete, missing)
             } else {
                 let cache_health = cache_path
@@ -4351,10 +4357,72 @@ mod variant_install_tests {
             "a never-fetched tier stays a clean missing (no spurious repair prompt — sc-9907)"
         );
 
-        // Model-level state aggregates: q4 is complete, so the model is installed overall — the torn
-        // q8 must not drag the whole model to incomplete (sc-9907), but it also must not itself count.
+        // Model-level state aggregates: q4 is complete, so the model is INSTALLED (usable) overall —
+        // and because q8 is genuinely TORN, it is also repairable (sc-14431). The complete q4 keeps
+        // `installed` true (the model still works via q4); the torn q8 raises `cache_incomplete` so the
+        // model-level Fix button appears and knows what to re-fetch. This is the fix to the old
+        // suppression that hid a torn sibling behind a complete one — distinct from sc-9907, where the
+        // OTHER tiers were merely never downloaded (missing), not torn.
         let state = install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
         assert!(state.installed, "model installed via the complete q4 tier");
+        assert!(
+            state.cache_incomplete,
+            "a genuinely torn q8 makes the model repairable even though q4 is complete (sc-14431)"
+        );
+        assert!(
+            state
+                .missing_required_files
+                .iter()
+                .any(|file| file.starts_with("q8/")),
+            "the model-level repair must name the torn q8 tier's missing files, got {:?}",
+            state.missing_required_files
+        );
+    }
+
+    /// sc-14431: the model-level repair signal keys on a genuinely TORN tier alone, not on
+    /// `!any_installed`. A complete sibling must NOT suppress repair for a half-downloaded tier — but a
+    /// never-fetched (missing) sibling must still NOT raise a spurious repair (sc-9907 preserved).
+    #[test]
+    fn torn_tier_stays_repairable_behind_a_complete_sibling_but_missing_does_not() {
+        let _env = isolate_hf_cache();
+        let repo = "SceneWorks/matrix";
+        let model = quant_matrix_model(repo);
+
+        // Case A — complete q4 + TORN q8 (metadata only) + missing bf16 → repairable, naming q8.
+        {
+            let tmp = tempfile::tempdir().unwrap();
+            let data_dir = tmp.path();
+            seed_diffusers_tier(data_dir, repo, "q4", true);
+            seed_diffusers_tier(data_dir, repo, "q8", false);
+            let state =
+                install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+            assert!(state.installed, "usable via the complete q4 tier");
+            assert!(
+                state.cache_incomplete,
+                "a torn q8 behind a complete q4 must be repairable (sc-14431)"
+            );
+            assert!(state
+                .missing_required_files
+                .iter()
+                .any(|file| file.starts_with("q8/")));
+        }
+
+        // Case B — complete q4 + q8/bf16 NEVER fetched (missing, not torn) → installed, NOT repairable.
+        // This is the sc-9907 scenario the fix must not regress.
+        {
+            let tmp = tempfile::tempdir().unwrap();
+            let data_dir = tmp.path();
+            seed_diffusers_tier(data_dir, repo, "q4", true);
+            let state =
+                install_state_for(model_download_context(&model).unwrap(), &model, data_dir);
+            assert!(state.installed, "usable via the complete q4 tier");
+            assert!(
+                !state.cache_incomplete,
+                "a clean single-tier install with the others merely un-downloaded must NOT read \
+                 repairable (sc-9907)"
+            );
+            assert!(state.missing_required_files.is_empty());
+        }
     }
 
     /// A SANA quant-matrix turnkey (family `sana`). Ships NO `model_index.json`, so the diffusers


### PR DESCRIPTION
Closes [sc-14431](https://app.shortcut.com/trefry/story/14431) (epic 8506). Catalog-wide — **not** SenseNova-specific.

## The bug

On a quant-matrix model, the model-level **Fix** button (`repairAvailable = downloadable && cache_incomplete`) was suppressed whenever *any* tier was complete — so a genuinely **torn** sibling (half-downloaded, fails at load) reported `repairAvailable: false`. Confirmed live against the running `GET /api/v1/models`:

| model | tiers | repairAvailable (before) |
|---|---|---|
| chroma1_base | q4 ✓ · **q8 torn · bf16 torn** | false |
| sdxl | **q4 torn · q8 torn** · bf16 ✓ | false |
| qwen_image | q4 ✓ · q8 ✓ · **bf16 torn** | false |
| wan_2_2_i2v_14b | q4 ✓ · q8 ✓ · **bf16 torn** | false |
| lens_turbo | q4 ✓ · **q8 torn** · bf16 ✓ | false |

The torn tiers still got a per-tier Fix button in the row, but the model-level signal was wrong.

## Root cause

`install_state_for`, the variant-matrix rollup:

```rust
let torn = variants.find(|v| v.cache_incomplete && !v.installed);
let incomplete = !any_installed && torn.is_some();   // <- suppression
```

The `!any_installed` guard is the sc-9907 fix — it stops a *missing* (never-downloaded) sibling from raising a false "incomplete + Fix" on a clean single-tier install. But it overshoots and also suppresses a genuinely torn sibling. It's *also redundant* for the missing case: a never-fetched tier already has `cache_incomplete == false` (`huggingface_cache_health` returns `incomplete: false` for a cleanly-absent tier — the `coarse_all_absent` arm), so it never enters `torn`.

## Fix

`incomplete = torn.is_some()`, and report the torn tier's missing files even when `any_installed`. A torn tier now yields `installState: "installed"` (still usable via the complete tier) + `cacheState: "incomplete"` + `repairAvailable: true`. A *missing* sibling still yields `repairAvailable: false` — sc-9907 preserved, because `torn` never matches a missing tier.

## Tests

- Updated `torn_diffusers_tier_reads_incomplete_not_installed` (its comment asserted the old suppression).
- Added `torn_tier_stays_repairable_behind_a_complete_sibling_but_missing_does_not`, pinning **both** halves: torn-behind-complete → repairable (and names the torn tier's files); missing-behind-complete → NOT repairable (sc-9907).
- `cargo test -p sceneworks-rust-api --lib models::` 57 pass; clippy `-D warnings` + fmt clean.

rust-api only — the web `ModelManagerScreen` already renders the model-level Fix off `repairAvailable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)