### PR TITLE
fix(worker): candle SDXL edit + IP-Adapter lanes load the installed turnkey [sc-14463]

### DIFF
--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -850,6 +850,28 @@ pub(crate) fn mlx_model(sceneworks_id: &str) -> Option<ResolvedModel> {
     Some(ResolvedModel { row, descriptor })
 }
 
+/// The default weights repo for a SceneWorks model id straight off its [`MODEL_TABLE`] row.
+///
+/// Unlike [`mlx_model`] this needs NO linked gen_core descriptor, so it answers on any backend and
+/// in unit tests that never build the registry. It exists so the conditioning lanes (candle SDXL
+/// edit / IP-Adapter) resolve the SAME repo the txt2img lane does instead of each carrying a private
+/// copy of the mapping (sc-14463).
+///
+/// That drift was a real defect, not a hypothetical: those lanes kept pointing at the flat upstream
+/// repos (`SG161222/RealVisXL_V5.0`, `stabilityai/stable-diffusion-xl-base-1.0`) after the Group-B
+/// cutover (sc-8746) repointed the manifest downloads at the SceneWorks turnkeys, so on a clean
+/// install `huggingface_snapshot_dir` — a cache lookup, NOT a fetch — returned `None` and the lanes
+/// silently declined every job to torch. One lookup site now, so the next repo move cannot desync.
+/// Only the candle-gated conditioning lanes call this, so on macOS it has no callers outside the
+/// test module — same shape as `image_jobs::base::dense_tier_subdir` (sc-10614).
+#[cfg_attr(target_os = "macos", allow(dead_code))]
+pub(crate) fn default_repo_for(sceneworks_id: &str) -> Option<&'static str> {
+    MODEL_TABLE
+        .iter()
+        .find(|row| row.sceneworks_id == sceneworks_id)
+        .map(|row| row.default_repo)
+}
+
 /// The registry-DERIVED subset of the MLX worker's capabilities (sc-3723): exactly the
 /// capabilities backed by a linked generator/trainer/captioner descriptor whose backend is
 /// enabled in `settings`. Off-macOS the provider crates aren't linked, so the registry is
@@ -2089,6 +2111,34 @@ mod tests {
         assert_ne!(base.default_repo, turbo.default_repo);
         assert_ne!(base.default_steps, turbo.default_steps);
         assert_ne!(base.default_guidance, turbo.default_guidance);
+    }
+
+    /// sc-14463: `default_repo_for` is the ONE lookup the candle conditioning lanes share with the
+    /// txt2img lane. Those lanes are `not(target_os = "macos")`-gated, so their own tests never run
+    /// here — this asserts the shared helper on every platform, and names the pre-fix upstream repos
+    /// so it discriminates rather than restating whatever the table happens to hold.
+    #[test]
+    fn default_repo_for_resolves_sdxl_family_to_installed_turnkeys() {
+        for (id, turnkey) in [
+            ("sdxl", "SceneWorks/sdxl-base-mlx"),
+            ("realvisxl", "SceneWorks/realvisxl-mlx"),
+            ("illustrious_xl_v1", "SceneWorks/illustrious-xl-v1-mlx"),
+            ("illustrious_xl_v2", "SceneWorks/illustrious-xl-v2-mlx"),
+        ] {
+            assert_eq!(default_repo_for(id), Some(turnkey), "{id} default repo");
+        }
+        // The exact repos the conditioning lanes used to hardcode. Nothing in any manifest
+        // `downloads` block stages either one, so resolving to them means resolving to nothing.
+        for stale in [
+            "SG161222/RealVisXL_V5.0",
+            "stabilityai/stable-diffusion-xl-base-1.0",
+        ] {
+            assert!(
+                !MODEL_TABLE.iter().any(|row| row.default_repo == stale),
+                "{stale} is not installed by any manifest download — no row may name it"
+            );
+        }
+        assert_eq!(default_repo_for("not_a_model"), None);
     }
 
     // sc-8746 (epic 8506, Group-B): the SDXL-family rows point at the SceneWorks pre-built

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -43,21 +43,13 @@ fn is_sdxl_edit_candle_model(model: &str) -> bool {
     )
 }
 
