### PR TITLE
chore(worker): run the diffusion audio lane on Metal [sc-14480]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +613,7 @@ source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8ba
 dependencies = [
  "byteorder",
  "candle-kernels",
+ "candle-metal-kernels",
  "candle-ug",
  "cudarc 0.19.7",
  "float8",
@@ -616,6 +623,8 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
+ "objc2-foundation",
+ "objc2-metal",
  "rand 0.9.4",
  "rand_distr 0.5.1",
  "rayon",
@@ -1094,14 +1103,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-metal-kernels"
+version = "0.10.2"
+source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
+dependencies = [
+ "half",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+ "once_cell",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "candle-nn"
 version = "0.10.2"
 source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d#1e6aa85e867eb007cba1b8bae517a10d1aaf0c0d"
 dependencies = [
  "candle-core",
+ "candle-metal-kernels",
  "half",
  "libc",
  "num-traits",
+ "objc2-metal",
  "rayon",
  "safetensors 0.7.0",
  "serde",
@@ -1133,6 +1158,7 @@ source = "git+https://github.com/huggingface/candle?rev=1e6aa85e867eb007cba1b8ba
 dependencies = [
  "ug",
  "ug-cuda",
+ "ug-metal",
 ]
 
 [[package]]
@@ -1356,8 +1382,19 @@ checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -3682,6 +3719,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,6 +3792,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.11.1",
+ "block",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -4588,6 +4649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,6 +4794,20 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -7921,6 +8005,20 @@ checksum = "9f0a1fa748f26166778c33b8498255ebb7c6bffb472bcc0a72839e07ebb1d9b5"
 dependencies = [
  "cudarc 0.17.8",
  "half",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
+]
+
+[[package]]
+name = "ug-metal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
+dependencies = [
+ "half",
+ "metal",
+ "objc",
  "serde",
  "thiserror 1.0.69",
  "ug",

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -72,7 +72,13 @@ backend-candle = ["dep:runtime-cuda", "dep:ort", "dep:zip"]
 ort = { version = "=2.0.0-rc.12", features = ["coreml", "load-dynamic", "download-binaries"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Canonical Apple inference composition. Bespoke provider APIs are re-exported by the bundle.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "e322bdf71636b16ea74dcb5927b9e51066182f94" }
+# `audio-metal` is additive over the default `media` + `audio` lanes: it runs the DIFFUSION audio
+# providers (moss-sfx, acestep) on the Metal GPU. This is not a nice-to-have — MOSS-SoundEffect
+# denoises a full 30 s latent window with quadratic attention (sc-14441), which is ~159 s on Metal
+# against 35+ minutes on CPU for a single 3 s clip. The nearest-upsample-vocoder providers (Kokoro,
+# Chatterbox) are auto-routed back to CPU inside the lane, because candle-core's Metal backend lacks
+# upsample_nearest1d (sc-13691) — so enabling this stays correct instead of crashing them.
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "e322bdf71636b16ea74dcb5927b9e51066182f94", features = ["audio-metal"] }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 


### PR DESCRIPTION
**Scope shrank to a one-line feature flag.** This PR originally bumped the inference pin and re-audited third-party source for it. Since then `main` moved twice:

- [#1815](https://github.com/SceneWorks/SceneWorks/pull/1815) bumped the pin and independently did the `mlx-gen-mage` / cephes disclosure work — arriving at the same structure this branch had (mage architecture area with `latent.rs` excluded, plus a cephes `about-license` area).
- [#1823](https://github.com/SceneWorks/SceneWorks/pull/1823) carried the pin to `e322bdf7`, **which already contains the audio fixes** (sc-14441, sc-14442).

So both of those commits are dropped rather than duplicated. The pin is untouched here, which means the license audit is untouched too.

## What's left, and why it matters

The GPU lane is still missing from `main`, and without it the SFX fix is *correct but unusable*.

sc-14441 restored the reference's full 30 s denoise window. That's ~10× the sequence length with quadratic attention — measured at **159 s on Metal against 35+ minutes unfinished on CPU** for a single 3 s clip. Shipping the fix without the GPU lane trades one bad experience for another.

`audio-metal` is additive over the default `media` + `audio` lanes and moves only the diffusion providers (moss-sfx, acestep) to the GPU.

**Safe to enable:** the nearest-upsample-vocoder providers (Kokoro, Chatterbox) are auto-routed back to CPU inside the lane via `default_device_metal_incompatible`, because candle-core's Metal backend lacks `upsample_nearest1d` (sc-13691). The inference-side feature was written for exactly this consumer.

## Verification

- `cargo check -p sceneworks-worker` clean.
- **Feature resolves rather than merely parsing** — confirmed in the graph: `sceneworks-worker → runtime-macos/audio-metal → candle-audio-catalog/metal → candle-audio/metal` (12 occurrences via `cargo tree -e features`). A flag that is accepted but never reaches the leaf crate looks identical from a successful build, which matters given the 159 s vs 35 min difference.
- `check:license-coverage` unchanged: 79/82 models across 58 components (the 3 UNDETERMINED are pre-existing upstream ambiguities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)