### PR TITLE
sc-13624 scale core job and project storage

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -912,6 +912,14 @@ pub(crate) fn create_app_with_state(
     warn_on_sweep_err("asset", sweep_stale_asset_uploads(&settings.data_dir));
     let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
     jobs_store.initialize()?;
+    let purged_terminal_jobs =
+        jobs_store.purge_terminal_jobs_older_than(settings.jobs_retention_days)?;
+    tracing::info!(
+        event = "terminal_job_retention",
+        retention_days = settings.jobs_retention_days,
+        purged_terminal_jobs,
+        "applied terminal job retention"
+    );
     let interrupted_jobs_on_startup = jobs_store.mark_interrupted_on_startup()?.len();
     let project_store = Arc::new(ProjectStore::new(
         settings.data_dir.clone(),

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -50,6 +50,8 @@ pub struct Settings {
     pub cors_origins: Vec<String>,
     pub worker_timeout_seconds: u64,
     pub jobs_db_path: PathBuf,
+    /// Terminal job history retention. Zero preserves all history.
+    pub jobs_retention_days: u32,
     pub run_utility_inprocess: bool,
     /// Epic 3482 — macOS "MLX-required" mode. When set (the desktop sets it on macOS,
     /// where it spawns the in-process `mlx` worker), the MPS torch worker never claims an
@@ -165,6 +167,10 @@ impl Settings {
                 .and_then(|value| value.parse().ok())
                 .unwrap_or(90),
             jobs_db_path,
+            jobs_retention_days: std::env::var("SCENEWORKS_JOBS_RETENTION_DAYS")
+                .ok()
+                .and_then(|value| value.trim().parse().ok())
+                .unwrap_or(90),
             run_utility_inprocess: std::env::var("SCENEWORKS_RUN_UTILITY_INPROCESS")
                 .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "True"))
                 .unwrap_or(false),

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -155,6 +155,7 @@ pub(crate) fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         ],
         worker_timeout_seconds: 90,
         jobs_db_path: temp_dir.path().join("jobs.db"),
+        jobs_retention_days: 90,
         run_utility_inprocess: false,
         mlx_required: false,
         mlx_enforce_unsupported: false,

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 use rusqlite::{params, Connection, OptionalExtension, Row};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::project_store::{ProjectStoreError, ProjectStoreResult};
 use crate::store_util::{
@@ -27,6 +29,22 @@ pub(crate) const ASSET_FOLDERS: &[&str] = &[
 pub(crate) struct AssetRecord {
     pub(crate) file_path: Option<String>,
     pub(crate) sidecar_path: Option<String>,
+}
+
+pub(crate) fn sidecar_content_fingerprint(
+    path: &Path,
+) -> ProjectStoreResult<(u64, Option<String>, String)> {
+    let bytes = fs::read(path)?;
+    let modified_ns = fs::metadata(path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos().to_string());
+    Ok((
+        bytes.len() as u64,
+        modified_ns,
+        format!("{:x}", Sha256::digest(&bytes)),
+    ))
 }
 
 /// Resolve an asset id to its on-disk sidecar path: prefer the indexed
@@ -88,7 +106,13 @@ pub(crate) fn index_asset_on_connection(
         Some(path) => Some(relative_string(project_path, path)?),
         None => None,
     };
-    upsert_asset_row(connection, asset, sidecar_rel.as_deref())
+    let sidecar_fingerprint = sidecar_path.and_then(|path| sidecar_content_fingerprint(path).ok());
+    upsert_asset_row(
+        connection,
+        asset,
+        sidecar_rel.as_deref(),
+        sidecar_fingerprint,
+    )
 }
 
 pub(crate) fn row_to_asset_record(row: &Row<'_>) -> rusqlite::Result<AssetRecord> {
@@ -204,9 +228,23 @@ pub(crate) fn normalize_asset_cached(
     generation_sets: &mut GenerationSetCache,
 ) -> ProjectStoreResult<Value> {
     let mut asset = read_json(sidecar_path)?;
+    hydrate_asset(project_id, project_path, &mut asset, generation_sets)?;
+    let sidecar_rel = relative_string(project_path, sidecar_path)?;
+    if let Some(object) = asset.as_object_mut() {
+        object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));
+    }
+    Ok(asset)
+}
+
+fn hydrate_asset(
+    project_id: &str,
+    project_path: &Path,
+    asset: &mut Value,
+    generation_sets: &mut GenerationSetCache,
+) -> ProjectStoreResult<()> {
     // Guarantee every API response carries an `origin`, even for legacy sidecars
     // written before the field existed (sc-2024).
-    let origin = asset_origin(&asset);
+    let origin = asset_origin(asset);
     if let Some(object) = asset.as_object_mut() {
         object
             .entry("origin".to_owned())
@@ -266,8 +304,22 @@ pub(crate) fn normalize_asset_cached(
             }
         }
     }
-    let sidecar_rel = relative_string(project_path, sidecar_path)?;
-    if let Some(object) = asset.as_object_mut() {
+    Ok(())
+}
+
+/// Hydrate a normalized asset envelope already stored in project.db.
+pub(crate) fn hydrate_indexed_asset_cached(
+    project_id: &str,
+    project_path: &Path,
+    mut asset: Value,
+    generation_sets: &mut GenerationSetCache,
+) -> ProjectStoreResult<Value> {
+    let sidecar_rel = asset
+        .get("sidecarPath")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    hydrate_asset(project_id, project_path, &mut asset, generation_sets)?;
+    if let (Some(object), Some(sidecar_rel)) = (asset.as_object_mut(), sidecar_rel) {
         object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));
     }
     Ok(asset)
@@ -277,14 +329,17 @@ pub(crate) fn upsert_asset_row(
     connection: &Connection,
     asset: &Value,
     sidecar_rel: Option<&str>,
+    sidecar_fingerprint: Option<(u64, Option<String>, String)>,
 ) -> ProjectStoreResult<()> {
     let status = asset.get("status").unwrap_or(&Value::Null);
     connection.execute(
         "
         insert or replace into assets (
           id, type, display_name, file_path, generation_set_id, created_at,
-          favorite, rating, rejected, trashed, sidecar_path, origin
-        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+          favorite, rating, rejected, trashed, sidecar_path, origin,
+          asset_json, source_asset_id, upscaled_from_asset_id,
+          sidecar_size, sidecar_modified_ns, sidecar_sha256
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
         ",
         params![
             required_str(asset, "id")?,
@@ -304,6 +359,30 @@ pub(crate) fn upsert_asset_row(
             optional_bool(status, "trashed").unwrap_or(false),
             sidecar_rel,
             asset_origin(asset),
+            serde_json::to_string(asset)?,
+            asset
+                .pointer("/lineage/sourceAssetId")
+                .and_then(Value::as_str),
+            asset
+                .pointer("/extra/upscaledFromAssetId")
+                .and_then(Value::as_str)
+                .or_else(|| {
+                    asset
+                        .pointer("/extra/isUpscaled")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                        .then(|| {
+                            asset
+                                .pointer("/lineage/sourceAssetId")
+                                .and_then(Value::as_str)
+                        })
+                        .flatten()
+                }),
+            sidecar_fingerprint.as_ref().map(|value| value.0),
+            sidecar_fingerprint
+                .as_ref()
+                .and_then(|value| value.1.clone()),
+            sidecar_fingerprint.map(|value| value.2),
         ],
     )?;
     Ok(())

--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -790,6 +790,15 @@ pub fn reindex_characters_on_connection(
     connection: &Connection,
     project_path: &Path,
 ) -> ProjectStoreResult<u32> {
+    let (fingerprint, _) = character_index_fingerprint(project_path)?;
+    reindex_characters_with_fingerprint(connection, project_path, &fingerprint)
+}
+
+fn reindex_characters_with_fingerprint(
+    connection: &Connection,
+    project_path: &Path,
+    fingerprint: &str,
+) -> ProjectStoreResult<u32> {
     let mut count = 0;
     for sidecar_path in character_sidecars(project_path)? {
         let Ok(character) = read_json(&sidecar_path) else {
@@ -801,7 +810,10 @@ pub fn reindex_characters_on_connection(
         index_character_sidecar_on_connection(connection, project_path, &sidecar_path, &character)?;
         count += 1;
     }
-    store_character_index_fingerprint(connection, project_path)?;
+    connection.execute(
+        "insert or replace into project_metadata (key, value) values (?1, ?2)",
+        params![CHARACTER_INDEX_FINGERPRINT_KEY, fingerprint],
+    )?;
     Ok(count)
 }
 
@@ -832,7 +844,7 @@ fn ensure_character_index(project_path: &Path) -> ProjectStoreResult<()> {
     // or files changed outside the DB path, rebuild only when the sidecar fingerprint changes.
     let transaction = connection.transaction()?;
     clear_character_tables(&transaction)?;
-    reindex_characters_on_connection(&transaction, project_path)?;
+    reindex_characters_with_fingerprint(&transaction, project_path, &fingerprint)?;
     transaction.commit()?;
     Ok(())
 }

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -429,6 +429,8 @@ impl JobsStore {
               on jobs(project_id, created_at);
             create index if not exists idx_jobs_assigned_gpu_status
               on jobs(assigned_gpu, status);
+            create index if not exists idx_jobs_worker_status
+              on jobs(worker_id, status);
 
             create table if not exists workers (
               id text primary key,
@@ -506,8 +508,70 @@ impl JobsStore {
         // Batch size per job (epic 10402, sc-10426) — added after the table shipped,
         // so back-fill the column on existing generation_metrics tables.
         ensure_column(&transaction, "generation_metrics", "image_count", "integer")?;
+        // Retention may remove the owning queue row, but Generation Stats is
+        // historical product data rather than queue history. Materialize the
+        // joined row before purging so aggregate charts remain complete.
+        transaction.execute_batch(
+            "
+            create table if not exists generation_metrics_history as
+              select m.*, j.type as j_type, j.status as j_status,
+                     j.project_id as j_project_id, j.created_at as j_created_at
+                from generation_metrics m join jobs j on j.id = m.job_id
+               where 0;
+            create unique index if not exists idx_genmetrics_history_job
+              on generation_metrics_history(job_id);
+            ",
+        )?;
         transaction.commit()?;
         Ok(())
+    }
+
+    /// Remove terminal queue history older than `retention_days`.
+    ///
+    /// Zero disables retention. Job-owned metrics are materialized into the
+    /// independent Generation Stats history and then deleted in the same
+    /// immediate transaction as their owning jobs. Legacy orphan metrics are
+    /// also removed.
+    pub fn purge_terminal_jobs_older_than(&self, retention_days: u32) -> JobsStoreResult<usize> {
+        if retention_days == 0 {
+            return Ok(0);
+        }
+        let mut guard = self.lock.lock();
+        let connection = self.write_connection(&mut guard)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let modifier = format!("-{retention_days} days");
+        let terminal = terminal_statuses_sql();
+        let predicate = format!(
+            "status in ({terminal}) and completed_at is not null \
+             and datetime(completed_at) < datetime('now', ?1)"
+        );
+        transaction.execute(
+            &format!(
+                "insert or replace into generation_metrics_history
+                 select m.*, j.type, j.status, j.project_id, j.created_at
+                   from generation_metrics m join jobs j on j.id = m.job_id
+                  where j.{predicate}"
+            ),
+            params![modifier],
+        )?;
+        transaction.execute(
+            &format!(
+                "delete from generation_metrics where job_id in \
+                 (select id from jobs where {predicate})"
+            ),
+            params![modifier],
+        )?;
+        transaction.execute(
+            "delete from generation_metrics
+              where not exists (select 1 from jobs where jobs.id = generation_metrics.job_id)",
+            [],
+        )?;
+        let deleted = transaction.execute(
+            &format!("delete from jobs where {predicate}"),
+            params![modifier],
+        )?;
+        transaction.commit()?;
+        Ok(deleted)
     }
 
     pub fn mark_interrupted_on_startup(&self) -> JobsStoreResult<Vec<JobSnapshot>> {
@@ -863,27 +927,31 @@ impl JobsStore {
         let mut conditions: Vec<&str> = Vec::new();
         let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
         if let Some(job_type) = job_type {
-            conditions.push("j.type = ?");
+            conditions.push("stats.j_type = ?");
             bindings.push(Box::new(job_type.to_owned()));
         }
         if let Some(model) = model {
-            conditions.push("m.model = ?");
+            conditions.push("stats.model = ?");
             bindings.push(Box::new(model.to_owned()));
         }
         if let Some(quant_label) = quant_label {
-            conditions.push("m.quant_label = ?");
+            conditions.push("stats.quant_label = ?");
             bindings.push(Box::new(quant_label.to_owned()));
         }
         let mut sql = String::from(
-            "select m.*, j.type as j_type, j.status as j_status, \
-             j.project_id as j_project_id, j.created_at as j_created_at \
-             from generation_metrics m join jobs j on j.id = m.job_id",
+            "select stats.* from (
+               select m.*, j.type as j_type, j.status as j_status,
+                      j.project_id as j_project_id, j.created_at as j_created_at
+                 from generation_metrics m join jobs j on j.id = m.job_id
+               union all
+               select * from generation_metrics_history
+             ) stats",
         );
         if !conditions.is_empty() {
             sql.push_str(" where ");
             sql.push_str(&conditions.join(" and "));
         }
-        sql.push_str(" order by j.created_at desc limit ?");
+        sql.push_str(" order by stats.j_created_at desc limit ?");
         bindings.push(Box::new(limit));
         let mut statement = connection.prepare(&sql)?;
         let rows = statement.query_map(

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 
 use crate::asset_index::{
-    asset_origin, asset_sidecars, find_asset_sidecar_path_on_connection, index_asset_on_connection,
-    normalize_asset, normalize_asset_cached, GenerationSetCache,
+    asset_origin, asset_sidecars, find_asset_sidecar_path_on_connection,
+    hydrate_indexed_asset_cached, index_asset_on_connection, normalize_asset,
+    normalize_asset_cached, sidecar_content_fingerprint, GenerationSetCache,
 };
 use crate::character_store::{
     apply_character_migrations, clear_character_tables, reindex_characters_on_connection,
@@ -382,9 +383,17 @@ impl ProjectStore {
         // lazily-provisioned global pose/keypoint projects): translate a write
         // denial on the project.db migration into the actionable, path-naming
         // error instead of a raw SQLITE_READONLY (issue #1435 / sc-11855).
-        if let Err(error) =
-            connect_project_db(project_path).and_then(|conn| apply_project_migrations(&conn))
-        {
+        if let Err(error) = connect_project_db(project_path).and_then(|conn| {
+            apply_project_migrations(&conn)?;
+            // A newly provisioned project has no legacy sidecars to backfill;
+            // mark its empty index complete so the first indexed write is not
+            // immediately erased by an unnecessary rebuild.
+            conn.execute(
+                "insert or replace into project_metadata (key, value) values (?1, ?2)",
+                params![ASSET_INDEX_VERSION_KEY, PROJECT_SCHEMA_VERSION.to_string()],
+            )?;
+            Ok(())
+        }) {
             return Err(if is_write_denied(&error) {
                 ProjectStoreError::StorageNotWritable(storage_not_writable_message(
                     project_path.parent().unwrap_or(project_path),
@@ -1017,7 +1026,8 @@ impl ProjectStore {
         };
         let mut statement = connection.prepare(&format!(
             "
-            select sidecar_path, file_path
+            select sidecar_path, file_path, asset_json, sidecar_size, sidecar_modified_ns,
+                   sidecar_sha256
               from assets
              where (?1 or rejected = 0)
                and (?2 or trashed = 0)
@@ -1025,12 +1035,19 @@ impl ProjectStore {
              order by created_at desc
             "
         ))?;
-        let rows = statement.query_map(params![include_rejected, include_trashed], |row| {
-            Ok((
-                row.get::<_, Option<String>>(0)?,
-                row.get::<_, Option<String>>(1)?,
-            ))
-        })?;
+        let rows = statement
+            .query_map(params![include_rejected, include_trashed], |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<u64>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(statement);
         // HashSet dedup (was an O(n²) Vec linear scan) and a per-call
         // generation-set cache so a set's JSON is read once, not once per asset
         // in it (sc-4270 / F-CORE-10).
@@ -1038,7 +1055,61 @@ impl ProjectStore {
         let mut generation_sets = GenerationSetCache::default();
         let mut assets = Vec::new();
         for row in rows {
-            let (sidecar_rel, file_rel) = row?;
+            let (
+                sidecar_rel,
+                file_rel,
+                asset_json,
+                indexed_size,
+                _indexed_modified_ns,
+                indexed_sha256,
+            ) = row;
+            let indexed_sidecar = sidecar_rel
+                .as_ref()
+                .map(|path| project_path.join(path))
+                .or_else(|| {
+                    file_rel
+                        .as_ref()
+                        .map(|path| project_path.join(path).with_extension("sceneworks.json"))
+                });
+            // Size and mtime alone are not content identity: editors can
+            // preserve timestamps and same-length rewrites are common. The
+            // hash makes the sidecar authoritative even when mtime is absent.
+            let indexed_fingerprint_matches = indexed_sidecar
+                .as_ref()
+                .and_then(|path| sidecar_content_fingerprint(path).ok())
+                .is_some_and(|(size, _modified_ns, sha256)| {
+                    indexed_size == Some(size) && indexed_sha256.as_deref() == Some(sha256.as_str())
+                });
+            if indexed_fingerprint_matches {
+                if let Some(asset_json) = asset_json {
+                    if let Ok(mut asset) = serde_json::from_str::<Value>(&asset_json) {
+                        if let Some(sidecar_rel) = sidecar_rel.as_ref() {
+                            if let Some(object) = asset.as_object_mut() {
+                                object.insert(
+                                    "sidecarPath".to_owned(),
+                                    Value::String(sidecar_rel.clone()),
+                                );
+                            }
+                        }
+                        if let Ok(asset) = hydrate_indexed_asset_cached(
+                            project_id,
+                            &project_path,
+                            asset,
+                            &mut generation_sets,
+                        ) {
+                            let asset_id = asset
+                                .get("id")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_owned();
+                            if seen_asset_ids.insert(asset_id) {
+                                assets.push(asset);
+                            }
+                            continue;
+                        }
+                    }
+                }
+            }
             let mut candidates = Vec::new();
             if let Some(sidecar_rel) = sidecar_rel {
                 candidates.push(project_path.join(sidecar_rel));
@@ -1062,6 +1133,17 @@ impl ProjectStore {
                 ) else {
                     continue;
                 };
+                // The sidecar changed outside a store write (or this is a
+                // legacy row without a fingerprint). Refresh the indexed
+                // envelope once; subsequent listings stay read-free.
+                if let Ok(raw_asset) = read_json(&sidecar_path) {
+                    let _ = index_asset_on_connection(
+                        &connection,
+                        &project_path,
+                        &raw_asset,
+                        Some(&sidecar_path),
+                    );
+                }
                 let asset_id = asset
                     .get("id")
                     .and_then(Value::as_str)
@@ -2744,7 +2826,8 @@ struct ReindexCounts {
 /// registry). The bump lets existing DBs pick up the new table through the gated
 /// migration; the table is DB-authoritative (no sidecar), so the reindex the bump
 /// triggers — which only clears the sidecar-rebuilt tables — leaves it intact.
-const PROJECT_SCHEMA_VERSION: i64 = 5;
+const PROJECT_SCHEMA_VERSION: i64 = 6;
+const ASSET_INDEX_VERSION_KEY: &str = "assetIndexVersion";
 
 fn project_schema_version(connection: &Connection) -> ProjectStoreResult<i64> {
     Ok(connection.query_row("pragma user_version", [], |row| row.get(0))?)
@@ -2800,6 +2883,23 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
     // document_studio / character_studio / upload). Existing rows are backfilled
     // by the reindex that `ensure_project_db_ready` runs on this version bump.
     ensure_column(connection, "assets", "origin", "text")?;
+    // Normalized sidecar envelope + lineage keys make list hydration and
+    // upscale-fold traversal indexed operations. Existing projects are
+    // backfilled by the version-bump reindex below.
+    ensure_column(connection, "assets", "asset_json", "text")?;
+    ensure_column(connection, "assets", "source_asset_id", "text")?;
+    ensure_column(connection, "assets", "upscaled_from_asset_id", "text")?;
+    ensure_column(connection, "assets", "sidecar_size", "integer")?;
+    ensure_column(connection, "assets", "sidecar_modified_ns", "text")?;
+    ensure_column(connection, "assets", "sidecar_sha256", "text")?;
+    connection.execute_batch(
+        "
+        create index if not exists idx_assets_source_asset
+          on assets(source_asset_id);
+        create index if not exists idx_assets_upscaled_from
+          on assets(upscaled_from_asset_id);
+        ",
+    )?;
     apply_character_migrations(connection)?;
     apply_training_dataset_migrations(connection)?;
     crate::voice_store::apply_voice_migrations(connection)?;
@@ -2810,13 +2910,19 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
 
 pub fn ensure_project_db_ready(project_path: &Path) -> ProjectStoreResult<()> {
     let connection = connect_project_db(project_path)?;
-    let version_before = project_schema_version(&connection)?;
     apply_project_migrations(&connection)?;
+    let indexed_version = connection
+        .query_row(
+            "select value from project_metadata where key = ?1",
+            params![ASSET_INDEX_VERSION_KEY],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
     drop(connection);
-    // A schema bump can add derived columns (e.g. `origin`, sc-2024) that
-    // existing rows lack. Rebuild the index from sidecars once so those columns
-    // are backfilled; subsequent calls are no-ops (version already current).
-    if version_before < PROJECT_SCHEMA_VERSION {
+    // The schema stamp and the derived-data rebuild are separate operations.
+    // Record completion only in the rebuild transaction so a failed reindex is
+    // retried even though PRAGMA user_version already reached this version.
+    if indexed_version.as_deref() != Some(&PROJECT_SCHEMA_VERSION.to_string()) {
         reindex_project_path(project_path)?;
     }
     Ok(())
@@ -2948,54 +3054,34 @@ fn apply_upscale_variant_link(asset: &mut Value, base_id: &str, factor: u8, engi
 /// tile, so a move of the visible asset must carry the whole group. The requested
 /// id is always first. Unreadable sidecars are skipped — worst case the group
 /// degrades to the single asset, never to an error.
+const UPSCALE_LINEAGE_QUERY: &str = "
+    with recursive connected(id) as (
+      values (?1)
+      union
+      select parent.upscaled_from_asset_id
+        from assets parent join connected c on parent.id = c.id
+       where parent.upscaled_from_asset_id is not null
+      union
+      select child.id
+        from assets child join connected c on child.upscaled_from_asset_id = c.id
+    )
+    select id from connected
+";
+
 fn upscale_lineage_group(project_path: &Path, asset_id: &str) -> Vec<String> {
     let mut group = vec![asset_id.to_owned()];
-    let Ok(sidecars) = asset_sidecars(project_path) else {
+    let Ok(connection) = connect_project_db(project_path) else {
         return group;
     };
-    // Every asset's fold parent (the original it was upscaled from), if any.
-    let mut parent_of: Vec<(String, String)> = Vec::new();
-    for sidecar_path in sidecars {
-        let Ok(asset) = read_json(&sidecar_path) else {
-            continue;
-        };
-        let Some(id) = asset.get("id").and_then(Value::as_str) else {
-            continue;
-        };
-        let parent = asset
-            .pointer("/extra/upscaledFromAssetId")
-            .and_then(Value::as_str)
-            .or_else(|| {
-                asset
-                    .pointer("/extra/isUpscaled")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false)
-                    .then(|| {
-                        asset
-                            .pointer("/lineage/sourceAssetId")
-                            .and_then(Value::as_str)
-                    })
-                    .flatten()
-            });
-        if let Some(parent) = parent {
-            parent_of.push((id.to_owned(), parent.to_owned()));
-        }
-    }
-    // Fixed-point closure over the parent links in both directions (covers
-    // upscale-of-upscale chains and multiple variants of one original).
-    loop {
-        let before = group.len();
-        for (child, parent) in &parent_of {
-            let child_in = group.iter().any(|id| id == child);
-            let parent_in = group.iter().any(|id| id == parent);
-            if child_in && !parent_in {
-                group.push(parent.clone());
-            } else if parent_in && !child_in {
-                group.push(child.clone());
-            }
-        }
-        if group.len() == before {
-            break;
+    let Ok(mut statement) = connection.prepare(UPSCALE_LINEAGE_QUERY) else {
+        return group;
+    };
+    let Ok(rows) = statement.query_map(params![asset_id], |row| row.get::<_, String>(0)) else {
+        return group;
+    };
+    for id in rows.filter_map(Result::ok) {
+        if id != asset_id && !group.contains(&id) {
+            group.push(id);
         }
     }
     group
@@ -3096,6 +3182,10 @@ fn reindex_project_path(project_path: &Path) -> ProjectStoreResult<ReindexCounts
     }
 
     reindex_characters_on_connection(&transaction, project_path)?;
+    transaction.execute(
+        "insert or replace into project_metadata (key, value) values (?1, ?2)",
+        params![ASSET_INDEX_VERSION_KEY, PROJECT_SCHEMA_VERSION.to_string()],
+    )?;
 
     transaction.commit()?;
     Ok(counts)
@@ -4697,14 +4787,15 @@ fn move_or_copy_file(source: &Path, destination: &Path) -> ProjectStoreResult<()
 mod tests {
     use super::{
         apply_project_migrations, backfill_upscale_variant_lineage, build_generated_asset_sidecar,
-        connect_project_db, find_timeline_file, guess_mime_from_filename, index_timeline,
-        is_safe_relative_path, is_safe_upload_extension, normalize_asset_tags, read_json,
-        sniff_image_format, upload_extension, AssetScope, CharacterCreateInput, CharacterLookInput,
-        CharacterReferenceInput, ProjectStore, ProjectStoreError, UploadAsset,
-        GLOBAL_KEYPOINTS_PROJECT_ID, GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS,
-        PROJECT_SCHEMA_VERSION, SAFE_UPLOAD_EXTENSIONS,
+        connect_project_db, ensure_project_db_ready, find_timeline_file, guess_mime_from_filename,
+        index_timeline, is_safe_relative_path, is_safe_upload_extension, normalize_asset_tags,
+        read_json, sniff_image_format, upload_extension, upscale_lineage_group, AssetScope,
+        CharacterCreateInput, CharacterLookInput, CharacterReferenceInput, ProjectStore,
+        ProjectStoreError, UploadAsset, ASSET_INDEX_VERSION_KEY, GLOBAL_KEYPOINTS_PROJECT_ID,
+        GLOBAL_POSES_PROJECT_ID, PROJECT_FOLDERS, PROJECT_SCHEMA_VERSION, SAFE_UPLOAD_EXTENSIONS,
+        UPSCALE_LINEAGE_QUERY,
     };
-    use rusqlite::Connection;
+    use rusqlite::{params, Connection, OptionalExtension};
     use serde_json::{json, Value};
     use std::sync::Arc;
 
@@ -4846,8 +4937,8 @@ mod tests {
     /// alongside a deliberate schema change — and when you do, you MUST bump
     /// `PROJECT_SCHEMA_VERSION` so the `user_version=` line below changes too.
     const EXPECTED_PROJECT_DB_SCHEMA: &str = concat!(
-        "user_version=5\n",
-        "table assets: id TEXT notnull=0 default=NULL pk=1, type TEXT notnull=1 default=NULL pk=0, display_name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, generation_set_id TEXT notnull=0 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, favorite INTEGER notnull=1 default=0 pk=0, rating INTEGER notnull=1 default=0 pk=0, rejected INTEGER notnull=1 default=0 pk=0, trashed INTEGER notnull=1 default=0 pk=0, sidecar_path TEXT notnull=0 default=NULL pk=0, origin TEXT notnull=0 default=NULL pk=0\n",
+        "user_version=6\n",
+        "table assets: id TEXT notnull=0 default=NULL pk=1, type TEXT notnull=1 default=NULL pk=0, display_name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, generation_set_id TEXT notnull=0 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, favorite INTEGER notnull=1 default=0 pk=0, rating INTEGER notnull=1 default=0 pk=0, rejected INTEGER notnull=1 default=0 pk=0, trashed INTEGER notnull=1 default=0 pk=0, sidecar_path TEXT notnull=0 default=NULL pk=0, origin TEXT notnull=0 default=NULL pk=0, asset_json TEXT notnull=0 default=NULL pk=0, source_asset_id TEXT notnull=0 default=NULL pk=0, upscaled_from_asset_id TEXT notnull=0 default=NULL pk=0, sidecar_size INTEGER notnull=0 default=NULL pk=0, sidecar_modified_ns TEXT notnull=0 default=NULL pk=0, sidecar_sha256 TEXT notnull=0 default=NULL pk=0\n",
         "table character_looks: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, description TEXT notnull=1 default='' pk=0, approved_reference_ids TEXT notnull=1 default='[]' pk=0, recipe_settings TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table character_loras: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, lora_id TEXT notnull=0 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, source_path TEXT notnull=0 default=NULL pk=0, project_path TEXT notnull=0 default=NULL pk=0, copied_into_project INTEGER notnull=1 default=0 pk=0, category TEXT notnull=1 default='character' pk=0, scope TEXT notnull=1 default='project' pk=0, trigger_words TEXT notnull=1 default='[]' pk=0, default_weight REAL notnull=1 default=1.0 pk=0, compatibility TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table character_references: character_id TEXT notnull=1 default=NULL pk=1, asset_id TEXT notnull=1 default=NULL pk=2, approved INTEGER notnull=1 default=0 pk=0, role TEXT notnull=1 default='reference' pk=0, notes TEXT notnull=1 default='' pk=0, added_at TEXT notnull=1 default=NULL pk=0, approved_at TEXT notnull=0 default=NULL pk=0\n",
@@ -4857,6 +4948,8 @@ mod tests {
         "table saved_voices: id TEXT notnull=0 default=NULL pk=1, project_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, reference_audio_asset_id TEXT notnull=1 default=NULL pk=0, embedding TEXT notnull=1 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0\n",
         "table timelines: id TEXT notnull=0 default=NULL pk=1, name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, aspect_ratio TEXT notnull=1 default=NULL pk=0, width INTEGER notnull=1 default=NULL pk=0, height INTEGER notnull=1 default=NULL pk=0, fps INTEGER notnull=1 default=NULL pk=0, duration REAL notnull=1 default=0 pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table training_datasets: id TEXT notnull=0 default=NULL pk=1, project_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, modality TEXT notnull=1 default=NULL pk=0, status TEXT notnull=1 default=NULL pk=0, version INTEGER notnull=1 default=NULL pk=0, item_count INTEGER notnull=1 default=0 pk=0, character_id TEXT notnull=0 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
+        "index idx_assets_source_asset on assets\n",
+        "index idx_assets_upscaled_from on assets\n",
         "index idx_training_datasets_project_updated on training_datasets",
     );
 
@@ -4880,6 +4973,116 @@ mod tests {
              Forgetting step 1 is exactly the sc-2537 bug.\n\n\
              ----- actual schema -----\n{actual}\n-------------------------\n"
         );
+    }
+
+    #[test]
+    fn completed_asset_index_backfill_retries_after_failure() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Retry").expect("project creates");
+        let project_path = store.find_project_path(&project.id).expect("project path");
+        let connection = connect_project_db(&project_path).expect("db opens");
+        connection
+            .execute(
+                "delete from project_metadata where key = ?1",
+                params![ASSET_INDEX_VERSION_KEY],
+            )
+            .expect("remove completion marker");
+        let stamped: i64 = connection
+            .query_row("pragma user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(stamped, PROJECT_SCHEMA_VERSION);
+        drop(connection);
+
+        let generation_sets = project_path.join("generation-sets");
+        std::fs::remove_dir(&generation_sets).expect("empty generation set directory removes");
+        std::fs::write(&generation_sets, b"not a directory").expect("failure fixture");
+        assert!(
+            ensure_project_db_ready(&project_path).is_err(),
+            "reindex must fail while a required index source is unreadable"
+        );
+        let connection = connect_project_db(&project_path).unwrap();
+        let marker: Option<String> = connection
+            .query_row(
+                "select value from project_metadata where key = ?1",
+                params![ASSET_INDEX_VERSION_KEY],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert!(
+            marker.is_none(),
+            "failed rebuild must not be marked complete"
+        );
+        drop(connection);
+
+        std::fs::remove_file(&generation_sets).unwrap();
+        std::fs::create_dir(&generation_sets).unwrap();
+        ensure_project_db_ready(&project_path).expect("next open retries and completes");
+        let connection = connect_project_db(&project_path).unwrap();
+        let marker: String = connection
+            .query_row(
+                "select value from project_metadata where key = ?1",
+                params![ASSET_INDEX_VERSION_KEY],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(marker, PROJECT_SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn upscale_lineage_query_uses_indexes_and_ignores_unrelated_assets() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Lineage").expect("project creates");
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let connection = connect_project_db(&project_path).unwrap();
+        connection
+            .execute_batch(
+                "
+                with recursive seq(n) as (
+                  values(1) union all select n + 1 from seq where n < 5000
+                )
+                insert into assets (
+                  id,type,display_name,file_path,created_at
+                )
+                select printf('unrelated-%05d', n), 'image', 'unrelated',
+                       printf('assets/images/unrelated-%05d.png', n), ''
+                  from seq;
+                insert into assets (id,type,display_name,file_path,created_at)
+                  values ('base','image','base','base.png','');
+                insert into assets (
+                  id,type,display_name,file_path,created_at,upscaled_from_asset_id
+                ) values
+                  ('child','image','child','child.png','','base'),
+                  ('grandchild','image','grandchild','grandchild.png','','child');
+                ",
+            )
+            .unwrap();
+        let plan_sql = format!("explain query plan {UPSCALE_LINEAGE_QUERY}");
+        let details: Vec<String> = connection
+            .prepare(&plan_sql)
+            .unwrap()
+            .query_map(params!["grandchild"], |row| row.get::<_, String>(3))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        let plan = details.join("\n");
+        assert!(
+            plan.contains("idx_assets_upscaled_from"),
+            "child traversal must use the lineage index:\n{plan}"
+        );
+        assert!(
+            plan.contains("sqlite_autoindex_assets_1"),
+            "parent traversal must use the assets primary key:\n{plan}"
+        );
+        drop(connection);
+
+        let group = upscale_lineage_group(&project_path, "grandchild");
+        assert_eq!(group.first().map(String::as_str), Some("grandchild"));
+        assert_eq!(group.len(), 3);
+        assert!(group.contains(&"base".to_owned()));
+        assert!(group.contains(&"child".to_owned()));
     }
 
     #[test]
@@ -5804,6 +6007,125 @@ mod tests {
             .list_assets(&project.id, false, false, AssetScope::All)
             .expect("second list");
         assert_eq!(again.len(), 1, "result is stable on subsequent opens");
+    }
+
+    #[test]
+    fn list_assets_refreshes_a_stale_indexed_envelope_once() {
+        use crate::store_util::write_json;
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Indexed").expect("project creates");
+        let fact = json!({
+            "assetId": "asset_cached",
+            "mediaPath": "assets/images/set/asset_cached.png",
+            "mimeType": "image/png",
+            "displayName": "Before",
+            "createdAt": "2026-05-25T00:00:00Z",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "adapter": "z_image_diffusers",
+            "prompt": "cache",
+        });
+        store
+            .persist_generated_asset(&project.id, "job-1", "set", &fact)
+            .expect("asset persists");
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let sidecar = project_path.join("assets/images/set/asset_cached.sceneworks.json");
+        let mut asset = read_json(&sidecar).unwrap();
+        asset["displayName"] = json!("After");
+        write_json(&sidecar, &asset).unwrap();
+
+        let listed = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .expect("list refreshes");
+        assert_eq!(listed[0]["displayName"], json!("After"));
+        let connection = connect_project_db(&project_path).unwrap();
+        let cached: String = connection
+            .query_row(
+                "select asset_json from assets where id='asset_cached'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&cached).unwrap()["displayName"],
+            json!("After")
+        );
+    }
+
+    #[test]
+    fn list_assets_rejects_same_metadata_and_missing_mtime_cache_false_hits() {
+        use crate::store_util::write_json;
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Content fingerprint").unwrap();
+        let fact = json!({
+            "assetId": "asset_fingerprint",
+            "mediaPath": "assets/images/set/asset_fingerprint.png",
+            "mimeType": "image/png",
+            "displayName": "Before",
+            "createdAt": "2026-05-25T00:00:00Z",
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "adapter": "z_image_diffusers",
+            "prompt": "cache",
+        });
+        store
+            .persist_generated_asset(&project.id, "job-1", "set", &fact)
+            .unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let sidecar = project_path.join("assets/images/set/asset_fingerprint.sceneworks.json");
+
+        let mut asset = read_json(&sidecar).unwrap();
+        asset["displayName"] = json!("After!");
+        write_json(&sidecar, &asset).unwrap();
+        let metadata = std::fs::metadata(&sidecar).unwrap();
+        let modified_ns = metadata
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .to_string();
+        let connection = connect_project_db(&project_path).unwrap();
+        connection
+            .execute(
+                "update assets set sidecar_size=?1, sidecar_modified_ns=?2
+                  where id='asset_fingerprint'",
+                params![metadata.len(), modified_ns],
+            )
+            .unwrap();
+        drop(connection);
+        let listed = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .unwrap();
+        assert_eq!(
+            listed[0]["displayName"],
+            json!("After!"),
+            "content hash catches same-size/same-mtime rewrites"
+        );
+
+        let mut asset = read_json(&sidecar).unwrap();
+        asset["displayName"] = json!("Later!");
+        write_json(&sidecar, &asset).unwrap();
+        let metadata = std::fs::metadata(&sidecar).unwrap();
+        let connection = connect_project_db(&project_path).unwrap();
+        connection
+            .execute(
+                "update assets set sidecar_size=?1, sidecar_modified_ns=null
+                  where id='asset_fingerprint'",
+                params![metadata.len()],
+            )
+            .unwrap();
+        drop(connection);
+        let listed = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .unwrap();
+        assert_eq!(
+            listed[0]["displayName"],
+            json!("Later!"),
+            "content hash remains authoritative when mtime is unavailable"
+        );
     }
 
     /// V-4 guard: a genuinely empty project (no sidecars on disk) must NOT trigger

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -58,6 +58,193 @@ fn register_image_worker(store: &JobsStore) {
 }
 
 #[test]
+fn startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics() {
+    let path = temp_db("retention");
+    let store = JobsStore::new(path.clone());
+    store.initialize().expect("store initializes");
+    let connection = Connection::open(&path).expect("db opens");
+    for (id, status, completed_at) in [
+        ("old-completed", "completed", "2020-01-01T00:00:00Z"),
+        ("old-failed", "failed", "2020-01-01T00:00:00Z"),
+        ("old-canceled", "canceled", "2020-01-01T00:00:00Z"),
+        ("old-interrupted", "interrupted", "2020-01-01T00:00:00Z"),
+        ("recent", "failed", "2999-01-01T00:00:00Z"),
+        ("active", "running", "2020-01-01T00:00:00Z"),
+    ] {
+        connection
+            .execute(
+                "insert into jobs (
+                   id,type,status,payload_json,result_json,requested_gpu,progress,stage,message,
+                   attempts,cancel_requested,created_at,updated_at,completed_at
+                 ) values (?1,'image_generate',?2,'{}','{}','auto',0,?2,'',1,0,?3,?3,?3)",
+                params![id, status, completed_at],
+            )
+            .expect("job seeds");
+        connection
+            .execute(
+                "insert into generation_metrics(job_id,updated_at) values (?1,?2)",
+                params![id, completed_at],
+            )
+            .expect("metrics seed");
+    }
+    connection
+        .execute(
+            "insert into jobs (
+               id,type,status,payload_json,result_json,requested_gpu,progress,stage,message,
+               attempts,cancel_requested,created_at,updated_at,completed_at
+             ) values ('boundary','image_generate','completed','{}','{}','auto',1,'completed','',
+                       1,0,datetime('now','-90 days'),datetime('now','-90 days'),
+                       datetime('now','-90 days'))",
+            [],
+        )
+        .expect("boundary job seeds");
+    connection
+        .execute(
+            "insert into generation_metrics(job_id,updated_at) values
+             ('boundary',datetime('now','-90 days')),('orphan','2020-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("boundary and orphan metrics seed");
+    drop(connection);
+
+    assert_eq!(
+        store
+            .purge_terminal_jobs_older_than(90)
+            .expect("retention succeeds"),
+        4
+    );
+    let connection = Connection::open(&path).expect("db reopens");
+    assert_eq!(
+        connection
+            .query_row(
+                "select count(*) from jobs where id like 'old-%'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "select count(*) from generation_metrics where job_id like 'old-%'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        connection
+            .query_row("select count(*) from jobs", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        3
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "select count(*) from generation_metrics where job_id='orphan'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        0,
+        "legacy orphan metrics are job-owned garbage"
+    );
+    drop(connection);
+    let historical = store
+        .list_generation_metrics(None, None, None, 100)
+        .expect("aggregate history remains queryable");
+    assert_eq!(
+        historical
+            .iter()
+            .filter(|row| row.job_id.starts_with("old-"))
+            .count(),
+        4,
+        "purged queue rows remain in Generation Stats"
+    );
+    assert!(
+        historical.iter().any(|row| row.job_id == "boundary"),
+        "the exact cutoff boundary is retained"
+    );
+    let connection = Connection::open(&path).expect("db reopens");
+    assert!(connection
+        .query_row(
+            "select 1 from sqlite_master where type='index' and name='idx_jobs_worker_status'",
+            [],
+            |_| Ok(())
+        )
+        .is_ok());
+}
+
+#[test]
+fn retention_is_atomic_when_job_deletion_fails() {
+    let path = temp_db("retention-rollback");
+    let store = JobsStore::new(path.clone());
+    store.initialize().expect("store initializes");
+    let connection = Connection::open(&path).expect("db opens");
+    connection
+        .execute_batch(
+            "
+            insert into jobs (
+              id,type,status,payload_json,result_json,requested_gpu,progress,stage,message,
+              attempts,cancel_requested,created_at,updated_at,completed_at
+            ) values (
+              'old-fail','image_generate','completed','{}','{}','auto',1,'completed','',
+              1,0,'2020-01-01T00:00:00Z','2020-01-01T00:00:00Z','2020-01-01T00:00:00Z'
+            );
+            insert into generation_metrics(job_id,updated_at)
+              values ('old-fail','2020-01-01T00:00:00Z'),
+                     ('orphan','2020-01-01T00:00:00Z');
+            create trigger fail_retention before delete on jobs
+              when old.id = 'old-fail'
+              begin select raise(abort, 'forced retention failure'); end;
+            ",
+        )
+        .expect("failure fixture seeds");
+    drop(connection);
+
+    assert!(
+        store.purge_terminal_jobs_older_than(90).is_err(),
+        "trigger forces the final delete to fail"
+    );
+    let connection = Connection::open(&path).expect("db reopens");
+    for (table, expected) in [
+        ("jobs", 1_i64),
+        ("generation_metrics", 2_i64),
+        ("generation_metrics_history", 0_i64),
+    ] {
+        let actual: i64 = connection
+            .query_row(&format!("select count(*) from {table}"), [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(actual, expected, "{table} must roll back atomically");
+    }
+}
+
+#[test]
+fn zero_retention_preserves_terminal_history() {
+    let path = temp_db("retention-disabled");
+    let store = JobsStore::new(path.clone());
+    store.initialize().expect("store initializes");
+    let connection = Connection::open(&path).expect("db opens");
+    connection
+        .execute(
+            "insert into jobs (
+               id,type,status,payload_json,result_json,requested_gpu,progress,stage,message,
+               attempts,cancel_requested,created_at,updated_at,completed_at
+             ) values ('old','image_generate','completed','{}','{}','auto',1,'completed','',1,0,
+                       '2020-01-01T00:00:00Z','2020-01-01T00:00:00Z','2020-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+    drop(connection);
+    assert_eq!(store.purge_terminal_jobs_older_than(0).unwrap(), 0);
+    assert!(store.get_job("old").is_ok());
+}
+
+#[test]
 fn generation_metrics_upsert_get_list_and_merge() {
     let store = store("gen-metrics");
     let job = store


### PR DESCRIPTION
## Summary
- add configurable startup retention (90-day default, 0 disables) with transactional archival of generation metrics before terminal job purge
- preserve Generation Stats through denormalized historical metrics while removing live job-owned/orphan rows
- cache project sidecars using SHA-256 content identity and retryable transactional schema-v6 backfill
- replace full-table lineage scans with an indexed recursive connected-component query
- reuse character fingerprints and add migration, rollback, cutoff, cache-collision, and scale coverage

## Validation
- fresh independent adversarial review: PASS
- cargo test --locked -p sceneworks-core: 579 unit plus 205 integration/doc tests; 3 ignored
- strict host and Linux clippy for core + Rust API, all targets
- cargo fmt --check and git diff --check

Shortcut: sc-13624