### PR TITLE
sc-13622 recollapse video backend policy twins

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs/bernini.rs
+++ b/crates/sceneworks-worker/src/video_jobs/bernini.rs
@@ -30,7 +30,10 @@ use super::wan::{generate_video, VideoGenInput};
 pub(super) const BERNINI_ADAPTER: &str = "mlx_bernini";
 
 /// SceneWorks Bernini model id → mlx-gen registry id, or `None` if `model` is not the Bernini family.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn bernini_engine_id(model: &str) -> Option<&'static str> {
     (model == "bernini").then_some("bernini")
 }
@@ -254,7 +257,10 @@ pub(crate) async fn ensure_bernini_tier_present(
 }
 
 /// Raw-settings recorded on a real MLX Bernini asset (mirrors `wan_raw_settings`).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn bernini_raw_settings(request: &VideoRequest) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
@@ -271,7 +277,10 @@ pub(super) fn bernini_raw_settings(request: &VideoRequest) -> Value {
 /// Map a SceneWorks video mode to the Bernini engine `video_mode` task string (which selects the
 /// renderer guidance mode). The engine also infers the mode from the supplied conditioning, but the
 /// explicit task keeps the mapping unambiguous. Unknown / `text_to_video` ⇒ plain `t2v`.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn bernini_engine_video_mode(mode: &str) -> &'static str {
     match mode {
         "video_to_video" => "v2v",
@@ -461,48 +470,6 @@ pub(super) async fn generate_bernini(
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 pub(super) const CANDLE_BERNINI_ADAPTER: &str = "candle_bernini";
 
-/// SceneWorks Bernini model id → candle registry id, or `None` if `model` is not the Bernini video
-/// family. The candle sibling of the macOS `bernini_engine_id`; drives the `CandleVideoRoute::Bernini`
-/// arm (routed on the model id, not weight availability).
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) fn candle_bernini_engine_id(model: &str) -> Option<&'static str> {
-    (model == "bernini").then_some("bernini")
-}
-
-/// Map a SceneWorks video mode to the Bernini engine `video_mode` task string (which selects the
-/// renderer guidance mode). The candle sibling of the macOS `bernini_engine_video_mode` — the identical
-/// mapping so the two lanes render the same mode for the same request. Unknown / `text_to_video` ⇒
-/// plain `t2v`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) fn candle_bernini_engine_video_mode(mode: &str) -> &'static str {
-    match mode {
-        "video_to_video" => "v2v",
-        "reference_to_video" => "r2v",
-        "reference_video_to_video" => "rv2v",
-        // Multi-source-video modes (sc-5425): mv2v (multiple source clips) and ads2v (source video +
-        // reference video + reference images). Both resolve to the engine's `V2vApg` guidance; they
-        // differ only in the supplied media.
-        "multi_video_to_video" => "mv2v",
-        "ads2v" => "ads2v",
-        _ => "t2v",
-    }
-}
-
-/// Raw-settings recorded on a real candle Bernini VIDEO asset (mirrors the macOS `bernini_raw_settings`).
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) fn candle_bernini_raw_settings(request: &VideoRequest) -> Value {
-    let mut raw = request.advanced.clone();
-    raw.insert("realModelInference".to_owned(), Value::Bool(true));
-    raw.insert("model".to_owned(), Value::String(request.model.clone()));
-    raw.insert("fps".to_owned(), json!(request.fps));
-    // The engine guidance task the SceneWorks mode resolved to (lineage / observability).
-    raw.insert(
-        "berniniTask".to_owned(),
-        Value::String(candle_bernini_engine_video_mode(&request.mode).to_owned()),
-    );
-    Value::Object(raw)
-}
-
 /// Resolve the source media for a candle Bernini editing/reference request into the planner
 /// conditioning — the candle sibling of the macOS `resolve_bernini_conditioning`. Source clips →
 /// [`Conditioning::VideoClip`] (the edit structure, VAE/ViT-encoded by the engine) and subject
@@ -608,7 +575,7 @@ async fn resolve_candle_bernini_conditioning(
 
 /// Real candle Bernini video generation (sc-10997 / epic 6562): build the `VideoGenInput` and run the
 /// shared [`generate_video`] path. The SceneWorks mode resolves to the engine `video_mode` task
-/// ([`candle_bernini_engine_video_mode`]) and the source media into the planner conditioning
+/// ([`bernini_engine_video_mode`]) and the source media into the planner conditioning
 /// ([`resolve_candle_bernini_conditioning`]) — empty for t2v, one or more `VideoClip`s for
 /// v2v/mv2v/rv2v/ads2v, and `MultiReference` for r2v/rv2v/ads2v. The converted `SceneWorks/bernini`
 /// snapshot descends into the requested quant tier subfolder (`bf16/`|`q8/`|`q4/`, sc-11003) via the
@@ -651,7 +618,7 @@ pub(super) async fn generate_candle_bernini(
         frames: wan_frame_count(request.raw_frame_count()),
         fps: request.fps,
         seed: resolve_video_seed(request) as u64,
-        video_mode: Some(candle_bernini_engine_video_mode(&request.mode).to_owned()),
+        video_mode: Some(bernini_engine_video_mode(&request.mode).to_owned()),
         ..VideoGenInput::default()
     };
     generate_video(api, settings, job, backend, &request.advanced, input).await

--- a/crates/sceneworks-worker/src/video_jobs/candle.rs
+++ b/crates/sceneworks-worker/src/video_jobs/candle.rs
@@ -6,6 +6,7 @@ use super::{
         ensure_mochi_bf16_present, ensure_mochi_q8_present, mochi_precheck_dir, mochi_tier_quant,
         mochi_vram_precheck, resolve_mochi_model_dir, MOCHI_REPO,
     },
+    scail2::{scail2_engine_video_mode, scail2_raw_settings},
     svd::{svd_f32, svd_i32, svd_raw_settings, svd_steps, SVD_REPO},
     vace::{
         build_extend_bridge_vace_conditioning, build_vace_conditioning, extend_anchor_frames,
@@ -13,8 +14,9 @@ use super::{
         replacement_status_value, resolve_character_references,
     },
     wan::{
-        advanced_opt_f32, advanced_opt_u32, generate_video, generate_video_using,
-        ClipFramePosition, ComfyuiWanExperts, VideoGenInput, WAN_LIGHTNING_REVISION,
+        advanced_opt_f32, advanced_opt_u32, ensure_wan_lightning_present, generate_video,
+        generate_video_using, resolve_scail2_adapters, resolve_wan_adapters, scail2_sampling,
+        wan_sampling, ClipFramePosition, ComfyuiWanExperts, VideoGenInput,
     },
 };
 
@@ -397,260 +399,6 @@ pub(super) fn resolve_candle_video_conditioning(
     }])
 }
 
