### PR TITLE
sc-13640: resolve worker CV review findings

### DIFF
--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -73,6 +73,42 @@ const DETECTOR_BACKEND: &str = "mlx";
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const DETECTOR_BACKEND: &str = "candle";
 
+struct KpsDetection {
+    bbox: [f32; 4],
+    kps: [[f32; 2]; 5],
+    score: f32,
+}
+
+fn extraction_from_detections(
+    detections: impl IntoIterator<Item = KpsDetection>,
+    width: u32,
+    height: u32,
+) -> KpsExtraction {
+    let largest = detections.into_iter().max_by(|a, b| {
+        let area =
+            |d: &KpsDetection| (d.bbox[2] - d.bbox[0]).max(0.0) * (d.bbox[3] - d.bbox[1]).max(0.0);
+        area(a).total_cmp(&area(b))
+    });
+    let Some(det) = largest else {
+        return KpsExtraction::none(width, height);
+    };
+
+    let kps = det
+        .kps
+        .map(|point| normalize_to_square(point[0], point[1], width, height));
+    let tl = normalize_to_square(det.bbox[0], det.bbox[1], width, height);
+    let br = normalize_to_square(det.bbox[2], det.bbox[3], width, height);
+    KpsExtraction {
+        detected: true,
+        kps: Some(kps),
+        bbox: Some([tl[0], tl[1], br[0], br[1]]),
+        det_score: det.score,
+        low_confidence: det.score < LOW_CONF_THRESH,
+        source_width: width,
+        source_height: height,
+    }
+}
+
 /// Map a detected pixel coordinate into the square-normalized `[0,1]` preset space, applying
 /// the engine's centered-letterbox geometry analytically (no image resize needed). Pure +
 /// unit-tested. `M = max(w, h)`; for a square image this is just `px/w, py/h`.
@@ -216,32 +252,15 @@ fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtra
             .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))
     })?;
 
-    let (w, h) = (image.width, image.height);
-    let largest = dets.into_iter().max_by(|a, b| {
-        let area = |d: &runtime_macos::providers::face::Detection| {
-            (d.bbox[2] - d.bbox[0]).max(0.0) * (d.bbox[3] - d.bbox[1]).max(0.0)
-        };
-        area(a).total_cmp(&area(b))
-    });
-    let Some(det) = largest else {
-        return Ok(KpsExtraction::none(w, h));
-    };
-
-    let mut kps = [[0.0f32; 2]; 5];
-    for (i, point) in det.kps.iter().enumerate() {
-        kps[i] = normalize_to_square(point[0], point[1], w, h);
-    }
-    let tl = normalize_to_square(det.bbox[0], det.bbox[1], w, h);
-    let br = normalize_to_square(det.bbox[2], det.bbox[3], w, h);
-    Ok(KpsExtraction {
-        detected: true,
-        kps: Some(kps),
-        bbox: Some([tl[0], tl[1], br[0], br[1]]),
-        det_score: det.score,
-        low_confidence: det.score < LOW_CONF_THRESH,
-        source_width: w,
-        source_height: h,
-    })
+    Ok(extraction_from_detections(
+        dets.into_iter().map(|det| KpsDetection {
+            bbox: det.bbox,
+            kps: det.kps,
+            score: det.score,
+        }),
+        image.width,
+        image.height,
+    ))
 }
 
 /// Off-Mac sibling of [`detect_largest_kps`] (sc-5497, epic 5482): load the candle SCRFD/ArcFace stack
@@ -270,32 +289,15 @@ fn detect_largest_kps_candle(face_dir: &Path, image: &Image) -> WorkerResult<Kps
             .map_err(|error| WorkerError::Engine(format!("SCRFD detect: {error}")))
     })?;
 
-    let (w, h) = (image.width, image.height);
-    let largest = dets.into_iter().max_by(|a, b| {
-        let area = |d: &gen_core::DetectedFace| {
-            (d.bbox[2] - d.bbox[0]).max(0.0) * (d.bbox[3] - d.bbox[1]).max(0.0)
-        };
-        area(a).total_cmp(&area(b))
-    });
-    let Some(det) = largest else {
-        return Ok(KpsExtraction::none(w, h));
-    };
-
-    let mut kps = [[0.0f32; 2]; 5];
-    for (i, point) in det.kps.iter().enumerate() {
-        kps[i] = normalize_to_square(point[0], point[1], w, h);
-    }
-    let tl = normalize_to_square(det.bbox[0], det.bbox[1], w, h);
-    let br = normalize_to_square(det.bbox[2], det.bbox[3], w, h);
-    Ok(KpsExtraction {
-        detected: true,
-        kps: Some(kps),
-        bbox: Some([tl[0], tl[1], br[0], br[1]]),
-        det_score: det.det_score,
-        low_confidence: det.det_score < LOW_CONF_THRESH,
-        source_width: w,
-        source_height: h,
-    })
+    Ok(extraction_from_detections(
+        dets.into_iter().map(|det| KpsDetection {
+            bbox: det.bbox,
+            kps: det.kps,
+            score: det.det_score,
+        }),
+        image.width,
+        image.height,
+    ))
 }
 
 /// Resolve the source image from the payload: a project `sourceAssetId` (+ `projectId`) or a
