### PR TITLE
fix(worker): resolve manifest repo readers from installed defaults [sc-14476]

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
@@ -6,7 +6,9 @@ use super::{
     ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Progress, Settings, Value, WorkerError,
     WorkerResult,
 };
-use super::{resolve_app_managed_model_dir, safe_weight_filename, DownloadContext};
+use super::{
+    resolve_app_managed_model_dir, safe_weight_filename, standard_tier_subdir, DownloadContext,
+};
 use serde_json::json;
 
 // Candle (Windows/CUDA) FLUX.1-dev strict-control Fun-Controlnet-Union route (sc-8412, epic 8236) —
@@ -64,9 +66,10 @@ pub(super) fn is_flux1_control_model(model: &str) -> bool {
     model == "flux_dev"
 }
 
-/// Resolve the FLUX.1-dev base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
-/// HF cache snapshot for the manifest `repo` (default `black-forest-labs/FLUX.1-dev`). `None` ⇒ not
-/// present locally (the job is not candle-runnable). Mirrors `resolve_flux2_control_base`.
+/// Resolve the FLUX.1-dev base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) →
+/// the HF cache snapshot for the manifest `repo`, otherwise the installed [`MODEL_TABLE`] repo.
+/// `None` ⇒ not present locally (the job is not candle-runnable). Mirrors
+/// `resolve_flux2_control_base`.
 fn resolve_flux1_control_base(
     request: &ImageRequest,
     settings: &Settings,
@@ -89,8 +92,12 @@ fn resolve_flux1_control_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(FLUX1_CONTROL_CANDLE_BASE_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(FLUX1_CONTROL_CANDLE_BASE_REPO)
+        });
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible FLUX.1-dev strict-control job: `flux_dev` with a non-empty
@@ -361,7 +368,10 @@ pub(super) async fn generate_candle_flux1_control_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(FLUX1_CONTROL_CANDLE_BASE_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(FLUX1_CONTROL_CANDLE_BASE_REPO)
+        })
         .to_owned();
 
     let pose_count = pose_entries(request).len();

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -6,7 +6,9 @@ use super::{
     Flux2ControlPaths, Flux2ControlRequest, Image, ImagePlan, ImageRequest, JobSnapshot,
     JsonObject, Path, PathBuf, Progress, Quant, Settings, Value, WorkerError, WorkerResult,
 };
-use super::{resolve_app_managed_model_dir, safe_weight_filename, DownloadContext};
+use super::{
+    resolve_app_managed_model_dir, safe_weight_filename, standard_tier_subdir, DownloadContext,
+};
 use serde_json::json;
 
 // Candle (Windows/CUDA) FLUX.2-dev strict-pose Fun-Controlnet-Union route (sc-7736, epic 6564) —
@@ -88,8 +90,12 @@ fn resolve_flux2_control_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(FLUX2_CONTROL_CANDLE_BASE_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(FLUX2_CONTROL_CANDLE_BASE_REPO)
+        });
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible FLUX.2-dev strict-pose job: `flux2_dev` with a non-empty
@@ -371,7 +377,10 @@ pub(super) async fn generate_candle_flux2_control_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(FLUX2_CONTROL_CANDLE_BASE_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(FLUX2_CONTROL_CANDLE_BASE_REPO)
+        })
         .to_owned();
 
     let pose_count = pose_entries(request).len();

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -7,7 +7,7 @@ use super::{
     IpAdapterFluxRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings, Value, WorkerError,
     WorkerResult,
 };
-use super::{resolve_app_managed_model_dir, DownloadContext};
+use super::{resolve_app_managed_model_dir, standard_tier_subdir, DownloadContext};
 use serde_json::json;
 
 // Candle (Windows/CUDA) FLUX XLabs IP-Adapter reference route (sc-5872, epic 5480) — reference-image
@@ -53,12 +53,9 @@ fn is_flux_ipadapter_model(model: &str) -> bool {
     matches!(model, "flux_dev" | "flux_schnell")
 }
 
-/// The black-forest-labs base repo when the manifest omits `repo` (variant-keyed).
+/// The installed base repo when the manifest omits `repo` (variant-keyed).
 fn flux_ipadapter_default_repo(model: &str) -> &'static str {
-    match model {
-        "flux_schnell" => "black-forest-labs/FLUX.1-schnell",
-        _ => "black-forest-labs/FLUX.1-dev",
-    }
+    crate::engines::default_repo_for(model).unwrap_or("SceneWorks/flux1-dev-mlx")
 }
 
 /// Distilled default step count (FLUX parity): schnell 4, dev 25.
