### PR TITLE
fix(security): harden remaining low-risk boundaries [sc-13639]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6253,6 +6253,8 @@ dependencies = [
  "sceneworks-worker",
  "serde",
  "serde_json",
+ "sha2",
+ "subtle",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -25,6 +25,8 @@ sceneworks-mcp = { path = "../../crates/sceneworks-mcp" }
 sceneworks-worker = { path = "../../crates/sceneworks-worker" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
+subtle = "2.6"
 tokio = { version = "1.40", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = { workspace = true }

--- a/apps/rust-api/src/auth.rs
+++ b/apps/rust-api/src/auth.rs
@@ -1,6 +1,8 @@
 use super::*;
 use axum::extract::ConnectInfo;
+use sha2::{Digest, Sha256};
 use std::net::{IpAddr, SocketAddr};
+use subtle::ConstantTimeEq;
 
 // sc-8870 (F-068): failed-attempt throttle for the token oracle. `POST
 // /api/v1/auth/verify` is public and returns `{ok}` for any candidate token, and
@@ -313,10 +315,9 @@ pub(crate) fn is_authorized(headers: &HeaderMap, settings: &Settings) -> bool {
     if settings.access_token.is_empty() {
         return true;
     }
-    constant_time_eq(
-        token_from_headers(headers).as_bytes(),
-        settings.access_token.as_bytes(),
-    )
+    let candidate = token_digest(token_from_headers(headers).as_bytes());
+    let expected = token_digest(settings.access_token.as_bytes());
+    candidate.ct_eq(&expected).into()
 }
 
 fn token_from_headers(headers: &HeaderMap) -> String {
@@ -338,12 +339,6 @@ fn token_from_headers(headers: &HeaderMap) -> String {
         .to_owned()
 }
 
-fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
-    if left.len() != right.len() {
-        return false;
-    }
-    left.iter()
-        .zip(right.iter())
-        .fold(0, |difference, (left, right)| difference | (left ^ right))
-        == 0
+pub(crate) fn token_digest(token: &[u8]) -> [u8; 32] {
+    Sha256::digest(token).into()
 }

--- a/apps/rust-api/src/control_overlays.rs
+++ b/apps/rust-api/src/control_overlays.rs
@@ -108,13 +108,14 @@ pub(crate) async fn control_overlay_catalog(
 
 /// Resolve a selected control overlay id (`advanced.controlWeights.overlayId`, set by the Studio's
 /// ControlPanel picker) to what the worker strict-control lane (`ensure_krea_control_weights`) reads
-/// (sc-10165 B4 + sc-8466). An INSTALLED overlay resolves to its `.safetensors` path
-/// (`advanced.controlWeights.path`, studio-trained/registered or an already-cached hosted overlay); a
-/// hosted overlay not yet on disk (the built-in beta or any un-cached hosted entry) resolves to
-/// `advanced.controlWeights.{repo,filename}` so the worker lazy-downloads it on first use (the FLUX.2
-/// control precedent). A no-op when no overlay is selected. A selected-but-unknown overlay, or a
-/// training/local overlay that is not installed, is a clean 400 rather than a deep worker error. Mirrors
-/// the LoRA id→path resolution: one catalog snapshot, in-place `advanced` mutation.
+/// (sc-10165 B4 + sc-8466). A hosted overlay always resolves to its immutable
+/// `advanced.controlWeights.{repo,filename,revision}` tuple, even when the catalog normalization found
+/// something cached: `installState`/`installedPath` may be derived from a mutable `refs/main` entry and
+/// is not authority to replace the pinned snapshot. An installed training/local overlay resolves to its
+/// `.safetensors` path. A no-op when no overlay is selected. A selected-but-unknown overlay, a hosted
+/// overlay without a 40-hex revision, or a training/local overlay that is not installed is a clean 400
+/// rather than a deep worker error. Mirrors the LoRA id→path resolution: one catalog snapshot, in-place
+/// `advanced` mutation.
 pub(crate) async fn resolve_control_overlay_selection(
     state: &AppState,
     project_id: Option<&str>,
@@ -151,49 +152,7 @@ pub(crate) async fn resolve_control_overlay_selection(
         }
     }
 
-    // What the worker resolves the overlay from: an installed local `.safetensors` (`controlWeights.path`
-    // — studio-trained/registered, or an already-cached hosted overlay), else a hosted repo/filename it
-    // lazy-downloads on first use (`controlWeights.{repo,filename}` — the built-in beta or any not-yet-
-    // cached hosted overlay). A training/local overlay that is not installed is a real 400.
-    let installed = overlay.get("installState").and_then(Value::as_str) == Some("installed");
-    let weights: Vec<(&str, Value)> = if installed {
-        let installed_path = overlay
-            .get("installedPath")
-            .and_then(Value::as_str)
-            .ok_or_else(|| {
-                ApiError::bad_request(format!(
-                    "Control overlay '{overlay_id}' has no installed weights"
-                ))
-            })?;
-        let weights_path = resolve_overlay_weights_file(installed_path, overlay.get("files"))
-            .ok_or_else(|| {
-                ApiError::bad_request(format!(
-                    "Control overlay '{overlay_id}' weights (.safetensors) not found under {installed_path}"
-                ))
-            })?;
-        vec![("path", Value::String(weights_path))]
-    } else if overlay
-        .pointer("/source/provider")
-        .or_else(|| overlay.get("provider"))
-        .and_then(Value::as_str)
-        == Some("huggingface")
-    {
-        let (repo, filename, revision) =
-            hosted_overlay_repo_file(&overlay).ok_or_else(|| {
-                ApiError::bad_request(format!(
-                    "Control overlay '{overlay_id}' must register one weights file and a pinned 40-hex source.revision"
-                ))
-            })?;
-        vec![
-            ("repo", Value::String(repo)),
-            ("filename", Value::String(filename)),
-            ("revision", Value::String(revision)),
-        ]
-    } else {
-        return Err(ApiError::bad_request(format!(
-            "Control overlay '{overlay_id}' is not installed"
-        )));
-    };
+    let weights = authorized_overlay_weights(&overlay_id, &overlay)?;
 
     let advanced = job_payload
         .entry("advanced".to_owned())
@@ -215,6 +174,57 @@ pub(crate) async fn resolve_control_overlay_selection(
         }
     }
     Ok(())
+}
+
+/// Translate one catalog entry to the only worker location the API will authorize.
+///
+/// Hosted entries are checked first and always stay a pinned remote tuple. This deliberately
+/// disregards a normalized `installedPath`: only the worker's exact `snapshots/<revision>/<file>`
+/// resolver may turn the tuple into a local path. Local training entries retain their installed
+/// `.safetensors` behavior.
+fn authorized_overlay_weights(
+    overlay_id: &str,
+    overlay: &Value,
+) -> Result<Vec<(&'static str, Value)>, ApiError> {
+    let hosted = overlay
+        .pointer("/source/provider")
+        .or_else(|| overlay.get("provider"))
+        .and_then(Value::as_str)
+        == Some("huggingface");
+    if hosted {
+        let (repo, filename, revision) = hosted_overlay_repo_file(overlay).ok_or_else(|| {
+            ApiError::bad_request(format!(
+                "Control overlay '{overlay_id}' must register one weights file and a pinned 40-hex source.revision"
+            ))
+        })?;
+        return Ok(vec![
+            ("repo", Value::String(repo)),
+            ("filename", Value::String(filename)),
+            ("revision", Value::String(revision)),
+        ]);
+    }
+
+    let installed = overlay.get("installState").and_then(Value::as_str) == Some("installed");
+    if installed {
+        let installed_path = overlay
+            .get("installedPath")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ApiError::bad_request(format!(
+                    "Control overlay '{overlay_id}' has no installed weights"
+                ))
+            })?;
+        let weights_path = resolve_overlay_weights_file(installed_path, overlay.get("files"))
+            .ok_or_else(|| {
+                ApiError::bad_request(format!(
+                    "Control overlay '{overlay_id}' weights (.safetensors) not found under {installed_path}"
+                ))
+            })?;
+        return Ok(vec![("path", Value::String(weights_path))]);
+    }
+    Err(ApiError::bad_request(format!(
+        "Control overlay '{overlay_id}' is not installed"
+    )))
 }
 
 /// The (repo, filename) of a hosted overlay entry (`source.provider="huggingface"` + `source.repo` +
@@ -389,6 +399,57 @@ mod tests {
             "source": { "provider": "huggingface", "repo": "acme/x", "file": "w.safetensors" }
         });
         assert_eq!(hosted_overlay_repo_file(&overlay), None);
+    }
+
+    #[test]
+    fn already_cached_hosted_overlay_still_requires_a_pinned_revision() {
+        let cache = tempfile::tempdir().expect("cache dir");
+        let mutable_main = cache.path().join("refs-main/w.safetensors");
+        std::fs::create_dir_all(mutable_main.parent().unwrap()).expect("cache parent");
+        std::fs::write(&mutable_main, b"cached").expect("cached weights");
+        let overlay = json!({
+            "installState": "installed",
+            "installedPath": mutable_main,
+            "source": {
+                "provider": "huggingface",
+                "repo": "acme/x",
+                "file": "w.safetensors"
+            }
+        });
+        assert!(
+            authorized_overlay_weights("cached-without-pin", &overlay).is_err(),
+            "a mutable cached path must not bypass the hosted revision requirement"
+        );
+    }
+
+    #[test]
+    fn installed_hosted_overlay_remains_an_immutable_remote_tuple() {
+        let overlay = json!({
+            "installState": "installed",
+            "installedPath": "/cache/models--acme--x/refs/main/w.safetensors",
+            "source": {
+                "provider": "huggingface",
+                "repo": "acme/x",
+                "file": "w.safetensors",
+                "revision": "0123456789abcdef0123456789abcdef01234567"
+            }
+        });
+        let weights = authorized_overlay_weights("cached-with-pin", &overlay).unwrap();
+        assert_eq!(
+            weights,
+            vec![
+                ("repo", Value::String("acme/x".to_owned())),
+                ("filename", Value::String("w.safetensors".to_owned())),
+                (
+                    "revision",
+                    Value::String("0123456789abcdef0123456789abcdef01234567".to_owned())
+                )
+            ]
+        );
+        assert!(
+            weights.iter().all(|(key, _)| *key != "path"),
+            "only the worker's pinned-snapshot resolver may produce a hosted local path"
+        );
     }
 
     #[test]