@@ -588,6 +590,33 @@ mod tests {
         // A square image: side cancels, normalized = px/side, py/side.
         assert_eq!(normalize_to_square(512.0, 256.0, 1024, 1024), [0.5, 0.25]);
         assert_eq!(normalize_to_square(0.0, 0.0, 800, 800), [0.0, 0.0]);
+    }
+
+    #[test]
+    fn shared_detection_tail_selects_largest_and_normalizes_once() {
+        let small = KpsDetection {
+            bbox: [0.0, 0.0, 10.0, 10.0],
+            kps: [[1.0, 1.0]; 5],
+            score: 0.99,
+        };
+        let large = KpsDetection {
+            bbox: [100.0, 20.0, 500.0, 420.0],
+            kps: [[300.0, 220.0]; 5],
+            score: 0.8,
+        };
+        let result = extraction_from_detections([small, large], 600, 400);
+        assert!(result.detected);
+        assert_eq!(result.det_score, 0.8);
+        let kps = result.kps.expect("kps");
+        assert!((kps[0][0] - 0.5).abs() < 1e-6);
+        assert!((kps[0][1] - 0.533_333_36).abs() < 1e-6);
+        let bbox = result.bbox.expect("bbox");
+        for (actual, expected) in bbox
+            .into_iter()
+            .zip([1.0 / 6.0, 0.2, 5.0 / 6.0, 0.866_666_7])
+        {
+            assert!((actual - expected).abs() < 1e-6, "{actual} != {expected}");
+        }
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -919,7 +919,7 @@ impl OrtYolo {
 }
 
 #[cfg(not(target_os = "macos"))]
-static DETECTOR: OnceLock<Mutex<Option<OrtYolo>>> = OnceLock::new();
+static DETECTOR: OnceLock<Mutex<Option<(PathBuf, OrtYolo)>>> = OnceLock::new();
 
 /// Blocking person detection on a single rendered frame (off-Mac `ort`/CUDA backend). The
 /// session is loaded once and cached process-wide; invoke via `spawn_blocking`.
@@ -942,10 +942,12 @@ pub(crate) fn detect_people_blocking(
         *guard = None;
         guard
     });