@@ -78,8 +75,8 @@ fn flux_ipadapter_default_guidance(model: &str) -> f32 {
 }
 
 /// Resolve the FLUX base (BFL snapshot) for the IP-Adapter route: an explicit `modelPath` dir
-/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
-/// `black-forest-labs/FLUX.1-{dev,schnell}` by variant). `None` means the base is not present locally,
+/// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (the installed
+/// `MODEL_TABLE` turnkey by variant). `None` means the base is not present locally,
 /// so the job is not candle-runnable (falls through to torch). Mirrors `resolve_kolors_ipadapter_base`.
 fn resolve_flux_ipadapter_base(
     request: &ImageRequest,
@@ -104,7 +101,8 @@ fn resolve_flux_ipadapter_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| flux_ipadapter_default_repo(&request.model));
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible FLUX IP-Adapter job: a `flux_dev`/`flux_schnell` model with a

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use super::{
     ensure_hf_cached_file, huggingface_snapshot_dir, resolve_app_managed_model_dir,
-    safe_weight_filename, DownloadContext,
+    safe_weight_filename, standard_tier_subdir, DownloadContext,
 };
 use serde_json::json;
 
@@ -86,8 +86,11 @@ fn resolve_kolors_control_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(KOLORS_CONTROL_DEFAULT_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model).unwrap_or(KOLORS_CONTROL_DEFAULT_REPO)
+        });
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible Kolors strict-pose job: `kolors` with a non-empty
@@ -387,7 +390,9 @@ pub(super) async fn generate_candle_kolors_control_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(KOLORS_CONTROL_DEFAULT_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model).unwrap_or(KOLORS_CONTROL_DEFAULT_REPO)
+        })
         .to_owned();
 
     let pose_count = pose_entries(request).len();

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -8,7 +8,7 @@ use super::{
     IpAdapterKolorsRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings, Value, WorkerError,
     WorkerResult,
 };
-use super::{resolve_app_managed_model_dir, DownloadContext};
+use super::{resolve_app_managed_model_dir, standard_tier_subdir, DownloadContext};
 use serde_json::json;
 
 // Candle (Windows/CUDA) Kolors IP-Adapter-Plus reference route (sc-5488, epic 5480) — reference-image
@@ -84,8 +84,12 @@ fn resolve_kolors_ipadapter_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(KOLORS_IPADAPTER_DEFAULT_REPO)
+        });
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible Kolors IP-Adapter job: the `kolors` model with a reference image
@@ -296,7 +300,10 @@ pub(super) async fn generate_candle_kolors_ipadapter_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(KOLORS_IPADAPTER_DEFAULT_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(KOLORS_IPADAPTER_DEFAULT_REPO)
+        })
         .to_owned();
     let raw_settings = kolors_ipadapter_raw_settings(request, &repo, steps, guidance, ip_scale);
 

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -135,11 +135,19 @@ pub(super) fn resolve_krea_control_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(KREA_CONTROL_BASE_REPO);
-    // Legacy / bring-your-own dense diffusers base (`krea/Krea-2-Turbo`), if separately cached — keeps
-    // existing dense-install behavior byte-identical.
-    if let Some(dense) = huggingface_snapshot_dir(&settings.data_dir, repo) {
-        return Ok(Some(dense));
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model).unwrap_or(KREA_CONTROL_BASE_REPO)
+        });
+    if let Some(root) = huggingface_snapshot_dir(&settings.data_dir, repo) {
+        if repo == KREA_CONTROL_MLX_REPO {
+            let tier = krea_model_subdir(&root, request);
+            if tier.join("transformer").is_dir() {
+                return Ok(Some(tier));
+            }
+        } else {
+            // Explicit legacy / bring-your-own dense diffusers base.
+            return Ok(Some(root));
+        }
     }
     // The installed `SceneWorks/krea-2-turbo-mlx` tier the user actually has (q8 default / q4 / bf16),
     // resolved EXACTLY like the txt2img lane (`krea_model_subdir` honours `advanced.mlxQuantize` and falls
