### PR TITLE
chore(ci): harden platform scripts [sc-13650]

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -162,14 +162,14 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          changed="$(gh pr view "${{ github.event.pull_request.number }}" --json files --jq '.files[].path')"
-          if printf '%s\n' "$changed" | grep -qE '^(docker/|config/|docker-compose\.yml|Cargo\.lock|\.github/workflows/check\.yml|scripts/check-(docker-api-runtime|compose-config)\.mjs)'; then
-            echo "Docker-relevant files changed; running the Docker runtime smoke."
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No Docker-relevant changes; skipping the Docker runtime smoke (sc-10823)."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
+          pr="${{ github.event.pull_request.number }}"
+          changed_file_count="$(gh api "repos/${GH_REPO}/pulls/${pr}" --jq '.changed_files')"
+          # The files endpoint pages at 100 and caps very large PRs at 3,000. The helper
+          # compares the returned count with `changed_files`; any truncation runs the
+          # smoke conservatively instead of treating an unseen Docker input as irrelevant.
+          gh api --paginate "repos/${GH_REPO}/pulls/${pr}/files?per_page=100" \
+            --jq '.[].filename' |
+            node scripts/docker-smoke-relevance.mjs --expected-count "$changed_file_count"
       - name: Smoke default Rust API Docker runtime
         if: steps.docker_smoke_gate.outputs.run == 'true'
         env:

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -53,6 +53,7 @@ on:
       - "Cargo.lock"
       # Root build script (api:build:embedded:candle) driven by build-sidecar.mjs.
       - "package.json"
+      - ".github/actions/prepare-rust-runner/**"
       - ".github/workflows/desktop-windows.yml"
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ concurrency:
 jobs:
   macos:
     # Self-hosted macOS 26.2 runner; same-repo only — never run fork code.
-    if: ${{ github.repository == 'SceneWorks/SceneWorks' }}
+    if: ${{ github.repository == 'SceneWorks/SceneWorks' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: [self-hosted, macOS, ARM64, nax]
     env:
       CARGO_NET_OFFLINE: "true"
@@ -202,7 +202,9 @@ jobs:
             '## Linux x86_64 (CUDA GPU)' \
             'Run the AppImage or install the .deb on Ubuntu 22.04/24.04. Requires an NVIDIA GPU; the CUDA/cuDNN runtime is downloaded on first launch.')
           args=(--draft --generate-notes --title "SceneWorks $TAG" --notes "$notes")
-          case "$TAG" in *-*) args+=(--prerelease) ;; esac
+          if [[ "${TAG#v}" == *-* ]]; then
+            args+=(--prerelease)
+          fi
           # Attach the DMG (fresh install) + the updater tarball (in-app update payload).
           gh release create "$TAG" "${args[@]}" "${dmgs[0]}" "${tarballs[0]}"
 
@@ -226,7 +228,7 @@ jobs:
     # build-windows job — keep them in sync. This is the heavy candle CUDA release
     # build (the SHIPPED artifacts), so it needs the CUDA Toolkit + MSVC toolset.
     needs: macos
