### PR TITLE
fix(worker): address training review findings [sc-13644]

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -90,7 +90,7 @@ pub(crate) async fn create_job(
             payload.job_type.as_str()
         )));
     }
-    validate_raw_job_model_id(&payload.job_type, &payload.payload)?;
+    validate_raw_job_payload(&state, &payload.job_type, &payload.payload)?;
     let job = store_call(state.clone(), move |store, _timeout| {
         store.create_job(CreateJob {
             job_type: payload.job_type,
@@ -411,6 +411,8 @@ async fn validate_and_canonicalize_merged_generation_payload(
     merged.extend(payload_changes.clone());
     if generation_job_model_is_path_backed(&job_type) {
         validate_payload_model(&merged)?;
+    } else {
+        validate_raw_job_payload(state, &job_type, &merged)?;
     }
     if matches!(job_type, JobType::ImageGenerate | JobType::ImageEdit) {
         crate::control_overlays::resolve_control_overlay_selection(
@@ -426,9 +428,14 @@ async fn validate_and_canonicalize_merged_generation_payload(
 /// Jobs created through the raw queue route do not pass a typed request validator. Keep this
 /// inventory aligned with worker payload fields that reach filesystem model resolution:
 /// `image_upscale` and `prompt_refine` consume `model`; the model-management jobs consume
-/// `modelId`. Other raw job payloads may contain descriptive model metadata, but are deliberately
-/// absent unless that field selects a filesystem path.
-fn validate_raw_job_model_id(job_type: &JobType, payload: &JsonObject) -> Result<(), ApiError> {
+/// `modelId`, and `model_convert.outputDir` selects its final install location. Other raw job
+/// payloads may contain descriptive model metadata, but are deliberately absent unless that field
+/// selects a filesystem path.
+fn validate_raw_job_payload(
+    state: &AppState,
+    job_type: &JobType,
+    payload: &JsonObject,
+) -> Result<(), ApiError> {
     if matches!(job_type, JobType::ImageUpscale | JobType::PromptRefine) {
         validate_payload_model(payload)?;
     }
@@ -437,6 +444,15 @@ fn validate_raw_job_model_id(job_type: &JobType, payload: &JsonObject) -> Result
         JobType::ModelDownload | JobType::ModelImport | JobType::ModelConvert
     ) {
         validate_payload_model_id(payload)?;
+    }
+    if matches!(job_type, JobType::ModelConvert) {
+        let output_dir = payload
+            .get("outputDir")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| ApiError::bad_request("model_convert outputDir must be a string"))?;
+        sceneworks_worker::resolve_model_convert_output(&state.settings.data_dir, output_dir)
+            .map_err(|error| ApiError::bad_request(error.to_string()))?;
     }
     Ok(())
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -469,11 +469,19 @@ pub fn gpu_check() -> Result<(), String> {
 /// (sc-10723). Running ≥2 loops lets independent downloads proceed in parallel; the
 /// per-file `DownloadLock` (sc-8900) still serializes two jobs resolving the *same*
 /// cache target, so concurrency never corrupts a shared file.
-fn spawn_inprocess_utility_worker(port: u16) -> InProcessUtilityWorker {
+async fn spawn_inprocess_utility_worker(
+    port: u16,
+    data_dir: PathBuf,
+) -> Result<InProcessUtilityWorker, sceneworks_worker::WorkerError> {
     let mut worker_settings = sceneworks_worker::Settings::from_env();
     worker_settings.api_url = format!("http://127.0.0.1:{port}");
+    worker_settings.data_dir = data_dir;
     worker_settings.gpu_id =
         inprocess_worker_gpu_id(std::env::var("SCENEWORKS_RUST_WORKER_GPU_ID").ok());
+    // This API process is the top-level owner of the in-process utility loops, which deliberately
+    // call `run_worker_loop` directly. Recover once here before any loop can claim a conversion;
+    // never put recovery inside each child loop, where sibling restarts could sweep live backups.
+    sceneworks_worker::recover_stranded_model_conversions(&worker_settings.data_dir).await?;
     let grace = Duration::from_secs(worker_settings.shutdown_timeout_seconds.max(1));
     let count = inprocess_utility_worker_count();
     let base_worker_id = worker_settings.worker_id.clone();
@@ -492,7 +500,7 @@ fn spawn_inprocess_utility_worker(port: u16) -> InProcessUtilityWorker {
             tokio::spawn(async move { sceneworks_worker::run_worker_loop(settings).await })
         })
         .collect();
-    InProcessUtilityWorker { handles, grace }
+    Ok(InProcessUtilityWorker { handles, grace })
 }
 
 /// Number of in-process CPU utility worker loops to run. Defaults to **2** so desktop

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -348,6 +348,21 @@ pub(crate) async fn create_model_convert_job(
     Path(model_id): Path<String>,
     ApiJson(payload): ApiJson<ModelConvertRequest>,
 ) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    // Derive and confine the route-selected destination before catalog assembly performs any
+    // filesystem/cache inspection. Path-shaped IDs must fail at the request boundary rather than
+    // falling through to a misleading catalog 404 after that work.
+    let output_dir = state
+        .settings
+        .data_dir
+        .join("models")
+        .join("mlx")
+        .join(&model_id);
+    sceneworks_worker::resolve_model_convert_output(
+        &state.settings.data_dir,
+        &output_dir.display().to_string(),
+    )
+    .map_err(|error| ApiError::bad_request(error.to_string()))?;
+
     let model = model_catalog(&state)
         .await?
         .into_iter()
@@ -388,12 +403,6 @@ pub(crate) async fn create_model_convert_job(
             "Model does not require MLX conversion",
         ));
     };
-    let output_dir = state
-        .settings
-        .data_dir
-        .join("models")
-        .join("mlx")
-        .join(&model_id);
     let mut job_payload = JsonObject::new();
     job_payload.insert("modelId".to_owned(), Value::String(model_id.clone()));
     job_payload.insert(

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -373,6 +373,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     let run_utility_inprocess = settings.run_utility_inprocess;
+    let utility_data_dir = settings.data_dir.clone();
     let app = create_app(settings)?;
     let listener = tokio::net::TcpListener::bind(address).await?;
     // Use the actual bound address so port 0 (OS-assigned) is reported and the
@@ -385,7 +386,11 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         "SceneWorks API listening"
     );
 
-    let utility_worker = run_utility_inprocess.then(|| spawn_inprocess_utility_worker(port));
+    let utility_worker = if run_utility_inprocess {
+        Some(spawn_inprocess_utility_worker(port, utility_data_dir).await?)
+    } else {
+        None
+    };
 
     // `into_make_service_with_connect_info` exposes the peer `SocketAddr` to the auth
     // middleware so loopback callers can be trusted (epic 4484: keep the local desktop UI

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -165,6 +165,100 @@ async fn generic_model_utility_jobs_reject_path_unsafe_model_id_before_create() 
     assert!(jobs.as_array().expect("jobs array").is_empty());
 }
 
+#[tokio::test]
+async fn raw_model_convert_rejects_unrecoverable_output_before_enqueue() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let conversion_root = settings.data_dir.join("models/mlx");
+    let app = create_app(settings).expect("app creates");
+
+    let request_convert = |output_dir: &std::path::Path| {
+        json!({
+            "type": "model_convert",
+            "requestedGpu": "auto",
+            "payload": {
+                "modelId": "model-1",
+                "sourceRepo": "owner/source",
+                "outputDir": output_dir.display().to_string(),
+            },
+        })
+    };
+
+    let (status, accepted) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        request_convert(&conversion_root.join(".foo.finalize-backup-123")),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "backup-looking model names remain valid in the disjoint recovery design: {accepted}"
+    );
+
+    for (output_dir, expected) in [
+        (conversion_root.join("nested/model-2"), "direct child"),
+        (
+            temp_dir.path().join("data/models/custom-model"),
+            "direct child",
+        ),
+        (
+            conversion_root.join(".sceneworks-finalize-backups"),
+            "reserved",
+        ),
+    ] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/jobs",
+            request_convert(&output_dir),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{output_dir:?}: {body}");
+        assert!(
+            body["detail"]
+                .as_str()
+                .is_some_and(|detail| detail.contains(expected)),
+            "{output_dir:?}: expected {expected:?} in {body}"
+        );
+    }
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        jobs.as_array().expect("jobs array").len(),
+        1,
+        "invalid conversion targets must fail before persistence"
+    );
+}
+
+/// The route-derived output path is a trust-boundary input too. Confinement must run before
+/// `model_catalog` performs its filesystem/cache sweep, so an invalid path-shaped ID wins over the
+/// catalog's otherwise-observable "Model not found" response.
+#[tokio::test]
+async fn typed_model_convert_confines_route_id_before_catalog_lookup() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    for (encoded_model_id, expected) in [
+        ("%2E%2E", "direct child"),
+        (".sceneworks-finalize-backups", "reserved"),
+    ] {
+        let endpoint = format!("/api/v1/models/{encoded_model_id}/convert");
+        let (status, body) = request(app.clone(), "POST", &endpoint, json!({})).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{endpoint}: {body}");
+        let detail = body["detail"].as_str().unwrap_or_default();
+        assert!(
+            detail.contains(expected),
+            "{endpoint}: confinement must precede catalog/404 work, got {body}"
+        );
+        assert!(
+            !detail.contains("Model not found"),
+            "{endpoint}: invalid route ID must not fall through to catalog lookup"
+        );
+    }
+}
+
 /// sc-13617 / F-011: retry and duplicate merge payloadChanges into an existing generation
 /// payload. Validate the merged model before either operation can persist a new job.
 #[tokio::test]

--- a/apps/rust-api/src/tests/server.rs
+++ b/apps/rust-api/src/tests/server.rs
@@ -158,6 +158,38 @@ fn inprocess_utility_worker_ids_are_distinct_and_stable() {
     assert_eq!(ids.len(), 4);
 }
 
+/// The rust-api does not call the worker crate's top-level `run`; it owns and spawns
+/// `run_worker_loop` tasks directly. Exercise that exact production spawn boundary and prove
+/// recovery runs before any loop is created by giving it an unsafe conversion root. If recovery
+/// were removed from the topology, this would return a live pool instead of the confinement error.
+#[cfg(unix)]
+#[tokio::test]
+async fn inprocess_utility_worker_startup_runs_conversion_recovery_before_spawning_loops() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let models_dir = data_dir.join("models");
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&models_dir).expect("models root");
+    std::fs::create_dir_all(&outside).expect("outside root");
+    std::os::unix::fs::symlink(&outside, models_dir.join("mlx"))
+        .expect("nested conversion-root symlink");
+
+    let result = crate::spawn_inprocess_utility_worker(0, data_dir).await;
+
+    match result {
+        Err(error) => assert!(
+            error.to_string().contains("escapes managed data root"),
+            "the production spawn boundary surfaces recovery confinement: {error:?}"
+        ),
+        Ok(worker) => {
+            for handle in worker.handles {
+                handle.abort();
+            }
+            panic!("production in-process startup skipped conversion recovery");
+        }
+    }
+}
+
 /// The watchdog must stay pending while the parent lives and resolve once it
 /// exits — the desktop-sidecar orphan fix. Mirrors the Python worker's
 /// parent-death test: spawn a dummy parent, confirm it isn't flagged alive