@@ -466,7 +474,9 @@ pub(super) async fn generate_candle_krea_control_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(KREA_CONTROL_BASE_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model).unwrap_or(KREA_CONTROL_BASE_REPO)
+        })
         .to_owned();
 
     let pose_count = pose_entries(request).len();

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
@@ -244,7 +244,9 @@ pub(super) async fn generate_candle_krea_edit_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or("SceneWorks/krea-2-raw-mlx")
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model).unwrap_or("SceneWorks/krea-2-raw-mlx")
+        })
         .to_owned();
 
     let (width, height) = (request.width, request.height);

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -1,7 +1,7 @@
 use super::advanced;
 use super::{
     ensure_hf_cached_file, huggingface_snapshot_dir, resolve_app_managed_model_dir,
-    safe_weight_filename, DownloadContext,
+    safe_weight_filename, standard_tier_subdir, DownloadContext,
 };
 use super::{
     pose_entries, resolve_advanced_or_manifest_f32, resolve_advanced_or_manifest_u32,
@@ -102,8 +102,11 @@ fn resolve_qwen_control_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(QWEN_CONTROL_DEFAULT_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model).unwrap_or(QWEN_CONTROL_DEFAULT_REPO)
+        });
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible Qwen strict-pose job: `qwen_image` with a non-empty
@@ -424,7 +427,9 @@ pub(super) async fn generate_candle_qwen_control_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(QWEN_CONTROL_DEFAULT_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model).unwrap_or(QWEN_CONTROL_DEFAULT_REPO)
+        })
         .to_owned();
 
     let pose_count = pose_entries(request).len();

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -10200,8 +10200,9 @@ fn candle_control_providers_resolve_models_and_repos() {
         "bf16/model.safetensors"
     );
 
-    // sc-8379 — z-image base: both Turbo and base are recognized; the base selects the base repos + the
-    // ~50-step default + the `z_image_control` engine-id row.
+    // sc-8379 — z-image base: both Turbo and base are recognized; the base selects the installed
+    // turnkey repos + the ~50-step default + the `z_image_control` engine-id row. sc-14476 — these
+    // assertions deliberately guard the effective repo fallback rather than the legacy manifest alias.
     assert!(is_zimage_control_model("z_image_turbo"));
     assert!(is_zimage_control_model("z_image"));
     assert!(!is_zimage_base_model("z_image_turbo"));
@@ -10210,11 +10211,11 @@ fn candle_control_providers_resolve_models_and_repos() {
     let base = request(json!({ "projectId": "p", "model": "z_image" }));
     assert_eq!(
         zimage_control_base_default_repo(&turbo.model),
-        "Tongyi-MAI/Z-Image-Turbo"
+        "SceneWorks/z-image-turbo-mlx"
     );
     assert_eq!(
         zimage_control_base_default_repo(&base.model),
-        "Tongyi-MAI/Z-Image"
+        "SceneWorks/z-image-mlx"
     );
     let (turbo_ctrl_repo, _) = zimage_control_repo_file(&turbo).expect("defaults resolve");
     let (base_ctrl_repo, _) = zimage_control_repo_file(&base).expect("defaults resolve");

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -6,7 +6,9 @@ use super::{
     JsonObject, Path, PathBuf, Progress, Settings, Value, WorkerError, WorkerResult, ZImageControl,
     ZImageControlPaths, ZImageControlRequest,
 };
-use super::{resolve_app_managed_model_dir, safe_weight_filename, DownloadContext};
+use super::{
+    resolve_app_managed_model_dir, safe_weight_filename, standard_tier_subdir, DownloadContext,
+};
 use serde_json::json;
 
 // Candle (Windows/CUDA) Z-Image Fun-ControlNet (strict pose) route (sc-5489, epic 5480) —
@@ -88,11 +90,13 @@ pub(super) fn is_zimage_base_model(model: &str) -> bool {
 /// The default base diffusers repo for this control job's model — Turbo (`Tongyi-MAI/Z-Image-Turbo`) or
 /// the base undistilled `Tongyi-MAI/Z-Image` (sc-8379), selected by the request model id.
 pub(super) fn zimage_control_base_default_repo(model: &str) -> &'static str {
-    if is_zimage_base_model(model) {
-        ZIMAGE_CTRL_BASE_DEFAULT_REPO
-    } else {
-        ZIMAGE_CTRL_DEFAULT_REPO
-    }
+    crate::engines::default_repo_for(model).unwrap_or_else(|| {
+        if is_zimage_base_model(model) {
+            ZIMAGE_CTRL_BASE_DEFAULT_REPO
+        } else {
+            ZIMAGE_CTRL_DEFAULT_REPO
+        }
+    })
 }
 
 /// Resolve the Z-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
@@ -122,7 +126,8 @@ pub(super) fn resolve_zimage_control_base(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| zimage_control_base_default_repo(&request.model));
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible Z-Image strict-control job: `z_image_turbo` or the base `z_image`

--- a/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
@@ -1,4 +1,6 @@
-use super::{advanced, huggingface_snapshot_dir, resolve_app_managed_model_dir};
+use super::{
+    advanced, huggingface_snapshot_dir, resolve_app_managed_model_dir, standard_tier_subdir,
+};
 use super::{
     consume_gen_events, drive_gen_items, fit_engine_image, load_reference_image, non_empty,
     resolve_advanced_or_manifest_u32, resolve_seed, start_gen_stream, ApiClient, Image, ImagePlan,
@@ -63,8 +65,12 @@ pub(super) fn resolve_zimage_edit_candle_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO);
-    Ok(huggingface_snapshot_dir(&settings.data_dir, repo))
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO)
+        });
+    Ok(huggingface_snapshot_dir(&settings.data_dir, repo)
+        .map(|root| standard_tier_subdir(&root, request)))
 }
 
 /// True when this is a candle-eligible Z-Image edit job: a z-image-family `edit_image` job with a source