-    if guard.is_none() {
-        *guard = Some(OrtYolo::load(&weights_path)?);
+    if !guard.as_ref().is_some_and(|(cached_path, _)| {
+        crate::util::resolved_cache_paths_match([cached_path.as_path()], [weights_path.as_path()])
+    }) {
+        *guard = Some((weights_path.clone(), OrtYolo::load(&weights_path)?));
     }
-    let detector = guard.as_mut().expect("detector loaded");
+    let detector = &mut guard.as_mut().expect("detector loaded").1;
     let device = detector.device;
     let detections = detector.detect_people(&img, conf)?;
     Ok(DetectResult {

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -76,12 +76,74 @@ fn parse_quant_bits(value: &str) -> Option<i32> {
     }
 }
 
+fn validate_square_mask_len(grid: usize, len: usize) -> WorkerResult<()> {
+    if len == grid.saturating_mul(grid) {
+        return Ok(());
+    }
+    Err(WorkerError::Engine(format!(
+        "sam3 mask grid is {grid}x{grid} but contains {len} values"
+    )))
+}
+
 /// The parsed SAM3 checkpoint is cached process-wide (the 3.2 GB safetensors parse is the
 /// expensive part). A **fresh** `Sam3VideoModel` is assembled from it per clip: the model carries
 /// per-session tracking state (obj ids, memory banks) and exposes no reset, so reusing one across
 /// clips would leak identities. Building from cached weights is cheap (layer assembly over
 /// already-resident arrays). Mirrors the SAM2 predictor cache + poison-recovery idiom.
 static WEIGHTS: OnceLock<Mutex<Option<Weights>>> = OnceLock::new();
+
+fn propagate_person_concept(
+    model_path: &Path,
+    tokenizer_path: &Path,
+    frames: &[Array],
+    cancel: Option<&CancelFlag>,
+    mut progress: Option<SegmentProgress>,
+) -> WorkerResult<Vec<VideoFrameOutput>> {
+    check_segment_canceled(cancel)?;
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(model_path)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    let mut model = Sam3VideoModel::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
+    if let Some(bits) = quant_bits() {
+        model
+            .quantize(bits)
+            .map_err(|e| WorkerError::Engine(format!("sam3 quantize q{bits}: {e}")))?;
+    }
+    let tokenizer = Sam3Tokenizer::from_file(tokenizer_path, &Sam3TextConfig::sam3())
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
+    let (input_ids, text_mask) = tokenizer
+        .encode(CONCEPT_PROMPT)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+    check_segment_canceled(cancel)?;
+
+    model
+        .propagate(
+            frames,
+            &input_ids,
+            &text_mask,
+            cancel,
+            progress
+                .as_deref_mut()
+                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
+        )
+        .map_err(|e| match e {
+            runtime_macos::media::Error::Canceled => {
+                WorkerError::Canceled(CANCEL_MESSAGE.to_owned())
+            }
+            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
+        })
+}
 
 /// Cache key for the smart-select single-image models: the resolved weight path + the quant tier in
 /// effect. A change in either (different model snapshot, `SCENEWORKS_SAM3_QUANT` flip) rebuilds, so a
@@ -311,7 +373,7 @@ pub(crate) fn segment_track_blocking(
     clip_frame_paths: Vec<PathBuf>,
     anchors: Vec<Option<BoxNorm>>,
     cancel: Option<CancelFlag>,
-    mut progress: Option<SegmentProgress>,
+    progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
     // A frames/anchors length mismatch is a caller contract violation. The old `assert_eq!`
     // panicked inside `spawn_blocking`, which `media_jobs` absorbed as a silent "degraded"
@@ -348,63 +410,13 @@ pub(crate) fn segment_track_blocking(
         frames.push(input_tensor(&img));
     }
 
-    // Guard the cold 3.2 GB checkpoint parse + model build + quantize — the engine only observes
-    // the flag once propagation starts.
-    check_segment_canceled(cancel.as_ref())?;
-
-    // Cached checkpoint; recover from a poisoned lock by dropping the cached weights and reloading
-    // (mirrors person_segment / sc-4277 F-MLXW-13).
-    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
-        let mut guard = poisoned.into_inner();
-        *guard = None;
-        guard
-    });
-    if guard.is_none() {
-        let weights = Weights::from_file(&model_path)
-            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
-        *guard = Some(weights);
-    }
-    let weights = guard.as_ref().expect("weights loaded");
-
-    // Fresh model per clip (clean tracking state) + tokenize the concept once.
-    let mut model = Sam3VideoModel::from_weights(weights)
-        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
-    // Quantize (Q8 default) for a ~0.9 GB footprint vs F32 ~3.2 GB (sc-4925). The dense path is
-    // parity-preserving, so the F32 (`SCENEWORKS_SAM3_QUANT=off`) result is unchanged.
-    if let Some(bits) = quant_bits() {
-        model
-            .quantize(bits)
-            .map_err(|e| WorkerError::Engine(format!("sam3 quantize q{bits}: {e}")))?;
-    }
-    let tokenizer = Sam3Tokenizer::from_file(&tokenizer_path, &Sam3TextConfig::sam3())
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
-    let (input_ids, text_mask) = tokenizer
-        .encode(CONCEPT_PROMPT)
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
-    // The quantize pass above is seconds-long on a cold start; re-check before committing to the
-    // propagate loop.
-    check_segment_canceled(cancel.as_ref())?;
-
-    // gen-core d8038beb (sc-7176 pin sync): `propagate` takes `cancel` + per-frame `progress`
-    // (the video per-step cancel contract). Thread the caller's flag/callback so a user cancel
-    // stops between frames and each frame reports progress (sc-8807).
-    let outputs = model
-        .propagate(
-            &frames,
-            &input_ids,
-            &text_mask,
-            cancel.as_ref(),
-            progress
-                .as_deref_mut()
-                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
-        )
-        .map_err(|e| match e {
-            runtime_macos::media::Error::Canceled => {
-                WorkerError::Canceled(CANCEL_MESSAGE.to_owned())
-            }
-            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
-        })?;
+    let outputs = propagate_person_concept(
+        &model_path,
+        &tokenizer_path,
+        &frames,
+        cancel.as_ref(),
+        progress,
+    )?;
 
     // Associate SAM3's identities to the selected track, then emit that object's per-frame mask.
     let Some(selected) = select_object(&outputs, &anchors) else {
@@ -550,6 +562,7 @@ fn segment_box_on_thread(
             .map_err(|e| WorkerError::Engine(format!("sam3 mask read: {e}")))?
             .as_slice::<f32>()
             .to_vec();
+        validate_square_mask_len(grid, m.len())?;
         let mut inside = 0u64;
         for gy in 0..grid {
             for gx in 0..grid {
@@ -677,7 +690,7 @@ pub(crate) fn segment_all_persons_in_memory(
     tokenizer_path: &Path,
     frames: &[gen_core::Image],
     cancel: Option<CancelFlag>,
-    mut progress: Option<SegmentProgress>,
+    progress: Option<SegmentProgress>,
 ) -> WorkerResult<AllPersonMasks> {
     check_segment_canceled(cancel.as_ref())?;
     let first = frames.first().ok_or_else(|| {
@@ -707,57 +720,13 @@ pub(crate) fn segment_all_persons_in_memory(
         })
         .collect::<WorkerResult<Vec<Array>>>()?;
 
-    // Guard the cold 3.2 GB checkpoint parse + model build + quantize — the engine only observes
-    // the flag once propagation starts.
-    check_segment_canceled(cancel.as_ref())?;
-
-    // Cached checkpoint; recover from a poisoned lock by dropping + reloading (mirrors
-    // `segment_track_blocking` / sc-4277 F-MLXW-13).
-    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
-        let mut guard = poisoned.into_inner();
-        *guard = None;
-        guard
-    });
-    if guard.is_none() {
-        let weights = Weights::from_file(model_path)
-            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
-        *guard = Some(weights);
-    }
-    let weights = guard.as_ref().expect("weights loaded");
-
-    let mut model = Sam3VideoModel::from_weights(weights)
-        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
-    if let Some(bits) = quant_bits() {
-        model
-            .quantize(bits)
-            .map_err(|e| WorkerError::Engine(format!("sam3 quantize q{bits}: {e}")))?;
-    }
-    let tokenizer = Sam3Tokenizer::from_file(tokenizer_path, &Sam3TextConfig::sam3())
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
-    let (input_ids, text_mask) = tokenizer
-        .encode(CONCEPT_PROMPT)
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
-    check_segment_canceled(cancel.as_ref())?;
-
-    // gen-core d8038beb (sc-7176 pin sync): `propagate` takes `cancel` + per-frame `progress`
-    // (the video per-step cancel contract). Thread the caller's flag/callback (sc-8807).
-    let outputs = model
-        .propagate(
-            &tensors,
-            &input_ids,
-            &text_mask,
-            cancel.as_ref(),
-            progress
-                .as_deref_mut()
-                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
-        )
-        .map_err(|e| match e {
-            runtime_macos::media::Error::Canceled => {
-                WorkerError::Canceled(CANCEL_MESSAGE.to_owned())
-            }
-            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
-        })?;
+    let outputs = propagate_person_concept(
+        model_path,
+        tokenizer_path,
+        &tensors,
+        cancel.as_ref(),
+        progress,
+    )?;
 
     // Paint order + per-frame masks are backend-neutral pure logic shared with the candle twin via
     // `person_segment_sam3_common` (sc-11191, F-018), so the tie-break and mask selection stay
@@ -776,6 +745,15 @@ pub(crate) fn segment_all_persons_in_memory(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn smart_select_rejects_non_square_mask_storage_before_indexing() {
+        assert!(validate_square_mask_len(3, 9).is_ok());
+        let error = validate_square_mask_len(3, 8).expect_err("truncated mask must fail");
+        assert!(
+            matches!(error, WorkerError::Engine(ref message) if message.contains("3x3") && message.contains("8 values"))
+        );
+    }
     // The checkpoint filenames now live in the shared module; the real-weights smokes below join them
     // onto a snapshot dir to build the model/tokenizer paths. `MASK_GRID` sizes the synthetic mask
     // fixtures (the production paths call it inside the shared `person_segment_sam3_common` helpers).

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -80,6 +80,60 @@ fn parse_quant(value: &str) -> Option<Quant> {
 /// identities. Mirrors the MLX module's cache + poison-recovery idiom.
 static WEIGHTS: OnceLock<Mutex<Option<Weights>>> = OnceLock::new();
 
+fn propagate_person_concept(
+    model_path: &Path,
+    tokenizer_path: &Path,
+    frames: &[Tensor],
+    device: &Device,
+    cancel: Option<&CancelFlag>,
+    mut progress: Option<SegmentProgress>,
+) -> WorkerResult<Vec<VideoFrameOutput>> {
+    check_segment_canceled(cancel)?;
+    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
+        let mut guard = poisoned.into_inner();
+        *guard = None;
+        guard
+    });
+    if guard.is_none() {
+        let weights = Weights::from_file(model_path, device)
+            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
+        *guard = Some(weights);
+    }
+    let weights = guard.as_ref().expect("weights loaded");
+
+    let mut model = Sam3VideoModel::from_weights(weights)
+        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
+    if let Some(quant) = quant_level() {
+        model
+            .quantize(quant)
+            .map_err(|e| WorkerError::Engine(format!("sam3 quantize: {e}")))?;
+    }
+    let tokenizer = Sam3Tokenizer::from_file(tokenizer_path, &Sam3TextConfig::sam3())
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
+    let (input_ids, text_mask) = tokenizer
+        .encode(CONCEPT_PROMPT, device)
+        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
+    check_segment_canceled(cancel)?;
+
+    model
+        .propagate(
+            frames,
+            &input_ids,
+            &text_mask,
+            cancel,
+            progress
+                .as_deref_mut()
+                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
+        )
+        .map_err(|e| match e {
+            runtime_cuda::media::CandleError::Canceled => {
+                WorkerError::Canceled(CANCEL_MESSAGE.to_owned())
+            }
+            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
+        })
+}
+
 /// Preprocess an RGB frame to the SAM3 input tensor: resize to a 1008×1008 square (bilinear, fixed-
 /// square — *not* aspect-preserving), normalize by mean/std `0.5` to `[-1,1]`, packed NCHW
 /// `[1,3,1008,1008]` f32 on `device`.
@@ -121,7 +175,7 @@ pub(crate) fn segment_track_blocking(
     clip_frame_paths: Vec<PathBuf>,
     anchors: Vec<Option<BoxNorm>>,
     cancel: Option<CancelFlag>,
-    mut progress: Option<SegmentProgress>,
+    progress: Option<SegmentProgress>,
 ) -> WorkerResult<Vec<Vec<u8>>> {
     // A frames/anchors length mismatch is a caller contract violation. The old `assert_eq!`
     // panicked inside `spawn_blocking`, which `media_jobs` absorbed as a silent "degraded"
@@ -160,60 +214,14 @@ pub(crate) fn segment_track_blocking(
         frames.push(input_tensor(&img, &device)?);
     }
 
-    // Guard the cold multi-GB checkpoint parse + model build — the engine only observes the flag
-    // once propagation starts.
-    check_segment_canceled(cancel.as_ref())?;
-
-    // Cached checkpoint; recover from a poisoned lock by dropping the cached weights and reloading.
-    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
-        let mut guard = poisoned.into_inner();
-        *guard = None;
-        guard
-    });
-    if guard.is_none() {
-        let weights = Weights::from_file(&model_path, &device)
-            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
-        *guard = Some(weights);
-    }
-    let weights = guard.as_ref().expect("weights loaded");
-
-    // Fresh model per clip (clean tracking state) + tokenize the concept once.
-    let mut model = Sam3VideoModel::from_weights(weights)
-        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
-    // Optional quant (opt-in via `SCENEWORKS_SAM3_QUANT`); off-Mac defaults to dense (sc-6361), so
-    // unset leaves the F32 result unchanged.
-    if let Some(quant) = quant_level() {
-        model
-            .quantize(quant)
-            .map_err(|e| WorkerError::Engine(format!("sam3 quantize: {e}")))?;
-    }
-    let tokenizer = Sam3Tokenizer::from_file(&tokenizer_path, &Sam3TextConfig::sam3())
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
-    let (input_ids, text_mask) = tokenizer
-        .encode(CONCEPT_PROMPT, &device)
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
-    check_segment_canceled(cancel.as_ref())?;
-
-    // candle-gen-sam3 `propagate` takes `cancel` + per-frame `progress` (sc-8972, the candle
-    // sibling of the MLX video per-step cancel contract, gen-core d8038beb). Thread the caller's
-    // flag/callback so a user cancel stops between frames and each frame reports progress.
-    let outputs = model
-        .propagate(
-            &frames,
-            &input_ids,
-            &text_mask,
-            cancel.as_ref(),
-            progress
-                .as_deref_mut()
-                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
-        )
-        .map_err(|e| match e {
-            runtime_cuda::media::CandleError::Canceled => {
-                WorkerError::Canceled(CANCEL_MESSAGE.to_owned())
-            }
-            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
-        })?;
+    let outputs = propagate_person_concept(
+        &model_path,
+        &tokenizer_path,
+        &frames,
+        &device,
+        cancel.as_ref(),
+        progress,
+    )?;
 
     // Associate SAM3's identities to the selected track, then emit that object's per-frame mask.
     let Some(selected) = select_object(&outputs, &anchors) else {
@@ -244,7 +252,7 @@ pub(crate) fn segment_all_persons_in_memory(
     tokenizer_path: &Path,
     frames: &[gen_core::Image],
     cancel: Option<CancelFlag>,
-    mut progress: Option<SegmentProgress>,
+    progress: Option<SegmentProgress>,
 ) -> WorkerResult<AllPersonMasks> {
     check_segment_canceled(cancel.as_ref())?;
     let first = frames.first().ok_or_else(|| {
@@ -276,59 +284,14 @@ pub(crate) fn segment_all_persons_in_memory(
         })
         .collect::<WorkerResult<Vec<_>>>()?;
 
-    // Guard the cold multi-GB checkpoint parse + model build — the engine only observes the flag
-    // once propagation starts.
-    check_segment_canceled(cancel.as_ref())?;
-
-    // Cached checkpoint; recover from a poisoned lock by dropping + reloading (mirrors
-    // `segment_track_blocking`).
-    let cell = WEIGHTS.get_or_init(|| Mutex::new(None));
-    let mut guard = cell.lock().unwrap_or_else(|poisoned| {
-        let mut guard = poisoned.into_inner();
-        *guard = None;
-        guard
-    });
-    if guard.is_none() {
-        let weights = Weights::from_file(model_path, &device)
-            .map_err(|e| WorkerError::Engine(format!("sam3 weights load: {e}")))?;
-        *guard = Some(weights);
-    }
-    let weights = guard.as_ref().expect("weights loaded");
-
-    // Fresh model per call (clean tracking state) + tokenize the concept once. Off-Mac defaults to
-    // dense (sc-6361); `SCENEWORKS_SAM3_QUANT` opts back in.
-    let mut model = Sam3VideoModel::from_weights(weights)
-        .map_err(|e| WorkerError::Engine(format!("sam3 model build: {e}")))?;
-    if let Some(quant) = quant_level() {
-        model
-            .quantize(quant)
-            .map_err(|e| WorkerError::Engine(format!("sam3 quantize: {e}")))?;
-    }
-    let tokenizer = Sam3Tokenizer::from_file(tokenizer_path, &Sam3TextConfig::sam3())
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenizer load: {e}")))?;
-    let (input_ids, text_mask) = tokenizer
-        .encode(CONCEPT_PROMPT, &device)
-        .map_err(|e| WorkerError::Engine(format!("sam3 tokenize: {e}")))?;
-    check_segment_canceled(cancel.as_ref())?;
-
-    // candle-gen-sam3 `propagate` takes `cancel` + per-frame `progress` (sc-8972). Thread the
-    // caller's flag/callback (mirrors `segment_track_blocking`).
-    let outputs = model
-        .propagate(
-            &tensors,
-            &input_ids,
-            &text_mask,
-            cancel.as_ref(),
-            progress
-                .as_deref_mut()
-                .map(|cb| cb as &mut dyn FnMut(usize, usize)),
-        )
-        .map_err(|e| match e {
-            runtime_cuda::media::CandleError::Canceled => {
-                WorkerError::Canceled(CANCEL_MESSAGE.to_owned())
-            }
-            e => WorkerError::Engine(format!("sam3 propagate: {e}")),
-        })?;
+    let outputs = propagate_person_concept(
+        model_path,
+        tokenizer_path,
+        &tensors,
+        &device,
+        cancel.as_ref(),
+        progress,
+    )?;
 
     // Paint order + per-frame masks are backend-neutral pure logic shared with the MLX twin via
     // `person_segment_sam3_common` (sc-11191, F-018), so the tie-break and mask selection stay

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -39,6 +39,7 @@ use ort::value::Tensor;
 use serde_json::{json, Value};
 
 use crate::openpose_skeleton::{body_stickwidth, draw_wholebody, Keypoint};
+use crate::util::{resolve_env_file_pin, resolved_cache_paths_match};
 use crate::{
     heartbeat, normalize_app_managed_cache_path, optional_payload_string, progress_payload,
     run_blocking_with_heartbeat, task_join_error, update_job, ApiClient, Settings, WorkerError,
@@ -481,7 +482,7 @@ struct Detector {
     device: &'static str,
 }
 
-static DETECTOR: OnceLock<Mutex<Option<Detector>>> = OnceLock::new();
+static DETECTOR: OnceLock<Mutex<Option<(PathBuf, PathBuf, Detector)>>> = OnceLock::new();
 
 /// Build a session, optionally registering the platform hardware EP (CoreML on macOS,
 /// CUDA off-Mac). `accel == false` builds a plain CPU session (the fallback).
@@ -644,10 +645,20 @@ fn detect_batch(
         *guard = None;
         guard
     });
-    if guard.is_none() {
-        *guard = Some(Detector::load(&det_path, &pose_path)?);
+    let cache_matches = guard.as_ref().is_some_and(|(cached_det, cached_pose, _)| {
+        resolved_cache_paths_match(
+            [cached_det.as_path(), cached_pose.as_path()],
+            [det_path.as_path(), pose_path.as_path()],
+        )
+    });
+    if !cache_matches {
+        *guard = Some((
+            det_path.clone(),
+            pose_path.clone(),
+            Detector::load(&det_path, &pose_path)?,
+        ));
     }
-    let detector = guard.as_mut().expect("detector loaded");
+    let detector = &mut guard.as_mut().expect("detector loaded").2;
     let device = detector.device;
     let mut out = Vec::with_capacity(images.len());
     for path in images {
@@ -693,10 +704,6 @@ fn detect_batch(
 /// Blocking (onnx forward + raster); callers on an async runtime should wrap it in
 /// `spawn_blocking`, exactly as the batch job does for its detect + render loops.
 ///
-/// Lands with its registry wrapper ahead of the first non-test caller — the folder-ingest
-/// data-prep pipeline (A2, sc-10161) drives it through [`crate::control_preprocess::PosePreprocessor`];
-/// allow dead_code until then.
-#[allow(dead_code)]
 pub(crate) fn detect_and_render_skeleton(
     det_path: &Path,
     pose_path: &Path,
@@ -716,10 +723,20 @@ pub(crate) fn detect_and_render_skeleton(
         *guard = None;
         guard
     });
-    if guard.is_none() {
-        *guard = Some(Detector::load(det_path, pose_path)?);
+    let cache_matches = guard.as_ref().is_some_and(|(cached_det, cached_pose, _)| {
+        resolved_cache_paths_match(
+            [cached_det.as_path(), cached_pose.as_path()],
+            [det_path, pose_path],
+        )
+    });
+    if !cache_matches {
+        *guard = Some((
+            det_path.to_path_buf(),
+            pose_path.to_path_buf(),
+            Detector::load(det_path, pose_path)?,
+        ));
     }
-    let detector = guard.as_mut().expect("detector loaded");
+    let detector = &mut guard.as_mut().expect("detector loaded").2;
     let people = detector.detect(image)?;
 
     // Convert + squareify each person, keep the largest-area one (same ordering rule as the
@@ -821,29 +838,6 @@ async fn ensure_weights(
     Ok((det, pose))
 }
 
-/// Resolve an explicit env-pinned weight path (sc-8911). Unset → `Ok(None)` (fall through
-/// to cache/download). Set and existing → `Ok(Some(path))`. Set but missing → an
-/// `InvalidPayload` error, so an operator's typo fails loudly rather than silently
-/// loading whatever the download path resolves. Takes the raw value explicitly so it's
-/// unit-testable without mutating the process environment.
-fn resolve_pinned_weight(
-    env_key: &str,
-    value: Option<std::ffi::OsString>,
-    file: &str,
-) -> WorkerResult<Option<PathBuf>> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    let path = PathBuf::from(&value);
-    if path.exists() {
-        return Ok(Some(path));
-    }
-    Err(WorkerError::InvalidPayload(format!(
-        "{env_key} is set to {} but that path does not exist. Point it at the local {file}, or unset it to download on first use.",
-        path.display()
-    )))
-}
-
 async fn ensure_one(
     env_key: &str,
     file: &str,
@@ -856,7 +850,7 @@ async fn ensure_one(
     // path is missing, that's an operator error — surface it instead of silently falling
     // through to the cache/network (sc-8911), which would mask a typo and load different
     // weights than the operator intended.
-    if let Some(path) = resolve_pinned_weight(env_key, std::env::var_os(env_key), file)? {
+    if let Some(path) = resolve_env_file_pin(env_key, std::env::var_os(env_key), file)? {
         return Ok(path);
     }
     let target = cache.join(file);

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -343,18 +343,18 @@ fn dwpose_zip_digests_are_pinned_sha256() {
 /// sc-8911: an env-pinned weight path that is set-but-missing must error, not silently
 /// fall through to the cache/download. Unset → `None`; set + existing → `Some(path)`.
 #[test]
-fn resolve_pinned_weight_errors_on_missing_env_path() {
+fn shared_resolve_env_file_pin_errors_on_missing_env_path() {
     use std::ffi::OsString;
 
     // Unset: fall through.
     assert_eq!(
-        resolve_pinned_weight("SCENEWORKS_DWPOSE_DET", None, DET_FILE).expect("unset ok"),
+        resolve_env_file_pin("SCENEWORKS_DWPOSE_DET", None, DET_FILE).expect("unset ok"),
         None,
         "an unset pin must fall through"
     );
 
     // Set but nonexistent: error (not a silent fall-through).
-    let missing = resolve_pinned_weight(
+    let missing = resolve_env_file_pin(
         "SCENEWORKS_DWPOSE_DET",
         Some(OsString::from("/nonexistent/dwpose/yolox.onnx")),
         DET_FILE,
@@ -368,7 +368,7 @@ fn resolve_pinned_weight_errors_on_missing_env_path() {
     let existing_path =
         std::env::temp_dir().join(format!("sw-dwpose-pin-test-{}.onnx", std::process::id()));
     std::fs::write(&existing_path, b"onnx").expect("write temp weight");
-    let resolved = resolve_pinned_weight(
+    let resolved = resolve_env_file_pin(
         "SCENEWORKS_DWPOSE_DET",
         Some(existing_path.as_os_str().to_owned()),
         DET_FILE,

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -226,7 +226,11 @@ struct Upscaler {
     device: &'static str,
 }
 
-static UPSCALERS: OnceLock<Mutex<HashMap<u8, Upscaler>>> = OnceLock::new();
+static UPSCALERS: OnceLock<Mutex<HashMap<(u8, PathBuf), Upscaler>>> = OnceLock::new();
+
+fn upscaler_cache_key(factor: u8, onnx_path: &Path) -> (u8, PathBuf) {
+    (factor, onnx_path.to_path_buf())
+}
 
 fn ort_err<R>(e: ort::Error<R>) -> WorkerError {
     WorkerError::Engine(format!("onnxruntime: {e}"))
@@ -432,7 +436,7 @@ fn upscale_blocking(
         guard.clear();
         guard
     });
-    let upscaler = match guard.entry(factor) {
+    let upscaler = match guard.entry(upscaler_cache_key(factor, &onnx_path)) {
         Entry::Occupied(e) => e.into_mut(),
         Entry::Vacant(e) => e.insert(Upscaler::load(&onnx_path)?),
     };

--- a/crates/sceneworks-worker/src/upscale_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs/tests.rs
@@ -3,6 +3,22 @@
 //! macOS and on the off-Mac candle lane (sc-5499), since the tiling path is now shared.
 
 use super::*;
+
+#[test]
+fn ort_upscaler_cache_key_includes_factor_and_resolved_path() {
+    assert_eq!(
+        upscaler_cache_key(2, Path::new("/weights/a.onnx")),
+        upscaler_cache_key(2, Path::new("/weights/a.onnx"))
+    );
+    assert_ne!(
+        upscaler_cache_key(2, Path::new("/weights/a.onnx")),
+        upscaler_cache_key(2, Path::new("/weights/b.onnx"))
+    );
+    assert_ne!(
+        upscaler_cache_key(2, Path::new("/weights/a.onnx")),
+        upscaler_cache_key(4, Path::new("/weights/a.onnx"))
+    );
+}
 // `Rgb`/`RgbImage` back the Real-ESRGAN tiling/crop tests + the off-Mac ort smoke (the `ort` path,
 // macOS + the candle lane) AND the SeedVR2 real-weight smoke (Mac MLX + the candle lane).
 #[cfg(any(

--- a/crates/sceneworks-worker/src/util.rs
+++ b/crates/sceneworks-worker/src/util.rs
@@ -158,3 +158,42 @@ pub(crate) fn resolve_env_file_pin(
         path.display()
     )))
 }
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn resolved_cache_paths_match<const N: usize>(
+    cached: [&Path; N],
+    requested: [&Path; N],
+) -> bool {
+    cached == requested
+}
+
+#[cfg(all(
+    test,
+    any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )
+))]
+mod cache_path_tests {
+    use super::*;
+
+    #[test]
+    fn resolved_cache_identity_changes_with_any_weight_path() {
+        let det_a = Path::new("/weights/a/det.onnx");
+        let det_b = Path::new("/weights/b/det.onnx");
+        let pose_a = Path::new("/weights/a/pose.onnx");
+        let pose_b = Path::new("/weights/b/pose.onnx");
+        assert!(resolved_cache_paths_match([det_a, pose_a], [det_a, pose_a]));
+        assert!(!resolved_cache_paths_match(
+            [det_a, pose_a],
+            [det_b, pose_a]
+        ));
+        assert!(!resolved_cache_paths_match(
+            [det_a, pose_a],
+            [det_a, pose_b]
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- route DWPose pins through the shared resolver and key every process-wide ORT cache by resolved weights
- reject malformed SAM3 mask storage and consolidate backend-neutral KPS extraction
- consolidate duplicated person-concept propagation within both MLX and Candle backends and remove the stale pose annotation

## Validation
- full worker library: 1,006 passed / 176 ignored
- no-backend x86_64 Linux check: passed
- all-target worker clippy with warnings denied: passed
- focused path-key, mask, KPS, and resolver regressions: passed
- formatting and diff checks: passed

The local Candle feature build remains hardware-environment dependent; required Windows Candle CI is authoritative.

Shortcut: https://app.shortcut.com/trefry/story/13640