--- a/apps/rust-api/src/control_overlays.rs
+++ b/apps/rust-api/src/control_overlays.rs
@@ -120,6 +120,7 @@ pub(crate) async fn resolve_control_overlay_selection(
     project_id: Option<&str>,
     job_payload: &mut JsonObject,
 ) -> Result<(), ApiError> {
+    validate_raw_control_weights(job_payload)?;
     let Some(overlay_id) = job_payload
         .get("advanced")
         .and_then(Value::as_object)
@@ -139,13 +140,23 @@ pub(crate) async fn resolve_control_overlay_selection(
         .into_iter()
         .find(|item| item.get("id").and_then(Value::as_str) == Some(overlay_id.as_str()))
         .ok_or_else(|| ApiError::bad_request(format!("Control overlay not found: {overlay_id}")))?;
+    if let (Some(model), Some(base_model)) = (
+        job_payload.get("model").and_then(Value::as_str),
+        overlay.get("baseModel").and_then(Value::as_str),
+    ) {
+        if model != base_model {
+            return Err(ApiError::bad_request(format!(
+                "Control overlay '{overlay_id}' is registered for {base_model}, not {model}"
+            )));
+        }
+    }
 
     // What the worker resolves the overlay from: an installed local `.safetensors` (`controlWeights.path`
     // — studio-trained/registered, or an already-cached hosted overlay), else a hosted repo/filename it
     // lazy-downloads on first use (`controlWeights.{repo,filename}` — the built-in beta or any not-yet-
     // cached hosted overlay). A training/local overlay that is not installed is a real 400.
     let installed = overlay.get("installState").and_then(Value::as_str) == Some("installed");
-    let weights: Vec<(&str, String)> = if installed {
+    let weights: Vec<(&str, Value)> = if installed {
         let installed_path = overlay
             .get("installedPath")
             .and_then(Value::as_str)
@@ -160,9 +171,24 @@ pub(crate) async fn resolve_control_overlay_selection(
                     "Control overlay '{overlay_id}' weights (.safetensors) not found under {installed_path}"
                 ))
             })?;
-        vec![("path", weights_path)]
-    } else if let Some((repo, filename)) = hosted_overlay_repo_file(&overlay) {
-        vec![("repo", repo), ("filename", filename)]
+        vec![("path", Value::String(weights_path))]
+    } else if overlay
+        .pointer("/source/provider")
+        .or_else(|| overlay.get("provider"))
+        .and_then(Value::as_str)
+        == Some("huggingface")
+    {
+        let (repo, filename, revision) =
+            hosted_overlay_repo_file(&overlay).ok_or_else(|| {
+                ApiError::bad_request(format!(
+                    "Control overlay '{overlay_id}' must register one weights file and a pinned 40-hex source.revision"
+                ))
+            })?;
+        vec![
+            ("repo", Value::String(repo)),
+            ("filename", Value::String(filename)),
+            ("revision", Value::String(revision)),
+        ]
     } else {
         return Err(ApiError::bad_request(format!(
             "Control overlay '{overlay_id}' is not installed"
@@ -177,8 +203,14 @@ pub(crate) async fn resolve_control_overlay_selection(
             .entry("controlWeights".to_owned())
             .or_insert_with(|| Value::Object(JsonObject::new()));
         if let Some(control_weights) = control_weights.as_object_mut() {
+            // The catalog selection is authoritative. Remove every caller value
+            // before writing the registered location so a mixed payload cannot
+            // retain an injected repo, filename, path, revision, or internal bit.
+            control_weights.clear();
+            control_weights.insert("overlayId".to_owned(), Value::String(overlay_id));
+            control_weights.insert("_catalogAuthorized".to_owned(), Value::Bool(true));
             for (key, value) in weights {
-                control_weights.insert(key.to_owned(), Value::String(value));
+                control_weights.insert(key.to_owned(), value);
             }
         }
     }
@@ -188,7 +220,7 @@ pub(crate) async fn resolve_control_overlay_selection(
 /// The (repo, filename) of a hosted overlay entry (`source.provider="huggingface"` + `source.repo` +
 /// `files[0]`/`source.file`) — the worker lazy-downloads these when the overlay is not yet cached,
 /// mirroring the built-in default in `ensure_krea_control_weights`. `None` for a training/local overlay.
-fn hosted_overlay_repo_file(overlay: &Value) -> Option<(String, String)> {
+fn hosted_overlay_repo_file(overlay: &Value) -> Option<(String, String, String)> {
     let source = overlay.get("source").and_then(Value::as_object);
     let provider = source
         .and_then(|s| s.get("provider"))
@@ -213,7 +245,77 @@ fn hosted_overlay_repo_file(overlay: &Value) -> Option<(String, String)> {
         .map(str::trim)
         .filter(|v| !v.is_empty())?
         .to_owned();
-    Some((repo, filename))
+    let revision = source
+        .and_then(|s| s.get("revision"))
+        .or_else(|| overlay.get("revision"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|revision| {
+            revision.len() == 40
+                && revision
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        })?
+        .to_owned();
+    Some((repo, filename, revision))
+}
+
+/// Reject raw remote/local control-weight locations before a job is queued.
+///
+/// A caller may omit `controlWeights` and use the shipped engine default, name
+/// an exact shipped repo/file tuple, or select a registered `overlayId`. It may
+/// not manufacture a catalog authorization bit or choose an arbitrary remote
+/// repository/path. The worker repeats the engine-specific exact-tuple check.
+fn validate_raw_control_weights(job_payload: &mut JsonObject) -> Result<(), ApiError> {
+    let Some(control_weights) = job_payload
+        .get_mut("advanced")
+        .and_then(Value::as_object_mut)
+        .and_then(|advanced| advanced.get_mut("controlWeights"))
+        .and_then(Value::as_object_mut)
+    else {
+        return Ok(());
+    };
+
+    // Internal fields are derived only after a successful catalog lookup.
+    control_weights.remove("_catalogAuthorized");
+    control_weights.remove("revision");
+
+    let overlay_id = control_weights
+        .get("overlayId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if overlay_id.is_some() {
+        return Ok(());
+    }
+    if control_weights.contains_key("path") {
+        return Err(ApiError::bad_request(
+            "advanced.controlWeights.path requires a registered overlayId",
+        ));
+    }
+
+    let repo = control_weights
+        .get("repo")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let file = control_weights
+        .get("filename")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    match (repo, file) {
+        (None, None) => Ok(()),
+        (Some(repo), Some(file))
+            if sceneworks_core::control_weights::shipped_control_weight_by_repo_file(repo, file)
+                .is_some() =>
+        {
+            Ok(())
+        }
+        _ => Err(ApiError::bad_request(
+            "advanced.controlWeights repo/filename must be an exact shipped artifact or come from a registered overlayId",
+        )),
+    }
 }
 
 /// The overlay's registered `installedPath` may be the overlay dir (the normalized `source.path`) or the
@@ -246,7 +348,8 @@ mod tests {
             "source": {
                 "provider": "huggingface",
                 "repo": "SceneWorks/krea2-pose-controlnet-beta",
-                "file": "should-not-win.safetensors"
+                "file": "should-not-win.safetensors",
+                "revision": "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac"
             },
             "files": ["control_step5000.safetensors"]
         });
@@ -254,7 +357,8 @@ mod tests {
             hosted_overlay_repo_file(&overlay),
             Some((
                 "SceneWorks/krea2-pose-controlnet-beta".to_owned(),
-                "control_step5000.safetensors".to_owned()
+                "control_step5000.safetensors".to_owned(),
+                "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac".to_owned()
             ))
         );
     }
@@ -262,12 +366,29 @@ mod tests {
     #[test]
     fn hosted_overlay_repo_file_falls_back_to_source_file() {
         let overlay = json!({
-            "source": { "provider": "huggingface", "repo": "acme/x", "file": "w.safetensors" }
+            "source": {
+                "provider": "huggingface",
+                "repo": "acme/x",
+                "file": "w.safetensors",
+                "revision": "0123456789abcdef0123456789abcdef01234567"
+            }
         });
         assert_eq!(
             hosted_overlay_repo_file(&overlay),
-            Some(("acme/x".to_owned(), "w.safetensors".to_owned()))
+            Some((
+                "acme/x".to_owned(),
+                "w.safetensors".to_owned(),
+                "0123456789abcdef0123456789abcdef01234567".to_owned()
+            ))
         );
+    }
+
+    #[test]
+    fn hosted_overlay_requires_a_pinned_revision() {
+        let overlay = json!({
+            "source": { "provider": "huggingface", "repo": "acme/x", "file": "w.safetensors" }
+        });
+        assert_eq!(hosted_overlay_repo_file(&overlay), None);
     }
 
     #[test]
@@ -279,5 +400,58 @@ mod tests {
             "files": ["overlay.safetensors"]
         });
         assert_eq!(hosted_overlay_repo_file(&overlay), None);
+    }
+
+    #[test]
+    fn raw_control_weights_accept_only_exact_shipped_artifacts() {
+        let mut shipped = json!({
+            "advanced": {
+                "controlWeights": {
+                    "repo": "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+                    "filename": "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors"
+                }
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        assert!(validate_raw_control_weights(&mut shipped).is_ok());
+
+        for weights in [
+            json!({"repo": "attacker/payload", "filename": "model.safetensors"}),
+            json!({
+                "repo": "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+                "filename": "other.safetensors"
+            }),
+            json!({"path": "/tmp/payload.safetensors"}),
+        ] {
+            let mut payload = json!({"advanced": {"controlWeights": weights}})
+                .as_object()
+                .unwrap()
+                .clone();
+            assert!(validate_raw_control_weights(&mut payload).is_err());
+        }
+    }
+
+    #[test]
+    fn raw_catalog_stamp_is_removed_before_overlay_lookup() {
+        let mut payload = json!({
+            "advanced": {
+                "controlWeights": {
+                    "overlayId": "registered",
+                    "repo": "attacker/payload",
+                    "filename": "payload.safetensors",
+                    "revision": "0123456789abcdef0123456789abcdef01234567",
+                    "_catalogAuthorized": true
+                }
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        validate_raw_control_weights(&mut payload).unwrap();
+        let weights = payload["advanced"]["controlWeights"].as_object().unwrap();
+        assert!(!weights.contains_key("_catalogAuthorized"));
+        assert!(!weights.contains_key("revision"));
     }
 }

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -332,8 +332,13 @@ pub(crate) async fn retry_job(
     Path(job_id): Path<String>,
     request: AxumRequest,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
-    let payload = retry_job_request_from_body(request).await?;
-    validate_merged_generation_model(&state, &job_id, &payload.payload_changes).await?;
+    let mut payload = retry_job_request_from_body(request).await?;
+    payload.payload_changes = validate_and_canonicalize_merged_generation_payload(
+        &state,
+        &job_id,
+        &payload.payload_changes,
+    )
+    .await?;
     let job = store_call(state.clone(), move |store, _timeout| {
         store.retry_job(
             &job_id,
@@ -364,9 +369,14 @@ async fn retry_job_request_from_body(request: AxumRequest) -> Result<RetryJobReq
 pub(crate) async fn duplicate_job(
     State(state): State<AppState>,
     Path(job_id): Path<String>,
-    ApiJson(payload): ApiJson<DuplicateJobRequest>,
+    ApiJson(mut payload): ApiJson<DuplicateJobRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
-    validate_merged_generation_model(&state, &job_id, &payload.payload_changes).await?;
+    payload.payload_changes = validate_and_canonicalize_merged_generation_payload(
+        &state,
+        &job_id,
+        &payload.payload_changes,
+    )
+    .await?;
     let job = store_call(state.clone(), move |store, _timeout| {
         store.duplicate_job(
             &job_id,
@@ -382,22 +392,34 @@ pub(crate) async fn duplicate_job(
     Ok((StatusCode::CREATED, Json(job)))
 }
 
-/// Validate the exact payload a retry/duplicate will enqueue. Existing job payloads are
-/// immutable, so reading and merging before the create transaction cannot race with a payload
-/// update; importantly, validation still happens before the new row is persisted or published.
-async fn validate_merged_generation_model(
+/// Validate and canonicalize the exact payload a retry/duplicate will enqueue. Existing job
+/// payloads are immutable, so reading and merging before the create transaction cannot race with a
+/// payload update. Returning the complete merged payload is intentional: the store's shallow merge
+/// then persists this canonical object rather than allowing a nested `advanced.controlWeights`
+/// replacement to bypass the typed image route's authorization boundary.
+async fn validate_and_canonicalize_merged_generation_payload(
     state: &AppState,
     job_id: &str,
     payload_changes: &JsonObject,
-) -> Result<(), ApiError> {
+) -> Result<JsonObject, ApiError> {
     let job_id = job_id.to_owned();
     let job = store_call(state.clone(), move |store, _timeout| store.get_job(&job_id)).await?;
-    if !generation_job_model_is_path_backed(&job.job_type) {
-        return Ok(());
-    }
+    let job_type = job.job_type.clone();
+    let project_id = job.project_id.clone();
     let mut merged = job.payload;
     merged.extend(payload_changes.clone());
-    validate_payload_model(&merged)
+    if generation_job_model_is_path_backed(&job_type) {
+        validate_payload_model(&merged)?;
+    }
+    if matches!(job_type, JobType::ImageGenerate | JobType::ImageEdit) {
+        crate::control_overlays::resolve_control_overlay_selection(
+            state,
+            project_id.as_deref(),
+            &mut merged,
+        )
+        .await?;
+    }
+    Ok(merged)
 }
 
 /// Jobs created through the raw queue route do not pass a typed request validator. Keep this

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -2,6 +2,18 @@
 use super::support::*;
 
 #[test]
+fn access_tokens_are_compared_as_fixed_size_hashes() {
+    use crate::auth::token_digest;
+
+    let short = token_digest(b"x");
+    let long = token_digest(&vec![b'y'; 4096]);
+    assert_eq!(short.len(), 32);
+    assert_eq!(long.len(), 32);
+    assert_ne!(short, long);
+    assert_eq!(token_digest(b"same"), token_digest(b"same"));
+}
+
+#[test]
 fn warns_only_on_open_bind_without_token() {
     use std::net::IpAddr;
     let v4 = |s: &str| s.parse::<IpAddr>().unwrap();

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -241,6 +241,105 @@ async fn retry_and_duplicate_reject_path_unsafe_merged_generation_model_before_c
     assert_eq!(jobs.as_array().expect("jobs array").len(), 3);
 }
 
+/// sc-13639: retry/duplicate are alternate image-job creation boundaries. Their shallow
+/// `payloadChanges` merge must not let a caller manufacture the catalog-only authorization bit,
+/// a hosted tuple, or an app-managed local path that the original typed image route would reject.
+#[tokio::test]
+async fn retry_and_duplicate_reauthorize_merged_control_weights_before_create() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_style_test_manifests(&temp_dir.path().join("config"));
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Control Retry Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+    let (status, original) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "a fox",
+            "model": "img-model",
+            "count": 1,
+            "width": 1024,
+            "height": 1024
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{original}");
+    let job_id = original["id"].as_str().expect("job id");
+
+    let forged_hosted = json!({
+        "advanced": {
+            "controlWeights": {
+                "overlayId": "forged-overlay",
+                "_catalogAuthorized": true,
+                "repo": "attacker/weights",
+                "filename": "payload.safetensors",
+                "revision": "0123456789abcdef0123456789abcdef01234567"
+            }
+        }
+    });
+    let forged_path = json!({
+        "advanced": {
+            "controlWeights": {
+                "path": temp_dir.path()
+                    .join("data/models/krea_2/control.safetensors")
+                    .display()
+                    .to_string(),
+                "_catalogAuthorized": true
+            }
+        }
+    });
+    for operation in ["retry", "duplicate"] {
+        for injection in [&forged_hosted, &forged_path] {
+            let (status, body) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{job_id}/{operation}"),
+                json!({ "payloadChanges": injection }),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{operation} must reject {injection}: {body}"
+            );
+        }
+    }
+
+    // Legitimate operations retain their existing success semantics after the merged payload is
+    // canonicalized; rejected injections above must not have persisted hidden jobs.
+    for operation in ["retry", "duplicate"] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/jobs/{job_id}/{operation}"),
+            json!({ "payloadChanges": { "prompt": format!("safe {operation}") } }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "{operation}: {body}");
+        assert_eq!(
+            body["payload"]["prompt"],
+            format!("safe {operation}"),
+            "{operation} must persist the clean merged payload"
+        );
+    }
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        jobs.as_array().expect("jobs array").len(),
+        3,
+        "only the original and two clean operations may persist"
+    );
+}
+
 #[test]
 fn serialize_job_lora_carries_network_type_to_payload() {
     // A trained LoKr adapter records networkType (epic 2193); the generation

--- a/crates/sceneworks-core/src/control_weights.rs
+++ b/crates/sceneworks-core/src/control_weights.rs
@@ -1,0 +1,158 @@
+//! Trusted remote artifacts for strict-control inference.
+//!
+//! A job payload is not an authority to choose an arbitrary Hugging Face
+//! repository. Shipped strict-control artifacts are admitted by the exact
+//! engine/repository/file tuple below and are always fetched at the pinned
+//! revision. User and project overlays use the separate registered-overlay
+//! catalog path in the Rust API.
+
+/// One immutable strict-control weight artifact shipped by SceneWorks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ShippedControlWeight {
+    pub engine_id: &'static str,
+    pub repo: &'static str,
+    pub file: &'static str,
+    pub revision: &'static str,
+}
+
+/// Exact shipped control-weight allow-list.
+///
+/// Z-Image base has distinct MLX and Candle filenames in the upstream repo, and
+/// Qwen has one artifact per packed quantization tier. They are separate rows so
+/// matching never broadens to a repository- or organization-wide trust rule.
+pub const SHIPPED_CONTROL_WEIGHTS: &[ShippedControlWeight] = &[
+    ShippedControlWeight {
+        engine_id: "flux1_dev_control",
+        repo: "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0",
+        file: "diffusion_pytorch_model.safetensors",
+        revision: "5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5",
+    },
+    ShippedControlWeight {
+        engine_id: "flux2_dev_control",
+        repo: "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+        file: "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors",
+        revision: "b3dcd7836a0e926248dac3ccba8fc0853495764b",
+    },
+    ShippedControlWeight {
+        engine_id: "z_image_turbo_control",
+        repo: "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
+        file: "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors",
+        revision: "5155fc56d17821007d6f62ac192c09e0f0e72016",
+    },
+    ShippedControlWeight {
+        engine_id: "z_image_control",
+        repo: "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1",
+        file: "Z-Image-Fun-Controlnet-Union-2.1.safetensors",
+        revision: "755999a934909bd5832e20718bb7c639d2a63eb9",
+    },
+    ShippedControlWeight {
+        engine_id: "z_image_control",
+        repo: "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1",
+        file: "diffusion_pytorch_model.safetensors",
+        revision: "755999a934909bd5832e20718bb7c639d2a63eb9",
+    },
+    ShippedControlWeight {
+        engine_id: "qwen_image_control",
+        repo: "SceneWorks/qwen-image-2512-fun-controlnet-union",
+        file: "q4/model.safetensors",
+        revision: "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
+    },
+    ShippedControlWeight {
+        engine_id: "qwen_image_control",
+        repo: "SceneWorks/qwen-image-2512-fun-controlnet-union",
+        file: "q8/model.safetensors",
+        revision: "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
+    },
+    ShippedControlWeight {
+        engine_id: "qwen_image_control",
+        repo: "SceneWorks/qwen-image-2512-fun-controlnet-union",
+        file: "bf16/model.safetensors",
+        revision: "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
+    },
+    ShippedControlWeight {
+        engine_id: "kolors_control",
+        repo: "Kwai-Kolors/Kolors-ControlNet-Pose",
+        file: "diffusion_pytorch_model.safetensors",
+        revision: "83e35a8033a89d2e75044b412d0e2474111578f7",
+    },
+    ShippedControlWeight {
+        engine_id: "krea_2_turbo_control",
+        repo: "SceneWorks/krea2-pose-controlnet-beta",
+        file: "control_step5000.safetensors",
+        revision: "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac",
+    },
+];
+
+/// Find the exact shipped artifact for an engine/repository/file tuple.
+pub fn shipped_control_weight(
+    engine_id: &str,
+    repo: &str,
+    file: &str,
+) -> Option<&'static ShippedControlWeight> {
+    SHIPPED_CONTROL_WEIGHTS.iter().find(|artifact| {
+        artifact.engine_id == engine_id && artifact.repo == repo && artifact.file == file
+    })
+}
+
+/// Find a shipped artifact without choosing an engine.
+///
+/// The API uses this only to reject arbitrary raw payload repositories before a
+/// job is queued. The worker performs the stronger engine-specific check.
+pub fn shipped_control_weight_by_repo_file(
+    repo: &str,
+    file: &str,
+) -> Option<&'static ShippedControlWeight> {
+    SHIPPED_CONTROL_WEIGHTS
+        .iter()
+        .find(|artifact| artifact.repo == repo && artifact.file == file)
+}
+
+/// Default repository for an engine (all variants for one engine share a repo).
+pub fn default_control_repo(engine_id: &str) -> Option<&'static str> {
+    SHIPPED_CONTROL_WEIGHTS
+        .iter()
+        .find(|artifact| artifact.engine_id == engine_id)
+        .map(|artifact| artifact.repo)
+}
+
+/// Default immutable revision for an engine.
+pub fn default_control_revision(engine_id: &str) -> Option<&'static str> {
+    SHIPPED_CONTROL_WEIGHTS
+        .iter()
+        .find(|artifact| artifact.engine_id == engine_id)
+        .map(|artifact| artifact.revision)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_list_is_exact_and_revisions_are_pinned() {
+        assert!(shipped_control_weight(
+            "flux2_dev_control",
+            "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+            "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors"
+        )
+        .is_some());
+        assert!(shipped_control_weight(
+            "flux2_dev_control",
+            "alibaba-pai/other",
+            "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors"
+        )
+        .is_none());
+        assert!(shipped_control_weight(
+            "flux2_dev_control",
+            "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+            "other.safetensors"
+        )
+        .is_none());
+        assert!(SHIPPED_CONTROL_WEIGHTS.iter().all(|artifact| {
+            artifact.revision.len() == 40
+                && artifact
+                    .revision
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        }));
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod base_weights;
 pub mod builtin_manifests;
 pub mod character_store;
 pub mod contracts;
+pub mod control_weights;
 pub mod credentials;
 pub mod dataset_quality;
 pub mod external_roots;

--- a/crates/sceneworks-mcp/src/lib.rs
+++ b/crates/sceneworks-mcp/src/lib.rs
@@ -69,6 +69,7 @@ pub fn streamable_http_service_with_hosts(
     allowed_hosts: Vec<String>,
 ) -> McpHttpService {
     let api = ApiClient::new(config);
+    let forwarded_hosts = allowed_hosts.clone();
     let transport_config = if allowed_hosts.is_empty() {
         // Empty ⇒ allow any Host (rmcp semantics). Only reached for the wildcard
         // LAN bind with no operator override; the access token is the control there.
@@ -77,10 +78,47 @@ pub fn streamable_http_service_with_hosts(
         StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts)
     };
     StreamableHttpService::new(
-        move || Ok(SceneWorksMcp::new(api.clone()).with_job_wait(job_wait.clone())),
+        move || {
+            Ok(SceneWorksMcp::new(api.clone())
+                .with_job_wait(job_wait.clone())
+                .with_allowed_hosts(forwarded_hosts.clone()))
+        },
         Arc::new(LocalSessionManager::default()),
         transport_config,
     )
+}
+
+/// Match an HTTP authority against the MCP Host allow-list using the same
+/// host/optional-port semantics as rmcp. Unlike rmcp's inbound-host fallback,
+/// an empty list admits no forwarded authority: wildcard deployments must
+/// explicitly configure `SCENEWORKS_MCP_ALLOWED_HOSTS` before forwarded headers
+/// can influence ticket-bearing URLs.
+pub(crate) fn forwarded_authority_is_allowed(authority: &str, allowed_hosts: &[String]) -> bool {
+    let Ok(authority) = http::uri::Authority::try_from(authority.trim()) else {
+        return false;
+    };
+    let host = authority
+        .host()
+        .trim_matches(['[', ']'])
+        .to_ascii_lowercase();
+    let port = authority.port_u16();
+    !allowed_hosts.is_empty()
+        && allowed_hosts.iter().any(|allowed| {
+            let allowed = allowed.trim();
+            let (allowed_host, allowed_port) =
+                if let Ok(authority) = http::uri::Authority::try_from(allowed) {
+                    (
+                        authority
+                            .host()
+                            .trim_matches(['[', ']'])
+                            .to_ascii_lowercase(),
+                        authority.port_u16(),
+                    )
+                } else {
+                    (allowed.trim_matches(['[', ']']).to_ascii_lowercase(), None)
+                };
+            allowed_host == host && allowed_port.map_or(true, |allowed| port == Some(allowed))
+        })
 }
 
 /// The loopback host set always accepted for `/mcp`: `localhost`, `127.0.0.1`,
@@ -154,7 +192,7 @@ pub fn mcp_allowed_hosts(host: &str, port: u16, extra: &[String]) -> Vec<String>
 
 #[cfg(test)]
 mod tests {
-    use super::mcp_allowed_hosts;
+    use super::{forwarded_authority_is_allowed, mcp_allowed_hosts};
 
     const LOOPBACK: [&str; 3] = ["localhost", "127.0.0.1", "::1"];
 
@@ -224,5 +262,30 @@ mod tests {
                 "box.lan"
             ],
         );
+    }
+
+    #[test]
+    fn forwarded_authority_requires_an_exact_configured_host() {
+        let allowed = vec![
+            "studio.example.com:443".to_owned(),
+            "scenebox.local".to_owned(),
+        ];
+        assert!(forwarded_authority_is_allowed(
+            "studio.example.com:443",
+            &allowed
+        ));
+        assert!(!forwarded_authority_is_allowed(
+            "studio.example.com:444",
+            &allowed
+        ));
+        assert!(forwarded_authority_is_allowed(
+            "scenebox.local:8000",
+            &allowed
+        ));
+        assert!(!forwarded_authority_is_allowed(
+            "attacker.example",
+            &allowed
+        ));
+        assert!(!forwarded_authority_is_allowed("studio.example.com", &[]));
     }
 }

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -107,6 +107,7 @@ impl JobWaitConfig {
 pub struct SceneWorksMcp {
     api: ApiClient,
     job_wait: JobWaitConfig,
+    allowed_hosts: Vec<String>,
     tool_router: ToolRouter<Self>,
 }
 
@@ -115,6 +116,7 @@ impl SceneWorksMcp {
         Self {
             api,
             job_wait: JobWaitConfig::default(),
+            allowed_hosts: crate::loopback_allowed_hosts(),
             tool_router: Self::tool_router(),
         }
     }
@@ -122,6 +124,11 @@ impl SceneWorksMcp {
     /// Override the blocking-job polling cadence/deadline (tests).
     pub fn with_job_wait(mut self, job_wait: JobWaitConfig) -> Self {
         self.job_wait = job_wait;
+        self
+    }
+
+    pub fn with_allowed_hosts(mut self, allowed_hosts: Vec<String>) -> Self {
+        self.allowed_hosts = allowed_hosts;
         self
     }
 }
@@ -429,6 +436,7 @@ impl SceneWorksMcp {
             .and_then(Value::as_str)
             .unwrap_or(&args.project_id)
             .to_owned();
+        let project_path_segment = encode_path_segment(&project_id);
         let assets: Vec<&Value> = job
             .pointer("/result/assets")
             .and_then(Value::as_array)
@@ -455,7 +463,7 @@ impl SceneWorksMcp {
             let (bytes, header_mime) = self
                 .api
                 .get_bytes(&format!(
-                    "/api/v1/projects/{project_id}/files/{}",
+                    "/api/v1/projects/{project_path_segment}/files/{}",
                     encode_media_path(&media_path)
                 ))
                 .await
@@ -610,7 +618,7 @@ impl SceneWorksMcp {
     fn request_link_base(&self, extensions: &Extensions) -> String {
         extensions
             .get::<http::request::Parts>()
-            .and_then(|parts| request_base_url(&parts.headers, &parts.uri))
+            .and_then(|parts| request_base_url(&parts.headers, &parts.uri, &self.allowed_hosts))
             .unwrap_or_else(|| self.api.base_url().to_owned())
     }
 
@@ -675,9 +683,10 @@ impl SceneWorksMcp {
 
         let mut blocks = Vec::with_capacity(assets.len() + 1);
         let mut summary_assets = Vec::with_capacity(assets.len());
+        let project_path_segment = encode_path_segment(project_id);
         for (asset, media_path) in assets {
             let relative_url = format!(
-                "/api/v1/projects/{project_id}/files/{}?ticket={ticket}",
+                "/api/v1/projects/{project_path_segment}/files/{}?ticket={ticket}",
                 encode_media_path(&media_path)
             );
             let url = format!("{link_base}{relative_url}");
@@ -1079,18 +1088,32 @@ pub(crate) fn media_mime_type(path: &str, sidecar_mime: Option<&str>) -> Option<
 /// the request-target authority as a last resort), and `X-Forwarded-Proto` then
 /// the request scheme (default `http`) for the scheme. Returns `None` when no
 /// authority is available, so the caller falls back to the configured API base.
-pub(crate) fn request_base_url(headers: &http::HeaderMap, uri: &http::Uri) -> Option<String> {
-    let raw_authority = header_str(headers, "x-forwarded-host")
-        .or_else(|| header_str(headers, "host"))
-        .or_else(|| uri.authority().map(http::uri::Authority::as_str))?;
-    let authority = first_csv(raw_authority);
-    if authority.is_empty() {
-        return None;
+pub(crate) fn request_base_url(
+    headers: &http::HeaderMap,
+    uri: &http::Uri,
+    allowed_hosts: &[String],
+) -> Option<String> {
+    if let Some(raw_forwarded) = header_str(headers, "x-forwarded-host") {
+        let authority = first_csv(raw_forwarded);
+        if !crate::forwarded_authority_is_allowed(authority, allowed_hosts) {
+            // Deliberately fall back to SCENEWORKS_API_URL rather than silently
+            // reflecting the proxy's internal Host when its public authority is
+            // not configured.
+            return None;
+        }
+        let scheme = header_str(headers, "x-forwarded-proto")
+            .map(first_csv)
+            .map(str::to_ascii_lowercase)
+            .filter(|scheme| matches!(scheme.as_str(), "http" | "https"))?;
+        return Some(format!("{scheme}://{authority}"));
     }
-    let scheme = header_str(headers, "x-forwarded-proto")
-        .or_else(|| uri.scheme_str())
-        .map(first_csv)
-        .filter(|scheme| !scheme.is_empty())
+
+    let raw_authority = header_str(headers, "host")
+        .or_else(|| uri.authority().map(http::uri::Authority::as_str))?;
+    let authority = http::uri::Authority::try_from(raw_authority.trim()).ok()?;
+    let scheme = uri
+        .scheme_str()
+        .filter(|scheme| matches!(*scheme, "http" | "https"))
         .unwrap_or("http");
     Some(format!("{scheme}://{authority}"))
 }
@@ -1125,22 +1148,29 @@ fn is_image_asset(asset: &Value) -> bool {
 /// silently mis-resolving. The set is the URL path percent-encode set plus `%`
 /// itself (the input is a raw filesystem path, not an already-escaped URL).
 pub(crate) fn encode_media_path(path: &str) -> String {
+    path.split('/')
+        .map(encode_path_segment)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Percent-encode one untrusted URL path segment, including `/` so a project id
+/// cannot escape its route slot.
+pub(crate) fn encode_path_segment(segment: &str) -> String {
     use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
     const SEGMENT: &AsciiSet = &CONTROLS
         .add(b' ')
         .add(b'"')
         .add(b'#')
         .add(b'%')
+        .add(b'/')
         .add(b'<')
         .add(b'>')
         .add(b'?')
         .add(b'`')
         .add(b'{')
         .add(b'}');
-    path.split('/')
-        .map(|segment| utf8_percent_encode(segment, SEGMENT).to_string())
-        .collect::<Vec<_>>()
-        .join("/")
+    utf8_percent_encode(segment, SEGMENT).to_string()
 }
 
 /// The project-relative media path of a result asset, normalized for the
@@ -1800,31 +1830,48 @@ mod tests {
     }
 
     #[test]
-    fn request_base_url_prefers_forwarded_then_host_then_none() {
+    fn request_base_url_accepts_only_configured_forwarded_authority() {
         use http::{HeaderMap, HeaderValue, Uri};
         let uri: Uri = "/mcp".parse().unwrap();
+        let allowed = vec!["studio.example.com".to_owned()];
 
         // A plain Host header → http scheme by default.
         let mut headers = HeaderMap::new();
         headers.insert("host", HeaderValue::from_static("192.168.4.97:8000"));
         assert_eq!(
-            request_base_url(&headers, &uri).as_deref(),
+            request_base_url(&headers, &uri, &allowed).as_deref(),
             Some("http://192.168.4.97:8000")
         );
 
-        // Reverse-proxy headers win, and only the first CSV entry is used.
+        // A configured reverse-proxy authority wins, and only the first CSV entry is used.
         headers.insert(
             "x-forwarded-host",
             HeaderValue::from_static("studio.example.com, inner:8000"),
         );
         headers.insert("x-forwarded-proto", HeaderValue::from_static("https"));
         assert_eq!(
-            request_base_url(&headers, &uri).as_deref(),
+            request_base_url(&headers, &uri, &allowed).as_deref(),
             Some("https://studio.example.com")
         );
 
+        // An arbitrary forwarded authority never receives ticket-bearing URLs:
+        // None deliberately selects the configured API base.
+        headers.insert(
+            "x-forwarded-host",
+            HeaderValue::from_static("attacker.example"),
+        );
+        assert_eq!(request_base_url(&headers, &uri, &allowed), None);
+        assert_eq!(request_base_url(&headers, &uri, &[]), None);
+
+        headers.insert(
+            "x-forwarded-host",
+            HeaderValue::from_static("studio.example.com"),
+        );
+        headers.insert("x-forwarded-proto", HeaderValue::from_static("ftp"));
+        assert_eq!(request_base_url(&headers, &uri, &allowed), None);
+
         // No authority anywhere → None so the caller keeps the configured base.
-        assert_eq!(request_base_url(&HeaderMap::new(), &uri), None);
+        assert_eq!(request_base_url(&HeaderMap::new(), &uri, &allowed), None);
     }
 
     #[test]
@@ -1841,6 +1888,15 @@ mod tests {
         );
         // A '?' in a segment can't be mistaken for the query string.
         assert_eq!(encode_media_path("a/b?c.png"), "a/b%3Fc.png");
+    }
+
+    #[test]
+    fn encode_project_id_cannot_escape_its_route_segment() {
+        assert_eq!(encode_path_segment("project_123"), "project_123");
+        assert_eq!(
+            encode_path_segment("../other?ticket=stolen"),
+            "..%2Fother%3Fticket=stolen"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -436,7 +436,11 @@ impl SceneWorksMcp {
             .and_then(Value::as_str)
             .unwrap_or(&args.project_id)
             .to_owned();
-        let project_path_segment = encode_path_segment(&project_id);
+        if !valid_project_id(&project_id) {
+            return tool_error(format!(
+                "Image job {job_id} returned an invalid project id, so its files cannot be located."
+            ));
+        }
         let assets: Vec<&Value> = job
             .pointer("/result/assets")
             .and_then(Value::as_array)
@@ -463,7 +467,7 @@ impl SceneWorksMcp {
             let (bytes, header_mime) = self
                 .api
                 .get_bytes(&format!(
-                    "/api/v1/projects/{project_path_segment}/files/{}",
+                    "/api/v1/projects/{project_id}/files/{}",
                     encode_media_path(&media_path)
                 ))
                 .await
@@ -644,6 +648,11 @@ impl SceneWorksMcp {
                  cannot be located."
             ));
         };
+        if !valid_project_id(project_id) {
+            return tool_error(format!(
+                "Job {job_id} returned an invalid project id, so its files cannot be located."
+            ));
+        }
         let assets: Vec<(&Value, String)> = job
             .pointer("/result/assets")
             .and_then(Value::as_array)
@@ -683,10 +692,9 @@ impl SceneWorksMcp {
 
         let mut blocks = Vec::with_capacity(assets.len() + 1);
         let mut summary_assets = Vec::with_capacity(assets.len());
-        let project_path_segment = encode_path_segment(project_id);
         for (asset, media_path) in assets {
             let relative_url = format!(
-                "/api/v1/projects/{project_path_segment}/files/{}?ticket={ticket}",
+                "/api/v1/projects/{project_id}/files/{}?ticket={ticket}",
                 encode_media_path(&media_path)
             );
             let url = format!("{link_base}{relative_url}");
@@ -1154,9 +1162,19 @@ pub(crate) fn encode_media_path(path: &str) -> String {
         .join("/")
 }
 
-/// Percent-encode one untrusted URL path segment, including `/` so a project id
-/// cannot escape its route slot.
-pub(crate) fn encode_path_segment(segment: &str) -> String {
+/// Project identifiers are filesystem and URL route identifiers, not arbitrary path segments.
+/// Match the core store's safe-id contract before interpolating a job-supplied id into either the
+/// inline file request or a ticket-bearing result URL. Rejecting `%` also prevents a downstream
+/// decoder from turning single- or double-encoded traversal into route separators.
+pub(crate) fn valid_project_id(project_id: &str) -> bool {
+    !project_id.trim().is_empty()
+        && project_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+}
+
+/// Percent-encode one untrusted media-path segment.
+fn encode_path_segment(segment: &str) -> String {
     use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
     const SEGMENT: &AsciiSet = &CONTROLS
         .add(b' ')
@@ -1891,12 +1909,19 @@ mod tests {
     }
 
     #[test]
-    fn encode_project_id_cannot_escape_its_route_segment() {
-        assert_eq!(encode_path_segment("project_123"), "project_123");
-        assert_eq!(
-            encode_path_segment("../other?ticket=stolen"),
-            "..%2Fother%3Fticket=stolen"
-        );
+    fn project_id_validation_rejects_normalization_and_encoding_escapes() {
+        assert!(valid_project_id("project_123-ABC"));
+        for invalid in [
+            ".",
+            "..",
+            "..\\other",
+            "../other",
+            "project/other",
+            "%2e%2e",
+            "%252e%252e",
+        ] {
+            assert!(!valid_project_id(invalid), "{invalid:?} must be rejected");
+        }
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control.rs
@@ -18,9 +18,10 @@ const FLUX1_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
 /// Pinned revision for the default `Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0` control-weights
 /// repo (sc-9879, F-077 follow-up). Fetching the mutable `main` branch means a re-push (or a compromised
 /// token) could silently swap the ControlNet checkpoint we load; pin the exact commit for defense-in-depth
-/// (mirrors the SeedVR2/Real-ESRGAN pins, sc-8879/sc-9682). Applied ONLY to the default table repo — a
-/// manifest `controlWeights.repo` override carries its own revision layout, so it keeps `main`. HF's tree
-/// API still reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+/// (mirrors the SeedVR2/Real-ESRGAN pins, sc-8879/sc-9682). Registered overlays carry their own
+/// catalog-authorized immutable revision. HF's tree API still reports the file's `lfs.oid`, which
+/// `ensure_hf_cached_file` verifies against.
+#[cfg(test)]
 const FLUX1_CONTROL_REVISION: &str = "5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5";
 /// The asset `adapter` id recorded on FLUX.1-dev strict-control assets (the dev base MLX label —
 /// shared with the plain FLUX.1 path).
@@ -56,17 +57,20 @@ fn flux1_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, Stri
             .unwrap_or(default)
             .to_owned()
     };
+    let repo = pick(
+        "repo",
+        strict_control_default_repo(FLUX1_DEV_CONTROL_ENGINE_ID),
+    );
+    let file = safe_weight_filename(
+        &pick("filename", FLUX1_CONTROL_FILE),
+        "advanced.controlWeights.filename",
+    )?;
+    trusted_control_weight_revision(request, FLUX1_DEV_CONTROL_ENGINE_ID, &repo, &file)?;
     Ok((
         // Default repo from the shared strict-control table (single source of truth); the file stays
         // engine-specific.
-        pick(
-            "repo",
-            strict_control_default_repo(FLUX1_DEV_CONTROL_ENGINE_ID),
-        ),
-        safe_weight_filename(
-            &pick("filename", FLUX1_CONTROL_FILE),
-            "advanced.controlWeights.filename",
-        )?,
+        repo,
+        file,
     ))
 }
 
@@ -87,7 +91,11 @@ async fn ensure_flux1_control_weights(
             return Ok(p);
         }
     }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision =
+        trusted_control_weight_revision(request, FLUX1_DEV_CONTROL_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -108,14 +116,8 @@ async fn ensure_flux1_control_weights(
         .join("controlnet-flux1")
         .join(&file);
     // Pin the exact commit for the default table control repo so `main` moving under us can't swap the
-    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
-    // revision layout, so only pin when we're on the default repo.
-    let revision = if repo == strict_control_default_repo(FLUX1_DEV_CONTROL_ENGINE_ID) {
-        FLUX1_CONTROL_REVISION
-    } else {
-        "main"
-    };
-    crate::downloads::ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await
+    // ControlNet checkpoint (sc-9879). Registered overlays carry their own immutable pin.
+    crate::downloads::ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await
 }
 
 /// Control lock strength for FLUX.1-dev: `advanced.controlScale` (default 0.7, clamp [0,2]). The Shakker

--- a/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux1_control_candle.rs
@@ -1,10 +1,10 @@
 use super::{advanced, ensure_hf_cached_file, huggingface_snapshot_dir};
 use super::{
     control_kind_label, pose_entries, requested_control_kind, resolve_advanced_or_manifest_f32,
-    resolve_advanced_or_manifest_u32, run_candle_strict_control, ApiClient, CancelFlag,
-    CandleStrictControl, Flux1ControlPaths, Flux1ControlRequest, Flux1DevControl, Image, ImagePlan,
-    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Progress, Settings, Value, WorkerError,
-    WorkerResult,
+    resolve_advanced_or_manifest_u32, run_candle_strict_control, trusted_control_weight_revision,
+    ApiClient, CancelFlag, CandleStrictControl, Flux1ControlPaths, Flux1ControlRequest,
+    Flux1DevControl, Image, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf,
+    Progress, Settings, Value, WorkerError, WorkerResult,
 };
 use super::{
     resolve_app_managed_model_dir, safe_weight_filename, standard_tier_subdir, DownloadContext,
@@ -39,9 +39,10 @@ const FLUX1_CONTROL_CANDLE_REPO: &str = "Shakker-Labs/FLUX.1-dev-ControlNet-Unio
 const FLUX1_CONTROL_CANDLE_FILE: &str = "diffusion_pytorch_model.safetensors";
 /// Pinned revision for the default `FLUX1_CONTROL_CANDLE_REPO` (sc-9879, F-077 follow-up). Fetching the
 /// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
-/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
-/// to the default repo — a manifest `controlWeights.repo` override keeps `main`. HF's tree API still
-/// reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Registered
+/// overlays carry their own catalog-authorized immutable revision. HF's tree API still reports the
+/// file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+#[cfg(test)]
 pub(super) const FLUX1_CONTROL_CANDLE_REVISION: &str = "5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5";
 /// The FLUX.1-dev base diffusers repo when the manifest omits `repo` (HF-gated). The candle lane loads
 /// the dense bf16 snapshot.
@@ -145,13 +146,13 @@ pub(super) fn flux1_control_candle_repo_file(
             .unwrap_or(default)
             .to_owned()
     };
-    Ok((
-        pick("repo", FLUX1_CONTROL_CANDLE_REPO),
-        safe_weight_filename(
-            &pick("filename", FLUX1_CONTROL_CANDLE_FILE),
-            "advanced.controlWeights.filename",
-        )?,
-    ))
+    let repo = pick("repo", FLUX1_CONTROL_CANDLE_REPO);
+    let file = safe_weight_filename(
+        &pick("filename", FLUX1_CONTROL_CANDLE_FILE),
+        "advanced.controlWeights.filename",
+    )?;
+    trusted_control_weight_revision(request, FLUX1_CONTROL_CANDLE_ENGINE_ID, &repo, &file)?;
+    Ok((repo, file))
 }
 
 /// Resolve the Shakker Union-Pro-2.0 weight **file** the `Flux1DevControl` provider loads, downloading on
@@ -172,7 +173,11 @@ async fn ensure_flux1_control_candle_weights(
             return Ok(p);
         }
     }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision =
+        trusted_control_weight_revision(request, FLUX1_CONTROL_CANDLE_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -194,14 +199,8 @@ async fn ensure_flux1_control_candle_weights(
         .join("controlnet-flux1-candle")
         .join(&file);
     // Pin the exact commit for the default control repo so `main` moving under us can't swap the
-    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
-    // revision layout, so only pin when we're on the default repo.
-    let revision = if repo == FLUX1_CONTROL_CANDLE_REPO {
-        FLUX1_CONTROL_CANDLE_REVISION
-    } else {
-        "main"
-    };
-    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
+    // ControlNet checkpoint (sc-9879). Registered overlays carry their own immutable pin.
+    ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/flux2.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2.rs
@@ -609,9 +609,10 @@ const FLUX2_CONTROL_FILE: &str = "FLUX.2-dev-Fun-Controlnet-Union-2602.safetenso
 /// Pinned revision for the default `alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union` control-weights repo
 /// (sc-9879, F-077 follow-up). Fetching the mutable `main` branch means a re-push (or a compromised token)
 /// could silently swap the ControlNet checkpoint we load; pin the exact commit for defense-in-depth
-/// (mirrors sc-8879/sc-9682). Applied ONLY to the default table repo — a manifest `controlWeights.repo`
-/// override carries its own revision layout, so it keeps `main`. HF's tree API still reports the file's
-/// `lfs.oid`, which `ensure_hf_cached_file` verifies the downloaded content against.
+/// (mirrors sc-8879/sc-9682). Registered overlays carry their own catalog-authorized immutable
+/// revision. HF's tree API still reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies
+/// the downloaded content against.
+#[cfg(test)]
 const FLUX2_CONTROL_REVISION: &str = "b3dcd7836a0e926248dac3ccba8fc0853495764b";
 /// The asset `adapter` id recorded on FLUX.2-dev strict-pose assets (the dev base MLX label).
 const FLUX2_CONTROL_ADAPTER_LABEL: &str = "mlx_flux2";
@@ -644,17 +645,20 @@ fn flux2_control_repo_file(request: &ImageRequest) -> WorkerResult<(String, Stri
             .unwrap_or(default)
             .to_owned()
     };
+    let repo = pick(
+        "repo",
+        strict_control_default_repo(FLUX2_DEV_CONTROL_ENGINE_ID),
+    );
+    let file = safe_weight_filename(
+        &pick("filename", FLUX2_CONTROL_FILE),
+        "advanced.controlWeights.filename",
+    )?;
+    trusted_control_weight_revision(request, FLUX2_DEV_CONTROL_ENGINE_ID, &repo, &file)?;
     Ok((
         // Default repo from the shared strict-control table (single source of truth); the file stays
         // engine-specific.
-        pick(
-            "repo",
-            strict_control_default_repo(FLUX2_DEV_CONTROL_ENGINE_ID),
-        ),
-        safe_weight_filename(
-            &pick("filename", FLUX2_CONTROL_FILE),
-            "advanced.controlWeights.filename",
-        )?,
+        repo,
+        file,
     ))
 }
 
@@ -675,7 +679,11 @@ async fn ensure_flux2_control_weights(
             return Ok(p);
         }
     }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision =
+        trusted_control_weight_revision(request, FLUX2_DEV_CONTROL_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -696,14 +704,8 @@ async fn ensure_flux2_control_weights(
         .join("controlnet-flux2")
         .join(&file);
     // Pin the exact commit for the default table control repo so `main` moving under us can't swap the
-    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
-    // revision layout, so only pin when we're on the default repo.
-    let revision = if repo == strict_control_default_repo(FLUX2_DEV_CONTROL_ENGINE_ID) {
-        FLUX2_CONTROL_REVISION
-    } else {
-        "main"
-    };
-    crate::downloads::ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await
+    // ControlNet checkpoint (sc-9879). Registered overlays carry their own immutable pin.
+    crate::downloads::ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await
 }
 
 /// Pose ControlNet lock strength for FLUX.2-dev: `advanced.controlScale` (default 0.75, clamp [0,2]).

--- a/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_control_candle.rs
@@ -2,9 +2,10 @@ use super::{advanced, ensure_hf_cached_file, huggingface_snapshot_dir};
 use super::{
     pid_effective_dims, pid_output_tier, pose_entries, resolve_advanced_or_manifest_f32,
     resolve_advanced_or_manifest_u32, resolve_pid_weights, resolve_quant,
-    run_candle_strict_control, ApiClient, CancelFlag, CandleStrictControl, Flux2Control,
-    Flux2ControlPaths, Flux2ControlRequest, Image, ImagePlan, ImageRequest, JobSnapshot,
-    JsonObject, Path, PathBuf, Progress, Quant, Settings, Value, WorkerError, WorkerResult,
+    run_candle_strict_control, trusted_control_weight_revision, ApiClient, CancelFlag,
+    CandleStrictControl, Flux2Control, Flux2ControlPaths, Flux2ControlRequest, Image, ImagePlan,
+    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Progress, Quant, Settings, Value,
+    WorkerError, WorkerResult,
 };
 use super::{
     resolve_app_managed_model_dir, safe_weight_filename, standard_tier_subdir, DownloadContext,
@@ -38,9 +39,10 @@ const FLUX2_CONTROL_CANDLE_REPO: &str = "alibaba-pai/FLUX.2-dev-Fun-Controlnet-U
 const FLUX2_CONTROL_CANDLE_FILE: &str = "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors";
 /// Pinned revision for the default `FLUX2_CONTROL_CANDLE_REPO` (sc-9879, F-077 follow-up). Fetching the
 /// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
-/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
-/// to the default repo — a manifest `controlWeights.repo` override keeps `main`. HF's tree API still
-/// reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Registered
+/// overlays carry their own catalog-authorized immutable revision. HF's tree API still reports the
+/// file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+#[cfg(test)]
 pub(super) const FLUX2_CONTROL_CANDLE_REVISION: &str = "b3dcd7836a0e926248dac3ccba8fc0853495764b";
 /// The FLUX.2-dev base diffusers repo when the manifest omits `repo` (the 32B flagship). The candle lane
 /// loads the dense snapshot and Q4-quantizes it at load.
@@ -143,13 +145,13 @@ pub(super) fn flux2_control_candle_repo_file(
             .unwrap_or(default)
             .to_owned()
     };
-    Ok((
-        pick("repo", FLUX2_CONTROL_CANDLE_REPO),
-        safe_weight_filename(
-            &pick("filename", FLUX2_CONTROL_CANDLE_FILE),
-            "advanced.controlWeights.filename",
-        )?,
-    ))
+    let repo = pick("repo", FLUX2_CONTROL_CANDLE_REPO);
+    let file = safe_weight_filename(
+        &pick("filename", FLUX2_CONTROL_CANDLE_FILE),
+        "advanced.controlWeights.filename",
+    )?;
+    trusted_control_weight_revision(request, FLUX2_CONTROL_CANDLE_ENGINE_ID, &repo, &file)?;
+    Ok((repo, file))
 }
 
 /// Resolve the Fun-Controlnet-Union weight **file** the `Flux2Control` provider loads, downloading on
@@ -170,7 +172,11 @@ async fn ensure_flux2_control_candle_weights(
             return Ok(p);
         }
     }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision =
+        trusted_control_weight_revision(request, FLUX2_CONTROL_CANDLE_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -192,14 +198,8 @@ async fn ensure_flux2_control_candle_weights(
         .join("controlnet-flux2")
         .join(&file);
     // Pin the exact commit for the default control repo so `main` moving under us can't swap the
-    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
-    // revision layout, so only pin when we're on the default repo.
-    let revision = if repo == FLUX2_CONTROL_CANDLE_REPO {
-        FLUX2_CONTROL_CANDLE_REVISION
-    } else {
-        "main"
-    };
-    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
+    // ControlNet checkpoint (sc-9879). Registered overlays carry their own immutable pin.
+    ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -2,10 +2,10 @@ use super::advanced;
 use super::{
     curated_image_menu, normalize_sampling_knob, pid_effective_dims, pid_output_tier, pose_entries,
     read_advanced_sampling_knobs, resolve_advanced_or_manifest_f32,
-    resolve_advanced_or_manifest_u32, resolve_pid_weights, run_candle_strict_control, ApiClient,
-    CancelFlag, CandleStrictControl, Image, ImagePlan, ImageRequest, JobSnapshot, JsonObject,
-    KolorsControl, KolorsControlPaths, KolorsControlRequest, Path, PathBuf, Progress, Settings,
-    Value, WorkerError, WorkerResult,
+    resolve_advanced_or_manifest_u32, resolve_pid_weights, run_candle_strict_control,
+    trusted_control_weight_revision, ApiClient, CancelFlag, CandleStrictControl, Image, ImagePlan,
+    ImageRequest, JobSnapshot, JsonObject, KolorsControl, KolorsControlPaths, KolorsControlRequest,
+    Path, PathBuf, Progress, Settings, Value, WorkerError, WorkerResult,
 };
 use super::{
     ensure_hf_cached_file, huggingface_snapshot_dir, resolve_app_managed_model_dir,
@@ -40,9 +40,10 @@ const KOLORS_CONTROL_REPO: &str = "Kwai-Kolors/Kolors-ControlNet-Pose";
 const KOLORS_CONTROL_FILE: &str = "diffusion_pytorch_model.safetensors";
 /// Pinned revision for the default `KOLORS_CONTROL_REPO` (sc-9879, F-077 follow-up). Fetching the
 /// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
-/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
-/// to the default repo — a manifest `controlWeights.repo` override carries its own revision layout, so it
-/// keeps `main`. HF's tree API still reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies.
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Registered
+/// overlays carry their own catalog-authorized immutable revision. HF's tree API still reports the
+/// file's `lfs.oid`, which `ensure_hf_cached_file` verifies.
+#[cfg(test)]
 pub(super) const KOLORS_CONTROL_REVISION: &str = "83e35a8033a89d2e75044b412d0e2474111578f7";
 /// The Kolors base diffusers repo when the manifest omits `repo`.
 const KOLORS_CONTROL_DEFAULT_REPO: &str = "Kwai-Kolors/Kolors-diffusers";
@@ -134,13 +135,13 @@ pub(super) fn kolors_control_repo_file(request: &ImageRequest) -> WorkerResult<(
             .unwrap_or(default)
             .to_owned()
     };
-    Ok((
-        pick("repo", KOLORS_CONTROL_REPO),
-        safe_weight_filename(
-            &pick("filename", KOLORS_CONTROL_FILE),
-            "advanced.controlWeights.filename",
-        )?,
-    ))
+    let repo = pick("repo", KOLORS_CONTROL_REPO);
+    let file = safe_weight_filename(
+        &pick("filename", KOLORS_CONTROL_FILE),
+        "advanced.controlWeights.filename",
+    )?;
+    trusted_control_weight_revision(request, KOLORS_CONTROL_ENGINE_ID, &repo, &file)?;
+    Ok((repo, file))
 }
 
 /// Resolve the Kolors ControlNet weight **file** the `KolorsControl` provider loads, downloading on first
@@ -159,7 +160,11 @@ async fn ensure_kolors_control_weights(
             return Ok(p);
         }
     }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision =
+        trusted_control_weight_revision(request, KOLORS_CONTROL_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -180,14 +185,8 @@ async fn ensure_kolors_control_weights(
         .join("controlnet-kolors")
         .join(&file);
     // Pin the exact commit for the default control repo so `main` moving under us can't swap the
-    // ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo` override may carry its own
-    // revision layout, so only pin when we're on the default repo.
-    let revision = if repo == KOLORS_CONTROL_REPO {
-        KOLORS_CONTROL_REVISION
-    } else {
-        "main"
-    };
-    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
+    // ControlNet checkpoint (sc-9879). Registered overlays carry their own immutable pin.
+    ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -45,8 +45,9 @@ const KREA_CONTROL_OVERLAY_REPO: &str = "SceneWorks/krea2-pose-controlnet-beta";
 /// `*.weight_p1` norm convention verbatim, sc-8465), so there is no separate MLX artifact to host.
 const KREA_CONTROL_OVERLAY_FILE: &str = "control_step5000.safetensors";
 /// Pinned revision for the default overlay repo (defense-in-depth, parity with the candle lane's
-/// `KREA_CONTROL_OVERLAY_REVISION` — a repo re-push can't swap the checkpoint under us). Applied ONLY to
-/// the default repo; a `controlWeights.repo` override keeps `main`.
+/// `KREA_CONTROL_OVERLAY_REVISION` — a repo re-push can't swap the checkpoint under us). Registered
+/// overlays carry their own catalog-authorized immutable revision.
+#[cfg(test)]
 const KREA_CONTROL_OVERLAY_REVISION: &str = "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac";
 /// The `SceneWorks/krea-2-turbo-mlx` turnkey (q8 default / q4 / bf16 self-contained subdirs) — the SAME
 /// base the txt2img lane loads. The pose-control lane falls back here (via the shared [`krea_model_subdir`])
@@ -92,13 +93,13 @@ fn resolve_krea_control_base(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| strict_control_default_repo(KREA_CONTROL_ENGINE_ID));
-    // The manifest `repo` (or the `krea_2_turbo_control` catalog default) resolved to a cached snapshot.
+        .unwrap_or(KREA_CONTROL_MLX_REPO);
+    // The manifest `repo` (or the packed Krea MLX default) resolved to a cached snapshot.
     // Two on-disk shapes share this arm: a LEGACY dense diffusers tree (`krea/Krea-2-Turbo` — `tokenizer/
     // text_encoder/ transformer/ vae/` AT THE ROOT), or the current turnkey `SceneWorks/krea-2-turbo-mlx`
     // (q8/q4/bf16 tier SUBDIRS, nothing loadable at the root). CRUCIAL divergence from the candle twin: the
-    // MLX `krea_2_turbo_control` catalog default (`strict_control_default_repo`) is the TIERED repo, whereas
-    // candle's step-3 default is the dense `krea/Krea-2-Turbo`. So the common MLX case lands the tiered
+    // MLX `KREA_CONTROL_MLX_REPO` default is the TIERED repo, whereas candle's step-3 default is the
+    // dense `krea/Krea-2-Turbo`. So the common MLX case lands the tiered
     // turnkey here — and returning its root un-descended made `KreaText::from_snapshot` look for
     // `<root>/tokenizer/tokenizer.json` on the tier-less root and fail with "tokenizer: No such file or
     // directory" (sc-11853). Only a genuine dense tree (tokenizer at the root) is the base as-is; a turnkey
@@ -161,13 +162,13 @@ fn krea_control_overlay_repo_file(request: &ImageRequest) -> WorkerResult<(Strin
             .unwrap_or(default)
             .to_owned()
     };
-    Ok((
-        pick("repo", KREA_CONTROL_OVERLAY_REPO),
-        safe_weight_filename(
-            &pick("filename", KREA_CONTROL_OVERLAY_FILE),
-            "advanced.controlWeights.filename",
-        )?,
-    ))
+    let repo = pick("repo", KREA_CONTROL_OVERLAY_REPO);
+    let file = safe_weight_filename(
+        &pick("filename", KREA_CONTROL_OVERLAY_FILE),
+        "advanced.controlWeights.filename",
+    )?;
+    trusted_control_weight_revision(request, KREA_CONTROL_ENGINE_ID, &repo, &file)?;
+    Ok((repo, file))
 }
 
 /// Confine a payload-supplied `advanced.controlWeights.path` to an app-managed root (sc-11168 / F-006).
@@ -223,7 +224,11 @@ async fn ensure_krea_control_weights(
         }
     }
     let (repo, file) = krea_control_overlay_repo_file(request)?;
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision =
+        trusted_control_weight_revision(request, KREA_CONTROL_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -244,13 +249,8 @@ async fn ensure_krea_control_weights(
         .join("controlnet-krea")
         .join(&file);
     // Pin the exact commit for the default overlay repo so `main` moving under us can't swap the
-    // checkpoint (parity with the candle lane); a `controlWeights.repo` override carries its own layout.
-    let revision = if repo == KREA_CONTROL_OVERLAY_REPO {
-        KREA_CONTROL_OVERLAY_REVISION
-    } else {
-        "main"
-    };
-    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
+    // checkpoint (parity with the candle lane). Registered overlays carry their own immutable pin.
+    ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await?;
     Ok(dst)
 }
 
@@ -400,7 +400,7 @@ async fn generate_krea_control_stream(
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| strict_control_default_repo(KREA_CONTROL_ENGINE_ID))
+        .unwrap_or(KREA_CONTROL_MLX_REPO)
         .to_owned();
 
     // Shared strict-control driver: validate the requested ControlKind against the engine's

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -5,9 +5,9 @@ use super::{
 use super::{
     gate_tier_key, gate_with_evict_reclaim, krea_model_subdir, lora_label, nvfp4_host_eligible,
     nvfp4_selected, pose_entries, resolve_adapters, resolve_advanced_or_manifest_u32,
-    resolve_text_style_gain, run_candle_strict_control, AdapterSpec, ApiClient, CancelFlag,
-    CandleStrictControl, Image, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf,
-    Progress, Settings, Value, WorkerError, WorkerResult,
+    resolve_text_style_gain, run_candle_strict_control, trusted_control_weight_revision,
+    AdapterSpec, ApiClient, CancelFlag, CandleStrictControl, Image, ImagePlan, ImageRequest,
+    JobSnapshot, JsonObject, Path, PathBuf, Progress, Settings, Value, WorkerError, WorkerResult,
 };
 use serde_json::json;
 
@@ -74,9 +74,10 @@ const KREA_CONTROL_OVERLAY_REPO: &str = "SceneWorks/krea2-pose-controlnet-beta";
 /// also carries the 4.5k for comparison).
 const KREA_CONTROL_OVERLAY_FILE: &str = "control_step5000.safetensors";
 /// Pinned revision for the default overlay repo (defense-in-depth: `main` moving under us can't swap the
-/// checkpoint we load — mirrors `FLUX2_CONTROL_CANDLE_REVISION` / sc-9879). Applied ONLY to the default
-/// repo; a `controlWeights.repo` override keeps `main`. `ensure_hf_cached_file` still verifies the file's
+/// checkpoint we load — mirrors `FLUX2_CONTROL_CANDLE_REVISION` / sc-9879). Registered overlays carry
+/// their own catalog-authorized immutable revision. `ensure_hf_cached_file` still verifies the file's
 /// `lfs.oid` from HF's tree API.
+#[cfg(test)]
 pub(super) const KREA_CONTROL_OVERLAY_REVISION: &str = "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac";
 
 /// The Krea control fit-ladder tier for the base directory the resolver will actually load.
@@ -184,7 +185,9 @@ fn krea_control_candle_steps(request: &ImageRequest) -> u32 {
 /// overrides (a not-yet-cached registered/hosted overlay the API passed through), else the default
 /// published beta overlay. Mirrors `flux2_control_candle_repo_file`; the filename must be a plain
 /// component (sc-8821 / F-019).
-fn krea_control_overlay_repo_file(request: &ImageRequest) -> WorkerResult<(String, String)> {
+pub(super) fn krea_control_overlay_repo_file(
+    request: &ImageRequest,
+) -> WorkerResult<(String, String)> {
     let cw = request
         .advanced
         .get("controlWeights")
@@ -197,13 +200,13 @@ fn krea_control_overlay_repo_file(request: &ImageRequest) -> WorkerResult<(Strin
             .unwrap_or(default)
             .to_owned()
     };
-    Ok((
-        pick("repo", KREA_CONTROL_OVERLAY_REPO),
-        safe_weight_filename(
-            &pick("filename", KREA_CONTROL_OVERLAY_FILE),
-            "advanced.controlWeights.filename",
-        )?,
-    ))
+    let repo = pick("repo", KREA_CONTROL_OVERLAY_REPO);
+    let file = safe_weight_filename(
+        &pick("filename", KREA_CONTROL_OVERLAY_FILE),
+        "advanced.controlWeights.filename",
+    )?;
+    trusted_control_weight_revision(request, KREA_CONTROL_ENGINE_ID, &repo, &file)?;
+    Ok((repo, file))
 }
 
 /// Confine a payload-supplied `advanced.controlWeights.path` to an app-managed root (sc-11168 / F-006).
@@ -267,7 +270,10 @@ async fn ensure_krea_control_weights(
     // 3. A hosted overlay: a `controlWeights.{repo,filename}` override (a not-yet-cached registered/hosted
     //    overlay the API passed through) or the default published beta overlay — HF cache, else download.
     let (repo, file) = krea_control_overlay_repo_file(request)?;
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision = trusted_control_weight_revision(request, KREA_CONTROL_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -288,14 +294,8 @@ async fn ensure_krea_control_weights(
         .join("controlnet-krea")
         .join(&file);
     // Pin the exact commit for the default overlay repo so `main` moving under us can't swap the
-    // checkpoint (sc-8466 / sc-9879). A `controlWeights.repo` override may carry its own layout, so only
-    // pin when we're on the default repo.
-    let revision = if repo == KREA_CONTROL_OVERLAY_REPO {
-        KREA_CONTROL_OVERLAY_REVISION
-    } else {
-        "main"
-    };
-    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
+    // checkpoint (sc-8466 / sc-9879). Registered overlays carry their own immutable pin.
+    ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -73,9 +73,9 @@ fn qwen_control_available(request: &ImageRequest, settings: &Settings) -> bool {
 /// Resolve the 2512-Fun-Controlnet-Union checkpoint to a single `.safetensors` in the HF cache
 /// (sc-9870). Default: the SceneWorks packed tier (repo from the shared `STRICT_CONTROL_ENGINES` row —
 /// single source of truth) at `<tier>/model.safetensors`, where `<tier>` tracks the selected transformer
-/// quant via [`qwen_control_tier_subdir`]. `advanced.controlWeights.{repo,filename}` overrides still
-/// address a flat repo with a plain-component file (sc-8821 / F-019); when a `filename` override is
-/// present the tier subdir is NOT applied. `Ok(None)` when the file is absent (the download flow /
+/// quant via [`qwen_control_tier_subdir`]. Registered overlays may address a catalog-authorized
+/// repo/file/revision tuple; when a filename is present the tier subdir is NOT applied. `Ok(None)` when
+/// the file is absent (the download flow /
 /// on-demand fetch provisions it ahead of generation, like base weights).
 fn resolve_qwen_control_weights(
     request: &ImageRequest,
@@ -95,19 +95,39 @@ fn resolve_qwen_control_weights(
     };
     let repo =
         override_field("repo").unwrap_or_else(|| strict_control_default_repo(QWEN_CONTROL_ENGINE_ID).to_owned());
-    let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo);
+    let default_revision = (repo == strict_control_default_repo(QWEN_CONTROL_ENGINE_ID)).then(|| {
+        sceneworks_core::control_weights::default_control_revision(QWEN_CONTROL_ENGINE_ID)
+            .expect("shipped Qwen control revision")
+    });
+    let snapshot = default_revision.and_then(|revision| {
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, revision)
+    });
     // Repo-relative path: an explicit override filename (plain component, no tier subdir) else the packed
     // tier subdir `<tier>/model.safetensors` selected by `advanced.mlxQuantize` — whose DEFAULT tier is
     // clamped to the installed overlay (`snapshot`) so a plain default job never forces a new fetch
     // (sc-10726).
     let rel = match override_field("filename") {
+        Some(name)
+            if sceneworks_core::control_weights::shipped_control_weight(
+                QWEN_CONTROL_ENGINE_ID,
+                &repo,
+                &name,
+            )
+            .is_some() =>
+        {
+            name
+        }
         Some(name) => safe_weight_filename(&name, "advanced.controlWeights.filename")?,
         None => format!(
             "{}/{QWEN_CONTROL_FILE}",
             qwen_control_tier_subdir(request, snapshot.as_deref())
         ),
     };
-    let Some(snapshot) = snapshot else {
+    let revision =
+        trusted_control_weight_revision(request, QWEN_CONTROL_ENGINE_ID, &repo, &rel)?;
+    let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    else {
         return Ok(None);
     };
     let path = snapshot.join(rel);

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -5,9 +5,10 @@ use super::{
 };
 use super::{
     pose_entries, resolve_advanced_or_manifest_f32, resolve_advanced_or_manifest_u32,
-    run_candle_strict_control, ApiClient, CancelFlag, CandleStrictControl, Image, ImagePlan,
-    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Progress, QwenFunControl,
-    QwenFunControlPaths, QwenFunControlRequest, Settings, Value, WorkerError, WorkerResult,
+    run_candle_strict_control, trusted_control_weight_revision, ApiClient, CancelFlag,
+    CandleStrictControl, Image, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf,
+    Progress, QwenFunControl, QwenFunControlPaths, QwenFunControlRequest, Settings, Value,
+    WorkerError, WorkerResult,
 };
 use serde_json::json;
 
@@ -45,10 +46,10 @@ const QWEN_CONTROL_REPO: &str = "SceneWorks/qwen-image-2512-fun-controlnet-union
 /// Pinned revision for the default `QWEN_CONTROL_REPO` (sc-9879, F-077 follow-up). Fetching the mutable
 /// `main` branch means a re-push (or a compromised token) could silently swap the ControlNet overlay we
 /// load; pin the exact commit for defense-in-depth (mirrors the other candle control lanes, e.g.
-/// `FLUX1_CONTROL_CANDLE_REVISION`). Applied ONLY to the default repo — a manifest/user
-/// `controlWeights.repo` override keeps `main`. The pin is the packed-tier repo's `main` HEAD as of the
-/// sc-9870 repoint. HF's tree API still reports each tier file's `lfs.oid`, which `ensure_hf_cached_file`
-/// verifies against.
+/// `FLUX1_CONTROL_CANDLE_REVISION`). Registered overlays carry their own catalog-authorized immutable
+/// revision. The pin is the packed-tier repo's `main` HEAD as of the sc-9870 repoint. HF's tree API still
+/// reports each tier file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+#[cfg(test)]
 pub(super) const QWEN_CONTROL_REVISION: &str = "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca";
 /// The single packed control file inside each tier subdir (`q4/`, `q8/`, `bf16/`). Deterministic —
 /// the packed tier ships exactly one `model.safetensors` per subdir, so the sc-8350 two-overlay
@@ -191,9 +192,8 @@ fn qwen_control_installed_default_tier(snapshot: Option<&Path>) -> &'static str 
 /// `<tier>/model.safetensors` where `<tier>` is [`qwen_control_tier_subdir`] (per `advanced.mlxQuantize`).
 /// Deterministic single-file resolution — each tier subdir ships exactly one `model.safetensors`.
 ///
-/// Override: `advanced.controlWeights.{repo,filename}` still points at a flat repo with a plain-component
-/// weight file (sc-8821 / F-019 — the filename must have no path separators). When a `filename` override
-/// is present the tier subdir is NOT applied (the override addresses a specific file directly).
+/// A registered overlay may provide a catalog-authorized repo/file/revision tuple. When a filename is
+/// present the tier subdir is NOT applied (the tuple addresses a specific file directly).
 pub(super) fn qwen_control_repo_file(
     request: &ImageRequest,
     settings: &Settings,
@@ -212,18 +212,42 @@ pub(super) fn qwen_control_repo_file(
     let repo = pick("repo").unwrap_or_else(|| QWEN_CONTROL_REPO.to_owned());
     let file = match pick("filename") {
         // Explicit override — a plain-component file in the override repo (no tier subdir).
+        Some(name)
+            if sceneworks_core::control_weights::shipped_control_weight(
+                QWEN_CONTROL_ENGINE_ID,
+                &repo,
+                &name,
+            )
+            .is_some() =>
+        {
+            name
+        }
         Some(name) => safe_weight_filename(&name, "advanced.controlWeights.filename")?,
         // Default packed tier — `<tier>/model.safetensors` selected by `advanced.mlxQuantize`, whose
         // DEFAULT tier is clamped to the installed overlay so a plain default job never forces a new
         // fetch (sc-10726).
         None => {
-            let snapshot = huggingface_snapshot_dir(&settings.data_dir, &repo);
+            let snapshot = (repo == QWEN_CONTROL_REPO)
+                .then(|| {
+                    sceneworks_core::control_weights::default_control_revision(
+                        QWEN_CONTROL_ENGINE_ID,
+                    )
+                    .expect("shipped Qwen control revision")
+                })
+                .and_then(|revision| {
+                    crate::model_jobs::huggingface_pinned_snapshot_dir(
+                        &settings.data_dir,
+                        &repo,
+                        revision,
+                    )
+                });
             format!(
                 "{}/{QWEN_CONTROL_FILE}",
                 qwen_control_tier_subdir(request, snapshot.as_deref())
             )
         }
     };
+    trusted_control_weight_revision(request, QWEN_CONTROL_ENGINE_ID, &repo, &file)?;
     Ok((repo, file))
 }
 
@@ -243,7 +267,10 @@ async fn ensure_qwen_control_weights(
             return Ok(p);
         }
     }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let revision = trusted_control_weight_revision(request, QWEN_CONTROL_ENGINE_ID, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -267,14 +294,8 @@ async fn ensure_qwen_control_weights(
     // ControlNet overlay (sc-9879). sc-9870 (merged concurrently) repointed `QWEN_CONTROL_REPO` from
     // `alibaba-pai/Qwen-Image-2512-Fun-Controlnet-Union` to the first-party SceneWorks PACKED tier
     // (`SceneWorks/qwen-image-2512-fun-controlnet-union`, per-quant `<tier>/model.safetensors`); the pin
-    // below is that repo's verified `main` HEAD. A manifest/user `controlWeights.repo` override may carry
-    // its own revision layout, so only pin when we're on the default repo.
-    let revision = if repo == QWEN_CONTROL_REPO {
-        QWEN_CONTROL_REVISION
-    } else {
-        "main"
-    };
-    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
+    // below is that repo's verified `main` HEAD. Registered overlays carry their own immutable pin.
+    ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/strict_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/strict_control.rs
@@ -21,9 +21,9 @@
 
 /// One Fun-Union strict-control engine: its registry id, default control-weights repo, and the set of
 /// [`ControlKind`]s it accepts. THE authority for `supported_kinds` (sc-8244 manifest / sc-8245 web
-/// picker consume the same notion). `repo` is the *default* Fun-Union control repo for the engine; the
-/// per-engine stream still honors an `advanced.controlWeights.{repo,filename}` override when resolving
-/// the actual checkpoint (this row is the catalog default, not a hard pin).
+/// picker consume the same notion). `repo` is the shipped Fun-Union control repo for the engine.
+/// Per-engine streams accept only an exact shipped tuple or an API-canonicalized registered overlay
+/// carrying explicit catalog authority and an immutable revision.
 #[derive(Clone, Copy, Debug)]
 struct StrictControlEngine {
     /// The mlx-gen registry id (`crate::inference_runtime::load(engine_id, spec)`).
@@ -104,10 +104,10 @@ const STRICT_CONTROL_ENGINES: &[StrictControlEngine] = &[
         // `controlMode = canny | depth` request is REJECTED (not silently rendered as pose). `repo` here
         // is INFORMATIONAL for Krea: neither lane resolves its base from this row. The MLX lane
         // (`krea_control.rs`) loads the packed `SceneWorks/krea-2-turbo-mlx` turnkey tier subdir (sc-11796);
-        // the candle lane keeps its own dense `krea/Krea-2-Turbo` const; both resolve the overlay from
-        // env / `advanced.controlWeights` / the hosted beta (sc-8466).
+        // the candle lane keeps its own dense `krea/Krea-2-Turbo` const. `repo` names the actual hosted
+        // overlay artifact both lanes load, not either backend's base-model repository.
         engine_id: "krea_2_turbo_control",
-        repo: "SceneWorks/krea-2-turbo-mlx",
+        repo: "SceneWorks/krea2-pose-controlnet-beta",
         supported_kinds: &[ControlKind::Pose],
     },
 ];
@@ -121,16 +121,74 @@ fn strict_control_engine(engine_id: &str) -> Option<&'static StrictControlEngine
 }
 
 /// The catalog DEFAULT control-weights repo for a Fun-Union strict-control engine — the single source of
-/// truth each engine's `controlWeights.repo`-override resolver falls back to. Panics on a non-Fun-Union
+/// truth each engine's control-weight resolver falls back to. Panics on a non-Fun-Union
 /// engine id (a programming error: only the three registry strict-control streams call this with their
 /// own engine id). Off-Mac the candle strict-control lanes keep their own per-lane default-repo constants
 /// (the qwen candle lane now resolves the table's 2512-Fun row, sc-8350), so this is unused on the candle
 /// lane.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn strict_control_default_repo(engine_id: &str) -> &'static str {
-    strict_control_engine(engine_id)
-        .unwrap_or_else(|| panic!("{engine_id} is not a Fun-Union strict-control engine"))
-        .repo
+    let catalog_repo = strict_control_engine(engine_id)
+        .unwrap_or_else(|| panic!("{engine_id} is not a strict-control engine"))
+        .repo;
+    let artifact_repo = sceneworks_core::control_weights::default_control_repo(engine_id)
+        .unwrap_or_else(|| panic!("{engine_id} has no shipped control-weight artifact"));
+    debug_assert_eq!(catalog_repo, artifact_repo);
+    artifact_repo
+}
+
+/// Resolve the immutable revision for a remote strict-control artifact.
+///
+/// Shipped artifacts must match the exact engine/repository/file registry tuple.
+/// A non-shipped artifact is accepted only when the Rust API resolved an
+/// `overlayId` from the user/project control-overlay catalog, replaced all
+/// caller-supplied location fields, and stamped the internal authorization bit
+/// plus a pinned 40-hex revision. The public jobs API always removes a
+/// caller-supplied stamp before performing that lookup, so raw payloads cannot
+/// turn this into a generic repository escape hatch.
+fn trusted_control_weight_revision(
+    request: &ImageRequest,
+    engine_id: &str,
+    repo: &str,
+    file: &str,
+) -> WorkerResult<String> {
+    if let Some(artifact) =
+        sceneworks_core::control_weights::shipped_control_weight(engine_id, repo, file)
+    {
+        return Ok(artifact.revision.to_owned());
+    }
+
+    let control = request
+        .advanced
+        .get("controlWeights")
+        .and_then(Value::as_object);
+    let catalog_authorized = control
+        .and_then(|weights| weights.get("_catalogAuthorized"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let overlay_id = control
+        .and_then(|weights| weights.get("overlayId"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let revision = control
+        .and_then(|weights| weights.get("revision"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| {
+            value.len() == 40
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        });
+    if let (true, Some(_), Some(revision)) = (catalog_authorized, overlay_id, revision) {
+        return Ok(revision.to_owned());
+    }
+
+    Err(WorkerError::InvalidPayload(format!(
+        "advanced.controlWeights repo/file is not trusted for {engine_id}: \
+         select a registered overlayId or use the shipped {engine_id} artifact"
+    )))
 }
 
 /// Validate a requested [`ControlKind`] against an engine's `supported_kinds` (the [`STRICT_CONTROL_ENGINES`]
@@ -453,4 +511,3 @@ fn build_control_conditioning(
     }
     conditioning
 }
-

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -4129,7 +4129,7 @@ fn flux2_control_scale_defaults_and_clamps() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn flux2_control_repo_file_defaults_and_overrides() {
+fn flux2_control_repo_file_defaults_and_rejects_arbitrary_overrides() {
     let (repo, file) =
         flux2_control_repo_file(&request(json!({ "projectId": "p" }))).expect("defaults resolve");
     // The default repo now comes from the shared strict-control table (single source of truth).
@@ -4139,14 +4139,12 @@ fn flux2_control_repo_file_defaults_and_overrides() {
     );
     assert_eq!(repo, "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union");
     assert_eq!(file, FLUX2_CONTROL_FILE);
-    // `advanced.controlWeights` overrides repo + filename (parity with the Z-Image resolver).
-    let (repo, file) = flux2_control_repo_file(&request(json!({
+    let error = flux2_control_repo_file(&request(json!({
         "projectId": "p",
         "advanced": { "controlWeights": { "repo": "me/custom", "filename": "x.safetensors" } }
     })))
-    .expect("plain override filename resolves");
-    assert_eq!(repo, "me/custom");
-    assert_eq!(file, "x.safetensors");
+    .expect_err("arbitrary payload repo must be rejected");
+    assert!(error.to_string().contains("is not trusted"));
 }
 
 /// sc-8821 / F-019: a payload `controlWeights.filename` that is not a plain component (traversal,
@@ -4193,14 +4191,175 @@ fn mlx_control_weight_filenames_reject_traversal() {
             );
         }
     }
-    // A plain filename still passes validation on the Option-returning resolvers (whether it maps to
-    // Some or None then depends only on the local HF cache, not on confinement).
+    // A plain but non-shipped filename is still untrusted.
     let plain = request(json!({
         "projectId": "p",
         "advanced": { "controlWeights": { "filename": "custom.safetensors" } }
     }));
-    assert!(resolve_control_weights(&plain, &settings).is_ok());
-    assert!(resolve_qwen_control_weights(&plain, &settings).is_ok());
+    assert!(resolve_control_weights(&plain, &settings).is_err());
+    assert!(resolve_qwen_control_weights(&plain, &settings).is_err());
+}
+
+/// sc-13639 / F-054: every MLX strict-control resolver rejects an arbitrary
+/// payload repository; exact shipped artifacts remain valid.
+#[cfg(target_os = "macos")]
+#[test]
+fn mlx_control_weight_repositories_are_exactly_trusted() {
+    let settings = Settings::from_env();
+    let arbitrary = request(json!({
+        "projectId": "p",
+        "advanced": {
+            "controlWeights": {
+                "repo": "alibaba-pai/not-a-shipped-control",
+                "filename": "model.safetensors"
+            }
+        }
+    }));
+    for (label, result) in [
+        (
+            "z-image turbo",
+            resolve_control_weights(&arbitrary, &settings).map(|_| ()),
+        ),
+        (
+            "z-image base",
+            resolve_base_control_weights(&arbitrary, &settings).map(|_| ()),
+        ),
+        (
+            "qwen",
+            resolve_qwen_control_weights(&arbitrary, &settings).map(|_| ()),
+        ),
+        ("flux1", flux1_control_repo_file(&arbitrary).map(|_| ())),
+        ("flux2", flux2_control_repo_file(&arbitrary).map(|_| ())),
+        (
+            "krea",
+            krea_control_overlay_repo_file(&arbitrary).map(|_| ()),
+        ),
+    ] {
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("is not trusted"),
+            "{label}: {error}"
+        );
+    }
+
+    for artifact in sceneworks_core::control_weights::SHIPPED_CONTROL_WEIGHTS {
+        assert!(
+            trusted_control_weight_revision(
+                &request(json!({"projectId": "p"})),
+                artifact.engine_id,
+                artifact.repo,
+                artifact.file,
+            )
+            .is_ok(),
+            "{} {}",
+            artifact.engine_id,
+            artifact.file
+        );
+    }
+}
+
+/// A mutable refs/main cache entry must not shadow the immutable artifact pin.
+#[cfg(target_os = "macos")]
+#[test]
+fn mlx_control_weight_cache_reads_only_the_pinned_revision() {
+    let root = tempfile::tempdir().unwrap();
+    let hub = root.path().join("hub");
+    std::fs::create_dir_all(&hub).unwrap();
+    let _hf = isolate_hf_hub_cache_to(&hub);
+    let mut settings = Settings::from_env();
+    settings.data_dir = root.path().to_path_buf();
+
+    let artifact = sceneworks_core::control_weights::shipped_control_weight(
+        ZIMAGE_CONTROL_ENGINE_ID,
+        strict_control_default_repo(ZIMAGE_CONTROL_ENGINE_ID),
+        ZIMAGE_CONTROL_FILE,
+    )
+    .unwrap();
+    let cache = hub.join(format!("models--{}", artifact.repo.replace('/', "--")));
+    std::fs::create_dir_all(cache.join("refs")).unwrap();
+    std::fs::write(cache.join("refs/main"), "stale-main").unwrap();
+    for (revision, contents) in [
+        ("stale-main", b"untrusted".as_slice()),
+        (artifact.revision, b"trusted".as_slice()),
+    ] {
+        let path = cache.join("snapshots").join(revision).join(artifact.file);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    let resolved = resolve_control_weights(
+        &request(json!({"projectId": "p", "model": "z_image_turbo"})),
+        &settings,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        resolved,
+        cache
+            .join("snapshots")
+            .join(artifact.revision)
+            .join(artifact.file)
+    );
+}
+
+/// Registered user/project overlays remain supported, but only after the API
+/// canonicalized an overlayId and supplied an immutable revision.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn registered_control_overlay_requires_catalog_authority_and_pin() {
+    let authorized = request(json!({
+        "projectId": "p",
+        "advanced": {
+            "controlWeights": {
+                "overlayId": "custom_pose",
+                "repo": "acme/custom-control",
+                "filename": "weights.safetensors",
+                "revision": "0123456789abcdef0123456789abcdef01234567",
+                "_catalogAuthorized": true
+            }
+        }
+    }));
+    assert_eq!(
+        trusted_control_weight_revision(
+            &authorized,
+            "krea_2_turbo_control",
+            "acme/custom-control",
+            "weights.safetensors",
+        )
+        .unwrap(),
+        "0123456789abcdef0123456789abcdef01234567"
+    );
+
+    for weights in [
+        json!({
+            "overlayId": "custom_pose",
+            "repo": "acme/custom-control",
+            "filename": "weights.safetensors",
+            "revision": "0123456789abcdef0123456789abcdef01234567"
+        }),
+        json!({
+            "overlayId": "custom_pose",
+            "repo": "acme/custom-control",
+            "filename": "weights.safetensors",
+            "revision": "main",
+            "_catalogAuthorized": true
+        }),
+    ] {
+        let untrusted = request(json!({
+            "projectId": "p",
+            "advanced": { "controlWeights": weights }
+        }));
+        assert!(trusted_control_weight_revision(
+            &untrusted,
+            "krea_2_turbo_control",
+            "acme/custom-control",
+            "weights.safetensors",
+        )
+        .is_err());
+    }
 }
 
 /// sc-11168 / F-006: the Krea strict-pose lanes accept a payload-supplied `advanced.controlWeights.path`
@@ -10308,8 +10467,7 @@ fn candle_control_providers_resolve_models_and_repos() {
 
 /// sc-8821 / F-019: a payload `controlWeights.filename` that is not a plain component (traversal,
 /// absolute, sub-path) is REJECTED with an `InvalidPayload` pointing at the field — never joined
-/// under the HF snapshot / app cache — on every candle control resolver. A plain override filename
-/// still resolves.
+/// under the HF snapshot / app cache — on every candle control resolver.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[test]
 fn candle_control_weight_filenames_reject_traversal() {
@@ -10358,9 +10516,69 @@ fn candle_control_weight_filenames_reject_traversal() {
         "projectId": "p",
         "advanced": { "controlWeights": { "repo": "me/custom", "filename": "x.safetensors" } }
     }));
-    let (repo, file) = kolors_control_repo_file(&plain).expect("plain override filename resolves");
-    assert_eq!(repo, "me/custom");
-    assert_eq!(file, "x.safetensors");
+    assert!(kolors_control_repo_file(&plain).is_err());
+}
+
+/// sc-13639 / F-054: every Candle strict-control resolver rejects an arbitrary
+/// payload repository; exact shipped artifacts remain valid.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn candle_control_weight_repositories_are_exactly_trusted() {
+    let empty_data = tempfile::tempdir().unwrap();
+    let mut settings = Settings::from_env();
+    settings.data_dir = empty_data.path().to_path_buf();
+    let arbitrary = request(json!({
+        "projectId": "p",
+        "advanced": {
+            "controlWeights": {
+                "repo": "alibaba-pai/not-a-shipped-control",
+                "filename": "model.safetensors"
+            }
+        }
+    }));
+    let arbitrary_base = request(json!({
+        "projectId": "p",
+        "model": "z_image",
+        "advanced": {
+            "controlWeights": {
+                "repo": "alibaba-pai/not-a-shipped-control",
+                "filename": "model.safetensors"
+            }
+        }
+    }));
+    for (label, result) in [
+        (
+            "qwen",
+            qwen_control_repo_file(&arbitrary, &settings).map(|_| ()),
+        ),
+        ("kolors", kolors_control_repo_file(&arbitrary).map(|_| ())),
+        (
+            "z-image turbo",
+            zimage_control_repo_file(&arbitrary).map(|_| ()),
+        ),
+        (
+            "z-image base",
+            zimage_control_repo_file(&arbitrary_base).map(|_| ()),
+        ),
+        (
+            "flux1",
+            flux1_control_candle_repo_file(&arbitrary).map(|_| ()),
+        ),
+        (
+            "flux2",
+            flux2_control_candle_repo_file(&arbitrary).map(|_| ()),
+        ),
+        (
+            "krea",
+            krea_control_overlay_repo_file(&arbitrary).map(|_| ()),
+        ),
+    ] {
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("is not trusted"),
+            "{label}: {error}"
+        );
+    }
 }
 
 /// The trait routes each provider: each lane's `CandleStrictControl` impl reports the right engine id

--- a/crates/sceneworks-worker/src/image_jobs/zimage.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage.rs
@@ -43,6 +43,7 @@ fn zimage_base_control_available(request: &ImageRequest, settings: &Settings) ->
 fn resolve_control_weights_for(
     request: &ImageRequest,
     settings: &Settings,
+    engine_id: &'static str,
     default_repo: &'static str,
     default_file: &'static str,
 ) -> WorkerResult<Option<PathBuf>> {
@@ -64,7 +65,10 @@ fn resolve_control_weights_for(
         &str_field("filename", default_file),
         "advanced.controlWeights.filename",
     )?;
-    let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) else {
+    let revision = trusted_control_weight_revision(request, engine_id, &repo, &filename)?;
+    let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    else {
         return Ok(None);
     };
     let path = snapshot.join(filename);
@@ -81,6 +85,7 @@ fn resolve_control_weights(
     resolve_control_weights_for(
         request,
         settings,
+        ZIMAGE_CONTROL_ENGINE_ID,
         strict_control_default_repo(ZIMAGE_CONTROL_ENGINE_ID),
         ZIMAGE_CONTROL_FILE,
     )
@@ -96,6 +101,7 @@ fn resolve_base_control_weights(
     resolve_control_weights_for(
         request,
         settings,
+        ZIMAGE_BASE_CONTROL_ENGINE_ID,
         strict_control_default_repo(ZIMAGE_BASE_CONTROL_ENGINE_ID),
         ZIMAGE_BASE_CONTROL_FILE,
     )

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -2,9 +2,9 @@ use super::{advanced, ensure_hf_cached_file, huggingface_snapshot_dir};
 use super::{
     pid_effective_dims, pid_output_tier, pose_entries, resolve_advanced_or_manifest_f32,
     resolve_advanced_or_manifest_u32_with, resolve_pid_weights, run_candle_strict_control,
-    ApiClient, CancelFlag, CandleStrictControl, Image, ImagePlan, ImageRequest, JobSnapshot,
-    JsonObject, Path, PathBuf, Progress, Settings, Value, WorkerError, WorkerResult, ZImageControl,
-    ZImageControlPaths, ZImageControlRequest,
+    trusted_control_weight_revision, ApiClient, CancelFlag, CandleStrictControl, Image, ImagePlan,
+    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Progress, Settings, Value, WorkerError,
+    WorkerResult, ZImageControl, ZImageControlPaths, ZImageControlRequest,
 };
 use super::{
     resolve_app_managed_model_dir, safe_weight_filename, standard_tier_subdir, DownloadContext,
@@ -30,9 +30,10 @@ const ZIMAGE_CTRL_REPO: &str = "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2
 const ZIMAGE_CTRL_FILE: &str = "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors";
 /// Pinned revision for the default Turbo `ZIMAGE_CTRL_REPO` (sc-9879, F-077 follow-up). Fetching the
 /// mutable `main` branch means a re-push (or a compromised token) could silently swap the ControlNet
-/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Applied ONLY
-/// to the default repo — a manifest `controlWeights.repo` override keeps `main`. HF's tree API still
-/// reports the file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+/// checkpoint we load; pin the exact commit for defense-in-depth (mirrors sc-8879/sc-9682). Registered
+/// overlays carry their own catalog-authorized immutable revision. HF's tree API still reports the
+/// file's `lfs.oid`, which `ensure_hf_cached_file` verifies against.
+#[cfg(test)]
 pub(super) const ZIMAGE_CTRL_REVISION: &str = "5155fc56d17821007d6f62ac192c09e0f0e72016";
 /// The Z-Image-Turbo base diffusers repo when the manifest omits `repo`.
 const ZIMAGE_CTRL_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
@@ -44,8 +45,9 @@ const ZIMAGE_CTRL_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
 const ZIMAGE_CTRL_BASE_REPO: &str = "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1";
 const ZIMAGE_CTRL_BASE_FILE: &str = "diffusion_pytorch_model.safetensors";
 /// Pinned revision for the default base `ZIMAGE_CTRL_BASE_REPO` (sc-9879, F-077 follow-up). Same
-/// defense-in-depth rationale as `ZIMAGE_CTRL_REVISION`; applied ONLY to the default base repo, an
-/// override keeps `main`, and the `lfs.oid` sha256 verify is retained.
+/// defense-in-depth rationale as `ZIMAGE_CTRL_REVISION`; registered overlays carry their own
+/// catalog-authorized immutable revision, and the `lfs.oid` sha256 verify is retained.
+#[cfg(test)]
 pub(super) const ZIMAGE_CTRL_BASE_REVISION: &str = "755999a934909bd5832e20718bb7c639d2a63eb9";
 /// The base Z-Image diffusers repo when the manifest omits `repo` (sc-8379).
 const ZIMAGE_CTRL_BASE_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image";
@@ -192,13 +194,18 @@ pub(super) fn zimage_control_repo_file(request: &ImageRequest) -> WorkerResult<(
             .unwrap_or(default)
             .to_owned()
     };
-    Ok((
-        pick("repo", default_repo),
-        safe_weight_filename(
-            &pick("filename", default_file),
-            "advanced.controlWeights.filename",
-        )?,
-    ))
+    let repo = pick("repo", default_repo);
+    let file = safe_weight_filename(
+        &pick("filename", default_file),
+        "advanced.controlWeights.filename",
+    )?;
+    let engine_id = if is_zimage_base_model(&request.model) {
+        ZIMAGE_CTRL_BASE_ENGINE_ID
+    } else {
+        ZIMAGE_CTRL_ENGINE_ID
+    };
+    trusted_control_weight_revision(request, engine_id, &repo, &file)?;
+    Ok((repo, file))
 }
 
 /// Resolve the Fun-Controlnet-Union weight **file** the `ZImageControl` provider loads, downloading on
@@ -217,7 +224,15 @@ async fn ensure_zimage_control_weights(
             return Ok(p);
         }
     }
-    if let Some(snapshot) = huggingface_snapshot_dir(&settings.data_dir, &repo) {
+    let engine_id = if is_zimage_base_model(&request.model) {
+        ZIMAGE_CTRL_BASE_ENGINE_ID
+    } else {
+        ZIMAGE_CTRL_ENGINE_ID
+    };
+    let revision = trusted_control_weight_revision(request, engine_id, &repo, &file)?;
+    if let Some(snapshot) =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(&settings.data_dir, &repo, &revision)
+    {
         let f = snapshot.join(&file);
         if f.is_file() {
             return Ok(f);
@@ -238,16 +253,9 @@ async fn ensure_zimage_control_weights(
         .join("controlnet-zimage")
         .join(&file);
     // Pin the exact commit for whichever default control repo (Turbo or base) we resolved so `main`
-    // moving under us can't swap the ControlNet checkpoint (sc-9879). A manifest `controlWeights.repo`
-    // override may carry its own revision layout, so only pin when we're on a default repo.
-    let revision = if repo == ZIMAGE_CTRL_REPO {
-        ZIMAGE_CTRL_REVISION
-    } else if repo == ZIMAGE_CTRL_BASE_REPO {
-        ZIMAGE_CTRL_BASE_REVISION
-    } else {
-        "main"
-    };
-    ensure_hf_cached_file(&context, &repo, revision, &file, &dst).await?;
+    // moving under us can't swap the ControlNet checkpoint (sc-9879). Registered overlays carry their
+    // own immutable pin.
+    ensure_hf_cached_file(&context, &repo, &revision, &file, &dst).await?;
     Ok(dst)
 }
 

--- a/packages/schemas/control-overlays.schema.json
+++ b/packages/schemas/control-overlays.schema.json
@@ -13,7 +13,7 @@
     },
     "overlaySource": {
       "type": "object",
-      "description": "How the runtime resolves an overlay's weights (apps/rust-api/src/control_overlays.rs). A hosted overlay carries provider + repo (+ an optional file/files filter and an optional pinned revision). Closed keys so a typo'd `repo`/`file`/`files` fails CI instead of producing a failed download at runtime.",
+      "description": "How the runtime resolves an overlay's weights (apps/rust-api/src/control_overlays.rs). A hosted overlay carries provider + repo + an immutable revision (+ an optional file/files filter). Closed keys so a typo'd `repo`/`file`/`files` fails CI instead of producing a failed download at runtime.",
       "additionalProperties": false,
       "required": ["provider", "repo"],
       "properties": {
@@ -39,7 +39,16 @@
           "type": "string",
           "description": "Local filesystem path for a non-hosted (studio-trained) overlay. Hosted builtin entries use provider + repo instead."
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "provider": { "const": "huggingface" } },
+            "required": ["provider"]
+          },
+          "then": { "required": ["revision"] }
+        }
+      ]
     }
   },
   "properties": {

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -44,6 +44,72 @@ MANIFEST_PATH = ROOT / "config" / "manifests" / "builtin.models.jsonc"
 SCHEMA_PATH = ROOT / "packages" / "schemas" / "model-manifest.schema.json"
 ENGINE_TABLE_PATH = ROOT / "crates" / "sceneworks-worker" / "src" / "engines.rs"
 WORKER_SOURCE_PATH = ROOT / "crates" / "sceneworks-worker" / "src"
+CONTROL_WEIGHTS_PATH = ROOT / "crates" / "sceneworks-core" / "src" / "control_weights.rs"
+
+EXPECTED_SHIPPED_CONTROL_WEIGHTS = frozenset(
+    {
+        (
+            "flux1_dev_control",
+            "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0",
+            "diffusion_pytorch_model.safetensors",
+            "5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5",
+        ),
+        (
+            "flux2_dev_control",
+            "alibaba-pai/FLUX.2-dev-Fun-Controlnet-Union",
+            "FLUX.2-dev-Fun-Controlnet-Union-2602.safetensors",
+            "b3dcd7836a0e926248dac3ccba8fc0853495764b",
+        ),
+        (
+            "z_image_turbo_control",
+            "alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1",
+            "Z-Image-Turbo-Fun-Controlnet-Union-2.1-8steps.safetensors",
+            "5155fc56d17821007d6f62ac192c09e0f0e72016",
+        ),
+        (
+            "z_image_control",
+            "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1",
+            "Z-Image-Fun-Controlnet-Union-2.1.safetensors",
+            "755999a934909bd5832e20718bb7c639d2a63eb9",
+        ),
+        (
+            "z_image_control",
+            "alibaba-pai/Z-Image-Fun-Controlnet-Union-2.1",
+            "diffusion_pytorch_model.safetensors",
+            "755999a934909bd5832e20718bb7c639d2a63eb9",
+        ),
+        (
+            "qwen_image_control",
+            "SceneWorks/qwen-image-2512-fun-controlnet-union",
+            "q4/model.safetensors",
+            "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
+        ),
+        (
+            "qwen_image_control",
+            "SceneWorks/qwen-image-2512-fun-controlnet-union",
+            "q8/model.safetensors",
+            "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
+        ),
+        (
+            "qwen_image_control",
+            "SceneWorks/qwen-image-2512-fun-controlnet-union",
+            "bf16/model.safetensors",
+            "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
+        ),
+        (
+            "kolors_control",
+            "Kwai-Kolors/Kolors-ControlNet-Pose",
+            "diffusion_pytorch_model.safetensors",
+            "83e35a8033a89d2e75044b412d0e2474111578f7",
+        ),
+        (
+            "krea_2_turbo_control",
+            "SceneWorks/krea2-pose-controlnet-beta",
+            "control_step5000.safetensors",
+            "cb3a0ac7590f5ec594a4eeb43b95ee1da0b5a0ac",
+        ),
+    }
+)
 
 
 def _strip_jsonc_comments(body: str) -> str:
@@ -231,6 +297,146 @@ def test_builtin_models_do_not_declare_a_top_level_repo():
     )
 
 
+def _assert_exact_shipped_control_weight_registry(source: str) -> None:
+    """Audit the central strict-control authority without compiling target-specific lanes."""
+    table = source.split("pub const SHIPPED_CONTROL_WEIGHTS", maxsplit=1)[1].split(
+        "];", maxsplit=1
+    )[0]
+    rows: set[tuple[str, str, str, str]] = set()
+    blocks = re.findall(r"ShippedControlWeight\s*\{(.*?)\n\s*\},", table, flags=re.DOTALL)
+    for block in blocks:
+        fields = {}
+        for field in ("engine_id", "repo", "file", "revision"):
+            match = re.search(rf'{field}:\s*"([^"]+)"', block)
+            assert match, f"unparseable SHIPPED_CONTROL_WEIGHTS {field}:\n{block}"
+            fields[field] = match.group(1)
+        row = (fields["engine_id"], fields["repo"], fields["file"], fields["revision"])
+        assert row not in rows, f"duplicate shipped control-weight tuple: {row}"
+        rows.add(row)
+
+    assert rows == EXPECTED_SHIPPED_CONTROL_WEIGHTS, (
+        "central strict-control authority changed; audit exact engine/repo/file/revision tuples: "
+        f"added={sorted(rows - EXPECTED_SHIPPED_CONTROL_WEIGHTS)}, "
+        f"removed={sorted(EXPECTED_SHIPPED_CONTROL_WEIGHTS - rows)}"
+    )
+    for engine_id, repo, filename, revision in rows:
+        assert re.fullmatch(r"[0-9a-f]{40}", revision), (
+            f"{engine_id} {repo}/{filename}: revision must be an immutable lowercase 40-hex commit"
+        )
+
+
+def test_shipped_control_weight_registry_is_exact_complete_and_pinned():
+    """sc-13639: central authority replaces seven retired manifest repo/modelPath readers."""
+    _assert_exact_shipped_control_weight_registry(
+        CONTROL_WEIGHTS_PATH.read_text(encoding="utf-8")
+    )
+
+
+def _assert_strict_control_consumers_use_central_pinned_authority(
+    sources: dict[str, str],
+) -> None:
+    expected_consumers = {
+        "image_jobs/flux1_control.rs",
+        "image_jobs/flux1_control_candle.rs",
+        "image_jobs/flux2.rs",
+        "image_jobs/flux2_control_candle.rs",
+        "image_jobs/kolors_control.rs",
+        "image_jobs/krea_control.rs",
+        "image_jobs/krea_control_candle.rs",
+        "image_jobs/qwen.rs",
+        "image_jobs/qwen_control.rs",
+        "image_jobs/zimage.rs",
+        "image_jobs/zimage_control.rs",
+    }
+    actual_consumers = {
+        path
+        for path, source in sources.items()
+        if path != "image_jobs/strict_control.rs"
+        and "trusted_control_weight_revision(" in source
+    }
+    assert actual_consumers == expected_consumers, (
+        "strict-control central-authority consumer inventory changed; "
+        f"added={sorted(actual_consumers - expected_consumers)}, "
+        f"removed={sorted(expected_consumers - actual_consumers)}"
+    )
+    for path in expected_consumers:
+        assert "huggingface_pinned_snapshot_dir" in sources[path], (
+            f"{path}: central tuple must resolve only through snapshots/<revision>, "
+            "never a mutable repo cache root"
+        )
+
+    strict_control = sources["image_jobs/strict_control.rs"]
+    assert (
+        "sceneworks_core::control_weights::shipped_control_weight(engine_id, repo, file)"
+        in strict_control
+    ), "strict_control.rs must authorize the exact engine/repo/file tuple centrally"
+
+
+def test_strict_control_consumers_use_central_pinned_authority():
+    sources = {
+        path.relative_to(WORKER_SOURCE_PATH).as_posix(): path.read_text(encoding="utf-8")
+        for path in WORKER_SOURCE_PATH.rglob("*.rs")
+        if "tests" not in path.relative_to(WORKER_SOURCE_PATH).parts
+        and path.name != "tests.rs"
+    }
+    _assert_strict_control_consumers_use_central_pinned_authority(sources)
+
+
+def _must_fail_assertion(callback, message: str) -> None:
+    try:
+        callback()
+    except AssertionError:
+        return
+    raise AssertionError(message)
+
+
+def test_control_weight_authority_audit_detects_absence_and_fallback_mutations():
+    """Mutation guard: missing tuples/pins and bypassed central consumers must fail this audit."""
+    registry = CONTROL_WEIGHTS_PATH.read_text(encoding="utf-8")
+    table_start = registry.index("pub const SHIPPED_CONTROL_WEIGHTS")
+    missing_row = registry[:table_start] + re.sub(
+        r"\s*ShippedControlWeight\s*\{.*?\n\s*\},",
+        "",
+        registry[table_start:],
+        count=1,
+        flags=re.DOTALL,
+    )
+    _must_fail_assertion(
+        lambda: _assert_exact_shipped_control_weight_registry(missing_row),
+        "removing one central tuple must fail the exact registry audit",
+    )
+    mutable_pin = registry.replace(
+        "5d700aaad96c5ddcdf8a38ef9b22a82aac2c38e5", "main", 1
+    )
+    _must_fail_assertion(
+        lambda: _assert_exact_shipped_control_weight_registry(mutable_pin),
+        "replacing one immutable pin with a mutable revision must fail the registry audit",
+    )
+
+    sources = {
+        path.relative_to(WORKER_SOURCE_PATH).as_posix(): path.read_text(encoding="utf-8")
+        for path in WORKER_SOURCE_PATH.rglob("*.rs")
+        if "tests" not in path.relative_to(WORKER_SOURCE_PATH).parts
+        and path.name != "tests.rs"
+    }
+    bypassed = dict(sources)
+    bypassed["image_jobs/flux1_control_candle.rs"] = bypassed[
+        "image_jobs/flux1_control_candle.rs"
+    ].replace("trusted_control_weight_revision(", "bypassed_revision(")
+    _must_fail_assertion(
+        lambda: _assert_strict_control_consumers_use_central_pinned_authority(bypassed),
+        "removing one central-authority consumer must fail the inventory audit",
+    )
+    unpinned = dict(sources)
+    unpinned["image_jobs/krea_control.rs"] = unpinned["image_jobs/krea_control.rs"].replace(
+        "huggingface_pinned_snapshot_dir", "huggingface_repo_cache_path"
+    )
+    _must_fail_assertion(
+        lambda: _assert_strict_control_consumers_use_central_pinned_authority(unpinned),
+        "replacing an immutable snapshot resolver with a mutable fallback must fail",
+    )
+
+
 def test_every_top_level_manifest_repo_reader_has_an_audited_installed_fallback():
     """sc-14476 lane inventory and regression guard.
 
@@ -241,22 +447,15 @@ def test_every_top_level_manifest_repo_reader_has_an_audited_installed_fallback(
     """
     audited_lanes = {
         "image_jobs/base.rs": "model.default_repo()",
-        "image_jobs/flux1_control_candle.rs": "default_repo_for(&request.model)",
-        "image_jobs/flux2_control_candle.rs": "default_repo_for(&request.model)",
         "image_jobs/flux_ipadapter.rs": "flux_ipadapter_default_repo(&request.model)",
         "image_jobs/instantid.rs": "INSTANTID_SDXL_REPO",
-        "image_jobs/kolors_control.rs": "default_repo_for(&request.model)",
         "image_jobs/kolors_ipadapter.rs": "default_repo_for(&request.model)",
-        "image_jobs/krea_control.rs": "strict_control_default_repo(KREA_CONTROL_ENGINE_ID)",
-        "image_jobs/krea_control_candle.rs": "default_repo_for(&request.model)",
         "image_jobs/krea_edit_candle.rs": "default_repo_for(&request.model)",
         "image_jobs/pulid.rs": "PULID_FLUX_REPO",
         "image_jobs/pulid_candle.rs": "PULID_CANDLE_FLUX_REPO",
-        "image_jobs/qwen_control.rs": "default_repo_for(&request.model)",
         "image_jobs/qwen_edit_candle.rs": "crate::engines::MODEL_TABLE",
         "image_jobs/sdxl_edit_candle.rs": "sdxl_edit_candle_default_repo(&request.model)",
         "image_jobs/sdxl_ipadapter.rs": "sdxl_ipadapter_default_repo(&request.model)",
-        "image_jobs/zimage_control.rs": "zimage_control_base_default_repo(&request.model)",
         "image_jobs/zimage_edit_candle.rs": "default_repo_for(&request.model)",
         "image_jobs/zimage_identity_candle.rs": "default_repo_for(&request.model)",
         "sensenova_jobs.rs": "default_repo_for(&request.model)",
@@ -306,22 +505,41 @@ def test_manifest_model_path_is_only_an_optional_override():
     and continue to repo resolution (or decline an imported-only lane) when it
     is absent.
     """
-    readers = 0
+    expected_readers = {
+        "image_jobs/base.rs",
+        "image_jobs/flux_ipadapter.rs",
+        "image_jobs/instantid.rs",
+        "image_jobs/kolors_ipadapter.rs",
+        "image_jobs/krea_imported.rs",
+        "image_jobs/pulid.rs",
+        "image_jobs/pulid_candle.rs",
+        "image_jobs/qwen_edit_candle.rs",
+        "image_jobs/sdxl_edit_candle.rs",
+        "image_jobs/sdxl_imported.rs",
+        "image_jobs/sdxl_ipadapter.rs",
+        "image_jobs/zimage_edit_candle.rs",
+    }
+    actual_readers: list[str] = []
     for path in WORKER_SOURCE_PATH.rglob("*.rs"):
         source = path.read_text(encoding="utf-8").split("\n#[cfg(test)]", maxsplit=1)[0]
         for match in re.finditer(
             r'request\.model_manifest_entry\.get\("modelPath"\)',
             source,
         ):
-            readers += 1
+            relative_path = path.relative_to(WORKER_SOURCE_PATH).as_posix()
+            actual_readers.append(relative_path)
             prefix = source[max(0, match.start() - 500) : match.start()]
             assert "if let Some(path) = request" in prefix or "let Some(raw_path) = request" in prefix, (
-                f"{path.relative_to(WORKER_SOURCE_PATH)}: modelPath is no longer read through an "
+                f"{relative_path}: modelPath is no longer read through an "
                 "optional branch"
             )
-    assert readers == 19, (
-        "modelPath reader inventory changed; audit every new reader for an absence fallback "
-        f"(expected 19, found {readers})"
+    assert len(actual_readers) == len(set(actual_readers)), (
+        f"multiple production modelPath reads require individual fallback audit: {actual_readers}"
+    )
+    assert set(actual_readers) == expected_readers, (
+        "modelPath reader inventory changed; audit every added/removed reader for an absence "
+        f"fallback: added={sorted(set(actual_readers) - expected_readers)}, "
+        f"removed={sorted(expected_readers - set(actual_readers))}"
     )
 
 


### PR DESCRIPTION
## Summary
- admit control weights only through exact shipped engine/repo/file/revision tuples or API-canonicalized registered overlays, across every MLX and Candle strict-control lane including FLUX.2
- pin cache reads as well as downloads, require immutable hosted-overlay revisions, and reject forged catalog authority
- compare access tokens as fixed-size SHA-256 digests in constant time
- encode MCP project IDs in media routes and emit ticket URLs only for configured forwarded authorities

## Validation
- cargo test -p sceneworks-core control_weights --lib
- cargo test -p sceneworks-mcp
- cargo test -p sceneworks-rust-api
- cargo test -p sceneworks-worker --lib
- cargo clippy --locked -p sceneworks-core -p sceneworks-mcp -p sceneworks-rust-api -p sceneworks-worker --all-targets -- -D warnings
- node scripts/check-candle-build.mjs
- node scripts/check-scaffold.mjs
- cargo fmt --all -- --check
- git diff --check

Shortcut: https://app.shortcut.com/trefry/story/13639