### PR TITLE
fix(worker): preflight SVD recipes on 32GB CUDA (sc-14492)

### DIFF
--- a/crates/sceneworks-worker/src/fit_gate.rs
+++ b/crates/sceneworks-worker/src/fit_gate.rs
@@ -164,6 +164,48 @@ pub(crate) fn mochi_needed_gb(
     })
 }
 
+// ---------------------------------------------------------------------------------------------
+// SVD CUDA: evidence-backed hardware/profile boundary (sc-14492)
+// ---------------------------------------------------------------------------------------------
+
+/// Largest SVD burst validated on a real 32 GB RTX PRO 4500.
+#[cfg(any(test, all(not(target_os = "macos"), feature = "backend-candle")))]
+pub(crate) const SVD_32GB_VALIDATED_MAX_FRAMES: u32 = 8;
+
+/// Largest SVD VAE decode chunk validated on a real 32 GB RTX PRO 4500.
+#[cfg(any(test, all(not(target_os = "macos"), feature = "backend-candle")))]
+pub(crate) const SVD_32GB_VALIDATED_MAX_DECODE_CHUNK: u32 = 1;
+
+/// Largest SVD denoise step count validated on a real 32 GB RTX PRO 4500.
+#[cfg(any(test, all(not(target_os = "macos"), feature = "backend-candle")))]
+pub(crate) const SVD_32GB_VALIDATED_MAX_STEPS: u32 = 12;
+
+/// Recommended physical-card class for longer SVD bursts.
+#[cfg(any(test, all(not(target_os = "macos"), feature = "backend-candle")))]
+pub(crate) const SVD_LONG_BURST_RECOMMENDED_VRAM_GB: f64 = 48.0;
+
+/// Whether the requested SVD recipe crosses the only real-hardware boundary currently established:
+/// above 8 frames, a decode chunk above 1, or more than 12 steps on a physical card below the
+/// recommended 48 GB class.
+///
+/// This intentionally does not invent a linear activation formula from the two measured outcomes.
+/// The same 32 GB card completed the full `(8 frames, chunk 1, 12 steps)` tuple at a 19.0 GB observed
+/// peak and OOMed the 25-frame profile twice. Admitting an arbitrary mixture of one proven setting
+/// with unproven defaults would turn the measured tuple into evidence it does not provide.
+#[cfg(any(test, all(not(target_os = "macos"), feature = "backend-candle")))]
+pub(crate) fn svd_profile_needs_larger_card(
+    frames: u32,
+    decode_chunk_size: u32,
+    steps: u32,
+    total_vram_gb: f64,
+) -> bool {
+    let exceeds_validated_profile = frames > SVD_32GB_VALIDATED_MAX_FRAMES
+        || decode_chunk_size > SVD_32GB_VALIDATED_MAX_DECODE_CHUNK
+        || steps > SVD_32GB_VALIDATED_MAX_STEPS;
+    exceeds_validated_profile
+        && total_vram_gb.round() + f64::EPSILON < SVD_LONG_BURST_RECOMMENDED_VRAM_GB
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,5 +292,15 @@ mod tests {
     fn mochi_needed_gb_has_no_signal_without_weights() {
         assert!(mochi_needed_gb(0, 151, 848, 480, 2.0).is_none());
         assert!(mochi_needed_gb(1, 151, 848, 480, 2.0).is_some());
+    }
+
+    /// sc-14492's discriminating real-hardware outcomes: do not collapse them into a model-wide ban.
+    #[test]
+    fn svd_cuda_boundary_requires_the_complete_validated_32gb_profile() {
+        assert!(svd_profile_needs_larger_card(25, 8, 15, 32.0));
+        assert!(svd_profile_needs_larger_card(8, 2, 12, 32.0));
+        assert!(svd_profile_needs_larger_card(8, 1, 13, 32.0));
+        assert!(!svd_profile_needs_larger_card(8, 1, 12, 32.0));
+        assert!(!svd_profile_needs_larger_card(25, 8, 15, 48.0));
     }
 }

--- a/crates/sceneworks-worker/src/video_jobs/candle.rs
+++ b/crates/sceneworks-worker/src/video_jobs/candle.rs
@@ -399,6 +399,47 @@ pub(super) fn resolve_candle_video_conditioning(
     }])
 }
 