@@ -166,7 +172,10 @@ pub(super) async fn generate_candle_zimage_edit_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO)
+        })
         .to_owned();
     let raw_settings = zimage_edit_candle_raw_settings(request, &repo, steps, strength);
 

--- a/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
@@ -190,7 +190,10 @@ pub(super) async fn generate_candle_zimage_identity_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO)
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or(ZIMAGE_EDIT_CANDLE_DEFAULT_REPO)
+        })
         .to_owned();
     let raw_settings = zimage_identity_candle_raw_settings(request, &repo, steps, strength);
 

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -1119,7 +1119,10 @@ fn model_repo_for(request: &ImageRequest) -> String {
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or("sensenova/SenseNova-U1-8B-MoT")
+        .unwrap_or_else(|| {
+            crate::engines::default_repo_for(&request.model)
+                .unwrap_or("sensenova/SenseNova-U1-8B-MoT")
+        })
         .to_owned()
 }
 

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -42,6 +42,8 @@ import jsonschema
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.models.jsonc"
 SCHEMA_PATH = ROOT / "packages" / "schemas" / "model-manifest.schema.json"
+ENGINE_TABLE_PATH = ROOT / "crates" / "sceneworks-worker" / "src" / "engines.rs"
+WORKER_SOURCE_PATH = ROOT / "crates" / "sceneworks-worker" / "src"
 
 
 def _strip_jsonc_comments(body: str) -> str:
@@ -91,6 +93,168 @@ def _strip_jsonc_comments(body: str) -> str:
 def _load_builtin_models_manifest() -> dict:
     raw = MANIFEST_PATH.read_text(encoding="utf-8")
     return json.loads(_strip_jsonc_comments(raw))