-// ---------------------------------------------------------------------------
-// Candle (Windows/CUDA) Wan Lightning toggle + adapter resolution (sc-10138) — the off-Mac analog of
-// the macOS `wan_lightning_on` / `wan_sampling` / `ensure_wan_lightning_present` / `resolve_wan_adapters`
-// (all `#[cfg(target_os = "macos")]`). The candle Wan engine now ACCEPTS adapters on a packed q4/q8 tier
-// via the additive branch (candle-gen sc-10094/10095, epic 10043), so off-Mac the A14B can get its 4-step
-// distill through the Lightning toggle and user LoRAs apply on the candle Wan video path. These are
-// candle-lane copies (the macOS lane keeps its own), reusing the backend-neutral helpers `lora_scale` /
-// `resolve_lora_file` / `crate::image_jobs::{lora_path, classify_adapter}` / `MAX_JOB_LORAS` /
-// `advanced_opt_*` / `huggingface_snapshot_dir` / `ensure_hf_files_cached`.
-// ---------------------------------------------------------------------------
-
-/// (sc-10138) The interim step default for the dense candle TI2V-5B (no distill LoRA exists yet) — the
-/// candle analog of the macOS `WAN5B_INTERIM_STEPS`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) const CANDLE_WAN5B_INTERIM_STEPS: u32 = 20;
-
-/// (sc-10138) `true` if the A14B MoE 4-step Lightning distill is engaged for this candle request — the
-/// candle analog of `wan_lightning_on`. A **default-on toggle** (`advanced.lightning`): absent or `true`
-/// opts in, a strict-bool `false` opts out (native multi-step CFG). Only the two A14B MoE models bake
-/// Lightning; every other engine returns `false`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) fn candle_wan_lightning_on(engine_id: &str, request: &VideoRequest) -> bool {
-    let is_moe = engine_id == "wan2_2_t2v_14b" || engine_id == "wan2_2_i2v_14b";
-    if !is_moe {
-        return false;
-    }
-    request
-        .advanced
-        .get("lightning")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(true)
-}
-
-/// (sc-10138) Per-model sampling for the candle Wan path — the candle analog of `wan_sampling`. On the
-/// A14B MoE models the recipe is conditional on the Lightning toggle: on (default) → 4 steps / CFG-off
-/// (the distill rides an adapter, so a user override can't break it); off → native multi-step CFG
-/// (honor an explicit user `steps`/`guidanceScale`, else `None` so the engine's config defaults stand).
-/// The dense TI2V-5B has no distill: user override wins, else the interim default.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) fn candle_wan_sampling(
-    engine_id: &str,
-    request: &VideoRequest,
-) -> (Option<u32>, Option<f32>) {
-    if engine_id == "wan2_2_t2v_14b" || engine_id == "wan2_2_i2v_14b" {
-        if candle_wan_lightning_on(engine_id, request) {
-            return (Some(4), Some(1.0));
-        }
-        return (
-            advanced_opt_u32(request, "steps"),
-            advanced_opt_f32(request, "guidanceScale"),
-        );
-    }
-    (
-        advanced_opt_u32(request, "steps").or(Some(CANDLE_WAN5B_INTERIM_STEPS)),
-        advanced_opt_f32(request, "guidanceScale"),
-    )
-}
-
-/// (sc-10138) The `.low_noise.safetensors` sibling of a Wan A14B MoE high-noise LoRA file, or `None`
-/// when the file is not the high-noise half of a pair — the candle analog of `wan_moe_low_noise_sibling`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_wan_moe_low_noise_sibling(primary: &Path) -> Option<PathBuf> {
-    const HIGH: &str = ".high_noise.safetensors";
-    let name = primary.file_name()?.to_str()?;
-    if !name.to_ascii_lowercase().ends_with(HIGH) {
-        return None;
-    }
-    let stem = &name[..name.len() - HIGH.len()];
-    let sibling = primary.with_file_name(format!("{stem}.low_noise.safetensors"));
-    sibling.is_file().then_some(sibling)
-}
-
-/// (sc-10138) The per-architecture 4-step Lightning distill LoRA pair (high/low) for an A14B MoE model
-/// (`lightx2v/Wan2.2-Lightning`, rank-64 Seko) — the candle analog of `resolve_lightning_loras`. T2V-A14B
-/// (V1.1) and I2V-A14B (V1) ship distinct, NOT cross-compatible LoRAs (sc-4997).
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_resolve_lightning_loras(
-    settings: &Settings,
-    engine_id: &str,
-) -> WorkerResult<(PathBuf, PathBuf)> {
-    let snapshot = crate::model_jobs::huggingface_snapshot_dir(
-        &settings.data_dir,
-        "lightx2v/Wan2.2-Lightning",
-    )
-    .ok_or_else(|| {
-        WorkerError::InvalidPayload(format!(
-            "{engine_id}: the Lightning distill LoRA (lightx2v/Wan2.2-Lightning) is not \
-                     downloaded — fetch it via the model manager"
-        ))
-    })?;
-    let base = match engine_id {
-        "wan2_2_t2v_14b" => "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1",
-        "wan2_2_i2v_14b" => "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1",
-        other => {
-            return Err(WorkerError::InvalidPayload(format!(
-                "{other}: no Lightning distill LoRA — only the A14B MoE models bake Lightning"
-            )))
-        }
-    };
-    let high = snapshot.join(base).join("high_noise_model.safetensors");
-    let low = snapshot.join(base).join("low_noise_model.safetensors");
-    for file in [&high, &low] {
-        if !file.is_file() {
-            return Err(WorkerError::InvalidPayload(format!(
-                "{engine_id}: Lightning LoRA file missing: {}",
-                file.display()
-            )));
-        }
-    }
-    Ok((high, low))
-}
-
-/// (sc-10138) On-demand fetch of the A14B Lightning distill pair for the candle lane — the analog of
-/// `ensure_wan_lightning_present`. Self-heals a worker that installed the tiers before the Lightning
-/// `coRequisite`. No-op when the toggle is off, for a non-A14B engine, or when the pair is cached. A
-/// pair still missing after the fetch makes resolve surface the clear "fetch it via the model manager" error.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) async fn candle_ensure_wan_lightning_present(
-    api: &ApiClient,
-    settings: &Settings,
-    job: &JobSnapshot,
-    request: &VideoRequest,
-    engine_id: &str,
-) -> WorkerResult<()> {
-    if !candle_wan_lightning_on(engine_id, request) {
-        return Ok(());
-    }
-    let subdir = match engine_id {
-        "wan2_2_t2v_14b" => "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1",
-        "wan2_2_i2v_14b" => "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1",
-        _ => return Ok(()),
-    };
-    const REPO: &str = "lightx2v/Wan2.2-Lightning";
-    if let Some(snapshot) = crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, REPO) {
-        let base = snapshot.join(subdir);
-        if base.join("high_noise_model.safetensors").is_file()
-            && base.join("low_noise_model.safetensors").is_file()
-        {
-            return Ok(());
-        }
-    }
-    let files = vec![
-        format!("{subdir}/high_noise_model.safetensors"),
-        format!("{subdir}/low_noise_model.safetensors"),
-    ];
-    crate::model_jobs::ensure_hf_files_cached(
-        api,
-        settings,
-        job,
-        REPO,
-        WAN_LIGHTNING_REVISION,
-        &files,
-    )
-    .await
-    .map(|_| ())
-}
-
-/// (sc-10138) Tag an A14B MoE Lightning/user LoRA to a specific expert — the candle analog of
-/// `moe_adapter`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_moe_adapter(
-    path: PathBuf,
-    scale: f32,
-    kind: gen_core::AdapterKind,
-    expert: gen_core::MoeExpert,
-) -> AdapterSpec {
-    AdapterSpec {
-        path,
-        scale,
-        kind,
-        pass_scales: None,
-        moe_expert: Some(expert),
-    }
-}
-
-/// (sc-10138) Build the adapter specs for a candle Wan generation — the candle analog of
-/// `resolve_wan_adapters`. The Lightning distill pair (both A14B MoE models, tagged high/low, only when
-/// the toggle is on) followed by the user LoRAs. On the MoE models a user `*.high_noise.safetensors` with
-/// a `.low_noise` sibling tags high→High / low→Low; a single-file LoRA is shared (both experts on MoE,
-/// the single model on the 5B). The candle Wan engine applies these additively on a packed q4/q8 tier
-/// (sc-10094/10095) or folds them on a dense tier.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_resolve_wan_adapters(
-    settings: &Settings,
-    request: &VideoRequest,
-    engine_id: &str,
-) -> WorkerResult<Vec<AdapterSpec>> {
-    if request.loras.len() > MAX_JOB_LORAS {
-        return Err(WorkerError::InvalidPayload(format!(
-            "Generation supports at most {MAX_JOB_LORAS} LoRAs per job."
-        )));
-    }
-    let is_moe = engine_id == "wan2_2_t2v_14b" || engine_id == "wan2_2_i2v_14b";
-    let mut specs: Vec<AdapterSpec> = Vec::new();
-
-    // Lightning distill (both A14B MoE models): 4-step, per-expert at strength 1.0, added only when the
-    // toggle is on. When off, the native multi-step CFG recipe runs with no Lightning adapter.
-    if is_moe && candle_wan_lightning_on(engine_id, request) {
-        let (high, low) = candle_resolve_lightning_loras(settings, engine_id)?;
-        specs.push(candle_moe_adapter(
-            high,
-            1.0,
-            gen_core::AdapterKind::Lora,
-            gen_core::MoeExpert::High,
-        ));
-        specs.push(candle_moe_adapter(
-            low,
-            1.0,
-            gen_core::AdapterKind::Lora,
-            gen_core::MoeExpert::Low,
-        ));
-    }
-
-    for lora in &request.loras {
-        let path = crate::image_jobs::lora_path(lora).ok_or_else(|| {
-            WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
-        })?;
-        let file = resolve_lora_file(
-            settings,
-            path,
-            crate::image_jobs::declared_adapter_file(lora),
-        )?;
-        let kind = crate::image_jobs::classify_adapter(&file)?;
-        let scale = lora_scale(lora);
-        match (is_moe, candle_wan_moe_low_noise_sibling(&file)) {
-            (true, Some(low)) => {
-                let low_kind = crate::image_jobs::classify_adapter(&low)?;
-                specs.push(candle_moe_adapter(
-                    file,
-                    scale,
-                    kind,
-                    gen_core::MoeExpert::High,
-                ));
-                specs.push(candle_moe_adapter(
-                    low,
-                    scale,
-                    low_kind,
-                    gen_core::MoeExpert::Low,
-                ));
-            }
-            _ => {
-                specs.push(AdapterSpec {
-                    path: file,
-                    scale,
-                    kind,
-                    pass_scales: None,
-                    moe_expert: None,
-                });
-            }
-        }
-    }
-    Ok(specs)
-}
-
 /// The candle Mochi pre-flight's gated result (sc-12306): the tier's baked-in quant marker, obtainable
 /// ONLY by passing the VRAM fit gate.
 ///