-/// Default SDXL base repo for a model id when the manifest omits `repo`.
-///
-/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots (the conditioning fallback when the
-/// manifest omits `repo`, per sc-10614). Illustrious has no such upstream — OnomaAI ship a single-file
-/// LDM checkpoint — so it names its tiered turnkey. In practice the built-in SDXL family points `repo`
-/// at the SceneWorks quant-matrix turnkey (`mlx.standardTierLayout`), and — as of sc-10813 — this edit
-/// lane packed-detects + serves the request's q4/q8 tier through `standard_tier_subdir`, exactly like
-/// the txt2img lane (sc-10767); this default is only the flat-repo fallback.
+/// Default SDXL base repo for a model id when the manifest omits `repo` — which, in production, is
+/// ALWAYS (sc-14463). The edit-lane twin of `sdxl_ipadapter_default_repo`; see that fn for why the
+/// old hardcoded upstream repos were a live defect rather than a fallback.
 fn sdxl_edit_candle_default_repo(model: &str) -> &'static str {
-    match model {
-        "realvisxl" => "SG161222/RealVisXL_V5.0",
-        "illustrious_xl_v1" => "SceneWorks/illustrious-xl-v1-mlx",
-        "illustrious_xl_v2" => "SceneWorks/illustrious-xl-v2-mlx",
-        _ => "stabilityai/stable-diffusion-xl-base-1.0",
-    }
+    // Every id `is_sdxl_edit_candle_model` admits has a MODEL_TABLE row; the SDXL base turnkey is a
+    // defensive floor rather than a reachable case.
+    crate::engines::default_repo_for(model).unwrap_or("SceneWorks/sdxl-base-mlx")
 }
 
 /// Which SDXL edit sub-mode a request maps onto — the candle subset of the macOS `sdxl_sub_mode` (the
@@ -427,4 +419,59 @@ pub(super) async fn generate_candle_sdxl_edit_stream(
         asset_writes,
     )
     .await
+}
+
+#[cfg(test)]
+mod sdxl_edit_candle_repo_tests {
+    use super::*;
+
+    /// sc-14463 regression guard — the edit-lane twin of the IP-Adapter test. Same reasoning: the
+    /// `assert_ne!`s name the pre-fix constants so this FAILS against the old code.
+    #[test]
+    fn edit_default_repo_is_the_installed_turnkey_not_the_upstream_source() {
+        assert_eq!(
+            sdxl_edit_candle_default_repo("realvisxl"),
+            "SceneWorks/realvisxl-mlx"
+        );
+        assert_ne!(
+            sdxl_edit_candle_default_repo("realvisxl"),
+            "SG161222/RealVisXL_V5.0",
+            "the installer has not staged the flat upstream since the Group-B cutover (sc-8746)"
+        );
+        assert_eq!(
+            sdxl_edit_candle_default_repo("sdxl"),
+            "SceneWorks/sdxl-base-mlx"
+        );
+        assert_ne!(
+            sdxl_edit_candle_default_repo("sdxl"),
+            "stabilityai/stable-diffusion-xl-base-1.0",
+            "same cutover moved the SDXL base to its turnkey"
+        );
+        assert_eq!(
+            sdxl_edit_candle_default_repo("illustrious_xl_v1"),
+            "SceneWorks/illustrious-xl-v1-mlx"
+        );
+        assert_eq!(
+            sdxl_edit_candle_default_repo("illustrious_xl_v2"),
+            "SceneWorks/illustrious-xl-v2-mlx"
+        );
+    }
+
+    /// The two conditioning lanes must not drift from each other again — they load the same backbone
+    /// for the same id, and a divergence is exactly the defect sc-14463 fixed.
+    #[test]
+    fn edit_and_ipadapter_lanes_agree_on_the_backbone() {
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ] {
+            assert_eq!(
+                sdxl_edit_candle_default_repo(model),
+                crate::image_jobs::sdxl_ipadapter::sdxl_ipadapter_default_repo(model),
+                "{model}: edit and IP-Adapter lanes must resolve one backbone"
+            );
+        }
+    }
 }

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -58,21 +58,24 @@ fn is_sdxl_ipadapter_model(model: &str) -> bool {
     )
 }
 
-/// Default SDXL base repo for a model id when the manifest omits `repo`.
+/// Default SDXL base repo for a model id when the manifest omits `repo` — which, in production, is
+/// ALWAYS (sc-14463).
 ///