+
+
+def _model_table_default_repos() -> dict[str, str]:
+    """Read the worker's pure-data ``MODEL_TABLE`` without importing Rust.
+
+    Each row is deliberately flat, so anchoring the two string fields inside a
+    ``ModelRow`` block is sufficient and keeps this catalog audit independent of
+    target-specific worker compilation.
+    """
+    source = ENGINE_TABLE_PATH.read_text(encoding="utf-8")
+    table = source.split("pub(crate) const MODEL_TABLE", maxsplit=1)[1].split("];", maxsplit=1)[0]
+    rows: dict[str, str] = {}
+    for block in re.findall(r"ModelRow\s*\{(.*?)\n\s*\},", table, flags=re.DOTALL):
+        model_id = re.search(r'sceneworks_id:\s*"([^"]+)"', block)
+        default_repo = re.search(r'default_repo:\s*"([^"]+)"', block)
+        assert model_id and default_repo, f"unparseable MODEL_TABLE row:\n{block}"
+        assert model_id.group(1) not in rows, f"duplicate MODEL_TABLE id: {model_id.group(1)}"
+        rows[model_id.group(1)] = default_repo.group(1)
+    assert rows, "MODEL_TABLE parser found no rows"
+    return rows
+
+
+def test_every_model_table_default_repo_is_installed_by_a_builtin_model():
+    """sc-14476: a worker fallback may only name a repo the model installer stages.
+
+    Built-ins intentionally have no top-level ``repo``; the worker lanes therefore
+    resolve through ``MODEL_TABLE.default_repo``. Keep the assertion direction
+    table -> downloads: co-requisites and shared components legitimately add extra
+    download repos that need no table row.
+    """
+    manifest = _load_builtin_models_manifest()
+    downloads_by_id = {
+        model["id"]: {
+            download["repo"]
+            for download in model.get("downloads", [])
+            if download.get("provider", "huggingface") == "huggingface" and download.get("repo")
+        }
+        for model in manifest["models"]
+    }
+    installed_repos = set().union(*downloads_by_id.values())
+    mismatches = {
+        model_id: {
+            "default_repo": default_repo,
+            "installed_repos": sorted(downloads_by_id.get(model_id, set())),
+        }
+        for model_id, default_repo in _model_table_default_repos().items()
+        # Legacy request aliases may retain MODEL_TABLE rows after their standalone
+        # manifest entries are collapsed (qwen_image_edit / _2509 -> _2511).
+        # They are safe only while another built-in stages the identical repo.
+        if default_repo not in installed_repos
+    }
+    assert not mismatches, (
+        "MODEL_TABLE defaults must be staged by a builtin model download; "
+        f"unstaged defaults: {mismatches}"
+    )
+
+
+def test_builtin_models_do_not_declare_a_top_level_repo():
+    """Document the contract that makes each lane's catalog default authoritative."""
+    offenders = [
+        model["id"]
+        for model in _load_builtin_models_manifest()["models"]
+        if model.get("repo")
+    ]
+    assert not offenders, (
+        "built-in repo ownership lives under downloads[]; top-level repo readers must retain an "
+        f"installed fallback. Unexpected declarations: {offenders}"
+    )
+
+
+def test_every_top_level_manifest_repo_reader_has_an_audited_installed_fallback():
+    """sc-14476 lane inventory and regression guard.
+
+    The marker names the effective resolution source in each lane. Explicit
+    constants below are justified because their repo is staged as a co-requisite
+    of a different model (InstantID/PuLID), while video resolves Wan tiers from
+    the request's own downloads. Any new reader must be consciously added here.
+    """
+    audited_lanes = {
+        "image_jobs/base.rs": "model.default_repo()",
+        "image_jobs/flux1_control_candle.rs": "default_repo_for(&request.model)",
+        "image_jobs/flux2_control_candle.rs": "default_repo_for(&request.model)",
+        "image_jobs/flux_ipadapter.rs": "flux_ipadapter_default_repo(&request.model)",
+        "image_jobs/instantid.rs": "INSTANTID_SDXL_REPO",
+        "image_jobs/kolors_control.rs": "default_repo_for(&request.model)",
+        "image_jobs/kolors_ipadapter.rs": "default_repo_for(&request.model)",
+        "image_jobs/krea_control.rs": "strict_control_default_repo(KREA_CONTROL_ENGINE_ID)",
+        "image_jobs/krea_control_candle.rs": "default_repo_for(&request.model)",
+        "image_jobs/krea_edit_candle.rs": "default_repo_for(&request.model)",
+        "image_jobs/pulid.rs": "PULID_FLUX_REPO",
+        "image_jobs/pulid_candle.rs": "PULID_CANDLE_FLUX_REPO",
+        "image_jobs/qwen_control.rs": "default_repo_for(&request.model)",
+        "image_jobs/qwen_edit_candle.rs": "crate::engines::MODEL_TABLE",
+        "image_jobs/sdxl_edit_candle.rs": "sdxl_edit_candle_default_repo(&request.model)",
+        "image_jobs/sdxl_ipadapter.rs": "sdxl_ipadapter_default_repo(&request.model)",
+        "image_jobs/zimage_control.rs": "zimage_control_base_default_repo(&request.model)",
+        "image_jobs/zimage_edit_candle.rs": "default_repo_for(&request.model)",
+        "image_jobs/zimage_identity_candle.rs": "default_repo_for(&request.model)",
+        "sensenova_jobs.rs": "default_repo_for(&request.model)",
+        "video_jobs/candle.rs": "candle_wan_tier_repo_from_downloads(request, engine_id)",
+    }
+    actual_lanes: set[str] = set()
+    for path in WORKER_SOURCE_PATH.rglob("*.rs"):
+        source = path.read_text(encoding="utf-8").split("\n#[cfg(test)]", maxsplit=1)[0]
+        if re.search(r"\.model_manifest_entry\s*\.get\(\"repo\"\)", source):
+            actual_lanes.add(path.relative_to(WORKER_SOURCE_PATH).as_posix())
+
+    assert actual_lanes == set(audited_lanes), (
+        "top-level model_manifest_entry.repo lane inventory changed; audit every added/removed lane: "
+        f"added={sorted(actual_lanes - set(audited_lanes))}, "
+        f"removed={sorted(set(audited_lanes) - actual_lanes)}"
+    )
+    for relative_path, fallback_marker in audited_lanes.items():
+        source = (
+            (WORKER_SOURCE_PATH / relative_path)
+            .read_text(encoding="utf-8")
+            .split("\n#[cfg(test)]", maxsplit=1)[0]
+        )
+        reads = list(re.finditer(r"\.model_manifest_entry\s*\.get\(\"repo\"\)", source))
+        assert reads, f"{relative_path}: inventoried lane no longer contains a top-level repo read"
+        for read in reads:
+            resolution = source[read.end() : read.end() + 900]
+            assert fallback_marker in resolution, (
+                f"{relative_path}: top-level repo read no longer resolves through audited source "
+                f"{fallback_marker!r}"
+            )
+    for relative_path in (
+        "image_jobs/flux_ipadapter.rs",
+        "image_jobs/sdxl_edit_candle.rs",
+        "image_jobs/sdxl_ipadapter.rs",
+        "image_jobs/zimage_control.rs",
+    ):
+        source = (WORKER_SOURCE_PATH / relative_path).read_text(encoding="utf-8")
+        assert "default_repo_for(model)" in source, (
+            f"{relative_path}: per-family fallback no longer delegates to MODEL_TABLE"
+        )
+
+
+def test_manifest_model_path_is_only_an_optional_override():
+    """sc-14476: converted installs may inject ``modelPath``; normal installs do not.
+
+    Every production reader must therefore inspect it inside an optional branch
+    and continue to repo resolution (or decline an imported-only lane) when it
+    is absent.
+    """
+    readers = 0
+    for path in WORKER_SOURCE_PATH.rglob("*.rs"):
+        source = path.read_text(encoding="utf-8").split("\n#[cfg(test)]", maxsplit=1)[0]
+        for match in re.finditer(
+            r'request\.model_manifest_entry\.get\("modelPath"\)',
+            source,
+        ):
+            readers += 1
+            prefix = source[max(0, match.start() - 500) : match.start()]
+            assert "if let Some(path) = request" in prefix or "let Some(raw_path) = request" in prefix, (
+                f"{path.relative_to(WORKER_SOURCE_PATH)}: modelPath is no longer read through an "
+                "optional branch"
+            )
+    assert readers == 19, (
+        "modelPath reader inventory changed; audit every new reader for an absence fallback "
+        f"(expected 19, found {readers})"
+    )
 
 
 def test_builtin_models_manifest_satisfies_authoring_schema():