+/// The SVD pre-flight's gated result (sc-14492). The frame count used by the engine is obtainable only
+/// by passing the CUDA VRAM check, so the generation arm cannot accidentally bypass admission while
+/// still compiling.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct SvdVramPreflight {
+    pub(super) frames: u32,
+    pub(super) decode_chunk_size: u32,
+    pub(super) steps: u32,
+}
+
+/// Refuse an SVD burst that exceeds the profile validated on this physical VRAM class before resolving
+/// the checkpoint or loading any component. `budget` is resolved by the caller so the decision stays
+/// deterministic under the `SCENEWORKS_CUDA_VRAM_CAP_GB` hardware-emulation lane.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub(super) fn svd_vram_preflight(
+    request: &VideoRequest,
+    gpu_id: &str,
+    budget: Option<crate::vram_gate::VramBudget>,
+) -> WorkerResult<SvdVramPreflight> {
+    let frames = svd_i32(request, "numFrames", "numFrames", 25, 1, 25) as u32;
+    let decode_chunk_size = svd_i32(request, "decodeChunkSize", "decodeChunkSize", 8, 1, 64) as u32;
+    let steps = svd_steps(request);
+    match crate::vram_gate::svd_fit_error(
+        frames,
+        decode_chunk_size,
+        steps,
+        request.width,
+        request.height,
+        gpu_id,
+        budget,
+    ) {
+        Some(error) => Err(error),
+        None => Ok(SvdVramPreflight {
+            frames,
+            decode_chunk_size,
+            steps,
+        }),
+    }
+}
+
 /// The candle Mochi pre-flight's gated result (sc-12306): the tier's baked-in quant marker, obtainable
 /// ONLY by passing the VRAM fit gate.
 ///