@@ -947,7 +695,7 @@ pub(super) async fn generate_candle_video_using(
         // else the sc-12344 weights floor. The non-Mochi half of this lane's admission check. Runs on
         // the RESOLVED tier (so it sizes the tier that will actually load, not the manifest's default —
         // the sc-12090 lesson; `candle_wan_tier_key` derives the manifest key from the resolver's own
-        // marker for exactly that reason) and BEFORE `candle_ensure_wan_lightning_present` below, so a
+        // marker for exactly that reason) and BEFORE `ensure_wan_lightning_present` below, so a
         // card that cannot fit the job is refused without first paying for the Lightning fetch. A no-op
         // for `ltx`/`svd`, which are exempt — see `vram_gate::wan_weight_components`.
         let dir = wan_vram_preflight(
@@ -1032,20 +780,20 @@ pub(super) async fn generate_candle_video_using(
     // candle Wan engine applies these additively on a packed q4/q8 tier (candle-gen sc-10094/10095) or
     // folds them on a dense tier. `Vec::new()` for the non-Wan (ltx) engine.
     let adapters = if is_wan {
-        candle_ensure_wan_lightning_present(api, settings, job, request, engine_id).await?;
-        candle_resolve_wan_adapters(settings, request, engine_id)?
+        ensure_wan_lightning_present(api, settings, job, request, engine_id).await?;
+        resolve_wan_adapters(settings, request, engine_id)?
     } else {
         Vec::new()
     };
 
     // Descriptor-narrowed sampling surface: wan (5B + 14B) takes guidance + a negative prompt; the
     // distilled ltx takes neither (single-stage, no CFG). Wan uses the Lightning-aware recipe
-    // ([`candle_wan_sampling`]: 4-step/CFG-off when the toggle is on, else native multi-step + CFG);
+    // ([`wan_sampling`]: 4-step/CFG-off when the toggle is on, else native multi-step + CFG);
     // ltx keeps its own step default and no CFG.
     //
     // Mochi needs its OWN arm (sc-11992) — it is not distilled, so it takes true CFG (negative prompt
-    // + guidance), but it is also not a Wan model: falling through to `candle_wan_sampling` would hit
-    // that function's dense-5B tail and force `CANDLE_WAN5B_INTERIM_STEPS` (20) on it, silently
+    // + guidance), but it is also not a Wan model: falling through to `wan_sampling` would hit
+    // that function's dense-5B tail and force `WAN5B_INTERIM_STEPS` (20) on it, silently
     // overriding the AsymmDiT's own 64-step default with a Wan tuning constant. `None` ⇒ the engine's
     // DEFAULT_STEPS (64) / DEFAULT_GUIDANCE (4.5) stand.
     let (steps, guidance, negative_prompt) = if is_ltx {
@@ -1057,7 +805,7 @@ pub(super) async fn generate_candle_video_using(
             non_empty_negative_prompt(request),
         )
     } else {
-        let (steps, guidance) = candle_wan_sampling(engine_id, request);
+        let (steps, guidance) = wan_sampling(engine_id, request);
         (steps, guidance, non_empty_negative_prompt(request))
     };
     let input = VideoGenInput {
@@ -1405,23 +1153,6 @@ pub(super) async fn generate_candle_wan_comfyui(
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 pub(super) const CANDLE_SCAIL2_ADAPTER: &str = "candle_scail2";
 
-/// SceneWorks SCAIL-2 model id → candle registry id, or `None` if `model` is not SCAIL-2.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) fn candle_scail2_engine_id(model: &str) -> Option<&'static str> {
-    (model == "scail2_14b").then_some("scail2_14b")
-}
-
-/// Map a SceneWorks video mode to the SCAIL-2 engine `video_mode` task string. `replace_person`
-/// (cross-identity) flips the engine `replace_flag`; everything else (`animate_character`) is plain
-/// animation. Mirrors the macOS `scail2_engine_video_mode`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_scail2_engine_video_mode(mode: &str) -> &'static str {
-    match mode {
-        "replace_person" => "replacement",
-        _ => "animation",
-    }
-}
-
 /// Resolve the candle SCAIL-2 snapshot dir from the `SCENEWORKS_CANDLE_SCAIL2_DIR` override, else the
 /// app-managed `<data>/models/candle/scail2`. The sentinel is the `transformer/` subdir (the converted
 /// SCAIL2Model DiT): the `candle_gen_scail2` provider builds its `Scail2Config` from hardcoded
@@ -1453,61 +1184,6 @@ fn resolve_candle_scail2_model_dir(settings: &Settings) -> WorkerResult<PathBuf>
     )))
 }
 