-/// `sdxl` and `realvisxl` name FLAT upstream diffusers snapshots (the conditioning fallback when the
-/// manifest omits `repo`, per sc-10614). Illustrious has no such upstream — OnomaAI ship a single-file
-/// LDM checkpoint — so it names its tiered turnkey. In practice the built-in SDXL family points `repo`
-/// at the SceneWorks quant-matrix turnkey (`mlx.standardTierLayout`), and — as of sc-10813 — this
-/// IP-Adapter lane packed-detects + serves the request's q4/q8 tier through `standard_tier_subdir`,
-/// exactly like the txt2img lane (sc-10767); this default is only the flat-repo fallback.
-fn sdxl_ipadapter_default_repo(model: &str) -> &'static str {
-    match model {
-        "realvisxl" => "SG161222/RealVisXL_V5.0",
-        "illustrious_xl_v1" => "SceneWorks/illustrious-xl-v1-mlx",
-        "illustrious_xl_v2" => "SceneWorks/illustrious-xl-v2-mlx",
-        _ => "stabilityai/stable-diffusion-xl-base-1.0",
-    }
+/// This reads `MODEL_TABLE` rather than carrying a private mapping, so it cannot drift from the
+/// txt2img lane (`base.rs::model_repo`) or InstantID (`INSTANTID_SDXL_REPO`) again. It previously
+/// hardcoded the flat upstream repos, and the comment here claimed "in practice the built-in SDXL
+/// family points `repo` at the SceneWorks turnkey" — that was false. The lanes read a TOP-LEVEL
+/// `repo` key, and no built-in model declares one (the manifest carries `downloads[].repo` and
+/// `paths.model`, which are different keys; `resolve_model_manifest_entry` injects only `modelPath`).
+/// So this is not a fallback, it is the only branch — and after the Group-B cutover (sc-8746) it
+/// named repos the installer no longer stages, silently routing every candle IP-Adapter job to torch.
+///
+/// The tier descent still applies on top: sc-10813 serves the request's q4/q8 tier via
+/// `standard_tier_subdir`, and `dense_tier_subdir` (sc-10614) takes the non-standard branch.
+pub(super) fn sdxl_ipadapter_default_repo(model: &str) -> &'static str {
+    // Every id `is_sdxl_ipadapter_model` admits has a MODEL_TABLE row; the SDXL base turnkey is a
+    // defensive floor rather than a reachable case.
+    crate::engines::default_repo_for(model).unwrap_or("SceneWorks/sdxl-base-mlx")
 }
 
 /// Resolve the SDXL base snapshot for the IP-Adapter route: an explicit `modelPath` dir (advanced or
@@ -472,4 +475,69 @@ pub(super) async fn generate_candle_sdxl_ipadapter_stream(
         asset_writes,
     )
     .await