@@ -486,9 +527,10 @@ pub(super) fn candle_wan_offload_policy(engine_id: &str) -> OffloadPolicy {
 /// tiers under-count by ~9-11 GiB (which is why a card that cannot fit the job is admitted and then
 /// OOMs — sc-12402's story) and the dense tier over-counts by ~44 GiB.
 ///
-/// `ltx`/`svd` carry no `candle` block and read `0` weights, so both paths return `None` and they are
-/// admitted unchanged — their on-disk bytes are not their loaded set either, so any byte-derived floor
-/// would wall-reject working cards (recorded on `vram_gate::wan_weight_components`; sc-12397).
+/// `ltx`/`svd` carry no `candle` block and read `0` weights, so both paths return `None` in this
+/// Wan-specific helper — their on-disk bytes are not their loaded set either, so any byte-derived floor
+/// would wall-reject working cards (recorded on `vram_gate::wan_weight_components`; sc-12397). SVD is
+/// independently protected by [`svd_vram_preflight`]'s frame-aware hardware-class gate (sc-14492).
 ///
 /// **Takes and returns `model_dir` rather than borrowing it**, so the gate cannot be deleted without
 /// breaking the build — the same "unskippable by construction" property [`MochiVramPreflight`] gets from
@@ -566,11 +608,11 @@ async fn candle_video_vram_budget(settings: &Settings) -> Option<crate::vram_gat
 /// conditioning, builds a `VideoGenInput`, and runs it through the shared [`generate_video`] streaming
 /// driver. Returns the decoded clip + the candle adapter label.
 ///
-/// Every engine passes a VRAM fit gate before the load: Mochi's frame-dependent decode gate (sc-12306),
-/// and the Wan gate — the tier's MEASURED `candle.vramGbByTier` peak where the manifest carries one
-/// (sc-12402), else sc-12344's on-disk weights floor. `ltx`/`svd` are explicitly EXEMPT from both: they
-/// carry no `candle` block AND their on-disk bytes are not their loaded set, so any byte-derived floor
-/// would wall-reject working cards; the reason is recorded on `vram_gate::wan_weight_components`.
+/// Admission is family-specific and happens before load: Mochi's frame-dependent decode gate
+/// (sc-12306), SVD's 32 GB / long-burst gate (sc-14492), and the Wan gate — the tier's MEASURED
+/// `candle.vramGbByTier` peak where the manifest carries one (sc-12402), else sc-12344's on-disk
+/// weights floor. LTX remains exempt because its on-disk bytes are not its loaded set and no measured
+/// peak exists; a byte-derived floor would wall-reject working cards.
 ///
 /// Mochi keeps its own gate rather than joining the Wan one: its AsymmVAE decode is UNTILED, so its peak
 /// grows linearly in clip length and no per-tier constant can express it (sc-12306). Wan's decode is
@@ -655,6 +697,19 @@ pub(super) async fn generate_candle_video_using(
         ensure_mochi_q8_present(api, settings, job, request).await?;
         ensure_mochi_bf16_present(api, settings, job, request).await?;
     }
+    // sc-14492: gate SVD before even resolving its already-installed snapshot. A full/default
+    // 25-frame burst OOMed twice on real 32 GB hardware, while the reduced 8-frame / chunk-1 / 12-step
+    // recipe completed. The returned recipe fields are the only ones the SVD generation arm can
+    // consume, making this check load-bearing.
+    let svd_preflight = if engine_id == "svd_xt" {
+        Some(svd_vram_preflight(
+            request,
+            &settings.gpu_id,
+            candle_video_vram_budget(settings).await,
+        )?)
+    } else {
+        None
+    };
     let snapshot_dir = if is_mochi {
         // Resolve-or-error; never a stub (the candle generic arm has no stub fallback once
         // `candle_video_engine_id` resolves the id).
@@ -697,7 +752,8 @@ pub(super) async fn generate_candle_video_using(
         // the sc-12090 lesson; `candle_wan_tier_key` derives the manifest key from the resolver's own
         // marker for exactly that reason) and BEFORE `ensure_wan_lightning_present` below, so a
         // card that cannot fit the job is refused without first paying for the Lightning fetch. A no-op
-        // for `ltx`/`svd`, which are exempt — see `vram_gate::wan_weight_components`.
+        // for `ltx`/`svd`, which are exempt from THIS Wan gate — SVD already passed its bespoke
+        // frame-aware hardware-class preflight above; see `vram_gate::wan_weight_components`.
         let dir = wan_vram_preflight(
             engine_id,
             &request.model_manifest_entry,
@@ -727,6 +783,11 @@ pub(super) async fn generate_candle_video_using(
     // conditioning_fps). Mirrors the MLX `generate_svd`; the conditioning is the source `Reference`
     // resolved above.
     if engine_id == "svd_xt" {
+        let SvdVramPreflight {
+            frames,
+            decode_chunk_size,
+            steps,
+        } = svd_preflight.expect("svd_xt must pass its VRAM preflight before model resolution");
         let input = VideoGenInput {
             sampler: None,
             scheduler: None,
@@ -735,9 +796,9 @@ pub(super) async fn generate_candle_video_using(
             conditioning,
             width: request.width,
             height: request.height,
-            frames: svd_i32(request, "numFrames", "numFrames", 25, 1, 25) as u32,
+            frames,
             fps: request.fps,
-            steps: Some(svd_steps(request)),
+            steps: Some(steps),
             seed: resolve_video_seed(request) as u64,
             motion_bucket_id: Some(
                 svd_i32(request, "motionBucketId", "motionBucketId", 127, 1, 255) as f32,
@@ -748,9 +809,7 @@ pub(super) async fn generate_candle_video_using(
                 "noiseAugStrength",
                 0.02,
             )),
-            decode_chunk_size: Some(
-                svd_i32(request, "decodeChunkSize", "decodeChunkSize", 8, 1, 64) as u32,
-            ),
+            decode_chunk_size: Some(decode_chunk_size),
             conditioning_fps: Some(svd_i32(request, "conditioningFps", "condFps", 7, 1, 30) as u32),
             ..VideoGenInput::default()
         };

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 #[cfg(target_os = "macos")]
 use super::{bernini::*, ltx::*, mochi::*, scail2::*, svd::*, vace::*, wan::*};
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-use super::{bernini::*, mochi::*, wan::*};
+use super::{bernini::*, mochi::*, svd::*, wan::*};
 
 #[test]
 fn video_jobs_remains_split_into_real_engine_modules() {
@@ -8217,6 +8217,88 @@ mod candle_video_label_tests {
     fn candle_video_engine_ids_map_svd() {
         assert_eq!(candle_video_engine_id("svd"), Some("svd_xt"));
         assert!(is_candle_video_engine("svd"));
+    }
+
+    /// sc-14492: the complete reduced recipe proven on 32 GB must still pass the real candle preflight
+    /// and retain the routing/recipe provenance required by the story.
+    #[test]
+    fn candle_svd_reduced_profile_preserves_provenance_after_vram_preflight() {
+        let request = request(json!({
+            "projectId": "p",
+            "model": "svd",
+            "mode": "image_to_video",
+            "width": 1024,
+            "height": 576,
+            "advanced": { "numFrames": 8, "decodeChunkSize": 1, "steps": 12 }
+        }));
+        let preflight = svd_vram_preflight(
+            &request,
+            "0",
+            crate::vram_gate::apply_vram_cap(None, Some(32.0)),
+        )
+        .expect("the real-hardware-validated reduced profile remains admitted");
+        assert_eq!(preflight.frames, 8);
+        assert_eq!(preflight.decode_chunk_size, 1);
+        assert_eq!(preflight.steps, 12);
+        assert_eq!(candle_video_engine_id(&request.model), Some("svd_xt"));
+        assert_eq!(candle_video_adapter_label("svd_xt"), "candle_svd");
+
+        let raw = svd_raw_settings(&request);
+        assert_eq!(raw["model"], json!("svd"));
+        assert_eq!(raw["numFrames"], json!(8));
+        assert_eq!(raw["decodeChunkSize"], json!(1));
+        assert_eq!(raw["steps"], json!(12));
+        assert_eq!(raw["realModelInference"], json!(true));
+    }
+
+    /// sc-14492's production-order pin: drive the real async candle arm under a synthetic 32 GB
+    /// hardware class. The default SVD recipe must return the actionable VRAM refusal before snapshot
+    /// resolution, source-image IO, or the supplied loader. A helper-only test would stay green if the
+    /// production call were deleted or moved below model load.
+    #[test]
+    fn generate_candle_svd_refuses_the_default_32gb_recipe_before_loading() {
+        let probe = ArmProbe::default();
+        let request = request(json!({
+            "projectId": "p",
+            "model": "svd",
+            "mode": "image_to_video",
+            "quality": "fast",
+            "width": 1024,
+            "height": 576
+        }));
+        let settings = offline_settings();
+        let job = mochi_job_snapshot();
+        let loader = probe.loader();
+        let out = temp_env_var(crate::vram_gate::CUDA_VRAM_CAP_ENV, "32", || {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime builds")
+                .block_on(generate_candle_video_using(
+                    &ApiClient::new(&settings),
+                    &settings,
+                    &job,
+                    &request,
+                    std::path::Path::new(""),
+                    "candle",
+                    loader,
+                ))
+        });
+
+        let message = out
+            .err()
+            .expect("the default SVD recipe must be rejected on a 32 GB card")
+            .to_string();
+        assert!(
+            message.contains("rejected before model load")
+                && message.contains("decodeChunkSize=1")
+                && message.contains("12 steps"),
+            "the production arm must surface the complete actionable SVD preflight: {message}"
+        );
+        assert!(
+            !probe.loaded(),
+            "the SVD preflight must refuse before snapshot resolution and engine load"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -209,8 +209,9 @@ fn candle_video_families_keep_explicit_cross_module_boundaries() {
         "Candle-shared VACE imports must not pull in macOS-only generation symbols"
     );
     assert!(
-        test_imports.contains("use super::{bernini::*, mochi::*, wan::*};")
-            && !test_imports.contains("use super::{bernini::*, mochi::*, vace::*, wan::*};"),
+        test_imports.contains("use super::{bernini::*, mochi::*, svd::*, wan::*};")
+            && !test_imports
+                .contains("use super::{bernini::*, mochi::*, svd::*, vace::*, wan::*};"),
         "Candle tests must not import the unused VACE family glob"
     );
     for dispatch in [

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -408,6 +408,55 @@ fn mochi_too_big_error(
 }
 
 // ---------------------------------------------------------------------------------------------
+// SVD candle-video long-burst gate (sc-14492)
+// ---------------------------------------------------------------------------------------------
+
+/// Pure SVD CUDA admission decision for the candle lane.
+///
+/// A 32 GB RTX PRO 4500 completed an 8-frame, decode-chunk-1, 12-step 1024x576 render but OOMed the
+/// supported/default 25-frame render, including a retry with `decodeChunkSize=2`. Until the provider
+/// gains a measured, shape-dependent peak model, only that complete proven profile (or lower settings)
+/// is admitted below the recommended 48 GB card class. Missing telemetry admits, matching every other
+/// fit gate: no invented signal means no rejection.
+///
+/// The check keys off physical `total_gb`, not momentary `free_gb`. This story establishes a hardware
+/// incompatibility even on an otherwise available 32 GB card; it does not establish a trustworthy
+/// transient-working-set threshold for larger but busy cards.
+pub(crate) fn svd_fit_error(
+    frames: u32,
+    decode_chunk_size: u32,
+    steps: u32,
+    width: u32,
+    height: u32,
+    gpu_id: &str,
+    budget: Option<VramBudget>,
+) -> Option<WorkerError> {
+    let budget = budget?;
+    if !crate::fit_gate::svd_profile_needs_larger_card(
+        frames,
+        decode_chunk_size,
+        steps,
+        budget.total_gb,
+    ) {
+        return None;
+    }
+    Some(WorkerError::InvalidPayload(format!(
+        "Stable Video Diffusion's {frames}-frame, decode-chunk-{decode_chunk_size}, {steps}-step \
+         {width}x{height} CUDA profile is not supported on \
+         GPU {gpu_id}'s {total} GB VRAM class: the default 25-frame profile OOMed on real 32 GB \
+         hardware, while the validated reduced profile completed with {validated_frames} frames, \
+         decodeChunkSize={validated_chunk}, and {validated_steps} steps. Use that complete reduced \
+         profile (or lower settings), or use a GPU with at least {recommended} GB VRAM (the recommended \
+         minimum for other SVD recipes). The job was rejected before model load.",
+        total = budget.total_gb.round() as i64,
+        validated_frames = crate::fit_gate::SVD_32GB_VALIDATED_MAX_FRAMES,
+        validated_chunk = crate::fit_gate::SVD_32GB_VALIDATED_MAX_DECODE_CHUNK,
+        validated_steps = crate::fit_gate::SVD_32GB_VALIDATED_MAX_STEPS,
+        recommended = crate::fit_gate::SVD_LONG_BURST_RECOMMENDED_VRAM_GB.round() as i64,
+    )))
+}
+
+// ---------------------------------------------------------------------------------------------
 // The Wan candle video weights-floor gate (epic 1788 / sc-12344)
 // ---------------------------------------------------------------------------------------------
 //
@@ -772,6 +821,42 @@ mod tests {
         );
         // No reading, no cap ⇒ None.
         assert_eq!(apply_vram_cap(None, None), None);
+    }
+
+    /// sc-14492: the default 25-frame SVD CUDA profile OOMed twice on a real 32 GB RTX PRO 4500,
+    /// while the reduced `(8 frames, chunk 1, 12 steps)` profile completed on that exact card at a
+    /// 19.0 GB observed peak. The admission decision must distinguish that complete recipe rather than
+    /// wall-rejecting SVD wholesale or generalizing one setting beyond the evidence.
+    #[test]
+    fn svd_cuda_preflight_requires_the_complete_validated_32gb_recipe() {
+        let card_32 = apply_vram_cap(None, Some(32.0));
+        let full = svd_fit_error(25, 8, 15, 1024, 576, "0", card_32)
+            .expect("the default 25-frame profile must be rejected before model load on 32 GB");
+        let message = full.to_string();
+        assert!(
+            message.contains("48 GB")
+                && message.contains("8 frames")
+                && message.contains("decodeChunkSize=1")
+                && message.contains("12 steps"),
+            "rejection must recommend the minimum card and the complete reduced profile: {message}"
+        );
+        assert!(
+            svd_fit_error(8, 1, 12, 1024, 576, "0", card_32).is_none(),
+            "the real-hardware-validated reduced recipe must remain runnable on 32 GB"
+        );
+        assert!(
+            svd_fit_error(8, 2, 12, 1024, 576, "0", card_32).is_some()
+                && svd_fit_error(8, 1, 13, 1024, 576, "0", card_32).is_some(),
+            "changing either unproven setting must reject instead of extrapolating the measured tuple"
+        );
+        assert!(
+            svd_fit_error(25, 8, 15, 1024, 576, "0", apply_vram_cap(None, Some(48.0))).is_none(),
+            "the documented full burst is admitted at the recommended 48 GB minimum"
+        );
+        assert!(
+            svd_fit_error(25, 8, 15, 1024, 576, "0", None).is_none(),
+            "missing telemetry must preserve the fit-gate convention: admit without invented evidence"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject unvalidated SVD recipes on sub-48GB CUDA cards before snapshot resolution or model load
- preserve the real-hardware-validated 32GB recipe: 1024x576, 8 frames, decode chunk 1, 12 steps
- keep `model=svd`, `adapter=candle_svd`, and `realModelInference=true` provenance intact

## Acceptance criteria
- [x] Default 25-frame SVD is truthfully rejected on 32GB with a clear 48GB minimum recommendation and complete reduced-profile fallback
- [x] Discriminating helper and production-arm regressions cover reject/admit behavior and prove the loader is untouched
- [ ] Revalidate the patched worker on real 32GB CUDA hardware and record settings, outcome, and peak VRAM
- [x] Preserve SVD routing and provenance

## Validation
- `cargo test -p sceneworks-worker --no-default-features svd_cuda_boundary_requires_the_complete_validated_32gb_profile`
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`
- candle worker all-target clippy under `backend-candle` with `-D warnings`
- rust-api `backend-candle` check
- rustfmt check and `git diff --check`
- independent adversarial review: PASS (high confidence)

## Hardware validation
The pre-change RTX PRO 4500 evidence is recorded in sc-14492: default 25 frames OOMed, while 8 frames / chunk 1 / 12 steps completed at a 19.0GB observed peak. A fresh post-change 32GB run remains required before this draft is ready to merge.

Shortcut: https://app.shortcut.com/trefry/story/14492/svd-cuda-render-ooms-on-32gb-rtx-pro-4500-after-successful-model-install