-/// Raw-settings recorded on a candle SCAIL-2 asset (mirrors the macOS `scail2_raw_settings`). When a
-/// lightx2v lightning LoRA is applied (`lightning`, sc-6838), records the effective step-distill recipe
-/// the worker dispatched so the chosen steps/CFG/shift is inspectable on the asset, not silent.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-pub(super) fn candle_scail2_raw_settings(request: &VideoRequest, lightning: bool) -> Value {
-    let mut raw = request.advanced.clone();
-    raw.insert("realModelInference".to_owned(), Value::Bool(true));
-    raw.insert("model".to_owned(), Value::String(request.model.clone()));
-    raw.insert("fps".to_owned(), json!(request.fps));
-    raw.insert(
-        "scail2Task".to_owned(),
-        Value::String(candle_scail2_engine_video_mode(&request.mode).to_owned()),
-    );
-    if lightning {
-        let (steps, guidance, shift) = candle_scail2_sampling(request, true);
-        raw.insert("scail2Lightning".to_owned(), Value::Bool(true));
-        if let Some(steps) = steps {
-            raw.insert("effectiveSteps".to_owned(), json!(steps));
-        }
-        if let Some(guidance) = guidance {
-            raw.insert("effectiveGuidanceScale".to_owned(), json!(guidance));
-        }
-        if let Some(shift) = shift {
-            raw.insert("effectiveSchedulerShift".to_owned(), json!(shift));
-        }
-    }
-    Value::Object(raw)
-}
-
-/// The lightx2v lightning step-distill recipe (sc-6838, the candle sibling of the MLX sc-5684/5700
-/// recipe): 8 steps, CFG off, scheduler shift 1.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const CANDLE_SCAIL2_LIGHTNING_STEPS: u32 = 8;
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const CANDLE_SCAIL2_LIGHTNING_GUIDANCE: f32 = 1.0;
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-const CANDLE_SCAIL2_LIGHTNING_SHIFT: f32 = 1.0;
-
-/// Build the candle SCAIL-2 adapter specs from `request.loras` — the candle sibling of the macOS
-/// `resolve_scail2_adapters` (sc-5451). SCAIL-2 is a single dense Wan2.1-14B-I2V transformer (no MoE
-/// high/low), so every adapter is shared (`moe_expert: None`); the engine merges LoRA / LoKr / LoHa and
-/// the lightx2v lightning diff-patch into the dense DiT before build ([`runtime_cuda::providers::scail2::merge_adapters`]).
-/// Carries both a user-selected SCAIL-2 LoRA and the bundled Bias-Aware DPO quality LoRA (both surface
-/// through `request.loras`); selecting a lightning diff-patch LoRA makes the worker apply the
-/// step-distill recipe ([`candle_scail2_sampling`]). Delegates to the shared [`resolve_dense_adapters`]
-/// (sc-8830) — the byte-identical MLX/candle twin, now one implementation whose LoRA-file resolver is
-/// core's recursive [`first_safetensors_path`] (the old candle twin's shallow scan is gone).
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_resolve_scail2_adapters(
-    settings: &Settings,
-    request: &VideoRequest,
-) -> WorkerResult<Vec<AdapterSpec>> {
-    resolve_dense_adapters(settings, request, MAX_JOB_LORAS)
-}
-
 /// `true` if any resolved adapter is a lightx2v diff-patch ("lightning") LoRA — the engine's own
 /// detector (a file carrying full-rank `.diff`/`.diff_b` tensors), so the recipe keys off the actual
 /// format, not a catalog id or filename. A file that can't be read is treated as non-lightning (the
@@ -1518,26 +1194,6 @@ fn candle_scail2_adapters_have_lightning(adapters: &[AdapterSpec]) -> bool {
     adapters
         .iter()
         .any(|a| runtime_cuda::providers::scail2::has_diff_patch_keys(&a.path).unwrap_or(false))
-}
-
-/// SCAIL-2 sampling recipe `(steps, guidance, scheduler_shift)`. When a lightx2v diff-patch "lightning"
-/// LoRA is selected (`lightning`), apply the step-distill recipe (CFG off → the engine short-circuits to
-/// a single DiT forward per step, scheduler shift 1.0; step count defaults to 8 but honors an explicit
-/// `advanced.steps`). Without it, all-`None` so the engine's quality defaults stand. The candle sibling
-/// of the macOS `scail2_sampling`.
-#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn candle_scail2_sampling(
-    request: &VideoRequest,
-    lightning: bool,
-) -> (Option<u32>, Option<f32>, Option<f32>) {
-    if !lightning {
-        return (None, None, None);
-    }
-    (
-        advanced_opt_u32(request, "steps").or(Some(CANDLE_SCAIL2_LIGHTNING_STEPS)),
-        Some(CANDLE_SCAIL2_LIGHTNING_GUIDANCE),
-        Some(CANDLE_SCAIL2_LIGHTNING_SHIFT),
-    )
 }
 
 /// Resolve a candle SCAIL-2 `animate_character` request into the engine conditioning — the candle