+}
+
+#[cfg(test)]
+mod sdxl_ipadapter_repo_tests {
+    use super::*;
+
+    /// sc-14463 regression guard. This lane must resolve the SAME repo the txt2img lane does, because
+    /// `modelManifestEntry.repo` is ALWAYS absent in production (no built-in model declares a
+    /// top-level `repo`), which makes `sdxl_ipadapter_default_repo` the only reachable branch.
+    ///
+    /// The `assert_ne!`s are the point: they name the exact pre-fix constants, so this test FAILS
+    /// against the old code rather than merely restating whatever the function happens to return.
+    /// Both named repos are absent from every manifest `downloads` block, so `huggingface_snapshot_dir`
+    /// (a cache lookup, not a fetch) returned `None` and the lane declined every job to torch.
+    #[test]
+    fn ipadapter_default_repo_is_the_installed_turnkey_not_the_upstream_source() {
+        assert_eq!(
+            sdxl_ipadapter_default_repo("realvisxl"),
+            "SceneWorks/realvisxl-mlx"
+        );
+        assert_ne!(
+            sdxl_ipadapter_default_repo("realvisxl"),
+            "SG161222/RealVisXL_V5.0",
+            "the installer has not staged the flat upstream since the Group-B cutover (sc-8746)"
+        );
+        assert_eq!(
+            sdxl_ipadapter_default_repo("sdxl"),
+            "SceneWorks/sdxl-base-mlx"
+        );
+        assert_ne!(
+            sdxl_ipadapter_default_repo("sdxl"),
+            "stabilityai/stable-diffusion-xl-base-1.0",
+            "same cutover moved the SDXL base to its turnkey"
+        );
+        // Illustrious was already correct; it must stay correct through the MODEL_TABLE rewire.
+        assert_eq!(
+            sdxl_ipadapter_default_repo("illustrious_xl_v1"),
+            "SceneWorks/illustrious-xl-v1-mlx"
+        );
+        assert_eq!(
+            sdxl_ipadapter_default_repo("illustrious_xl_v2"),
+            "SceneWorks/illustrious-xl-v2-mlx"
+        );
+    }
+
+    /// Every id this lane admits must have a MODEL_TABLE row — otherwise it silently takes the
+    /// defensive `unwrap_or` floor and loads the WRONG model's weights instead of failing.
+    #[test]
+    fn every_admitted_model_has_a_model_table_row() {
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ] {
+            assert!(
+                is_sdxl_ipadapter_model(model),
+                "{model} must stay admitted by this lane"
+            );
+            assert!(
+                crate::engines::default_repo_for(model).is_some(),
+                "{model} is admitted but has no MODEL_TABLE row — it would silently take the floor"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes [sc-14463](https://app.shortcut.com/trefry/story/14463).

## The bug

Both candle conditioning lanes hardcoded a flat upstream repo as their weight source:

```rust
"realvisxl" => "SG161222/RealVisXL_V5.0",
_           => "stabilityai/stable-diffusion-xl-base-1.0",
```

documented as the fallback for *"when the manifest omits `repo`."*

**The manifest always omits it.** These lanes read a TOP-LEVEL `repo` key, and no built-in model declares one:

```
grep -c '^      "repo"' config/manifests/builtin.models.jsonc   ->  0
```

The manifest carries `downloads[].repo` and `paths.model` — different keys. `resolve_model_manifest_entry` returns the merged jsonc entry verbatim and injects only `modelPath`. So the "fallback" was the only reachable branch.

Since the Group-B cutover (sc-8746) repointed downloads at the SceneWorks turnkeys, neither hardcoded repo is staged by any manifest download. `huggingface_snapshot_dir` is a **cache lookup, not a fetch**, so it returned `None`, the `*_available` gates saw no base, and every candle edit / inpaint / outpaint / IP-Adapter job for `sdxl` and `realvisxl` **silently fell through to torch**. It only worked on machines with the upstream repos still warm in the HF cache — which is why it went unnoticed.

## Relationship to sc-10614

sc-10614 preserved these targets with acceptance *"`sdxl` and `realvisxl` still resolve to their existing upstream repos; no behaviour change, asserted by test."* The cutover already predated that story, so it measured "no change" against a path that no longer resolved on a clean install. Its `dense_tier_subdir` work is untouched here.

## The fix

Both lanes resolve through `engines::default_repo_for` (`MODEL_TABLE`) — the same source the txt2img lane uses via `model_repo`, and consistent with InstantID's `INSTANTID_SDXL_REPO`. One lookup site instead of three copies of the mapping, which is what let them drift.

Tier descent is unchanged: `standard_tier_subdir` (sc-10813) for the standard layout, `dense_tier_subdir` (sc-10614) otherwise.

| lane | before | after |
|---|---|---|
| txt2img | `SceneWorks/realvisxl-mlx` | unchanged |
| InstantID | `SceneWorks/realvisxl-mlx` | unchanged |
| IP-Adapter | `SG161222/RealVisXL_V5.0` — never installed | `SceneWorks/realvisxl-mlx` |
| candle edit | `stabilityai/...` / `SG161222/...` — never installed | turnkeys |

**No HF upload required.** `SceneWorks/realvisxl-mlx/bf16/` is already a complete dense diffusers copy of `SG161222/RealVisXL_V5.0` — verified component-for-component identical (all seven subdirs), 1,680 F16 UNet tensors with zero `scales`/`biases`. The only upstream files absent are the two root single-file LDM checkpoints, which no gen crate reads.

## Verified

- `npm run rust:check` — exit 0, zero errors.
- `cargo test -p sceneworks-worker --lib` — 994 passed, 0 failed.
- `cargo fmt --all -- --check` clean (formatter touched only the three files in this diff).
- **Mutation check:** the tests name the pre-fix constants in `assert_ne!`, so they fail against the old code rather than restating the new value. Confirmed by reverting the `MODEL_TABLE` row to `SG161222/RealVisXL_V5.0` and watching the `engines.rs` guard go red with the expected message, then restoring.

## NOT verified locally — needs this PR's CI

Both lane files are `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]`, so macOS **never compiles them**; local green says nothing about them. A cross typecheck to `x86_64-unknown-linux-gnu` (with stubbed `nvcc`/`nvidia-smi`) reaches `candle-gen` and stops — its `cublasLt` bindings need a real CUDA toolchain, so `sceneworks-worker` is never reached.

The two lane test modules therefore run **only** in the `candle-worker` job. Per sc-10614's history, that job should be checked by reading the run log for a fresh `Compiling sceneworks-worker` rather than trusting the check bucket, since a candle check can pass off a stale fingerprint.

**Still unproven after CI:** that a real candle job loads the tier off disk. That needs a CUDA box, and — because this bug hides behind a warm cache — that box should be checked for `models--SG161222--RealVisXL_V5.0` / `models--stabilityai--stable-diffusion-xl-base-1.0` first, or both sides of the comparison will look green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)