### PR TITLE
Library: audio assets render as waveform tiles with a real transport (sc-14391)

### DIFF
--- a/apps/web/src/audioTakes.js
+++ b/apps/web/src/audioTakes.js
@@ -242,3 +242,30 @@ export function audioTakeTitle(job, asset) {
   const prompt = typeof job?.payload?.prompt === "string" ? job.payload.prompt.trim() : "";
   return prompt || asset?.displayName || "Untitled clip";
 }
+
+// The meta line an audio viewer shows under its mode chip — model · voice · language ·
+// rate/channels · age. Every clause is read off the asset's OWN recorded recipe and its
+// MEASURED file block (project_store's audio asset record), so a clip that recorded none
+// simply shows fewer clauses, and "mono" is a fact about the produced WAV rather than an
+// assumption about the model. The model shows its catalog label when still installed
+// (`run.modelName`), falling back to the recorded id.
+export function audioAssetMetaLine(asset, run = null) {
+  const settings = asset?.recipe?.normalizedSettings ?? {};
+  const rate = Number(asset?.file?.sampleRate);
+  const channels = Number(asset?.file?.channels);
+  const format = [
+    Number.isFinite(rate) && rate > 0 ? `${Math.round(rate / 100) / 10} kHz` : null,
+    channels === 1 ? "mono" : channels === 2 ? "stereo" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return [
+    run?.modelName || asset?.recipe?.model || null,
+    settings.voice ?? null,
+    settings.language ?? null,
+    format || null,
+    formatRelativeTime(asset?.createdAt) || null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}

--- a/apps/web/src/components/AssetGrid.test.jsx
+++ b/apps/web/src/components/AssetGrid.test.jsx
@@ -185,3 +185,85 @@ describe("AssetCard native context-menu suppression (sc-8731)", () => {
     expect(onPreview).toHaveBeenCalledWith(assets[0]);
   });
 });