--- a/crates/sceneworks-worker/src/control_dataset_byo.rs
+++ b/crates/sceneworks-worker/src/control_dataset_byo.rs
@@ -234,12 +234,6 @@ pub(crate) fn ingest_prepared_pose_pairs(
 
 // --- Annotated (COCO person_keypoints + captions) --------------------------------------------
 
-/// A COCO images/annotations JSON envelope (only the fields we read).
-#[derive(Deserialize)]
-struct CocoImages {
-    images: Vec<CocoImage>,
-}
-
 #[derive(Deserialize)]
 struct CocoImage {
     id: i64,
@@ -250,6 +244,7 @@ struct CocoImage {
 
 #[derive(Deserialize)]
 struct CocoKeypointFile {
+    images: Vec<CocoImage>,
     annotations: Vec<CocoKeypointAnn>,
 }
 
@@ -331,13 +326,12 @@ pub(crate) fn ingest_coco_annotated(
     let label = control_kind_label(&ControlKind::Pose);
     std::fs::create_dir_all(out_dir.join("train"))?;
 
-    let images: CocoImages = read_json(&source.keypoints_json)?;
     let keypoints: CocoKeypointFile = read_json(&source.keypoints_json)?;
     let captions: CocoCaptionFile = read_json(&source.captions_json)?;
 
     // image_id → (file_name, w, h)
     let image_by_id: std::collections::HashMap<i64, CocoImage> =
-        images.images.into_iter().map(|im| (im.id, im)).collect();
+        keypoints.images.into_iter().map(|im| (im.id, im)).collect();
     // image_id → first caption
     let mut caption_by_id: std::collections::HashMap<i64, String> =
         std::collections::HashMap::new();

--- a/crates/sceneworks-worker/src/control_training_jobs.rs
+++ b/crates/sceneworks-worker/src/control_training_jobs.rs
@@ -39,7 +39,9 @@ mod imp {
     use crate::control_preprocess::{control_kind_label, PreprocessResources};
     use crate::downloads::DownloadContext;
     use crate::paths::resolve_dataset_item_path;
-    use crate::training_jobs::{parse_plan, run_training_execution, training_progress};
+    use crate::training_jobs::{
+        parse_plan, run_training_execution, training_progress, validate_training_plan,
+    };
 
     /// The only kernel the studio job trains today — the Krea 2 pose-ControlNet branch. The API stamps
     /// it into the plan (`krea_control` target); a plan with any other kernel is rejected here rather
@@ -101,6 +103,10 @@ mod imp {
     ) -> WorkerResult<()> {
         let backend = backend_label(&settings.gpu_id);
         let mut plan = parse_plan(&job.payload)?;
+        // Validate caller-controlled output and input confinement before heartbeat, weight downloads,
+        // detector setup, or GPU rendering. The rewritten rendered-dataset plan is validated again by
+        // `run_training_execution` after preparation.
+        validate_training_plan(settings, &plan)?;
         if plan.target.kernel != CONTROL_KERNEL {
             return Err(WorkerError::InvalidPayload(format!(
                 "control_training expects a '{CONTROL_KERNEL}' plan, got kernel '{}'.",
@@ -444,7 +450,8 @@ mod imp {
 
     #[cfg(test)]
     mod tests {
-        use super::{control_kind_from_label, ControlKind, WorkDirGuard};
+        use super::*;
+        use serde_json::json;
 
         /// A unique temp path per test (process id + line) so parallel/leftover runs don't collide.
         fn unique_temp(tag: &str, line: u32) -> std::path::PathBuf {
@@ -504,6 +511,114 @@ mod imp {
             assert_eq!(
                 control_kind_from_label("scribble"),
                 ControlKind::Other("scribble".to_owned())
+            );
+        }
+
+        #[tokio::test]
+        async fn invalid_output_is_rejected_before_heartbeat_or_preprocessor_download() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let data_dir = temp.path().join("data");
+            let dataset_root = data_dir.join("datasets/ds-1");
+            std::fs::create_dir_all(&dataset_root).expect("dataset root");
+            std::fs::write(dataset_root.join("image.png"), b"present").expect("dataset image");
+
+            let mut settings = Settings::from_env();
+            settings.data_dir = data_dir.clone();
+            // No server listens here. Reaching heartbeat (and therefore any later weight download)
+            // would produce an HTTP error instead of the confinement error asserted below.
+            settings.api_url = "http://127.0.0.1:1".to_owned();
+            settings.worker_id = "test-worker".to_owned();
+            settings.gpu_id = "gpu-0".to_owned();
+            let plan = json!({
+                "schemaVersion": 1,
+                "planVersion": 1,
+                "jobId": "job-control",
+                "target": {
+                    "targetId": "krea_control_target",
+                    "kernel": "krea_control",
+                    "family": "krea",
+                    "modality": "image",
+                    "outputKind": "controlnet",
+                    "baseModel": "krea_2_raw",
+                    "baseModelPath": data_dir.join("models/krea").display().to_string()
+                },
+                "dataset": {
+                    "datasetId": "ds-1",
+                    "datasetVersion": 1,
+                    "rootPath": dataset_root.display().to_string(),
+                    "items": [{
+                        "imagePath": "image.png",
+                        "caption": "a person"
+                    }]
+                },
+                "config": {
+                    "rank": 16,
+                    "alpha": 16,
+                    "learningRate": 0.0001,
+                    "steps": 10,
+                    "batchSize": 1,
+                    "gradientAccumulation": 1,
+                    "resolution": 512,
+                    "saveEvery": 10,
+                    "seed": 1,
+                    "optimizer": "adamw",
+                    "advanced": { "controlType": "pose" }
+                },
+                "output": {
+                    "loraId": "control-1",
+                    "outputDir": data_dir.join("outside-managed-output").display().to_string(),
+                    "fileName": "control.safetensors",
+                    "format": "safetensors",
+                    "triggerWords": []
+                },
+                "provenance": {
+                    "datasetId": "ds-1",
+                    "datasetVersion": 1,
+                    "targetId": "krea_control_target",
+                    "baseModel": "krea_2_raw",
+                    "configSnapshot": {},
+                    "outputLoraId": "control-1",
+                    "sourceJobId": "job-control",
+                    "createdAt": "2026-07-25T00:00:00Z"
+                }
+            });
+            let job: JobSnapshot = serde_json::from_value(json!({
+                "id": "job-control",
+                "type": "control_training",
+                "status": "running",
+                "projectId": null,
+                "projectName": null,
+                "payload": { "plan": plan },
+                "result": {},
+                "requestedGpu": "auto",
+                "assignedGpu": "gpu-0",
+                "workerId": "test-worker",
+                "progress": 0.0,
+                "stage": "queued",
+                "message": "queued",
+                "error": null,
+                "etaSeconds": null,
+                "elapsedSeconds": null,
+                "attempts": 1,
+                "sourceJobId": null,
+                "duplicateOfJobId": null,
+                "cancelRequested": false,
+                "createdAt": "2026-07-25T00:00:00Z",
+                "updatedAt": "2026-07-25T00:00:00Z",
+                "startedAt": null,
+                "completedAt": null,
+                "canceledAt": null,
+                "lastHeartbeatAt": null
+            }))
+            .expect("job snapshot");
+            let api = ApiClient::new(&settings);
+
+            let error = run_control_training_job(&api, &settings, &reqwest::Client::new(), &job)
+                .await
+                .expect_err("out-of-root output is rejected");
+            assert!(
+                error.to_string().contains("Training outputDir"),
+                "confinement validation must win before network/GPU setup: {error:?}"
             );
         }
     }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -828,7 +828,11 @@ pub async fn run() -> WorkerResult<()> {
         );
     }
     let settings = Settings::from_env();
+    // Only the top-level worker process performs conversion recovery. It runs before any utility
+    // children are spawned, and the lifecycle lock excludes independently running finalizers.
+    // Child restarts must never sweep while sibling utility workers may be converting.
     if !settings.is_child_worker {
+        sweep_stranded_conversion_backups(&settings.data_dir).await?;
         if settings.gpu_id == "auto" {
             return supervise_auto_workers(settings).await;
         }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -120,6 +120,7 @@ mod vram_gate;
 mod krea_control_fit;
 use supervisor::*;
 mod model_jobs;
+pub use model_jobs::recover_stranded_model_conversions;
 use model_jobs::*;
 mod media_jobs;
 use media_jobs::*;
@@ -832,7 +833,7 @@ pub async fn run() -> WorkerResult<()> {
     // children are spawned, and the lifecycle lock excludes independently running finalizers.
     // Child restarts must never sweep while sibling utility workers may be converting.
     if !settings.is_child_worker {
-        sweep_stranded_conversion_backups(&settings.data_dir).await?;
+        recover_stranded_model_conversions(&settings.data_dir).await?;
         if settings.gpu_id == "auto" {
             return supervise_auto_workers(settings).await;
         }

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -426,7 +426,7 @@ pub(crate) async fn run_lora_download_job(
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );
-    download_snapshot_into_cache(
+    let resolved_revision = download_snapshot_into_cache(
         &DownloadContext {
             api,
             client: http_client,
@@ -441,17 +441,6 @@ pub(crate) async fn run_lora_download_job(
         &mut progress,
     )
     .await?;
-    // Symmetric with the `refs/<rev>` write in `download_snapshot_into_cache`: confine the read path
-    // so this receipt-facing lookup can't be turned into an arbitrary-file read by a `..`/absolute
-    // revision (sc-13583). `revision` is already validated at the entry point above; this is the
-    // defense-in-depth twin of the write-side `safe_join`.
-    let refs_path = safe_join(&repo_dir.join("refs"), revision)?;
-    let resolved_revision = tokio::fs::read_to_string(refs_path)
-        .await
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| revision.to_owned());
     let resolved_files = snapshot
         .files
         .iter()
@@ -1569,7 +1558,9 @@ pub(crate) async fn run_model_convert_job(
 
     // Promote the completed conversion atomically; on any rename failure the partial
     // temp dir is removed so it can't be picked up later.
-    if let Err(error) = finalize_converted_dir(&temp_dir, &final_dir).await {
+    if let Err(error) =
+        finalize_converted_dir(&temp_dir, &final_dir, &settings.data_dir.join("models/mlx")).await
+    {
         let _ = tokio::fs::remove_dir_all(&temp_dir).await;
         return Err(error);
     }
@@ -2062,43 +2053,12 @@ fn relink_to_blob(link: &Path) {
 /// first, rename temp → final, and only then delete the backup. If anything fails after
 /// the aside move, we RESTORE the backup back to `final_dir`, honoring the doc's promise
 /// that on error the previously working model is left untouched.
-pub(crate) async fn finalize_converted_dir(temp_dir: &Path, final_dir: &Path) -> WorkerResult<()> {
-    if let Some(parent) = final_dir.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-
-    // Move any stale install aside instead of destroying it, so a later failure can
-    // restore it. The backup lives next to `final_dir` (same filesystem) so the move is
-    // an atomic rename and the restore is equally cheap and safe.
-    let backup_dir: Option<PathBuf> = if final_dir.exists() {
-        let backup = converted_dir_backup_path(final_dir);
-        // A leftover backup from a prior interrupted finalize would block the aside move;
-        // clear it first (best effort — a stale backup is never the working install).
-        let _ = tokio::fs::remove_dir_all(&backup).await;
-        tokio::fs::rename(final_dir, &backup).await?;
-        Some(backup)
-    } else {
-        None
-    };
-
-    // Promote the freshly converted dir into place. On any failure, restore the stale
-    // install so the user keeps the previously working model.
-    if let Err(error) = tokio::fs::rename(temp_dir, final_dir).await {
-        if let Some(backup) = backup_dir {
-            // Best effort: the working install is the priority, so ignore restore errors
-            // (there is nothing more we can do) but surface the original failure.
-            let _ = tokio::fs::remove_dir_all(final_dir).await;
-            let _ = tokio::fs::rename(&backup, final_dir).await;
-        }
-        return Err(error.into());
-    }
-
-    // Success: the new install is in place; drop the stale backup (best effort — a
-    // leftover backup is harmless and never mistaken for the live install).
-    if let Some(backup) = backup_dir {
-        let _ = tokio::fs::remove_dir_all(&backup).await;
-    }
-    Ok(())
+pub(crate) async fn finalize_converted_dir(
+    temp_dir: &Path,
+    final_dir: &Path,
+    conversion_root: &Path,
+) -> WorkerResult<()> {
+    finalize_converted_dir_with_hook(temp_dir, final_dir, conversion_root, |_| {}).await
 }
 
 /// Sibling backup path used to move a stale converted dir aside during finalize
@@ -2109,11 +2069,259 @@ fn converted_dir_backup_path(final_dir: &Path) -> PathBuf {
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| "model".to_string());
-    let suffix = format!(".{name}.finalize-backup-{}", std::process::id());
+    let suffix = format!(
+        ".{name}.finalize-backup-{}-{}",
+        std::process::id(),
+        Uuid::new_v4()
+    );
     match final_dir.parent() {
         Some(parent) => parent.join(suffix),
         None => PathBuf::from(suffix),
     }
+}
+
+const CONVERSION_LIFECYCLE_LOCK: &str = ".conversion-finalize.lock";
+const CONVERSION_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const CONVERSION_LOCK_POLL: std::time::Duration = std::time::Duration::from_millis(25);
+
+/// Run one final promotion under a cross-process shared lifecycle lock plus an exclusive per-target
+/// lock. The shared lock excludes the startup sweep; the target lock serializes the four utility
+/// worker processes when they race to replace the same converted model.
+async fn finalize_converted_dir_with_hook<F>(
+    temp_dir: &Path,
+    final_dir: &Path,
+    conversion_root: &Path,
+    after_aside: F,
+) -> WorkerResult<()>
+where
+    F: FnOnce(&Path) + Send + 'static,
+{
+    let temp_dir = temp_dir.to_path_buf();
+    let final_dir = final_dir.to_path_buf();
+    let conversion_root = conversion_root.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        finalize_converted_dir_blocking(&temp_dir, &final_dir, &conversion_root, after_aside)
+    })
+    .await
+    .map_err(|error| task_join_error("converted model finalize", error))?
+}
+
+fn finalize_converted_dir_blocking<F>(
+    temp_dir: &Path,
+    final_dir: &Path,
+    conversion_root: &Path,
+    after_aside: F,
+) -> WorkerResult<()>
+where
+    F: FnOnce(&Path),
+{
+    std::fs::create_dir_all(conversion_root)?;
+    let conversion_root = std::fs::canonicalize(conversion_root)?;
+    let final_parent = final_dir.parent().ok_or_else(|| {
+        WorkerError::InvalidPayload("Converted model final directory has no parent.".to_owned())
+    })?;
+    let final_parent = std::fs::canonicalize(final_parent)?;
+    if final_parent != conversion_root {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Converted model final directory {} must be a direct child of {}.",
+            final_dir.display(),
+            conversion_root.display()
+        )));
+    }
+    let _locks = ConversionFinalizeLocks::acquire(&conversion_root, final_dir)?;
+
+    // Move any stale install aside instead of destroying it, so a later failure can restore it. No
+    // sweep runs here: another process may have a live recovery source. Stranded backups are handled
+    // only by the exclusive startup lifecycle pass.
+    let backup_dir = if final_dir.exists() {
+        let backup = converted_dir_backup_path(final_dir);
+        std::fs::rename(final_dir, &backup)?;
+        after_aside(&backup);
+        Some(backup)
+    } else {
+        None
+    };
+
+    if let Err(error) = std::fs::rename(temp_dir, final_dir) {
+        if let Some(backup) = backup_dir {
+            let _ = std::fs::remove_dir_all(final_dir);
+            let _ = std::fs::rename(&backup, final_dir);
+        }
+        return Err(error.into());
+    }
+
+    if let Some(backup) = backup_dir {
+        let _ = std::fs::remove_dir_all(backup);
+    }
+    Ok(())
+}
+
+struct ConversionFinalizeLocks {
+    _lifecycle: std::fs::File,
+    _target: std::fs::File,
+}
+
+impl ConversionFinalizeLocks {
+    fn acquire(conversion_root: &Path, final_dir: &Path) -> WorkerResult<Self> {
+        let lifecycle_path = conversion_root.join(CONVERSION_LIFECYCLE_LOCK);
+        let lifecycle = open_conversion_lock(&lifecycle_path)?;
+        lock_conversion_file(&lifecycle, &lifecycle_path, true)?;
+
+        let target_name = final_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "model".to_owned());
+        let target_path = conversion_root.join(format!(".{target_name}.finalize.lock"));
+        let target = open_conversion_lock(&target_path)?;
+        lock_conversion_file(&target, &target_path, false)?;
+        Ok(Self {
+            _lifecycle: lifecycle,
+            _target: target,
+        })
+    }
+}
+
+fn open_conversion_lock(path: &Path) -> WorkerResult<std::fs::File> {
+    Ok(std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)?)
+}
+
+fn lock_conversion_file(file: &std::fs::File, path: &Path, shared: bool) -> WorkerResult<()> {
+    let deadline = std::time::Instant::now() + CONVERSION_LOCK_TIMEOUT;
+    let contended = fs2::lock_contended_error().raw_os_error();
+    loop {
+        let result = if shared {
+            fs2::FileExt::try_lock_shared(file)
+        } else {
+            fs2::FileExt::try_lock_exclusive(file)
+        };
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) if error.raw_os_error() == contended => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(WorkerError::Io(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!(
+                            "timed out after {:?} waiting for conversion lock {}",
+                            CONVERSION_LOCK_TIMEOUT,
+                            path.display()
+                        ),
+                    )));
+                }
+                std::thread::sleep(CONVERSION_LOCK_POLL);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+/// Recover or remove crash-stranded converted-model backups at top-level worker startup.
+///
+/// The exclusive lifecycle lock guarantees no finalizer is active in any utility process. The scan
+/// is bounded to direct children of the one known conversion destination, `<data>/models/mlx`, and
+/// only real directories matching the exact backup naming convention are touched. If the canonical
+/// target is missing, the newest backup is restored before older copies are removed.
+pub(crate) async fn sweep_stranded_conversion_backups(data_dir: &Path) -> WorkerResult<()> {
+    let conversion_root = data_dir.join("models/mlx");
+    tokio::task::spawn_blocking(move || {
+        sweep_stranded_conversion_backups_blocking(&conversion_root)
+    })
+    .await
+    .map_err(|error| task_join_error("converted model startup sweep", error))?
+}
+
+fn sweep_stranded_conversion_backups_blocking(conversion_root: &Path) -> WorkerResult<()> {
+    std::fs::create_dir_all(conversion_root)?;
+    let conversion_root = std::fs::canonicalize(conversion_root)?;
+    let lifecycle_path = conversion_root.join(CONVERSION_LIFECYCLE_LOCK);
+    let lifecycle = open_conversion_lock(&lifecycle_path)?;
+    lock_conversion_file(&lifecycle, &lifecycle_path, false)?;
+
+    let mut by_target: HashMap<String, Vec<PathBuf>> = HashMap::new();
+    for entry in std::fs::read_dir(&conversion_root)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if !file_type.is_dir() || file_type.is_symlink() {
+            continue;
+        }
+        let Some(target) = converted_backup_target_name(&entry.file_name()) else {
+            continue;
+        };
+        by_target.entry(target).or_default().push(entry.path());
+    }
+
+    for (target, mut backups) in by_target {
+        let final_dir = conversion_root.join(&target);
+        match std::fs::symlink_metadata(&final_dir) {
+            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+                for backup in backups {
+                    std::fs::remove_dir_all(backup)?;
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                backups.sort_by(|left, right| {
+                    backup_modified_time(left)
+                        .cmp(&backup_modified_time(right))
+                        .then_with(|| left.file_name().cmp(&right.file_name()))
+                });
+                let restore = backups.pop().expect("backup group is non-empty");
+                std::fs::rename(&restore, &final_dir)?;
+                for backup in backups {
+                    std::fs::remove_dir_all(backup)?;
+                }
+            }
+            Ok(_) => {
+                tracing::warn!(
+                    event = "conversion_backup_sweep_skipped_target",
+                    target = %final_dir.display(),
+                    "converted-model startup sweep found a non-directory target; preserving backups"
+                );
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+fn converted_backup_target_name(name: &std::ffi::OsStr) -> Option<String> {
+    let name = name.to_str()?.strip_prefix('.')?;
+    let (target, suffix) = name.rsplit_once(".finalize-backup-")?;
+    let mut suffix_parts = suffix.splitn(2, '-');
+    let process_id = suffix_parts.next()?;
+    if target.is_empty()
+        || target.contains('/')
+        || target.contains('\\')
+        || process_id.parse::<u32>().is_err()
+        || suffix_parts
+            .next()
+            .is_some_and(|value| Uuid::parse_str(value).is_err())
+    {
+        return None;
+    }
+    Some(target.to_owned())
+}
+
+fn backup_modified_time(path: &Path) -> std::time::SystemTime {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+}
+
+#[cfg(test)]
+pub(crate) async fn finalize_converted_dir_with_test_hook<F>(
+    temp_dir: &Path,
+    final_dir: &Path,
+    conversion_root: &Path,
+    after_aside: F,
+) -> WorkerResult<()>
+where
+    F: FnOnce(&Path) + Send + 'static,
+{
+    finalize_converted_dir_with_hook(temp_dir, final_dir, conversion_root, after_aside).await
 }
 
 /// Fetch the `files` glob patterns from `repo`@`revision` into the shared Hugging Face hub cache
@@ -2352,6 +2560,7 @@ pub(crate) async fn run_lora_import_job(
     http_client: &reqwest::Client,
     job: &JobSnapshot,
 ) -> WorkerResult<()> {
+    validate_lora_import_digest_contract(&job.payload)?;
     let repo = optional_payload_string(&job.payload, "repo");
     let source_url = optional_payload_string(&job.payload, "sourceUrl");
     let source_path = optional_payload_string(&job.payload, "sourcePath");
@@ -2598,6 +2807,22 @@ pub(crate) async fn run_lora_import_job(
         ),
     )
     .await?;
+    Ok(())
+}
+
+/// A single `expectedSha256` cannot identify both files in a paired Wan MoE upload. Reject that
+/// ambiguous contract before heartbeat, target creation, or moving either staged upload. Single-file
+/// imports retain their existing digest verification.
+pub(crate) fn validate_lora_import_digest_contract(payload: &JsonObject) -> WorkerResult<()> {
+    if optional_payload_string(payload, "secondarySourcePath").is_some()
+        && optional_payload_string(payload, "expectedSha256").is_some()
+    {
+        return Err(WorkerError::InvalidPayload(
+            "LoRA import expectedSha256 is ambiguous with secondarySourcePath; provide a paired \
+             upload without a single-file digest."
+                .to_owned(),
+        ));
+    }
     Ok(())
 }
 

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1321,6 +1321,10 @@ pub(crate) async fn run_model_convert_job(
     let model_id = required_payload_string(&job.payload, "modelId")?.to_owned();
     let source_repo = required_payload_string(&job.payload, "sourceRepo")?.to_owned();
     let output_dir = required_payload_string(&job.payload, "outputDir")?.to_owned();
+    // Validate the final destination before heartbeat/status mutation, cancellation checks,
+    // checkpoint lookup, plan resolution, or any converter-specific provisioning. A malformed raw
+    // job must fail at the worker trust boundary without touching job state or local model storage.
+    let final_dir = resolve_model_convert_output(&settings.data_dir, &output_dir)?;
     // NOTE: there is intentionally no `dtype` knob. The native converters each produce a fixed
     // precision (the FLUX.2-klein converter is bf16-only; LTX / FLUX.2-dev honor `quantizeBits`),
     // so a client-supplied `dtype` had no converter to receive it and only ever appeared in the
@@ -1412,10 +1416,6 @@ pub(crate) async fn run_model_convert_job(
     // canceled/failed conversion never leaves a partial directory that the catalog
     // and adapter would treat as a ready model (convert tools write config.json
     // before all weight shards).
-    // Constrain the client-supplied outputDir to app-managed data/models the same way import
-    // jobs constrain targetDir; the worker is the trust boundary, so never create/rename a
-    // converted model tree to an arbitrary location.
-    let final_dir = resolve_model_convert_output(settings, &output_dir)?;
     let parent = final_dir
         .parent()
         .map(Path::to_path_buf)
@@ -1558,9 +1558,7 @@ pub(crate) async fn run_model_convert_job(
 
     // Promote the completed conversion atomically; on any rename failure the partial
     // temp dir is removed so it can't be picked up later.
-    if let Err(error) =
-        finalize_converted_dir(&temp_dir, &final_dir, &settings.data_dir.join("models/mlx")).await
-    {
+    if let Err(error) = finalize_converted_dir(&temp_dir, &final_dir, &settings.data_dir).await {
         let _ = tokio::fs::remove_dir_all(&temp_dir).await;
         return Err(error);
     }
@@ -2056,15 +2054,16 @@ fn relink_to_blob(link: &Path) {
 pub(crate) async fn finalize_converted_dir(
     temp_dir: &Path,
     final_dir: &Path,
-    conversion_root: &Path,
+    data_dir: &Path,
 ) -> WorkerResult<()> {
-    finalize_converted_dir_with_hook(temp_dir, final_dir, conversion_root, |_| {}).await
+    finalize_converted_dir_with_hook(temp_dir, final_dir, data_dir, |_| {}).await
 }
 
-/// Sibling backup path used to move a stale converted dir aside during finalize
-/// (sc-8837). Kept next to `final_dir` so the aside/restore moves are atomic renames on
-/// the same filesystem rather than cross-device copies.
-fn converted_dir_backup_path(final_dir: &Path) -> PathBuf {
+/// Backup path used to move a stale converted dir aside during finalize (sc-8837).
+/// Kept in a dedicated child of the conversion root so recovery cannot confuse a
+/// legitimate model name with a backup, while aside/restore remain same-filesystem
+/// atomic renames.
+fn converted_dir_backup_path(final_dir: &Path, backup_root: &Path) -> PathBuf {
     let name = final_dir
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
@@ -2074,13 +2073,12 @@ fn converted_dir_backup_path(final_dir: &Path) -> PathBuf {
         std::process::id(),
         Uuid::new_v4()
     );
-    match final_dir.parent() {
-        Some(parent) => parent.join(suffix),
-        None => PathBuf::from(suffix),
-    }
+    backup_root.join(suffix)
 }
 
-const CONVERSION_LIFECYCLE_LOCK: &str = ".conversion-finalize.lock";
+const CONVERSION_MODELS_DIR: &str = "models/mlx";
+const CONVERSION_LOCKS_DIR: &str = "cache/worker-locks/model-conversion";
+const CONVERSION_LIFECYCLE_LOCK: &str = "lifecycle.lock";
 const CONVERSION_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const CONVERSION_LOCK_POLL: std::time::Duration = std::time::Duration::from_millis(25);
 
@@ -2090,7 +2088,7 @@ const CONVERSION_LOCK_POLL: std::time::Duration = std::time::Duration::from_mill
 async fn finalize_converted_dir_with_hook<F>(
     temp_dir: &Path,
     final_dir: &Path,
-    conversion_root: &Path,
+    data_dir: &Path,
     after_aside: F,
 ) -> WorkerResult<()>
 where
@@ -2098,9 +2096,9 @@ where
 {
     let temp_dir = temp_dir.to_path_buf();
     let final_dir = final_dir.to_path_buf();
-    let conversion_root = conversion_root.to_path_buf();
+    let data_dir = data_dir.to_path_buf();
     tokio::task::spawn_blocking(move || {
-        finalize_converted_dir_blocking(&temp_dir, &final_dir, &conversion_root, after_aside)
+        finalize_converted_dir_blocking(&temp_dir, &final_dir, &data_dir, after_aside)
     })
     .await
     .map_err(|error| task_join_error("converted model finalize", error))?
@@ -2109,14 +2107,17 @@ where
 fn finalize_converted_dir_blocking<F>(
     temp_dir: &Path,
     final_dir: &Path,
-    conversion_root: &Path,
+    data_dir: &Path,
     after_aside: F,
 ) -> WorkerResult<()>
 where
     F: FnOnce(&Path),
 {
-    std::fs::create_dir_all(conversion_root)?;
-    let conversion_root = std::fs::canonicalize(conversion_root)?;
+    let ConversionManagedRoots {
+        conversion_root,
+        backup_root,
+        lock_root,
+    } = resolve_conversion_managed_roots(data_dir)?;
     let final_parent = final_dir.parent().ok_or_else(|| {
         WorkerError::InvalidPayload("Converted model final directory has no parent.".to_owned())
     })?;
@@ -2128,13 +2129,22 @@ where
             conversion_root.display()
         )));
     }
-    let _locks = ConversionFinalizeLocks::acquire(&conversion_root, final_dir)?;
+    let target_name = final_dir.file_name().ok_or_else(|| {
+        WorkerError::InvalidPayload("Converted model final directory has no name.".to_owned())
+    })?;
+    if target_name == std::ffi::OsStr::new(MODEL_CONVERSION_BACKUPS_DIR_NAME) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Converted model final directory name {MODEL_CONVERSION_BACKUPS_DIR_NAME} is reserved for conversion recovery."
+        )));
+    }
+    let canonical_target = conversion_root.join(target_name);
+    let _locks = ConversionFinalizeLocks::acquire(&lock_root, &canonical_target)?;
 
     // Move any stale install aside instead of destroying it, so a later failure can restore it. No
     // sweep runs here: another process may have a live recovery source. Stranded backups are handled
     // only by the exclusive startup lifecycle pass.
     let backup_dir = if final_dir.exists() {
-        let backup = converted_dir_backup_path(final_dir);
+        let backup = converted_dir_backup_path(final_dir, &backup_root);
         std::fs::rename(final_dir, &backup)?;
         after_aside(&backup);
         Some(backup)
@@ -2162,16 +2172,18 @@ struct ConversionFinalizeLocks {
 }
 
 impl ConversionFinalizeLocks {
-    fn acquire(conversion_root: &Path, final_dir: &Path) -> WorkerResult<Self> {
-        let lifecycle_path = conversion_root.join(CONVERSION_LIFECYCLE_LOCK);
+    fn acquire(lock_root: &Path, final_dir: &Path) -> WorkerResult<Self> {
+        let lifecycle_path = lock_root.join(CONVERSION_LIFECYCLE_LOCK);
         let lifecycle = open_conversion_lock(&lifecycle_path)?;
         lock_conversion_file(&lifecycle, &lifecycle_path, true)?;
 
-        let target_name = final_dir
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "model".to_owned());
-        let target_path = conversion_root.join(format!(".{target_name}.finalize.lock"));
+        // Hash the canonical target path so arbitrary/custom model ids can never alias the
+        // lifecycle lock or another model's lock-file pathname.
+        let target_digest = format!(
+            "{:x}",
+            Sha256::digest(final_dir.to_string_lossy().as_bytes())
+        );
+        let target_path = lock_root.join(format!("target-{target_digest}.lock"));
         let target = open_conversion_lock(&target_path)?;
         lock_conversion_file(&target, &target_path, false)?;
         Ok(Self {
@@ -2182,12 +2194,119 @@ impl ConversionFinalizeLocks {
 }
 
 fn open_conversion_lock(path: &Path) -> WorkerResult<std::fs::File> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(WorkerError::InvalidPayload(format!(
+                "Conversion lock path {} must be a regular file.",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
     Ok(std::fs::OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(false)
         .open(path)?)
+}
+
+/// Resolve one worker-owned directory and prove its canonical location remains inside the
+/// canonical configured data root. This permits a symlinked `data_dir` itself (the macOS
+/// `/var` -> `/private/var` case) while rejecting a nested `models`, `mlx`, or lock-root symlink
+/// that redirects cleanup/locking outside app-managed storage.
+fn canonical_managed_worker_dir(
+    data_dir: &Path,
+    relative: &str,
+    label: &str,
+) -> WorkerResult<PathBuf> {
+    std::fs::create_dir_all(data_dir)?;
+    let canonical_data_dir = std::fs::canonicalize(data_dir)?;
+    let requested = data_dir.join(relative);
+    // Resolve through the deepest existing ancestor before creating anything, so a nested symlink
+    // cannot cause even the directory creation itself to escape the managed root.
+    let normalized = normalize_existing_or_absolute(&requested)?;
+    if normalized == canonical_data_dir || !normalized.starts_with(&canonical_data_dir) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{label} {} escapes managed data root {}.",
+            requested.display(),
+            canonical_data_dir.display()
+        )));
+    }
+    std::fs::create_dir_all(&normalized)?;
+    let canonical = std::fs::canonicalize(&normalized)?;
+    if canonical == canonical_data_dir || !canonical.starts_with(&canonical_data_dir) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{label} {} escapes managed data root {}.",
+            requested.display(),
+            canonical_data_dir.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+struct ConversionManagedRoots {
+    conversion_root: PathBuf,
+    backup_root: PathBuf,
+    lock_root: PathBuf,
+}
+
+fn canonical_conversion_backup_root(conversion_root: &Path) -> WorkerResult<PathBuf> {
+    let backup_root = conversion_root.join(MODEL_CONVERSION_BACKUPS_DIR_NAME);
+    match std::fs::symlink_metadata(&backup_root) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(WorkerError::InvalidPayload(format!(
+                "Conversion backup root {} must be a real directory.",
+                backup_root.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir(&backup_root)?;
+        }
+        Err(error) => return Err(error.into()),
+    }
+    let canonical = std::fs::canonicalize(&backup_root)?;
+    if canonical.parent() != Some(conversion_root) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Conversion backup root {} must be a direct child of conversion model root {}.",
+            canonical.display(),
+            conversion_root.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+/// Resolve the model-conversion data and coordination roots and prove their canonical namespaces are
+/// disjoint. Checking each root only against `data_dir` is insufficient: an internal symlink can
+/// legally remain under app-managed storage while aliasing `cache/worker-locks/model-conversion` to
+/// `models/mlx` (or one root below the other). That would place `lifecycle.lock` / `target-*.lock`
+/// among model targets and let a reserved-looking model id rename or replace a live coordination
+/// file. Reject equality and either-direction ancestor overlap before opening a lock or touching an
+/// install.
+fn resolve_conversion_managed_roots(data_dir: &Path) -> WorkerResult<ConversionManagedRoots> {
+    let conversion_root =
+        canonical_managed_worker_dir(data_dir, CONVERSION_MODELS_DIR, "conversion model root")?;
+    let lock_root =
+        canonical_managed_worker_dir(data_dir, CONVERSION_LOCKS_DIR, "conversion lock root")?;
+    if conversion_root == lock_root
+        || conversion_root.starts_with(&lock_root)
+        || lock_root.starts_with(&conversion_root)
+    {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Conversion model root {} and lock root {} must be disjoint managed directories.",
+            conversion_root.display(),
+            lock_root.display()
+        )));
+    }
+    let backup_root = canonical_conversion_backup_root(&conversion_root)?;
+    Ok(ConversionManagedRoots {
+        conversion_root,
+        backup_root,
+        lock_root,
+    })
 }
 
 fn lock_conversion_file(file: &std::fs::File, path: &Path, shared: bool) -> WorkerResult<()> {
@@ -2222,27 +2341,29 @@ fn lock_conversion_file(file: &std::fs::File, path: &Path, shared: bool) -> Work
 /// Recover or remove crash-stranded converted-model backups at top-level worker startup.
 ///
 /// The exclusive lifecycle lock guarantees no finalizer is active in any utility process. The scan
-/// is bounded to direct children of the one known conversion destination, `<data>/models/mlx`, and
-/// only real directories matching the exact backup naming convention are touched. If the canonical
-/// target is missing, the newest backup is restored before older copies are removed.
-pub(crate) async fn sweep_stranded_conversion_backups(data_dir: &Path) -> WorkerResult<()> {
-    let conversion_root = data_dir.join("models/mlx");
-    tokio::task::spawn_blocking(move || {
-        sweep_stranded_conversion_backups_blocking(&conversion_root)
-    })
-    .await
-    .map_err(|error| task_join_error("converted model startup sweep", error))?
+/// is bounded to the worker-owned backup namespace under `<data>/models/mlx`, so a legitimate model
+/// directory whose name resembles the old sibling-backup grammar can never be touched. Only real
+/// directories matching the exact backup naming convention are considered. If the canonical target
+/// is missing, the newest backup is restored before older copies are removed.
+pub async fn recover_stranded_model_conversions(data_dir: &Path) -> WorkerResult<()> {
+    let data_dir = data_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || sweep_stranded_conversion_backups_blocking(&data_dir))
+        .await
+        .map_err(|error| task_join_error("converted model startup sweep", error))?
 }
 
-fn sweep_stranded_conversion_backups_blocking(conversion_root: &Path) -> WorkerResult<()> {
-    std::fs::create_dir_all(conversion_root)?;
-    let conversion_root = std::fs::canonicalize(conversion_root)?;
-    let lifecycle_path = conversion_root.join(CONVERSION_LIFECYCLE_LOCK);
+fn sweep_stranded_conversion_backups_blocking(data_dir: &Path) -> WorkerResult<()> {
+    let ConversionManagedRoots {
+        conversion_root,
+        backup_root,
+        lock_root,
+    } = resolve_conversion_managed_roots(data_dir)?;
+    let lifecycle_path = lock_root.join(CONVERSION_LIFECYCLE_LOCK);
     let lifecycle = open_conversion_lock(&lifecycle_path)?;
     lock_conversion_file(&lifecycle, &lifecycle_path, false)?;
 
     let mut by_target: HashMap<String, Vec<PathBuf>> = HashMap::new();
-    for entry in std::fs::read_dir(&conversion_root)? {
+    for entry in std::fs::read_dir(&backup_root)? {
         let entry = entry?;
         let file_type = entry.file_type()?;
         if !file_type.is_dir() || file_type.is_symlink() {
@@ -2315,13 +2436,13 @@ fn backup_modified_time(path: &Path) -> std::time::SystemTime {
 pub(crate) async fn finalize_converted_dir_with_test_hook<F>(
     temp_dir: &Path,
     final_dir: &Path,
-    conversion_root: &Path,
+    data_dir: &Path,
     after_aside: F,
 ) -> WorkerResult<()>
 where
     F: FnOnce(&Path) + Send + 'static,
 {
-    finalize_converted_dir_with_hook(temp_dir, final_dir, conversion_root, after_aside).await
+    finalize_converted_dir_with_hook(temp_dir, final_dir, data_dir, after_aside).await
 }
 
 /// Fetch the `files` glob patterns from `repo`@`revision` into the shared Hugging Face hub cache
@@ -3716,6 +3837,37 @@ mod convert_registry_tests {
             Err(err) => assert_eq!(err.message, "Unknown MLX converter."),
             Ok(_) => panic!("a bogus converter must not resolve to a plan"),
         }
+    }
+
+    /// A raw queue row can bypass the typed API, so output confinement is the worker's final trust
+    /// boundary. Both clients deliberately point at unreachable endpoints: if heartbeat/status work
+    /// or LTX planning/provisioning runs first, this returns an HTTP/download error instead. The
+    /// absent data root also proves the rejected job created no model/provisioning state.
+    #[tokio::test]
+    async fn invalid_convert_output_wins_before_api_or_ltx_provisioning_side_effects() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let data_dir = tmp.path().join("data");
+        let settings = minimal_settings(data_dir.clone());
+        let api = ApiClient::new(&settings);
+        let mut job = convert_job("ltx_video");
+        job.payload.insert(
+            "outputDir".to_owned(),
+            Value::String(tmp.path().join("outside").display().to_string()),
+        );
+
+        assert!(!data_dir.exists(), "fixture starts without app model state");
+        let error = run_model_convert_job(&api, &settings, &job)
+            .await
+            .expect_err("invalid output must fail before any API or download access");
+
+        assert!(
+            matches!(error, WorkerError::InvalidPayload(ref detail) if detail.contains("direct child")),
+            "output confinement must win error precedence, got {error}"
+        );
+        assert!(
+            !data_dir.exists(),
+            "invalid output must not create checkpoint, conversion, or provisioning state"
+        );
     }
 }
 

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -554,25 +554,33 @@ pub(crate) fn resolve_model_import_target(
     ))
 }
 
-pub(crate) fn resolve_model_convert_output(
-    settings: &Settings,
-    output_dir: &str,
-) -> WorkerResult<PathBuf> {
+pub const MODEL_CONVERSION_BACKUPS_DIR_NAME: &str = ".sceneworks-finalize-backups";
+
+pub fn resolve_model_convert_output(data_dir: &Path, output_dir: &str) -> WorkerResult<PathBuf> {
     // Canonicalize before the confinement check so a symlink/`..` can't escape the
-    // lexical `starts_with`; allow the managed root's lexical or canonical form so a
-    // not-yet-created output dir still matches (sc-8877 / F-075).
+    // lexical comparison. Model conversion finalization and crash recovery both
+    // operate on direct children of the one MLX conversion root, so enforce that
+    // contract before expensive conversion work begins.
     let target = normalize_existing_or_absolute(Path::new(output_dir))?;
-    let models_root = settings.data_dir.join("models");
-    let allowed_roots = [
-        normalize_absolute_path(&models_root)?,
-        normalize_existing_or_absolute(&models_root)?,
-    ];
-    if allowed_roots.iter().any(|root| target.starts_with(root)) {
-        return Ok(target);
+    let conversion_root = normalize_existing_or_absolute(&data_dir.join("models/mlx"))?;
+    if target.parent() != Some(conversion_root.as_path()) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Model convert outputDir must be a direct child of {}",
+            data_dir.join("models/mlx").display()
+        )));
     }
-    Err(WorkerError::InvalidPayload(
-        "Model convert outputDir must be inside app-managed data/models".to_owned(),
-    ))
+    let target_name = target.file_name().ok_or_else(|| {
+        WorkerError::InvalidPayload(
+            "Model convert outputDir must name a model directory".to_owned(),
+        )
+    })?;
+    if target_name == std::ffi::OsStr::new(MODEL_CONVERSION_BACKUPS_DIR_NAME) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Model convert outputDir name {} is reserved for conversion recovery",
+            MODEL_CONVERSION_BACKUPS_DIR_NAME
+        )));
+    }
+    Ok(target)
 }
 
 pub(crate) fn model_manifest_target(

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -20,7 +20,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio as StdStdio;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -62,7 +62,7 @@ use super::model_jobs::{
     check_downloaded_model_family, derived_tokenizer_overlay,
     downloaded_model_detection_io_error_is_inconclusive, finalize_converted_dir,
     finalize_converted_dir_with_test_hook, huggingface_receipt_weights_dir,
-    overlay_derived_tokenizer, sweep_stranded_conversion_backups, validate_hf_download_inputs,
+    overlay_derived_tokenizer, recover_stranded_model_conversions, validate_hf_download_inputs,
     DownloadFamilyCheck,
 };
 // `terminating_signal` is only exercised by a `#[cfg(unix)]` test (signal-death
@@ -84,6 +84,7 @@ use super::{
     write_model_install_marker, CredentialScheme, IdleHeartbeat, JsonObject,
     SafetensorsHeaderError, Settings, WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES,
     DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
+    MODEL_CONVERSION_BACKUPS_DIR_NAME,
 };
 
 // HF-CLI input validation, downloaded-model family detection, atomic converted-dir finalize, and the

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -61,7 +61,8 @@ use super::media_jobs::{mask_rollup_state, segment_assembly_frames, SegmentClip,
 use super::model_jobs::{
     check_downloaded_model_family, derived_tokenizer_overlay,
     downloaded_model_detection_io_error_is_inconclusive, finalize_converted_dir,
-    huggingface_receipt_weights_dir, overlay_derived_tokenizer, validate_hf_download_inputs,
+    finalize_converted_dir_with_test_hook, huggingface_receipt_weights_dir,
+    overlay_derived_tokenizer, sweep_stranded_conversion_backups, validate_hf_download_inputs,
     DownloadFamilyCheck,
 };
 // `terminating_signal` is only exercised by a `#[cfg(unix)]` test (signal-death

--- a/crates/sceneworks-worker/src/tests/hf_and_family.rs
+++ b/crates/sceneworks-worker/src/tests/hf_and_family.rs
@@ -333,11 +333,12 @@ fn download_family_check_proceeds_for_derived_family_base_architecture() {
 async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
     let temp = tempdir().expect("tempdir creates");
     let root = temp.path();
-    let conversion_root = root.join("mlx");
+    let data_dir = root.join("data");
+    let conversion_root = data_dir.join("models/mlx");
     let final_dir = conversion_root.join("wan_2_2");
 
     // A completed temp conversion sitting in its sibling staging dir.
-    let temp_dir = root.join("mlx").join(".wan_2_2.converting-job1");
+    let temp_dir = conversion_root.join(".wan_2_2.converting-job1");
     std::fs::create_dir_all(&temp_dir).expect("temp dir");
     std::fs::write(temp_dir.join("config.json"), "{}").expect("config");
     std::fs::write(temp_dir.join("model.safetensors"), b"weights").expect("weights");
@@ -345,7 +346,7 @@ async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
     // The canonical dir only appears after finalize, so a partial conversion can
     // never be picked up as a ready model.
     assert!(!final_dir.exists());
-    finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
+    finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
         .await
         .expect("finalize");
     assert!(final_dir.join("config.json").is_file());
@@ -355,15 +356,27 @@ async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
     // A re-conversion replaces a stale final dir wholesale.
     let stale_marker = final_dir.join("stale.txt");
     std::fs::write(&stale_marker, "old").expect("stale");
-    let temp_dir2 = root.join("mlx").join(".wan_2_2.converting-job2");
+    let temp_dir2 = conversion_root.join(".wan_2_2.converting-job2");
     std::fs::create_dir_all(&temp_dir2).expect("temp dir 2");
     std::fs::write(temp_dir2.join("config.json"), "{}").expect("config 2");
-    finalize_converted_dir(&temp_dir2, &final_dir, &conversion_root)
+    finalize_converted_dir(&temp_dir2, &final_dir, &data_dir)
         .await
         .expect("finalize 2");
     assert!(final_dir.join("config.json").is_file());
     assert!(!stale_marker.exists());
     assert!(!temp_dir2.exists());
+}
+
+fn conversion_backup_entries(conversion_root: &Path) -> Vec<String> {
+    let backup_root = conversion_root.join(MODEL_CONVERSION_BACKUPS_DIR_NAME);
+    match std::fs::read_dir(backup_root) {
+        Ok(entries) => entries
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => panic!("read conversion backup root: {error}"),
+    }
 }
 
 /// sc-8837 (F-035): when a previously working install exists and the temp→final
@@ -375,16 +388,17 @@ async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
 async fn finalize_converted_dir_restores_stale_install_on_rename_failure() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path();
-    let conversion_root = root.join("mlx");
+    let data_dir = root.join("data");
+    let conversion_root = data_dir.join("models/mlx");
     let final_dir = conversion_root.join("model");
     std::fs::create_dir_all(&final_dir).expect("final dir");
     std::fs::write(final_dir.join("weights.safetensors"), b"OLD-BUT-WORKING")
         .expect("seed old install");
 
     // Intentionally never created, so the temp→final rename fails after the stale aside.
-    let temp_dir = root.join("mlx").join(".model.converting-jobX");
+    let temp_dir = conversion_root.join(".model.converting-jobX");
 
-    let error = finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
+    let error = finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
         .await
         .expect_err("a missing temp dir must make the promotion fail");
     assert!(
@@ -402,13 +416,7 @@ async fn finalize_converted_dir_restores_stale_install_on_rename_failure() {
         b"OLD-BUT-WORKING",
         "restored install must have the original contents"
     );
-    // No leftover backup dir next to the install.
-    let leftovers: Vec<_> = std::fs::read_dir(final_dir.parent().expect("parent"))
-        .expect("read parent")
-        .flatten()
-        .map(|entry| entry.file_name().to_string_lossy().into_owned())
-        .filter(|name| name.contains("finalize-backup"))
-        .collect();
+    let leftovers = conversion_backup_entries(&conversion_root);
     assert!(
         leftovers.is_empty(),
         "no backup dir should remain after restore, found {leftovers:?}"
@@ -421,14 +429,15 @@ async fn finalize_converted_dir_restores_stale_install_on_rename_failure() {
 async fn finalize_converted_dir_replaces_existing_install_leaves_no_backup() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path();
-    let conversion_root = root.join("mlx");
+    let data_dir = root.join("data");
+    let conversion_root = data_dir.join("models/mlx");
     let final_dir = conversion_root.join("model");
     std::fs::create_dir_all(&final_dir).expect("final dir");
     std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("seed old");
-    let temp_dir = root.join("mlx").join(".model.converting-jobY");
+    let temp_dir = conversion_root.join(".model.converting-jobY");
     std::fs::create_dir_all(&temp_dir).expect("temp dir");
     std::fs::write(temp_dir.join("weights.safetensors"), b"NEW").expect("seed new");
-    finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
+    finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
         .await
         .expect("finalize should succeed");
 
@@ -441,12 +450,7 @@ async fn finalize_converted_dir_replaces_existing_install_leaves_no_backup() {
         !temp_dir.exists(),
         "temp dir must have been moved into place"
     );
-    let leftovers: Vec<_> = std::fs::read_dir(final_dir.parent().expect("parent"))
-        .expect("read parent")
-        .flatten()
-        .map(|entry| entry.file_name().to_string_lossy().into_owned())
-        .filter(|name| name.contains("finalize-backup"))
-        .collect();
+    let leftovers = conversion_backup_entries(&conversion_root);
     assert!(
         leftovers.is_empty(),
         "no backup dir should remain on success, found {leftovers:?}"
@@ -459,14 +463,15 @@ async fn finalize_converted_dir_replaces_existing_install_leaves_no_backup() {
 async fn finalize_converted_dir_first_install_succeeds() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path();
-    let conversion_root = root.join("mlx");
+    let data_dir = root.join("data");
+    let conversion_root = data_dir.join("models/mlx");
     let final_dir = conversion_root.join("model");
-    let temp_dir = root.join("mlx").join(".model.converting-jobZ");
+    let temp_dir = conversion_root.join(".model.converting-jobZ");
     std::fs::create_dir_all(&temp_dir).expect("temp dir");
     std::fs::write(temp_dir.join("weights.safetensors"), b"FRESH").expect("seed fresh");
 
     assert!(!final_dir.exists());
-    finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
+    finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
         .await
         .expect("first install should succeed");
 
@@ -483,30 +488,31 @@ async fn finalize_converted_dir_first_install_succeeds() {
 
 /// Startup runs before utility children are spawned and under the exclusive conversion lifecycle
 /// lock. It removes backups for a present target, restores the recovery source when the target is
-/// absent, and never broadens beyond direct real directories under `<data>/models/mlx`.
+/// absent, and never broadens beyond the dedicated backup namespace.
 #[tokio::test]
 async fn startup_sweeps_stranded_conversion_backups_with_recovery_and_confinement() {
     let temp = tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
     let parent = data_dir.join("models/mlx");
-    std::fs::create_dir_all(&parent).expect("parent");
+    let backup_root = parent.join(MODEL_CONVERSION_BACKUPS_DIR_NAME);
+    std::fs::create_dir_all(&backup_root).expect("backup root");
     let final_dir = parent.join("model");
     std::fs::create_dir_all(&final_dir).expect("current target");
     std::fs::write(final_dir.join("weights.safetensors"), b"CURRENT").expect("current contents");
-    let stale_one = parent.join(".model.finalize-backup-111");
+    let stale_one = backup_root.join(".model.finalize-backup-111");
     let stale_two =
-        parent.join(".model.finalize-backup-222-00000000-0000-4000-8000-000000000222");
+        backup_root.join(".model.finalize-backup-222-00000000-0000-4000-8000-000000000222");
     let recover =
-        parent.join(".recover.finalize-backup-333-00000000-0000-4000-8000-000000000333");
-    let unrelated = parent.join(".other.finalize-backup-not-a-process-id");
-    let matching_file = parent.join(".model.finalize-backup-file");
+        backup_root.join(".recover.finalize-backup-333-00000000-0000-4000-8000-000000000333");
+    let unrelated = backup_root.join(".other.finalize-backup-not-a-process-id");
+    let matching_file = backup_root.join(".model.finalize-backup-file");
     for dir in [&stale_one, &stale_two, &recover, &unrelated] {
         std::fs::create_dir_all(dir).expect("backup fixture");
         std::fs::write(dir.join("weights.safetensors"), b"weights").expect("backup contents");
     }
     std::fs::write(&matching_file, b"not a directory").expect("matching file");
 
-    sweep_stranded_conversion_backups(&data_dir)
+    recover_stranded_model_conversions(&data_dir)
         .await
         .expect("startup sweep succeeds");
 
@@ -526,21 +532,71 @@ async fn startup_sweeps_stranded_conversion_backups_with_recovery_and_confinemen
     );
 }
 
+#[tokio::test]
+async fn startup_recovery_preserves_backup_looking_model_when_base_target_is_absent() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
+    let legitimate = conversion_root.join(".foo.finalize-backup-123");
+    std::fs::create_dir_all(&legitimate).expect("legitimate model");
+    std::fs::write(legitimate.join("weights.safetensors"), b"LEGIT").expect("model contents");
+
+    recover_stranded_model_conversions(&data_dir)
+        .await
+        .expect("startup recovery succeeds");
+
+    assert_eq!(
+        std::fs::read(legitimate.join("weights.safetensors")).expect("legitimate model survives"),
+        b"LEGIT"
+    );
+    assert!(
+        !conversion_root.join("foo").exists(),
+        "a legitimate backup-looking target is never renamed into a fabricated base target"
+    );
+}
+
+#[tokio::test]
+async fn startup_recovery_preserves_backup_looking_model_when_base_target_exists() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
+    let base = conversion_root.join("foo");
+    let legitimate = conversion_root.join(".foo.finalize-backup-123");
+    std::fs::create_dir_all(&base).expect("base model");
+    std::fs::create_dir_all(&legitimate).expect("legitimate model");
+    std::fs::write(base.join("weights.safetensors"), b"BASE").expect("base contents");
+    std::fs::write(legitimate.join("weights.safetensors"), b"LEGIT").expect("model contents");
+
+    recover_stranded_model_conversions(&data_dir)
+        .await
+        .expect("startup recovery succeeds");
+
+    assert_eq!(
+        std::fs::read(base.join("weights.safetensors")).expect("base model survives"),
+        b"BASE"
+    );
+    assert_eq!(
+        std::fs::read(legitimate.join("weights.safetensors")).expect("legitimate model survives"),
+        b"LEGIT"
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn finalize_backup_sweep_does_not_follow_matching_symlink() {
     let temp = tempdir().expect("tempdir");
     let data_dir = temp.path().join("data");
     let parent = data_dir.join("models/mlx");
+    let backup_root = parent.join(MODEL_CONVERSION_BACKUPS_DIR_NAME);
     let outside = temp.path().join("outside");
-    std::fs::create_dir_all(&parent).expect("parent");
+    std::fs::create_dir_all(&backup_root).expect("backup root");
     std::fs::create_dir_all(&outside).expect("outside");
     std::fs::write(outside.join("keep.txt"), b"keep").expect("outside fixture");
     let link =
-        parent.join(".model.finalize-backup-444-00000000-0000-4000-8000-000000000444");
+        backup_root.join(".model.finalize-backup-444-00000000-0000-4000-8000-000000000444");
     std::os::unix::fs::symlink(&outside, &link).expect("matching symlink");
 
-    sweep_stranded_conversion_backups(&data_dir)
+    recover_stranded_model_conversions(&data_dir)
         .await
         .expect("sweep succeeds");
 
@@ -554,6 +610,286 @@ async fn finalize_backup_sweep_does_not_follow_matching_symlink() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn startup_recovery_rejects_a_symlinked_conversion_root_escape() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let models_dir = data_dir.join("models");
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&models_dir).expect("models root");
+    std::fs::create_dir_all(outside.join("model")).expect("outside target");
+    let outside_backup = outside.join(".model.finalize-backup-555");
+    std::fs::create_dir_all(&outside_backup).expect("outside backup");
+    std::fs::write(outside_backup.join("keep.txt"), b"keep").expect("outside contents");
+    std::os::unix::fs::symlink(&outside, models_dir.join("mlx"))
+        .expect("nested conversion-root symlink");
+
+    let error = recover_stranded_model_conversions(&data_dir)
+        .await
+        .expect_err("a nested symlink must not redirect startup cleanup");
+
+    assert!(
+        error.to_string().contains("escapes managed data root"),
+        "the error identifies the confinement violation: {error:?}"
+    );
+    assert!(
+        outside_backup.join("keep.txt").is_file(),
+        "recovery never removes a matching directory outside managed data"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn finalizer_rejects_a_symlinked_lock_root_before_touching_the_install() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
+    let final_dir = conversion_root.join("model");
+    let temp_dir = conversion_root.join(".model.converting-new");
+    std::fs::create_dir_all(&final_dir).expect("working install");
+    std::fs::create_dir_all(&temp_dir).expect("converted temp");
+    std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("old install");
+    std::fs::write(temp_dir.join("weights.safetensors"), b"NEW").expect("new conversion");
+
+    let cache_dir = data_dir.join("cache");
+    let outside = temp.path().join("outside-locks");
+    std::fs::create_dir_all(&cache_dir).expect("cache root");
+    std::fs::create_dir_all(&outside).expect("outside root");
+    std::os::unix::fs::symlink(&outside, cache_dir.join("worker-locks"))
+        .expect("nested lock-root symlink");
+
+    let error = finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
+        .await
+        .expect_err("a nested lock symlink must be rejected");
+
+    assert!(
+        error.to_string().contains("escapes managed data root"),
+        "the error identifies the lock confinement violation: {error:?}"
+    );
+    assert_eq!(
+        std::fs::read(final_dir.join("weights.safetensors")).expect("working install"),
+        b"OLD",
+        "lock validation happens before the working install is moved aside"
+    );
+    assert!(
+        !outside.join("model-conversion").exists(),
+        "validation creates no lock directories outside managed data"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn finalizer_rejects_an_internal_lock_root_alias_of_the_conversion_tree() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
+    let lock_parent = data_dir.join("cache/worker-locks");
+    let final_dir = conversion_root.join("lifecycle.lock");
+    let temp_dir = conversion_root.join(".lifecycle.lock.converting-new");
+    std::fs::create_dir_all(&conversion_root).expect("conversion root");
+    std::fs::create_dir_all(&lock_parent).expect("lock parent");
+    std::fs::create_dir_all(&temp_dir).expect("converted temp");
+    std::fs::write(temp_dir.join("weights.safetensors"), b"NEW").expect("new install");
+    std::os::unix::fs::symlink(
+        &conversion_root,
+        lock_parent.join("model-conversion"),
+    )
+    .expect("internal lock-root alias");
+
+    let error = finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
+        .await
+        .expect_err("the lock root cannot canonicalize onto the model namespace");
+
+    assert!(
+        error.to_string().contains("must be disjoint"),
+        "the error identifies the canonical namespace collision: {error:?}"
+    );
+    assert!(
+        !final_dir.exists(),
+        "validating the roots never creates the colliding lifecycle lock/model target"
+    );
+    assert!(
+        temp_dir.join("weights.safetensors").is_file(),
+        "the completed temp install is untouched on namespace rejection"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn startup_recovery_rejects_an_internal_conversion_root_alias_of_the_lock_tree() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let models_parent = data_dir.join("models");
+    let lock_root = data_dir.join("cache/worker-locks/model-conversion");
+    std::fs::create_dir_all(&models_parent).expect("models parent");
+    std::fs::create_dir_all(&lock_root).expect("lock root");
+    std::os::unix::fs::symlink(&lock_root, models_parent.join("mlx"))
+        .expect("internal conversion-root alias");
+    let stranded =
+        lock_root.join(".model.finalize-backup-777-00000000-0000-4000-8000-000000000777");
+    std::fs::create_dir_all(&stranded).expect("stranded backup");
+    std::fs::write(stranded.join("weights.safetensors"), b"OLD").expect("backup contents");
+
+    let error = recover_stranded_model_conversions(&data_dir)
+        .await
+        .expect_err("startup recovery cannot share the coordination namespace");
+
+    assert!(
+        error.to_string().contains("must be disjoint"),
+        "the error identifies the canonical namespace collision: {error:?}"
+    );
+    assert!(
+        stranded.join("weights.safetensors").is_file(),
+        "startup validation does not remove a backup from the aliased namespace"
+    );
+    assert!(
+        !lock_root.join("lifecycle.lock").exists(),
+        "startup validation rejects the alias before opening the lifecycle lock"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn finalizer_rejects_a_lock_root_that_canonicalizes_to_a_model_root_ancestor() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let models_root = data_dir.join("models");
+    let conversion_root = models_root.join("mlx");
+    let lock_parent = data_dir.join("cache/worker-locks");
+    let final_dir = conversion_root.join("model");
+    let temp_dir = conversion_root.join(".model.converting-new");
+    std::fs::create_dir_all(&conversion_root).expect("conversion root");
+    std::fs::create_dir_all(&lock_parent).expect("lock parent");
+    std::fs::create_dir_all(&temp_dir).expect("converted temp");
+    std::os::unix::fs::symlink(&models_root, lock_parent.join("model-conversion"))
+        .expect("lock root points at conversion-root ancestor");
+
+    let error = finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
+        .await
+        .expect_err("the lock namespace cannot contain the conversion root");
+
+    assert!(
+        error.to_string().contains("must be disjoint"),
+        "ancestor overlap is rejected: {error:?}"
+    );
+    assert!(temp_dir.is_dir(), "the temp install remains untouched");
+    assert!(!models_root.join("lifecycle.lock").exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn startup_recovery_rejects_a_conversion_root_that_contains_the_lock_root() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let models_parent = data_dir.join("models");
+    let worker_locks = data_dir.join("cache/worker-locks");
+    let lock_root = worker_locks.join("model-conversion");
+    std::fs::create_dir_all(&models_parent).expect("models parent");
+    std::fs::create_dir_all(&lock_root).expect("lock root");
+    std::os::unix::fs::symlink(&worker_locks, models_parent.join("mlx"))
+        .expect("conversion root points at lock-root ancestor");
+    let stranded =
+        worker_locks.join(".model.finalize-backup-888-00000000-0000-4000-8000-000000000888");
+    std::fs::create_dir_all(&stranded).expect("stranded backup");
+
+    let error = recover_stranded_model_conversions(&data_dir)
+        .await
+        .expect_err("the conversion namespace cannot contain the lock root");
+
+    assert!(
+        error.to_string().contains("must be disjoint"),
+        "reverse ancestor overlap is rejected: {error:?}"
+    );
+    assert!(stranded.is_dir(), "the stranded directory is untouched");
+    assert!(!lock_root.join("lifecycle.lock").exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn finalizer_rejects_a_symlinked_lifecycle_lock_file() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
+    let lock_root = data_dir.join("cache/worker-locks/model-conversion");
+    let final_dir = conversion_root.join("model");
+    let temp_dir = conversion_root.join(".model.converting-new");
+    std::fs::create_dir_all(&final_dir).expect("working install");
+    std::fs::create_dir_all(&temp_dir).expect("converted temp");
+    std::fs::create_dir_all(&lock_root).expect("lock root");
+    std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("old install");
+    std::fs::write(temp_dir.join("weights.safetensors"), b"NEW").expect("new conversion");
+
+    let outside_lock = temp.path().join("outside.lock");
+    std::fs::write(&outside_lock, b"unrelated").expect("outside lock target");
+    std::os::unix::fs::symlink(&outside_lock, lock_root.join("lifecycle.lock"))
+        .expect("lifecycle lock symlink");
+
+    let error = finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
+        .await
+        .expect_err("a symlink cannot stand in for a coordination lock");
+
+    assert!(
+        error.to_string().contains("must be a regular file"),
+        "the error identifies the unsafe lock entry: {error:?}"
+    );
+    assert_eq!(
+        std::fs::read(final_dir.join("weights.safetensors")).expect("working install"),
+        b"OLD",
+        "lock-file validation happens before the working install is moved aside"
+    );
+    assert_eq!(
+        std::fs::read(outside_lock).expect("outside lock target"),
+        b"unrelated",
+        "opening a lock never follows or modifies an external symlink target"
+    );
+}
+
+#[tokio::test]
+async fn conversion_lock_namespace_cannot_collide_with_model_target_names() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
+
+    for (index, target_name) in [
+        "lifecycle.lock",
+        "target-deadbeef.lock",
+        ".conversion-finalize.lock",
+        ".model.finalize.lock",
+        ".foo.finalize-backup-123",
+        "model",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let temp_dir = conversion_root.join(format!(".target-{index}.converting"));
+        let final_dir = conversion_root.join(target_name);
+        std::fs::create_dir_all(&temp_dir).expect("conversion temp");
+        std::fs::write(temp_dir.join("weights.safetensors"), target_name.as_bytes())
+            .expect("conversion contents");
+        finalize_converted_dir(&temp_dir, &final_dir, &data_dir)
+            .await
+            .expect("reserved-looking model name cannot alias a lock");
+        assert_eq!(
+            std::fs::read(final_dir.join("weights.safetensors")).expect("promoted contents"),
+            target_name.as_bytes()
+        );
+    }
+
+    let lock_root = data_dir.join("cache/worker-locks/model-conversion");
+    assert!(
+        lock_root.join("lifecycle.lock").is_file(),
+        "lifecycle coordination lives outside the model-target namespace"
+    );
+    assert!(
+        std::fs::read_dir(&lock_root)
+            .expect("lock root")
+            .flatten()
+            .all(|entry| entry.file_type().is_ok_and(|kind| kind.is_file())),
+        "the dedicated namespace contains only regular lock files"
+    );
+}
+
 /// Two utility processes may finalize the same target. Pause the first after it has moved the
 /// working install aside, then start a second promotion. The second must remain blocked until the
 /// first restores on failure; without the per-target lock it would promote NEW and the first
@@ -561,7 +897,8 @@ async fn finalize_backup_sweep_does_not_follow_matching_symlink() {
 #[tokio::test]
 async fn concurrent_finalizers_serialize_rollback_and_preserve_second_promotion() {
     let temp = tempdir().expect("tempdir");
-    let conversion_root = temp.path().join("mlx");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
     let final_dir = conversion_root.join("model");
     std::fs::create_dir_all(&final_dir).expect("working install");
     std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("old weights");
@@ -573,12 +910,12 @@ async fn concurrent_finalizers_serialize_rollback_and_preserve_second_promotion(
     let (aside_tx, aside_rx) = tokio::sync::oneshot::channel();
     let (release_tx, release_rx) = tokio::sync::oneshot::channel();
     let first_final = final_dir.clone();
-    let first_root = conversion_root.clone();
+    let first_data = data_dir.clone();
     let first = tokio::spawn(async move {
         finalize_converted_dir_with_test_hook(
             &missing_temp,
             &first_final,
-            &first_root,
+            &first_data,
             move |_| {
                 let _ = aside_tx.send(());
                 let _ = release_rx.blocking_recv();
@@ -589,9 +926,9 @@ async fn concurrent_finalizers_serialize_rollback_and_preserve_second_promotion(
     aside_rx.await.expect("first finalizer moved OLD aside");
 
     let second_final = final_dir.clone();
-    let second_root = conversion_root.clone();
+    let second_data = data_dir.clone();
     let second = tokio::spawn(async move {
-        finalize_converted_dir(&good_temp, &second_final, &second_root).await
+        finalize_converted_dir(&good_temp, &second_final, &second_data).await
     });
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(
@@ -613,17 +950,10 @@ async fn concurrent_finalizers_serialize_rollback_and_preserve_second_promotion(
         b"NEW",
         "the successful second promotion survives the first finalizer's rollback"
     );
-    let backups = std::fs::read_dir(&conversion_root)
-        .expect("read conversion root")
-        .flatten()
-        .filter(|entry| {
-            entry
-                .file_name()
-                .to_string_lossy()
-                .contains("finalize-backup")
-        })
-        .count();
-    assert_eq!(backups, 0, "both finalizers clean up only their own backup");
+    assert!(
+        conversion_backup_entries(&conversion_root).is_empty(),
+        "both finalizers clean up only their own backup"
+    );
 }
 
 /// The startup sweep takes the lifecycle lock exclusively. Even if another top-level process starts
@@ -641,12 +971,12 @@ async fn startup_sweep_waits_for_an_active_finalizers_recovery_source() {
     let (aside_tx, aside_rx) = tokio::sync::oneshot::channel();
     let (release_tx, release_rx) = tokio::sync::oneshot::channel();
     let active_final = final_dir.clone();
-    let active_root = conversion_root.clone();
+    let active_data = data_dir.clone();
     let finalizer = tokio::spawn(async move {
         finalize_converted_dir_with_test_hook(
             &missing_temp,
             &active_final,
-            &active_root,
+            &active_data,
             move |_| {
                 let _ = aside_tx.send(());
                 let _ = release_rx.blocking_recv();
@@ -657,7 +987,8 @@ async fn startup_sweep_waits_for_an_active_finalizers_recovery_source() {
     aside_rx.await.expect("finalizer moved OLD aside");
 
     let sweep_data = data_dir.clone();
-    let sweep = tokio::spawn(async move { sweep_stranded_conversion_backups(&sweep_data).await });
+    let sweep =
+        tokio::spawn(async move { recover_stranded_model_conversions(&sweep_data).await });
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(
         !sweep.is_finished(),

--- a/crates/sceneworks-worker/src/tests/hf_and_family.rs
+++ b/crates/sceneworks-worker/src/tests/hf_and_family.rs
@@ -333,7 +333,8 @@ fn download_family_check_proceeds_for_derived_family_base_architecture() {
 async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
     let temp = tempdir().expect("tempdir creates");
     let root = temp.path();
-    let final_dir = root.join("mlx").join("wan_2_2");
+    let conversion_root = root.join("mlx");
+    let final_dir = conversion_root.join("wan_2_2");
 
     // A completed temp conversion sitting in its sibling staging dir.
     let temp_dir = root.join("mlx").join(".wan_2_2.converting-job1");
@@ -344,7 +345,7 @@ async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
     // The canonical dir only appears after finalize, so a partial conversion can
     // never be picked up as a ready model.
     assert!(!final_dir.exists());
-    finalize_converted_dir(&temp_dir, &final_dir)
+    finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
         .await
         .expect("finalize");
     assert!(final_dir.join("config.json").is_file());
@@ -357,7 +358,7 @@ async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
     let temp_dir2 = root.join("mlx").join(".wan_2_2.converting-job2");
     std::fs::create_dir_all(&temp_dir2).expect("temp dir 2");
     std::fs::write(temp_dir2.join("config.json"), "{}").expect("config 2");
-    finalize_converted_dir(&temp_dir2, &final_dir)
+    finalize_converted_dir(&temp_dir2, &final_dir, &conversion_root)
         .await
         .expect("finalize 2");
     assert!(final_dir.join("config.json").is_file());
@@ -374,7 +375,8 @@ async fn finalize_converted_dir_promotes_atomically_and_replaces_stale() {
 async fn finalize_converted_dir_restores_stale_install_on_rename_failure() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path();
-    let final_dir = root.join("mlx").join("model");
+    let conversion_root = root.join("mlx");
+    let final_dir = conversion_root.join("model");
     std::fs::create_dir_all(&final_dir).expect("final dir");
     std::fs::write(final_dir.join("weights.safetensors"), b"OLD-BUT-WORKING")
         .expect("seed old install");
@@ -382,7 +384,7 @@ async fn finalize_converted_dir_restores_stale_install_on_rename_failure() {
     // Intentionally never created, so the temp→final rename fails after the stale aside.
     let temp_dir = root.join("mlx").join(".model.converting-jobX");
 
-    let error = finalize_converted_dir(&temp_dir, &final_dir)
+    let error = finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
         .await
         .expect_err("a missing temp dir must make the promotion fail");
     assert!(
@@ -419,14 +421,14 @@ async fn finalize_converted_dir_restores_stale_install_on_rename_failure() {
 async fn finalize_converted_dir_replaces_existing_install_leaves_no_backup() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path();
-    let final_dir = root.join("mlx").join("model");
+    let conversion_root = root.join("mlx");
+    let final_dir = conversion_root.join("model");
     std::fs::create_dir_all(&final_dir).expect("final dir");
     std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("seed old");
     let temp_dir = root.join("mlx").join(".model.converting-jobY");
     std::fs::create_dir_all(&temp_dir).expect("temp dir");
     std::fs::write(temp_dir.join("weights.safetensors"), b"NEW").expect("seed new");
-
-    finalize_converted_dir(&temp_dir, &final_dir)
+    finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
         .await
         .expect("finalize should succeed");
 
@@ -457,13 +459,14 @@ async fn finalize_converted_dir_replaces_existing_install_leaves_no_backup() {
 async fn finalize_converted_dir_first_install_succeeds() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path();
-    let final_dir = root.join("mlx").join("installed").join("model");
+    let conversion_root = root.join("mlx");
+    let final_dir = conversion_root.join("model");
     let temp_dir = root.join("mlx").join(".model.converting-jobZ");
     std::fs::create_dir_all(&temp_dir).expect("temp dir");
     std::fs::write(temp_dir.join("weights.safetensors"), b"FRESH").expect("seed fresh");
 
     assert!(!final_dir.exists());
-    finalize_converted_dir(&temp_dir, &final_dir)
+    finalize_converted_dir(&temp_dir, &final_dir, &conversion_root)
         .await
         .expect("first install should succeed");
 
@@ -475,6 +478,205 @@ async fn finalize_converted_dir_first_install_succeeds() {
     assert!(
         !temp_dir.exists(),
         "temp dir must have been moved into place"
+    );
+}
+
+/// Startup runs before utility children are spawned and under the exclusive conversion lifecycle
+/// lock. It removes backups for a present target, restores the recovery source when the target is
+/// absent, and never broadens beyond direct real directories under `<data>/models/mlx`.
+#[tokio::test]
+async fn startup_sweeps_stranded_conversion_backups_with_recovery_and_confinement() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let parent = data_dir.join("models/mlx");
+    std::fs::create_dir_all(&parent).expect("parent");
+    let final_dir = parent.join("model");
+    std::fs::create_dir_all(&final_dir).expect("current target");
+    std::fs::write(final_dir.join("weights.safetensors"), b"CURRENT").expect("current contents");
+    let stale_one = parent.join(".model.finalize-backup-111");
+    let stale_two =
+        parent.join(".model.finalize-backup-222-00000000-0000-4000-8000-000000000222");
+    let recover =
+        parent.join(".recover.finalize-backup-333-00000000-0000-4000-8000-000000000333");
+    let unrelated = parent.join(".other.finalize-backup-not-a-process-id");
+    let matching_file = parent.join(".model.finalize-backup-file");
+    for dir in [&stale_one, &stale_two, &recover, &unrelated] {
+        std::fs::create_dir_all(dir).expect("backup fixture");
+        std::fs::write(dir.join("weights.safetensors"), b"weights").expect("backup contents");
+    }
+    std::fs::write(&matching_file, b"not a directory").expect("matching file");
+
+    sweep_stranded_conversion_backups(&data_dir)
+        .await
+        .expect("startup sweep succeeds");
+
+    assert!(!stale_one.exists(), "first stranded backup is removed");
+    assert!(!stale_two.exists(), "second stranded backup is removed");
+    assert!(
+        parent.join("recover/weights.safetensors").is_file(),
+        "a lone recovery source is restored when its canonical target is absent"
+    );
+    assert!(
+        unrelated.exists(),
+        "a directory outside the exact backup convention is preserved"
+    );
+    assert!(
+        matching_file.is_file(),
+        "a matching non-directory is never removed"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn finalize_backup_sweep_does_not_follow_matching_symlink() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let parent = data_dir.join("models/mlx");
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&parent).expect("parent");
+    std::fs::create_dir_all(&outside).expect("outside");
+    std::fs::write(outside.join("keep.txt"), b"keep").expect("outside fixture");
+    let link =
+        parent.join(".model.finalize-backup-444-00000000-0000-4000-8000-000000000444");
+    std::os::unix::fs::symlink(&outside, &link).expect("matching symlink");
+
+    sweep_stranded_conversion_backups(&data_dir)
+        .await
+        .expect("sweep succeeds");
+
+    assert!(
+        std::fs::symlink_metadata(&link).is_ok(),
+        "matching symlink itself is preserved"
+    );
+    assert!(
+        outside.join("keep.txt").is_file(),
+        "sweep never follows the symlink outside the parent"
+    );
+}
+
+/// Two utility processes may finalize the same target. Pause the first after it has moved the
+/// working install aside, then start a second promotion. The second must remain blocked until the
+/// first restores on failure; without the per-target lock it would promote NEW and the first
+/// rollback would delete NEW and replace it with OLD.
+#[tokio::test]
+async fn concurrent_finalizers_serialize_rollback_and_preserve_second_promotion() {
+    let temp = tempdir().expect("tempdir");
+    let conversion_root = temp.path().join("mlx");
+    let final_dir = conversion_root.join("model");
+    std::fs::create_dir_all(&final_dir).expect("working install");
+    std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("old weights");
+    let missing_temp = conversion_root.join(".model.converting-fail");
+    let good_temp = conversion_root.join(".model.converting-good");
+    std::fs::create_dir_all(&good_temp).expect("good temp");
+    std::fs::write(good_temp.join("weights.safetensors"), b"NEW").expect("new weights");
+
+    let (aside_tx, aside_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let first_final = final_dir.clone();
+    let first_root = conversion_root.clone();
+    let first = tokio::spawn(async move {
+        finalize_converted_dir_with_test_hook(
+            &missing_temp,
+            &first_final,
+            &first_root,
+            move |_| {
+                let _ = aside_tx.send(());
+                let _ = release_rx.blocking_recv();
+            },
+        )
+        .await
+    });
+    aside_rx.await.expect("first finalizer moved OLD aside");
+
+    let second_final = final_dir.clone();
+    let second_root = conversion_root.clone();
+    let second = tokio::spawn(async move {
+        finalize_converted_dir(&good_temp, &second_final, &second_root).await
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        !second.is_finished(),
+        "second finalizer waits while the first owns the target recovery source"
+    );
+
+    release_tx.send(()).expect("release first finalizer");
+    first
+        .await
+        .expect("first task joins")
+        .expect_err("first promotion fails and rolls OLD back");
+    second
+        .await
+        .expect("second task joins")
+        .expect("second promotion succeeds after rollback");
+    assert_eq!(
+        std::fs::read(final_dir.join("weights.safetensors")).expect("final weights"),
+        b"NEW",
+        "the successful second promotion survives the first finalizer's rollback"
+    );
+    let backups = std::fs::read_dir(&conversion_root)
+        .expect("read conversion root")
+        .flatten()
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .contains("finalize-backup")
+        })
+        .count();
+    assert_eq!(backups, 0, "both finalizers clean up only their own backup");
+}
+
+/// The startup sweep takes the lifecycle lock exclusively. Even if another top-level process starts
+/// while a utility worker is finalizing, it must wait rather than deleting the live rollback source.
+#[tokio::test]
+async fn startup_sweep_waits_for_an_active_finalizers_recovery_source() {
+    let temp = tempdir().expect("tempdir");
+    let data_dir = temp.path().join("data");
+    let conversion_root = data_dir.join("models/mlx");
+    let final_dir = conversion_root.join("model");
+    std::fs::create_dir_all(&final_dir).expect("working install");
+    std::fs::write(final_dir.join("weights.safetensors"), b"OLD").expect("old weights");
+    let missing_temp = conversion_root.join(".model.converting-fail");
+
+    let (aside_tx, aside_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let active_final = final_dir.clone();
+    let active_root = conversion_root.clone();
+    let finalizer = tokio::spawn(async move {
+        finalize_converted_dir_with_test_hook(
+            &missing_temp,
+            &active_final,
+            &active_root,
+            move |_| {
+                let _ = aside_tx.send(());
+                let _ = release_rx.blocking_recv();
+            },
+        )
+        .await
+    });
+    aside_rx.await.expect("finalizer moved OLD aside");
+
+    let sweep_data = data_dir.clone();
+    let sweep = tokio::spawn(async move { sweep_stranded_conversion_backups(&sweep_data).await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        !sweep.is_finished(),
+        "startup sweep waits while a finalizer owns a live backup"
+    );
+
+    release_tx.send(()).expect("release finalizer");
+    finalizer
+        .await
+        .expect("finalizer task joins")
+        .expect_err("missing temp triggers rollback");
+    sweep
+        .await
+        .expect("sweep task joins")
+        .expect("startup sweep completes after rollback");
+    assert_eq!(
+        std::fs::read(final_dir.join("weights.safetensors")).expect("restored weights"),
+        b"OLD",
+        "startup cleanup cannot delete the active finalizer's recovery source"
     );
 }
 

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -146,6 +146,68 @@ async fn paired_moe_upload_writes_high_low_convention_files() {
 }
 
 #[tokio::test]
+async fn paired_moe_upload_rejects_single_digest_before_network_or_file_move() {
+    use sha2::{Digest, Sha256};
+
+    let temp = tempdir().expect("tempdir creates");
+    let mut settings = test_settings("http://127.0.0.1:1".to_owned(), None);
+    settings.data_dir = temp.path().join("data");
+    settings.api_url = "http://127.0.0.1:1".to_owned();
+    let upload_dir = settings.data_dir.join("cache/lora-uploads/upload-1");
+    tokio::fs::create_dir_all(&upload_dir).await.unwrap();
+    let high_upload = upload_dir.join("high.safetensors");
+    let low_upload = upload_dir.join("low.safetensors");
+    tokio::fs::write(&high_upload, b"high").await.unwrap();
+    tokio::fs::write(&low_upload, b"low").await.unwrap();
+    // This digest matches the lexicographically first/high file, the exact case the old
+    // enumeration-first verification incorrectly accepted while leaving the low half unchecked.
+    let first_digest = format!("{:x}", Sha256::digest(b"high"));
+
+    let mut job_json = job_snapshot_json("job-1", false);
+    job_json["type"] = json!("lora_import");
+    job_json["payload"] = json!({
+        "loraId": "my_moe",
+        "sourcePath": high_upload.display().to_string(),
+        "secondarySourcePath": low_upload.display().to_string(),
+        "uploadedSourcePath": true,
+        "expectedSha256": first_digest,
+    });
+    let job: JobSnapshot = serde_json::from_value(job_json).expect("job deserializes");
+    let api = ApiClient::new(&settings);
+    let client = reqwest::Client::new();
+
+    let error = super::model_jobs::run_lora_import_job(&api, &settings, &client, &job)
+        .await
+        .expect_err("one digest cannot verify a two-file upload");
+    assert!(
+        error.to_string().contains("ambiguous with secondarySourcePath"),
+        "digest contract rejection must win before the unreachable heartbeat: {error:?}"
+    );
+    assert!(high_upload.is_file(), "high staged source was not moved");
+    assert!(low_upload.is_file(), "low staged source was not moved");
+    assert!(
+        !settings.data_dir.join("loras/my_moe").exists(),
+        "no target directory is created for a rejected contract"
+    );
+}
+
+#[test]
+fn lora_import_digest_contract_allows_unambiguous_single_or_pair_inputs() {
+    let mut payload = JsonObject::new();
+    payload.insert("expectedSha256".to_owned(), json!("a".repeat(64)));
+    super::model_jobs::validate_lora_import_digest_contract(&payload)
+        .expect("single-file digest remains supported");
+
+    payload.remove("expectedSha256");
+    payload.insert(
+        "secondarySourcePath".to_owned(),
+        json!("/staged/low.safetensors"),
+    );
+    super::model_jobs::validate_lora_import_digest_contract(&payload)
+        .expect("paired upload without one ambiguous digest remains supported");
+}
+
+#[tokio::test]
 async fn lora_url_import_downloads_to_named_file() {
     let temp = tempdir().expect("tempdir creates");
     let source_url = spawn_binary_stub(b"url-lora".to_vec()).await;

--- a/crates/sceneworks-worker/src/tests/media_and_paths.rs
+++ b/crates/sceneworks-worker/src/tests/media_and_paths.rs
@@ -194,9 +194,9 @@ fn model_destinations_are_constrained_to_data_models() {
         .expect_err("destination outside data/models is rejected");
     assert!(error.to_string().contains("data/models"));
 
-    // model_convert: outputDir under data/models is accepted, traversal is rejected.
+    // model_convert: only a direct child of the managed MLX conversion root is accepted.
     let ok = resolve_model_convert_output(
-        &settings,
+        &settings.data_dir,
         &temp
             .path()
             .join("models")
@@ -205,8 +205,30 @@ fn model_destinations_are_constrained_to_data_models() {
             .display()
             .to_string(),
     )
-    .expect("convert output under data/models is accepted");
-    assert!(ok.starts_with(&models_root));
+    .expect("direct MLX convert output is accepted");
+    assert_eq!(ok.parent(), Some(models_root.join("mlx").as_path()));
+
+    let nested = temp
+        .path()
+        .join("models")
+        .join("mlx")
+        .join("nested")
+        .join("wan")
+        .display()
+        .to_string();
+    let nested_error = resolve_model_convert_output(&settings.data_dir, &nested)
+        .expect_err("nested output falls outside the finalizer/recovery contract");
+    assert!(nested_error.to_string().contains("direct child"));
+
+    let wrong_managed_root = temp
+        .path()
+        .join("models")
+        .join("custom")
+        .display()
+        .to_string();
+    let wrong_root_error = resolve_model_convert_output(&settings.data_dir, &wrong_managed_root)
+        .expect_err("other managed model roots are not conversion destinations");
+    assert!(wrong_root_error.to_string().contains("direct child"));
 
     let traversal = temp
         .path()
@@ -215,9 +237,9 @@ fn model_destinations_are_constrained_to_data_models() {
         .join("escape")
         .display()
         .to_string();
-    let convert_error = resolve_model_convert_output(&settings, &traversal)
+    let convert_error = resolve_model_convert_output(&settings.data_dir, &traversal)
         .expect_err("convert output escaping data/models is rejected");
-    assert!(convert_error.to_string().contains("data/models"));
+    assert!(convert_error.to_string().contains("models/mlx"));
 }
 
 #[cfg(unix)]
@@ -483,7 +505,10 @@ fn app_managed_helpers_resolve_symlinks_before_root_check() {
     // resolve_model_convert_output (write target confined to data/models)
     let convert_link = models_dir.join("convert-escape");
     std::os::unix::fs::symlink(&outside_target, &convert_link).expect("symlink creates");
-    let err = super::resolve_model_convert_output(&settings, &convert_link.display().to_string())
+    let err = super::resolve_model_convert_output(
+        &settings.data_dir,
+        &convert_link.display().to_string(),
+    )
         .expect_err("symlinked convert outputDir escape rejects");
     assert!(err.to_string().contains("data/models"));
 

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -74,7 +74,7 @@ pub(crate) fn parse_plan(payload: &JsonObject) -> WorkerResult<TrainingPlan> {
 /// Validate a resolved plan the way the Python `validate_training_plan` does:
 /// reject an unknown plan version, an empty dataset, or missing dataset images.
 /// Shared by the dry-run validator and the real run so both reject the same inputs.
-fn validate_training_plan(settings: &Settings, plan: &TrainingPlan) -> WorkerResult<()> {
+pub(crate) fn validate_training_plan(settings: &Settings, plan: &TrainingPlan) -> WorkerResult<()> {
     if plan.plan_version != TRAINING_PLAN_VERSION {
         return Err(WorkerError::InvalidPayload(format!(
             "Unsupported training plan version {}; this worker understands version {}.",
@@ -773,6 +773,7 @@ pub(crate) async fn run_training_execution(
     // forces gradient checkpointing on for them (Z-Image, Wan A14B-T2V) regardless of the plan value.
     // On macOS this is the identity. See its doc comment for the why.
     let config = finalize_training_config(map_training_config(&plan.config), plan);
+    let sample_config = config.clone();
     let total_steps = config.steps;
     let file_name = plan.output.file_name.clone();
     let trigger_words = plan.output.trigger_words.clone();
@@ -850,6 +851,7 @@ pub(crate) async fn run_training_execution(
         settings,
         job,
         plan,
+        sample_config,
         backend,
         total_steps,
         rx,
@@ -923,7 +925,12 @@ impl SamplePersister {
     /// Resolve the sample config + destination paths for a run. `output_dir`/`project_root` are
     /// resolved leniently (already validated upstream in `run_training_execution`); if either is
     /// unavailable, samples simply don't render but training is unaffected.
-    fn new(settings: &Settings, job: &JobSnapshot, plan: &TrainingPlan) -> Self {
+    fn new(
+        settings: &Settings,
+        job: &JobSnapshot,
+        plan: &TrainingPlan,
+        cfg: TrainingConfig,
+    ) -> Self {
         let output_dir =
             resolve_training_output_dir(settings, &plan.output.output_dir, "Training outputDir")
                 .ok();
@@ -951,7 +958,7 @@ impl SamplePersister {
             .unwrap_or("lora")
             .to_owned();
         Self {
-            cfg: map_training_config(&plan.config),
+            cfg,
             output_dir,
             project_root,
             stem,
@@ -1069,6 +1076,7 @@ async fn consume_training_events(
     settings: &Settings,
     job: &JobSnapshot,
     plan: &TrainingPlan,
+    sample_config: TrainingConfig,
     backend: &str,
     total_steps: u32,
     mut rx: tokio::sync::mpsc::Receiver<TrainEvent>,
@@ -1090,7 +1098,7 @@ async fn consume_training_events(
     // config + destination paths + the accumulated cumulative/this-cadence record lists. The event
     // loop's `Sample` arm delegates to `samples.persist(...)` and the `Done` arm reads
     // `samples.all_samples` / `samples.cfg` for the final result fold.
-    let mut samples = SamplePersister::new(settings, job, plan);
+    let mut samples = SamplePersister::new(settings, job, plan, sample_config);
 
     let mut heartbeat_interval = tokio::time::interval(progress_report_interval(settings));
     heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -2423,7 +2431,16 @@ mod tests {
         .expect("job snapshot deserializes");
 
         // Drive the REAL provenance — this is where the two operands are resolved.
-        let persister = SamplePersister::new(&settings, &job, &plan);
+        let mut finalized_config =
+            finalize_training_config(map_training_config(&plan.config), &plan);
+        // Deliberately differ from the raw-plan mapping to model a backend finalize override.
+        // The persister must receive the exact config handed to the trainer, not remap the plan.
+        finalized_config.sample_steps = 37;
+        let persister = SamplePersister::new(&settings, &job, &plan, finalized_config.clone());
+        assert_eq!(
+            persister.cfg.sample_steps, finalized_config.sample_steps,
+            "preview persistence uses the trainer's finalized config"
+        );
         let resolved_output = persister
             .output_dir
             .clone()


### PR DESCRIPTION
## Summary
- make converted-model finalization concurrency-safe across the four utility worker processes with a shared lifecycle lock and exclusive per-target locks
- sweep crash-stranded finalize backups only at top-level worker startup, only under the canonical `data/models/mlx` root, restoring a missing target and never following symlinks
- reject ambiguous one-digest paired Wan LoRA uploads before network or filesystem mutation, and bind HF LoRA receipts to the downloader-returned revision
- parse COCO keypoint envelopes once, pass the trainer-finalized config to preview persistence, and validate control-training confinement before downloads/rendering

## Lifecycle regression coverage
- overlapping finalizers serialize so rollback cannot delete a later promotion
- startup sweep waits for an active finalizer recovery source
- stranded backups are recovered or removed within the bounded conversion root
- matching symlinks and nonmatching entries are preserved

## Validation
- `cargo test -p sceneworks-worker --lib` (1009 passed, 0 failed, 176 ignored)
- `CARGO_TARGET_DIR=/tmp/sc13644-target-no-backend cargo check --locked -p sceneworks-worker --target x86_64-unknown-linux-gnu --no-default-features`
- `cargo clippy --locked -p sceneworks-worker --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- rebased on current `origin/main` `2287c59a236b2488be6b22c9a80c6a9f70166ba7`

The off-Mac `backend-candle` cross-check was attempted with `CUDARC_CUDA_VERSION=12080` but cannot build on this Mac because `candle-kernels` requires `nvcc`; the failure is environmental (`NvccNotFound`), before SceneWorks sources compile.

Shortcut: https://app.shortcut.com/trefry/story/13644