-    if: ${{ github.repository == 'SceneWorks/SceneWorks' }}
+    if: ${{ github.repository == 'SceneWorks/SceneWorks' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: windows-2022
     env:
       # compute_80 PTX the driver JITs forward to sm_120 — one binary covers
@@ -374,7 +376,7 @@ jobs:
     # Serializing the latest.json read/modify/write prevents platform entries
     # from clobbering one another. Build steps mirror desktop-linux.yml.
     needs: windows
-    if: ${{ github.repository == 'SceneWorks/SceneWorks' }}
+    if: ${{ github.repository == 'SceneWorks/SceneWorks' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-22.04
     env:
       # Build-side constant, not a secret. Keep this and the CUDA pin aligned

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -54,6 +54,7 @@ on:
       - "config/manifests/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - ".github/actions/prepare-rust-runner/**"
       - ".github/workflows/windows-candle.yml"
   pull_request:
     branches: [main]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "docker compose up --build",
     "stack:up": "docker compose up --build",
     "stack:down": "docker compose down",
-    "check": "node scripts/check-scaffold.mjs && node scripts/check-runpod-publish-workflow.mjs && node scripts/check-runpod-template.mjs && node --test scripts/validate-runpod-proxy.test.mjs",
+    "check": "node scripts/check-scaffold.mjs && node scripts/check-runpod-publish-workflow.mjs && node scripts/check-runpod-template.mjs && node --test scripts/validate-runpod-proxy.test.mjs scripts/docker-smoke-relevance.test.mjs scripts/platform-review-contracts.test.mjs scripts/lib/jsonc.test.mjs",
     "check:compose": "node scripts/check-compose-config.mjs",
     "check:health": "node scripts/check-health.mjs",
     "check:nc-weights": "node scripts/check-no-nc-weights.mjs",

--- a/scripts/check-docker-api-runtime.mjs
+++ b/scripts/check-docker-api-runtime.mjs
@@ -126,18 +126,9 @@ async function main() {
       throw error;
     }
   } finally {
-    // The api service runs as root in the container, so anything it seeds into the
-    // bind-mounted data dir is root-owned — notably data/projects/global-poses.sceneworks,
-    // the global pose store the API creates on boot (apps/rust-api ensure_global_poses_project).
-    // The host CI user then can't remove those files (EACCES on rmdir; fs.rm's `force`
-    // ignores ENOENT, not EACCES). Delete the root-owned tree from inside a one-off root
-    // container first. Scope it to data/projects so we never touch the Hugging Face cache
-    // bind-mounted under data/cache/huggingface.
-    await runDocker([
-      ...compose, "run", "--rm", "--no-deps", "--entrypoint", "rm", "api", "-rf", "/sceneworks/data/projects",
-    ], env).catch((error) => {
-      console.error(error.message);
-    });
+    // Compose runs the API as the calling host uid/gid above, so its bind-mounted
+    // files are host-removable. Tear the container down before removing the scratch
+    // root; no privileged cleanup container is needed.
     await runDocker([...compose, "down", "--remove-orphans"], env).catch((error) => {
       console.error(error.message);
     });

--- a/scripts/check-download-patterns.mjs
+++ b/scripts/check-download-patterns.mjs
@@ -44,54 +44,11 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { stripJsoncComments } from "./lib/jsonc.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const MODEL_MANIFEST = "config/manifests/builtin.models.jsonc";
 const LORA_MANIFEST = "config/manifests/builtin.loras.jsonc";
-
-// -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-no-nc-weights.mjs. --
-function stripJsoncComments(body) {
-  let result = "";
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < body.length; index += 1) {
-    const char = body[index];
-    const next = body[index + 1];
-    if (inString) {
-      result += char;
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      result += char;
-      continue;
-    }
-    if (char === "/" && next === "/") {
-      while (index < body.length && body[index] !== "\n") {
-        index += 1;
-      }
-      result += "\n";
-      continue;
-    }
-    if (char === "/" && next === "*") {
-      index += 2;
-      while (index < body.length && !(body[index] === "*" && body[index + 1] === "/")) {
-        index += 1;
-      }
-      index += 1;
-      continue;
-    }
-    result += char;
-  }
-  return result;
-}
 
 // Glob semantics must mirror the worker's `pattern_matches` (imports.rs), which uses the
 // Rust `glob` crate with default MatchOptions — `*` and `?` DO cross `/` there

--- a/scripts/check-health.mjs
+++ b/scripts/check-health.mjs
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-const apiBaseUrl = process.env.SCENEWORKS_API_BASE_URL ?? "http://localhost:8000";
+const apiBaseUrl = process.env.SCENEWORKS_API_BASE_URL ?? "http://localhost:8010";
 
 const response = await fetch(`${apiBaseUrl}/api/v1/health`);
 if (!response.ok) {

--- a/scripts/check-no-nc-weights.mjs
+++ b/scripts/check-no-nc-weights.mjs
@@ -113,6 +113,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import zlib from "node:zlib";
+import { stripJsoncComments } from "./lib/jsonc.mjs";
 
 const root = process.cwd();
 
@@ -256,50 +257,6 @@ const DEFAULT_ARCHIVE_LIMITS = {
   // bounds recursion). Top-level archive = depth 1.
   maxDepth: 8,
 };
-
-// -- JSONC parsing (manifests carry // comments). Mirrors scripts/check-scaffold.mjs. --
-function stripJsoncComments(body) {
-  let result = "";
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < body.length; index += 1) {
-    const char = body[index];
-    const next = body[index + 1];
-    if (inString) {
-      result += char;
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      result += char;
-      continue;
-    }
-    if (char === "/" && next === "/") {
-      while (index < body.length && body[index] !== "\n") {
-        index += 1;
-      }
-      result += "\n";
-      continue;
-    }
-    if (char === "/" && next === "*") {
-      index += 2;
-      while (index < body.length && !(body[index] === "*" && body[index + 1] === "/")) {
-        index += 1;
-      }
-      index += 1;
-      continue;
-    }
-    result += char;
-  }
-  return result;
-}
 
 async function readJsonc(relativePath) {
   const body = await readFile(path.join(root, relativePath), "utf8");

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import process from "node:process";
 import { promptGuideRequiredForModel } from "../apps/web/src/promptGuideContract.js";
 import { describeXmlCommentDefect, findXmlCommentDefects } from "../apps/web/src/entitlementsPlistContract.js";
+import { stripJsoncComments } from "./lib/jsonc.mjs";
 
 const root = process.cwd();
 
@@ -267,49 +268,6 @@ async function assertEmbeddedApiDockerTarget() {
       `${dockerfilePath} rust-api-embed must inherit the unchanged rust-api runtime`,
     );
   }
-}
-
-function stripJsoncComments(body) {
-  let result = "";
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < body.length; index += 1) {
-    const char = body[index];
-    const next = body[index + 1];
-    if (inString) {
-      result += char;
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      result += char;
-      continue;
-    }
-    if (char === "/" && next === "/") {
-      while (index < body.length && body[index] !== "\n") {
-        index += 1;
-      }
-      result += "\n";
-      continue;
-    }
-    if (char === "/" && next === "*") {
-      index += 2;
-      while (index < body.length && !(body[index] === "*" && body[index + 1] === "/")) {
-        index += 1;
-      }
-      index += 1;
-      continue;
-    }
-    result += char;
-  }
-  return result;
 }
 
 async function readJsonc(relativePath) {

--- a/scripts/docker-smoke-relevance.mjs
+++ b/scripts/docker-smoke-relevance.mjs
@@ -1,0 +1,52 @@
+import { appendFile } from "node:fs/promises";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const DOCKER_RELEVANT =
+  /^(?:docker\/|config\/|docker-compose\.yml$|Cargo\.toml$|Cargo\.lock$|\.github\/workflows\/check\.yml$|scripts\/(?:check-(?:docker-api-runtime|compose-config)|docker-smoke-relevance)(?:\.test)?\.mjs$)/;
+
+export function dockerSmokeDecision(changedFileCount, files) {
+  if (!Number.isSafeInteger(changedFileCount) || changedFileCount < 0) {
+    throw new Error(`invalid changed-file count: ${changedFileCount}`);
+  }
+  if (files.length !== changedFileCount) {
+    return {
+      run: true,
+      reason:
+        `GitHub reported ${changedFileCount} changed file(s), but pagination returned ` +
+        `${files.length}; running conservatively.`,
+    };
+  }
+  const relevant = files.find((file) => DOCKER_RELEVANT.test(file));
+  return relevant
+    ? { run: true, reason: `Docker-relevant file changed: ${relevant}` }
+    : { run: false, reason: "No Docker-relevant files changed." };
+}
+
+async function main() {
+  const countIndex = process.argv.indexOf("--expected-count");
+  if (countIndex < 0) {
+    throw new Error("usage: docker-smoke-relevance.mjs --expected-count <count>");
+  }
+  const changedFileCount = Number(process.argv[countIndex + 1]);
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  const files = input.split(/\r?\n/).filter(Boolean);
+  const decision = dockerSmokeDecision(changedFileCount, files);
+  console.log(decision.reason);
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `run=${decision.run}\n`, "utf8");
+  } else {
+    console.log(`run=${decision.run}`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/docker-smoke-relevance.test.mjs
+++ b/scripts/docker-smoke-relevance.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dockerSmokeDecision } from "./docker-smoke-relevance.mjs";
+
+test("root Cargo.toml is Docker relevant", () => {
+  assert.equal(dockerSmokeDecision(1, ["Cargo.toml"]).run, true);
+});
+
+test("an exhaustively listed unrelated pull request skips the Docker smoke", () => {
+  assert.equal(
+    dockerSmokeDecision(2, ["README.md", "apps/web/src/App.jsx"]).run,
+    false,
+  );
+});
+
+test("a paginated result mismatch runs conservatively instead of skipping", () => {
+  const firstThreeThousand = Array.from(
+    { length: 3000 },
+    (_, index) => `docs/change-${index}.md`,
+  );
+  const decision = dockerSmokeDecision(3001, firstThreeThousand);
+  assert.equal(decision.run, true);
+  assert.match(decision.reason, /pagination returned 3000/);
+});

--- a/scripts/lib/jsonc.mjs
+++ b/scripts/lib/jsonc.mjs
@@ -1,0 +1,42 @@
+export function stripJsoncComments(body) {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    const next = body[index + 1];
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      while (index < body.length && body[index] !== "\n") {
+        index += 1;
+      }
+      result += "\n";
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index < body.length && !(body[index] === "*" && body[index + 1] === "/")) {
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}

--- a/scripts/lib/jsonc.test.mjs
+++ b/scripts/lib/jsonc.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { stripJsoncComments } from "./jsonc.mjs";
+
+test("stripJsoncComments removes comments without changing string contents", () => {
+  const source = `{
+    // line comment
+    "url": "https://example.test/a//b",
+    "escaped": "quote: \\" // still a string",
+    /* block
+       comment */
+    "value": 7
+  }`;
+
+  assert.deepEqual(JSON.parse(stripJsoncComments(source)), {
+    url: "https://example.test/a//b",
+    escaped: 'quote: " // still a string',
+    value: 7,
+  });
+});

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+async function source(path) {
+  return readFile(new URL(`../${path}`, import.meta.url), "utf8");
+}
+
+test("Windows workflows watch the local Rust runner action", async () => {
+  for (const workflow of [
+    ".github/workflows/windows-candle.yml",
+    ".github/workflows/desktop-windows.yml",
+  ]) {
+    assert.match(
+      await source(workflow),
+      /^\s+- "\.github\/actions\/prepare-rust-runner\/\*\*"/m,
+      workflow,
+    );
+  }
+});
+
+test("Docker relevance gate paginates and checks for truncated file lists", async () => {
+  const workflow = await source(".github/workflows/check.yml");
+  assert.match(workflow, /gh api --paginate/);
+  assert.match(workflow, /docker-smoke-relevance\.mjs --expected-count/);
+  assert.doesNotMatch(workflow, /gh pr view .*--json files/);
+});
+
+test("every release job is confined to refs/tags/v", async () => {
+  const workflow = await source(".github/workflows/release.yml");
+  const jobConditions = [...workflow.matchAll(/^\s{4}if:\s*(.+)$/gm)].map((match) => match[1]);
+  assert.equal(jobConditions.length, 3);
+  for (const condition of jobConditions) {
+    assert.match(condition, /startsWith\(github\.ref, 'refs\/tags\/v'\)/);
+  }
+  assert.ok(
+    workflow.includes('if [[ "${TAG#v}" == *-* ]]; then'),
+    "prerelease classification must use the validated v-tag",
+  );
+});
+
+test("Lens smoke only terminates processes it started", async () => {
+  const script = await source("scripts/smoke-lens.ps1");
+  assert.doesNotMatch(script, /Get-Process/);
+  assert.match(script, /taskkill \/F \/T \/PID \$\(\$p\.Id\)/);
+});
+
+test("health check defaults to the compose API port", async () => {
+  assert.match(
+    await source("scripts/check-health.mjs"),
+    /http:\/\/localhost:8010/,
+  );
+});
+
+test("Docker cleanup relies on the configured host uid instead of a root container", async () => {
+  const script = await source("scripts/check-docker-api-runtime.mjs");
+  assert.doesNotMatch(script, /--entrypoint", "rm"/);
+  assert.match(script, /SCENEWORKS_UID/);
+});
+
+test("all three manifest scripts import the shared JSONC parser", async () => {
+  for (const scriptPath of [
+    "scripts/check-scaffold.mjs",
+    "scripts/check-download-patterns.mjs",
+    "scripts/check-no-nc-weights.mjs",
+  ]) {
+    const script = await source(scriptPath);
+    assert.match(script, /import \{ stripJsoncComments \} from "\.\/lib\/jsonc\.mjs";/);
+    assert.doesNotMatch(script, /function stripJsoncComments/);
+  }
+});

--- a/scripts/smoke-lens.ps1
+++ b/scripts/smoke-lens.ps1
@@ -65,11 +65,6 @@ $resultsPath = Join-Path $DataDir "lens-smoke-results-$stamp.json"
 $apiProc = $null; $workerProc = $null
 $results = @()
 
-# Clean slate: kill any leftover API/worker from a prior run (else they hold port $Port / the GPU).
-Get-Process -ErrorAction SilentlyContinue |
-  Where-Object { $_.ProcessName -in @("sceneworks-rust-api", "sceneworks-rust-worker") } |
-  ForEach-Object { try { Stop-Process -Id $_.Id -Force -ErrorAction Stop } catch {} }
-Start-Sleep -Seconds 1
 # Remove any stale recent-projects.json: POST /projects reads it, and a corrupt/BOM copy from a prior
 # run makes the API fail project creation with "expected value at line 1 column 1". A clean BOM-less
 # one is written after the project is created.


### PR DESCRIPTION
## Summary
- watch the shared Windows Rust-runner action from both consumer workflows
- make Docker-smoke relevance paginated, truncation-safe, and aware of root Cargo.toml
- share JSONC comment stripping and confine smoke cleanup to owned processes/users
- require v-tags for every release job, derive prerelease from the tag suffix, and use port 8010 by default
- add regression contracts for every repaired behavior

## Validation
- `npm run check`
- `npm run check:docker:rust-api:self-test`
- `npm run check:nc-weights`
- `node scripts/check-no-nc-weights.mjs --self-test`
- `npm run check:compose`
- `actionlint` on all changed workflows, ignoring only existing custom runner labels `cuda` and `nax`
- `git diff --check`

PowerShell is unavailable on the development host; `scripts/platform-review-contracts.test.mjs` verifies PID-confined teardown structurally.

Shortcut: https://app.shortcut.com/trefry/story/13650