### PR TITLE
Audio Studio: name the device on the in-flight strip (epic 14361)

### DIFF
--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -864,6 +864,32 @@ describe("AudioStudio Speech generation (sc-13408)", () => {
     expect(rememberLocalGenerationJob).toHaveBeenCalledWith("audio", { id: "audio-job-2" });
   });
 
+  it("names the device the run is executing on in the strip's message line (screen 2a)", async () => {
+    await render(
+      baseContext({
+        audioLocalJobs: [
+          {
+            id: "audio-job-running",
+            type: "audio_generate",
+            status: "running",
+            progress: 0.44,
+            message: "chunk 4 of 9 · ~6 s left",
+            workerId: "worker-1",
+            payload: { ...SPEECH_RUN_PAYLOAD },
+            result: { expectedCount: 3 },
+          },
+        ],
+        visibleWorkers: [{ id: "worker-1", capabilities: ["gpu"], gpuName: "Apple M3 Max (40-core)" }],
+        createAudioJob: vi.fn(),
+        rememberLocalGenerationJob: vi.fn(),
+      }),
+    );
+    const strip = container.querySelector('[data-testid="audio-inflight-strip"]');
+    expect(strip.textContent).toContain("chunk 4 of 9 · ~6 s left · Apple M3 Max (40-core)");
+    // Still just the device — the hardware pills and GPU meters stay in the Queue.
+    expect(strip.querySelector(".worker-progress-card__meters")).toBeNull();
+  });
+
   it("renders a running run as the slim in-flight strip, not the full worker card (sc-14364)", async () => {
     const jobAction = vi.fn();
     await render(

--- a/apps/web/src/screens/audioResults.jsx
+++ b/apps/web/src/screens/audioResults.jsx
@@ -18,6 +18,8 @@ import {
   formatRelativeTime,
 } from "../audioTakes.js";
 import { terminalStatuses } from "../jobTypes.js";
+import { useAppLive } from "../context/AppContext.js";
+import { deriveWorkerHardware, findWorkerForJob } from "../workers.js";
 // `job.progress` is a 0..1 fraction (the same value WorkerProgressCard renders); `percent`
 // is the one place that conversion lives.
 import { percent } from "../formatting.js";
@@ -55,13 +57,20 @@ function ModeChip({ mode, label, extra = null, className = "" }) {
  */
 export function AudioInflightStrip({ run, onCancel, onOpenQueue }) {
   const { job } = run;
+  const { workersById, visibleWorkers } = useAppLive();
   const takes = audioExpectedTakes(job);
   const numeric = Number(job.progress);
   const hasProgress = Number.isFinite(numeric) && numeric > 0;
   const title = [run.modeLabel, run.modelName, takes ? `${takes} takes` : null]
     .filter(Boolean)
     .join(" · ");
-  const message = job.message ?? "";
+  // The design's message line ends with WHERE the run is executing. The strip carries only the
+  // device name — the full hardware pills and GPU meters stay in the Queue.
+  const device = useMemo(() => {
+    const worker = (job.workerId && workersById?.get?.(job.workerId)) || findWorkerForJob(job, visibleWorkers ?? []);
+    return deriveWorkerHardware(worker)?.gpuLabel ?? "";
+  }, [job, workersById, visibleWorkers]);
+  const message = [job.message, device].filter(Boolean).join(" · ");
   return (
     <div className="audio-inflight" data-testid="audio-inflight-strip">
       <span className="audio-inflight__status">{job.cancelRequested ? "Canceling" : "Rendering"}</span>


### PR DESCRIPTION
Closes the last delta between the shipped Audio Studio results zone (#1799) and the
handoff's screen `2a`.

The design's in-flight strip message line ends with where the run is executing —
`chunk 4 of 9 · ~6 s left · Apple M3 Max`. Trimming the full `WorkerProgressCard` down to the
strip dropped the device along with everything else. It's back, resolved the same way the
worker card resolves it (`findWorkerForJob` → `deriveWorkerHardware`).

Only the device NAME comes across. The hardware pills, the architecture badge and the GPU
meters stay in the Queue — that separation is the point of the strip, and the test asserts it
(`.worker-progress-card__meters` must not appear).

Full web suite green: 2498 passed / 175 files. `eslint src`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