### PR DESCRIPTION
## Summary
- audit every production worker read of top-level `modelManifestEntry.repo`
- resolve FLUX, Kolors, Krea, Qwen, Z-Image, and SenseNova defaults from the installed `MODEL_TABLE` mapping
- descend installed quant-matrix turnkeys into the selected q4/q8/bf16 tier
- preserve justified InstantID, PuLID, and download-derived video defaults
- add CI guards for the full repo-reader inventory, installed defaults, absent top-level repo contract, and optional `modelPath` behavior

## Audited effective repo sources
- generic image lane: `MODEL_TABLE`
- FLUX.1/FLUX.2 control and FLUX IP-Adapter: `MODEL_TABLE`
- Kolors control/IP-Adapter: `MODEL_TABLE`
- Krea MLX control: strict-control catalog; Krea candle control/edit: `MODEL_TABLE`
- Qwen control/edit: `MODEL_TABLE`
- SDXL edit/IP-Adapter: `MODEL_TABLE` from sc-14463
- Z-Image control/edit/identity: `MODEL_TABLE`
- SenseNova telemetry: `MODEL_TABLE`
- InstantID and PuLID: installed co-requisite constants
- candle video: request downloads tier resolver, then installed per-engine defaults
- audio: no top-level repo reader; it reads `downloads[].repo`

## Validation
- `cargo fmt --all -- --check`
- `python -m pytest -q tests/test_builtin_manifest_audit.py --strict-markers` (51 passed)
- `npm run rust:check:candle` (cross-target candle clippy/check passed under `-D warnings`)
- `npm run rust:lint`
- `npm run rust:build`
- full Rust test run: 580 core + 362 API + 996 worker passed before sandbox-only `nax_guard` reported no Metal device
- independent adversarial review: PASS

## CI-required evidence
- candle tests execute on the `candle-worker`/Windows CUDA lane
- local `rust:check:neither` was unavailable because Docker Desktop was not running; CI parity remains authoritative

Shortcut: https://app.shortcut.com/trefry/story/14476