@@ -1680,9 +1336,9 @@ pub(super) async fn generate_candle_scail2(
     let conditioning =
         resolve_candle_scail2_conditioning(api, settings, job, request, project_path).await?;
     // Inference adapters (DPO / lightning / user LoRA) + the lightning step-distill recipe.
-    let adapters = candle_resolve_scail2_adapters(settings, request)?;
+    let adapters = resolve_scail2_adapters(settings, request)?;
     let lightning = candle_scail2_adapters_have_lightning(&adapters);
-    let (steps, guidance, scheduler_shift) = candle_scail2_sampling(request, lightning);
+    let (steps, guidance, scheduler_shift) = scail2_sampling(request, lightning);
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -1700,14 +1356,14 @@ pub(super) async fn generate_candle_scail2(
         guidance,
         scheduler_shift,
         seed: resolve_video_seed(request) as u64,
-        video_mode: Some(candle_scail2_engine_video_mode(&request.mode).to_owned()),
+        video_mode: Some(scail2_engine_video_mode(&request.mode).to_owned()),
         ..VideoGenInput::default()
     };
     let decoded = generate_video(api, settings, job, backend, &request.advanced, input).await?;
     Ok((
         decoded,
         CANDLE_SCAIL2_ADAPTER,
-        candle_scail2_raw_settings(request, lightning),
+        scail2_raw_settings(request, lightning),
     ))
 }
 

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -301,18 +301,16 @@ fn resolve_candle_video_route(request: &VideoRequest, settings: &Settings) -> Ca
         return CandleVideoRoute::Stub;
     }
     if request.mode == "replace_person" {
-        match candle_scail2_engine_id(&request.model) {
+        match scail2_engine_id(&request.model) {
             Some(engine_id) => CandleVideoRoute::ReplacePersonScail2(engine_id),
             None => CandleVideoRoute::ReplacePersonWanVace,
         }
-    } else if request.mode == "animate_character"
-        && candle_scail2_engine_id(&request.model).is_some()
-    {
-        let engine_id = candle_scail2_engine_id(&request.model).expect("scail2 model");
+    } else if request.mode == "animate_character" && scail2_engine_id(&request.model).is_some() {
+        let engine_id = scail2_engine_id(&request.model).expect("scail2 model");
         CandleVideoRoute::AnimateScail2(engine_id)
     } else if matches!(request.mode.as_str(), "extend_clip" | "video_bridge") {
         CandleVideoRoute::WanVaceExtendBridge
-    } else if let Some(engine_id) = candle_bernini_engine_id(&request.model) {
+    } else if let Some(engine_id) = bernini_engine_id(&request.model) {
         // Bernini (sc-10997, epic 6562): the full Qwen planner + Wan2.2-T2V-A14B renderer serves t2v +
         // the editing/reference/multi-source modes (v2v / r2v / rv2v / mv2v / ads2v). A DISTINCT engine
         // (`crate::inference_runtime::load("bernini")`), NOT a wan/ltx `is_candle_video_engine` id, so it is routed off the
@@ -706,7 +704,7 @@ pub(crate) async fn run_video_generate_job(
                     decoded,
                     CANDLE_SCAIL2_ADAPTER,
                     // The replace_person path doesn't resolve user LoRAs (sc-5452), so no lightning recipe.
-                    candle_scail2_raw_settings(&request, false),
+                    scail2_raw_settings(&request, false),
                     Some(status),
                 )
             }
@@ -784,7 +782,7 @@ pub(crate) async fn run_video_generate_job(
                 (
                     decoded,
                     CANDLE_BERNINI_ADAPTER,
-                    candle_bernini_raw_settings(&request),
+                    bernini_raw_settings(&request),
                     None::<Value>,
                 )
             }
@@ -1516,15 +1514,13 @@ use bernini::{
 };
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use bernini::{
-    candle_bernini_engine_id, candle_bernini_raw_settings, generate_candle_bernini,
-    CANDLE_BERNINI_ADAPTER,
+    bernini_engine_id, bernini_raw_settings, generate_candle_bernini, CANDLE_BERNINI_ADAPTER,
 };
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use candle::{
-    candle_scail2_engine_id, candle_scail2_raw_settings, generate_candle_scail2,
-    generate_candle_scail2_replace, generate_candle_video, generate_candle_wan_comfyui,
-    generate_candle_wan_vace, generate_candle_wan_vace_extend_bridge, is_candle_video_engine,
-    wan_comfyui_available, CANDLE_SCAIL2_ADAPTER, CANDLE_WAN_VACE_ADAPTER,
+    generate_candle_scail2, generate_candle_scail2_replace, generate_candle_video,
+    generate_candle_wan_comfyui, generate_candle_wan_vace, generate_candle_wan_vace_extend_bridge,
+    is_candle_video_engine, wan_comfyui_available, CANDLE_SCAIL2_ADAPTER, CANDLE_WAN_VACE_ADAPTER,
 };
 mod scail2;
 #[cfg(target_os = "macos")]
@@ -1532,6 +1528,8 @@ use scail2::{
     generate_scail2, generate_scail2_replace, scail2_available, scail2_engine_id,
     scail2_raw_settings, SCAIL2_ADAPTER,
 };
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use scail2::{scail2_engine_id, scail2_raw_settings};
 pub(crate) mod ltx;
 #[cfg(target_os = "macos")]
 use ltx::{generate_ltx, ltx_available, ltx_engine_id, ltx_raw_settings, LTX_ADAPTER};

--- a/crates/sceneworks-worker/src/video_jobs/scail2.rs
+++ b/crates/sceneworks-worker/src/video_jobs/scail2.rs
@@ -1,9 +1,13 @@
 #[allow(unused_imports)]
 use super::prelude::*;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+use super::wan::scail2_sampling;
 #[cfg(target_os = "macos")]
 use super::wan::{
-    generate_video, resolve_scail2_adapters, scail2_adapters_have_lightning, scail2_sampling,
-    VideoGenInput,
+    generate_video, resolve_scail2_adapters, scail2_adapters_have_lightning, VideoGenInput,
 };
 #[cfg(target_os = "macos")]
 use super::{
@@ -29,7 +33,10 @@ use super::{
 pub(super) const SCAIL2_ADAPTER: &str = "mlx_scail2";
 
 /// SceneWorks SCAIL-2 model id → mlx-gen registry id, or `None` if `model` is not SCAIL-2.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn scail2_engine_id(model: &str) -> Option<&'static str> {
     (model == "scail2_14b").then_some("scail2_14b")
 }
@@ -215,7 +222,10 @@ async fn ensure_scail2_tier_present(
 /// lightx2v lightning LoRA is applied (`lightning`, sc-5700), records the effective step-distill recipe
 /// the worker dispatched — so the chosen steps/CFG/shift is inspectable on the asset, not silent
 /// (mirrors `wan_raw_settings`).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn scail2_raw_settings(request: &VideoRequest, lightning: bool) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
@@ -245,7 +255,10 @@ pub(super) fn scail2_raw_settings(request: &VideoRequest, lightning: bool) -> Va
 /// Map a SceneWorks video mode to the SCAIL-2 engine `video_mode` task string. `replace_person`
 /// (cross-identity, sc-5452) flips the engine `replace_flag`; everything else (`animate_character`)
 /// is plain animation.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn scail2_engine_video_mode(mode: &str) -> &'static str {
     match mode {
         "replace_person" => "replacement",

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -119,6 +119,36 @@ fn sibling_video_modules_construct_private_types_through_owner_seams() {
 }
 
 #[test]
+fn backend_neutral_video_policy_has_no_candle_twins() {
+    const CANDLE: &str = include_str!("candle.rs");
+    const BERNINI: &str = include_str!("bernini.rs");
+
+    for stale_twin in [
+        "fn candle_wan_lightning_on(",
+        "fn candle_wan_sampling(",
+        "fn candle_resolve_lightning_loras(",
+        "fn candle_resolve_wan_adapters(",
+        "fn candle_scail2_sampling(",
+        "fn candle_scail2_engine_video_mode(",
+    ] {
+        assert!(
+            !CANDLE.contains(stale_twin),
+            "backend-neutral policy regressed to candle twin {stale_twin}"
+        );
+    }
+    for stale_twin in [
+        "fn candle_bernini_engine_id(",
+        "fn candle_bernini_engine_video_mode(",
+        "fn candle_bernini_raw_settings(",
+    ] {
+        assert!(
+            !BERNINI.contains(stale_twin),
+            "backend-neutral Bernini policy regressed to candle twin {stale_twin}"
+        );
+    }
+}
+
+#[test]
 fn candle_video_families_keep_explicit_cross_module_boundaries() {
     const PARENT: &str = include_str!("mod.rs");
     const BERNINI: &str = include_str!("bernini.rs");
@@ -1052,12 +1082,9 @@ fn no_candle_raw_settings_builder_records_its_own_frame_count() {
         ),
         (
             "candle_scail2",
-            candle_scail2_raw_settings(&req("scail2_14b"), false),
+            scail2_raw_settings(&req("scail2_14b"), false),
         ),
-        (
-            "candle_bernini",
-            candle_bernini_raw_settings(&req("bernini")),
-        ),
+        ("candle_bernini", bernini_raw_settings(&req("bernini"))),
         (
             "wan_vace",
             wan_vace_raw_settings(&req("wan_2_2"), "wan_vace"),
@@ -1081,7 +1108,7 @@ fn no_candle_raw_settings_builder_records_its_own_frame_count() {
     }
     // And the stamp still writes the clip's real length on this lane.
     let stamped = EncodedClip { frames: 7, fps: 25 }
-        .record_frame_count(candle_bernini_raw_settings(&req("bernini")));
+        .record_frame_count(bernini_raw_settings(&req("bernini")));
     assert_eq!(stamped["frameCount"], json!(7));
 }
 
@@ -2959,8 +2986,8 @@ fn seedvr2_video_revision_matches_image_lane() {
 }
 
 /// sc-11168 / F-007 (completes the sc-9879 rollout on the video lanes): both the MLX
-/// (`ensure_wan_lightning_present`) and candle (`candle_ensure_wan_lightning_present`) A14B Lightning
-/// self-heal fetches pull the FIXED `lightx2v/Wan2.2-Lightning` distill pair from the SHARED
+/// MLX and Candle A14B Lightning self-heal fetches share `ensure_wan_lightning_present` and pull the
+/// FIXED `lightx2v/Wan2.2-Lightning` distill pair from the SHARED
 /// `WAN_LIGHTNING_REVISION` const, so it must pin an exact commit rather than the mutable `main`
 /// branch — an upstream re-push would otherwise silently swap the high/low distill weights we load.
 /// Lock the pin to a real 40-hex lowercase commit id (mirrors the SeedVR2 format test above).
@@ -2985,6 +3012,24 @@ fn wan_lightning_revision_is_pinned_commit_not_main() {
             .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
         "the pinned revision must be lowercase hex"
     );
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn wan_lightning_subdir_is_canonical_for_fetch_and_resolution() {
+    assert_eq!(
+        wan_lightning_subdir("wan2_2_t2v_14b"),
+        Some("Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1")
+    );
+    assert_eq!(
+        wan_lightning_subdir("wan2_2_i2v_14b"),
+        Some("Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1")
+    );
+    assert_eq!(wan_lightning_subdir("wan2_2_ti2v_5b"), None);
+    assert_eq!(wan_lightning_subdir("bernini"), None);
 }
 
 /// sc-9879 (F-077 follow-up): `ensure_ltx_q8_present` pulls `q8/*` from the FIXED SceneWorks LTX-2.3
@@ -3079,7 +3124,7 @@ fn candle_video_route_gates_on_backend_flag_then_mode() {
     settings.backend_candle_enabled = true;
     assert_eq!(
         resolve_candle_video_route(&scail2_replace, &settings),
-        CandleVideoRoute::ReplacePersonScail2(candle_scail2_engine_id("scail2_14b").unwrap()),
+        CandleVideoRoute::ReplacePersonScail2(scail2_engine_id("scail2_14b").unwrap()),
     );
     let extend = request(json!({
         "projectId": "p", "model": "wan_2_2_ti2v_5b", "mode": "extend_clip",
@@ -3099,7 +3144,7 @@ fn candle_video_route_gates_on_backend_flag_then_mode() {
 fn candle_video_route_bernini_every_mode() {
     let mut settings = Settings::from_env();
     settings.backend_candle_enabled = true;
-    let engine = candle_bernini_engine_id("bernini").expect("bernini engine id");
+    let engine = bernini_engine_id("bernini").expect("bernini engine id");
     for mode in [
         "text_to_video",
         "video_to_video",
@@ -3130,32 +3175,26 @@ fn candle_video_route_bernini_every_mode() {
 /// the byte-identical twin of the MLX `bernini_engine_id` / `bernini_engine_video_mode`.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[test]
-fn candle_bernini_engine_id_and_video_mode_mapping() {
-    assert_eq!(candle_bernini_engine_id("bernini"), Some("bernini"));
+fn bernini_backends_share_engine_id_and_video_mode_mapping() {
+    assert_eq!(bernini_engine_id("bernini"), Some("bernini"));
     // The still `bernini_image` id + every other video family keep their own routing.
-    assert_eq!(candle_bernini_engine_id("bernini_image"), None);
-    assert_eq!(candle_bernini_engine_id("wan_2_2"), None);
-    assert_eq!(candle_bernini_engine_id("scail2_14b"), None);
-    assert_eq!(candle_bernini_engine_id(""), None);
+    assert_eq!(bernini_engine_id("bernini_image"), None);
+    assert_eq!(bernini_engine_id("wan_2_2"), None);
+    assert_eq!(bernini_engine_id("scail2_14b"), None);
+    assert_eq!(bernini_engine_id(""), None);
 
-    assert_eq!(candle_bernini_engine_video_mode("text_to_video"), "t2v");
-    assert_eq!(candle_bernini_engine_video_mode("video_to_video"), "v2v");
+    assert_eq!(bernini_engine_video_mode("text_to_video"), "t2v");
+    assert_eq!(bernini_engine_video_mode("video_to_video"), "v2v");
+    assert_eq!(bernini_engine_video_mode("reference_to_video"), "r2v");
     assert_eq!(
-        candle_bernini_engine_video_mode("reference_to_video"),
-        "r2v"
-    );
-    assert_eq!(
-        candle_bernini_engine_video_mode("reference_video_to_video"),
+        bernini_engine_video_mode("reference_video_to_video"),
         "rv2v"
     );
-    assert_eq!(
-        candle_bernini_engine_video_mode("multi_video_to_video"),
-        "mv2v"
-    );
-    assert_eq!(candle_bernini_engine_video_mode("ads2v"), "ads2v");
+    assert_eq!(bernini_engine_video_mode("multi_video_to_video"), "mv2v");
+    assert_eq!(bernini_engine_video_mode("ads2v"), "ads2v");
     // Unknown / image_to_video ⇒ plain t2v (the renderer is text-conditioned Wan2.2-T2V).
-    assert_eq!(candle_bernini_engine_video_mode("image_to_video"), "t2v");
-    assert_eq!(candle_bernini_engine_video_mode(""), "t2v");
+    assert_eq!(bernini_engine_video_mode("image_to_video"), "t2v");
+    assert_eq!(bernini_engine_video_mode(""), "t2v");
 }
 
 #[cfg(target_os = "macos")]
@@ -8221,9 +8260,9 @@ mod candle_video_label_tests {
         for moe in ["wan2_2_t2v_14b", "wan2_2_i2v_14b"] {
             // Default-on (absent flag): the 4-step / CFG-off Lightning recipe.
             let on = req(json!({}));
-            assert!(candle_wan_lightning_on(moe, &on), "{moe} default-on");
+            assert!(wan_lightning_on(moe, &on), "{moe} default-on");
             assert_eq!(
-                candle_wan_sampling(moe, &on),
+                wan_sampling(moe, &on),
                 (Some(4), Some(1.0)),
                 "{moe} lightning recipe"
             );
@@ -8231,29 +8270,26 @@ mod candle_video_label_tests {
             // Explicit opt-out → native multi-step CFG: no user override ⇒ (None, None) so the engine
             // config defaults stand; a user override is honored verbatim.
             let off = req(json!({ "lightning": false }));
-            assert!(!candle_wan_lightning_on(moe, &off), "{moe} opt-out");
+            assert!(!wan_lightning_on(moe, &off), "{moe} opt-out");
             assert_eq!(
-                candle_wan_sampling(moe, &off),
+                wan_sampling(moe, &off),
                 (None, None),
                 "{moe} native defaults"
             );
             let off_override =
                 req(json!({ "lightning": false, "steps": 30, "guidanceScale": 3.5 }));
-            assert_eq!(
-                candle_wan_sampling(moe, &off_override),
-                (Some(30), Some(3.5))
-            );
+            assert_eq!(wan_sampling(moe, &off_override), (Some(30), Some(3.5)));
         }
 
         // Dense TI2V-5B: no Lightning toggle (always off), interim step default, user override wins.
         let five_b = req(json!({}));
-        assert!(!candle_wan_lightning_on("wan2_2_ti2v_5b", &five_b));
+        assert!(!wan_lightning_on("wan2_2_ti2v_5b", &five_b));
         assert_eq!(
-            candle_wan_sampling("wan2_2_ti2v_5b", &five_b),
-            (Some(CANDLE_WAN5B_INTERIM_STEPS), None)
+            wan_sampling("wan2_2_ti2v_5b", &five_b),
+            (Some(WAN5B_INTERIM_STEPS), None)
         );
         assert_eq!(
-            candle_wan_sampling("wan2_2_ti2v_5b", &req(json!({ "steps": 12 }))).0,
+            wan_sampling("wan2_2_ti2v_5b", &req(json!({ "steps": 12 }))).0,
             Some(12)
         );
     }

--- a/crates/sceneworks-worker/src/video_jobs/wan.rs
+++ b/crates/sceneworks-worker/src/video_jobs/wan.rs
@@ -285,7 +285,7 @@ pub(super) const WAN_TI2V_5B_REVISION: &str = "bb1b055249614cf9d7cf4373fbdbc184b
 
 /// Pinned commit revision for the A14B Lightning distill-LoRA repo `lightx2v/Wan2.2-Lightning` (sc-11168 /
 /// F-007 — completes the sc-9879 rollout). Both the MLX (`ensure_wan_lightning_present`) and candle
-/// (`candle_ensure_wan_lightning_present`) self-heal fetches were pulling the mutable `main` branch, so an
+/// (formerly separate) self-heal fetches were pulling the mutable `main` branch, so an
 /// upstream re-push (or a compromised token) could silently swap the high/low distill weights we load.
 /// Pin the exact commit for defense-in-depth (the native downloader still verifies each file's own hash on
 /// download). Shared by BOTH lanes so the twins agree. Gated to the lanes that actually fetch it (macOS
@@ -295,6 +295,22 @@ pub(super) const WAN_TI2V_5B_REVISION: &str = "bb1b055249614cf9d7cf4373fbdbc184b
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
 pub(super) const WAN_LIGHTNING_REVISION: &str = "18bccf8884ec0a078eed79785eb4ef13ea16ce1e";
+
+/// Architecture-specific directory in `lightx2v/Wan2.2-Lightning`.
+///
+/// This mapping is shared by both backends and by both the cache-healing and resolution paths so a
+/// new architecture cannot silently fetch one pair and load another.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(super) fn wan_lightning_subdir(engine_id: &str) -> Option<&'static str> {
+    match engine_id {
+        "wan2_2_t2v_14b" => Some("Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1"),
+        "wan2_2_i2v_14b" => Some("Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1"),
+        _ => None,
+    }
+}
 
 /// The files that make an **A14B** (dual-expert MoE) Wan tier subdir COMPLETE: both experts + the T5
 /// encoder + VAE + tokenizer + `config.json`.
@@ -471,7 +487,10 @@ pub(super) async fn ensure_wan_tier_present(
 /// non-A14B engine, or when the pair is already cached. A pair still missing after the fetch makes
 /// resolve surface the clear "fetch it via the model manager" error. Fails loud on a real download error —
 /// fast, before any compute.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) async fn ensure_wan_lightning_present(
     api: &ApiClient,
     settings: &Settings,
@@ -486,11 +505,8 @@ pub(super) async fn ensure_wan_lightning_present(
         return Ok(());
     }
     // Per-architecture subdir (NOT cross-compatible, sc-4997); must match `resolve_lightning_loras`.
-    let subdir = match engine_id {
-        "wan2_2_t2v_14b" => "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1",
-        "wan2_2_i2v_14b" => "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1",
-        // Only the A14B MoE models bake Lightning — every other engine needs nothing here.
-        _ => return Ok(()),
+    let Some(subdir) = wan_lightning_subdir(engine_id) else {
+        return Ok(());
     };
     const REPO: &str = "lightx2v/Wan2.2-Lightning";
     // Fast path: both halves already materialized in the hub cache (the common case after install).
@@ -522,7 +538,10 @@ pub(super) async fn ensure_wan_lightning_present(
 /// (`lightx2v/Wan2.2-Lightning`, the rank-64 Seko distill). The subdir is architecture-specific:
 /// T2V-A14B (V1.1) and I2V-A14B (V1) ship distinct LoRAs that are NOT cross-compatible (sc-4997).
 /// Errors if not downloaded / the per-architecture subdir is missing.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn resolve_lightning_loras(
     settings: &Settings,
     engine_id: &str,
@@ -534,15 +553,11 @@ pub(super) fn resolve_lightning_loras(
                  downloaded — fetch it via the model manager"
             ))
         })?;
-    let base = match engine_id {
-        "wan2_2_t2v_14b" => "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V1.1",
-        "wan2_2_i2v_14b" => "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1",
-        other => {
-            return Err(WorkerError::InvalidPayload(format!(
-                "{other}: no Lightning distill LoRA — only the A14B MoE models bake Lightning"
-            )))
-        }
-    };
+    let base = wan_lightning_subdir(engine_id).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "{engine_id}: no Lightning distill LoRA — only the A14B MoE models bake Lightning"
+        ))
+    })?;
     let high = snapshot.join(base).join("high_noise_model.safetensors");
     let low = snapshot.join(base).join("low_noise_model.safetensors");
     for file in [&high, &low] {
@@ -559,7 +574,10 @@ pub(super) fn resolve_lightning_loras(
 /// The `.low_noise.safetensors` sibling of a Wan A14B MoE high-noise LoRA file, or
 /// `None` when the file is not the high-noise half of a pair (port of the Python
 /// `wan_moe_low_noise_sibling`; case-insensitive `.high_noise.safetensors` suffix).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn wan_moe_low_noise_sibling(primary: &Path) -> Option<PathBuf> {
     const HIGH: &str = ".high_noise.safetensors";
     let name = primary.file_name()?.to_str()?;
@@ -578,7 +596,10 @@ pub(super) fn wan_moe_low_noise_sibling(primary: &Path) -> Option<PathBuf> {
 /// single-file LoRA is shared (both experts on MoE, the single model on the 5B). peft LoKr AND
 /// third-party LyCORIS (LoHa / non-peft LoKr) both apply on the MLX Wan/LTX paths now (epic 3641,
 /// sc-3671) — `classify_adapter` returns `Lora` for third-party and the engine detects + merges it.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn resolve_wan_adapters(
     settings: &Settings,
     request: &VideoRequest,
@@ -600,12 +621,22 @@ pub(super) fn resolve_wan_adapters(
     // below are honored in both states. The subdir is resolved per architecture (not cross-compatible).
     if is_moe && wan_lightning_on(engine_id, request) {
         let (high, low) = resolve_lightning_loras(settings, engine_id)?;
-        specs.push(moe_adapter(high, 1.0, AdapterKind::Lora, MoeExpert::High));
-        specs.push(moe_adapter(low, 1.0, AdapterKind::Lora, MoeExpert::Low));
+        specs.push(moe_adapter(
+            high,
+            1.0,
+            gen_core::AdapterKind::Lora,
+            gen_core::MoeExpert::High,
+        ));
+        specs.push(moe_adapter(
+            low,
+            1.0,
+            gen_core::AdapterKind::Lora,
+            gen_core::MoeExpert::Low,
+        ));
     }
 
     for lora in &request.loras {
-        let path = lora_path(lora).ok_or_else(|| {
+        let path = crate::image_jobs::lora_path(lora).ok_or_else(|| {
             WorkerError::InvalidPayload("LoRA is missing a usable path.".to_owned())
         })?;
         let file = resolve_lora_file(
@@ -613,14 +644,14 @@ pub(super) fn resolve_wan_adapters(
             path,
             crate::image_jobs::declared_adapter_file(lora),
         )?;
-        let kind = classify_adapter(&file)?;
+        let kind = crate::image_jobs::classify_adapter(&file)?;
         let scale = lora_scale(lora);
         match (is_moe, wan_moe_low_noise_sibling(&file)) {
             (true, Some(low)) => {
                 // A MoE pair → high half to the high-noise expert, the sibling to the low.
-                let low_kind = classify_adapter(&low)?;
-                specs.push(moe_adapter(file, scale, kind, MoeExpert::High));
-                specs.push(moe_adapter(low, scale, low_kind, MoeExpert::Low));
+                let low_kind = crate::image_jobs::classify_adapter(&low)?;
+                specs.push(moe_adapter(file, scale, kind, gen_core::MoeExpert::High));
+                specs.push(moe_adapter(low, scale, low_kind, gen_core::MoeExpert::Low));
             }
             _ => {
                 // Single-file → shared (both experts on MoE; the dense single model on the 5B).
@@ -637,12 +668,15 @@ pub(super) fn resolve_wan_adapters(
     Ok(specs)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn moe_adapter(
     path: PathBuf,
     scale: f32,
-    kind: AdapterKind,
-    expert: MoeExpert,
+    kind: gen_core::AdapterKind,
+    expert: gen_core::MoeExpert,
 ) -> AdapterSpec {
     AdapterSpec {
         path,
@@ -678,7 +712,10 @@ pub(super) fn resolve_wan_vace_adapters(
 /// "lightning" LoRA installs via the engine's in-place diff-patch merge (sc-5684); selecting it makes
 /// the worker apply the step-distill recipe (`scail2_sampling`, sc-5700). Delegates to the shared
 /// [`resolve_dense_adapters`] (sc-8830) — the MLX Wan-VACE / SCAIL-2 twin.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn resolve_scail2_adapters(
     settings: &Settings,
     request: &VideoRequest,
@@ -969,7 +1006,10 @@ pub(super) fn resolve_wan_quant(request: &VideoRequest) -> Option<Quant> {
 /// (no 5B distill exists, so dropping it would hurt prompt adherence); the user can still dial
 /// `steps`/`guidanceScale` lower from VideoStudio, and the engine pre-flight guard (sc-4986) is
 /// the memory backstop. The full few-step / no-CFG preset lands once the 5B distill LoRA exists.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) const WAN5B_INTERIM_STEPS: u32 = 20;
 
 /// An optional positive-integer `advanced` knob (`steps`); accepts a number or a numeric string.
@@ -1009,7 +1049,10 @@ pub(super) fn advanced_opt_f32(request: &VideoRequest, key: &str) -> Option<f32>
 /// bake Lightning — for every other engine (the dense 5B, non-Wan) this is irrelevant and returns
 /// `false`. Backward compatible: an absent flag on an A14B job defaults to `true` (the prior
 /// always-on behavior). A strict-bool `false` opts out; `true` (or absent) opts in.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn wan_lightning_on(engine_id: &str, request: &VideoRequest) -> bool {
     let is_moe = engine_id == "wan2_2_t2v_14b" || engine_id == "wan2_2_i2v_14b";
     if !is_moe {
@@ -1034,7 +1077,10 @@ pub(super) fn wan_lightning_on(engine_id: &str, request: &VideoRequest) -> bool 
 /// The dense TI2V-5B has no distill LoRA yet (sc-4999) and no toggle: honor an explicit user
 /// `steps`/`guidanceScale`, else apply the interim default ([`WAN5B_INTERIM_STEPS`], CFG retained).
 /// `None` ⇒ the engine config default.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn wan_sampling(engine_id: &str, request: &VideoRequest) -> (Option<u32>, Option<f32>) {
     if engine_id == "wan2_2_t2v_14b" || engine_id == "wan2_2_i2v_14b" {
         if wan_lightning_on(engine_id, request) {
@@ -1056,11 +1102,20 @@ pub(super) fn wan_sampling(engine_id: &str, request: &VideoRequest) -> (Option<u
 }
 
 /// The lightx2v lightning step-distill recipe (sc-5684 / sc-5700): 8 steps, CFG off, scheduler shift 1.
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const SCAIL2_LIGHTNING_STEPS: u32 = 8;
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const SCAIL2_LIGHTNING_GUIDANCE: f32 = 1.0;
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 const SCAIL2_LIGHTNING_SHIFT: f32 = 1.0;
 
 /// SCAIL-2 sampling recipe `(steps, guidance, scheduler_shift)`. When a lightx2v diff-patch
@@ -1071,7 +1126,10 @@ const SCAIL2_LIGHTNING_SHIFT: f32 = 1.0;
 /// all-`None` so the engine's quality defaults (40 steps, guide 5.0, shift 5.0) stand exactly as before
 /// — this path is unchanged. The chosen knobs are recorded as `effective*` in [`scail2_raw_settings`]
 /// so what actually ran is inspectable on the asset (mirrors [`wan_raw_settings`]).
-#[cfg(target_os = "macos")]
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(super) fn scail2_sampling(
     request: &VideoRequest,
     lightning: bool,


### PR DESCRIPTION
## Summary
- consolidate backend-neutral Wan Lightning policy, cache healing, model pairing, adapter ordering, and sampling defaults
- share Bernini and SCAIL-2 engine/mode/settings policy while retaining backend-specific loading and generation
- add anti-drift and canonical-path regression coverage

## Validation
- fresh independent adversarial review: PASS
- cargo fmt --check
- targeted canonical mapping, anti-drift, and Wan sampling tests
- host all-target check and strict Clippy
- Linux x86_64 no-default all-target check and strict Clippy
- worker library suite: 995 passed, 0 failed, 176 ignored

Shortcut: sc-13622