### PR TITLE
chore(runpod): pin validated sc-14427 image

### DIFF
--- a/config/runpod-template.json
+++ b/config/runpod-template.json
@@ -1,7 +1,7 @@
 {
   "name": "SceneWorks GPU",
   "category": "NVIDIA",
-  "imageName": "ghcr.io/sceneworks/sceneworks-runpod:manual-sc10367-2c4dd777560a",
+  "imageName": "ghcr.io/sceneworks/sceneworks-runpod:manual-sc14427-4fe122b7dba3",
   "containerDiskInGb": 50,
   "volumeInGb": 20,
   "volumeMountPath": "/workspace",

--- a/docs/deploy-runpod.md
+++ b/docs/deploy-runpod.md
@@ -46,16 +46,16 @@ Exact Git release tags of the form `vX.Y.Z` publish both `:X.Y.Z` and
 Manual publication tags (`manual-*`) are validation artifacts, not official
 releases and are never promoted to `:latest`. Until the first official release,
 the checked-in template uses the anonymously pullable validation tag
-`manual-sc10367-2c4dd777560a`:
+`manual-sc14427-4fe122b7dba3`:
 
 ```text
-ghcr.io/sceneworks/sceneworks-runpod:manual-sc10367-2c4dd777560a
+ghcr.io/sceneworks/sceneworks-runpod:manual-sc14427-4fe122b7dba3
 ```
 
 That tag resolved during publication validation to this manifest:
 
 ```text
-ghcr.io/sceneworks/sceneworks-runpod@sha256:fdd60e35655708915ea046a9db86093360a81c2946f08fe63cef58f59f9ab065
+ghcr.io/sceneworks/sceneworks-runpod@sha256:376182ddbdf4c78d2a6f66a1e3ce66c573145b4c21b99300e42aeefba9f710ab
 ```
 
 The manifest digest is the immutable verification evidence; the tag is used in

--- a/scripts/check-runpod-template.mjs
+++ b/scripts/check-runpod-template.mjs
@@ -13,9 +13,10 @@ const [templateText, doc, workflow, readme, dockerfile] = await Promise.all([
 
 const template = JSON.parse(templateText);
 const validationDigest =
-  "sha256:fdd60e35655708915ea046a9db86093360a81c2946f08fe63cef58f59f9ab065";
+  "sha256:376182ddbdf4c78d2a6f66a1e3ce66c573145b4c21b99300e42aeefba9f710ab";
 const releaseRepository = "ghcr.io/sceneworks/sceneworks-runpod";
-const validationTag = "manual-sc10367-2c4dd777560a";
+const validationTag = "manual-sc14427-4fe122b7dba3";
+const staleValidationTag = "manual-sc10367-2c4dd777560a";
 const accessSecret = "{{ RUNPOD_SECRET_sceneworks_access_token }}";
 
 function validateTemplate(candidate) {
@@ -57,6 +58,11 @@ function validateTemplate(candidate) {
 }
 
 validateTemplate(template);
+assert.equal(
+  template.imageName,
+  `${releaseRepository}:${validationTag}`,
+  "checked-in template must pin the E2E-validated image",
+);
 
 // Mutation checks prove the validator rejects the security-sensitive non-defaults
 // that this contract is intended to prevent.
@@ -64,9 +70,19 @@ for (const mutation of [
   { ...template, ports: ["8010/tcp"] },
   { ...template, env: { ...template.env, SCENEWORKS_ACCESS_TOKEN: "" } },
   { ...template, imageName: `${releaseRepository}:latest` },
+  { ...template, imageName: `${releaseRepository}:${staleValidationTag}` },
 ]) {
   assert.throws(() => validateTemplate(mutation));
 }
+
+assert.ok(
+  !templateText.includes(staleValidationTag),
+  "template must not regress to the pre-sc-14427 validation image",
+);
+assert.ok(
+  !doc.includes(staleValidationTag),
+  "deployment guide must not recommend the pre-sc-14427 validation image",
+);
 
 for (const contract of [
   releaseRepository,


### PR DESCRIPTION
## Summary
- pin the checked-in RunPod template to the E2E-validated sc-14427 public image
- document the exact OCI index digest used for immutable verification
- enforce the new tag/digest and explicitly reject the stale pre-fix validation tag

## Acceptance criteria
- [x] Default template and deploy docs pin `manual-sc14427-4fe122b7dba3` and `sha256:376182ddbdf4c78d2a6f66a1e3ce66c573145b4c21b99300e42aeefba9f710ab`
- [x] Template checker enforces the new pin and rejects `manual-sc10367-2c4dd777560a`
- [x] Focused and applicable Node validation pass
- [x] Diff scan found no secret values, Pod IDs, or proxy URLs

## Validation
- `npm.cmd run check:runpod:template`
- stale-tag mutation: expected checker failure confirmed
- `npm.cmd run check`
- `git diff --check`
- added-line secret/environment-ID scan
- independent adversarial review: PASS (high confidence, no findings)

Shortcut: https://app.shortcut.com/trefry/story/14494