+
+// Audio in the Advanced Library (sc-14391). Audio assets only became visible here once
+// `audio_studio` was added to LIBRARY_ORIGINS (epic 14361); before this change they painted
+// an empty tile — no waveform, no duration, no way to hear the clip without opening it.
+describe("AssetGrid audio tiles (sc-14391)", () => {
+  let container;
+  let root;
+
+  const audioAsset = {
+    id: "au",
+    type: "audio",
+    displayName: "Take 1 · rain at the door",
+    projectId: "p1",
+    file: { path: "assets/audio/take_1.wav", mimeType: "audio/wav", duration: 12 },
+    recipe: { model: "kokoro_82m", normalizedSettings: { voice: "af_heart" } },
+  };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const render = (props = {}) =>
+    act(() =>
+      root.render(
+        <AssetGrid
+          assets={[audioAsset, ...assets]}
+          onPreview={vi.fn()}
+          selectedAsset={null}
+          setSelectedAssetId={vi.fn()}
+          {...props}
+        />,
+      ),
+    );
+
+  it("draws a waveform, a duration and a play control instead of a blank tile", async () => {
+    await render();
+    const tile = container.querySelector(".asset-tile--audio");
+    expect(tile).toBeTruthy();
+    // The waveform is a real <svg path>, not an empty box.
+    expect(tile.querySelector(".asset-tile-audio-wave .audio-wave__svg path")).toBeTruthy();
+    expect(tile.querySelector(".asset-tile-audio-time").textContent).toBe("0:12");
+    expect(tile.querySelector('[aria-label^="Play "]')).toBeTruthy();
+    // Image tiles keep the plain button cell — this is an audio-only branch.
+    expect(container.querySelectorAll(".asset-tile--audio").length).toBe(1);
+    expect(container.querySelectorAll("button.asset-tile").length).toBe(2);
+  });
+
+  it("keeps the tile's select / double-click-to-preview semantics on the audio cell", async () => {
+    const setSelectedAssetId = vi.fn();
+    const onPreview = vi.fn();
+    await render({ setSelectedAssetId, onPreview });
+    const open = container.querySelector(".asset-tile--audio .asset-tile-open");
+
+    await act(async () => open.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(setSelectedAssetId).toHaveBeenCalledWith("au");
+
+    await act(async () => open.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
+    expect(onPreview).toHaveBeenCalledWith(audioAsset);
+  });
+
+  it("arms the grid's single <audio> element on the played clip — never one per tile", async () => {
+    await render();
+    // Nothing loaded yet, so no element is mounted at all.
+    expect(container.querySelector("audio")).toBeNull();
+
+    const play = container.querySelector('.asset-tile--audio [aria-label^="Play "]');
+    await act(async () => play.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const els = container.querySelectorAll("audio");
+    expect(els.length).toBe(1);
+    expect(els[0].getAttribute("src")).toContain("assets/audio/take_1.wav");
+  });
+});

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -4,7 +4,24 @@ import { appConfirm } from "../appConfirm.jsx";
 import { assetMatchesCharacter } from "../characterMembership.js";
 import { saveAssetAs, revealAsset } from "../assetActions.js";
 import { isDesktop, isPageFullscreen, setViewerFullscreen } from "../runtime.js";
-import { AssetMedia, AssetThumbnail, assetCanRenderAsVideo, assetUrl, suppressThumbnailContextMenu } from "./assetMedia.jsx";
+import {
+  AssetMedia,
+  AssetThumbnail,
+  assetCanRenderAsAudio,
+  assetCanRenderAsVideo,
+  assetUrl,
+  suppressThumbnailContextMenu,
+} from "./assetMedia.jsx";
+import {
+  AudioClock,
+  AudioPlayButton,
+  AudioWaveform,
+  LoadedAudioElement,
+  WAVEFORM_BARS,
+  useAudioTakePlayer,
+} from "./audioTakeParts.jsx";
+import { audioAssetDurationSeconds } from "./WorkerProgressCard.jsx";
+import { audioAssetMetaLine, audioAssetRunGroups, formatClock } from "../audioTakes.js";
 import { DocumentView } from "./DocumentView.jsx";
 import { Icon } from "./Icons.jsx";
 import { LikenessBadge } from "./LikenessBadge.jsx";
@@ -305,7 +322,105 @@ function CharacterAssetLinker({ asset, characters = [], onMoveToCharacter }) {
 // a tile still opens the full asset via the detail/preview flow; the thumbnail only
 // changes what the grid paints, not what selection/open resolve to. Applies to every grid
 // that shares this component (Library, Pose Library, character-asset views).
-export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId, selectedIds = null, onToggleSelect = null }) {
+// Audio grid cell (sc-14391). `AssetThumbnail` has no poster path for audio, so an audio
+// asset used to paint an empty tile with only its name — invisible as a media type and
+// unplayable without opening it. It now draws the same waveform the studios use, over a bar
+// carrying a play button and the clip length.
+//
+// The cell can't be a <button> like the others: a play control inside it would nest
+// interactive elements. So the audio branch is a <div> whose body is an absolutely
+// positioned button (select on click, preview on double-click — identical semantics to the
+// standard tile), with the play bar layered above it. Non-audio tiles are untouched.
+// The detail pane's audio stage (sc-14391): mode chip + waveform + transport, the same
+// vocabulary the Audio Studio's deck and the Simple viewer use. The mode chip and model
+// name are derived from the clip's own replay record, so all three surfaces agree.
+function AudioAssetStage({ asset, models = [], player = null }) {
+  const ownPlayer = useAudioTakePlayer();
+  const transport = player ?? ownPlayer;
+  const run = React.useMemo(() => audioAssetRunGroups([asset], models)[0] ?? null, [asset, models]);
+  const loaded = transport.loadedTakeId === asset.id;
+  const duration = loaded && transport.duration > 0 ? transport.duration : audioAssetDurationSeconds(asset);
+  return (
+    <div className="asset-audio-stage">
+      {/* With a SHARED player the grid already mounts the one <audio> that transport drives;
+          mounting a second here would fight over the same ref. Only a stage that owns its
+          transport mounts its own element. */}
+      {player ? null : <LoadedAudioElement asset={asset} player={transport} className="asset-grid-audio-el" />}
+      <div className="asset-audio-stage__head">
+        {run ? (
+          <span className={`audio-mode-chip audio-mode-chip--${run.mode}`}>{run.modeLabel}</span>
+        ) : null}
+        <span className="asset-audio-stage__model">{audioAssetMetaLine(asset, run)}</span>
+      </div>
+      <div className="asset-audio-stage__wave">
+        <AudioWaveform
+          asset={asset}
+          bars={WAVEFORM_BARS.stage}
+          height={150}
+          label="Clip"
+          onSeek={transport.seekFraction}
+          progress={loaded ? transport.progress : 0}
+        />
+      </div>
+      <div className="asset-audio-stage__transport">
+        <AudioPlayButton onClick={() => transport.toggleTake(asset)} playing={loaded && transport.isPlaying} size="xl" />
+        <AudioClock current={loaded ? transport.currentTime : 0} total={duration} />
+      </div>
+    </div>
+  );
+}
+
+function AudioAssetTile({ asset, className, onSelect, onPreview, playing, onTogglePlay }) {
+  return (
+    <div className={`${className} asset-tile--audio`} onContextMenu={suppressThumbnailContextMenu}>
+      <button
+        aria-label={`Select ${asset.displayName ?? "audio clip"}`}
+        className="asset-tile-open"
+        onClick={onSelect}
+        onDoubleClick={() => onPreview(asset)}
+        type="button"
+      />
+      <span className="asset-tile-audio-wave">
+        <AudioWaveform asset={asset} bars={WAVEFORM_BARS.card} height={92} label={asset.displayName ?? "Clip"} />
+      </span>
+      <span className="asset-tile-audio-bar">
+        <AudioPlayButton
+          label={`${playing ? "Pause" : "Play"} ${asset.displayName ?? "clip"}`}
+          onClick={onTogglePlay}
+          playing={playing}
+          size="sm"
+        />
+        <span className="asset-tile-audio-time">{formatClock(audioAssetDurationSeconds(asset))}</span>
+      </span>
+      <strong>{asset.displayName}</strong>
+      {Array.isArray(asset.tags) && asset.tags.length ? (
+        <div className="asset-tile-tags">
+          {asset.tags.map((tag) => (
+            <span className="asset-tag compact" key={tag}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function AssetGrid({
+  assets,
+  onPreview,
+  selectedAsset,
+  setSelectedAssetId,
+  selectedIds = null,
+  onToggleSelect = null,
+  audioPlayer = null,
+}) {
+  // ONE transport per screen. The Library passes the same instance it gives AssetDetail, so a
+  // grid tile and the detail stage can never play two clips over each other; a grid rendered
+  // without one (character panels, Pose Library) falls back to its own.
+  const ownPlayer = useAudioTakePlayer();
+  const player = audioPlayer ?? ownPlayer;
+  const loadedAudio = assets.find((asset) => asset.id === player.loadedTakeId) ?? null;
   if (!assets.length) {
     return <div className="empty-panel">No assets in this view</div>;
   }
@@ -313,13 +428,24 @@ export function AssetGrid({ assets, onPreview, selectedAsset, setSelectedAssetId
 
   return (
     <div className="asset-grid">
+      {/* The grid's single <audio>, driven by whichever cell's play button is armed. */}
+      <LoadedAudioElement asset={loadedAudio} player={player} className="asset-grid-audio-el" />
       {assets.map((asset) => {
         // In single-select mode the button IS the grid cell, so it carries the
         // windowing class; in multi-select the wrap is the cell (below).
         const tileClasses = ["asset-tile"];
         if (selectedAsset?.id === asset.id) tileClasses.push("active");
         if (!multi) tileClasses.push("asset-tile-windowed");
-        const tile = (
+        const tile = assetCanRenderAsAudio(asset) ? (
+          <AudioAssetTile
+            asset={asset}
+            className={tileClasses.join(" ")}
+            onPreview={onPreview}
+            onSelect={() => setSelectedAssetId(asset.id)}
+            onTogglePlay={() => player.toggleTake(asset)}
+            playing={player.loadedTakeId === asset.id && player.isPlaying}
+          />
+        ) : (
           <button
             className={tileClasses.join(" ")}
             onClick={() => setSelectedAssetId(asset.id)}
@@ -441,6 +567,8 @@ export function AssetDetail({
   vqaEntries = [],
   vqaPending = false,
   createVqaJob,
+  audioModels = [],
+  audioPlayer = null,
 }) {
   if (!asset) {
     return <aside className="asset-detail empty-panel">No asset selected</aside>;
@@ -450,6 +578,10 @@ export function AssetDetail({
     <aside className="asset-detail">
       {asset.type === "document" ? (
         <DocumentReader asset={asset} />
+      ) : assetCanRenderAsAudio(asset) ? (
+        /* Audio gets the play deck rather than a bare <audio controls> inside a button —
+           its transport controls can't be nested in the preview button (sc-14391). */
+        <AudioAssetStage asset={asset} models={audioModels} player={audioPlayer} />
       ) : (
         <button className="preview-button" onClick={() => onPreview(asset)} type="button">
           <AssetMedia asset={asset} />

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { AssetBatchModal, AssetSelectionBar, useAssetBatch } from "../assetBatch.jsx";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
 import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
+import { useAudioTakePlayer } from "../components/audioTakeParts.jsx";
 import { isLibraryAsset, terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
@@ -39,9 +40,13 @@ export function LibraryScreen() {
     setActiveView,
     updateAssetStatus,
     updateAssetTags,
+    audioModels = [],
   } = useAppContext();
   // Shared multi-select + batch toolbar (selection state, fan-out, Discard/Move).
   const batch = useAssetBatch();
+  // ONE audio transport for the screen (sc-14391): the grid tiles and the detail stage drive
+  // the same element, so playing a clip from either surface stops whatever was playing.
+  const audioPlayer = useAudioTakePlayer();
   // Bind the fullscreen preview to the currently filtered library view so
   // navigation stays inside the same type/tag/trash scope the user is browsing.
   const onPreview = (asset) => setPreviewAsset(asset, visibleAssets);
@@ -226,6 +231,7 @@ export function LibraryScreen() {
 
       <div className="library-layout">
         <AssetGrid
+          audioPlayer={audioPlayer}
           assets={visibleAssets}
           onPreview={onPreview}
           selectedAsset={librarySelectedAsset}
@@ -234,6 +240,7 @@ export function LibraryScreen() {
           onToggleSelect={batch.toggleSelect}
         />
         <AssetDetail
+          audioPlayer={audioPlayer}
           asset={librarySelectedAsset}
           deleteAsset={deleteAsset}
           purgeAsset={purgeAsset}
@@ -249,6 +256,7 @@ export function LibraryScreen() {
           vqaEnabled={vqaEnabled}
           vqaEntries={vqaEntries}
           vqaPending={vqaPending}
+          audioModels={audioModels}
           createVqaJob={createVqaJob}
         />
       </div>

--- a/apps/web/src/simple/SimplePreview.jsx
+++ b/apps/web/src/simple/SimplePreview.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { AssetMedia, assetCanRenderAsAudio, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
 import { useAudioTakePlayer } from "../components/audioTakeParts.jsx";
-import { audioAssetRunGroups, formatRelativeTime } from "../audioTakes.js";
+import { audioAssetMetaLine, audioAssetRunGroups } from "../audioTakes.js";
 import { useAppContext } from "../context/AppContext.js";
 import { SimpleAudioViewer } from "./simpleAudioParts.jsx";
 import { DownloadButton } from "./studioParts.jsx";
@@ -68,7 +68,7 @@ export function SimplePreview({
           <SimpleAudioViewer
             asset={asset}
             breakpoint={breakpoint}
-            meta={audioMetaLine(asset, run)}
+            meta={audioAssetMetaLine(asset, run)}
             onSendToVideo={onSendToVideo}
             player={player}
             run={run}
@@ -105,30 +105,4 @@ export function SimplePreview({
       </div>
     </div>
   );
-}
-
-// The viewer's meta line — model · voice · language · rate/channels · age. Every clause is
-// read off the asset's OWN recorded recipe and measured file block (project_store's audio
-// asset record), so a clip that recorded none simply shows fewer clauses. The model is shown
-// by its catalog LABEL when it's still installed (the recipe records the id), falling back to
-// the recorded id so a clip from an uninstalled model still names what produced it.
-function audioMetaLine(asset, run) {
-  const settings = asset?.recipe?.normalizedSettings ?? {};
-  const rate = Number(asset?.file?.sampleRate);
-  const channels = Number(asset?.file?.channels);
-  const format = [
-    Number.isFinite(rate) && rate > 0 ? `${Math.round(rate / 100) / 10} kHz` : null,
-    channels === 1 ? "mono" : channels === 2 ? "stereo" : null,
-  ]
-    .filter(Boolean)
-    .join(" ");
-  return [
-    run?.modelName || asset?.recipe?.model || null,
-    settings.voice ?? null,
-    settings.language ?? null,
-    format || null,
-    formatRelativeTime(asset?.createdAt) || null,
-  ]
-    .filter(Boolean)
-    .join(" · ");
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15768,3 +15768,111 @@ button.audio-wave {
     text-align: left;
   }
 }
+
+/* ---------- Library: audio tiles + detail stage (sc-14391) ---------- */
+/* `AssetThumbnail` has no poster path for audio, so an audio asset used to paint an empty
+   tile. It now draws the shared waveform. The cell is a <div> rather than a <button> so its
+   play control isn't a nested interactive element; `.asset-tile-open` is the click target
+   and carries the tile's original select / double-click-to-preview semantics. */
+.asset-tile--audio {
+  position: relative;
+}
+
+.asset-tile-open {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  padding: 0;
+  border: 0;
+  border-radius: inherit;
+  background: none;
+  cursor: pointer;
+}
+
+.asset-tile-audio-wave {
+  display: block;
+  height: 92px;
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.asset-tile-audio-bar {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.asset-tile-audio-time {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+/* The tile's own text sits above the click layer so selection still reads naturally. */
+.asset-tile--audio strong,
+.asset-tile--audio .asset-tile-tags {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+}
+
+/* The grid's single hidden <audio> and the detail stage's. */
+.asset-grid-audio-el {
+  display: none;
+}
+
+.asset-audio-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-2);
+}
+
+.asset-audio-stage__head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.asset-audio-stage__model {
+  min-width: 0;
+  font-size: 12.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-audio-stage__wave {
+  height: 150px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.asset-audio-stage__transport {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+/* The viewer's hero transport is 56px, matching the Simple Assets viewer (design screen 4a). */
+.asset-audio-stage__transport .audio-play-btn--xl {
+  width: 56px;
+  height: 56px;
+}
+
+.asset-audio-stage__transport .audio-clock {
+  font-size: 15px;
+}


### PR DESCRIPTION
Follow-up to epic [sc-14361](https://app.shortcut.com/trefry/epic/14361) /
[sc-14391](https://app.shortcut.com/trefry/story/14391).

Adding `audio_studio` to `LIBRARY_ORIGINS` in #1799 made generated clips visible in the
Advanced Library for the first time — as **empty tiles** with a name and nothing else, and a
detail pane holding a bare `<audio controls>`. The handoff's Assets treatment is the page's
design language rather than a Simple-UI-only feature, so the Advanced surfaces get it too.

## Changes

- **Grid cell** — the shared waveform over a bar carrying a play button and the clip length.
  The audio cell is a `<div>` rather than a `<button>` so its play control isn't a nested
  interactive element; `.asset-tile-open` is the click target and keeps the tile's original
  select / double-click-to-preview semantics. Image and video tiles are byte-identical.
- **Detail pane** — the play deck at the handoff's viewer size: mode chip + meta line
  (model · voice · language · rate/channels · age), a 150px seekable waveform with the played
  band, and a 56px transport with the mono clock.
- **One transport per screen** — `LibraryScreen` owns a single `useAudioTakePlayer` and passes
  it to both the grid and the detail pane, so playing from either surface stops whatever was
  playing. Without this the two surfaces mounted independent `<audio>` elements and could play
  over each other; caught by driving the running app, not by a test. A grid rendered without a
  shared player (character panels, Pose Library) still falls back to its own.
- `audioAssetMetaLine` moves into `audioTakes.js` so the Advanced detail stage and the Simple
  viewer render the same string instead of two copies drifting apart.

## Verification

- Full web suite green: **2500 passed / 175 files**. `eslint src`: 0 errors.
- 3 new tests in `AssetGrid.test.jsx`: the tile draws a real waveform `path`, a duration and a
  play control (and image tiles keep the plain button cell); the audio cell keeps select +
  double-click-to-preview; the grid arms exactly **one** `<audio>` element, not one per tile.
- Driven in the running app against a local mock API with real WAVs, in **both themes**:
  playing from a grid tile and then from the detail stage leaves exactly one element playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
