### PR TITLE
fix(web): address low-priority screen review findings

### DIFF
--- a/apps/web/src/App.library.test.jsx
+++ b/apps/web/src/App.library.test.jsx
@@ -1100,6 +1100,88 @@ describe("SceneWorks app shell", () => {
     expect(document.body.querySelector(".studio-form")).toBeNull();
   });
 
+  it("restores Library import controls when an import rejects", async () => {
+    const importAsset = vi.fn(() => Promise.reject(new Error("upload failed")));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            importAsset,
+            deleteAsset: vi.fn(),
+            purgeAsset: vi.fn(),
+            setPreviewAsset: vi.fn(),
+            sendAssetToImage: vi.fn(),
+            sendAssetToVideo: vi.fn(),
+            selectedAsset: null,
+            setSelectedAssetId: vi.fn(),
+            setActiveView: vi.fn(),
+            updateAssetStatus: vi.fn(),
+          },
+          <LibraryScreen />,
+        ),
+      );
+    });
+    const input = document.body.querySelector('.file-upload-button input[type="file"]');
+    const file = new File(["broken"], "broken.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    await act(async () => {
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await settle();
+
+    expect(importAsset).toHaveBeenCalledWith(file);
+    expect(input.disabled).toBe(false);
+    expect(input.closest("label").textContent).toContain("Import");
+    expect(input.closest("label").textContent).not.toContain("Importing");
+  });
+
+  it("restores Document Studio submit controls when job creation rejects", async () => {
+    const createInterleaveJob = vi.fn(() => Promise.reject(new Error("queue failed")));
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Noir" },
+            assets: [],
+            createInterleaveJob,
+            documentLocalJobs: [],
+            gpuOptions: ["auto"],
+            imageModels: [
+              {
+                id: "sensenova_u1_8b",
+                name: "SenseNova-U1 8B",
+                type: "image",
+                capabilities: ["text_to_image", "interleave"],
+              },
+            ],
+            jobAction: vi.fn(),
+            rememberLocalGenerationJob: vi.fn(),
+            setActiveView: vi.fn(),
+            requestedGpu: "auto",
+            setRequestedGpu: vi.fn(),
+          },
+          <DocumentStudio />,
+        ),
+      );
+    });
+    await changeField(document.body.querySelector("textarea"), "An illustrated failure case");
+    const submit = [...document.body.querySelectorAll("button")].find((button) =>
+      button.textContent.includes("Compose document"),
+    );
+    await act(async () => {
+      submit.closest("form").dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await settle();
+
+    expect(createInterleaveJob).toHaveBeenCalledTimes(1);
+    expect(submit.disabled).toBe(false);
+    expect(submit.textContent).toContain("Compose document");
+  });
+
   it("DocumentStudio renders an interleaved document and submits a compose job", async () => {
     const createInterleaveJob = vi.fn(() =>
       Promise.resolve({ id: "job-il-new", type: "image_interleave", status: "queued" }),

--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -19,6 +19,28 @@ import { injectStyleIntoCaption, isCaption, parseCaption, serializeCaption } fro
 // This is the single-submit payload verbatim (the correct reference), parameterized only by those
 // overrides. Every omit-when-default and mode gate is preserved; `advanced` is delegated to the
 // already-pure buildImageJobAdvanced so its guards stay in one place.
+export function composeImageJobPrompt({ promptToSend, sendStructured, styleText }) {
+  const hasStyle = typeof styleText === "string" && styleText.trim() !== "";
+  const proseStyleApplied = !sendStructured && hasStyle;
+  const structuredStyleSelected = sendStructured && hasStyle;
+  let prompt = promptToSend;
+  let structuredInjected = false;
+  if (proseStyleApplied) {
+    prompt = composeStyledPrompt({ styleText, userPrompt: promptToSend });
+  } else if (structuredStyleSelected) {
+    const { caption } = parseCaption(promptToSend);
+    if (isCaption(caption)) {
+      prompt = serializeCaption(injectStyleIntoCaption(caption, styleText));
+      structuredInjected = true;
+    }
+  }
+  return {
+    prompt,
+    styleApplied: proseStyleApplied || structuredInjected,
+    structuredInjected,
+  };
+}
+
 export function buildImageJobRequest(state) {
   const {
     // Prompt / resolution overrides — the one legitimate single-vs-batch difference.
@@ -133,21 +155,11 @@ export function buildImageJobRequest(state) {
   // client never transformed — silently dropping the style. So `structuredInjected` is computed
   // INSIDE the isCaption branch and gates `styleApplied`; a non-caption structured prompt is passed
   // through with no flag/styleId so the server can still handle it.
-  const hasStyle = typeof styleText === "string" && styleText.trim() !== "";
-  const proseStyleApplied = !sendStructured && hasStyle;
-  const structuredStyleSelected = sendStructured && hasStyle;
-  let composedPrompt = promptToSend;
-  let structuredInjected = false;
-  if (proseStyleApplied) {
-    composedPrompt = composeStyledPrompt({ styleText, userPrompt: promptToSend });
-  } else if (structuredStyleSelected) {
-    const { caption } = parseCaption(promptToSend);
-    if (isCaption(caption)) {
-      composedPrompt = serializeCaption(injectStyleIntoCaption(caption, styleText));
-      structuredInjected = true;
-    }
-  }
-  const styleApplied = proseStyleApplied || structuredInjected;
+  const { prompt: composedPrompt, styleApplied, structuredInjected } = composeImageJobPrompt({
+    promptToSend,
+    sendStructured,
+    styleText,
+  });
 
   return {
     mode,

--- a/apps/web/src/imageJobRequest.style.test.js
+++ b/apps/web/src/imageJobRequest.style.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildImageJobRequest } from "./imageJobRequest.js";
+import { buildImageJobRequest, composeImageJobPrompt } from "./imageJobRequest.js";
 import { composeStyledPrompt } from "./styleComposer.js";
 import { styleTextForId } from "./data/styleCatalog.js";
 import {
@@ -97,6 +97,43 @@ function baseState(overrides = {}) {
 const STYLE_TEXT = "A gentle, hand-painted animation illustration style.";
 
 describe("buildImageJobRequest — Style Catalog fold (sc-13130)", () => {
+  it("the prompt-only composer preserves the builder's prose and pass-through semantics", () => {
+    const styled = composeImageJobPrompt({
+      promptToSend: "a fox in the snow",
+      sendStructured: false,
+      styleText: STYLE_TEXT,
+    });
+    expect(styled).toEqual({
+      prompt: composeStyledPrompt({ styleText: STYLE_TEXT, userPrompt: "a fox in the snow" }),
+      styleApplied: true,
+      structuredInjected: false,
+    });
+    expect(composeImageJobPrompt({
+      promptToSend: "a fox in the snow",
+      sendStructured: false,
+      styleText: null,
+    })).toEqual({ prompt: "a fox in the snow", styleApplied: false, structuredInjected: false });
+  });
+
+  it("the prompt-only composer preserves valid and invalid structured-caption semantics", () => {
+    const caption = '{"compositional_deconstruction":{"background":"snow","elements":[]}}';
+    const expected = serializeCaption(
+      injectStyleIntoCaption(parseCaption(caption).caption, STYLE_TEXT),
+    );
+    expect(composeImageJobPrompt({
+      promptToSend: caption,
+      sendStructured: true,
+      styleText: STYLE_TEXT,
+    })).toEqual({ prompt: expected, styleApplied: true, structuredInjected: true });
+
+    const invalidCaption = '{"scene":"snow"}';
+    expect(composeImageJobPrompt({
+      promptToSend: invalidCaption,
+      sendStructured: true,
+      styleText: STYLE_TEXT,
+    })).toEqual({ prompt: invalidCaption, styleApplied: false, structuredInjected: false });
+  });
+
   it("no style selected → prompt is the untouched user prompt (identity)", () => {
     const req = buildImageJobRequest(baseState({ styleText: null }));
     expect(req.prompt).toBe("a fox in the snow");

--- a/apps/web/src/imageStylePreview.parity.test.js
+++ b/apps/web/src/imageStylePreview.parity.test.js
@@ -1,19 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { buildImageJobRequest } from "./imageJobRequest.js";
+import { buildImageJobRequest, composeImageJobPrompt } from "./imageJobRequest.js";
 import { composePreset } from "./presetUtils.js";
 import { composeStyledPrompt } from "./styleComposer.js";
 import { STYLE_GROUPS, styleTextForId } from "./data/styleCatalog.js";
 
 // sc-13131 — CORE DoD guard: the live Style preview must equal the submitted `prompt` BYTE-FOR-BYTE.
 //
-// In ImageStudio the preview value is `buildJobRequest({ promptToSend: prompt }).prompt` — the SAME
-// function the single Generate submit calls — so the preview cannot drift from the payload by
-// construction. `buildJobRequest` folds the general-preset stack into the user text FIRST (via
-// composePreset), then hands that preset-folded prompt to `buildImageJobRequest`, which applies the
-// style wrap LAST (composeStyledPrompt). This suite pins that final `buildImageJobRequest` composition
-// step — the one both the preview and the payload share — against the composer directly, so a change
-// that made the payload compose differently from `composeStyledPrompt` (i.e. from the preview) fails.
+// ImageStudio's preview and full request builder share the prompt-only
+// composeImageJobPrompt primitive. The studio folds the general-preset stack into
+// the user text FIRST (via composePreset), then the primitive applies the style
+// wrap LAST. This suite pins the exact string without rebuilding an entire job
+// request for each preview keystroke or batch-budget prompt.
 
 // A representative studio state for a plain free-text (non-structured) model. Only the fields
 // buildImageJobRequest reads need to be present; arrays are empty and edit/upscale branches are off.
@@ -64,11 +62,11 @@ describe("Style preview ↔ payload prompt parity (sc-13131)", () => {
   // The exact recipe ImageStudio uses to derive the preview / payload prompt from the raw prompt:
   //   1. fold the preset stack into the user text (composePreset) — FIRST,
   //   2. wrap the preset-folded prompt in the selected style (buildImageJobRequest → composeStyledPrompt) — LAST.
-  // Returns { payloadPrompt } exactly as the submit path produces it.
+  // Returns the composed prompt exactly as the preview and submit paths produce it.
   function payloadPromptFor({ prompt, stack = [] }) {
     const foldPrompt = stack.length > 0;
     const promptToSend = foldPrompt ? composePreset({ generalStack: stack, userText: prompt }).prompt : prompt;
-    return buildImageJobRequest(baseState({ promptToSend, styleText })).prompt;
+    return composeImageJobPrompt({ promptToSend, sendStructured: false, styleText }).prompt;
   }
 
   it("plain prompt: payload prompt equals the composer's Subject/Style block", () => {

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -63,7 +63,7 @@ const MODE_LABELS = {
   voiceclone: "Voice Clone",
 };
 
-// Per-mode prompt placeholder. Named so the shell reads sensibly before C1 wires generation.
+// Per-mode prompt placeholder for each fully wired generation surface.
 const MODE_PLACEHOLDER = {
   speech: "Type the words to speak…",
   sfx: "Describe the sound — a door creak, distant thunder, footsteps on gravel…",
@@ -482,7 +482,7 @@ export function AudioStudio() {
   // Generate is guarded (never a silent no-op): a run needs a wired mode, generation content (a
   // non-empty prompt, or — for a multi-speaker model — at least one non-empty script turn), an
   // installed model, and no run already in flight. The empty-content guard is the DoD's "disable on
-  // empty prompt"; the WIRED_MODES gate keeps the still-scaffold tabs (Music / Voice Clone) inert.
+  // empty prompt"; the WIRED_MODES gate keeps any future display-only mode inert.
   const scriptReady = scriptSegmentsForSubmit(script).length > 0;
   // Multi-speaker Speech submits the script instead of the prompt, so its content signal is a
   // non-empty script; every other mode (and single-voice Speech) still requires a prompt.
@@ -632,8 +632,8 @@ export function AudioStudio() {
     if (submitting) {
       return;
     }
-    // Only the wired modes submit (Speech C1 sc-13408, Sound FX C2 sc-13409); Music / Voice Clone
-    // keep the C0 scaffold, so their submit is intentionally inert. `canGenerate` also covers the
+    // All four current modes are wired; WIRED_MODES remains the authoritative guard if a future
+    // display-only mode is added. `canGenerate` also covers the
     // empty-prompt / no-model / in-flight guards, so a direct form submit can never slip past them.
     if (!canGenerate) {
       return;

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -753,7 +753,6 @@ export function CharacterStudio() {
 
               <CharacterLooks
                 approvedReferences={approvedReferences}
-                createCharacterLook={createCharacterLook}
                 deleteCharacterLook={deleteCharacterLook}
                 lookDraft={lookDraft}
                 selectedCharacter={selectedCharacter}

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -344,20 +344,26 @@ export function DocumentStudio() {
     if (sourceAssetIds.length > 0) {
       advanced.imageGuidanceScale = referenceGuidance;
     }
-    const job = await createInterleaveJob({
-      prompt: prompt.trim(),
-      model: model || undefined,
-      maxImages: clampMaxImages(maxImages),
-      width,
-      height,
-      sourceAssetIds,
-      advanced,
-    });
-    setSubmitting(false);
-    if (job) {
-      // Stack the run in the studio instead of routing to the Queue, so its output
-      // streams in below the prompt as it composes.
-      rememberLocalGenerationJob?.("document", job);
+    try {
+      const job = await createInterleaveJob({
+        prompt: prompt.trim(),
+        model: model || undefined,
+        maxImages: clampMaxImages(maxImages),
+        width,
+        height,
+        sourceAssetIds,
+        advanced,
+      });
+      if (job) {
+        // Stack the run in the studio instead of routing to the Queue, so its output
+        // streams in below the prompt as it composes.
+        rememberLocalGenerationJob?.("document", job);
+      }
+    } catch {
+      // The app-level job creator owns request-error reporting; this screen only
+      // owns restoring its submit affordance when an injected creator rejects.
+    } finally {
+      setSubmitting(false);
     }
   }
 

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -431,6 +431,25 @@ export function editReferenceIds(sourceAssetId, refIds, max = MAX_EDIT_REFERENCE
   return Array.from(new Set(ids)).slice(0, max);
 }
 
+// Import every selected reference independently so one bad file does not discard
+// the successful imports. importAsset normally reports request errors itself; the
+// dialog still needs an exact failure count instead of silently filtering them.
+export async function importEditorReferenceFiles(files, importAsset) {
+  const results = await Promise.allSettled(
+    Array.from(files ?? []).map((file) => importAsset(file, { throwOnError: true })),
+  );
+  const assets = [];
+  let failureCount = 0;
+  for (const result of results) {
+    if (result.status === "fulfilled" && result.value?.id) {
+      assets.push(result.value);
+    } else {
+      failureCount += 1;
+    }
+  }
+  return { assets, failureCount };
+}
+
 // Output aspect presets for the editor's canvas-extend / outpaint control (sc-2556).
 // "match" keeps the working size, so the fit mode then has no border to act on.
 export const EDIT_OUTPUT_ASPECTS = [
@@ -3587,14 +3606,21 @@ export function ImageEditor() {
           onImport={async (files) => {
             // Upload dropped images into the project, then attach them as references (sc-6107).
             setRefPickerOpen(false);
-            const imported = await Promise.all(
-              Array.from(files ?? []).map((file) => importAsset(file).catch(() => null)),
-            );
-            const ids = imported.filter(Boolean).map((asset) => asset.id);
+            const { assets: imported, failureCount } = await importEditorReferenceFiles(files, importAsset);
+            const ids = imported.map((asset) => asset.id);
             if (ids.length) {
               setRefAssetIds((prev) =>
                 Array.from(new Set([...prev, ...ids])).slice(0, MAX_EDIT_REFERENCES - 1),
               );
+            }
+            if (failureCount > 0) {
+              const added = ids.length
+                ? `Added ${ids.length} reference image${ids.length === 1 ? "" : "s"}. `
+                : "";
+              setStatus({
+                loading: false,
+                error: `${added}Could not import ${failureCount} reference image${failureCount === 1 ? "" : "s"}.`,
+              });
             }
           }}
           title="Add reference image"

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -80,6 +80,7 @@ import {
   tintMaskRgbaInPlace,
   MASK_PREVIEW_RGBA,
   editReferenceIds,
+  importEditorReferenceFiles,
   MAX_EDIT_REFERENCES,
   leaveGuardMessage,
   leaveGuardArming,
@@ -1434,6 +1435,24 @@ describe("reference conditioning (sc-6107)", () => {
     expect(editReferenceIds("", ["a", "b"])).toEqual(["a", "b"]);
     expect(editReferenceIds("", [])).toEqual([]);
     expect(editReferenceIds("work", null)).toEqual(["work"]);
+  });
+
+  it("keeps successful reference imports and counts every rejected or invalid result", async () => {
+    const files = [new File(["a"], "a.png"), new File(["b"], "b.png"), new File(["c"], "c.png")];
+    const importAsset = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "asset-a" })
+      .mockRejectedValueOnce(new Error("bad image"))
+      .mockResolvedValueOnce(null);
+
+    await expect(importEditorReferenceFiles(files, importAsset)).resolves.toEqual({
+      assets: [{ id: "asset-a" }],
+      failureCount: 2,
+    });
+    expect(importAsset).toHaveBeenCalledTimes(3);
+    expect(importAsset).toHaveBeenNthCalledWith(1, files[0], { throwOnError: true });
+    expect(importAsset).toHaveBeenNthCalledWith(2, files[1], { throwOnError: true });
+    expect(importAsset).toHaveBeenNthCalledWith(3, files[2], { throwOnError: true });
   });
 });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1181,8 +1181,7 @@ export function ImageStudio() {
       probe.onload = null;
       probe.src = "";
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [img2imgReferenceAssetId, editImageAssets]);
+  }, [img2imgReferenceAssetId, editImageAssets, onReferenceImageLoaded]);
   // Sampler / scheduler menus declared by the model, gated to the ACTIVE backend
   // (epic 7114 P5): `macGatingActive` is the worker `mlx_required` master switch, so
   // it picks the manifest's `mlx.limits` override on Mac/MLX and the `candle.limits`

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -43,7 +43,7 @@ import {
   serializeCaption,
   validateCaption,
 } from "../ideogramCaption.js";
-import { buildImageJobRequest } from "../imageJobRequest.js";
+import { buildImageJobRequest, composeImageJobPrompt } from "../imageJobRequest.js";
 import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
 
 const PROMPT_SUGGESTION_POOL = [
@@ -1168,13 +1168,19 @@ export function ImageStudio() {
     const asset = editImageAssets.find((item) => item.id === img2imgReferenceAssetId);
     const src = asset && assetUrl(asset);
     if (!src || typeof Image === "undefined") return;
+    let cancelled = false;
     const probe = new Image();
     probe.onload = () => {
-      if (probe.naturalWidth && probe.naturalHeight) {
+      if (!cancelled && probe.naturalWidth && probe.naturalHeight) {
         onReferenceImageLoaded(probe.naturalWidth, probe.naturalHeight);
       }
     };
     probe.src = src;
+    return () => {
+      cancelled = true;
+      probe.onload = null;
+      probe.src = "";
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [img2imgReferenceAssetId, editImageAssets]);
   // Sampler / scheduler menus declared by the model, gated to the ACTIVE backend
@@ -1954,6 +1960,31 @@ export function ImageStudio() {
   // sendStructured / submitCaption / submitBackend / resolutionOverride). This replaced a
   // hand-copied batch twin that had drifted (dropped the img2img reference + pidTarget/img2img
   // advanced knobs), silently ignoring an img2img reference and PiD "2K" tier on batch runs.
+  const activeStyleText = styleTextForId(effectiveStyleId);
+  const composeJobPrompt = useCallback(
+    (overrides = {}) => {
+      const stackActive = generalStack.length > 0;
+      const isStructured = overrides.sendStructured ?? false;
+      const foldPrompt = stackActive && !isStructured;
+      const promptToSend =
+        foldPrompt && overrides.promptToSend != null
+          ? composePreset({
+              base: selectedPreset,
+              generalStack,
+              userText: overrides.promptToSend,
+              resolutionOptions,
+            }).prompt
+          : overrides.promptToSend;
+      const { prompt: composedPrompt } = composeImageJobPrompt({
+        promptToSend,
+        sendStructured: isStructured,
+        styleText: activeStyleText,
+      });
+      return { composedPrompt, foldPrompt, isStructured, promptToSend };
+    },
+    [activeStyleText, generalStack, resolutionOptions, selectedPreset],
+  );
+
   const buildJobRequest = (overrides = {}) => {
     // Fold the general-preset stack (epic 11949) into this request. The prompt is composed per
     // call so it wraps either the single prompt or a per-batch-item prompt; a structured JSON
@@ -1961,13 +1992,7 @@ export function ImageStudio() {
     // negative/aspect/count still apply). When the stack folds the prompt, the client is
     // authoritative — presetPromptResolvedClientSide tells the server to skip its own fold.
     const stackActive = generalStack.length > 0;
-    const isStructured = overrides.sendStructured ?? false;
-    const foldPrompt = stackActive && !isStructured;
-    const promptToSend =
-      foldPrompt && overrides.promptToSend != null
-        ? composePreset({ base: selectedPreset, generalStack, userText: overrides.promptToSend, resolutionOptions })
-            .prompt
-        : overrides.promptToSend;
+    const { foldPrompt, isStructured, promptToSend } = composeJobPrompt(overrides);
     const stackResolution = stackActive && composedStack.resolution ? parseResolution(composedStack.resolution) : null;
     return buildImageJobRequest({
       // Overrides — the one legitimate single-vs-batch difference.
@@ -1995,7 +2020,7 @@ export function ImageStudio() {
       // produced `promptToSend` — so the style's `Style:` block wraps the already-preset-composed
       // user prompt as `Subject:`. Null → pass-through (prompt sent unchanged). Structured
       // caption models ignore it (the builder skips composition when sendStructured is true).
-      styleText: styleTextForId(effectiveStyleId),
+      styleText: activeStyleText,
       // sc-13132: the opaque style id travels with the recipe so replay can re-select the picker.
       styleId: effectiveStyleId,
       characterId,
@@ -2104,7 +2129,7 @@ export function ImageStudio() {
       stylePreviewActive && !structuredPromptModel
         ? resolved.map(({ prompt: resolvedPrompt }) => {
             const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
-            return buildBatchJobRequest(cleanPrompt).prompt;
+            return composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
           })
         : [],
     );
@@ -2227,7 +2252,6 @@ export function ImageStudio() {
   // auto-write a caption per resolved prompt (sc-9980).
   const batchStructuredExpandBlocked =
     structuredPromptModel && (magicModelMissing || typeof magicPrompt !== "function");
-  const activeStyleText = styleTextForId(effectiveStyleId);
   const styleSelected = typeof activeStyleText === "string" && activeStyleText.trim() !== "";
   const stylePreviewActive = !structuredPromptModel && styleSelected;
   // sc-13224: structured JSON-caption models apply the Style axis by merging into the caption's
@@ -2264,17 +2288,23 @@ export function ImageStudio() {
     ],
   );
   // sc-13131 / sc-13133: the live composed-prompt preview for the selected Style Catalog entry, and
-  // the budget the composed string spends against the backend cap. ANTI-DRIFT: we do NOT re-derive
-  // the composition here — we run the SAME buildJobRequest the single Generate submit calls (with the
-  // live prompt as promptToSend) and read its `.prompt`, so the previewed/measured string is
-  // byte-for-byte the prompt that will be sent (preset stack folds into the prompt FIRST, the style's
-  // Subject:/Style: wrap is applied LAST — see imageJobRequest.js). It recomputes every render, so
-  // it tracks the prompt text, the selected style, and the active preset stack live. Only active for
+  // the budget the composed string spends against the backend cap. ANTI-DRIFT: composeJobPrompt is
+  // the shared prompt-only primitive used by both this preview and buildJobRequest, so the
+  // previewed/measured string is byte-for-byte the prompt that will be sent without rebuilding the
+  // entire request on every keystroke (preset stack folds into the prompt FIRST, the style's
+  // Subject:/Style: wrap is applied LAST — see imageJobRequest.js). Its memo dependencies track the
+  // prompt text, selected style, and active preset stack. Only active for
   // free-text models with a style actually selected: structured-caption models (Ideogram) merge the
   // style into the caption's `aesthetics` instead (sc-13224), so there's no Subject:/Style: prose
   // to preview, and a null/empty styleText is a pass-through with nothing extra to preview and no
   // style-composition budget to guard.
-  const styledPreviewPrompt = stylePreviewActive ? buildJobRequest({ promptToSend: prompt }).prompt : null;
+  const styledPreviewPrompt = useMemo(
+    () =>
+      stylePreviewActive
+        ? composeJobPrompt({ promptToSend: prompt }).composedPrompt
+        : null,
+    [composeJobPrompt, prompt, stylePreviewActive],
+  );
   const generateDraft = useMemo(
     () => ({
       activeProject,

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1969,6 +1969,82 @@ describe("ImageStudio Image-reference (img2img) tile (epic 8588, sc-8593/sc-1019
       ),
     ).toBe(true);
   });
+
+  it("ignores a superseded reference probe that loads after the newer image", async () => {
+    const originalImage = global.Image;
+    const probes = [];
+    class FakeImageProbe {
+      constructor() {
+        this.naturalWidth = 0;
+        this.naturalHeight = 0;
+        this.onload = null;
+        probes.push(this);
+      }
+
+      set src(value) {
+        this._src = value;
+      }
+
+      get src() {
+        return this._src;
+      }
+    }
+    global.Image = FakeImageProbe;
+    const portrait = {
+      id: "portrait",
+      type: "image",
+      projectId: "project_1",
+      displayName: "Portrait reference",
+      url: "/portrait.png",
+      status: {},
+    };
+    const landscape = {
+      id: "landscape",
+      type: "image",
+      projectId: "project_1",
+      displayName: "Landscape reference",
+      url: "/landscape.png",
+      status: {},
+    };
+    const model = {
+      ...KREA_IMG2IMG,
+      defaults: { resolution: "1024x1024" },
+      limits: { resolutions: ["1024x1536", "1536x1024"] },
+    };
+
+    try {
+      await render(baseContext({ assets: [portrait, landscape], imageModels: [model], models: [model] }));
+      await click(tileByText("Image reference"));
+      await click(tileByText("Select reference image"));
+      let cards = [...document.body.querySelectorAll(".asset-picker-card")];
+      await click(cards.find((card) => card.textContent.includes("Portrait reference")));
+      await click(tileByText("Use Selection"));
+      expect(probes).toHaveLength(1);
+      const staleOnload = probes[0].onload;
+
+      await click(tileByText("Change"));
+      cards = [...document.body.querySelectorAll(".asset-picker-card")];
+      await click(cards.find((card) => card.textContent.includes("Landscape reference")));
+      await click(tileByText("Use Selection"));
+      expect(probes).toHaveLength(2);
+
+      probes[1].naturalWidth = 1600;
+      probes[1].naturalHeight = 900;
+      await act(async () => {
+        probes[1].onload();
+      });
+      expect(field(container, "Aspect").value).toBe("1536x1024");
+
+      probes[0].naturalWidth = 900;
+      probes[0].naturalHeight = 1600;
+      await act(async () => {
+        staleOnload();
+      });
+      expect(field(container, "Aspect").value).toBe("1536x1024");
+    } finally {
+      global.Image = originalImage;
+    }
+  });
 });
 
 describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1920,6 +1920,28 @@ describe("ImageStudio Image-reference (img2img) tile (epic 8588, sc-8593/sc-1019
   const KREA_IMG2IMG = { ...Z_IMAGE, id: "krea_2_turbo", name: "Krea 2 Turbo", ui: { img2img: true } };
   const tileByText = (text) =>
     [...document.body.querySelectorAll("button")].find((b) => b.textContent.includes(text));
+  function installFakeImageProbes() {
+    const originalImage = global.Image;
+    const probes = [];
+    class FakeImageProbe {
+      constructor() {
+        this.naturalWidth = 0;
+        this.naturalHeight = 0;
+        this.onload = null;
+        probes.push(this);
+      }
+
+      set src(value) {
+        this._src = value;
+      }
+
+      get src() {
+        return this._src;
+      }
+    }
+    global.Image = FakeImageProbe;
+    return { probes, restore: () => { global.Image = originalImage; } };
+  }
 
   it("hides the 'Image reference' tile for a plain t2i model without ui.img2img", async () => {
     // sc-10195: img2img is its own tile, gated purely on `ui.img2img`. A plain model with no captioner
@@ -1971,25 +1993,7 @@ describe("ImageStudio Image-reference (img2img) tile (epic 8588, sc-8593/sc-1019
   });
 
   it("ignores a superseded reference probe that loads after the newer image", async () => {
-    const originalImage = global.Image;
-    const probes = [];
-    class FakeImageProbe {
-      constructor() {
-        this.naturalWidth = 0;
-        this.naturalHeight = 0;
-        this.onload = null;
-        probes.push(this);
-      }
-
-      set src(value) {
-        this._src = value;
-      }
-
-      get src() {
-        return this._src;
-      }
-    }
-    global.Image = FakeImageProbe;
+    const { probes, restore } = installFakeImageProbes();
     const portrait = {
       id: "portrait",
       type: "image",
@@ -2042,7 +2046,77 @@ describe("ImageStudio Image-reference (img2img) tile (epic 8588, sc-8593/sc-1019
       });
       expect(field(container, "Aspect").value).toBe("1536x1024");
     } finally {
-      global.Image = originalImage;
+      restore();
+    }
+  });
+
+  it("restarts a pending reference probe when the model resolution options change", async () => {
+    const { probes, restore } = installFakeImageProbes();
+    const portrait = {
+      id: "portrait",
+      type: "image",
+      projectId: "project_1",
+      displayName: "Portrait reference",
+      url: "/portrait.png",
+      status: {},
+    };
+    const oldCatalogModel = {
+      ...KREA_IMG2IMG,
+      defaults: { resolution: "1024x1536" },
+      limits: { resolutions: ["1024x1536", "1536x1024"] },
+    };
+    const updatedCatalogModel = {
+      ...oldCatalogModel,
+      // The old bucket remains valid, but the refreshed catalog adds an exact
+      // 3:4 match that must win for a 900x1200 reference.
+      limits: { resolutions: ["1024x1536", "768x1024", "1536x1024"] },
+    };
+    const assets = [portrait];
+
+    try {
+      await render(
+        baseContext({
+          assets,
+          imageModels: [oldCatalogModel],
+          models: [oldCatalogModel],
+        }),
+      );
+      await click(tileByText("Image reference"));
+      await click(tileByText("Select reference image"));
+      await click(document.body.querySelector(".asset-picker-card"));
+      await click(tileByText("Use Selection"));
+      expect(probes).toHaveLength(1);
+      const staleOnload = probes[0].onload;
+      expect(field(container, "Aspect").value).toBe("1024x1536");
+
+      // Keep the same asset and selected model id while refreshing its declared
+      // resolution buckets. The in-flight probe must be cancelled and restarted
+      // because its callback otherwise closes over the old options.
+      await render(
+        baseContext({
+          assets,
+          imageModels: [updatedCatalogModel],
+          models: [updatedCatalogModel],
+        }),
+      );
+      expect(probes).toHaveLength(2);
+      expect(field(container, "Aspect").value).toBe("1024x1536");
+
+      probes[1].naturalWidth = 900;
+      probes[1].naturalHeight = 1200;
+      await act(async () => {
+        probes[1].onload();
+      });
+      expect(field(container, "Aspect").value).toBe("768x1024");
+
+      probes[0].naturalWidth = 900;
+      probes[0].naturalHeight = 1200;
+      await act(async () => {
+        staleOnload();
+      });
+      expect(field(container, "Aspect").value).toBe("768x1024");
+    } finally {
+      restore();
     }
   });
 });

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -130,14 +130,21 @@ export function LibraryScreen() {
   });
 
   async function handleImport(event) {
-    const [file] = event.target.files;
+    const input = event.currentTarget;
+    const [file] = input.files;
     if (!file) {
       return;
     }
     setIsImporting(true);
-    await importAsset(file);
-    setIsImporting(false);
-    event.target.value = "";
+    try {
+      await importAsset(file);
+    } catch {
+      // importAsset owns the user-facing request error; always restore this
+      // screen's file control even when an injected importer rejects.
+    } finally {
+      setIsImporting(false);
+      input.value = "";
+    }
   }
 
   const imageCount = libraryAssets.filter((asset) => asset.type === "image").length;

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { terminalStatuses } from "../constants.js";
@@ -111,6 +111,12 @@ const MODEL_TYPE_OPTIONS = [
   { value: "video", label: "Video" },
   { value: "audio", label: "Audio" },
   { value: "utility", label: "Utility" },
+];
+const MODEL_TAB_TYPES = [
+  ["image", "Image Models"],
+  ["video", "Video Models"],
+  ["audio", "Audio Models"],
+  ["utility", "Utility Models"],
 ];
 
 // sc-7081 (epic 7080, P0) originally hid this form on every platform because an imported
@@ -777,7 +783,10 @@ export function ModelManagerScreen() {
     });
   }, [models]);
   const hasGatedModel = models.some((model) => model.gated);
-  const visibleLoras = loras.filter((lora) => matchesFamily(lora, familyFilter));
+  const visibleLoras = useMemo(
+    () => loras.filter((lora) => matchesFamily(lora, familyFilter)),
+    [familyFilter, loras],
+  );
   // Wan A14B MoE paired upload (sc-1991): when the user targets the wan-video
   // family, let them pick the specific base model and (for two-expert A14B models)
   // upload the low-noise expert half alongside the high-noise primary.
@@ -1602,37 +1611,81 @@ export function ModelManagerScreen() {
   // dropdown is built from) and to LoRAs via matchesFamily — so a selected token never hides
   // everything. Search is case-insensitive over name/family/capability labels (models) and
   // name/family (LoRAs).
-  const modelMatchesFamily = (model) => familyFilter === "all" || modelLoraFamilies(model).includes(familyFilter);
-  const modelCapabilityLabels = (model) =>
-    (Array.isArray(model.capabilities) ? model.capabilities : []).map(capabilityLabel);
-  const modelMatchesQuery = (model) =>
-    !hasSearch ||
-    (model.name ?? model.id ?? "").toLowerCase().includes(query) ||
-    (model.family ?? "").toLowerCase().includes(query) ||
-    modelCapabilityLabels(model).some((label) => label.toLowerCase().includes(query));
-  const loraMatchesQuery = (lora) =>
-    !hasSearch ||
-    (lora.name ?? lora.id ?? "").toLowerCase().includes(query) ||
-    (lora.family ?? "").toLowerCase().includes(query);
+  // Derive every model tab, count, and search group in one memoized catalog pass.
+  // Rendering the Recommended band and the full tab panel then shares the same
+  // arrays instead of repeating type/search/family filters for each consumer.
+  const { modelGroupsByType, modelTypeCounts, searchModelMatches } = useMemo(() => {
+    const activeByType = Object.fromEntries(MODEL_TAB_TYPES.map(([type]) => [type, []]));
+    const counts = Object.fromEntries(MODEL_TAB_TYPES.map(([type]) => [type, 0]));
+    const searchMatches = [];
+    for (const model of models) {
+      if (counts[model.type] !== undefined) {
+        counts[model.type] += 1;
+      }
+      const familyMatches =
+        familyFilter === "all" || modelLoraFamilies(model).includes(familyFilter);
+      const queryMatches =
+        !hasSearch ||
+        (model.name ?? model.id ?? "").toLowerCase().includes(query) ||
+        (model.family ?? "").toLowerCase().includes(query) ||
+        (Array.isArray(model.capabilities) ? model.capabilities : [])
+          .map(capabilityLabel)
+          .some((label) => label.toLowerCase().includes(query));
+      if (!familyMatches || !queryMatches) {
+        continue;
+      }
+      searchMatches.push(model);
+      activeByType[model.type]?.push(model);
+    }
 
-  // Cross-type search matches feed the transient Search Results tab + its badge count. LoRAs are
-  // taken from the already family-filtered `visibleLoras`.
-  const searchModelMatches = models.filter(modelMatchesQuery).filter(modelMatchesFamily);
-  const searchLoraMatches = visibleLoras.filter(loraMatchesQuery);
+    const groups = {};
+    for (const [type] of MODEL_TAB_TYPES) {
+      const recommended = [];
+      const others = [];
+      for (const model of activeByType[type]) {
+        (isRecommendedModel(model) ? recommended : others).push(model);
+      }
+      const typeLabel = type;
+      groups[type] = {
+        activeModels: activeByType[type],
+        recommended,
+        others,
+        othersHeading:
+          recommended.length > 0
+            ? `All ${typeLabel} models`
+            : `${typeLabel.charAt(0).toUpperCase()}${typeLabel.slice(1)} models`,
+      };
+    }
+    return {
+      modelGroupsByType: groups,
+      modelTypeCounts: counts,
+      searchModelMatches: searchMatches,
+    };
+  }, [familyFilter, hasSearch, models, query]);
+  const searchLoraMatches = useMemo(
+    () =>
+      visibleLoras.filter(
+        (lora) =>
+          !hasSearch ||
+          (lora.name ?? lora.id ?? "").toLowerCase().includes(query) ||
+          (lora.family ?? "").toLowerCase().includes(query),
+      ),
+    [hasSearch, query, visibleLoras],
+  );
   const searchTotalCount = searchModelMatches.length + searchLoraMatches.length;
 
   // Tab definitions — counts are TOTALS per type (not the filtered view). The transient Search
   // Results tab is appended only while a search is active; its badge is the live match count.
-  const tabDefs = [
-    ["image", "Image Models", models.filter((model) => model.type === "image").length],
-    ["video", "Video Models", models.filter((model) => model.type === "video").length],
-    ["audio", "Audio Models", models.filter((model) => model.type === "audio").length],
-    ["utility", "Utility Models", models.filter((model) => model.type === "utility").length],
-    ["lora", "LoRAs", loras.length],
-  ];
-  if (hasSearch) {
-    tabDefs.push(["search", "⌕ Search Results", searchTotalCount]);
-  }
+  const tabDefs = useMemo(() => {
+    const definitions = [
+      ...MODEL_TAB_TYPES.map(([type, label]) => [type, label, modelTypeCounts[type]]),
+      ["lora", "LoRAs", loras.length],
+    ];
+    if (hasSearch) {
+      definitions.push(["search", "⌕ Search Results", searchTotalCount]);
+    }
+    return definitions;
+  }, [hasSearch, loras.length, modelTypeCounts, searchTotalCount]);
 
   const isSearchTab = effectiveTab === "search";
   const isLoraTab = effectiveTab === "lora";
@@ -1640,26 +1693,11 @@ export function ModelManagerScreen() {
 
   // A model type panel: an accent Recommended band (when any recommended match) over an
   // "All {type} models" grid of the rest. Both filtered by the active search + family.
-  // Filter the catalog for a type by the active search + family, split into the
-  // curated Recommended picks (surfaced in the work-panel) and the rest.
-  function modelTabGroups(type) {
-    const activeModels = models
-      .filter((model) => model.type === type)
-      .filter(modelMatchesQuery)
-      .filter(modelMatchesFamily);
-    const recommended = activeModels.filter(isRecommendedModel);
-    const others = activeModels.filter((model) => !isRecommendedModel(model));
-    const typeLabel = { image: "image", video: "video", audio: "audio", utility: "utility" }[type] ?? type;
-    const othersHeading =
-      recommended.length > 0 ? `All ${typeLabel} models` : `${typeLabel.charAt(0).toUpperCase()}${typeLabel.slice(1)} models`;
-    return { recommended, others, othersHeading };
-  }
-
   // Recommended picks, rendered flush inside the work-panel (Page-Frame standard:
   // curated getting-started content belongs to the action, not floating on the
   // canvas). No accent-band card here — the work-panel is already the one card.
   function renderRecommendedPicks(type) {
-    const { recommended } = modelTabGroups(type);
+    const { recommended } = modelGroupsByType[type];
     if (!recommended.length) {
       return null;
     }
@@ -1816,7 +1854,7 @@ export function ModelManagerScreen() {
   // The catalog grid on the canvas: "All {type} models" (the non-recommended
   // rest). Recommended picks render separately in the work-panel above.
   function renderModelTabPanel(type) {
-    const { recommended, others, othersHeading } = modelTabGroups(type);
+    const { recommended, others, othersHeading } = modelGroupsByType[type];
     return (
       <div className="models-tab-panel">
         {type === "image" ? renderModelImportPanel() : null}
@@ -1839,13 +1877,8 @@ export function ModelManagerScreen() {
   // The transient Search Results tab: cross-type model matches grouped by type, then a LoRA
   // section using the shared row. Only non-empty groups render.
   function renderSearchTabPanel() {
-    const groups = [
-      ["image", "Image Models"],
-      ["video", "Video Models"],
-      ["audio", "Audio Models"],
-      ["utility", "Utility Models"],
-    ]
-      .map(([type, label]) => ({ label, items: searchModelMatches.filter((model) => model.type === type) }))
+    const groups = MODEL_TAB_TYPES
+      .map(([type, label]) => ({ label, items: modelGroupsByType[type].activeModels }))
       .filter((group) => group.items.length > 0);
     const isEmpty = groups.length === 0 && searchLoraMatches.length === 0;
     return (

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -969,16 +969,31 @@ export function VideoStudio() {
   // left enabled so a reduced catalog can't strand you on a disabled tab. `macVideoModeBlock` still
   // gates the in-mode model picker + submit (via `modelsForMode` / `supportsMode`).
   const macModeTabBlocked = (value) => macGating && modelsForMode(value).length === 0;
-  const matchingTracks = personTracks.filter((track) => track.sourceAssetId === sourceClipAssetId);
-  const latestDetectionJob = jobs
-    .filter(
-      (job) =>
+  const matchingTracks = useMemo(
+    () =>
+      mode === "replace_person"
+        ? personTracks.filter((track) => track.sourceAssetId === sourceClipAssetId)
+        : [],
+    [mode, personTracks, sourceClipAssetId],
+  );
+  const latestDetectionJob = useMemo(() => {
+    if (mode !== "replace_person" || !activeProject?.id || !sourceClipAssetId) {
+      return null;
+    }
+    let latest = null;
+    for (const job of jobs) {
+      if (
         job.type === "person_detect" &&
         job.status === "completed" &&
-        job.projectId === activeProject?.id &&
-        job.payload?.sourceAssetId === sourceClipAssetId,
-    )
-    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+        job.projectId === activeProject.id &&
+        job.payload?.sourceAssetId === sourceClipAssetId &&
+        (!latest || job.createdAt.localeCompare(latest.createdAt) > 0)
+      ) {
+        latest = job;
+      }
+    }
+    return latest;
+  }, [activeProject?.id, jobs, mode, sourceClipAssetId]);
   const detectionResult = latestDetectionJob?.result ?? null;
   const representativeFrame = assets.find((asset) => asset.id === detectionResult?.frameAssetId);
   const selectedDetection = detectionResult?.detections?.find((item) => item.id === selectedDetectionId) ?? detectionResult?.detections?.[0];


### PR DESCRIPTION
## Summary
- make Library and Document Studio busy state exception-safe and cancel stale img2img dimension probes
- share prompt-only composition for style preview and batch budget checks while preserving request semantics
- surface partial Image Editor reference-import failures and remove stale props/comments
- memoize replace-person scans and Model Manager tab derivation

## Validation
- `npm test` — 178 files, 2,527 tests passed
- `npm run build` — passed
- `npm run lint` — passed with 63 pre-existing warnings and no errors/new warnings
- `git diff --check` — passed

Shortcut: [sc-13648](https://app.shortcut.com/trefry/story/13648)