### PR TITLE
docs(runpod): add human deployment and operations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,23 @@ generation directly on your machine's GPU — **MLX** on macOS (Apple Silicon) a
 **candle / CUDA** on Windows (NVIDIA) — with **no Python, no cloud, and no Docker
 required**. Your prompts, models, and media never leave the workstation.
 
-The same codebase also ships as an optional **Docker server** for headless, LAN,
-or shared-GPU deployments (see [Server deployment](#server-deployment-docker)),
-but the primary target is a single-installer desktop app.
+The same codebase also ships as an optional **GPU server** for headless, LAN,
+shared-GPU, or RunPod deployments (see
+[RunPod GPU deployment](#runpod-gpu-deployment) and
+[Server deployment](#server-deployment-docker)), but the primary target is a
+single-installer desktop app.
 
 ![SceneWorks](screenshot.png)
 
 ## Two ways to run it
 
-| | **Desktop app** (primary) | **Server** (Docker) |
+| | **Desktop app** (primary) | **Server** (Docker or RunPod) |
 | --- | --- | --- |
-| Install | One native installer — no Docker, no terminal, no Python | `docker compose` stack |
-| Engine | MLX (macOS) / candle CUDA (Windows), in-process | candle CUDA worker container (NVIDIA + container toolkit) |
-| Access | Local app window (loopback), optional LAN opt-in | Web UI over the network (opt-in, token-gated) |
+| Install | One native installer — no Docker, no terminal, no Python | `docker compose` stack or public RunPod image |
+| Engine | MLX (macOS) / candle CUDA (Windows), in-process | candle CUDA worker container on an NVIDIA GPU |
+| Access | Local app window (loopback), optional LAN opt-in | Token-gated web UI over the network |
 | Credentials | Per-user OS keychain | `0600 credentials.json` / env vars |
-| Best for | A single creator on one Mac or Windows workstation | Shared/remote GPUs, multiple users, headless hosts |
+| Best for | A single creator on one Mac or Windows workstation | Shared GPUs, headless hosts, or an on-demand cloud GPU |
 
 **→ For the desktop app** — install, hardware requirements, first-run, storage
 layout, macOS GPU-memory tuning, and troubleshooting — see
@@ -199,6 +201,32 @@ overlays the optional `SCENEWORKS_CREDENTIALS` env var, a JSON map
 host**, so operators can inject secrets from a vault without writing the file.
 Hugging Face keeps its dedicated path: set `HF_TOKEN` for gated HF repos (the same
 variable `huggingface_hub` reads). Both are picked up at worker startup.
+
+## RunPod GPU deployment
+
+SceneWorks has first-class support for an on-demand NVIDIA GPU in a RunPod Pod.
+The public `linux/amd64` image combines the web UI, authenticated API, candle
+CUDA worker, CPU utility worker, ffmpeg, and Model Manager downloader, so the
+Pod does not need Docker Compose, SSH setup, or GHCR credentials.
+
+A secure deployment uses:
+
+- the public `ghcr.io/sceneworks/sceneworks-runpod` image pinned to an official
+  version;
+- a RunPod Secret for the required SceneWorks login token;
+- one HTTP service on port `8010`; and
+- a network volume mounted at `/workspace` to preserve projects, generated
+  assets, configuration, and downloaded models when the Pod is replaced.
+
+RTX PRO 4500 Blackwell (32 GB) and A40 (48 GB) Pods have passed live
+end-to-end validation. Other Ampere, Ada, Hopper, and consumer/workstation
+Blackwell GPUs are supported by the image, subject to each model's VRAM
+requirement.
+
+Follow the human-oriented
+**[RunPod deployment and operations guide](docs/deploy-runpod.md)** for the
+exact template fields, secret creation, storage setup, first generation,
+stop/restart behavior, upgrades, release-image publishing, and troubleshooting.
 
 ## Server deployment (Docker)
 

--- a/docs/deploy-runpod.md
+++ b/docs/deploy-runpod.md
@@ -1,82 +1,363 @@
-# Deploy SceneWorks on a RunPod Pod
+# Deploy and run SceneWorks on RunPod
 
-SceneWorks publishes a combined Linux/amd64 image containing the embedded web
-UI, Rust API, candle CUDA workers, CPU utility worker, ffmpeg, and Model Manager
-downloader:
+This guide takes you from an empty RunPod account to a working SceneWorks web
+app on an NVIDIA GPU. No SSH session, Docker Compose stack, or container
+registry login is required.
+
+The RunPod image contains the complete application:
+
+- the SceneWorks web interface;
+- the authenticated Rust API;
+- one candle/CUDA worker for each visible NVIDIA GPU;
+- a CPU utility worker for model downloads and media tasks; and
+- ffmpeg and the native Model Manager downloader.
+
+You will create one secret, one persistent network volume, one private template,
+and one Pod. The web interface and API share a single HTTPS address.
+
+## Before you start
+
+You need:
+
+- a RunPod account with enough credit to deploy an on-demand GPU;
+- a private, randomly generated SceneWorks access token;
+- about 15 minutes for setup, plus the time needed to pull the image and
+  download your chosen model; and
+- optionally, a Hugging Face read token for gated models.
+
+For a first deployment, use at least **100 GB** of network-volume storage.
+Individual models are large, and keeping them on the network volume prevents
+another download when you replace the Pod.
+
+The image is public:
 
 ```text
 ghcr.io/sceneworks/sceneworks-runpod
 ```
 
-The image is public, so RunPod does not need registry credentials. SceneWorks
-still requires its own access token before it will listen on RunPod's
-network-reachable interface.
+RunPod does not need GitHub Container Registry credentials. SceneWorks still
+requires its own access token because the web service is reachable through a
+public proxy URL.
 
-## Before you deploy
+## 1. Choose the image version
 
-1. In RunPod, create a **Secure Cloud network volume** with enough room for
-   models and generated assets. Choose its region carefully: a network volume
-   limits Pod selection to GPUs available in that datacenter. Network volumes
-   must be attached when a Pod is created and cannot be attached later.
-2. Open RunPod's **Secrets** section and create
-   `sceneworks_access_token`. Give it a unique, high-entropy value; do not reuse
-   a RunPod API key or Hugging Face token.
-3. If you need gated Hugging Face repositories, also create an `hf_token`
-   secret containing a Hugging Face read token for an account that has accepted
-   the model's license.
-
-RunPod expands a secret reference such as
-`{{ RUNPOD_SECRET_sceneworks_access_token }}` into an environment variable
-without putting the value in the template. See RunPod's
-[environment-variable](https://docs.runpod.io/pods/templates/environment-variables)
-and [Secret](https://docs.runpod.io/pods/templates/secrets) documentation.
-
-## Choose an image version
-
-For production, use an immutable release tag:
+For an official release, use its immutable version tag:
 
 ```text
 ghcr.io/sceneworks/sceneworks-runpod:X.Y.Z
 ```
 
-Exact Git release tags of the form `vX.Y.Z` publish both `:X.Y.Z` and
-`:latest`. Prefer the immutable version tag for reproducible Pods. Do not assume
-`:latest` exists before the first official release.
+Replace `X.Y.Z` with the SceneWorks release version. Prefer this versioned tag
+over `latest` so a future Pod starts the exact version you tested.
+Do not assume `:latest` exists before the first official release.
 
-Manual publication tags (`manual-*`) are validation artifacts, not official
-releases and are never promoted to `:latest`. Until the first official release,
-the checked-in template uses the anonymously pullable validation tag
-`manual-sc14427-4fe122b7dba3`:
+Until the first official release, the repository template uses this public
+validation build:
 
 ```text
 ghcr.io/sceneworks/sceneworks-runpod:manual-sc14427-4fe122b7dba3
 ```
 
-That tag resolved during publication validation to this manifest:
+Its immutable OCI index digest is:
 
 ```text
 ghcr.io/sceneworks/sceneworks-runpod@sha256:376182ddbdf4c78d2a6f66a1e3ce66c573145b4c21b99300e42aeefba9f710ab
 ```
 
-The manifest digest is the immutable verification evidence; the tag is used in
-the template because RunPod's template API specifies `imageName` as an image
-tag. After an official release, replace the template's `imageName` with the
-desired `:X.Y.Z` tag before registering it. Do not substitute another
-unreviewed `manual-*` tag for an official release.
+Tags beginning with `manual-` are validation artifacts, not official releases.
+Do not replace a release tag with an unreviewed manual tag.
 
-## Create the reusable template
+## 2. Create the SceneWorks secret
 
-[`config/runpod-template.json`](../config/runpod-template.json) is a RunPod Pod
-template payload with these safe defaults:
+1. In the RunPod console, open **Settings -> Secrets**.
+2. Select **New Secret**.
+3. Name it `sceneworks_access_token`.
+4. Paste a unique, high-entropy random value and save it.
 
-- the public SceneWorks image;
-- NVIDIA Pod mode, not Serverless;
-- `8010/http` as the only exposed port;
-- the access token supplied through a RunPod Secret;
-- `/workspace` as the volume base and mount point;
-- no entrypoint override, start-command override, or raw TCP port.
+This value is the password you will enter when SceneWorks opens. Do not reuse a
+RunPod API key, GitHub token, or Hugging Face token.
 
-Register it with RunPod's template API:
+The template will refer to the secret without containing its value:
+
+```text
+{{ RUNPOD_SECRET_sceneworks_access_token }}
+```
+
+If you plan to use a gated Hugging Face model:
+
+1. Accept the model's license on Hugging Face.
+2. Create a read-only Hugging Face access token.
+3. Create a second RunPod secret named `hf_token`.
+
+Do not add `HF_TOKEN` unless you need it. RunPod explains secret creation and
+template references in its
+[Secrets documentation](https://docs.runpod.io/pods/templates/secrets).
+
+## 3. Create persistent storage
+
+1. In RunPod, open **Storage -> Network Volumes**.
+2. Create a **Secure Cloud** network volume.
+3. Choose at least **100 GB** for a useful model cache.
+4. Note the datacenter you selected.
+
+The volume's datacenter controls which GPUs can use it. A network volume must be
+selected when the Pod is created; it cannot be attached later.
+
+SceneWorks uses `/workspace` for durable data:
+
+| Path | Contents |
+| --- | --- |
+| `/workspace/data` | Projects, generated assets, imported models, and application data |
+| `/workspace/config` | SceneWorks configuration and user manifests |
+| `/workspace/cache/huggingface` | Downloaded Hugging Face model files |
+
+The live job queue is intentionally stored on the Pod's local disk. Projects,
+assets, configuration, and model files persist; completed queue cards do not
+need to survive a Pod replacement.
+
+See RunPod's
+[Network volumes documentation](https://docs.runpod.io/storage/network-volumes)
+for current region and lifecycle rules.
+
+## 4. Create a private Pod template
+
+The easiest route is the RunPod web console:
+
+1. Open **Templates -> New Template**.
+2. Name it `SceneWorks GPU`.
+3. Enter the values below.
+4. Leave the Docker entrypoint and start command empty.
+5. Save it as a private Pod template.
+
+| Template field | Value |
+| --- | --- |
+| Container image | The versioned image chosen in step 1 |
+| Container disk | `50 GB` |
+| Volume disk | `20 GB` fallback; the network volume selected at deployment replaces it |
+| Volume mount path | `/workspace` |
+| Expose HTTP ports | `8010` (stored as `8010/http` in the template API) |
+| Expose TCP ports | Leave empty |
+| `SCENEWORKS_ACCESS_TOKEN` | `{{ RUNPOD_SECRET_sceneworks_access_token }}` |
+| `SCENEWORKS_API_PORT` | `8010` |
+| `SCENEWORKS_VOLUME` | `/workspace` |
+
+For gated Hugging Face models, also add:
+
+```text
+HF_TOKEN={{ RUNPOD_SECRET_hf_token }}
+```
+
+The checked-in [`config/runpod-template.json`](../config/runpod-template.json)
+contains the same fields. RunPod documents the web form in
+[Manage Pod templates](https://docs.runpod.io/pods/templates/manage-templates).
+
+Important:
+
+- expose `8010` as an **HTTP** port, not a raw TCP port;
+- never paste a secret value directly into the template;
+- do not override the image's entrypoint or start command; and
+- keep the network-volume mount and `SCENEWORKS_VOLUME` set to the same path.
+
+## 5. Deploy the Pod
+
+1. Open **Pods -> Deploy**.
+2. Select the network volume created in step 3.
+3. Choose an NVIDIA GPU available in that volume's datacenter.
+4. Select the private **SceneWorks GPU** template.
+5. Confirm the volume is mounted at `/workspace`.
+6. Confirm the template exposes `8010` under **HTTP Services**.
+7. Deploy the Pod.
+
+Two GPUs have passed end-to-end SceneWorks validation:
+
+| GPU | VRAM | What was validated |
+| --- | ---: | --- |
+| NVIDIA RTX PRO 4500 Blackwell | 32 GB | Cold start, GPU and CPU worker registration, model download, image generation, reduced-memory video generation, stop/start persistence |
+| NVIDIA A40 | 48 GB | Cold start, CUDA execution, GPU and CPU worker registration |
+
+Other supported Ampere, Ada, Hopper, and consumer/workstation Blackwell GPUs are
+listed in [Supported GPU architectures](#supported-gpu-architectures). Model
+memory requirements still apply: an image may support a GPU architecture even
+when a particular model is too large for that card.
+
+## 6. Wait for SceneWorks to become ready
+
+The Pod can show **Running** while it is still pulling the image or starting the
+workers.
+
+1. Expand the Pod and open its container logs.
+2. Wait for messages saying the API is healthy and the candle GPU and utility
+   workers are starting.
+3. Open **Connect**.
+4. Under **HTTP Services**, open the link for port `8010`.
+
+The address has this general form:
+
+```text
+https://<podid>-<port>.proxy.runpod.net
+```
+
+With the default port, that becomes:
+
+```text
+https://<podid>-8010.proxy.runpod.net
+```
+
+Use the link supplied by RunPod instead of typing the Pod ID yourself. The proxy
+provides transport encryption: RunPod's HTTP proxy provides HTTPS. The
+SceneWorks token provides application authentication.
+
+At the SceneWorks login screen, enter the value stored in
+`sceneworks_access_token`.
+
+## 7. Verify the deployment and run a generation
+
+Before downloading a large model:
+
+1. Open **Queue** and confirm SceneWorks reports one GPU worker and one CPU
+   utility worker. A one-GPU Pod normally shows **2 workers / 1 GPU**.
+2. Open **Model Manager**.
+3. Select a model that fits the GPU's VRAM.
+4. Choose **Download** and wait for the queue job to complete.
+5. Open the matching Studio and run a small generation.
+6. Confirm the result appears in the project and Asset Library.
+
+For the validated 32 GB RTX PRO 4500 configuration, RealVisXL Q4 is a practical
+first image-generation check.
+
+The first Model Manager visit on a large, previously populated volume can take
+longer while SceneWorks scans the cache. If the RunPod proxy returns `524`,
+wait a moment and refresh. Check **Queue** before assuming the Pod or GPU worker
+failed.
+
+### Notes for larger models
+
+- A gated model needs both an accepted license and the optional `HF_TOKEN`
+  secret. Restart the Pod after adding the environment variable.
+- Ideogram 4 Q4 downloads successfully with the appropriate Hugging Face access,
+  but its measured inference peak is above 32 GB. Use a larger-memory GPU for
+  generation.
+- Stable Video Diffusion's default 25-frame, 1024x576 job can exceed 32 GB.
+  Reducing the job to 8 frames and using a decode chunk of 1 passed validation
+  on the RTX PRO 4500.
+
+## 8. Stop, restart, update, or remove the deployment
+
+### Stop when idle
+
+Stop the Pod when you are not generating. GPU compute billing stops, while
+storage can continue to incur charges under RunPod's current pricing.
+
+Do not rely on files outside `/workspace`. RunPod can replace or reset a Pod's
+container disk, but the separate network volume remains available for another
+Pod in the same datacenter.
+
+### Restart with the same data
+
+Start the stopped Pod, or deploy a replacement Pod and select the same network
+volume. SceneWorks will reuse the projects, assets, configuration, and model
+cache stored under `/workspace`.
+
+### Update SceneWorks
+
+1. Find the new official SceneWorks version.
+2. Edit the template's container image to
+   `ghcr.io/sceneworks/sceneworks-runpod:X.Y.Z`.
+3. Stop the current Pod.
+4. Deploy a fresh Pod from the updated template with the same network volume.
+5. Repeat the verification checklist in step 7.
+6. Terminate the old Pod after the replacement is healthy.
+
+Using an explicit version makes rollback straightforward: point the template at
+the previous version and deploy another Pod with the same volume.
+
+### Remove everything
+
+Terminate the Pod first. Delete the template, secrets, and network volume only
+when you are sure you no longer need them. Deleting the network volume removes
+the persisted SceneWorks projects, generated assets, and downloaded models.
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| HTTP Services link is missing | The template must expose `8010` as HTTP. Edit the template and redeploy. |
+| SceneWorks never opens | The image may still be pulling. Check the Pod logs and retry after the API reports healthy. |
+| Startup refuses a public bind | `SCENEWORKS_ACCESS_TOKEN` is missing or blank. Confirm the environment variable uses the RunPod secret reference. |
+| Login is rejected | Enter the SceneWorks access-token value, not the RunPod API key. If you rotated the secret, restart or replace the Pod. |
+| Only the CPU worker appears | Wait for GPU initialization, then inspect logs and RunPod GPU telemetry. Confirm an NVIDIA GPU is actually attached. |
+| A managed directory is not writable | Confirm the network volume is mounted at `/workspace` and permits writes by the container's root user. |
+| A model remains gated | Accept its license, provide a read-only `HF_TOKEN` through a RunPod secret, and restart the Pod. |
+| A generation reports insufficient memory | Choose a smaller quantization tier or workload, reduce video frames/resolution, or use a GPU with more VRAM. |
+| Model Manager returns `524` | A large cache scan can outlast the proxy request. Wait, refresh, and check Queue/worker health. |
+| Data disappeared after a Pod edit | Only data below `/workspace` is intended to persist. Reattach the original network volume if it still exists. |
+
+Treat the proxy URL as public. Never put the SceneWorks token in a URL, template,
+screenshot, log, or support message. Do not expose `8010/tcp` as a workaround;
+that bypasses RunPod's HTTPS proxy.
+
+## Environment reference
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `SCENEWORKS_ACCESS_TOKEN` | **Yes** | none | SceneWorks login/API credential. The public-bind entrypoint refuses to start when it is missing or blank. |
+| `HF_TOKEN` | Only for gated Hugging Face repositories | unset | Read-only Hugging Face token used by Model Manager. |
+| `SCENEWORKS_VOLUME` | No | `/workspace` | Base for durable SceneWorks data, config, and model-cache directories. |
+| `SCENEWORKS_API_PORT` | No | `8010` | Internal UI/API port. If changed, expose the same HTTP port in RunPod. |
+| `SCENEWORKS_CORS_ORIGINS` | Only for a different-origin frontend | built-in development origins | Exact allowed origins. Not needed for the default same-origin embedded UI. |
+
+The combined image intentionally binds to `0.0.0.0` so RunPod's proxy can reach
+it. It refuses to start without a nonblank access token.
+`SCENEWORKS_CORS_ORIGINS` is not needed for the default embedded UI.
+
+## Supported GPU architectures
+
+The v1 image supports these NVIDIA architecture families:
+
+| Architecture | Compute capability | Common RunPod GPUs | Status |
+| --- | --- | --- | --- |
+| Ampere | 8.0, 8.6 | A100, A30, A40, A10, RTX A6000/A5000/A4000, RTX 30-series | Supported |
+| Ada | 8.9 | L4, L40/L40S, RTX 6000/5000/4500 Ada, RTX 40-series | Supported |
+| Hopper | 9.0 | H100, H200 | Supported |
+| Consumer/workstation Blackwell | 12.0 | RTX PRO 6000/5000/4500/4000/2000 Blackwell, RTX 50-series | Supported |
+| Turing | 7.5 | T4, RTX 20-series, Quadro RTX | Not supported in v1 |
+| Datacenter Blackwell | 10.0, 10.3 | B200/GB200, B300/GB300 | Not supported in v1 |
+
+The published worker contains `sm_80`, `sm_90`, and `sm_120` quantized kernels.
+The Docker build checks those targets before publication. NVIDIA's
+[compute-capability table](https://developer.nvidia.com/cuda/gpus) is the
+authoritative reference for a specific GPU.
+
+The v1 build sets `CUDA_COMPUTE_CAP=80`, so its general CUDA path carries
+`compute_80` PTX. Its quantized-kernel fat binary contains `sm_80`, `sm_90`, and
+`sm_120` cubins plus `compute_120` PTX. It does not contain `sm_75`, `sm_100`,
+or `sm_103` cubins. This is why Turing and Datacenter Blackwell are marked
+**Unsupported in v1** even though newer drivers can JIT some of the general
+kernels. Extending every native CUDA archive together is tracked in `sc-14423`;
+changing only the top-level compute-capability setting would be incomplete.
+
+### Published-image validation record
+
+The public validation image was checked on two fresh RunPod Pods:
+
+- At `2026-07-25T01:32:36Z`, an NVIDIA RTX PRO 4500 Blackwell reported driver
+  `580.126.20` and `32,623 MiB` VRAM. A `4,096 bytes` CUDA round trip passed,
+  the authenticated API reported `authRequired=true`, and the runtime
+  registered `runpod-worker-0` plus `runpod-worker-cpu`.
+- At `2026-07-25T01:40:55Z`, an NVIDIA A40 reported driver `570.195.03` and
+  `46,068 MiB` VRAM. The same CUDA, authenticated API, and two-worker checks
+  passed.
+
+Those checks used
+`ghcr.io/sceneworks/sceneworks-runpod:manual-sc14427-4fe122b7dba3` at OCI index
+`sha256:376182ddbdf4c78d2a6f66a1e3ce66c573145b4c21b99300e42aeefba9f710ab`.
+They validate the image and worker startup, not that every model fits each
+GPU's memory.
+
+## Optional: create the template with the API
+
+Instead of filling out the web form, register the checked-in payload with
+RunPod's template API:
 
 ```bash
 export RUNPOD_API_KEY='<your RunPod API key>'
@@ -85,213 +366,40 @@ curl --fail-with-body --request POST \
   --header "Authorization: Bearer ${RUNPOD_API_KEY}" \
   --header 'Content-Type: application/json' \
   --data-binary @config/runpod-template.json
+unset RUNPOD_API_KEY
 ```
 
-The response includes the new template ID. The payload follows RunPod's current
-[Create template API](https://docs.runpod.io/api-reference/templates/POST/templates).
-You can instead create the same private template under **Templates → New
-Template** by copying the image, port, environment, and storage values from the
-JSON. If the template name already exists in your account, rename it before
-registering.
+The response includes the new template ID. Rename the template in the JSON first
+if an object with the same name already exists.
 
-## Deploy the Pod
+## For maintainers: publish an official image
 
-1. Open **Pods → Deploy** and select the network volume created earlier.
-2. Choose a supported NVIDIA GPU in the same datacenter.
-3. Select the **SceneWorks GPU** custom template. Confirm that the network
-   volume is mounted at `/workspace` and `8010` is exposed as an **HTTP** port.
-   Attaching a network volume replaces the template's 20 GB fallback local
-   volume; it does not change the `/workspace` mount path.
-4. Confirm `SCENEWORKS_ACCESS_TOKEN` resolves from
-   `{{ RUNPOD_SECRET_sceneworks_access_token }}`. If gated Hugging Face models
-   are needed, add:
+The [Publish RunPod image workflow](../.github/workflows/publish-runpod.yml)
+is part of the existing release flow:
 
-   ```text
-   HF_TOKEN={{ RUNPOD_SECRET_hf_token }}
-   ```
+1. Create and push an exact Git tag of the form `vX.Y.Z`.
+2. The workflow builds the combined `linux/amd64` RunPod image.
+3. It publishes both
+   `ghcr.io/sceneworks/sceneworks-runpod:X.Y.Z` and
+   `ghcr.io/sceneworks/sceneworks-runpod:latest`.
+4. Copy the published digest from the GitHub Actions job summary.
+5. Update and validate the private RunPod template with the immutable version
+   tag before announcing support for the release.
 
-5. Deploy the Pod. Do not override the image's entrypoint or start command.
-6. Wait for the Pod telemetry and container logs to show that the API is
-   healthy and the GPU and utility workers have started.
+A manual workflow dispatch can publish only a `manual-*` validation tag. It
+cannot update `latest`. The full CUDA build is intentionally expensive and can
+take well over an hour on a cold hosted runner.
 
-RunPod documents network-volume attachment and lifecycle constraints in
-[Network volumes](https://docs.runpod.io/storage/network-volumes), and the
-template fields in [Manage Pod templates](https://docs.runpod.io/pods/templates/manage-templates).
+## Optional: validate the RunPod proxy
 
-## Supported GPUs
+The repository probe checks authenticated job events, SSE heartbeats, and a
+large multipart upload through the real RunPod HTTPS proxy. Keep a representative
+image or video of at least 100 MiB available.
 
-The v1 image uses `CUDA_COMPUTE_CAP=80`, and its complete support contract has
-two parts:
-
-- Candle's general CUDA kernels include `compute_80` PTX, which the NVIDIA
-  driver can JIT for compute capability 8.0 or newer.
-- The quantized GGUF/MoE kernels are a separate fat binary with `sm_80`,
-  `sm_90`, and `sm_120` cubins plus `compute_120` PTX. NVIDIA's same-major
-  binary compatibility lets the `sm_80` cubin run on 8.6 and 8.9 GPUs.
-
-The image build inspects that quantized-kernel fat binary with `cuobjdump`
-before packaging it. Based on that whole-image contract, use this matrix:
-
-| Architecture | Compute capability | Common RunPod GPUs | v1 status |
-| --- | --- | --- | --- |
-| Ampere | 8.0, 8.6 | A100, A30, A40, A10, RTX A6000/A5000/A4000, RTX 30-series | **Supported.** `sm_80` covers the quantized path; the general path carries `compute_80` PTX. |
-| Ada | 8.9 | L4, L40/L40S, RTX 6000/5000/4500 Ada, RTX 40-series | **Supported.** NVIDIA guarantees an `sm_80` cubin on later 8.x devices. |
-| Hopper | 9.0 | H100, H200 | **Supported.** The quantized path includes native `sm_90`; the general path JITs `compute_80` PTX. |
-| Consumer/workstation Blackwell | 12.0 | RTX PRO 6000/5000/4500/4000/2000 Blackwell, RTX 50-series | **Supported.** The quantized path includes native `sm_120`; the general path JITs `compute_80` PTX. |
-| Turing | 7.5 | T4, RTX 20-series, Quadro RTX | **Unsupported in v1.** Neither `compute_80` PTX nor an 8.x-or-newer cubin can run backward on `sm_75`. |
-| Datacenter Blackwell | 10.0, 10.3 | B200/GB200, B300/GB300 | **Unsupported in v1.** General kernels can JIT from `compute_80`, but the quantized fat binary has no `sm_100`/`sm_103` cubin and its `compute_120` PTX cannot JIT backward. |
-
-On 2026-07-24, `cuobjdump` inspection of the worker executable extracted
-from the public validation manifest
-`sha256:fdd60e35655708915ea046a9db86093360a81c2946f08fe63cef58f59f9ab065`
-reported `sm_80`, `sm_90`, and `sm_120` cubins plus `sm_120` PTX. This
-checks the shipped artifact, while the Docker build guard prevents future
-publications from dropping those targets unnoticed.
-
-### Measured GPU validation
-
-At `2026-07-25T01:32:36Z`, a fresh RunPod cold boot of
-`ghcr.io/sceneworks/sceneworks-runpod:manual-sc14427-4fe122b7dba3`
-(OCI index
-`sha256:376182ddbdf4c78d2a6f66a1e3ce66c573145b4c21b99300e42aeefba9f710ab`)
-passed on an NVIDIA RTX PRO 4500 Blackwell:
-
-- compute capability 12.0, driver 580.126.20, and 32,623 MiB VRAM;
-- an ONNX Runtime CUDA host-to-device-to-host round trip passed for 4,096 bytes;
-- the authenticated API was healthy with `authRequired=true`;
-- `/workers` reported an idle GPU child, `runpod-worker-0`, with GPU ID 0,
-  the measured GPU name and memory, and the `gpu`, `nvidia`, `candle`,
-  `image_generate`, and `video_generate` capability markers;
-- `/workers` also reported the idle `runpod-worker-cpu` utility child with
-  capabilities including `model_download`; and
-- the process tree contained the API, the supervisor, and exactly those two
-  children.
-
-At `2026-07-25T01:40:55Z`, a second fresh cold boot of the same tag and OCI
-index passed on an NVIDIA A40:
-
-- compute capability 8.6, driver 570.195.03, and 46,068 MiB VRAM;
-- an ONNX Runtime CUDA host-to-device-to-host round trip passed for 4,096 bytes;
-- the authenticated API was healthy with `authRequired=true`;
-- `/workers` reported the idle `runpod-worker-0` GPU child with GPU ID 0, the
-  measured A40 name and memory, and the `gpu`, `nvidia`, `candle`,
-  `image_generate`, and `video_generate` capability markers;
-- `/workers` also reported the idle `runpod-worker-cpu` utility child with
-  capabilities including `model_download`; and
-- the process tree contained the API, the supervisor, and exactly those two
-  children.
-
-This is an image-level support statement, not a promise that every model fits
-every supported card. Check the model's VRAM requirement separately. RunPod's
-GPU inventory also changes over time; confirm the exact product name and
-compute capability shown for the Pod. NVIDIA maintains the authoritative
-[GPU compute-capability table](https://developer.nvidia.com/cuda/gpus), and its
-[CUDA programming guide](https://docs.nvidia.com/cuda/cuda-programming-guide/01-introduction/cuda-platform.html)
-defines cubin and PTX compatibility.
-
-For v1, SceneWorks deliberately keeps the `sm_80` baseline and does not add
-Turing code to this already-large image. Expanding the general and quantized
-kernel builds together for Turing and datacenter Blackwell is tracked in
-`sc-14423`; changing only the top-level `CUDA_COMPUTE_CAP` would not cover every
-native CUDA archive.
-
-## Open and authenticate the UI
-
-RunPod proxy URLs have the form
-`https://<podid>-<port>.proxy.runpod.net`. With the template's default port,
-open:
-
-```text
-https://<podid>-8010.proxy.runpod.net
-```
-
-RunPod's Connect panel also provides this link under **HTTP Services**. Its
-[HTTP proxy URL](https://docs.runpod.io/pods/configuration/expose-ports) uses the
-Pod's internal port and provides HTTPS in front of the container's HTTP service.
-
-SceneWorks shows a login gate. Enter the same value stored in
-`sceneworks_access_token`; the UI verifies it and uses it for authenticated API
-requests. After login:
-
-1. Open **Model Manager**.
-2. Select an image or video model supported by the chosen GPU.
-3. Choose **Download** and wait for the job to finish.
-4. Run a small generation before starting a large job.
-
-Model downloads, generated assets, imported models, projects, configuration,
-and the Hugging Face cache persist below `/workspace`. The job queue database is
-intentionally kept on ephemeral local storage at
-`/tmp/sceneworks/cache/jobs.db`, because SQLite locking is unsafe on many
-NFS-style network volumes.
-
-## Environment reference
-
-| Variable | Required | Default | Purpose |
-| --- | --- | --- | --- |
-| `SCENEWORKS_ACCESS_TOKEN` | **Yes** | none | SceneWorks login/API credential. The public-bind entrypoint refuses to start if it is missing or blank. Supply it with a RunPod Secret reference. |
-| `HF_TOKEN` | Only for gated Hugging Face repositories | unset | Hugging Face read token used by Model Manager. Add it as a separate RunPod Secret only when needed. |
-| `SCENEWORKS_VOLUME` | No | `/workspace` | Absolute base for durable SceneWorks data, config, and model-cache directories. Keep it equal to the network-volume mount. |
-| `SCENEWORKS_API_PORT` | No | `8010` | Internal API/UI port. If changed, update the template's HTTP port and proxy URL to the same value. |
-| `SCENEWORKS_CORS_ORIGINS` | Only for a different-origin frontend | built-in local-development origins | Comma-separated, exact allowed origins such as `https://studio.example.com`. It is not needed for the default embedded UI served through the same RunPod proxy origin. |
-
-The combined image intentionally defaults `SCENEWORKS_API_HOST` to `0.0.0.0` so
-RunPod's proxy can reach it. Do not blank `SCENEWORKS_ACCESS_TOKEN` or set
-`SCENEWORKS_ALLOW_OPEN_BIND`; the combined image removes the latter and refuses
-an unauthenticated public bind.
-
-## Security and troubleshooting
-
-- Expose `8010/http`, not `8010/tcp`. RunPod's HTTP proxy provides HTTPS, but
-  HTTPS is transport protection, not application authentication; keep the
-  SceneWorks token enabled.
-- Never publish a raw TCP port for SceneWorks without an additional,
-  independently verified authentication and TLS boundary. A raw TCP mapping
-  bypasses RunPod's HTTPS proxy.
-- Treat the proxy URL as public. Do not put the SceneWorks token in its query
-  string, browser history, screenshots, logs, template JSON, or support
-  messages.
-- A Pod can be marked Running before its service is ready. Check telemetry and
-  logs, then retry the HTTP Services link.
-- If startup reports that a managed directory is not writable, verify that the
-  volume is attached at `/workspace` and that its export/ACL permits writes by
-  the container's root user.
-- If a model remains gated, verify that `HF_TOKEN` is present, the Hugging Face
-  account has accepted the repository's license, and the Pod was restarted
-  after adding the environment variable.
-- RunPod documents a 100-second Cloudflare proxy timeout for a service that has
-  not responded. SceneWorks generation uses short asynchronous API requests,
-  and `/api/v1/jobs/events` responds immediately before carrying progress as
-  SSE. The stream sends a 15-second heartbeat so an otherwise idle connection
-  continues to produce traffic. The web client reconnects with a new
-  short-lived event ticket if the connection is interrupted.
-- RunPod does not currently document a separate Pod HTTP-proxy request-body
-  limit. SceneWorks itself accepts a streaming multipart body up to 2 GiB, so
-  the file must remain slightly below that ceiling to leave room for framing.
-  Upload success still depends on sending the request body and receiving the
-  response within the proxy's timeout; use a stable uplink and retry a failed
-  import. Transcode or split very large video into parts that fit the tested
-  envelope rather than exposing an unauthenticated raw TCP port.
-
-## Validate the proxy path
-
-Before treating a new Pod, region, or RunPod proxy revision as production
-ready, verify the actual path with a real media file. The repository's probe:
-
-- connects to the authenticated job-event stream and requires the initial
-  `ready` event;
-- creates a harmless placeholder job and requires its matching `job.updated`
-  event within 10 seconds, then cancels if necessary and clears the probe job;
-- keeps that same SSE connection open for 110 seconds, past the documented
-  100-second boundary, and requires at least five 15-second heartbeat events;
-- streams a representative image or video of at least 100 MiB as multipart
-  data through the public proxy, requires a successful asset import, and
-  deletes the imported probe asset afterward.
-
-The token is accepted only through the environment and is never printed. The
-result also redacts the Pod ID. On macOS/Linux:
+macOS/Linux:
 
 ```bash
-export SCENEWORKS_BASE_URL='https://<podid>-8010.proxy.runpod.net'
+export SCENEWORKS_BASE_URL='https://<pod-id>-8010.proxy.runpod.net'
 read -rsp 'SceneWorks access token: ' SCENEWORKS_ACCESS_TOKEN
 export SCENEWORKS_ACCESS_TOKEN
 node scripts/validate-runpod-proxy.mjs \
@@ -299,43 +407,29 @@ node scripts/validate-runpod-proxy.mjs \
 unset SCENEWORKS_ACCESS_TOKEN
 ```
 
-On PowerShell:
+PowerShell:
 
 ```powershell
-$env:SCENEWORKS_BASE_URL = 'https://<podid>-8010.proxy.runpod.net'
+$env:SCENEWORKS_BASE_URL = 'https://<pod-id>-8010.proxy.runpod.net'
 $env:SCENEWORKS_ACCESS_TOKEN = Read-Host 'SceneWorks access token'
 node scripts/validate-runpod-proxy.mjs `
   --upload-file C:\path\to\representative-large-video.mp4
 Remove-Item Env:SCENEWORKS_ACCESS_TOKEN
 ```
 
-Also keep the browser UI open while submitting a real generation job. Confirm
-that its queue card and progress change before the job completes; the probe
-validates the same transport, while this manual check confirms the UI consumes
-it. Record the file size, elapsed upload time, event latency, heartbeat count,
-observation duration, and any `524` or disconnect. Never record the access
-token, event ticket, full proxy hostname, or Pod ID in committed evidence.
+The probe redacts the Pod ID and never prints the token. Also keep the browser
+open during one real generation and confirm that its Queue card updates before
+the job completes.
 
-### Measured live result
+The live proxy validation on 2026-07-24 also established a reference result:
 
-On 2026-07-24, the probe passed through a real RunPod Pod HTTPS proxy:
+- the same SSE connection stayed open beyond the documented `100-second`
+  boundary and delivered a `15-second heartbeat`, totaling
+  **seven heartbeat events** over 110 seconds;
+- the browser Queue moved through `Preparing / 10%` and completed without a
+  direct-origin URL; and
+- a valid `105,000,054-byte` (100.14 MiB) upload completed in `33.851 seconds`
+  and the probe asset was removed afterward.
 
-- the initial SSE `ready` event arrived in 528 ms;
-- the matching `job.updated` event arrived in 464 ms, before the job request
-  completed its wider workflow;
-- the same connection remained open for the full 110-second observation and
-  delivered seven heartbeat events, with no buffering or premature disconnect;
-- in the browser UI at 2026-07-24T22:45:51Z, the proxied queue showed the same
-  placeholder job live at Preparing / 10% on the CPU utility worker, then
-  Completed / 100% after six seconds, without using a direct-origin URL;
-- a valid 105,000,054-byte (100.14 MiB) BMP completed as a streaming multipart
-  upload in 33.851 seconds with HTTP 201; and
-- the probe asset was trashed and permanently purged after validation.
-
-This establishes the tested body-size envelope at 100.14 MiB; it does not claim
-that RunPod has no higher undocumented cap. The 110-second connected stream
-also shows that the documented 100-second timeout does not terminate an SSE
-response that starts immediately and continues delivering heartbeat traffic.
-
-RunPod's current [HTTP proxy documentation](https://docs.runpod.io/pods/configuration/expose-ports)
-describes the proxy chain and timeout.
+This is a measured envelope, not a promise that RunPod has no higher
+undocumented limit.


### PR DESCRIPTION
## Summary
- rewrite the RunPod guide as an eight-step, human-oriented deployment flow
- document secrets, persistent storage, GPU selection, first generation, lifecycle, upgrades, and troubleshooting
- explain how official release tags publish the RunPod image
- add a prominent RunPod support section and guide link to the root README

## Validation
- npm.cmd run check
- npm.cmd run check:docker:runpod
- git diff --check
- verified local Markdown links resolve