### PR TITLE
chore(rust): purge stale torch fallback comments (sc-14630)

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -406,7 +406,7 @@ pub(crate) struct PersonDetectionJobRequest {
     #[serde(default)]
     pub(crate) source_timestamp: Option<f64>,
     /// Opt into the Rust utility worker's procedural preview instead of real,
-    /// model-backed detection on the Python GPU worker. Defaults to real.
+    /// model-backed detection on the native MLX/candle worker. Defaults to real.
     #[serde(default)]
     pub(crate) preview: bool,
     #[serde(default = "default_requested_gpu")]
@@ -422,7 +422,7 @@ pub(crate) struct PersonTrackJobRequest {
     #[serde(default = "default_track_name")]
     pub(crate) track_name: String,
     /// Opt into the Rust utility worker's procedural preview instead of real,
-    /// model-backed tracking on the Python GPU worker. Defaults to real.
+    /// model-backed tracking on the native MLX/candle worker. Defaults to real.
     #[serde(default)]
     pub(crate) preview: bool,
     #[serde(default = "default_requested_gpu")]

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -131,7 +131,7 @@ pub(crate) async fn claim_job(
             // Off-Mac candle-required (sc-5502, epic 5483): the Windows/Linux twins of the two
             // sweeps above — fail any candle-eligible job stranded with no live candle worker, and
             // (enforce) any queued job the candle/CUDA flow can't serve. Both no-op when the flag
-            // is off (the default), so a deployment still keeping the torch worker is unaffected.
+            // is off (the default), so normal capability routing is unaffected.
             let candle_stranded = store.fail_stranded_candle_jobs(candle_required, timeout)?;
             let candle_unsupported =
                 store.fail_unsupported_candle_jobs(candle_required, candle_enforce)?;
@@ -166,17 +166,17 @@ pub(crate) async fn claim_job(
         emit_route_decision(decision);
     }
     if let Some(job) = &response {
-        // Warn-only (sc-3484): an unsupported job the torch worker just claimed on a Mac —
-        // log the gap once so the inventory materializes while the job still runs on torch.
+        // Warn-only (sc-3484): an unsupported job claimed by a non-MLX GPU descriptor on a Mac —
+        // log the gap once so the inventory materializes.
         // In enforce mode such a job was already failed above and never reaches here.
         if mlx_required && !enforce_unsupported {
             if let Err(reason) = mac_rust_supported(job) {
                 emit_mlx_unsupported(job, &reason, "warn");
             }
         }
-        // Warn-only (sc-5502): the off-Mac candle twin — log the gap once while the job still
-        // runs on the co-resident torch worker, so the off-Mac port-or-drop inventory
-        // materializes. In enforce mode such a job was already failed above and never reaches here.
+        // Warn-only (sc-5502): the off-Mac candle twin — log the gap once if a non-candle GPU
+        // descriptor claims it, so the off-Mac port-or-drop inventory materializes. In enforce mode
+        // such a job was already failed above and never reaches here.
         if candle_required && !candle_enforce {
             if let Err(reason) = candle_supported(job) {
                 emit_candle_unsupported(job, &reason, "warn");
@@ -205,8 +205,8 @@ pub(crate) async fn claim_job(
 
 /// Emit the macOS `mlx_unsupported` gap event (epic 3482 / sc-3484) as a structured JSON line
 /// for the desktop stdout capture + headless `GET /api/v1/logs` buffer (sc-3447/3451/3453).
-/// `mode` is `"enforce"` (the job was failed terminal) or `"warn"` (logged but still run on
-/// torch). The body is the feature-precise [`UnsupportedReason`] — model/feature/detail/
+/// `mode` is `"enforce"` (the job was failed terminal) or `"warn"` (logged while it remains
+/// queued for a compatible native worker). The body is the feature-precise [`UnsupportedReason`] — model/feature/detail/
 /// suggestedEpic — so the Logs surface and the gap inventory name the exact port-or-drop work.
 fn emit_mlx_unsupported(job: &JobSnapshot, reason: &UnsupportedReason, mode: &str) {
     let mut value = serde_json::to_value(reason).unwrap_or_else(|_| json!({}));
@@ -231,7 +231,8 @@ fn emit_mlx_unsupported(job: &JobSnapshot, reason: &UnsupportedReason, mode: &st
 /// the desktop's stdout capture + the headless `GET /api/v1/logs` buffer (sc-3447/3451/3453).
 /// Mirrors [`emit_route_decision`]: this is the System → Logs surface that turns "no MLX
 /// worker took the job" into a named, actionable line instead of a job silently stuck or
-/// run on MPS (sc-3483). `reason` carries the full actionable error set on the job.
+/// entering the legacy MPS compatibility branch (sc-3483). `reason` carries the full actionable
+/// error set on the job.
 fn emit_mlx_unavailable(job: &JobSnapshot) {
     let model = job.payload.get("model").and_then(Value::as_str);
     sceneworks_core::observability::emit_event(
@@ -248,7 +249,7 @@ fn emit_mlx_unavailable(job: &JobSnapshot) {
 
 /// Emit the off-Mac `candle_unsupported` gap event (sc-5502, epic 5483) — the candle twin of
 /// [`emit_mlx_unsupported`]. `mode` is `"enforce"` (the job was failed terminal) or `"warn"`
-/// (logged but still run on the co-resident torch worker). The body is the feature-precise
+/// (logged if a non-candle GPU descriptor claimed it). The body is the feature-precise
 /// [`UnsupportedReason`] so the Logs surface + the off-Mac gap inventory name the exact
 /// port-or-drop work.
 fn emit_candle_unsupported(job: &JobSnapshot, reason: &UnsupportedReason, mode: &str) {

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -2936,7 +2936,7 @@ fn apply_gating_fields(object: &mut JsonObject) {
 }
 
 // Mac UI gating (sc-3486): per-model Rust/MLX support so the web client can hide/
-// disable a torch-only model in the pickers, plus (macOS only) the MLX availability +
+// disable a model with no native Mac lane in the pickers, plus (macOS only) the MLX availability +
 // conversion status for models that declare an `mlx` variant. Additive fields the
 // web/Docker build ignores; the client only acts on macSupport when the capabilities
 // endpoint reports `macGatingActive`, so non-Mac pickers are untouched.

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -8,8 +8,7 @@ pub(crate) const MAX_MOOD_BOARD_IMAGES: usize = 6;
 
 /// Enqueue a `prompt_refine` job: a lightweight, non-GPU job that asks an
 /// OpenAI-compatible LLM to rewrite the user's prompt to follow the selected
-/// model's prompt guide. The job runs in the Python worker (which reuses the
-/// vendored Lens reasoner's calling approach) and the client reads the refined
+/// model's prompt guide. The job runs through a native TextLlm provider, and the client reads the refined
 /// prompt from the completed job's `result.refinedPrompt`.
 pub(crate) async fn create_prompt_refine_job(
     State(state): State<AppState>,

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -54,18 +54,18 @@ pub struct Settings {
     pub jobs_retention_days: u32,
     pub run_utility_inprocess: bool,
     /// Epic 3482 — macOS "MLX-required" mode. When set (the desktop sets it on macOS,
-    /// where it spawns the in-process `mlx` worker), the MPS torch worker never claims an
+    /// where it spawns the in-process `mlx` worker), any non-MLX GPU descriptor never claims an
     /// MLX-eligible job: it defers unconditionally to the `mlx` worker, and a job no live
     /// `mlx` worker takes within the grace window fails terminal with `mlx_unavailable`
-    /// instead of silently falling back to MPS (sc-3483). Absent on Windows/Linux/Docker
-    /// (no `mlx` worker) → today's behaviour unchanged. Ships default OFF (observe); the
+    /// instead of remaining queued indefinitely (sc-3483). Absent on Windows/Linux/Docker
+    /// (no `mlx` worker). Ships default OFF (observe); the
     /// final cutover (sc-3492) flips it on for the packaged Mac build.
     pub mlx_required: bool,
     /// Epic 3482 / sc-3484 — when MLX-required, what to do with a job the Rust/MLX flow can't
     /// run (`mac_rust_supported` returns `Err`). **false = warn-only** (default): log a
     /// structured `mlx_unsupported` gap event at claim time but still run the job on the
-    /// existing torch path, so flipping `mlx_required` on for observation materializes the gap
-    /// list without breaking anything. **true = enforce**: fail the job terminal with
+    /// normal capability routing; without a capable native worker the job remains queued. Flipping
+    /// `mlx_required` on for observation materializes the gap list. **true = enforce**: fail the job terminal with
     /// `mlx_unsupported`. Read from `SCENEWORKS_MLX_UNSUPPORTED_MODE` (`enforce` vs anything
     /// else). Irrelevant unless `mlx_required`.
     pub mlx_enforce_unsupported: bool,
@@ -73,15 +73,15 @@ pub struct Settings {
     /// the candle (CUDA) worker is the only GPU backend: a candle-eligible job no live candle
     /// worker takes within the grace window fails terminal with `candle_unavailable` instead of
     /// waiting forever, and (under `candle_enforce_unsupported`) a job the candle/CUDA flow can't
-    /// serve (`candle_supported` returns `Err`) fails with `candle_unsupported` instead of silently
-    /// falling back to torch. Ships default OFF (the Python torch worker is still the fallback until
-    /// the Phase-7 cutover); flip it on per-deployment as candle reaches parity. Read from
+    /// serve (`candle_supported` returns `Err`) fails with `candle_unsupported` instead of remaining
+    /// queued without a capable native worker. Ships default OFF; flip it on per-deployment when
+    /// terminal gap reporting is desired. Read from
     /// `SCENEWORKS_CANDLE_REQUIRED`. Absent on macOS (the `mlx_required` path governs there).
     pub candle_required: bool,
     /// Epic 5483 (sc-5502) — the candle twin of `mlx_enforce_unsupported`. **false = warn-only**
-    /// (default): log a structured `candle_unsupported` gap event at claim time but still let the
-    /// job run on the existing torch path, so flipping `candle_required` on for observation
-    /// materializes the off-Mac gap list without breaking anything. **true = enforce**: fail the
+    /// (default): log a structured `candle_unsupported` gap event if an unsupported job is claimed;
+    /// otherwise normal capability routing leaves it queued. Flipping `candle_required` on for
+    /// observation materializes the off-Mac gap list. **true = enforce**: fail the
     /// job terminal with `candle_unsupported`. Read from `SCENEWORKS_CANDLE_UNSUPPORTED_MODE`
     /// (`enforce` vs anything else). Irrelevant unless `candle_required`.
     pub candle_enforce_unsupported: bool,

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -398,9 +398,10 @@ async fn models_catalog_carries_mac_support_and_capabilities_endpoint() {
             .unwrap_or(Value::Null)
     };
     // Unported image model (no Rust/MLX engine) → unsupported on Mac, with a gap reason. No real
-    // image model is torch-only anymore: every family was ported to MLX — Kolors (sc-3875),
+    // image model is unsupported solely because of a retired backend anymore: every family was
+    // ported to MLX — Kolors (sc-3875),
     // PuLID-FLUX (sc-3344), and finally Lens / Lens-Turbo (epic 3164 / sc-5105, the last one) — so
-    // the torch-only gating is demonstrated with a synthetic unported id, which has no dedicated
+    // unsupported gating is demonstrated with a synthetic unported id, which has no dedicated
     // port epic (suggestedEpic absent → "needs an epic", epic 3482 policy).
     let torch_only = by_id("unported_image_model");
     assert_eq!(torch_only["macSupport"]["supported"], false);
@@ -3310,7 +3311,7 @@ fn builtin_manifest_registers_wan_a14b_lightning_corequisite() {
             lightning["repo"], "lightx2v/Wan2.2-Lightning",
             "{model_id} coRequisite points at the lightx2v Lightning repo"
         );
-        // macOS-only (the native MLX path is Mac; Windows/Linux use the torch adapter).
+        // macOS-only because this co-requisite is consumed by the native MLX path.
         let platforms: Vec<&str> = lightning["platforms"]
             .as_array()
             .expect("coRequisite platforms array")

--- a/apps/rust-api/src/workers.rs
+++ b/apps/rust-api/src/workers.rs
@@ -62,8 +62,8 @@ pub(crate) async fn person_capability_readiness(
 }
 
 /// Mac UI gating capabilities (sc-3486): the master switch (`macGatingActive`, the
-/// `SCENEWORKS_MLX_REQUIRED` rollout flag) plus every non-model Python surface the web client
-/// disables on Mac (LyCORIS, upscale, pose-from-photo, person detect/track, captioning, advanced
+/// `SCENEWORKS_MLX_REQUIRED` rollout flag) plus every non-model capability surface the web client
+/// may gate on Mac (LyCORIS, upscale, pose-from-photo, person detect/track, captioning, advanced
 /// video, training kernels). Platform is the API host's OS, so a Docker/Windows/Linux client reads
 /// `macGatingActive=false` and applies no gating at all. Per-model support rides on
 /// `GET /api/v1/models` (`macSupport`); this endpoint carries the global/feature half.

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -228,22 +228,22 @@ string_enum! {
         // it through the audio registry to the `Modality::Audio` generator.
         AudioGenerate => "audio_generate",
         // Whole-body DWPose keypoint detection (photo -> body/hands/face) for the
-        // Pose Library (epic 2282). onnxruntime-backed like person_detect; advertised
-        // by the Python worker, routed via requested_gpu (not in NON_GPU_JOB_TYPES).
+        // Pose Library (epic 2282). onnxruntime-backed like person_detect; advertised by
+        // the native MLX/candle workers and routed via requested_gpu (not in NON_GPU_JOB_TYPES).
         PoseDetect => "pose_detect",
         // SCRFD 5-point face-landmark extraction from one image (Key Point Library,
         // epic 4422 / sc-4433): photo -> normalized [left_eye, right_eye, nose,
         // mouth_left, mouth_right] in square-canvas [0,1], consumable as an InstantID
-        // angle/framing preset (pass-in kps via generate_with_kps). Native-MLX SCRFD on
-        // the Rust worker (zero-Python, epic 3482); InsightFace on the Python worker.
+        // angle/framing preset (pass-in kps via generate_with_kps). Native-MLX SCRFD on Mac
+        // and the candle SCRFD/ArcFace stack off-Mac.
         // GPU-routed like pose_detect (not in NON_GPU_JOB_TYPES).
         KpsExtract => "kps_extract",
         // Standalone upscale of an existing image asset (Image Editor, epic 2427).
-        // Torch-backed (Real-ESRGAN / AuraSR), GPU-required like generation; reuses
-        // the upscale engines that previously only ran as a generation post-step.
+        // Native Real-ESRGAN / SeedVR2, GPU-required like generation; reuses the
+        // upscale engines that previously only ran as a generation post-step.
         ImageUpscale => "image_upscale",
         // Standalone tile-ControlNet detail refine of an existing image asset (Image
-        // Editor, epic 2427; spike sc-2437). Torch-backed SDXL/RealVisXL img2img + a
+        // Editor, epic 2427; spike sc-2437). Native MLX SDXL/RealVisXL img2img + a
         // tile ControlNet run over feathered tiles to add micro-texture; GPU-required
         // like generation. Composes after image_upscale (creative upscale).
         ImageDetail => "image_detail",
@@ -251,14 +251,14 @@ string_enum! {
         // / sc-6105): a box prompt → a binary inpaint mask asset (white-on-black PNG at
         // source dims) the editor loads into the sc-2436 mask layer. Native-MLX SAM3 on
         // the macOS Rust worker (zero-Python, the box-PVS path of the sc-4926 SAM3 stack);
-        // GPU-required like generation, mac-only (no torch SAM3 image path yet).
+        // GPU-required like generation, mac-only (no off-Mac standalone image-segment lane).
         ImageSegment => "image_segment",
         // Standalone upscale of an existing VIDEO asset (Video Studio, epic 4811 /
         // sc-4816) — SceneWorks' first video upscaler. Native-MLX SeedVR2 one-step
         // super-resolution on the macOS Rust worker (zero-Python, epic 3482): decode
         // the source clip -> temporal-chunked 5D upscale -> re-encode + source-audio
         // passthrough. GPU-required like generation; native MLX on Mac and
-        // candle/CUDA off-Mac (no torch fallback).
+        // candle/CUDA off-Mac, with no alternate fallback.
         VideoUpscale => "video_upscale",
         FrameExtract => "frame_extract",
         TimelineExport => "timeline_export",
@@ -867,10 +867,10 @@ pub struct ProgressRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peak_gpu_load_pct: Option<ContractNumber>,
     /// Runtime backend the worker actually executed this job on
-    /// ("mlx" / "mps" / "cuda" / "cpu"). Distinct from the worker's
-    /// device-architecture heuristic — the same Apple-Silicon worker can
-    /// serve both MLX and MPS-Diffusers jobs, and the WorkerProgressCard's
-    /// arch pill should reflect which one ran. First non-null value sticks.
+    /// ("mlx" / "mps" / "cuda" / "cpu"). The `mps` value is retained for historical rows and
+    /// compatibility fixtures; current Apple-Silicon execution uses the native MLX lane. Distinct
+    /// from the device-architecture heuristic; the WorkerProgressCard reflects what actually ran.
+    /// First non-null value sticks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend: Option<String>,
     /// Id of the worker reporting this progress. When present, the server
@@ -923,9 +923,9 @@ pub struct JobSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peak_gpu_load_pct: Option<ContractNumber>,
     /// Runtime backend the worker actually used to execute the job
-    /// ("mlx" / "mps" / "cuda" / "cpu"). Surfaced by the WorkerProgressCard
-    /// arch pill so an MLX run and a Diffusers-on-MPS run on the same worker
-    /// read differently.
+    /// ("mlx" / "mps" / "cuda" / "cpu"). `mps` remains readable for historical rows and synthetic
+    /// compatibility fixtures; current Apple-Silicon work runs on native MLX. Surfaced by the
+    /// WorkerProgressCard arch pill.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend: Option<String>,
     /// Human-readable job title derived server-side from job type + payload
@@ -1012,7 +1012,8 @@ pub struct GenerationMetrics {
     /// Best-effort peak GPU load percentage sampled during the run (0..100).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peak_gpu_load_pct: Option<ContractNumber>,
-    /// Runtime backend the run executed on ("mlx" / "mps" / "cuda" / "cpu").
+    /// Runtime backend the run executed on ("mlx" / "mps" / "cuda" / "cpu"); `mps` is retained
+    /// for historical rows and compatibility fixtures.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend: Option<String>,
     #[serde(flatten)]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -452,9 +452,9 @@ impl JobsStore {
         // along with progress so a completed row shows the peak the run reached.
         ensure_column(&transaction, "jobs", "peak_gpu_memory_pct", "real")?;
         ensure_column(&transaction, "jobs", "peak_gpu_load_pct", "real")?;
-        // Runtime backend label written by the worker ("mlx" / "mps" / "cuda"
-        // / "cpu"). First-non-null wins so the WorkerProgressCard's arch pill
-        // stays stable across the run.
+        // Runtime backend label written by the worker ("mlx" / "mps" / "cuda" / "cpu"); `mps`
+        // remains readable for historical rows. First-non-null wins so the WorkerProgressCard's
+        // arch pill stays stable across the run.
         ensure_column(&transaction, "jobs", "backend", "text")?;
         // Soft-hide marker for the "Clear completed" queue action (sc-12231, issue #1556).
         // A cleared job is dropped from the operator's queue list + counts (see
@@ -1519,14 +1519,14 @@ impl JobsStore {
     }
 
     /// macOS "MLX-required" grace sweep (epic 3482 / sc-3483). When `mlx_required`, the
-    /// non-mlx (MPS) worker never claims an MLX-eligible job — it defers unconditionally
+    /// synthetic non-mlx descriptor never claims an MLX-eligible job — it defers unconditionally
     /// to the in-process `mlx` worker (see `should_defer_*`). If no **live** `mlx` worker
     /// claims such a job within the grace window — because the worker is down, never
     /// started, or has been crashed longer than the supervisor's auto-restart can
     /// self-heal — the job would otherwise sit queued forever. This fails those jobs
     /// terminal (`status = failed`) with an actionable `mlx_unavailable` error naming the
     /// model + job type, so the failure is loud and points at the real gap instead of
-    /// silently falling back to MPS.
+    /// entering the legacy MPS compatibility branch.
     ///
     /// "Live `mlx` worker" = a `gpu_id = 'mlx'` worker that is not offline and has
     /// heartbeat within the grace window. While one exists (even if it is merely busy),
@@ -1622,13 +1622,13 @@ impl JobsStore {
     /// macOS "MLX-unsupported" enforce sweep (epic 3482 / sc-3484). When `mlx_required` AND
     /// `enforce`, fails every queued job the Rust/MLX flow can't run (`mac_rust_supported`
     /// returns `Err`) terminal with a feature-precise `mlx_unsupported` error — the forcing
-    /// function that turns "still on torch" into a loud, named failure instead of a silent
-    /// fallback. Unlike the stranded sweep there is no grace window: an unsupported job is
+    /// function that turns an unsupported native gap into a loud, named failure instead of leaving
+    /// it queued. Unlike the stranded sweep there is no grace window: an unsupported job is
     /// permanently unsupported until its surface is ported or dropped, so it fails immediately.
     ///
-    /// Default mode is **warn** (`enforce == false`) → this is a no-op and the gap is logged
-    /// at claim time instead (the job still runs on torch), so flipping `mlx_required` on for
-    /// observation surfaces the gap list without breaking anything. Off (`!mlx_required`) →
+    /// Default mode is **warn** (`enforce == false`) → this sweep is a no-op; normal capability
+    /// routing either finds a capable native worker or leaves the job queued. Flipping
+    /// `mlx_required` on for observation surfaces the gap list. Off (`!mlx_required`) →
     /// immediate no-op, so Windows/Linux/Docker are unaffected. MLX-*eligible* jobs are
     /// `Ok` here and handled by `fail_stranded_mlx_jobs`/routing — the two sweeps partition
     /// the queue and never touch the same job. Returns `(job, reason)` pairs so the caller can
@@ -1679,7 +1679,7 @@ impl JobsStore {
     /// Off-Mac candle grace sweep (sc-5502, epic 5483) — the Windows/Linux twin of
     /// [`Self::fail_stranded_mlx_jobs`]. When `candle_required`, fails any candle-eligible job left
     /// queued past the grace window when no live candle worker exists, terminal with
-    /// `candle_unavailable` — so a retired-torch deployment fails loudly instead of queuing forever.
+    /// `candle_unavailable` — so a deployment can fail loudly instead of queuing forever.
     ///
     /// "Live candle worker" = a worker advertising the `candle` marker capability that is not
     /// offline and has a heartbeat within `grace_seconds` (the marker is a fixed JSON string in
@@ -1687,8 +1687,8 @@ impl JobsStore {
     /// index, not the `mlx` sentinel, so it can't be matched by `gpu_id`; see [`worker_is_candle`]).
     /// While one exists (even merely busy) this is a no-op and candle-eligible jobs wait, so a
     /// transient candle crash the supervisor restarts inside the window never fails a job. Off
-    /// (`!candle_required`) it returns immediately, so a deployment still keeping the Python torch
-    /// worker is completely unaffected. Returns the jobs it failed so the caller can surface the
+    /// (`!candle_required`) it returns immediately, leaving normal capability routing unaffected.
+    /// Returns the jobs it failed so the caller can surface the
     /// structured event and publish their updates.
     pub fn fail_stranded_candle_jobs(
         &self,
@@ -1774,15 +1774,15 @@ impl JobsStore {
     /// Off-Mac "candle-unsupported" enforce sweep (sc-5502, epic 5483) — the Windows/Linux twin of
     /// [`Self::fail_unsupported_mlx_jobs`]. When `candle_required` AND `enforce`, fails every queued
     /// job the candle/CUDA flow can't run ([`candle_supported`] returns `Err`) terminal with a
-    /// feature-precise `candle_unsupported` error — the forcing function that turns "still on torch"
-    /// into a loud, named failure instead of a silent fallback. Unlike the stranded sweep there is
+    /// feature-precise `candle_unsupported` error — the forcing function that turns an unsupported
+    /// native gap into a loud, named failure instead of leaving it queued. Unlike the stranded sweep there is
     /// no grace window: an unsupported job is permanently unsupported until its surface is ported or
     /// dropped, so it fails immediately.
     ///
-    /// Default mode is **warn** (`enforce == false`) → no-op, and the gap is logged at claim time
-    /// instead (the job still runs on torch), so flipping `candle_required` on for observation
-    /// surfaces the gap list without breaking anything. Off (`!candle_required`) → immediate no-op,
-    /// so a deployment still keeping the torch worker is unaffected. Candle-*eligible* jobs are `Ok`
+    /// Default mode is **warn** (`enforce == false`) → this sweep is a no-op; normal capability
+    /// routing either finds a capable native worker or leaves the job queued. Flipping
+    /// `candle_required` on for observation surfaces the gap list. Off (`!candle_required`) →
+    /// immediate no-op. Candle-*eligible* jobs are `Ok`
     /// here and handled by routing / [`Self::fail_stranded_candle_jobs`] — the two sweeps partition
     /// the queue and never touch the same job. Returns `(job, reason)` pairs so the caller can emit
     /// the structured event.
@@ -1833,9 +1833,9 @@ impl JobsStore {
         Ok(self.claim_next_job_routed(worker_id, false)?.0)
     }
 
-    /// Like [`Self::claim_next_job`], but also reports the MLX↔torch routing decision
+    /// Like [`Self::claim_next_job`], but also reports the native-GPU routing decision
     /// so the caller (the API claim handler) can log *why* a job landed where it did —
-    /// the single most useful line for diagnosing "MLX-eligible job ran on torch"
+    /// the single most useful line for diagnosing an MLX-eligible job claimed elsewhere
     /// (sc-3449). A `None` decision means the claim was routing-neutral: no job was
     /// available, an unrelated balancing deferral fired, or the job is one no `mlx`
     /// worker would ever want.
@@ -2169,7 +2169,7 @@ impl JobsStore {
         // database lock. rusqlite's default busy timeout is 0ms, so any cross-process
         // overlap — e.g. a sidecar restart where the old process hasn't fully released the
         // db, or a concurrent claim/heartbeat — surfaces as `database is locked` and the
-        // job loses its claim (MLX-eligible jobs then fall through to the torch worker).
+        // job loses its claim (the job then remains available for another capable worker).
         // A 5s wait lets the holder finish; paired with BEGIN IMMEDIATE on write
         // transactions (below), writers queue cleanly rather than deadlocking on lock upgrade.
         connection.busy_timeout(Duration::from_millis(5000))?;
@@ -2913,11 +2913,11 @@ fn should_defer_auto_gpu_claim(
     // The in-process `mlx` worker is the designated home for the jobs it claims
     // (a non-mlx worker defers MLX-eligible jobs to it via
     // `should_defer_image_to_mlx_worker` & siblings). It must never hand one of
-    // those jobs to a "healthier" non-mlx GPU through this health-based dispatch:
-    // on Apple Silicon the `mlx` and `mps` workers share the same physical GPU,
-    // and that worker would only defer the job straight back, deadlocking it in
-    // the queue. Keeping the mlx worker out of the auto-GPU health comparison
-    // breaks that cycle regardless of whether it reports utilization.
+    // those jobs to a "healthier" non-mlx GPU through this health-based dispatch. The synthetic
+    // MPS compatibility descriptor used by legacy tests represents the same physical Apple GPU
+    // and would defer the job straight back, deadlocking it in the queue. Production runs the
+    // supported job on the native mlx lane. Keeping mlx out of the auto-GPU health comparison
+    // breaks the compatibility-path cycle regardless of utilization reporting.
     if worker.gpu_id.eq_ignore_ascii_case("mlx") {
         return Ok(false);
     }
@@ -2967,8 +2967,8 @@ fn should_defer_auto_gpu_claim(
 /// jobs. A non-mlx GPU worker defers an `auto` `image_generate` job the mlx
 /// worker can run when an idle `mlx` worker exists, so the fast NAX path claims
 /// it. When no mlx worker is registered (Windows/Linux, or the mlx worker is
-/// down), nothing defers and the torch worker is the fallback — a job is never
-/// stuck. An explicit (non-`auto`) GPU choice is always honoured, never deferred.
+/// down), nothing defers; normal capability routing either finds another capable worker or
+/// leaves the job queued. An explicit (non-`auto`) GPU choice is never soft-deferred.
 fn should_defer_image_to_mlx_worker(
     connection: &Connection,
     job: &JobSnapshot,
@@ -2978,18 +2978,18 @@ fn should_defer_image_to_mlx_worker(
     if worker.gpu_id.eq_ignore_ascii_case("mlx") || !job_is_mlx_eligible(job) {
         return Ok(false);
     }
-    // macOS "MLX-required" (epic 3482 / sc-3483): the non-mlx (MPS) worker NEVER claims
+    // macOS "MLX-required" (epic 3482 / sc-3483): a synthetic non-mlx descriptor NEVER claims
     // an MLX-eligible job — it yields unconditionally, even when no idle `mlx` worker is
     // ready *right now*. The job waits for the `mlx` worker and, if none takes it within
     // the grace window, `fail_stranded_mlx_jobs` fails it terminal with `mlx_unavailable`
-    // rather than letting MPS silently run it. This covers explicit-GPU pins too: "never
-    // MPS" is absolute on Mac.
+    // rather than entering the legacy MPS compatibility branch. This covers explicit-GPU pins too:
+    // production has no MPS fallback.
     if mlx_required {
         return Ok(true);
     }
-    // Off (Windows/Linux/Docker, and Mac pre-cutover): unchanged — defer only an `auto`
-    // job to an actually-idle `mlx` worker; otherwise the torch worker is the fallback and
-    // an explicit (non-`auto`) GPU choice is always honoured.
+    // Off (Windows/Linux/Docker, and Mac pre-cutover): defer only an `auto` job to an
+    // actually-idle `mlx` worker; otherwise normal capability routing decides. An explicit
+    // (non-`auto`) GPU choice is never soft-deferred.
     if job.requested_gpu != "auto" {
         return Ok(false);
     }
@@ -3022,10 +3022,9 @@ fn should_defer_video_to_mlx_worker(
 /// Training sibling of [`should_defer_image_to_mlx_worker`] (epic 3039): a non-mlx
 /// GPU worker defers an `auto` MLX-eligible `lora_train` job when an idle `mlx`
 /// worker can run it, so the native Rust trainer (`mlx_gen::load_trainer`) claims
-/// it. Same fallback guarantees — no mlx worker registered (Windows/Linux, or the
-/// mlx worker is down) → nothing defers and the Python torch trainer runs it; an
-/// explicit (non-`auto`) GPU choice is always honoured. The torch trainers stay
-/// the cross-platform path + the Mac fallback (sc-3049), so a job is never stuck.
+/// it. With no mlx worker registered (Windows/Linux, or the mlx worker is down), nothing
+/// defers; only a worker advertising a compatible native trainer may claim it. An explicit
+/// (non-`auto`) GPU choice is never soft-deferred.
 fn should_defer_training_to_mlx_worker(
     connection: &Connection,
     job: &JobSnapshot,
@@ -3047,8 +3046,8 @@ fn should_defer_training_to_mlx_worker(
 
 /// Captioning sibling of [`should_defer_image_to_mlx_worker`] (sc-3556): a non-mlx
 /// GPU worker defers JoyCaption dataset-caption jobs to an idle mlx worker, so the
-/// native Rust captioner (`mlx_gen::load_captioner`) can run them. Windows/Linux and
-/// explicit non-auto GPU requests keep the existing Python torch captioner fallback.
+/// native Rust captioner (`mlx_gen::load_captioner`) can run them. Without a compatible
+/// native captioner, the job remains queued; explicit non-auto requests are not soft-deferred.
 fn should_defer_caption_to_mlx_worker(
     connection: &Connection,
     job: &JobSnapshot,
@@ -3069,8 +3068,8 @@ fn should_defer_caption_to_mlx_worker(
 
 /// Understanding sibling of [`should_defer_image_to_mlx_worker`] (sc-3905): a non-mlx GPU worker
 /// defers an `auto` MLX-eligible SenseNova-U1 `image_vqa` / `image_interleave` job to an idle mlx
-/// worker, so the in-process `T2iModel` (`vqa` / `interleave_gen`) claims it. Windows/Linux and
-/// explicit non-auto GPU requests keep the Python torch SenseNova path.
+/// worker, so the in-process `T2iModel` (`vqa` / `interleave_gen`) claims it. Without a compatible
+/// native understanding worker, the job remains queued; explicit non-auto requests are not soft-deferred.
 fn should_defer_understanding_to_mlx_worker(
     connection: &Connection,
     job: &JobSnapshot,
@@ -3165,12 +3164,12 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     if job_requires_gpu(&job.job_type) && worker.gpu_id.eq_ignore_ascii_case("cpu") {
         return false;
     }
-    // Epic 3039 (sc-3049): a training kernel with no torch fallback (the retired Python
-    // MLX LTX trainer) runs only on a Rust worker — a non-mlx worker must refuse it
+    // Epic 3039 (sc-3049): a native-only training kernel (the retired Python MLX LTX trainer)
+    // runs only on a Rust worker — a non-mlx worker must refuse it
     // (leaving it queued for the mlx worker) instead of claiming it and failing. The
-    // exception (sc-8614): `krea_lora` is no-torch-fallback AND has a candle trainer, so a
+    // exception (sc-8614): `krea_lora` has a candle trainer, so a
     // candle worker it is candle-eligible for must NOT be refused here (the candle training
-    // gate below admits it); only torch (and any non-candle non-mlx worker) still defers.
+    // gate below admits it); any non-candle, non-mlx worker still defers.
     if !worker.gpu_id.eq_ignore_ascii_case("mlx")
         && training_kernel_is_mlx_only(job)
         && !(worker_is_candle(worker) && training_job_is_candle_eligible(job))
@@ -3178,15 +3177,15 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         return false;
     }
     // Epic 3018/3041 + sc-3036: the in-process MLX worker (gpu_id "mlx") serves a fixed
-    // set of model families. It must not claim a job that needs the torch path — a family
-    // not yet ported, an unsupported shape, or a third-party LyCORIS LoRA — those stay on
-    // the Python worker. Non-mlx workers are unaffected here; the *preference* to route
+    // set of model families. It must not claim an unsupported family or request shape; those
+    // remain queued unless another capable native worker registers. Non-mlx workers are
+    // unaffected here; the *preference* to route
     // eligible jobs to an idle mlx worker is a soft deferral in the claim path.
     if worker.gpu_id.eq_ignore_ascii_case("mlx") {
         // Image: sc-3026 txt2img/LoRA + sc-3060 reference/edit/inpaint/outpaint +
         // image_detail + sc-3513 the `image_edit` job type (plain Image Edit). A
-        // torch-only edit model (kolors/lens/pulid) is not MLX-eligible, so the mlx
-        // worker refuses it and it stays on torch. (z_image_edit was ported to MLX,
+        // non-MLX edit model (kolors/lens/pulid) is not MLX-eligible, so the mlx
+        // worker refuses it. (z_image_edit was ported to MLX,
         // epic 3529 / sc-3923; instantid + sensenova are MLX-routed too.)
         if matches!(
             job.job_type,
@@ -3202,7 +3201,7 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         // (LTX IC-LoRA, sc-3522), and `person_replace` → native Wan-VACE (sc-3521). The
         // per-(model, mode) gate in `video_job_is_mlx_eligible` keeps each mode to its
         // capable engines; everything it rejects — a non-MLX model, Wan extend/bridge
-        // (no IC-LoRA keyframe-append path), LoKr-on-Wan — stays on the Python worker.
+        // (no IC-LoRA keyframe-append path), LoKr-on-Wan — is refused by this worker.
         if matches!(
             job.job_type,
             JobType::VideoGenerate
@@ -3215,7 +3214,7 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         }
         // Training (epic 3039): the mlx worker trains only the MLX-native families
         // (z_image / sdxl / kolors / wan / ltx) via `mlx_gen::load_trainer`. `lens_lora`
-        // (sidecar, no mlx-gen crate) and LoKr-on-Wan stay on the Python torch worker.
+        // (sidecar, no mlx-gen crate) and LoKr-on-Wan are refused by this worker.
         // Applies to both dry-run and real runs.
         if matches!(job.job_type, JobType::LoraTrain | JobType::ControlTraining)
             && !training_job_is_mlx_eligible(job)
@@ -3233,13 +3232,12 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         }
         // Image upscale (sc-3489): the mlx worker runs Real-ESRGAN (the default engine) via
         // `ort`/CoreML and SeedVR2 via in-process `mlx-gen-seedvr2` (sc-4815). `aura-sr` has no
-        // Rust path, so the mlx worker refuses it and it stays on the Python torch worker.
+        // Rust path, so the mlx worker refuses it and it remains queued.
         if matches!(job.job_type, JobType::ImageUpscale) && !upscale_job_is_mlx_eligible(job) {
             return false;
         }
         // Video upscale (epic 4811 / sc-4816): the mlx worker runs the native SeedVR2 engine
-        // (`mlx-gen-seedvr2`). Any non-SeedVR2 engine is refused; since there is no torch
-        // video-upscale backend, this is mac-only by construction.
+        // (`mlx-gen-seedvr2`). Any non-SeedVR2 engine is refused; this is mac-only by construction.
         if matches!(job.job_type, JobType::VideoUpscale) && !video_upscale_job_is_mlx_eligible(job)
         {
             return false;
@@ -3247,19 +3245,19 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         // SenseNova-U1 understanding (sc-3905): the mlx worker serves `image_vqa` /
         // `image_interleave` only for the SenseNova-U1 ids (the sole in-process understanding
         // path). A non-SenseNova understanding job is not MLX-eligible, so the mlx worker
-        // refuses it and it stays on the Python torch worker.
+        // refuses it and it remains queued.
         if matches!(job.job_type, JobType::ImageVqa | JobType::ImageInterleave)
             && !understanding_job_is_mlx_eligible(job)
         {
             return false;
         }
     }
-    // No-silent-T2I / no-torch-fallback (sc-5968, epic 5483): the co-resident Python torch worker (a
-    // non-candle, non-mlx GPU worker) must DECLINE the unsupported-pose shapes the candle worker
-    // owns-to-reject (a `advanced.poses` job on a candle model with no pose lane, e.g. sdxl) — so torch
-    // can't claim + silently render an unconditioned T2I image, and the candle worker reliably wins
+    // No-silent-T2I / no-fallback (sc-5968, epic 5483): any non-candle, non-mlx GPU descriptor must
+    // DECLINE the unsupported-pose shapes the candle worker owns-to-reject (an `advanced.poses` job
+    // on a candle model with no pose lane, e.g. sdxl), so no generic claimant can silently render an
+    // unconditioned T2I image and the candle worker reliably wins
     // them (then rejects with a typed error). Mac is unaffected: those shapes are MLX-served there
-    // (model_mac_support pose), so the `mlx` worker still claims them and only torch/`mps` declines.
+    // (model_mac_support pose), so the `mlx` worker still claims them and other descriptors decline.
     if !worker_is_candle(worker)
         && !worker.gpu_id.eq_ignore_ascii_case("mlx")
         && image_job_candle_pose_reject(job)
@@ -3270,19 +3268,19 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     // sc-5097): the candle worker advertises `image_generate` (+ `video_generate` once video engines
     // are wired) and serves gated, narrow **txt2img / txt2video-only** lanes. It must refuse every
     // other shape — a non-candle family, or a conditioned (img2img/edit/reference/inpaint/pose/
-    // i2v/extend/bridge/replace) / LoRA request — so those transparently fall back to the Python torch
-    // worker that co-resides on the box. Identified by the `candle` marker capability (not `gpu_id`,
+    // i2v/extend/bridge/replace) / LoRA request — so unsupported work remains queued unless another
+    // capable native worker registers. Identified by the `candle` marker capability (not `gpu_id`,
     // which is a real CUDA index here). When candle is disabled the marker is absent and this is inert,
     // so production routing is unchanged until the lane is turned on.
     if worker_is_candle(worker) {
         // ImageGenerate + ImageEdit: claim the candle-served shapes (incl. the sc-5487
         // SdxlEdit/Flux2Edit/QwenEdit `image_edit` lanes) AND the unsupported-pose shapes the candle
         // worker must OWN to reject (a `advanced.poses` job on a candle model with no pose lane, e.g.
-        // sdxl) — so those fail loudly on candle instead of falling back to torch + silently rendering
-        // an unconditioned T2I image (sc-5968, the no-torch-fallback / no-silent-T2I directive). Every
-        // other shape candle declines, staying on the co-resident torch worker. `image_edit` is gated
+        // sdxl) — so those fail loudly on candle instead of silently rendering an unconditioned T2I
+        // image (sc-5968, the no-fallback / no-silent-T2I directive). Every other unsupported shape is
+        // declined and remains queued. `image_edit` is gated
         // here too (mirroring the mlx `JobType::ImageGenerate | JobType::ImageEdit` claim arm): without
-        // it a torch-only edit model would be claimed by candle and fail instead of falling back.
+        // it an unsupported edit model would be claimed by candle and fail instead of remaining queued.
         if matches!(job.job_type, JobType::ImageGenerate | JobType::ImageEdit)
             && !(image_job_is_candle_eligible(job) || image_job_candle_pose_reject(job))
         {
@@ -3302,11 +3300,11 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         }
         // Training (sc-7817, epic 5164): the candle worker trains only the candle-native families
         // (sdxl / z_image / lens / the Wan A14B T2V MoE) via `gen_core::load_trainer`. Everything
-        // else — Kolors, LTX, the dense Wan 5B, the Wan I2V A14B — has no candle trainer and stays on
-        // the co-resident Python torch worker. WITHOUT this gate the candle worker would claim a real
+        // else — Kolors, LTX, the dense Wan 5B, the Wan I2V A14B — has no candle trainer and remains
+        // queued. WITHOUT this gate the candle worker would claim a real
         // training job it can't execute (the `lora_train_execute` advertisement is coarse — it lights
         // up whenever ANY candle trainer is registered) and fail it terminally instead of leaving it
-        // for torch. Applies to both dry-run and real runs; mirrors the mlx training gate above.
+        // queued. Applies to both dry-run and real runs; mirrors the mlx training gate above.
         if matches!(job.job_type, JobType::LoraTrain | JobType::ControlTraining)
             && !training_job_is_candle_eligible(job)
         {
@@ -3316,7 +3314,7 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
             return false;
         }
         // Dataset captioning (sc-5098): the candle worker serves only JoyCaption (the candle
-        // captioner provider). A non-`joy_caption` caption job stays on the Python torch worker.
+        // captioner provider). A non-`joy_caption` caption job is refused and remains queued.
         // Eligibility is backend-neutral (captioner == joy_caption), so reuse the mlx gate.
         if matches!(job.job_type, JobType::TrainingCaption) && !caption_job_is_mlx_eligible(job) {
             return false;
@@ -3325,7 +3323,7 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         // `image_interleave` only for the SenseNova-U1 ids (via the concrete candle `T2iModel::{vqa,
         // interleave_gen}` — the off-Mac sibling of the MLX understanding path). Eligibility is
         // backend-neutral (the model is SenseNova-U1), so reuse the understanding gate; a
-        // non-SenseNova understanding job stays on the Python torch worker.
+        // non-SenseNova understanding job is refused and remains queued.
         if matches!(job.job_type, JobType::ImageVqa | JobType::ImageInterleave)
             && !understanding_job_is_mlx_eligible(job)
         {
@@ -3333,8 +3331,8 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
         }
         // Image upscale (sc-5928 SeedVR2 + sc-5499 Real-ESRGAN, epic 4811 / epic 5482): the candle
         // worker serves Real-ESRGAN (`ort`/CUDA, sc-5499) AND SeedVR2 (`candle-gen-seedvr2`, the
-        // Windows/CUDA sibling of mlx-gen-seedvr2). Only `aura-sr` has no candle path — it is refused
-        // and runs on the Python torch worker until Phase 7.
+        // Windows/CUDA sibling of mlx-gen-seedvr2). Only `aura-sr` has no candle path, so it is
+        // refused and remains queued.
         if matches!(job.job_type, JobType::ImageUpscale) && !upscale_job_is_candle_eligible(job) {
             return false;
         }
@@ -3346,12 +3344,12 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
             return false;
         }
     }
-    // SeedVR2 upscaling has NO torch backend — it runs on the native MLX worker (Mac) or the candle
-    // worker (Windows/Linux). A plain torch GPU/CPU worker (neither `mlx` nor candle) must refuse a
+    // SeedVR2 upscaling runs on the native MLX worker (Mac) or the candle worker (Windows/Linux).
+    // Any generic GPU/CPU descriptor (neither `mlx` nor candle) must refuse a
     // SeedVR2 `image_upscale` job so it stays queued for the mlx/candle worker instead of being
     // claimed and failing with "no generator registered". This is the inverse of the AuraSR gate
-    // (torch-only → mlx/candle refuse it). `video_upscale` is candle/mlx-only by capability (a torch
-    // worker never advertises it), so it needs no torch guard here.
+    // (unsupported by native lanes → mlx/candle refuse it). `video_upscale` is candle/mlx-only by
+    // capability, so it needs no extra generic-worker guard here.
     if !worker.gpu_id.eq_ignore_ascii_case("mlx")
         && !worker_is_candle(worker)
         && upscale_job_requests_seedvr2(job)
@@ -3371,7 +3369,7 @@ fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
     // capability, which a worker advertises only when its inference backend is
     // available. Dry-run plan validation needs just the base `lora_train`
     // capability. This keeps a real run queued for a capable worker instead of
-    // failing terminally after a torch-less worker claims it.
+    // failing terminally after a worker without a matching native engine claims it.
     if is_real_training_job(job) {
         return advertises(WorkerCapability::LoraTrainExecute.as_str());
     }
@@ -3392,7 +3390,7 @@ fn is_real_training_job(job: &JobSnapshot) -> bool {
 }
 
 /// The worker capability a job requires. Person detection/tracking default to
-/// the real, model-backed capability served by the Python GPU worker; an
+/// the real, model-backed capability served by a native GPU worker; an
 /// explicit `preview: true` payload requests the Rust utility worker's
 /// procedural preview capability instead — so a real job never routes to the
 /// placeholder. Mirrors the dry-run training capability split.

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -27,8 +27,8 @@ pub(crate) const CANDLE_VIDEO_LORA_MODELS: &[&str] = &["wan_2_2_t2v_14b", "wan_2
 /// `generate_candle_stream` drives plain text-to-image, and the bespoke lanes branched out below add
 /// the conditioned shapes ported under epic 5480 — SDXL/FLUX.2/Qwen `edit_image` (sc-5487), IP-Adapter
 /// reference (sc-5488/sc-5872), InstantID/PuLID identity (sc-5491/sc-5492), and strict-pose ControlNet
-/// (sc-5489). Anything still without a candle lane (a torch-only family, an unported shape, a LoRA on a
-/// non-Lens family) falls back to the Python torch worker, so the candle worker refuses it here.
+/// (sc-5489). Anything still without a candle lane (an unsupported family or shape, or a LoRA on a
+/// non-Lens family) is refused here and remains queued for a capable native worker.
 ///
 /// Like the MLX twin [`image_job_is_mlx_eligible`], this accepts BOTH `image_generate` and the distinct
 /// `image_edit` job type (the Image Studio/Editor "plain Image Edit": `mode == "edit_image"` +
@@ -279,8 +279,9 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
             .and_then(Value::as_str)
             .is_some_and(|value| !value.trim().is_empty())
     };
-    // Any conditioning asset (img2img source, IP-Adapter reference, or inpaint mask) → torch. Applies
-    // to EVERY candle family including Lens (pure T2I — no conditioning shapes in the Lens port).
+    // Any conditioning asset (img2img source, IP-Adapter reference, or inpaint mask) is refused by
+    // this base lane. Applies to EVERY candle family including Lens (pure T2I — no conditioning
+    // shapes in the Lens port).
     if has_nonempty_id("sourceAssetId")
         || has_nonempty_id("referenceAssetId")
         || has_nonempty_id("maskAssetId")
@@ -307,7 +308,7 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     {
         return false;
     }
-    // Strict-pose ControlNet (`advanced.poses`, object-shaped entries) → torch.
+    // Strict-pose ControlNet (`advanced.poses`, object-shaped entries) is refused by this base lane.
     let has_poses = payload
         .get("advanced")
         .and_then(Value::as_object)
@@ -317,9 +318,9 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     if has_poses {
         return false;
     }
-    // On-the-fly quantization (`advanced.mlxQuantize` > 0) → torch UNLESS the family advertises quant.
+    // On-the-fly quantization (`advanced.mlxQuantize` > 0) is refused UNLESS the family advertises quant.
     // The sc-3675/sc-5096 candle providers advertise `supported_quants: &[]` (dense bf16/fp16 only), so
-    // an explicit quant request can't be honored — route to Python rather than silently running dense
+    // an explicit quant request can't be honored — refuse it rather than silently running dense
     // (sc-5099). Lens (sc-5126), SD3.5 (sc-7880), Krea (sc-9607/sc-9983), the Ideogram/Boogu packed
     // families (sc-9607), and Qwen-Image (sc-11020) advertise Q4/Q8, so their quant requests stay on
     // candle. For the packed families
@@ -352,8 +353,8 @@ pub(crate) fn candle_request_wants_quant(payload: &Map<String, Value>) -> bool {
 /// text-to-video, the 14B I2V's single source-image conditioning (sc-5175), SVD image→video (sc-5493),
 /// **and** the Wan-VACE advanced modes — replace_person / extend / bridge (sc-5494, the `PersonReplace`
 /// / `VideoExtend` / `VideoBridge` job types → the candle `wan_vace` engine). Every other shape
-/// (reference/mask/first-last-frame conditioning, LoRAs) must fall back to the Python torch worker, so
-/// the candle worker refuses it here. SCAIL-2 (`scail2_14b`) adds a DISTINCT candle engine off-Mac —
+/// (reference/mask/first-last-frame conditioning, LoRAs) is refused here and remains queued for a
+/// capable native worker. SCAIL-2 (`scail2_14b`) adds a DISTINCT candle engine off-Mac —
 /// `animate_character` + `replace_person` (sc-6837, epic 6563) — gated separately (it is not a VACE
 /// model). Bernini (`bernini`) adds another DISTINCT candle engine off-Mac — t2v + the editing/
 /// reference/multi-source video modes (sc-10997, epic 6562) — also gated separately. The per-model
@@ -401,7 +402,7 @@ pub(crate) fn video_request_candle_eligible(model: &str, payload: &Map<String, V
     };
     if CANDLE_VIDEO_I2V_ROUTED_MODELS.contains(&model) {
         // Wan 14B I2V is image→video ONLY (sc-5175): require the `image_to_video` mode + a source
-        // image. A txt2video shape (no source) is rejected so a mis-picked text job stays on torch.
+        // image. A txt2video shape (no source) is rejected and remains queued.
         if payload.get("mode").and_then(Value::as_str) != Some("image_to_video") {
             return false;
         }
@@ -420,7 +421,7 @@ pub(crate) fn video_request_candle_eligible(model: &str, payload: &Map<String, V
         }
     }
     // Reference / inpaint-mask conditioning is never in the candle video lane (i2v needs only the
-    // single source image; reference + mask are the character / inpaint shapes that stay on torch).
+    // single source image; reference + mask are unsupported character / inpaint shapes).
     if has_nonempty_id("referenceAssetId") || has_nonempty_id("maskAssetId") {
         return false;
     }
@@ -428,7 +429,7 @@ pub(crate) fn video_request_candle_eligible(model: &str, payload: &Map<String, V
     // engines (`wan_2_2_t2v_14b` / `wan_2_2_i2v_14b`) advertise `supports_lora` and their worker path
     // (`candle_resolve_wan_adapters`) applies each `request.loras` entry from its file path — so a wan-14B
     // job carrying user LoRAs stays on candle. Every other candle video provider (wan-5B TI2V, LTX, SVD)
-    // advertises no LoRA slot, so a LoRA there is refused here (no torch fallback — epic 8283). sc-10539.
+    // advertises no LoRA slot, so a LoRA there is refused here and remains queued (epic 8283). sc-10539.
     if !CANDLE_VIDEO_LORA_MODELS.contains(&model)
         && payload
             .get("loras")
@@ -437,7 +438,7 @@ pub(crate) fn video_request_candle_eligible(model: &str, payload: &Map<String, V
     {
         return false;
     }
-    // On-the-fly quantization → torch (the candle video providers are dense; sc-5099).
+    // On-the-fly quantization is refused (the candle video providers are dense; sc-5099).
     if candle_request_wants_quant(payload) {
         return false;
     }
@@ -507,7 +508,7 @@ pub(crate) fn video_request_candle_vace_eligible(
 /// (`referenceAssetId` / `referenceAssetIds` / `sourceAssetId`) + a driving clip (`sourceClipAssetId`).
 /// Inference LoRA / LoKr / LoHa + the Bias-Aware DPO LoRA + the lightx2v lightning diff-patch ARE on the
 /// candle path now (sc-6838 — the provider merges them into the dense DiT), so a LoRA-bearing animate job
-/// stays on candle. On-the-fly quantization is still torch (the candle provider is dense). Mirrors the
+/// stays on candle. On-the-fly quantization is refused and remains queued (the provider is dense). Mirrors the
 /// MLX `video_mode_is_mlx_eligible(scail2_14b, animate_character)` shape, expressed as a candle-claim
 /// gate. Factored out so the routing tests can probe it (parity with [`video_request_candle_eligible`]).
 pub(crate) fn scail2_animate_candle_eligible(model: &str, payload: &Map<String, Value>) -> bool {
@@ -539,7 +540,7 @@ pub(crate) fn scail2_animate_candle_eligible(model: &str, payload: &Map<String, 
         return false;
     }
     // Inference LoRA (DPO / lightning / user adapter) merges into the candle DiT (sc-6838), so a
-    // LoRA-bearing animate job is candle-eligible — only on-the-fly quant still falls back to torch.
+    // LoRA-bearing animate job is candle-eligible — only on-the-fly quant is still refused.
     if candle_request_wants_quant(payload) {
         return false;
     }
@@ -933,7 +934,7 @@ pub(crate) fn sdxl_ipadapter_candle_eligible(payload: &Map<String, Value>) -> bo
 /// Kolors IP-Adapter-Plus candle-routing conditions (sc-5488, epic 5480). The candle `IpAdapterKolors`
 /// provider serves PURE reference (image-prompt) conditioning on the `kolors` family — the same payload
 /// shape as the SDXL IP lane: a `referenceAssetId` with NO img2img source / inpaint mask and NOT an
-/// `edit_image` (those advanced Kolors shapes are sc-5487, still torch). Mirrors the worker's
+/// `edit_image` (those advanced Kolors shapes are refused and remain queued). Mirrors the worker's
 /// `kolors_ipadapter_available` gate (minus the local weight-resolve check) so the router and worker
 /// agree on the lane boundary. Candle-only — the macOS Kolors IP path is the registry `Reference` route,
 /// not a separate candle-eligible gate.
@@ -953,7 +954,7 @@ pub(crate) fn kolors_ipadapter_candle_eligible(payload: &Map<String, Value>) -> 
 /// FLUX XLabs IP-Adapter candle-routing conditions (sc-5872, epic 5480). The candle `IpAdapterFlux`
 /// provider serves PURE reference (image-prompt) conditioning on the `flux_dev`/`flux_schnell` families
 /// — the same payload shape as the SDXL/Kolors IP lanes: a `referenceAssetId` with NO img2img source /
-/// inpaint mask and NOT an `edit_image` (those advanced FLUX shapes are sc-5487, still torch). Mirrors
+/// inpaint mask and NOT an `edit_image` (those advanced FLUX shapes are refused and remain queued). Mirrors
 /// the worker's `flux_ipadapter_available` gate (minus the local weight-resolve check) so the router and
 /// worker agree on the lane boundary. Candle-only — the macOS FLUX IP path is the registry `Reference`
 /// route (epic 3621), not a separate candle-eligible gate.
@@ -1157,14 +1158,14 @@ pub(crate) fn model_has_candle_pose_lane(model: &str) -> bool {
 
 /// A strict-pose (`advanced.poses`) job on a **candle-routed model with no candle pose lane** —
 /// `sdxl` / `realvisxl` / `chroma*` / `flux*` / `lens*` / `sensenova*` (everything but the three wired
-/// pose families), not `edit_image` (sc-5968, epic 5483). Neither candle nor the co-resident torch
-/// worker has a pose path for these models off-Mac (the torch `sdxl` adapter's OpenPose lives only in
-/// the `instantid_realvisxl` adapter), so torch would silently drop the poses → an unconditioned T2I
+/// pose families), not `edit_image` (sc-5968, epic 5483). No native lane has a pose path for these
+/// models off-Mac (the historical `sdxl` adapter's OpenPose lived only in
+/// the `instantid_realvisxl` adapter), so a generic claimant could silently drop the poses and render an unconditioned T2I
 /// image. The candle worker therefore CLAIMS these (`worker_supports_job`) to REJECT them with a typed
-/// error in the handler, and the co-resident torch worker DECLINES them (below) so candle reliably wins
+/// error in the handler, while every other GPU descriptor declines them so candle reliably wins
 /// and nothing silently mis-serves them. **Mac is unaffected:** `sdxl + poses` is MLX-served there
-/// (`model_mac_support("sdxl").features.pose`), so the MLX worker claims it and only the torch/`mps`
-/// worker declines. Pairs with the worker's `candle_unsupported_pose_reject` dispatch guard.
+/// (`model_mac_support("sdxl").features.pose`), so the MLX worker claims it and other descriptors
+/// decline. Pairs with the worker's `candle_unsupported_pose_reject` dispatch guard.
 pub(crate) fn image_request_candle_pose_reject(model: &str, payload: &Map<String, Value>) -> bool {
     if !CANDLE_ROUTED_MODELS.contains(&model) || model_has_candle_pose_lane(model) {
         return false;
@@ -1205,12 +1206,12 @@ pub(crate) fn worker_is_candle(worker: &WorkerSnapshot) -> bool {
 }
 
 /// Epic 5164 / sc-7817 routing — does this `lora_train` job belong on the candle (Windows/CUDA +
-/// Linux/NVIDIA) worker (vs the Python torch worker)? The training sibling of
+/// Linux/NVIDIA) worker? The training sibling of
 /// [`image_job_is_candle_eligible`]/[`video_job_is_candle_eligible`]: the candle engine has a native
 /// trainer for the family. Both dry-run and real runs are eligible (the dry-run validates the same
 /// resolved plan). `wan_moe_lora` is candle-eligible ONLY for the **T2V** A14B base model
 /// (`wan_2_2_t2v_14b`) — the candle Wan trainer is registered under `wan2_2_t2v_14b` only; the I2V
-/// A14B and the dense `wan_lora` 5B have no candle trainer, so they stay on torch. UNLIKE the mlx Wan
+/// A14B and the dense `wan_lora` 5B have no candle trainer, so they are refused and remain queued. UNLIKE the mlx Wan
 /// path, the candle Wan trainer DOES support LoKr (its `build_lokr_targets` merge), so there is no
 /// LoKr-on-Wan exclusion here. The resolved plan is stamped into the payload at submit (apps/rust-api
 /// training.rs), so the kernel + base model are readable without touching the dataset or weights.
@@ -1233,7 +1234,7 @@ pub(crate) fn training_job_is_candle_eligible(job: &JobSnapshot) -> bool {
         return true;
     }
     // The A14B MoE: candle registers only the T2V trainer (`wan2_2_t2v_14b`). The I2V A14B base
-    // model has no candle trainer, so it stays on torch.
+    // model has no candle trainer, so it is refused and remains queued.
     if kernel == "wan_moe_lora" {
         let base_model = target
             .and_then(|target| target.get("baseModel"))
@@ -1249,9 +1250,8 @@ pub(crate) fn training_job_is_candle_eligible(job: &JobSnapshot) -> bool {
 /// the Mac CoreML path — sc-5499) AND **SeedVR2** (`candle-gen-seedvr2`, sc-5928) off-Mac. This now
 /// mirrors `upscale_job_is_mlx_eligible` exactly (the default `real-esrgan` engine + `seedvr2`);
 /// `aura-sr` was dropped as an offered engine (sc-3668 Mac / sc-5499 off-Mac) so it has no candle
-/// path — a candle worker refuses it (it runs only on the Python torch worker until Phase 7). Note
-/// Real-ESRGAN keeps its torch path as a co-resident fallback (the torch worker is NOT refused it,
-/// unlike SeedVR2), so a Real-ESRGAN job may run on whichever worker claims it first.
+/// path — a candle worker refuses it, so it remains queued. Real-ESRGAN is candle-eligible, while
+/// SeedVR2 is admitted only by its explicit native lanes.
 pub(crate) fn upscale_job_is_candle_eligible(job: &JobSnapshot) -> bool {
     upscale_job_is_mlx_eligible(job)
 }

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Map, Value};
 use crate::jobs_store::routing::gaps::{classify_image_gap, classify_video_gap, UnsupportedReason};
 use crate::jobs_store::routing::mlx::{image_request_mlx_eligible, video_mode_is_mlx_eligible};
 
-/// The user-facing affordance prefix the Mac UI shows in place of a torch-only control
+/// The user-facing affordance prefix the Mac UI shows in place of a control with no native Mac lane
 /// (sc-3486). Centralised so the API, the web client, and the gap docs read identically.
 pub const MAC_NOT_AVAILABLE_LABEL: &str = "Not available on Mac (MLX only)";
 
@@ -18,7 +18,7 @@ pub const MAC_NOT_AVAILABLE_LABEL: &str = "Not available on Mac (MLX only)";
 /// predicates as the [`mac_rust_supported`] job oracle — one source of truth, so what the UI
 /// hides can never drift from what routing refuses. `supported` = at least one generation config
 /// for this model routes to the in-process Rust/MLX flow on macOS, so the model stays in the
-/// picker; `false` = a torch-only model the Mac UI hides/disables once gating is active (its
+/// picker; `false` = a model with no native Mac lane that the UI hides/disables once gating is active (its
 /// `reason` names the porting epic). The per-feature flags use "available in *some* MLX config"
 /// semantics (they never over-gate a valid combination) so a control is disabled only when the
 /// model can't use it on MLX at all; residual config-specific dead ends are caught by the
@@ -67,7 +67,7 @@ pub(crate) fn probe_payload(model: &str, entries: &[(&str, Value)]) -> Map<Strin
 
 /// UI gating support for a model id of the given catalog `model_type` ("image" / "video" / other).
 /// Non-image/video types (utility/infra: upscalers, captioners) are reported `supported` — their
-/// Python-only *actions* are gated by [`mac_capabilities`] at the job-type level, not by hiding
+/// Capability-specific *actions* are gated by [`mac_capabilities`] at the job-type level, not by hiding
 /// the model from a picker. Same source of truth as [`mac_rust_supported`].
 ///
 /// `family` is the model's catalog-declared architecture family (`None` for a builtin whose routing
@@ -188,7 +188,8 @@ pub(crate) fn image_model_mac_support(model: &str, family: Option<&str>) -> Mode
 /// The `video_generate` modes the UI offers, in display order, so the gating mirrors
 /// [`video_mode_is_mlx_eligible`] for every mode a Mac user could pick. The clip-conditioning
 /// modes `extend_clip` / `video_bridge` are included (sc-3773) so the Mac UI gates them
-/// per-model — MLX on the LTX IC-LoRA path, torch on Wan — rather than via a coarse global flag.
+/// per-model — native on the supported LTX/Wan paths, queued when unsupported — rather than via a
+/// coarse global flag.
 pub(crate) const VIDEO_UI_MODES: &[&str] = &[
     "text_to_video",
     "image_to_video",
@@ -247,7 +248,7 @@ pub struct MacFeatureSupport {
 impl MacFeatureSupport {
     // Declares a Mac feature gap with the reason + suggested port epic. Currently no
     // feature is gated (poseFromPhoto was the last, ported in sc-3487/flipped in
-    // sc-4206) — kept as the gating vocabulary for the next torch-only surface that
+    // sc-4206) — kept as the gating vocabulary for the next unsupported native surface that
     // appears before its Rust port lands, so a gap is declared the same way every time.
     #[allow(dead_code)]
     fn unsupported(feature: &str, detail: &str, suggested_epic: &str) -> Self {
@@ -264,7 +265,7 @@ impl MacFeatureSupport {
 }
 
 /// macOS training support (sc-3486): the kernels with a native mlx-gen Rust trainer, so the
-/// Training studio can disable a base model whose kernel only runs on the Python torch trainer.
+/// Training studio can disable a base model whose kernel has no native Mac trainer.
 /// `lokr_on_wan_supported=false` mirrors the LoKr-on-Wan routing caveat.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -273,7 +274,7 @@ pub struct MacTrainingSupport {
     pub lokr_on_wan_supported: bool,
 }
 
-/// What the Mac UI needs to gate every non-model Python surface plus the master switch
+/// What the Mac UI needs to gate every non-model native gap plus the master switch
 /// (sc-3486). `mac_gating_active` is the rollout flag (`SCENEWORKS_MLX_REQUIRED`): when `false`
 /// (Windows/Linux, or a Mac still in observe mode) the client applies no gating at all, so
 /// non-Mac pickers are untouched. The per-feature entries are facts about the Rust flow
@@ -316,15 +317,15 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
     );
     features.insert(
         // The AuraSR upscale engine (`engine=aura-sr`) is dropped on Mac (sc-3668, port-or-drop
-        // spike): it is a 617M-param torch-only GigaGAN with no viable Rust path and only a marginal,
+        // spike): it is a 617M-param legacy GigaGAN with no viable Rust path and only a marginal,
         // ~35-50x-slower quality difference vs the already-ported Real-ESRGAN x4. As of sc-5499 it is
         // also dropped as an OFFERED engine off-Mac — there is no native (MLX/candle) path and the
-        // Python torch backend that served it on Windows/Linux is retired in Phase 7 (epic 5483), so
-        // exposing it would point users at a path about to disappear. `supported: false` on every
+        // historical Python backend that served it on Windows/Linux is retired, so exposing it would
+        // point users at a nonexistent path. `supported: false` on every
         // platform (platform-intrinsic, like `imageUpscaleSeedvr2`), so the UI hides the engine
         // everywhere. Must agree with the AuraSR arm of `mac_rust_supported` (UI-hidden == routing
-        // refuses): the native MLX/candle workers refuse it; only the (transitional) torch worker runs
-        // an explicitly-submitted aura-sr job until Phase 7.
+        // refuses): the native MLX/candle workers refuse it, so an explicitly submitted AuraSR job
+        // remains queued.
         "imageUpscaleAuraSr".to_owned(),
         MacFeatureSupport {
             supported: false,
@@ -344,7 +345,7 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
         // (a backend exists, regardless of the gating rollout flag) so the web upscale picker offers
         // SeedVR2 on every platform that has a backend (Mac, Windows, Linux) and hides it only where
         // there is none (contrast AuraSR, which the UI hides only under active gating). Must agree with
-        // the routing oracle (mlx OR candle claims seedvr2; a plain torch worker refuses it).
+        // the routing oracle (mlx OR candle claims SeedVR2; every other descriptor refuses it).
         "imageUpscaleSeedvr2".to_owned(),
         MacFeatureSupport {
             supported: seedvr2_supported,
@@ -417,7 +418,7 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
     features.insert(
         // Video upscaling is net-new on Mac (epic 4811 / sc-4816): the native-MLX SeedVR2
         // engine gives SceneWorks its first video upscaler, running in-process on the macOS
-        // MLX worker (zero-Python). There is no torch fallback (mac-only), so this feature is
+        // MLX worker. There is no fallback (mac-only), so this feature is
         // the gate for the Video Studio "Upscale" action. Must agree with the VideoUpscale arm
         // of `mac_rust_supported` (what the UI shows == what routing accepts).
         "videoUpscale".to_owned(),
@@ -656,7 +657,8 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     ModelCaps::new("illustrious_xl_v2", true, true, false, false, true),
     // RealVisXL Lightning (MLX sc-6075 / candle sc-7176): standalone few-step distilled SDXL checkpoint
     // on the shared `sdxl` engine, few-step `lightning` accel sampler. **txt2img only** on both backends —
-    // edit / reference / mask / pose shapes fall back to torch (accel sampler is conditioning-incompatible).
+    // edit / reference / mask / pose shapes are refused and remain queued (the accel sampler is
+    // conditioning-incompatible).
     // sc-10812 (epic 9083): shares `candle-gen-sdxl`, which advertises `supported_quants: [Q4, Q8]` +
     // inference LoRA-on-packed after sc-10767 (packed UNet sc-9416 / dual-CLIP sc-9527 / adapter fold
     // sc-9528). Its `SceneWorks/realvisxl-lightning-mlx` turnkey ships the standard q4/q8/bf16 tiers
@@ -734,12 +736,13 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // packed ChatGLM3 (the four GLM projections) + the vendored packed-detecting SDXL UNet, VAE dense —
     // and advertises `supported_quants: [Q4, Q8]`. So a quant tier-select stays on candle → `candle_quant`.
     // NOT `candle_quant_lora`: kolors advertises NO candle inference LoRA (`supports_lora: false`), so a
-    // LoRA still defers to torch. bf16 still resolves to Quant::None (dense), verbatim.
+    // A LoRA is still refused by the candle lane and remains queued. bf16 still resolves to
+    // Quant::None (dense), verbatim.
     ModelCaps::new("kolors", true, true, true, false, false),
     // Microsoft Lens / Lens-Turbo (epic 3164 / sc-5105 MLX; sc-5126 candle): pure T2I family. UNLIKE the
     // other candle families it DOES advertise on-the-fly quant AND LoRA/LoKr, so `candle_quant_lora` is
-    // set — the first (and, with SD3.5/Krea, one of the) candle families exempt from the quant/LoRA → torch
-    // fallbacks. Lens was the LAST whole-model torch-only image family — once it routed, the per-model
+    // set — the first (and, with SD3.5/Krea, one of the) candle families exempt from quant/LoRA
+    // refusal. Lens was the LAST whole-model torch-only image family — once it routed, the per-model
     // torch-only image epic seam matched nothing and was retired (sc-8951).
     ModelCaps::new("lens", true, true, false, false, true),
     ModelCaps::new("lens_turbo", true, true, false, false, true),
@@ -788,7 +791,7 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     ModelCaps::new("krea_2_raw", true, true, false, false, true),
     // Stable Diffusion 3.5 Large / Large Turbo / Medium (epic 7841 / sc-7871 MLX; sc-7880 candle):
     // pure txt2img. Candle advertises Q4/Q8 (sc-7879) but NOT inference LoRA (`supports_lora: false`), so
-    // `candle_quant` is set — an explicit quant request stays on candle while a LoRA still defers to torch.
+    // `candle_quant` is set — an explicit quant request stays on candle while a LoRA is refused.
     ModelCaps::new("sd3_5_large", true, true, true, false, false),
     ModelCaps::new("sd3_5_large_turbo", true, true, true, false, false),
     ModelCaps::new("sd3_5_medium", true, true, true, false, false),
@@ -797,7 +800,7 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // (Windows/CUDA + Linux, candle-gen #495 — loads the whole `Efficient-Large-Model/
     // Sana_1600M_1024px_diffusers` HF snapshot dense), so `candle_routed = true`. Pure txt2img; NOT
     // `candle_quant` / `candle_lora`: the candle base path advertises neither (dense bf16, no adapter
-    // fold) — an `mlxQuantize` or LoRA request defers to torch off-Mac.
+    // fold) — an `mlxQuantize` or LoRA request is refused off-Mac and remains queued.
     ModelCaps::new("sana_1600m", true, true, false, false, false),
     // SANA-Sprint 1.6B (epic 8485 / sc-8490 MLX; sc-11781 candle): NVIDIA's few-step CFG-FREE distill of
     // SANA — the SAME 1.6B Linear-DiT trunk with a guidance embedder, sampled by the SCM/TrigFlow
@@ -806,7 +809,7 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // candle-gen #498 — loads the whole `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` HF
     // snapshot dense), so `candle_routed = true`. Pure txt2img; NOT `candle_quant` / `candle_lora`: the
     // candle Sprint path advertises neither (the adapter rejects quant / LoRA / control) — an `mlxQuantize`
-    // or LoRA request defers to torch off-Mac.
+    // or LoRA request is refused off-Mac and remains queued.
     ModelCaps::new("sana_sprint_1600m", true, true, false, false, false),
     // Anima base / aesthetic / turbo (epic 10512): anime txt2img on BOTH backends — native-MLX (macOS,
     // install-time Q4/Q8 quant) and the candle off-Mac lane (sc-10676), which sc-10625 GPU-validated on
@@ -916,7 +919,7 @@ macro_rules! derive_model_list {
 derive_model_list! {
     /// Models the in-process Rust MLX worker generates today, by id (derived from
     /// [`IMAGE_MODEL_CAPS`]`.mlx_routed`, sc-9495). A model id absent here is never routed to the mlx
-    /// worker, so the Python torch path stays authoritative for it.
+    /// worker, so an absent id remains unclaimed unless family-based imported routing admits it.
     pub(crate) MLX_ROUTED_MODELS, IMAGE_MODEL_CAPS, mlx_routed
 }
 
@@ -1081,8 +1084,8 @@ pub(crate) fn imported_image_request_family_eligible(
 derive_model_list! {
     /// The models the candle (Windows/CUDA) lane can serve for base txt2img (derived from
     /// [`IMAGE_MODEL_CAPS`]`.candle_routed`, sc-9495). Mirrors the worker's `image_jobs::is_candle_engine`.
-    /// Deliberately narrow: candle is a gated txt2img-only lane, so every conditioning shape falls back to
-    /// the Python torch worker unless a bespoke candle lane in `image_job_is_candle_eligible` claims it.
+    /// Deliberately narrow: candle is a gated txt2img-only lane, so every conditioning shape is
+    /// refused unless a bespoke candle lane in `image_job_is_candle_eligible` claims it.
     pub(crate) CANDLE_ROUTED_MODELS, IMAGE_MODEL_CAPS, candle_routed
 }
 
@@ -1100,7 +1103,7 @@ derive_model_list! {
     /// The candle image families that advertise on-the-fly Q4/Q8 quant AND LoRA/LoKr adapters — Lens /
     /// Lens-Turbo and Krea 2 Turbo (derived from [`IMAGE_MODEL_CAPS`]`.candle_quant_lora`, sc-9495; Krea
     /// added sc-9983 once sc-9607 flipped its `supported_quants`). For these a LoRA or an explicit quant
-    /// request does NOT force the job to torch. Subset of [`CANDLE_ROUTED_MODELS`].
+    /// request stays on candle instead of being refused. Subset of [`CANDLE_ROUTED_MODELS`].
     pub(crate) CANDLE_QUANT_LORA_MODELS, IMAGE_MODEL_CAPS, candle_quant_lora
 }
 
@@ -1108,7 +1111,8 @@ derive_model_list! {
     /// The candle image families that advertise on-the-fly Q4/Q8 quant but NOT inference LoRA — Stable
     /// Diffusion 3.5, Ideogram 4 (+Turbo), and Boogu (Base/Turbo/Edit) (derived from
     /// [`IMAGE_MODEL_CAPS`]`.candle_quant`, sc-9495; the ideogram/boogu packed families added sc-9983 once
-    /// sc-9607 flipped their `supported_quants`). Quant stays on candle; a LoRA still defers to torch.
+    /// sc-9607 flipped their `supported_quants`). Quant stays on candle; a LoRA is refused and remains
+    /// queued.
     /// Disjoint from [`CANDLE_QUANT_LORA_MODELS`]; both are consulted by the gate. Subset of
     /// [`CANDLE_ROUTED_MODELS`].
     pub(crate) CANDLE_QUANT_MODELS, IMAGE_MODEL_CAPS, candle_quant
@@ -1159,10 +1163,10 @@ derive_model_list! {
 /// kernel and base model onto an engine trainer id). `kolors_lora` (SDXL U-Net plus
 /// ChatGLM3) gained a native trainer in sc-4568, cut over here in sc-4732. `lens_lora`
 /// gained a native mlx-gen-lens trainer in sc-5148, cut over here in sc-5180 (off-Mac
-/// keeps the Python sidecar trainer). `krea_lora` is the native `mlx-gen-krea` trainer
-/// (sc-7577); it has no torch path, so it is also listed in `MLX_ONLY_TRAINING_KERNELS`
+/// has no off-Mac trainer). `krea_lora` is the native `mlx-gen-krea` trainer
+/// (sc-7577); it is native-only, so it is also listed in `MLX_ONLY_TRAINING_KERNELS`
 /// (sc-7578). `sd3_lora` is the native `mlx-gen-sd3` trainer (sc-7883/7885; Large +
-/// MMDiT-X Medium training bases), cut over here in sc-7884; it has no torch path either,
+/// MMDiT-X Medium training bases), cut over here in sc-7884; it is native-only too,
 /// so it is also in `MLX_ONLY_TRAINING_KERNELS`. A kernel absent here is never routed to
 /// the mlx worker.
 pub(crate) const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
@@ -1176,7 +1180,7 @@ pub(crate) const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
     "wan_moe_lora",
     "ltx_mlx_lora",
     // Anima (epic 10512, sc-10522): the native `mlx-gen-anima` LoRA/LoKr trainer (DiT + `llm_adapter`
-    // conditioner). No torch path, so it is also in `MLX_ONLY_TRAINING_KERNELS`.
+    // conditioner). It is native-only, so it is also in `MLX_ONLY_TRAINING_KERNELS`.
     "anima_lora",
 ];
 
@@ -1185,13 +1189,13 @@ pub(crate) const MLX_ROUTED_TRAINING_KERNELS: &[&str] = &[
 /// holds trainers for `sdxl`, `z_image_turbo`, `lens`, `krea_2_raw` (the Krea 2 Raw 12B DiT, epic
 /// 7565 P4 — sc-8614 wires it here), and the Wan **A14B T2V** MoE (`wan2_2_t2v_14b`); the first four
 /// map straight from kernel, while `wan_moe_lora` is base-model gated (handled in
-/// [`training_job_is_candle_eligible`]). UNLIKE the torch families (z-image/sdxl/lens/wan), Krea has
-/// NO torch trainer — it is in BOTH this set and [`MLX_ONLY_TRAINING_KERNELS`] (Rust-only: mlx OR
-/// candle, never torch). The dense Wan 5B + the I2V A14B have no candle trainer yet (sc-5167
-/// follow-ups) and Kolors/LTX none at all — those kernels stay on the Python torch worker off-Mac.
+/// [`training_job_is_candle_eligible`]). Krea is in BOTH this set and
+/// [`MLX_ONLY_TRAINING_KERNELS`] (Rust-only: mlx OR candle). The dense Wan 5B + the I2V A14B have no
+/// candle trainer yet (sc-5167 follow-ups), and Kolors/LTX none at all; unsupported kernels remain
+/// queued off-Mac.
 /// `krea_control` (epic 10159, B2 sc-10163 / B1 sc-10162) is the Krea 2 pose-ControlNet branch trainer
-/// (candle-gen-krea `ControlTrainer`, dispatched under `krea_2_control`); it too has NO torch or MLX
-/// trainer, so — like `krea_lora` — it is also in [`MLX_ONLY_TRAINING_KERNELS`] but NOT
+/// (candle-gen-krea `ControlTrainer`, dispatched under `krea_2_control`); it has no MLX trainer, so —
+/// like `krea_lora` — it is also in [`MLX_ONLY_TRAINING_KERNELS`] but NOT
 /// [`MLX_ROUTED_TRAINING_KERNELS`] (the MLX control lane is B5/sc-10177).
 pub(crate) const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] = &[
     "z_image_lora",
@@ -1201,18 +1205,17 @@ pub(crate) const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] = &[
     "krea_control",
 ];
 
-/// Training kernels with NO **torch** fallback — only a Rust worker can run them, so a torch worker
+/// Native-only training kernels — only a Rust worker can run them, so a generic worker descriptor
 /// must refuse the job (leaving it queued for a Rust worker) rather than claim it and fail with "no
 /// training kernel". `ltx_mlx_lora` was Apple-Silicon-only MLX-Python; epic 3039 (sc-3049) retired
-/// that Python trainer, leaving the native Rust LTX trainer as the sole path. The torch families
-/// (z-image/sdxl/wan) keep their Python trainer as the Windows path + Mac fallback, so they are
-/// deliberately NOT listed here. `krea_lora` (epic 7565) is Rust-native with no torch trainer — but
+/// that Python trainer, leaving the native Rust LTX trainer as the sole path. Kernels that have an
+/// alternate native trainer are deliberately NOT listed here. `krea_lora` (epic 7565) is Rust-native — but
 /// UNLIKE LTX/SD3 it now ALSO has a candle trainer (sc-8614, P4), so it is the one member that runs
 /// on EITHER Rust backend (mlx in-process on Mac, candle off-Mac); the [`worker_supports_job`] gate
 /// exempts a candle worker for a `krea_lora` job it is candle-eligible for (it is also in
-/// [`CANDLE_ROUTED_TRAINING_KERNELS`]), while torch is still refused. `sd3_lora` (epic 7841 T3
-/// sc-7884) is MLX-native with no torch trainer and no candle trainer yet (the off-Mac/candle SD3.5
-/// trainer is epic 7982), so — like LTX — only an mlx worker runs it today.
+/// [`CANDLE_ROUTED_TRAINING_KERNELS`]), while a generic worker is refused. `sd3_lora` (epic 7841 T3
+/// sc-7884) is MLX-native with no candle trainer yet (the off-Mac/candle SD3.5 trainer is epic
+/// 7982), so — like LTX — only an mlx worker runs it today.
 pub(crate) const MLX_ONLY_TRAINING_KERNELS: &[&str] = &[
     "ltx_mlx_lora",
     "krea_lora",

--- a/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
@@ -39,7 +39,7 @@ pub(crate) fn job_is_any_mlx_eligible(job: &JobSnapshot) -> bool {
 /// ([`JobsStore::fail_stranded_candle_jobs`]). Deliberately excludes the unsupported-pose shapes
 /// the candle worker only *owns to reject* ([`image_job_candle_pose_reject`]) — those are gaps,
 /// not served, so they must strand/enforce-fail rather than wait for a candle worker. Training
-/// (sc-7817) is included only for the candle-trainable kernels; the rest stay on the torch worker.
+/// (sc-7817) is included only for the candle-trainable kernels; unsupported kernels remain queued.
 pub(crate) fn job_is_any_candle_eligible(job: &JobSnapshot) -> bool {
     image_job_is_candle_eligible(job)
         || video_job_is_candle_eligible(job)
@@ -260,7 +260,7 @@ impl UnsupportedReason {
 
 /// macOS "can the Rust/MLX flow run this?" oracle (sc-3484). `Ok(())` = the in-process mlx
 /// worker — or an MLX-agnostic in-process path (downloads, ffmpeg, prompt refine) — runs it
-/// with no Python torch dependency. `Err` names the exact Python-torch gap. This is the epic's
+/// natively. `Err` names the exact native gap. This is the epic's
 /// *forcing function*: under mlx-required **enforce** mode an `Err` job fails terminal with
 /// `mlx_unsupported`, and the set of `Err`s IS the port-or-drop roadmap. Consistent with
 /// routing by construction — anything `job_is_any_mlx_eligible` accepts is `Ok`.
@@ -270,7 +270,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
     }
     let model = job.payload.get("model").and_then(Value::as_str);
     match job.job_type {
-        // In-process macOS job types with no Python torch dependency: MLX-agnostic metadata/utility
+        // In-process macOS job types with native implementations: MLX-agnostic metadata/utility
         // work + ffmpeg, plus prompt refine — now served by the native MLX `prompt_refine` TextLlm
         // provider (sc-5552, the mlx twin of the candle sc-5525 cutover), so the worker advertises +
         // claims it and this `Ok` is backed by a real capability (no longer the pre-sc-5552 strand).
@@ -283,23 +283,23 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         | JobType::TimelineExport
         | JobType::PromptRefine
         // sc-6535: dataset_analysis is a native Rust/MLX job (the CLIP image embedder), not a
-        // Python-torch gap — so it's `Ok` here. Its real capability is gated by the worker's
+        // native-flow gap — so it's `Ok` here. Its real capability is gated by the worker's
         // advertisement once `mlx-gen-clip` is linked; until then it queues, never enforce-fails.
         | JobType::DatasetAnalysis
         // sc-6539: dataset_upscale runs the Real-ESRGAN ONNX engine natively in the Rust worker
-        // (the same engine as image_upscale) — not a Python-torch gap. Its real availability is the
+        // (the same engine as image_upscale) — not a native-flow gap. Its real availability is the
         // worker's capability advertisement, so it queues rather than enforce-fails here.
         | JobType::DatasetUpscale
         // sc-6538: dataset_face_analysis runs the native SCRFD+ArcFace stack (mlx-gen-face) in the Rust
-        // worker — not a Python-torch gap. Gated by the worker's capability advertisement, so it queues
+        // worker — not a native-flow gap. Gated by the worker's capability advertisement, so it queues
         // rather than enforce-fails here.
         | JobType::DatasetFaceAnalysis
         // sc-4415: face_likeness_compare runs the same native SCRFD+ArcFace stack to score two existing
-        // assets on demand — a native Rust/MLX job, not a Python-torch gap. Gated by the worker's
+        // assets on demand — a native Rust/MLX job, not a native-flow gap. Gated by the worker's
         // capability advertisement, so it queues rather than enforce-fails here.
         | JobType::FaceLikenessCompare => Ok(()),
 
-        // Forward-compat: an unrecognized job type isn't a known Python-torch gap, so don't
+        // Forward-compat: an unrecognized job type isn't a known native-flow gap, so don't
         // enforce-fail it (it would otherwise break a newer job type this build doesn't model).
         JobType::Unknown(_) => Ok(()),
 
@@ -341,7 +341,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // replace_person → native Wan-VACE (the replace-capable models) or native SCAIL-2
         // (scail2_14b, sc-5452) is MLX-eligible (handled by the early `job_is_any_mlx_eligible` Ok
         // above). This arm is only reached for a replace_person job on a model with no MLX video
-        // engine — that stays torch.
+        // engine — that remains unsupported on Mac.
         JobType::PersonReplace => Err(UnsupportedReason::new(
             model,
             "replace_person",
@@ -352,9 +352,8 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // Person detection + tracking are now ported to the Rust worker (epic 3482,
         // sc-3488): native-MLX YOLO11 detection (sc-3633), SORT/ByteTrack track assembly
         // (sc-3634), and SAM2 per-frame segmentation (sc-3709) all run in-process on the
-        // macOS MLX worker, so the Replace-Person detect → track → mask flow is
-        // Python-free. (replace_person end-to-end still needs the video-gen/inpaint half,
-        // a tracked torch gap on `PersonReplace` below — epic 3040.)
+        // macOS MLX worker, so the Replace-Person detect → track → mask flow is native.
+        // Eligible replacement then runs through native Wan-VACE or SCAIL-2.
         JobType::PersonDetect | JobType::PersonTrack => Ok(()),
 
         // DWPose pose detection is now ported to the Rust worker (sc-3487): RTMW
@@ -371,13 +370,13 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt
         // segmentation runs in-process on the macOS Rust worker (the box-PVS path of the
         // sc-4926 SAM3 stack — `segment_jobs::run_image_segment_job`), so the Image Editor
-        // smart-select tool is Python-free on Mac. Mac-only by construction: the capability
-        // is advertised only by `mlx_gpu`, so no torch/candle worker ever claims it.
+        // smart-select tool is native on Mac. Mac-only by construction: the capability
+        // is advertised only by `mlx_gpu`, so no other native worker claims it.
         JobType::ImageSegment => Ok(()),
 
         // Pure audio synthesis (SceneWorks Audio Studio, epic 13400 / sc-13404): Kokoro TTS runs
         // in-process on the runtime's candle audio lane (`catalog().audio()`, shipped default-on in
-        // `runtime-macos`) — audio is candle-native on every platform, so it is not a Python-torch
+        // `runtime-macos`) — audio is candle-native on every platform, so it is not a native-flow
         // gap. Its real availability is the worker's `audio_generate` capability advertisement, so it
         // queues rather than enforce-fails here.
         JobType::AudioGenerate => Ok(()),
@@ -385,10 +384,10 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // Real-ESRGAN image upscaling is ported to the Rust worker (sc-3489) and SeedVR2 (the
         // native-MLX one-step diffusion upscaler, epic 4811 / sc-4815) runs in-process via
         // `mlx-gen-seedvr2`, so the upscale tool runs Python-free. The AuraSR engine (`aura-sr`,
-        // a 617M-param torch-only GigaGAN) was DROPPED on Mac after the sc-3668 port-or-drop
+        // a 617M-param legacy GigaGAN) was DROPPED on Mac after the sc-3668 port-or-drop
         // spike (no viable Rust path; only a marginal, ~35-50x-slower quality difference vs
         // Real-ESRGAN x4) and is now dropped as an offered engine off-Mac too (sc-5499 — the
-        // Python torch backend that served it is retired in Phase 7). The UI hides the AuraSR
+        // historical Python backend that served it has been retired). The UI hides the AuraSR
         // engine option on every platform, so this Err is a defensive submit-time guard.
         JobType::ImageUpscale => {
             if upscale_job_is_mlx_eligible(job) {
@@ -404,7 +403,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         }
 
         // Video upscaling is net-new on Mac (epic 4811 / sc-4816): the native-MLX SeedVR2
-        // engine is the only path (there is no torch video upscaler), so a SeedVR2 job is
+        // engine is the only path, so a SeedVR2 job is
         // supported and anything else has no in-process engine. Eligible jobs early-return
         // `Ok` above via `job_is_any_mlx_eligible`; this arm is the defensive guard.
         JobType::VideoUpscale => {
@@ -426,7 +425,7 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
 
         // ControlNet Training Studio (epic 10159): the control-branch trainer is candle-only — there is
         // no MLX control trainer yet (that is B5/sc-10177) — so a `control_training` job stranded on Mac
-        // with no candle worker is a real gap, not a torch fallback.
+        // with no candle worker is a real gap, not a fallback.
         JobType::ControlTraining => Err(UnsupportedReason::new(
             None,
             "ControlNet branch training",
@@ -445,19 +444,19 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
 
 /// Off-Mac "can the candle/CUDA flow run this?" oracle (sc-5502, epic 5483) — the Windows/Linux
 /// twin of [`mac_rust_supported`]. `Ok(())` = the candle worker (or an MLX-agnostic in-process
-/// Rust path: downloads, ffmpeg, prompt refine — sc-5525) runs it with zero torch; `Err` names the
-/// exact torch gap. Under `candle_required` **enforce** an `Err` job fails terminal with
+/// Rust path: downloads, ffmpeg, prompt refine — sc-5525) runs it natively; `Err` names the
+/// exact native gap. Under `candle_required` **enforce** an `Err` job fails terminal with
 /// `candle_unsupported`, so the set of `Err`s is the off-Mac port-or-drop roadmap. Consistent with
 /// routing by construction — anything [`job_is_any_candle_eligible`] accepts is `Ok`.
 ///
 /// **Scope (this slice):** biased toward `Ok` exactly like the MLX oracle ("never over-gate a
 /// valid combination"). It enforce-fails only the **generation** gaps that have crisp candle
 /// eligibility predicates — the shapes that would otherwise silently mis-serve as an unconditioned
-/// torch T2I (the sc-5968 concern, generalized from poses to the whole image/video surface). The
+/// T2I (the sc-5968 concern, generalized from poses to the whole image/video surface). The
 /// CV-aux / segment / detail / training / convert / infra job types route by capability and their
 /// candle parity is still landing (Phase 5, epic 5482; the training cutover); they stay `Ok` here
-/// so the enforce sweep never kills a job the co-resident torch worker still serves. Each converts
-/// to an `Err` arm as its phase epic closes and torch is retired for that surface (sc-5503).
+/// so capability routing can leave unsupported work queued rather than force-failing it. Each
+/// converts to an `Err` arm when that surface's enforcement contract is explicit (sc-5503).
 pub fn candle_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
     if job_is_any_candle_eligible(job) {
         return Ok(());
@@ -465,7 +464,7 @@ pub fn candle_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
     let model = job.payload.get("model").and_then(Value::as_str);
     match job.job_type {
         // Reached only for an ineligible image shape (the eligible candle lanes early-return `Ok`
-        // above): a torch-only family, or a conditioned shape with no candle lane — incl. the
+        // above): an unsupported family, or a conditioned shape with no candle lane — incl. the
         // sc-5968 strict-pose-on-an-unwired-family trap.
         JobType::ImageGenerate | JobType::ImageEdit => Err(classify_candle_image_gap(&job.payload)),
 
@@ -527,12 +526,10 @@ pub fn candle_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         )),
 
         // Not enforce-failed by this slice (biased to `Ok`). The MLX-agnostic in-process job types
-        // (downloads, model import/convert, ffmpeg, prompt refine — sc-5525) run with zero torch
-        // off-Mac. The CV-aux / segment / tile-detail / training surfaces route by capability and
-        // are still co-served by the Python torch worker until their phase epics close (Phase 5
-        // epic 5482 for person/pose/kps; the candle SAM3 segment of sc-5062; the training cutover
-        // for lora_train) — leaving them `Ok` keeps the enforce sweep from killing a job torch
-        // still serves. An unrecognized job type is never a known gap (forward-compat).
+        // (downloads, model import/convert, ffmpeg, prompt refine — sc-5525) run natively off-Mac.
+        // The CV-aux / segment / tile-detail / training surfaces route by capability; leaving them
+        // `Ok` lets unsupported work remain queued instead of being force-failed. An unrecognized
+        // job type is never a known gap (forward-compat).
         JobType::Placeholder
         | JobType::ModelDownload
         | JobType::ModelImport
@@ -613,7 +610,7 @@ pub(crate) fn classify_candle_image_gap(payload: &Map<String, Value>) -> Unsuppo
 }
 
 /// Name the precise gap for a candle-ineligible `video_generate` job (sc-5502) — the candle-worded
-/// twin of [`classify_video_gap`]: a torch-only video model or an advanced/conditioned mode with no
+/// twin of [`classify_video_gap`]: an unsupported video model or an advanced/conditioned mode with no
 /// candle lane.
 pub(crate) fn classify_candle_video_gap(payload: &Map<String, Value>) -> UnsupportedReason {
     let Some(model) = payload.get("model").and_then(Value::as_str) else {
@@ -637,15 +634,15 @@ pub(crate) fn classify_candle_video_gap(payload: &Map<String, Value>) -> Unsuppo
     )
 }
 
-/// Name the precise gap for an ineligible `image_generate` / `image_edit` job: a torch-only
-/// model, or a torch-only feature on an otherwise-MLX family. Mirrors the per-family
+/// Name the precise gap for an ineligible `image_generate` / `image_edit` job: an unsupported
+/// model, or an unsupported feature on an otherwise-MLX family. Mirrors the per-family
 /// `*_mlx_eligible` gates so the reason matches why routing refused it.
 pub(crate) fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedReason {
     let Some(model) = payload.get("model").and_then(Value::as_str) else {
         return UnsupportedReason::new(None, "image generation", "no model specified.", None);
     };
     if !MLX_ROUTED_MODELS.contains(&model) {
-        // No whole-model torch-only image family remains: every one was ported to MLX and moved
+        // No whole-model legacy-only image family remains: every one was ported to MLX and moved
         // into `MLX_ROUTED_MODELS`, so anything reaching here is an unported model with no port
         // epic yet. Kolors (epic 3090 / sc-3875), InstantID (epic 3109 / sc-3345), PuLID-FLUX
         // (epic 3069 / sc-3344), z_image_edit (epic 3529 / sc-3923), Chroma (epic 3531 /
@@ -653,7 +650,7 @@ pub(crate) fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedRea
         // / sc-5105 — the LAST one) all routed. Models with a partial surface (e.g. InstantID
         // pose-library, PuLID reference-less) are named per-feature below, not here. The old
         // `torch_only_image_model_epic` seam was retired once it became permanently `None`
-        // (sc-8951); a future torch-only image model reintroduces per-model epic mapping here.
+        // (sc-8951); a future unsupported image model reintroduces per-model epic mapping here.
         // Keep in sync with `docs/mac-rust-gaps.md` §1.
         return UnsupportedReason::new(
             Some(model),
@@ -740,7 +737,7 @@ pub(crate) fn classify_image_gap(payload: &Map<String, Value>) -> UnsupportedRea
     }
 }
 
-/// Name the precise gap for an ineligible `video_generate` job: a torch-only model (incl. SVD) or
+/// Name the precise gap for an ineligible `video_generate` job: an unsupported model (incl. SVD) or
 /// an advanced mode. Mirrors `video_job_is_mlx_eligible`. (Third-party LyCORIS and LoKr-on-Wan now
 /// apply on the MLX Wan/LTX paths — epic 3641 sc-3671 — so neither is a video gap anymore.)
 pub(crate) fn classify_video_gap(payload: &Map<String, Value>) -> UnsupportedReason {

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -27,9 +27,9 @@ pub(crate) fn image_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     // `mode=edit_image` + `sourceAssetId`, epic 2427) route through the same
     // per-model predicates. The engine dispatches on payload model+mode, not job
     // type (`run_image_generate_job`), and the per-model arms below already gate
-    // `edit_image` (qwen/flux2/sdxl edit → eligible; torch-only edit models aren't
-    // in `MLX_ROUTED_MODELS` → torch). Without `image_edit` in this gate, plain
-    // Image Edit fell through to torch silently with no `gpu_route_decision`
+    // `edit_image` (qwen/flux2/sdxl edit → eligible; unsupported edit models aren't
+    // in `MLX_ROUTED_MODELS` and remain queued). Without `image_edit` in this gate, plain
+    // Image Edit was left unclaimed with no `gpu_route_decision`
     // (sc-3513).
     if !matches!(job.job_type, JobType::ImageGenerate | JobType::ImageEdit) {
         return false;
@@ -107,8 +107,8 @@ pub(crate) fn image_request_mlx_eligible(model: &str, payload: &Map<String, Valu
 /// ports the tile-ControlNet detail refine onto the engine. Detail is SDXL-family only
 /// (`sdxl` / `realvisxl`, the detail-capable backbones; the payload defaults to `realvisxl`).
 /// Third-party LyCORIS (LoHa / non-peft LoKr) now applies on the SDXL merge path too (epic 3641,
-/// sc-3671), so it no longer forces torch. On Windows/Linux no `mlx` worker exists, so detail stays
-/// on the Python torch path.
+/// sc-3671), so it no longer changes eligibility. On Windows/Linux no `mlx` worker exists, so detail
+/// remains queued unless a compatible native worker registers.
 pub(crate) fn image_detail_mlx_eligible(job: &JobSnapshot) -> bool {
     if !matches!(job.job_type, JobType::ImageDetail) {
         return false;
@@ -137,7 +137,7 @@ pub(crate) fn job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// because the `Generator` contract emits Images/Video only. SenseNova-U1 is the only model with an
 /// in-process understanding path, so eligibility = a SenseNova-U1 id (the worker handler validates
 /// the per-mode request: VQA needs a source image + question; interleave needs a prompt). Other
-/// models on these job types have no MLX path and stay on the Python torch worker.
+/// models on these job types have no MLX path and remain queued.
 pub(crate) fn understanding_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     if !matches!(job.job_type, JobType::ImageVqa | JobType::ImageInterleave) {
         return false;
@@ -168,8 +168,8 @@ pub(crate) fn understanding_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// SDXL MLX-routing conditions. sc-3026 brought txt2img + LoRA; sc-3060 (epic 3041) adds the
 /// advanced shapes the Rust `mlx-gen-sdxl` engine now handles — reference/IP-Adapter, img2img
 /// `edit_image`, masked inpaint, and outpaint — so they route to the in-process MLX worker on
-/// Mac instead of the Python torch `SdxlDiffusersAdapter`. The torch path stays authoritative
-/// on Windows/Linux (no `mlx` worker registered → nothing defers) and as the Mac fallback.
+/// Mac instead of the historical Python `SdxlDiffusersAdapter`. On Windows/Linux, no `mlx` worker is
+/// registered; only a compatible native lane may claim the job.
 /// Third-party LyCORIS (LoHa / non-peft LoKr) now applies on the SDXL merge path (epic 3641,
 /// sc-3671), so every SDXL shape — including a LyCORIS-tagged job — is MLX-eligible.
 /// `image_detail` is a separate job type with its own routing (see `image_detail_mlx_eligible`).
@@ -181,7 +181,7 @@ pub(crate) fn sdxl_mlx_eligible(_payload: &Map<String, Value>) -> bool {
 /// `sdxl` engine on its few-step `lightning` (Euler-trailing) sampler, which the engine restricts to
 /// **txt2img** (it rejects an img2img/reference init — `mlx-gen-sdxl` "acceleration sampler is
 /// txt2img-only"). So only a plain text-to-image job is MLX-eligible here; any `edit_image`, source,
-/// reference, or mask conditioning falls back to the torch worker (or is hidden by the manifest's
+/// reference, or mask conditioning is refused and remains queued (or is hidden by the manifest's
 /// txt2img-only `capabilities`). LoRAs + quant are fine on the SDXL path, so they don't gate.
 pub(crate) fn realvisxl_lightning_mlx_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
@@ -244,9 +244,9 @@ pub(crate) fn flux2_mlx_eligible(_payload: &Map<String, Value>) -> bool {
 
 /// Qwen-Image (sc-3024 / strict pose sc-3575) MLX-routing conditions: text-to-image,
 /// plus the base-Qwen strict pose tier (`advanced.poses`) handled by the `qwen_image_control`
-/// engine variant. A reference without poses (character/edit flow) and `edit_image` stay on
-/// the Python torch path. Third-party LyCORIS (LoHa / non-peft LoKr) now applies on the core MLX
-/// loader (epic 3641, sc-3642/3643), so it no longer forces torch.
+/// engine variant. A reference without poses (character/edit flow) and `edit_image` are refused and
+/// remain queued. Third-party LyCORIS (LoHa / non-peft LoKr) now applies on the core MLX
+/// loader (epic 3641, sc-3642/3643), so it no longer changes eligibility.
 pub(crate) fn qwen_mlx_eligible(payload: &Map<String, Value>) -> bool {
     if payload.get("mode").and_then(Value::as_str) == Some("edit_image") {
         return false;
@@ -294,11 +294,6 @@ pub(crate) fn qwen_edit_mlx_eligible(payload: &Map<String, Value>) -> bool {
     }
 }
 
-/// FLUX.1 (sc-3023) MLX-routing conditions, ported from `_should_route_flux_to_mlx`:
-/// text-to-image only — FLUX.1 reference/IP-Adapter and `edit_image` stay on the
-/// Python torch path (`FluxDiffusersAdapter`). A third-party LyCORIS LoRA also falls
-/// back to torch: the engine + the worker's `classify_adapter` apply LoRA and peft
-/// LoKr natively, but not arbitrary LyCORIS (which the worker would reject).
 /// FLUX.1 (`flux_schnell` / `flux_dev`) MLX-routing conditions. Text-to-image and
 /// **reference-image** (the XLabs IP-Adapter, epic 3621 — `referenceAssetId`, both
 /// variants: the Rust engine has no diffusers `load_ip_adapter` schnell limitation,
@@ -390,8 +385,8 @@ pub(crate) fn mage_flow_edit_mlx_eligible(payload: &Map<String, Value>) -> bool 
 /// `_should_route_z_image_to_mlx`: text-to-image, reference-identity img2img-init
 /// (sc-3619 — `referenceAssetId` without a pose set, the plain img2img path the
 /// base engine already supports), reference+pose (the Fun-ControlNet pose tier
-/// lives only on MLX — sc-2257/sc-2328, so a reference+pose job must NOT divert to
-/// torch, which would honour count while dropping the poses), and `edit_image`
+/// lives only on MLX — sc-2257/sc-2328, so a reference+pose job must stay on MLX rather
+/// than reach a claimant that would honour count while dropping the poses), and `edit_image`
 /// img2img-edit (epic 3529 — the engine's `Conditioning::Reference` img2img path with a
 /// `sourceAssetId` init, shared by `z_image_turbo` edit_image mode and the `z_image_edit`
 /// model, both on Turbo weights). An `edit_image` without a source asset has nothing to
@@ -436,7 +431,8 @@ pub(crate) fn chroma_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// (base path), instruction edit (`edit_image` → `Conditioning::Reference`), and Character Studio
 /// (`character_image` → `Conditioning::MultiReference`, incl. the angle set) — all via the Rust
 /// worker. It has NO ControlNet, so the strict-pose tier (`advanced.poses`) is unsupported and
-/// drops to torch on non-Mac (it has no Mac path — epic 3482). Edit/character require the
+/// is refused and remains queued on non-Mac (it has no alternate native path — epic 3482).
+/// Edit/character require the
 /// reference the it2i path needs; plain T2I is always eligible. User LoRAs are not supported
 /// (`supports_lora=false`) and the manifest surfaces no LoRA slot, so no LoRA gate is needed.
 pub(crate) fn sensenova_mlx_eligible(payload: &Map<String, Value>) -> bool {
@@ -625,16 +621,16 @@ pub(crate) fn sana_mlx_eligible(payload: &Map<String, Value>) -> bool {
 ///
 /// Anima is `mlx_routed` with `candle_routed = false`, so this predicate is the ONLY thing that can
 /// make an Anima job claimable: the mlx worker refuses a job it is not eligible for
-/// (`worker_supports_job`) and no candle/torch lane advertises the family. A missing arm here left
+/// (`worker_supports_job`) and no candle lane advertises the family. A missing arm here left
 /// every Anima job queued on "Waiting for an available worker." forever.
 pub(crate) fn anima_mlx_eligible(payload: &Map<String, Value>) -> bool {
     payload.get("mode").and_then(Value::as_str) != Some("edit_image")
 }
 
 /// Epic 3018 routing (sc-3036, the video sibling of [`image_job_is_mlx_eligible`]):
-/// does this video job belong on the in-process Rust MLX worker? Encodes today's
-/// Python `create_video_adapter` MLX-eligibility (video_adapters.py) at the claim
-/// layer, minus the worker-local gates (MPS presence / sidecar) — those are now
+/// does this video job belong on the in-process Rust MLX worker? Encodes the retired Python
+/// `create_video_adapter` MLX-eligibility (video_adapters.py) at the claim
+/// layer, minus the legacy worker-local gates (synthetic MPS presence / sidecar) — those are now
 /// expressed by whether an `mlx` worker is registered and idle (see
 /// [`should_defer_video_to_mlx_worker`]).
 ///
@@ -644,8 +640,8 @@ pub(crate) fn anima_mlx_eligible(payload: &Map<String, Value>) -> bool {
 /// `video_bridge` on the LTX IC-LoRA path **and Wan TI2V-5B** (sc-3522 / sc-3357, the `VideoExtend`
 /// / `VideoBridge` job types — Wan via single-frame boundary keyframe conditioning), and
 /// `replace_person` → native Wan-VACE (the `PersonReplace` job type, sc-3521 — see
-/// [`video_mode_is_mlx_eligible`]). Still on the Python torch path: a non-MLX model, and
-/// extend/bridge on the 14B Wan MoE engines (no `Keyframe` path).
+/// [`video_mode_is_mlx_eligible`]). A non-MLX model, or extend/bridge on the 14B Wan MoE engines
+/// (no `Keyframe` path), is refused and remains queued.
 /// **Third-party LyCORIS (LoHa / non-peft LoKr) and LoKr-on-Wan now run on MLX**
 /// (epic 3641, sc-3671 + sc-3644): the Wan/LTX engine paths reconstruct + merge/residual the delta —
 /// the peft-LoKr-on-Wan merge has existed since sc-2393, and the old `create_video_adapter` torch
@@ -696,14 +692,14 @@ pub(crate) fn video_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// additionally MLX on the FLF-capable engines — LTX (`ltx_2_3`/`ltx_2_3_eros`, the
 /// reference-grounded `Keyframe` path, sc-3052) and Wan TI2V-5B (`wan_2_2`, the mask-blend
 /// multi-keyframe path, sc-3357). The 14B Wan MoE engines have no `Keyframe` path, so FLF on
-/// them stays torch. **SVD (`svd`) is image-conditioned only** — it serves `image_to_video`
+/// them is refused. **SVD (`svd`) is image-conditioned only** — it serves `image_to_video`
 /// exclusively (no text→video, sc-3523). The clip-conditioning modes `extend_clip` /
 /// `video_bridge` are MLX on the **LTX** engines (`ltx_2_3`/`ltx_2_3_eros`, the IC-LoRA
 /// multi-frame keyframe-append path — sc-3522, engine `build_clips` sc-3052/3053) **and Wan
 /// TI2V-5B** (`wan_2_2`, single-frame boundary `Keyframe` conditioning — sc-3357: extend pins the
 /// source clip's last frame, bridge pins the two boundary frames, the same mask-blend primitive as
 /// Wan FLF, matching the torch Wan reference which routed these to plain i2v). The 14B Wan MoE
-/// engines have no `Keyframe` path so they stay torch. `replace_person` is MLX on the
+/// engines have no `Keyframe` path, so those requests are refused. `replace_person` is MLX on the
 /// replace-capable models (→ native Wan-VACE, sc-3521).
 pub(crate) fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
     if model == "svd" {
@@ -754,7 +750,7 @@ pub(crate) fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
         // generated-span mask) and falls back to the TI2V-5B single-frame boundary keyframe path
         // (sc-3357) when the VACE snapshot is unprovisioned. Both run MLX-native, so `wan_2_2` is
         // eligible regardless of which the worker picks. The 14B Wan MoE engines have neither
-        // path, so extend/bridge on them stay torch.
+        // path, so extend/bridge on them are refused and remain queued.
         "extend_clip" | "video_bridge" => matches!(model, "ltx_2_3" | "ltx_2_3_eros" | "wan_2_2"),
         // replace_person → native Wan-VACE (sc-3521): the engine `wan_vace` provider serves it
         // regardless of the user-picked replace-capable model (ltx_2_3 / ltx_2_3_eros / wan_2_2,
@@ -765,10 +761,10 @@ pub(crate) fn video_mode_is_mlx_eligible(model: &str, mode: &str) -> bool {
 }
 
 /// Epic 3039 routing — does this `lora_train` job belong on the in-process Rust MLX
-/// worker (vs the Python torch worker)? The training sibling of
+/// worker? The training sibling of
 /// [`image_job_is_mlx_eligible`]/[`video_job_is_mlx_eligible`]: the engine has a
 /// native trainer for the family. Both dry-run and real runs are eligible (the
-/// dry-run validates the same resolved plan). LoKr-on-Wan stays torch — the mlx Wan
+/// dry-run validates the same resolved plan). LoKr-on-Wan is refused — the mlx Wan
 /// inference path can't load a Kronecker adapter, mirroring [`video_job_is_mlx_eligible`];
 /// LoKr on Z-Image/SDXL/LTX is fine (the Rust engine applies it natively).
 ///
@@ -791,7 +787,7 @@ pub(crate) fn training_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
     if !MLX_ROUTED_TRAINING_KERNELS.contains(&kernel) {
         return false;
     }
-    // LoKr-on-Wan stays on the torch path (no Kronecker merge in the mlx Wan path).
+    // LoKr-on-Wan is refused (no Kronecker merge in the mlx Wan path).
     if matches!(kernel, "wan_lora" | "wan_moe_lora") && training_plan_is_lokr(plan) {
         return false;
     }
@@ -813,9 +809,9 @@ pub(crate) fn caption_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 /// Whether an `image_upscale` job runs on the Rust/MLX path (epic 3482, sc-3489): the
 /// Real-ESRGAN (RRDBNet) engine — the default — is ported to the Rust worker, and `seedvr2`
 /// (the native-MLX one-step diffusion upscaler, epic 4811 / sc-4815) runs in-process via
-/// `mlx-gen-seedvr2`. `aura-sr` (a 617M-param torch-only GigaGAN) was dropped on Mac after the
-/// sc-3668 port-or-drop spike, so the mlx worker refuses it (it runs on the Python worker on
-/// Windows/Linux). Engine defaults to `real-esrgan` when absent (mirrors `run_image_upscale`).
+/// `mlx-gen-seedvr2`. `aura-sr` (a 617M-param historical GigaGAN backend) was dropped on Mac after
+/// the sc-3668 port-or-drop spike, so the mlx worker refuses it and it remains queued.
+/// Engine defaults to `real-esrgan` when absent (mirrors `run_image_upscale`).
 /// SeedVR2 is Mac-only here (a Windows/Linux Candle backend is the separate sc-5157); the Mac UI
 /// gating + `imageUpscaleSeedvr2` capability keep it off non-Mac pickers.
 pub(crate) fn upscale_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
@@ -835,8 +831,8 @@ pub(crate) fn upscale_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 }
 
 /// Whether a `video_upscale` job is MLX-eligible (epic 4811 / sc-4816). The only Mac engine is the
-/// native-MLX SeedVR2 upscaler (`mlx-gen-seedvr2`); there is no torch fallback. A job with any other
-/// engine is refused by the mlx worker. The off-Mac candle lane mirrors this predicate for its
+/// native-MLX SeedVR2 upscaler (`mlx-gen-seedvr2`); there is no fallback. A job with any other engine
+/// is refused by the mlx worker. The off-Mac candle lane mirrors this predicate for its
 /// SeedVR2 provider, so both native GPU backends enforce the same contract boundary. Defaults to
 /// `seedvr2` when the payload omits the engine.
 pub(crate) fn video_upscale_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
@@ -853,8 +849,8 @@ pub(crate) fn video_upscale_job_is_mlx_eligible(job: &JobSnapshot) -> bool {
 }
 
 /// Whether an `image_upscale` job explicitly requests the SeedVR2 engine (`engine=seedvr2`, the id the
-/// web sends and the worker accepts). SeedVR2 has no torch backend — it runs on MLX (Mac) or candle
-/// (Windows/Linux) — so this also drives the torch worker's refusal (the inverse of the AuraSR gate).
+/// web sends and the worker accepts). SeedVR2 runs on MLX (Mac) or candle (Windows/Linux), so this
+/// also drives every generic worker descriptor's refusal (the inverse of the AuraSR gate).
 /// The image default engine is Real-ESRGAN, so an absent engine is NOT SeedVR2.
 pub(crate) fn upscale_job_requests_seedvr2(job: &JobSnapshot) -> bool {
     matches!(job.job_type, JobType::ImageUpscale)
@@ -865,11 +861,12 @@ pub(crate) fn upscale_job_requests_seedvr2(job: &JobSnapshot) -> bool {
             .is_some_and(|engine| engine.trim().eq_ignore_ascii_case("seedvr2"))
 }
 
-/// Whether this training job targets a kernel with no torch fallback (see
+/// Whether this training job targets a native-only kernel (see
 /// [`MLX_ONLY_TRAINING_KERNELS`]). Such a job can only run on a Rust worker (mlx, or candle when the
-/// candle exception in [`worker_supports_job`] admits it — e.g. `krea_control`), so a torch worker
-/// must refuse it. Covers both the `lora_train` and the ControlNet studio (`control_training`) jobs —
-/// both stamp a resolved plan whose `krea_control` kernel is no-torch-fallback (epic 10159).
+/// candle exception in [`worker_supports_job`] admits it — e.g. `krea_control`), so any generic
+/// worker descriptor must refuse it. Covers both the `lora_train` and the ControlNet studio
+/// (`control_training`) jobs; both stamp a resolved plan whose `krea_control` kernel is native-only
+/// (epic 10159).
 pub(crate) fn training_kernel_is_mlx_only(job: &JobSnapshot) -> bool {
     if !matches!(job.job_type, JobType::LoraTrain | JobType::ControlTraining) {
         return false;
@@ -1285,7 +1282,7 @@ mod tests {
             builtin_with_family.as_object().expect("probe is an object")
         ));
 
-        // A torch-only builtin id-keyed verdict is unchanged: `flux_dev` edit stays off MLX even if a
+        // An unsupported builtin id-keyed verdict is unchanged: `flux_dev` edit stays off MLX even if a
         // (spurious) krea_2 manifest family rides along — the builtin arm decides, never the fallback.
         let builtin_edit = json!({
             "model": "flux_dev",

--- a/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
@@ -1,6 +1,6 @@
 //! Candle (Windows/CUDA) SDXL lane routing (epic 3672, sc-3678): the candle worker serves a
-//! gated, narrow SDXL/RealVisXL **txt2img-only** lane and must defer every other shape to the
-//! Python torch worker. These tests pin the lane boundary (`image_request_candle_eligible`) and
+//! gated, narrow SDXL/RealVisXL **txt2img-only** lane and must refuse every other shape, leaving it
+//! queued for a compatible native worker. These tests pin the lane boundary (`image_request_candle_eligible`) and
 //! the full claim gate (`worker_supports_job` via the `candle` marker capability).
 use super::*;
 use serde_json::{json, Value};
@@ -54,7 +54,7 @@ fn image_edit_job(payload: Value) -> JobSnapshot {
 }
 
 /// A worker on a real CUDA gpu index advertising `capabilities` (string ids). The candle worker
-/// carries the `candle` marker; the torch worker on the same box does not.
+/// carries the `candle` marker; a synthetic generic descriptor does not.
 fn gpu_worker(capabilities: &[&str]) -> WorkerSnapshot {
     serde_json::from_value(json!({
         "id": "worker_1",
@@ -71,7 +71,7 @@ fn gpu_worker(capabilities: &[&str]) -> WorkerSnapshot {
 // Mirrors the real candle advertised set (`with_candle_capabilities`): `image_generate` (derived)
 // plus the `image_edit` carve-out (sc-5487 edit lanes) and the `candle` lane marker.
 const CANDLE_CAPS: &[&str] = &["gpu", "image_generate", "image_edit", "candle"];
-// The Python torch worker advertises the broad image surface but no `candle` marker.
+// Synthetic generic descriptor used to exercise the non-candle branch; production has no fallback.
 const TORCH_CAPS: &[&str] = &["gpu", "image_generate", "image_edit", "image_detail"];
 
 #[test]
@@ -294,7 +294,7 @@ fn candle_routed_models_plain_txt2img_are_eligible() {
     // INCLUDING base `z_image` (sc-8679): the registered candle `z_image` base generator makes a plain
     // txt2img `z_image` job candle-eligible, the base sibling of `z_image_turbo`. (Its strict-pose
     // control lane is branched out earlier in `image_job_is_candle_eligible`; its edit shapes reject
-    // below — see `new_candle_families_conditioning_shapes_fall_back_to_torch`.)
+    // below — see the conditioning-shape refusal test.)
     for model in CANDLE_ROUTED_MODELS {
         assert!(
             image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
@@ -402,8 +402,8 @@ fn imported_krea_family_plain_single_file_job_is_candle_eligible() {
 #[test]
 fn base_z_image_txt2img_is_candle_eligible_but_edit_shapes_are_not() {
     // sc-8679: base `z_image` plain txt2img rides the candle lane (the base sibling of z_image_turbo);
-    // its edit / reference / mask conditioning shapes still defer to the Python torch worker (no candle
-    // base-z-image edit provider — that is a separate story).
+    // its edit / reference / mask conditioning shapes are refused and remain queued (no candle
+    // base-z-image edit provider).
     assert!(
         image_request_candle_eligible("z_image", &object(json!({ "prompt": "a red fox" }))),
         "base z_image plain txt2img must be candle-eligible (sc-8679)"
@@ -423,9 +423,9 @@ fn base_z_image_txt2img_is_candle_eligible_but_edit_shapes_are_not() {
 #[test]
 fn non_candle_families_and_variants_are_never_candle_eligible() {
     // The still-unwired weight/shape variants of wired families (edit ids) plus a genuinely
-    // txt2img-torch-only image id (`pulid_flux_dev` — its only candle lane is the bespoke
-    // character-reference path, so a PLAIN txt2img prompt has no candle route) all stay on the Python
-    // torch worker. (chroma / kolors / sensenova ARE candle-routed now — sc-5484 / sc-5576 — for
+    // unsupported plain-txt2img image id (`pulid_flux_dev` — its only candle lane is the bespoke
+    // character-reference path, so a PLAIN txt2img prompt has no native route) all remain queued.
+    // (chroma / kolors / sensenova ARE candle-routed now — sc-5484 / sc-5576 — for
     // txt2img; the FLUX.2-klein `_kv` / `_true_v2` weight variants are too — sc-7459 — see the
     // dedicated test below. `bernini_image` is now candle-routed off-Mac too — sc-10996. Base
     // `sana_1600m` AND the Sprint distill `sana_sprint_1600m` are candle-routed off-Mac too —
@@ -445,8 +445,8 @@ fn sana_candle_txt2img_routes_to_candle() {
     // Sana_1600M_1024px_diffusers` snapshot). sc-11781: the CFG-free SANA-Sprint distill
     // `sana_sprint_1600m` rides it too (the `candle-gen-sana` Sprint pipeline, candle-gen #498 — the
     // whole `Efficient-Large-Model/Sana_Sprint_1.6B_1024px_diffusers` snapshot). Pure txt2img on BOTH:
-    // any conditioning / LoRA / quant shape still defers to the Python torch worker (neither candle
-    // base path advertises adapters or quant — the Sprint adapter rejects all three).
+    // any conditioning / LoRA / quant shape is refused and remains queued (neither candle base path
+    // advertises adapters or quant — the Sprint adapter rejects all three).
     for model in ["sana_1600m", "sana_sprint_1600m"] {
         assert!(
             image_request_candle_eligible(model, &object(json!({ "prompt": "a red fox" }))),
@@ -478,8 +478,8 @@ fn flux2_klein_weight_variants_route_txt2img_to_candle() {
         );
     }
     // ...but their reference/edit shapes are NOT in scope (txt2img weight parity only). The `_kv`
-    // checkpoint's whole point is the reference-edit KV-cache accel — that stays on the Python torch
-    // worker (the candle lane has no klein edit path), same as every other candle conditioning shape.
+    // checkpoint's whole point is the reference-edit KV-cache accel; candle has no klein edit path,
+    // so the request is refused and remains queued.
     for payload in [
         json!({ "referenceAssetId": "a" }),
         json!({ "mode": "edit_image", "sourceAssetId": "a" }),
@@ -493,8 +493,8 @@ fn flux2_klein_weight_variants_route_txt2img_to_candle() {
 
 #[test]
 fn new_candle_families_conditioning_shapes_fall_back_to_torch() {
-    // Every candle image family is txt2img-only on candle: any conditioning shape defers to torch
-    // (the worker advertises none of these, so this is the no-silently-dropped-control boundary).
+    // Every candle image family is txt2img-only on candle: unsupported conditioning shapes are
+    // refused (the worker advertises none of these, so this is the no-silently-dropped-control boundary).
     let cases = [
         (
             "z_image_turbo",
@@ -508,8 +508,8 @@ fn new_candle_families_conditioning_shapes_fall_back_to_torch() {
         ),
         // NB: `flux2_klein_9b` + `edit_image` is NOT here — sc-5487 wired it to the candle `Flux2Edit`
         // lane (asserted via `image_job_is_candle_eligible` in `candle_worker_claims_*`), like SDXL
-        // edit. The txt2img gate still rejects it (it rejects all `edit_image`), but it no longer
-        // "falls back to torch" at the router level.
+        // edit. The txt2img gate still rejects it (it rejects all `edit_image`), but the bespoke
+        // candle edit lane claims it at the router level.
         // sc-5484 / sc-5576: Chroma / Kolors / SenseNova-U1 are pure T2I on candle. Their MLX-only
         // conditioning shapes (Kolors edit / IP-reference / pose-control; SenseNova edit) defer.
         (
@@ -545,8 +545,8 @@ fn ideogram_candle_txt2img_and_edit_route_to_candle() {
     // text-to-image via the generic `image_request_candle_eligible` gate. sc-6598: img2img / Remix +
     // mask inpaint / outpaint now route to candle too — via the bespoke `ideogram_edit_candle_eligible`
     // branch in `image_job_is_candle_eligible` (the generic gate stays txt2img-only, like every other
-    // candle edit family). A pure `referenceAssetId` (IP-Adapter — no candle Ideogram path) still
-    // defers to torch.
+    // candle edit family). A pure `referenceAssetId` (IP-Adapter — no candle Ideogram path) is
+    // refused and remains queued.
     for model in ["ideogram_4", "ideogram_4_turbo"] {
         // Plain txt2img → the generic gate.
         assert!(
@@ -673,7 +673,7 @@ fn bernini_candle_txt2img_and_i2i_route_to_candle() {
         "model": "bernini_image", "mode": "edit_image"
     }))));
     // NOT `candle_quant` (sc-10996): the off-Mac packed-tier select is deferred (sc-11003), so an
-    // explicit `mlxQuantize` request defers to torch rather than staying on candle — the descriptor
+    // explicit `mlxQuantize` request is refused rather than staying on candle — the descriptor
     // advertises Q4/Q8 but no consumable off-Mac tier exists yet.
     assert!(!image_request_candle_eligible(
         "bernini_image",
@@ -803,7 +803,7 @@ fn boogu_base_and_turbo_img2img_route_to_candle() {
 #[test]
 fn explicit_quantization_falls_back_to_torch_image_and_video() {
     // sc-5099: a candle provider that advertises NO quant (supported_quants: &[]) must route an
-    // explicit `advanced.mlxQuantize > 0` to Python rather than silently running dense. chroma1_hd
+    // explicit `advanced.mlxQuantize > 0` is refused rather than silently running dense. chroma1_hd
     // is such a dense-only candle family (contrast the SDXL family, sc-10767, which now advertises
     // Q4/Q8 packed tiers and stays on candle — covered by `sdxl_family_quant_and_lora_stay_on_candle`).
     assert!(!image_request_candle_eligible(
@@ -849,7 +849,7 @@ fn qwen_image_quant_tier_select_stays_on_candle() {
         "qwen_image",
         &object(json!({ "prompt": "x" }))
     ));
-    // A LoRA request still defers to torch — no candle inference LoRA on base qwen.
+    // A LoRA request is still refused — no candle inference LoRA on base qwen.
     assert!(!image_request_candle_eligible(
         "qwen_image",
         &object(json!({ "loras": [{ "name": "x", "path": "/x.safetensors" }] }))
@@ -886,7 +886,7 @@ fn flux2_turnkey_quant_tier_select_stays_on_candle() {
                 "{model} dense/plain shape must stay candle-eligible"
             );
         }
-        // No candle inference LoRA on any FLUX.2 id — a LoRA still defers to torch.
+        // No candle inference LoRA on any FLUX.2 id, so a LoRA is still refused.
         assert!(
             !image_request_candle_eligible(
                 model,
@@ -988,8 +988,7 @@ fn sdxl_family_quant_and_lora_stay_on_candle() {
 #[test]
 fn lens_quant_and_lora_stay_on_the_candle_lane() {
     // sc-5126: Lens / Lens-Turbo advertise Q4/Q8 + LoRA/LoKr, so — UNLIKE the sc-3675/sc-5096
-    // families — a quant request or a LoRA does NOT defer to torch; the candle lane maps both into
-    // the LoadSpec.
+    // families — a quant request or a LoRA stays on candle; the lane maps both into the LoadSpec.
     for model in ["lens", "lens_turbo"] {
         assert!(
             image_request_candle_eligible(
@@ -1018,7 +1017,7 @@ fn lens_quant_and_lora_stay_on_the_candle_lane() {
 #[test]
 fn lens_conditioning_shapes_fall_back_to_torch() {
     // Lens is pure T2I (the port has no img2img/edit/reference/ControlNet), so every conditioning
-    // shape still defers to the Python worker — quant/LoRA being allowed does not widen this.
+    // shape is refused and remains queued — quant/LoRA being allowed does not widen this.
     let cases = [
         json!({ "mode": "edit_image", "sourceAssetId": "a" }),
         json!({ "referenceAssetId": "a" }),
@@ -1039,7 +1038,7 @@ fn lens_conditioning_shapes_fall_back_to_torch() {
 fn sd3_5_quant_stays_on_candle_but_lora_and_conditioning_defer() {
     // sc-7880 (epic 7982): the candle SD3.5 descriptor advertises supported_quants: [Q4, Q8] but
     // supports_lora: false, so — unlike Lens — an explicit quant request stays on the candle lane
-    // while a LoRA (and every conditioning shape) still defers to the Python torch worker.
+    // while a LoRA (and every conditioning shape) is refused and remains queued.
     for model in ["sd3_5_large", "sd3_5_large_turbo", "sd3_5_medium"] {
         // Plain txt2img is eligible.
         assert!(
@@ -1086,8 +1085,8 @@ fn krea_lora_and_quant_stay_on_candle_but_conditioning_defers() {
     // inference) AND, since sc-9607, `supported_quants: [Q4, Q8]` (a no-op on the already-packed q4/q8
     // turnkey subdir), so BOTH a LoRA and a Q8/Q4 tier-select stay on the candle lane (Krea is in
     // CANDLE_QUANT_LORA_MODELS). Only the conditioning shapes (edit/reference/mask/pose) defer to the
-    // Python torch worker. Regression guard for the two missed router un-gates: before sc-7836 a Krea
-    // LoRA, and before sc-9983 a Krea Q8/Q4, each hit the no-torch-fallback candle gap off-Mac.
+    // queue. Regression guard for the two missed router un-gates: before sc-7836 a Krea LoRA, and
+    // before sc-9983 a Krea Q8/Q4, each hit the native-support gap off-Mac.
     let model = "krea_2_turbo";
     // Plain txt2img is eligible.
     assert!(
@@ -1334,7 +1333,7 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         "sana_1600m",
         // sc-11781 (epic 8485): the CFG-free SANA-Sprint distill `sana_sprint_1600m` rides the candle
         // lane too (the `candle-gen-sana` Sprint pipeline, candle-gen #498). Pure txt2img (1–4 step
-        // SCM/TrigFlow) — the Sprint adapter rejects quant / LoRA / control, so those defer to torch.
+        // SCM/TrigFlow) — the Sprint adapter rejects quant / LoRA / control, so those requests remain queued.
         "sana_sprint_1600m",
     ] {
         assert!(
@@ -1345,10 +1344,10 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
             "candle worker should claim {model} plain txt2img"
         );
     }
-    // Refuses a genuinely txt2img-torch-only image id (`pulid_flux_dev` — its only candle lane is the
+    // Refuses a genuinely unsupported plain-txt2img image id (`pulid_flux_dev` — its only candle lane is the
     // bespoke character-reference path, so a PLAIN txt2img prompt has no candle route, candle_routed=
     // false), an adapter shape on the txt2img-only SANA base (candle SANA advertises neither quant nor
-    // LoRA — sc-11780/sc-11781), and a conditioning shape on a wired family — all defer to torch.
+    // LoRA — sc-11780/sc-11781), and a conditioning shape on a wired family — all are refused.
     assert!(!worker_supports_job(
         &candle,
         &image_generate_job(json!({ "model": "pulid_flux_dev", "prompt": "p" }))
@@ -1409,9 +1408,9 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         "candle worker should claim z_image_turbo strict-pose (sc-5489)"
     );
     // sc-5968: plain `sdxl` + poses has NO candle pose lane (SDXL pose ships via InstantID), and
-    // the torch `sdxl` adapter has no pose path either — so the candle worker CLAIMS it (to reject
-    // with a typed error in the handler) rather than declining → torch silently rendering an
-    // unconditioned T2I image. `worker_supports_job` is therefore TRUE here (candle owns it to fail
+    // no native fallback can serve it off-Mac — so the candle worker CLAIMS it (to reject
+    // with a typed error in the handler) rather than allowing a generic claimant to silently render
+    // an unconditioned T2I image. `worker_supports_job` is therefore TRUE here (candle owns it to fail
     // it loudly); the handler's `candle_unsupported_pose_reject` guard does the rejecting.
     assert!(worker_supports_job(
         &candle,
@@ -1421,7 +1420,7 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         }))
     ));
     // sc-5487: a plain SDXL edit (img2img: `edit_image` + a source) is now a candle lane (the
-    // bespoke `SdxlEdit` route), so the candle worker CLAIMS it — it no longer declines → torch.
+    // bespoke `SdxlEdit` route), so the candle worker CLAIMS it.
     assert!(worker_supports_job(
         &candle,
         &image_generate_job(json!({
@@ -1431,7 +1430,7 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         }))
     ));
     // sc-5487: a FLUX.2-klein edit (`edit_image` + a source) is now the candle `Flux2Edit` lane.
-    // klein has no torch path, so the candle worker CLAIMS it (the only off-Mac lane for it).
+    // candle is the only off-Mac lane for klein, so the worker CLAIMS it.
     assert!(worker_supports_job(
         &candle,
         &image_generate_job(json!({
@@ -1441,7 +1440,7 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
         }))
     ));
     // The -kv distill edit has no candle provider yet (needs the reference-K/V cache port) → NOT
-    // claimed by candle; it stays on the MLX/torch path.
+    // claimed by candle; it remains queued until an MLX worker can serve it.
     assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
         "model": "flux2_klein_9b_kv",
         "mode": "edit_image",
@@ -1463,7 +1462,7 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
     }))));
     // sc-7736: a pure-reference flux2_dev job (a `referenceAssetId`, NO `edit_image` source, NO poses)
     // is neither the edit lane (needs `edit_image` + a source) nor the control lane (needs poses), so
-    // the txt2img gate rejects the reference shape → it still defers to torch.
+    // the txt2img gate rejects the reference shape, so it remains queued.
     assert!(!image_job_is_candle_eligible(&image_generate_job(json!({
         "model": "flux2_dev",
         "referenceAssetId": "asset_1"
@@ -1514,10 +1513,9 @@ fn candle_worker_claims_txt2img_but_refuses_unsupported_shapes() {
 
 #[test]
 fn torch_worker_claims_everything_the_candle_worker_defers() {
-    // The co-resident Python torch worker (no `candle` marker) is ungated here: it claims the
-    // shapes the candle worker refused, so nothing is stranded — EXCEPT the unsupported-pose shapes
-    // the candle worker now owns-to-reject (sc-5968, asserted at the end of this test): torch
-    // declines those so it can't silently render an unconditioned T2I image.
+    // This synthetic generic descriptor (no `candle` marker) exercises the legacy non-candle branch.
+    // Production has no fallback: shapes refused by candle remain queued, including unsupported-pose
+    // shapes that candle owns-to-reject (sc-5968) to prevent unconditioned T2I rendering.
     let torch = gpu_worker(TORCH_CAPS);
     // A family with no candle provider (`sana_1600m` — MLX-only, candle_routed=false; `bernini_image`
     // is now candle-routed off-Mac, sc-10996), and a conditioning shape on a wired family.
@@ -1548,10 +1546,10 @@ fn torch_worker_claims_everything_the_candle_worker_defers() {
             "sourceAssetId": "asset_1"
         }))
     ));
-    // sc-5968: but torch DECLINES the unsupported-pose shape the candle worker owns-to-reject
-    // (sdxl + poses) — so it can't silently render an unconditioned T2I; only candle takes it (and
-    // rejects). On Mac the same shape is MLX-served, so the `mlx` worker still claims it (asserted
-    // in `unsupported_pose_is_owned_by_candle_declined_by_torch_served_by_mlx`).
+    // sc-5968: the synthetic generic descriptor DECLINES the unsupported-pose shape the candle
+    // worker owns-to-reject (sdxl + poses), preventing silent unconditioned T2I; candle takes it and
+    // rejects. On Mac the same shape is MLX-served, so the `mlx` worker still claims it (asserted
+    // in the cross-descriptor unsupported-pose test).
     assert!(!worker_supports_job(
         &torch,
         &image_generate_job(json!({
@@ -1561,8 +1559,8 @@ fn torch_worker_claims_everything_the_candle_worker_defers() {
     ));
 }
 
-/// sc-5968: the unsupported-pose routing across the three GPU workers — candle OWNS it (to reject),
-/// torch DECLINES it (no silent T2I), and the Mac `mlx` worker still SERVES it (no Mac regression,
+/// sc-5968: unsupported-pose routing across descriptors — candle OWNS it (to reject), the synthetic
+/// generic descriptor DECLINES it (no silent T2I), and the Mac `mlx` worker SERVES it (no regression,
 /// `sdxl_mlx_eligible` is unconditional). Plus: the wired candle pose families are unaffected, and
 /// `image_job_is_candle_eligible` still reports sdxl+poses as NOT candle-*served* (it's owned only
 /// to reject — the distinction the worker's dispatch guard keys on).
@@ -1677,8 +1675,8 @@ fn candle_routed_video_models_are_eligible_in_their_native_shape() {
 #[test]
 fn non_candle_video_models_and_conditioned_shapes_fall_back() {
     // `ltx_2_3_eros` now routes to candle for plain text_to_video (sc-5495 — it's a full dense
-    // LTX-2.3 fine-tune on the `ltx_2_3_distilled` engine), but any conditioned eros shape stays on
-    // the Python torch worker (the candle LTX lane is txt2video-only).
+    // LTX-2.3 fine-tune on the `ltx_2_3_distilled` engine), but any conditioned eros shape is
+    // refused and remains queued (the candle LTX lane is txt2video-only).
     assert!(
         video_request_candle_eligible("ltx_2_3_eros", &object(json!({ "mode": "text_to_video" }))),
         "ltx_2_3_eros text_to_video must route to the candle lane"
@@ -1690,7 +1688,7 @@ fn non_candle_video_models_and_conditioned_shapes_fall_back() {
         ),
         "a conditioned ltx_2_3_eros shape must fall back to the Python worker"
     );
-    // A genuinely non-candle video model stays on torch.
+    // A genuinely non-candle video model is refused and remains queued.
     assert!(
         !video_request_candle_eligible(
             "some_unported_model",
@@ -1698,7 +1696,7 @@ fn non_candle_video_models_and_conditioned_shapes_fall_back() {
         ),
         "an unported model must fall back to the Python worker"
     );
-    // A txt2video model in any conditioned shape (default/i2v mode, a source, or a LoRA) → torch.
+    // A txt2video model in any conditioned shape (default/i2v mode, a source, or a LoRA) is refused.
     let cases = [
         json!({ "prompt": "p" }), // no mode → defaults to i2v
         json!({ "mode": "image_to_video", "sourceAssetId": "a" }),
@@ -1712,7 +1710,7 @@ fn non_candle_video_models_and_conditioned_shapes_fall_back() {
             "wan_2_2 shape must fall back to torch: {case}"
         );
     }
-    // The 14B T2V is text-only: any image_to_video / sourced shape falls back to torch (sc-5175).
+    // The 14B T2V is text-only: any image_to_video / sourced shape is refused (sc-5175).
     for case in [
         json!({ "mode": "image_to_video", "sourceAssetId": "a" }),
         json!({ "mode": "text_to_video", "sourceAssetId": "a" }),
@@ -1722,7 +1720,7 @@ fn non_candle_video_models_and_conditioned_shapes_fall_back() {
             "wan_2_2_t2v_14b conditioned shape must fall back to torch: {case}"
         );
     }
-    // The 14B I2V + SVD are image→video only: a txt2video shape or an i2v with no source → torch
+    // The 14B I2V + SVD are image→video only: a txt2video shape or an i2v with no source is refused
     // (sc-5175 / sc-5493).
     for model in ["wan_2_2_i2v_14b", "svd"] {
         for case in [
@@ -1839,7 +1837,7 @@ fn candle_vace_modes_eligible_with_required_assets() {
 
 #[test]
 fn candle_vace_modes_fall_back_without_assets_or_for_unsupported_models() {
-    // Missing required assets → torch.
+    // Missing required assets make the request ineligible, so it remains queued.
     assert!(!video_request_candle_vace_eligible(
         "wan_2_2",
         &object(json!({ "sourceClipAssetId": "clip_1" })), // no personTrackId / characterId
@@ -1857,7 +1855,7 @@ fn candle_vace_modes_fall_back_without_assets_or_for_unsupported_models() {
         &object(json!({ "sourceClipAssetId": "c", "personTrackId": "t", "characterId": "ch" })),
         &JobType::PersonReplace
     ));
-    // A LoRA shape → torch (the candle VACE provider advertises no adapters).
+    // A LoRA shape is refused (the candle VACE provider advertises no adapters).
     assert!(!video_request_candle_vace_eligible(
         "wan_2_2",
         &object(json!({
@@ -1917,7 +1915,7 @@ fn scail2_candle_serves_animation_and_replace_in_native_shape() {
         );
     }
     // An animate job carrying an inference LoRA (DPO / lightning / user adapter) stays on candle —
-    // the provider merges it into the dense DiT (sc-6838); only on-the-fly quant defers to torch.
+    // the provider merges it into the dense DiT (sc-6838); only on-the-fly quant is refused.
     assert!(
         scail2_animate_candle_eligible(
             "scail2_14b",
@@ -2083,7 +2081,7 @@ fn scail2_candle_rejects_incomplete_or_wrong_shape() {
             "sourceClipAssetId": "c"
         }))
     ));
-    // On-the-fly quant still defers to torch (the candle SCAIL-2 provider is dense).
+    // On-the-fly quant is still refused (the candle SCAIL-2 provider is dense).
     {
         let mut payload = object(json!({
             "mode": "animate_character",
@@ -2096,7 +2094,7 @@ fn scail2_candle_rejects_incomplete_or_wrong_shape() {
             "scail2 animate with on-the-fly quant must defer to torch: {payload:?}"
         );
     }
-    // replace_person needs the clip + track + character; missing any → torch.
+    // replace_person needs the clip + track + character; missing any makes it ineligible.
     for case in [
         json!({ "sourceClipAssetId": "c", "personTrackId": "t" }),
         json!({ "sourceClipAssetId": "c", "characterId": "ch" }),
@@ -2166,7 +2164,8 @@ fn candle_worker_claims_txt2video_but_refuses_other_video_shapes() {
         &candle,
         &video_generate_job(json!({ "model": "wan_2_2_i2v_14b", "mode": "text_to_video" }))
     ));
-    // The co-resident torch worker claims everything the candle worker defers.
+    // This synthetic generic-GPU descriptor can claim the legacy compatibility shape in isolation;
+    // no deployed fallback worker registers it, so production leaves unsupported work queued.
     let torch = gpu_worker(TORCH_VIDEO_CAPS);
     assert!(worker_supports_job(
         &torch,
@@ -2303,7 +2302,7 @@ fn image_upscale_job(payload: Value) -> JobSnapshot {
 /// sc-5499 + sc-5928: the candle worker claims both off-Mac image upscalers — Real-ESRGAN
 /// (`ort`/CUDA, sc-5499, incl. the default engine) and SeedVR2 (`candle-gen-seedvr2`, sc-5928).
 /// Only `aura-sr` (an offered engine dropped on every platform, sc-3668 / sc-5499) has no candle
-/// path → refused (it runs only on the Python torch worker until Phase 7).
+/// path and is refused, so it remains queued.
 #[test]
 fn candle_worker_claims_real_esrgan_and_seedvr2_image_upscale_refuses_aura_sr() {
     let candle = gpu_worker(&["gpu", "image_upscale", "candle"]);
@@ -2349,9 +2348,9 @@ fn candle_worker_claims_seedvr2_video_upscale_and_refuses_other_engines() {
     ));
 }
 
-/// sc-5928: SeedVR2 has no torch backend, so a plain torch GPU worker (neither `mlx` nor candle)
-/// REFUSES a `seedvr2` image upscale — it stays queued for the mlx/candle worker instead of being
-/// claimed and failing. Real-ESRGAN (the torch engine) is still claimed. The inverse of AuraSR.
+/// sc-5928: a synthetic generic GPU descriptor (neither `mlx` nor candle) REFUSES a `seedvr2`
+/// image upscale, so it stays queued for an mlx/candle worker. Real-ESRGAN exercises the generic
+/// compatibility branch. The inverse of AuraSR.
 #[test]
 fn torch_worker_refuses_seedvr2_image_upscale_but_claims_real_esrgan() {
     let torch = gpu_worker(&["gpu", "image_upscale"]); // no candle marker, gpu_id != "mlx"
@@ -2388,10 +2387,8 @@ fn kps_extract_job(payload: Value) -> JobSnapshot {
 }
 
 /// sc-5497: the candle worker advertises `kps_extract` (the candle SCRFD/ArcFace face stack) and
-/// claims a kps_extract job — the off-Mac sibling of the native-MLX path. UNLIKE SeedVR2, the Python
-/// InsightFace path CAN serve kps_extract, so there is NO torch-refusal gate: a co-resident torch
-/// worker that advertises the capability still claims it (the candle worker just runs it Python-free
-/// when it polls first; the Python path is retired wholesale in Phase 7, epic 5483). A worker that
+/// claims a kps_extract job — the off-Mac sibling of the native-MLX path. The generic descriptor
+/// below is a synthetic capability-routing check, not a deployed fallback worker. A worker that
 /// never advertises the capability (e.g. a candle-disabled box) refuses it.
 #[test]
 fn candle_worker_claims_kps_extract_no_torch_refusal() {
@@ -2436,12 +2433,9 @@ fn pose_detect_job(payload: Value) -> JobSnapshot {
 }
 
 /// sc-5496: the candle worker advertises `pose_detect` (the DWPose RTMW detector via the `ort` CUDA
-/// EP) and claims a pose_detect job — the off-Mac sibling of the macOS `ort`/CoreML path. Like
-/// kps_extract (and unlike SeedVR2), the Python rtmlib path CAN serve pose_detect, so there is NO
-/// torch-refusal gate: a co-resident torch worker that advertises the capability still claims it (the
-/// candle worker just runs it Python-free when it polls first; the Python path is retired wholesale in
-/// Phase 7, epic 5483). A worker that never advertises the capability (e.g. a candle-disabled box)
-/// refuses it.
+/// EP) and claims a pose_detect job — the off-Mac sibling of the macOS `ort`/CoreML path. The generic
+/// descriptor below is a synthetic capability-routing check, not a deployed fallback worker. A
+/// worker that never advertises the capability (e.g. a candle-disabled box) refuses it.
 #[test]
 fn candle_worker_claims_pose_detect_no_torch_refusal() {
     let payload = json!({ "sources": [{ "assetId": "a" }], "projectId": "p" });
@@ -2507,10 +2501,8 @@ fn person_track_job(payload: Value) -> JobSnapshot {
 /// sc-5498: the candle worker advertises `person_detect` + `person_track` (YOLO11 via the `ort`
 /// CUDA EP + the pure-Rust ByteTrack) and claims both — the off-Mac sibling of the macOS
 /// native-MLX path (sc-3633/sc-3634). Like kps_extract / pose_detect (and unlike SeedVR2), the
-/// Python Ultralytics path CAN serve them, so there is NO torch-refusal gate: a co-resident
-/// torch worker that advertises the capability still claims it (the candle worker just runs it
-/// Python-free when it polls first; the Python path is retired wholesale in Phase 7, epic 5483).
-/// A worker that never advertises the capability refuses the job. (These are the real,
+/// capability branch is also covered with a synthetic generic descriptor. Production has no
+/// Python fallback; a worker that never advertises the capability refuses the job. (These are the real,
 /// non-preview jobs; the procedural `preview: true` path keys off the separate
 /// `person_detect_preview` / `person_track_preview` capabilities.)
 #[test]
@@ -2575,7 +2567,7 @@ fn candle_worker_claims_joycaption_but_refuses_other_captioners() {
         &candle,
         &caption_job(json!({ "captioner": "joy_caption", "datasetId": "ds_1" }))
     ));
-    // Refuses a non-JoyCaption captioner → falls back to the Python torch worker.
+    // Refuses a non-JoyCaption captioner; without another native captioner it remains queued.
     assert!(!worker_supports_job(
         &candle,
         &caption_job(json!({ "captioner": "blip2", "datasetId": "ds_1" }))
@@ -2588,8 +2580,8 @@ fn candle_worker_claims_joycaption_but_refuses_other_captioners() {
 }
 
 /// sc-5501: the candle worker claims SenseNova-U1 `image_vqa` / `image_interleave` (served off-Mac
-/// by the concrete candle `T2iModel::{vqa, interleave_gen}`) but refuses other models, which stay
-/// on the Python torch worker.
+/// by the concrete candle `T2iModel::{vqa, interleave_gen}`) but refuses other models, which remain
+/// queued without another compatible native worker.
 #[test]
 fn candle_worker_claims_sensenova_understanding_but_refuses_other_models() {
     let candle = gpu_worker(&["gpu", "image_vqa", "image_interleave", "candle"]);
@@ -2659,7 +2651,7 @@ fn candle_worker_claims_sensenova_understanding_but_refuses_other_models() {
             json!({ "model": "sensenova_u1_8b_infographic_v3", "prompt": "an illustrated explainer" })
         )
     ));
-    // Refuses a non-SenseNova understanding job → falls back to the Python torch worker.
+    // Refuses a non-SenseNova understanding job; without another compatible native worker it remains queued.
     assert!(!worker_supports_job(
         &candle,
         &understanding_job(
@@ -2724,7 +2716,7 @@ fn sdxl_ipadapter_reference_jobs_route_to_candle() {
     assert!(!sdxl_ipadapter_candle_eligible(&object(
         json!({ "model": "sdxl" })
     )));
-    // img2img / inpaint / edit shapes are NOT this lane (those are sc-5487, still torch).
+    // img2img / inpaint / edit shapes are NOT this lane; unsupported shapes remain queued.
     assert!(!sdxl_ipadapter_candle_eligible(&object(json!({
         "model": "sdxl", "mode": "edit_image", "referenceAssetId": "a", "sourceAssetId": "s"
     }))));
@@ -2902,9 +2894,9 @@ fn image_edit_job_type_routes_through_candle_edit_lane() {
             "{model} edit via the `image_edit` job type must reach its candle lane"
         );
     }
-    // A torch-only edit family (`kolors` has a candle txt2img lane but no candle EDIT lane) submitted
-    // as `image_edit` is NOT candle-eligible: the candle worker must refuse it so it falls back to the
-    // co-resident torch worker, which claims it. (Mirrors the `image_generate` + edit_image case.)
+    // An unsupported edit family (`kolors` has a candle txt2img lane but no candle EDIT lane)
+    // submitted as `image_edit` is NOT candle-eligible. The generic descriptor asserted below is a
+    // synthetic compatibility check, not a deployed fallback; production leaves the job queued.
     let kolors_edit = json!({
         "model": "kolors",
         "mode": "edit_image",
@@ -2938,7 +2930,7 @@ fn kolors_ipadapter_reference_jobs_route_to_candle() {
     assert!(!kolors_ipadapter_candle_eligible(&object(
         json!({ "model": "kolors" })
     )));
-    // img2img / inpaint / edit shapes are NOT this lane (those are sc-5487, still torch).
+    // img2img / inpaint / edit shapes are NOT this lane; unsupported shapes remain queued.
     assert!(!kolors_ipadapter_candle_eligible(&object(json!({
         "model": "kolors", "mode": "edit_image", "referenceAssetId": "a", "sourceAssetId": "s"
     }))));
@@ -2964,7 +2956,7 @@ fn flux_ipadapter_reference_jobs_route_to_candle() {
     assert!(!flux_ipadapter_candle_eligible(&object(
         json!({ "model": "flux_dev" })
     )));
-    // img2img / inpaint / edit shapes are NOT this lane (those are sc-5487, still torch).
+    // img2img / inpaint / edit shapes are NOT this lane; unsupported shapes remain queued.
     assert!(!flux_ipadapter_candle_eligible(&object(json!({
         "model": "flux_dev", "mode": "edit_image", "referenceAssetId": "a", "sourceAssetId": "s"
     }))));
@@ -3007,7 +2999,7 @@ fn pulid_flux_character_jobs_route_to_candle_off_mac() {
 #[test]
 fn qwen_control_pose_jobs_route_to_candle() {
     // qwen_image + advanced.poses routes to the candle strict-pose lane (sc-5489) via the bespoke
-    // branch, NOT the txt2img gate (which DEFERS any advanced.poses job to torch).
+    // branch, NOT the txt2img gate (which refuses any `advanced.poses` job).
     let payload = json!({ "model": "qwen_image", "advanced": { "poses": [{ "keypoints": [] }] } });
     assert!(qwen_control_candle_eligible(&object(payload.clone())));
     assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
@@ -3035,7 +3027,7 @@ fn qwen_control_pose_jobs_route_to_candle() {
 #[test]
 fn kolors_control_pose_jobs_route_to_candle() {
     // kolors + advanced.poses routes to the candle strict-pose lane (sc-5489) via the bespoke
-    // branch, NOT the txt2img gate (which DEFERS any advanced.poses job to torch).
+    // branch, NOT the txt2img gate (which refuses any `advanced.poses` job).
     let payload = json!({ "model": "kolors", "advanced": { "poses": [{ "keypoints": [] }] } });
     assert!(kolors_control_candle_eligible(&object(payload.clone())));
     assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
@@ -3059,7 +3051,7 @@ fn kolors_control_pose_jobs_route_to_candle() {
 #[test]
 fn zimage_control_pose_jobs_route_to_candle() {
     // z_image_turbo + advanced.poses routes to the candle VACE strict-pose lane (sc-5489, the last
-    // family) via the bespoke branch, NOT the txt2img gate (which DEFERS any advanced.poses to torch).
+    // family) via the bespoke branch, NOT the txt2img gate (which refuses any `advanced.poses` job).
     let payload =
         json!({ "model": "z_image_turbo", "advanced": { "poses": [{ "keypoints": [] }] } });
     assert!(zimage_control_candle_eligible(&object(payload.clone())));
@@ -3085,8 +3077,8 @@ fn zimage_base_control_pose_jobs_route_to_candle() {
     assert!(zimage_control_candle_eligible(&object(payload.clone())));
     assert!(image_job_is_candle_eligible(&image_generate_job(payload)));
     // A base z_image with no poses is plain txt2img — now a candle lane too (sc-8679: the registered
-    // candle `z_image` base generator), so it routes to the generic candle txt2img gate rather than
-    // deferring to torch. It is NOT this strict-control lane, though.
+    // candle `z_image` base generator), so it routes to the generic candle txt2img gate. It is NOT
+    // this strict-control lane, though.
     let plain = json!({ "model": "z_image", "prompt": "a misty fjord" });
     assert!(!zimage_control_candle_eligible(&object(plain.clone())));
     assert!(image_job_is_candle_eligible(&image_generate_job(plain)));
@@ -3098,7 +3090,7 @@ fn zimage_base_control_pose_jobs_route_to_candle() {
 #[test]
 fn flux1_dev_control_pose_jobs_route_to_candle() {
     // sc-8412: flux_dev + advanced.poses routes to the candle Shakker Union-Pro-2.0 strict-control
-    // lane via the bespoke branch, NOT the txt2img gate (which DEFERS any advanced.poses to torch).
+    // lane via the bespoke branch, NOT the txt2img gate (which refuses any `advanced.poses` job).
     let payload = json!({ "model": "flux_dev", "advanced": { "poses": [{ "keypoints": [] }] } });
     assert!(flux1_control_candle_eligible(&object(payload.clone())));
     assert!(image_job_is_candle_eligible(&image_generate_job(payload)));

--- a/crates/sceneworks-core/src/jobs_store/tests/mlx_routing_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/mlx_routing_tests.rs
@@ -173,7 +173,7 @@ fn z_image_reference_without_poses_is_eligible() {
 #[test]
 fn z_image_reference_with_poses_stays_on_mlx() {
     // The strict pose ControlNet tier lives only on MLX, so a reference+pose
-    // job must route to the mlx worker, not torch (which would drop the poses).
+    // job must route to the mlx worker; a generic claimant could otherwise drop the poses.
     assert!(z_image_mlx_eligible(&object(json!({
         "referenceAssetId": "asset_1",
         "advanced": { "poses": [{ "id": "pose_1" }] }
@@ -294,11 +294,11 @@ fn qwen_edit_routes_edit_and_reference_flows_to_mlx() {
 
 #[test]
 fn qwen_edit_without_reference_falls_back_to_torch() {
-    // edit_image with nothing to edit (no source, no reference) → torch.
+    // edit_image with nothing to edit (no source, no reference) is refused and remains queued.
     assert!(!qwen_edit_mlx_eligible(&object(
         json!({ "mode": "edit_image" })
     )));
-    // character_image without a reference → torch (the edit model needs a reference).
+    // character_image without a reference is refused and remains queued (the edit model needs a reference).
     assert!(!qwen_edit_mlx_eligible(&object(
         json!({ "mode": "character_image" })
     )));
@@ -742,7 +742,7 @@ fn video_mode_eligibility_admits_flf_only_on_flf_capable_engines() {
         "first_last_frame"
     ));
     assert!(video_mode_is_mlx_eligible("wan_2_2", "first_last_frame"));
-    // FLF stays torch on the 14B Wan MoE engines (no engine Keyframe path).
+    // FLF remains queued on the 14B Wan MoE engines (no native engine Keyframe path).
     assert!(!video_mode_is_mlx_eligible(
         "wan_2_2_t2v_14b",
         "first_last_frame"
@@ -757,7 +757,7 @@ fn video_mode_eligibility_admits_flf_only_on_flf_capable_engines() {
         assert!(video_mode_is_mlx_eligible("ltx_2_3", mode));
         assert!(video_mode_is_mlx_eligible("ltx_2_3_eros", mode));
         assert!(video_mode_is_mlx_eligible("wan_2_2", mode));
-        // The 14B Wan MoE engines have no `Keyframe` path → torch.
+        // The 14B Wan MoE engines have no `Keyframe` path, so the request is refused.
         assert!(!video_mode_is_mlx_eligible("wan_2_2_t2v_14b", mode));
         assert!(!video_mode_is_mlx_eligible("wan_2_2_i2v_14b", mode));
     }

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -493,8 +493,8 @@ pub fn model_capabilities_for_type_and_family(model_type: &str, family: &str) ->
         model_type.trim().to_ascii_lowercase().as_str(),
         normalize_model_family(family).as_str(),
     ) {
-        // No `character_image`: the worker's ZImageDiffusersAdapter has no IP-Adapter
-        // / reference-conditioning code, and no Z-Image IP-Adapter exists upstream
+        // No `character_image`: the native Z-Image lane has no IP-Adapter/reference-conditioning
+        // code, and no Z-Image IP-Adapter exists upstream
         // (sc-2005). Custom z-image models that override capabilities can still
         // re-declare it, but the family default shouldn't claim what it can't do.
         ("image", "z-image") => vec!["text_to_image", "style_variations"],

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -1,10 +1,9 @@
 //! Rust-owned contracts for SceneWorks native LoRA training.
 //!
 //! SceneWorks owns its training product surface: dataset storage, manifests,
-//! validation, queue semantics, the target registry, and LoRA registration all
-//! live in Rust. Python is a narrow execution kernel that consumes a fully
-//! normalized [`TrainingPlan`] and produces weights — it never reads SceneWorks
-//! storage, config defaults, or this registry directly.
+//! validation, queue semantics, the target registry, LoRA registration, and
+//! execution all live in Rust. Native MLX/candle trainers consume a normalized
+//! [`TrainingPlan`]; unsupported backend/target combinations remain queued.
 //!
 //! These contracts are intentionally generic over `modality`, `output kind`,
 //! and `family` so the same shapes serve future image, video, and audio
@@ -182,7 +181,7 @@ pub struct TrainingTarget {
     /// Optional source repository for the base model weights.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_model_repo: Option<String>,
-    /// Identifier of the Python execution kernel that runs this target.
+    /// Identifier of the native execution kernel that runs this target.
     pub kernel: String,
     /// Visible (simple-panel) config defaults for this target.
     pub defaults: TrainingConfig,
@@ -270,7 +269,7 @@ pub struct TrainingConfig {
     /// knobs live here: `sampleEvery` (cadence in steps; 0 disables), `sampleSteps`,
     /// `sampleGuidanceScale`, `sampleCount` (images per step; default 4), and
     /// `samplePrompts` (string array; the UI prefills trigger-derived defaults).
-    /// All backends (torch/Lens/candle/MLX) cap the prompt pool at `sampleCount`
+    /// All native backends cap the prompt pool at `sampleCount`
     /// (one preview per prompt, truncated — never padded).
     pub advanced: JsonObject,
     #[serde(flatten)]
@@ -1307,9 +1306,8 @@ fn z_image_turbo_lora_target() -> TrainingTarget {
             "resolutions": [512, 768, 1024],
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-            // Network parameterization for the adapter. `lora` is the universal
-            // default; `lokr` (LyCORIS Kronecker) is a torch/PEFT-only option
-            // advertised on the validated image backends (epic 2193).
+            // Network parameterization for the adapter. `lora` is the universal default; `lokr`
+            // (LyCORIS Kronecker) is advertised on the validated native image backends (epic 2193).
             "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "outputScopes": ["project", "global"]
@@ -1441,10 +1439,10 @@ fn lens_turbo_lora_target() -> TrainingTarget {
 /// time by **family match, no base-model gating** (`lora_family.rs` gates only `wan-video`). The
 /// Turbo manifest declares `loraCompatibility.families: [krea_2]`.
 ///
-/// Rust-native, **no torch trainer** — but NOT Apple-Silicon-only (sc-8614): the `krea_lora` kernel
+/// Rust-native and NOT Apple-Silicon-only (sc-8614): the `krea_lora` kernel
 /// runs the in-process `mlx-gen-krea` trainer on Apple Silicon AND the `candle-gen-krea` trainer on
 /// Windows/Linux NVIDIA (a functional-autograd flow-match velocity loop on the single-stream DiT).
-/// There is no torch path, so `MLX_ONLY_TRAINING_KERNELS` keeps it off the torch worker while
+/// `MLX_ONLY_TRAINING_KERNELS` keeps it on native workers while
 /// `CANDLE_ROUTED_TRAINING_KERNELS` admits it on candle. The `appleSiliconOnly`/`requiresBackend`
 /// mlx-only markers are therefore omitted (matching the candle-capable z-image/lens targets);
 /// `MacTrainingSupport::supported_kernels` already lists `krea_lora` and is inert off-Mac.
@@ -1528,7 +1526,7 @@ fn krea_raw_lora_target() -> TrainingTarget {
             "lrSchedulers": ["constant", "linear", "cosine"],
             "outputScopes": ["project", "global"]
             // No `requiresBackend`/`appleSiliconOnly` markers: a Rust trainer runs on BOTH backends
-            // (mlx on Apple Silicon, candle on Windows/Linux NVIDIA — sc-8614), no torch path.
+            // (mlx on Apple Silicon, candle on Windows/Linux NVIDIA — sc-8614).
         })),
         ui: object(json!({
             "label": "Krea 2 LoRA",
@@ -1545,8 +1543,8 @@ fn krea_raw_lora_target() -> TrainingTarget {
 /// ([`TrainingOutputKind::ControlBranch`]), not a LoRA: the `krea_control` kernel trains a frozen-base
 /// conditioning branch on the Krea 2 Raw DiT that applies at Krea 2 Turbo inference — the off-Mac
 /// candle `krea_2_control` trainer (`engine_trainer_id`; candle-gen-krea `ControlTrainer`). It is
-/// **candle-only** today (no torch/MLX control trainer — the MLX lane is B5/sc-10177), so it is in
-/// [`CANDLE_ROUTED_TRAINING_KERNELS`] + [`MLX_ONLY_TRAINING_KERNELS`] (no-torch-fallback) but NOT
+/// **candle-only** today (no MLX control trainer — the MLX lane is B5/sc-10177), so it is in
+/// [`CANDLE_ROUTED_TRAINING_KERNELS`] + [`MLX_ONLY_TRAINING_KERNELS`] but NOT
 /// [`MLX_ROUTED_TRAINING_KERNELS`]. `defaults.advanced.controlType` selects the preprocessor/condition
 /// (pose first; canny/depth are Phase C, added by extending `controlTypes` once each trains through the
 /// studio). Gradient checkpointing is forced on (`candle_requires_gradient_checkpointing`) — the dense
@@ -1640,7 +1638,7 @@ fn krea_control_target() -> TrainingTarget {
 /// `mlx-gen-sd3` `register_trainer` id `sd3_5_large`, T2 sc-7883) and apply back at `sd3_5_large`
 /// — and the family-arch-identical `sd3_5_large_turbo` — inference via the `sd3` LoRA family
 /// (no base-model gating; the family match alone gates eligibility, mirroring Krea Raw→Turbo).
-/// Native MLX only (no torch SD3 trainer; off-Mac/candle is epic 7982), so Apple-Silicon-gated.
+/// Native MLX only (off-Mac/candle is epic 7982), so Apple-Silicon-gated.
 fn sd3_large_lora_target() -> TrainingTarget {
     TrainingTarget {
         id: "sd3_5_large_lora".to_owned(),
@@ -1715,7 +1713,7 @@ fn sd3_large_lora_target() -> TrainingTarget {
             "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "outputScopes": ["project", "global"],
-            // Native MLX trainer — no torch SD3 path (mirrors the Krea / LTX MLX targets).
+            // Native MLX trainer, mirroring the Krea / LTX MLX targets.
             "requiresBackend": "mlx",
             "appleSiliconOnly": true
         })),
@@ -1905,10 +1903,11 @@ fn ltx_video_lora_target() -> TrainingTarget {
 /// encodes to a single Wan-VAE latent frame, `numFrames: 1`) with a flow-matching
 /// velocity loop on the `WanTransformer3DModel` attention projections
 /// (`to_q`/`to_k`/`to_v`/`to_out.0`). The trainer is per-platform: off-Mac the
-/// `wan_lora` kernel is torch/diffusers (CUDA), while on macOS the job routes to
-/// the native in-process MLX trainer (`mlx-gen-wan`'s `wan2_2_ti2v_5b`), which
+/// `wan_lora` kernel has a native in-process MLX trainer on macOS
+/// (`mlx-gen-wan`'s `wan2_2_ti2v_5b`), which
 /// loads the installed `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey's dense bf16 tier —
-/// NOT torch/MPS (sc-13878). The output registers as a `wan-video` family LoRA the
+/// is selected instead of the retired backend (sc-13878). Off-Mac, this dense-5B shape has no
+/// candle trainer and remains queued. The output registers as a `wan-video` family LoRA the
 /// Wan video adapter loads at generation. This dense 5B target is the base the 14B
 /// (A14B MoE) trainer extends for the two-expert (high/low-noise) case.
 fn wan_lora_target() -> TrainingTarget {
@@ -1920,13 +1919,10 @@ fn wan_lora_target() -> TrainingTarget {
         family: "wan-video".to_owned(),
         base_model: "wan_2_2".to_owned(),
         // sc-13860: intentionally the `Wan-AI/Wan2.2-TI2V-5B-Diffusers` diffusers snapshot, NOT the
-        // `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey. The off-Mac `wan_lora` kernel is torch/diffusers, so it
-        // needs DIFFUSERS weights — not the MLX-packed turnkey. On Windows/Linux the catalog installs
-        // exactly this repo as the `bf16` variant (builtin.models.jsonc), so the install gate finds it
-        // there (that torch/CUDA path is where #1694 was reported). This is NOT the epic-8506 mis-naming
-        // class the sibling targets hit — the repo is correct — so pointing at the MLX turnkey would only
-        // hand the off-Mac torch trainer weights it can't load. The diffusers download is gated to
-        // Windows/Linux; on macOS the job runs the native MLX trainer against the installed
+        // `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey. This diffusers repository remains the canonical
+        // off-Mac install artifact, although the dense-5B training shape currently has no candle
+        // trainer and remains queued. This is NOT the epic-8506 mis-naming class the sibling targets
+        // hit — the repo is correct. On macOS the job runs the native MLX trainer against the installed
         // `SceneWorks/wan2.2-ti2v-5b-mlx` turnkey instead, which the platform-aware training gate +
         // base-path resolver select (apps/rust-api/src/training.rs `macos_wan_*`, sc-13878) — so
         // `base_model_repo` stays the diffusers repo and is simply not consulted on macOS.
@@ -1942,9 +1938,8 @@ fn wan_lora_target() -> TrainingTarget {
             resolution: 512,
             save_every: 250,
             seed: 42,
-            // torch AdamW: cross-platform (CUDA + MPS). adamw8bit is CUDA-only
-            // (bitsandbytes) and falls back to AdamW elsewhere, so the default
-            // stays plain adamw like the LTX video target.
+            // Plain AdamW is the portable contract default; accelerator-specific optimizers can be
+            // selected explicitly, so the default stays aligned with the LTX video target.
             optimizer: "adamw".to_owned(),
             trigger_word: None,
             advanced: object(json!({
@@ -1984,10 +1979,9 @@ fn wan_lora_target() -> TrainingTarget {
             "resolutions": [512, 768],
             "batchSize": [1, 2],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-            // Wan2.2 TI2V-5B is a torch/diffusers backend: the PEFT LoKr trainer
-            // (sc-2196) applies and the diffusers video inference loads it via PEFT
-            // injection (sc-2197/2211). MLX video has no Kronecker merge yet, so a
-            // LoKr Wan job falls back to the torch path (sc-2211; native MLX is sc-2213).
+            // Wan2.2 TI2V-5B offers LoRA and LoKr plans. The MLX trainer has no Kronecker
+            // merge yet, so a LoKr Wan job is refused by that lane and remains queued for
+            // a compatible native trainer (sc-2211; native MLX work was tracked in sc-2213).
             "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "outputScopes": ["project", "global"]
@@ -2008,9 +2002,9 @@ fn wan_lora_target() -> TrainingTarget {
 /// low-noise expert (`transformer_2`), so the `wan_moe_lora` kernel trains a
 /// separate LoRA on each, split at the pipeline `boundary_ratio` (0.875), and
 /// saves two `wan-video` family files. Same flow-matching recipe as the dense 5B
-/// `wan_lora` target (still-image dataset), and the same per-platform backend split —
-/// off-Mac torch/diffusers (CUDA), on macOS the native MLX trainer against the
-/// installed `SceneWorks/wan2.2-{t2v,i2v}-a14b-mlx` turnkey's dense tier (sc-13878).
+/// `wan_lora` target (still-image dataset). On macOS it uses the native MLX trainer against the
+/// installed `SceneWorks/wan2.2-{t2v,i2v}-a14b-mlx` turnkey's dense tier (sc-13878). Off-Mac,
+/// candle serves the T2V A14B trainer; the unsupported I2V shape remains queued.
 /// The A14B bf16 base is GPU-only (~56GB of transformers); the Q8_0 GGUF base path
 /// fits memory-bound hosts. `base_model` records the specific A14B variant so the
 /// inference loader gates the LoRA to the matching model (not the 5B).
@@ -2069,8 +2063,8 @@ fn wan_moe_lora_target(
             "resolutions": [512, 768],
             "batchSize": [1, 2],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-            // Wan is a torch backend, but epic 2193 v1 validates LoKr on the
-            // image backends (Z-Image/SDXL) first; video stays `lora`-only.
+            // Wan video training currently stays `lora`-only; epic 2193 v1 validates LoKr on the
+            // image backends (Z-Image/SDXL) first.
             "networkTypes": ["lora"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "outputScopes": ["project", "global"]
@@ -2181,7 +2175,7 @@ fn sdxl_lora_target() -> TrainingTarget {
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
             // See the Z-Image target: `lokr` (LyCORIS Kronecker) is advertised on
-            // the validated torch/PEFT image backends (epic 2193).
+            // the validated native image backends (epic 2193).
             "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
             "outputScopes": ["project", "global"]
@@ -2412,8 +2406,8 @@ fn kolors_lora_target() -> TrainingTarget {
             "resolutions": [768, 1024],
             "batchSize": [1, 4],
             "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
-            // Kolors is an SDXL-architecture torch/PEFT backend, so it advertises
-            // `lokr` like the SDXL target — inherited from the shared SDXL backend's
+            // Kolors uses the SDXL-architecture adapter contract, so it advertises
+            // `lokr` like the SDXL target — inherited from the shared backend's
             // LoKr save + PEFT-injection inference path (epic 2193, sc-2217).
             "networkTypes": ["lora", "lokr"],
             "lrSchedulers": ["constant", "linear", "cosine"],
@@ -2731,7 +2725,7 @@ fn validate_lr_scheduler(config: &TrainingConfig) -> Result<(), TrainingPlanErro
 /// 10512, sc-10522). Trained on the undistilled `anima_base` (like Krea Raw→Turbo / SD3 Large→turbo);
 /// the family-arch-identical aesthetic/turbo variants apply the same adapter back via
 /// `apply_anima_adapters`. The native `mlx-gen-anima` trainer trains the 448 DiT targets **and** the
-/// 60 `llm_adapter` conditioner targets (508 total). mlx-only (no torch/candle Anima trainer). NB the
+/// 60 `llm_adapter` conditioner targets (508 total). MLX-only (no candle Anima trainer). NB the
 /// `mlx-gen-anima` trainer does not yet honor gradient checkpointing or preview sampling (dense-only,
 /// no in-training previews), so those advanced knobs default off here — that parity work (gradient
 /// checkpointing + OOM guard, in-training preview, mid-run resume, and the >1024 resolution ceiling)

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -11,9 +11,9 @@
 //! / `person_track`) are parsed and carried so the asset fact + routing layer see
 //! them. The MLX video path now consumes them for the cutover modes: `first_last_frame`
 //! (two keyframes, sc-3520) and `replace_person` (the `source_clip` + `person_track` +
-//! character refs → native Wan-VACE, sc-3521). `extend_clip` / `video_bridge` still stay
-//! on the Python torch worker for now (sc-3522). The MLX-vs-Python routing decision is
-//! sc-3036.
+//! character refs → native Wan-VACE, sc-3521), plus `extend_clip` / `video_bridge` on LTX and Wan
+//! TI2V-5B (sc-3522 / sc-3357). Unsupported modes are refused and remain queued. The native-worker
+//! routing decision is sc-3036.
 
 use serde_json::Value;
 
@@ -86,7 +86,7 @@ pub struct VideoRequest {
     /// to the same `fit_engine_image` helper the image-edit lane uses so a square
     /// source no longer silently stretches into an off-aspect output.
     pub fit_mode: String,
-    // --- Advanced-mode fields: parsed + carried, but Python-routed (sc-3036). ---
+    // --- Advanced-mode fields parsed and carried into the native MLX/candle dispatch paths. ---
     pub person_track_id: Option<String>,
     pub replacement_mode: String,
     pub last_frame_asset_id: Option<String>,

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -2587,7 +2587,7 @@ fn image_job_with(payload: Value, requested_gpu: &str) -> CreateJob {
 }
 
 /// Capabilities a real image GPU worker advertises once it also serves the distinct
-/// `image_edit` job type (sc-3513) — both the Python torch worker (`IMAGE_JOB_TYPES`)
+/// `image_edit` job type (sc-3513). The synthetic generic descriptor used by these routing tests
 /// and the macOS mlx worker (`gpu::mlx_gpu`) carry `image_edit` alongside `image_generate`.
 fn image_edit_caps() -> Vec<WorkerCapability> {
     vec![
@@ -2648,7 +2648,7 @@ fn mlx_eligible_image_job_defers_from_torch_worker_to_idle_mlx_worker() {
         ))
         .expect("job creates");
 
-    // The torch worker defers the MLX-eligible job to the idle mlx worker.
+    // The synthetic generic descriptor refuses the MLX-eligible job; the idle mlx worker claims it.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -2681,7 +2681,7 @@ fn qwen_edit_image_job_defers_to_mlx_worker() {
         ))
         .expect("job creates");
 
-    // The torch worker defers it to the idle mlx worker, which claims it.
+    // The synthetic generic descriptor refuses it; the idle mlx worker claims it.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -2735,7 +2735,7 @@ fn sensenova_understanding_jobs_defer_to_mlx_worker() {
             })
             .expect("job creates");
 
-        // The torch worker defers it to the idle mlx worker, which claims it in-process.
+        // The synthetic generic descriptor refuses it; the idle mlx worker claims it in-process.
         assert!(
             store
                 .claim_next_job("worker-torch")
@@ -2789,7 +2789,7 @@ fn mlx_worker_excluded_from_torch_only_image_job() {
     let store = store("mlx-routing-exclude");
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // edit_image on a Z-Image model is not a txt2img request → torch path only.
+    // edit_image on a Z-Image model without the required source shape is refused by MLX.
     let job = store
         .create_job(image_job_with(
             json!({
@@ -2801,13 +2801,13 @@ fn mlx_worker_excluded_from_torch_only_image_job() {
         ))
         .expect("job creates");
 
-    // The mlx worker must not claim a torch-only image job.
+    // The mlx worker must not claim an unsupported image job.
     assert!(store
         .claim_next_job("worker-mlx")
         .expect("mlx claim ok")
         .is_none());
 
-    // A torch worker is the home for it.
+    // The generic descriptor below is a synthetic compatibility check, not a deployed fallback.
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     let claimed = store
         .claim_next_job("worker-torch")
@@ -2830,7 +2830,8 @@ fn mlx_eligible_image_job_falls_back_to_torch_when_no_mlx_worker() {
         ))
         .expect("job creates");
 
-    // With no idle mlx worker, nothing defers — the torch worker is the fallback.
+    // Legacy warn-mode fixture: the synthetic generic descriptor can claim when no mlx worker is idle.
+    // Production has no fallback; unsupported work remains queued.
     let claimed = store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -2839,10 +2840,10 @@ fn mlx_eligible_image_job_falls_back_to_torch_when_no_mlx_worker() {
     assert_eq!(claimed.assigned_gpu.as_deref(), Some("cuda:0"));
 }
 
-// epic 3482 / sc-3483 — macOS "MLX-required": the MPS worker never claims an MLX-eligible
+// epic 3482 / sc-3483 — macOS "MLX-required": a synthetic MPS descriptor never claims an MLX-eligible
 // job, and a job no live `mlx` worker takes within the grace window fails terminal with
-// `mlx_unavailable` rather than silently running on MPS. Ships behind a flag (default OFF);
-// the sibling `*_falls_back_to_torch_*` tests above pin the OFF behaviour.
+// `mlx_unavailable` rather than entering the legacy compatibility branch. Ships behind a flag
+// (default OFF); the sibling legacy-routing fixtures above pin the OFF behaviour.
 
 /// Backdate a job's `created_at` so the grace sweep treats it as having outlived the
 /// window (mirrors how `stale_sweep_*` backdates `last_seen_at`).
@@ -2908,8 +2909,8 @@ fn queue_summary_counts_and_active_jobs_ignore_500_row_cap() {
 fn mlx_required_defers_eligible_job_even_with_no_idle_mlx_worker() {
     let store = store("mlx-required-defer");
     // Only an MPS worker is registered — no idle `mlx` worker to take the job. With the
-    // flag OFF this is exactly the torch fallback; with it ON the MPS worker yields
-    // unconditionally ("never MPS" on Mac).
+    // flag OFF this exercises the legacy generic-worker branch; with it ON the MPS worker yields
+    // unconditionally ("never MPS" on Mac). Production has no Python fallback.
     register_gpu_worker(&store, "worker-mps", "mps", image_caps());
     store
         .create_job(image_job_with(
@@ -3006,8 +3007,8 @@ fn fail_stranded_mlx_jobs_is_noop_when_not_required() {
 
 #[test]
 fn mlx_required_still_lets_mps_claim_a_non_eligible_model() {
-    // 3483 only kills the MPS fallback for MLX-*eligible* jobs. A torch-only model is not
-    // eligible, so it is NOT deferred and still runs on MPS — surfacing it as a loud
+    // 3483 only gates MLX-*eligible* jobs. An unsupported model is not eligible, so this synthetic
+    // MPS descriptor can still claim it — surfacing it as a loud
     // `mlx_unsupported` failure is sc-3484's job, not this slice's.
     let store = store("mlx-required-noneligible");
     register_gpu_worker(&store, "worker-mps", "mps", image_caps());
@@ -3055,7 +3056,7 @@ fn candle_supported_accepts_eligible_and_in_process_jobs() {
         json!({ "model": "z_image_turbo", "prompt": "p" }),
     );
     assert!(candle_supported(&eligible).is_ok());
-    // In-process job types run off-Mac with zero torch.
+    // In-process job types run off-Mac on native Rust lanes.
     let download = job_of(&store, JobType::ModelDownload, json!({ "repo": "x/y" }));
     assert!(candle_supported(&download).is_ok());
     let refine = job_of(&store, JobType::PromptRefine, json!({ "prompt": "p" }));
@@ -3082,14 +3083,14 @@ fn candle_supported_rejects_unsupported_strict_pose() {
 
 #[test]
 fn candle_supported_flags_a_torch_only_image_model() {
-    // `pulid_flux_dev` is txt2img-torch-only off-Mac: its ONLY candle lane is the bespoke
+    // `pulid_flux_dev` plain txt2img is unsupported off-Mac: its ONLY candle lane is the bespoke
     // character-reference path (`pulid_flux_candle_eligible`, which needs character_image + a
     // referenceAssetId), so a PLAIN txt2img prompt has no candle route and it is not in
     // CANDLE_ROUTED_MODELS — the candle/CUDA oracle must flag it as an unsupported image model off-Mac.
     // (`bernini_image` used to be the example here but is now candle-routed — sc-10996, epic 6562; the
     // base `sana_1600m` was the example next but is now candle-routed too — sc-11780, epic 8485; then
     // `sana_sprint_1600m`, but the CFG-free SANA-Sprint distill is candle-routed too now — sc-11781,
-    // epic 8485. PuLID-FLUX's reference-less txt2img shape is the still-torch-only representative.)
+    // epic 8485. PuLID-FLUX's reference-less txt2img shape is the remaining unsupported representative.)
     let store = store("candle-oracle-torch-model");
     let job = job_of(
         &store,
@@ -3111,7 +3112,7 @@ fn candle_required_enforce_fails_unsupported_job() {
         JobType::ImageGenerate,
         json!({ "model": "sdxl", "prompt": "p", "advanced": { "poses": [{ "id": "p" }] } }),
     );
-    // Warn mode (enforce = false): no-op, the job stays queued (still runs on torch).
+    // Warn mode (enforce = false): no-op; the unsupported job stays queued.
     let warn = store
         .fail_unsupported_candle_jobs(true, false)
         .expect("sweep ok");
@@ -3166,7 +3167,7 @@ fn candle_required_enforce_leaves_eligible_job_queued() {
 #[test]
 fn candle_required_fails_stranded_eligible_job_when_no_live_candle_worker() {
     let store = store("candle-strand");
-    // A non-candle torch GPU worker exists, but no candle worker — the candle-eligible job strands.
+    // A synthetic generic GPU descriptor exists, but no candle worker; the candle-eligible job strands.
     register_gpu_worker(&store, "worker-torch", "0", image_caps());
     let job = job_of(
         &store,
@@ -3459,7 +3460,7 @@ fn mac_rust_supported_names_infra_job_types() {
     let person_track = job_of(&store, JobType::PersonTrack, json!({}));
     assert!(mac_rust_supported(&person_track).is_ok());
     // replace_person → native Wan-VACE is supported on a replace-capable MLX video model
-    // (sc-3521); a replace_person job on a model with no MLX video engine stays a torch gap.
+    // (sc-3521); a replace_person job on a model with no native video engine remains queued.
     let replace_mlx = job_of(
         &store,
         JobType::PersonReplace,
@@ -3513,7 +3514,8 @@ fn mac_rust_supported_names_infra_job_types() {
 #[test]
 fn mac_rust_supported_names_advanced_video_and_svd() {
     let store = store("oracle-video");
-    // extend / bridge on a 14B Wan MoE engine: no `Keyframe` path → torch gap (sc-3522 / sc-3357).
+    // Extend / bridge on a 14B Wan MoE engine has no `Keyframe` path, so it is a native gap
+    // (sc-3522 / sc-3357).
     // The mode is derived from the job type, so a missing payload `mode` still classifies correctly.
     let extend = job_of(
         &store,
@@ -3604,7 +3606,7 @@ fn mac_rust_supported_convert_flux2_ok_else_python_gap() {
         json!({ "model": "sd3_5_medium", "converter": "sd3_5_medium_quant" }),
     );
     assert!(mac_rust_supported(&sd3).is_ok());
-    // The default/absent converter is the Python mlx-video Wan/LTX path → gap.
+    // The default/absent converter has no native implementation and remains an unsupported gap.
     let wan = job_of(&store, JobType::ModelConvert, json!({ "model": "wan_2_2" }));
     assert_eq!(
         mac_rust_supported(&wan)
@@ -3922,7 +3924,7 @@ fn model_mac_support_feature_flags_mirror_routing_without_over_gating() {
         .video_modes;
     assert_eq!(ltx.get("extend_clip"), Some(&true));
     assert_eq!(ltx.get("video_bridge"), Some(&true));
-    // The 14B Wan MoE engines have no FLF Keyframe path → torch.
+    // The 14B Wan MoE engines have no FLF Keyframe path, so FLF is unsupported.
     assert_eq!(
         model_mac_support("wan_2_2_t2v_14b", "video", None)
             .features
@@ -4177,7 +4179,7 @@ fn routing_decision_reports_claimed_by_candle() {
     let store = store("route-decision-candle");
     // The Windows/Linux happy path: the candle (CUDA) worker — identified by the `candle`
     // capability marker, on a real gpu index ("0") — claims an MLX-eligible auto job. The
-    // decision names candle, never "fell back to torch": nothing is missing here.
+    // decision names candle directly: nothing is missing here.
     register_candle_worker(&store, "worker-candle");
     let job = store
         .create_job(image_job_with(
@@ -4264,9 +4266,9 @@ fn routing_decision_is_none_for_non_mlx_model() {
 // "Plain Image Edit" is submitted as JobType::ImageEdit (mode=edit_image + sourceAssetId),
 // a *distinct* job type from the character/reference flow (JobType::ImageGenerate). The
 // engine dispatches edits on payload model+mode, not job type, so the edit-capable families
-// (qwen/flux2/sdxl) must route to the in-process mlx worker exactly like the generate flow;
-// torch-only edit models stay on torch. Before sc-3513 the routing gate excluded every
-// non-ImageGenerate type, so these jobs ran on torch silently with no `gpu_route_decision`.
+// (qwen/flux2/sdxl) must route to the in-process mlx worker exactly like the generate flow.
+// Unsupported edit models remain queued. Before sc-3513 the routing gate excluded every
+// non-ImageGenerate type, so these jobs took the generic branch with no `gpu_route_decision`.
 
 #[test]
 fn qwen_image_edit_job_type_defers_to_mlx_worker() {
@@ -4286,7 +4288,7 @@ fn qwen_image_edit_job_type_defers_to_mlx_worker() {
         ))
         .expect("job creates");
 
-    // The torch worker defers the MLX-eligible edit to the idle mlx worker, which claims it.
+    // The synthetic generic descriptor refuses the MLX-eligible edit; the idle mlx worker claims it.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -4357,10 +4359,10 @@ fn active_mlx_image_edit_blocks_mps_image_edit_claim() {
     assert_eq!(claimed_mlx.id, mlx_job.id);
     assert_eq!(claimed_mlx.assigned_gpu.as_deref(), Some("mlx"));
 
-    // An unported image model is the MPS job: not in MLX_ROUTED_MODELS, so it isn't MLX-eligible and
-    // isn't soft-deferred to the mlx worker — it stays on the torch worker, exercising the shared-GPU
-    // exclusion cleanly. (No real image model is torch-only anymore: Lens — formerly this example —
-    // is MLX after epic 3164 / sc-5105, as Kolors/PuLID-FLUX were before it.)
+    // An unported image model is assigned to the synthetic generic descriptor in this compatibility
+    // test: it is not in MLX_ROUTED_MODELS, so it is not soft-deferred to the mlx worker. Production
+    // has no such fallback worker, so an unsupported model remains queued. (Every real built-in image
+    // family is MLX-routed after Lens landed in epic 3164 / sc-5105.)
     let mps_job = store
         .create_job(image_job_with(
             json!({
@@ -4394,9 +4396,8 @@ fn active_mps_image_edit_blocks_mlx_image_edit_claim() {
     register_gpu_worker(&store, "worker-mps", "mps", image_edit_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
-    // An unported image model is the MPS job (not in MLX_ROUTED_MODELS, so it isn't soft-deferred to
-    // the mlx worker). No real image model is torch-only anymore — Lens, the last one, is MLX after
-    // epic 3164 / sc-5105 (PuLID-FLUX was MLX after sc-3344).
+    // A synthetic unported image model exercises the MPS compatibility descriptor (not in
+    // MLX_ROUTED_MODELS, so it is not soft-deferred to mlx). Production has no MPS fallback.
     let mps_job = store
         .create_job(image_job_with(
             json!({
@@ -4474,10 +4475,10 @@ fn torch_only_image_model_stays_on_torch() {
     let store = store("mlx-routing-image-torch-only");
     register_gpu_worker(&store, "worker-mlx", "mlx", image_edit_caps());
 
-    // An unported image model (not in MLX_ROUTED_MODELS) stays on the Python torch path and the mlx
-    // worker must refuse it. Every ported image family — incl. Kolors' full surface (epic 3090),
-    // PuLID-FLUX (sc-3344), and Lens (epic 3164 / sc-5105, the last one) — is MLX now, so a
-    // torch-only example must come from an unported model id.
+    // An unported image model (not in MLX_ROUTED_MODELS) is refused by the mlx worker and remains
+    // queued in production. Every ported image family — incl. Kolors' full surface (epic 3090),
+    // PuLID-FLUX (sc-3344), and Lens (epic 3164 / sc-5105, the last one) — is MLX now, so this
+    // synthetic compatibility example must use an unported model id.
     let job = store
         .create_job(image_job_with(
             json!({
@@ -4493,7 +4494,8 @@ fn torch_only_image_model_stays_on_torch() {
         .expect("mlx claim ok")
         .is_none());
 
-    // A torch worker is the home for it, and the claim is routing-neutral (no event).
+    // This legacy fixture exercises a synthetic generic claim, which is routing-neutral (no event).
+    // Production has no fallback; unsupported shapes remain queued.
     register_gpu_worker(&store, "worker-torch", "mps", image_edit_caps());
     let (claimed, decision) = store
         .claim_next_job_routed("worker-torch", false)
@@ -4542,7 +4544,7 @@ fn explicit_gpu_image_job_is_not_deferred_to_mlx_worker() {
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // The user explicitly pinned this MLX-eligible job to the torch GPU; honour it.
+    // This legacy fixture pins the MLX-eligible job to a synthetic generic GPU descriptor.
     let job = store
         .create_job(image_job_with(
             json!({ "model": "z_image_turbo", "prompt": "p" }),
@@ -4698,7 +4700,7 @@ fn mlx_eligible_training_job_defers_from_torch_worker_to_idle_mlx_worker() {
         ))
         .expect("job creates");
 
-    // The torch worker defers the MLX-native training job to the idle mlx worker.
+    // The synthetic generic descriptor refuses the MLX-native job; the idle mlx worker claims it.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -4730,7 +4732,7 @@ fn mlx_eligible_kolors_training_job_defers_from_torch_worker_to_idle_mlx_worker(
         ))
         .expect("job creates");
 
-    // The torch worker defers the now-MLX-native kolors training job to the idle mlx worker.
+    // The synthetic generic descriptor refuses the MLX-native job; the idle mlx worker claims it.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -4780,7 +4782,7 @@ fn mlx_worker_excluded_from_lokr_wan_training_job() {
     let store = store("mlx-training-lokr-wan");
     register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
 
-    // LoKr-on-Wan has no Kronecker merge in the mlx Wan path → torch only.
+    // LoKr-on-Wan has no Kronecker merge in the mlx Wan path, so MLX refuses it.
     let job = store
         .create_job(mlx_training_job(
             "wan_moe_lora",
@@ -4836,7 +4838,8 @@ fn lokr_z_image_training_stays_mlx_eligible() {
 #[test]
 fn mlx_eligible_training_falls_back_to_torch_when_no_mlx_worker() {
     let store = store("mlx-training-fallback");
-    // No mlx worker (Windows/Linux, or it's down) — torch is the only path.
+    // Legacy compatibility fixture with no mlx worker. Production has no fallback; unsupported
+    // work remains queued for a compatible native worker.
     register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
 
     let job = store
@@ -4865,8 +4868,8 @@ fn candle_training_caps() -> Vec<WorkerCapability> {
 #[test]
 fn candle_worker_claims_candle_native_training_kernels() {
     // The five families with a candle trainer (sdxl / z_image / lens / Krea 2 Raw / Wan A14B T2V)
-    // route to the candle worker off-Mac. `krea_lora` is no-torch-fallback (MLX_ONLY) yet candle
-    // claims it (sc-8614) — the gate exempts a candle-eligible job from the mlx-only refusal. Each in
+    // route to the candle worker off-Mac. `krea_lora` is listed in MLX_ONLY yet candle claims it
+    // (sc-8614) — the gate exempts a candle-eligible job from the mlx-only refusal. Each in
     // its own store so the claim is unambiguous.
     let cases: &[(&str, &str, &str)] = &[
         ("sdxl_lora", "sdxl", "lora"),
@@ -4897,10 +4900,10 @@ fn candle_worker_claims_candle_native_training_kernels() {
 
 #[test]
 fn candle_worker_refuses_torch_served_training_kernels() {
-    // Kernels with no candle trainer but a torch fallback: the candle worker must REFUSE them (the
-    // `lora_train_execute` advertisement is coarse), leaving them for the co-resident torch worker —
-    // otherwise the candle worker would claim and fail terminally. Covers Kolors, the dense Wan 5B,
-    // and the I2V A14B (candle has only the T2V A14B trainer).
+    // Kernels with no candle trainer must be refused by candle because the
+    // `lora_train_execute` advertisement is coarse; production leaves them queued instead of
+    // mis-claiming and failing terminally. The generic descriptor below is a synthetic compatibility
+    // check. Covers Kolors, the dense Wan 5B, and the I2V A14B.
     let cases: &[(&str, &str)] = &[
         ("kolors_lora", "kolors"),
         ("wan_lora", "wan_2_2"),
@@ -4919,7 +4922,7 @@ fn candle_worker_refuses_torch_served_training_kernels() {
                 .is_none(),
             "candle must refuse {kernel}/{base_model} (no candle trainer)"
         );
-        // The co-resident torch worker serves it.
+        // A synthetic generic training descriptor can claim it in this isolated routing test.
         register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
         let claimed = store
             .claim_next_job("worker-torch")
@@ -4931,8 +4934,8 @@ fn candle_worker_refuses_torch_served_training_kernels() {
 
 #[test]
 fn candle_worker_refuses_ltx_mlx_only_training() {
-    // ltx_mlx_lora has no torch fallback (MLX_ONLY_TRAINING_KERNELS) AND no candle trainer, so off-Mac
-    // neither the candle worker nor a torch worker may claim it — it stays queued for an mlx worker.
+    // ltx_mlx_lora is native-MLX-only (MLX_ONLY_TRAINING_KERNELS) and has no candle trainer, so off-Mac
+    // neither candle nor a generic descriptor may claim it; it stays queued for an mlx worker.
     let store = store("candle-refuse-ltx");
     register_gpu_worker(&store, "worker-candle", "0", candle_training_caps());
     register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
@@ -4964,8 +4967,8 @@ fn candle_worker_refuses_ltx_mlx_only_training() {
 #[test]
 fn ltx_training_is_mlx_worker_only_with_no_torch_fallback() {
     let store = store("mlx-training-ltx-only");
-    // sc-3049 retired the Python MLX LTX trainer, so `ltx_mlx_lora` has no torch
-    // fallback: a torch worker must NOT claim it — it stays queued for the mlx worker.
+    // sc-3049 retired the Python MLX LTX trainer, so `ltx_mlx_lora` is native-only: a generic
+    // worker must NOT claim it — it stays queued for the mlx worker.
     register_gpu_worker(&store, "worker-torch", "mps", training_caps());
     let job = store
         .create_job(mlx_training_job(
@@ -4995,8 +4998,8 @@ fn ltx_training_is_mlx_worker_only_with_no_torch_fallback() {
 #[test]
 fn krea_training_has_no_torch_fallback_but_runs_on_either_rust_backend() {
     let store = store("training-krea-no-torch");
-    // Krea 2 (epic 7565) trains on a native Rust trainer and has NO torch path, so — like LTX — a
-    // torch worker must NOT claim a `krea_lora` job. UNLIKE LTX it is Rust-only on BOTH backends:
+    // Krea 2 (epic 7565) trains on a native Rust trainer, so — like LTX — a generic worker must NOT
+    // claim a `krea_lora` job. UNLIKE LTX it is Rust-only on BOTH backends:
     // the mlx worker (Mac) and, since sc-8614, the candle worker (off-Mac) each run it.
     register_gpu_worker(&store, "worker-torch", "mps", training_caps());
     let job = store
@@ -5009,13 +5012,13 @@ fn krea_training_has_no_torch_fallback_but_runs_on_either_rust_backend() {
         ))
         .expect("job creates");
 
-    // Torch defers (no Krea torch trainer).
+    // The synthetic generic descriptor refuses Krea because it has no matching native trainer.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
         .is_none());
 
-    // The candle worker claims it off-Mac (sc-8614): no-torch-fallback no longer means mlx-only.
+    // The candle worker claims it off-Mac (sc-8614), so Krea is native on both Rust backends.
     register_gpu_worker(&store, "worker-candle", "0", candle_training_caps());
     let claimed = store
         .claim_next_job("worker-candle")
@@ -5050,9 +5053,9 @@ fn control_training_job(requested_gpu: &str) -> CreateJob {
 
 #[test]
 fn control_training_routes_to_candle_only() {
-    // The Krea pose-ControlNet trainer is candle-only (epic 10159): `krea_control` has no torch and no
-    // MLX trainer (the MLX control lane is B5/sc-10177), so neither a torch nor an mlx worker may claim
-    // a `control_training` job — only the candle worker does.
+    // The Krea pose-ControlNet trainer is candle-only (epic 10159): it has no MLX trainer (the MLX
+    // control lane is B5/sc-10177), so a generic or mlx descriptor refuses `control_training`;
+    // only the candle worker claims it.
     let store = store("control-training-candle-only");
     register_gpu_worker(&store, "worker-torch", "cuda:0", training_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
@@ -5060,7 +5063,7 @@ fn control_training_routes_to_candle_only() {
         .create_job(control_training_job("auto"))
         .expect("job creates");
 
-    // Torch refuses (no torch control trainer — krea_control is no-torch-fallback).
+    // The synthetic generic descriptor refuses because it has no native control trainer.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -5113,7 +5116,7 @@ fn krea_training_runs_on_the_mlx_worker() {
 fn lokr_krea_training_stays_mlx_eligible() {
     let store = store("mlx-training-krea-lokr");
     // Unlike Wan (no MLX Kronecker merge), Krea's native trainer + Turbo inference seam both
-    // handle LoKr, so a LoKr `krea_lora` job stays MLX-eligible and is NOT shed to torch.
+    // handle LoKr, so a LoKr `krea_lora` job stays MLX-eligible.
     register_gpu_worker(&store, "worker-torch", "mps", training_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", training_caps());
     let job = store
@@ -5126,7 +5129,7 @@ fn lokr_krea_training_stays_mlx_eligible() {
         ))
         .expect("job creates");
 
-    // Torch defers (Krea is MLX-only); the mlx worker claims the LoKr job.
+    // The synthetic generic descriptor refuses Krea; the mlx worker claims the LoKr job.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -5183,7 +5186,7 @@ fn mlx_eligible_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
         ))
         .expect("job creates");
 
-    // The torch worker defers the MLX-eligible video job to the idle mlx worker.
+    // The synthetic generic descriptor refuses the MLX-eligible job; the idle mlx worker claims it.
     assert!(store
         .claim_next_job("worker-torch")
         .expect("torch claim ok")
@@ -5201,9 +5204,9 @@ fn mlx_worker_excluded_from_advanced_mode_video_job() {
     let store = store("mlx-video-routing-exclude");
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
-    // extend_clip / video_bridge stay torch on engines with no keyframe path — the 14B Wan MoE
-    // here (sc-3522 / sc-3357: LTX + Wan TI2V-5B serve them on MLX, the MoE engines do not); the
-    // mlx worker must not claim this one.
+    // extend_clip / video_bridge are refused on engines with no keyframe path — the 14B Wan MoE
+    // here (sc-3522 / sc-3357: LTX + Wan TI2V-5B serve them on MLX, the MoE engines do not); no
+    // native worker claims this one, so production leaves it queued.
     let job = store
         .create_job(video_job_with(
             json!({ "model": "wan_2_2_t2v_14b", "mode": "extend_clip" }),
@@ -5228,7 +5231,7 @@ fn mlx_worker_excluded_from_advanced_mode_video_job() {
 #[test]
 fn replace_person_job_defers_from_torch_worker_to_idle_mlx_worker() {
     // sc-3521 cutover: replace_person → native Wan-VACE is MLX-eligible on the replace-capable
-    // models, so a torch worker defers the `PersonReplace` job to an idle mlx worker.
+    // models, so the generic test descriptor refuses it and an idle mlx worker claims it.
     let store = store("mlx-video-routing-replace");
     register_gpu_worker(&store, "worker-torch", "mps", video_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
@@ -5259,7 +5262,7 @@ fn replace_person_job_defers_from_torch_worker_to_idle_mlx_worker() {
 #[test]
 fn flf_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
     // sc-3055 cutover: first_last_frame is MLX-eligible on the FLF-capable engines (LTX +
-    // Wan TI2V-5B `wan_2_2`), so a torch worker defers it to an idle mlx worker.
+    // Wan TI2V-5B `wan_2_2`), so the generic test descriptor refuses it and mlx claims it.
     for model in ["ltx_2_3", "wan_2_2"] {
         let store = store(&format!("mlx-video-routing-flf-{model}"));
         register_gpu_worker(&store, "worker-torch", "mps", video_caps());
@@ -5293,7 +5296,7 @@ fn flf_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
 
 #[test]
 fn flf_video_job_stays_on_torch_for_non_flf_capable_wan_moe() {
-    // FLF on the 14B Wan MoE engines has no engine Keyframe path → stays torch.
+    // FLF on the 14B Wan MoE engines has no native engine Keyframe path and remains queued.
     let store = store("mlx-video-routing-flf-moe");
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
@@ -5321,8 +5324,8 @@ fn flf_video_job_stays_on_torch_for_non_flf_capable_wan_moe() {
 #[test]
 fn clip_conditioning_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
     // sc-3522 / sc-3357 cutover: extend_clip / video_bridge are MLX-eligible on the LTX IC-LoRA
-    // path and Wan TI2V-5B (`wan_2_2`, boundary-keyframe conditioning), so a torch worker defers
-    // the dedicated job types to an idle mlx worker.
+    // path and Wan TI2V-5B (`wan_2_2`, boundary-keyframe conditioning), so the generic test
+    // descriptor refuses the dedicated job types and an idle mlx worker claims them.
     for (job_type, mode) in [
         (JobType::VideoExtend, "extend_clip"),
         (JobType::VideoBridge, "video_bridge"),
@@ -5362,8 +5365,8 @@ fn clip_conditioning_video_job_defers_from_torch_worker_to_idle_mlx_worker() {
 
 #[test]
 fn clip_conditioning_video_job_stays_on_torch_for_wan_moe_engines() {
-    // extend_clip / video_bridge have no `Keyframe` path on the 14B Wan MoE engines → stays torch,
-    // even though the mlx worker advertises the VideoExtend/VideoBridge capabilities. (Wan TI2V-5B
+    // extend_clip / video_bridge have no `Keyframe` path on the 14B Wan MoE engines, so they remain
+    // queued even though the mlx worker advertises VideoExtend/VideoBridge. (Wan TI2V-5B
     // `wan_2_2` IS MLX-eligible — sc-3357 — and is covered by the defer test above.)
     for (job_type, mode) in [
         (JobType::VideoExtend, "extend_clip"),
@@ -5445,8 +5448,8 @@ fn lokr_on_wan_video_routes_to_mlx() {
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
     // LoKr-on-Wan now routes to MLX (epic 3641 / sc-3644): the Wan engine merges the Kronecker
-    // delta in-place (merge_one_lokr, sc-2393) — the old torch gate was a routing caution, not an
-    // engine limit. (Wan LoKr *training* still stays torch, epic 3039 — a separate path.)
+    // delta in-place (merge_one_lokr, sc-2393) — the old gate was a routing caution, not an engine
+    // limit. Wan LoKr training is a separate native-support decision.
     let job = store
         .create_job(video_job_with(
             json!({
@@ -5471,8 +5474,7 @@ fn lokr_on_ltx_video_routes_to_mlx_worker() {
     register_gpu_worker(&store, "worker-torch", "mps", video_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", video_caps());
 
-    // LoKr-on-LTX stays MLX: the torch LTX path has no LoKr loader; the Rust engine
-    // applies it natively.
+    // LoKr-on-LTX stays MLX; the Rust engine applies it natively.
     let job = store
         .create_job(video_job_with(
             json!({
@@ -5601,8 +5603,8 @@ fn flux_reference_job_routes_to_mlx() {
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // FLUX.1 reference/IP-Adapter (epic 3621) now runs natively on the Rust/MLX worker →
-    // torch refuses it, mlx claims it.
+    // FLUX.1 reference/IP-Adapter (epic 3621) runs natively on Rust/MLX; the synthetic generic
+    // descriptor refuses it and mlx claims it.
     let job = store
         .create_job(image_job_with(
             json!({ "model": "flux_dev", "prompt": "p", "referenceAssetId": "asset_1" }),
@@ -5818,7 +5820,7 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
     }
 
     // sc-3060: SDXL reference/IP-Adapter + edit_image (inpaint/outpaint) now run on the Rust
-    // engine, so they route to the mlx worker (the torch worker defers).
+    // engine, so the generic test descriptor refuses them and they route to the mlx worker.
     for payload in [
         json!({ "model": "sdxl", "prompt": "p", "referenceAssetId": "asset_1" }),
         json!({ "model": "sdxl", "prompt": "p", "mode": "edit_image", "sourceAssetId": "src_1" }),
@@ -5880,8 +5882,8 @@ fn sdxl_and_realvisxl_route_to_mlx_worker() {
 fn realvisxl_lightning_reference_falls_back_off_mlx() {
     // sc-6075: RealVisXL Lightning is txt2img-only — the engine's few-step `lightning` sampler
     // rejects reference/img2img conditioning. A reference or edit_image job is therefore NOT
-    // MLX-eligible (`realvisxl_lightning_mlx_eligible`), so the torch worker claims it directly
-    // instead of deferring to the mlx worker (the txt2img case is covered above).
+    // MLX-eligible (`realvisxl_lightning_mlx_eligible`). This legacy fixture exercises the generic
+    // descriptor branch; production has no fallback and leaves the shape queued.
     let store = store("mlx-routing-realvisxl-lightning");
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
@@ -5928,8 +5930,8 @@ fn realvisxl_lightning_reference_falls_back_off_mlx() {
 #[test]
 fn image_detail_routes_to_mlx_worker() {
     // sc-3060: the tile-ControlNet detail refine (`image_detail`) now runs on the Rust
-    // engine for SDXL-family backbones, so it routes to the `mlx` worker (the torch worker
-    // defers); a third-party LyCORIS LoRA also runs on MLX now (epic 3641, sc-3671).
+    // engine for SDXL-family backbones, so the generic test descriptor refuses it and it routes to
+    // the `mlx` worker; a third-party LyCORIS LoRA also runs on MLX now (epic 3641, sc-3671).
     let store = store("mlx-routing-detail");
     let caps = vec![
         WorkerCapability::Gpu,
@@ -6012,9 +6014,9 @@ fn non_mlx_model_image_job_is_not_routed_to_mlx_worker() {
     register_gpu_worker(&store, "worker-torch", "mps", image_caps());
     register_gpu_worker(&store, "worker-mlx", "mlx", image_caps());
 
-    // A torch-only image model with no mlx-gen engine (pulid_flux_dev — PuLID has no MLX crate;
-    // Kolors base T2I is ported via sc-3875, InstantID via sc-3345, SenseNova-U1 via sc-3900) stays
-    // on the Python path: the torch worker claims it without deferral, and the mlx worker refuses it.
+    // A synthetic unsupported image model shape with no mlx-gen engine (`pulid_flux_dev` plain
+    // txt2img) exercises the generic-descriptor branch while the mlx worker refuses it. Production
+    // has no Python fallback; the shape remains queued.
     let job = store
         .create_job(image_job_with(
             json!({ "model": "pulid_flux_dev", "prompt": "p" }),
@@ -6034,7 +6036,7 @@ fn non_mlx_model_image_job_is_not_routed_to_mlx_worker() {
 fn mlx_worker_claims_eligible_job_with_idle_mps_worker_present() {
     // Regression for the auto-GPU deferral deadlock (sc-3289): an Apple-Silicon
     // mlx worker reports no utilization (the real `gpu_utilization("mlx")` probes
-    // nvidia-smi and finds nothing -> None), while an idle Python mps worker does
+    // nvidia-smi and finds nothing -> None), while an idle synthetic MPS descriptor does
     // report utilization. A queued auto MLX-eligible job (here flux2_klein_9b_kv
     // text_to_image) must be claimed by the mlx worker; the mps worker must defer
     // it. Before the fix, `dispatch_score` scored the no-utilization mlx worker as
@@ -6091,7 +6093,7 @@ fn mlx_worker_claims_eligible_job_with_idle_mps_worker_present() {
         }))))
         .expect("job creates");
 
-    // The mps worker must defer (an idle mlx worker can run it).
+    // The synthetic MPS descriptor must defer because an idle mlx worker can run it.
     assert!(
         store
             .claim_next_job("mps-worker")
@@ -6451,7 +6453,7 @@ fn progress_from_non_owner_worker_is_rejected() {
 /// `anima_turbo` shipped as `mlx_routed = true` rows in `IMAGE_MODEL_CAPS`, but
 /// `image_request_mlx_eligible` had no dispatch arm for them, so they fell through to `_ => false`.
 /// The mlx worker then refused to claim them (`worker_supports_job`), and because Anima advertises
-/// no candle/torch lane (`candle_routed = false`, macOnly) NOTHING could claim the job — every
+/// no candle lane (`candle_routed = false`, macOnly) NOTHING could claim the job — every
 /// Anima generation sat on "Waiting for an available worker." forever.
 #[test]
 fn mlx_worker_claims_anima_text_to_image_jobs() {

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -105,8 +105,8 @@ fn builtin_targets_gate_network_types() {
             .is_some_and(|types| types.iter().any(|entry| entry.as_str() == Some(value)))
     };
 
-    // Every target advertises `lora`; the validated torch/PEFT backends (epic 2193)
-    // advertise `lokr`: the Z-Image/SDXL image backends (v1), the Kolors image backend
+    // Every target advertises `lora`; validated native backends (epic 2193) advertise `lokr`:
+    // the Z-Image/SDXL image backends (v1), the Kolors image backend
     // (SDXL-architecture, epic 1929 / sc-2217), the Lens sidecar backend (sc-2218), and
     // the Wan2.2 5B video backend (sc-2211). Krea 2 (epic 7565) is the first *native-MLX*
     // LoKr target: its `mlx-gen-krea` trainer reports `supports_lokr` and builds LoKr targets
@@ -529,7 +529,7 @@ fn builtin_registry_exposes_krea_target() {
     // Krea 2 (epic 7565) trains on the undistilled `krea/Krea-2-Raw` 12B single-stream
     // DiT via the `krea_lora` kernel and applies at Krea 2 Turbo inference (family `krea_2`,
     // no base-model gating). Rust-native on BOTH backends — mlx (Apple Silicon) + candle
-    // (Windows/Linux NVIDIA, sc-8614) — no torch path.
+    // (Windows/Linux NVIDIA, sc-8614).
     let registry = builtin_training_targets();
     let target = registry
         .targets
@@ -560,7 +560,7 @@ fn builtin_registry_exposes_krea_target() {
         target.limits.get("networkTypes"),
         Some(&serde_json::json!(["lora", "lokr"]))
     );
-    // No torch Krea trainer, but Rust-native on BOTH backends (mlx + candle, sc-8614) — so it is
+    // Rust-native on BOTH backends (mlx + candle, sc-8614), so it is
     // NOT Apple-Silicon-only: the `appleSiliconOnly`/`requiresBackend` mlx-only markers are gone
     // (matching the candle-capable z-image/lens targets; routing is enforced by the worker tables).
     assert_eq!(target.limits.get("appleSiliconOnly"), None);
@@ -632,7 +632,7 @@ fn builtin_registry_exposes_sd3_targets() {
             Some(&serde_json::json!(["lora", "lokr"])),
             "{id} advertises lora + lokr"
         );
-        // No torch SD3 trainer — Apple-Silicon/MLX-only (off-Mac/candle is epic 7982).
+        // Apple-Silicon/MLX-only (off-Mac/candle is epic 7982).
         assert_eq!(
             target.limits.get("appleSiliconOnly"),
             Some(&serde_json::Value::Bool(true)),
@@ -742,8 +742,8 @@ fn builtin_registry_exposes_wan_target() {
     assert_eq!(target.kernel, "wan_lora");
     assert_eq!(target.defaults.rank, 32);
     assert_eq!(target.defaults.resolution, 512);
-    // Cross-platform default: plain AdamW (adamw8bit is CUDA-only and falls back off it). The
-    // backend is per-platform — off-Mac torch/CUDA, on macOS the native MLX trainer (sc-13878).
+    // Cross-platform plan default: plain AdamW. The native MLX trainer serves this target on macOS;
+    // the unsupported off-Mac shape remains queued (sc-13878).
     assert_eq!(target.defaults.optimizer, "adamw");
     // Wan transformer attention projections drive the LoRA injection.
     assert_eq!(
@@ -755,9 +755,9 @@ fn builtin_registry_exposes_wan_target() {
         target.defaults.advanced.get("numFrames"),
         Some(&serde_json::json!(1))
     );
-    // Not Apple-Silicon-gated: it runs off-Mac (torch/CUDA) AND on macOS (the native MLX trainer
-    // against the installed MLX turnkey, sc-13878), so it carries no `appleSiliconOnly` marker —
-    // unlike the MLX-only LTX target. The macOS base-weight resolution lives in the rust-api
+    // The shared contract carries no `appleSiliconOnly` marker, while current execution is the
+    // native MLX trainer against the installed MLX turnkey on macOS (sc-13878); unsupported
+    // off-Mac work remains queued. The macOS base-weight resolution lives in the rust-api
     // `macos_wan_*` gate/resolver, guarded by `macos_wan_targets_have_a_macos_installable_mlx_turnkey_base`.
     assert_eq!(target.limits.get("appleSiliconOnly"), None);
 }

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -5,8 +5,8 @@
 //! backend-neutral `crate::inference_runtime::load_captioner` seam: the macOS `mlx` worker via mlx-gen's
 //! JoyCaption provider, and the Windows/CUDA candle worker via candle-gen-joycaption
 //! (`--features backend-candle`). `cfg(target_os)` only decides which provider crate registers the
-//! captioner; the job flow below is identical. The Python torch captioner remains the explicit
-//! non-MLX/non-candle fallback (and the default Windows/Linux path).
+//! captioner; the job flow below is identical. Without either native provider the capability is not
+//! advertised and captioning jobs remain queued.
 
 use super::*;
 

--- a/crates/sceneworks-worker/src/engines.rs
+++ b/crates/sceneworks-worker/src/engines.rs
@@ -371,9 +371,8 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // encoder + SDXL VAE, EulerDiscrete sampler. Real CFG (negative prompt + guidance 5.0).
     // Python `MODEL_TARGETS` / `KolorsDiffusersAdapter` parity: 25 steps, guidance 5.0. The engine
     // `kolors` model (sc-3874) supports the full surface — img2img / ControlNet-pose /
-    // IP-Adapter-Plus / Q8/Q4 / LoRA/LoKr — but this base row drives plain T2I (+ quant + LoRA)
-    // through `generate_stream`; the advanced conditioning modes are gated to torch by
-    // `kolors_mlx_eligible` until their dedicated streams land (subsequent epic-3090 slices).
+    // IP-Adapter-Plus / Q8/Q4 / LoRA/LoKr. This base row drives plain T2I (+ quant + LoRA)
+    // through `generate_stream`; dedicated image-job streams handle the advanced conditioning modes.
     ModelRow {
         sceneworks_id: "kolors",
         // sc-9946 (epic 8506): flipped to the SceneWorks re-host `SceneWorks/kolors-mlx`, which ships
@@ -517,8 +516,8 @@ pub(crate) const MODEL_TABLE: &[ModelRow] = &[
     // no conditioning — no img2img / ControlNet / IP), so both ids ride the base [`generate_stream`]
     // path with quant (Q8 default) + LoRA/LoKr. Standard guidance family: `supports_guidance=true` +
     // `supports_negative_prompt=true` (NOT [`uses_true_cfg`]), so the CFG scale flows through
-    // `guidance` and the negative prompt is forwarded. `mac_only` — there is no torch fallback on the
-    // macOS path (the Python `/opt/lens-venv` sidecar is retired on Mac; Win/Linux/Docker keep it).
+    // `guidance` and the negative prompt is forwarded. `mac_only` — this row is the MLX path; the
+    // off-Mac native candle lane is registered separately.
     // The two SceneWorks ids map 1:1 to the engine registry ids of the same name and differ only in
     // their step/guidance defaults: base `lens` is 20-step / CFG 5.0, distilled `lens_turbo` is
     // 4-step / guidance 1.0 (≈ no CFG) — Python `MODEL_TARGETS` parity. Each variant resolves its own
@@ -1027,8 +1026,8 @@ fn registry_capabilities_from(
     // model-first: mlx-llm's `mlx-llama` on macOS (sc-7158), candle-llm's `candle-llama` on the
     // Windows/CUDA candle build (sc-7404). Light up `prompt_refine` when an enabled backend has a
     // core-llm text (non-vision) provider linked — the vision providers (mlx-joycaption / candle-llava)
-    // set `supports_vision` and are excluded. The Python torch `PromptRefiner` stays the fallback on
-    // platforms with neither.
+    // set `supports_vision` and are excluded. On platforms with neither, the capability is not
+    // advertised and prompt-refine jobs remain queued.
     //
     // sc-8105: the `image_caption` task (reference image → Ideogram JSON caption) rides on this SAME
     // `PromptRefine` capability + job — it is a payload `task` discriminator, not a separate cap, so it

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -17,7 +17,7 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
         // Seed the registration with a live snapshot so the worker shows
         // memory/load immediately, mirroring the nvidia path (heartbeats refresh
         // it). `query_mlx_utilization` reads Apple-Silicon unified-memory + GPU
-        // load from the same unprivileged probes the Python mps worker uses.
+        // load from the same unprivileged probes the retired Python mps worker used.
         gpu.utilization = query_mlx_utilization().await;
         return gpu;
     }
@@ -49,8 +49,8 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
 /// from the linked candle generator descriptors, plus `lora_train` + `lora_train_execute` from the
 /// linked candle trainers — sc-7817) plus a `candle` marker capability. The marker lets the API
 /// routing gate (`jobs_store::worker_supports_job`) recognize this worker and confine each lane to
-/// the candle-served shapes (txt2img/txt2video, the candle-trainable kernels, …) — every other shape
-/// falls back to the Python torch worker. Mirrors the macOS `mlx_gpu` derivation, but bolted onto
+/// the candle-served shapes (txt2img/txt2video, the candle-trainable kernels, …); every unsupported
+/// shape is refused and remains queued. Mirrors the macOS `mlx_gpu` derivation, but bolted onto
 /// the real nvidia GPU descriptor rather than a sentinel id.
 ///
 /// All-targets signature so `discover_gpu` is uniform; a no-op everywhere except the Windows candle
@@ -80,8 +80,8 @@ fn with_candle_capabilities(
             // from a single generator descriptor (`registry_capabilities` only emits `image_generate`),
             // so advertise it explicitly — otherwise the candle worker never claims an edit job and the
             // API enforce-fails it `candle_unsupported`. The routing gate confines the claim to the
-            // candle-eligible edit models (`image_job_is_candle_eligible`); torch-only edit models stay on
-            // the co-resident Python worker.
+            // candle-eligible edit models (`image_job_is_candle_eligible`); unsupported edit models
+            // are refused and remain queued.
             if !gpu.capabilities.contains(&WorkerCapability::ImageEdit) {
                 gpu.capabilities.push(WorkerCapability::ImageEdit);
             }
@@ -107,7 +107,7 @@ fn with_candle_capabilities(
             // modality), so they aren't in `registry_capabilities`; advertise them explicitly. The
             // routing gate (`upscale_job_is_candle_eligible` / `video_upscale_job_is_candle_eligible`)
             // admits Real-ESRGAN + SeedVR2; only `aura-sr` has no candle path (dropped as an offered
-            // engine, sc-3668 / sc-5499) and runs on the Python torch worker until Phase 7.
+            // engine, sc-3668 / sc-5499) and remains queued if submitted defensively.
             for capability in [
                 WorkerCapability::ImageUpscale,
                 WorkerCapability::VideoUpscale,
@@ -121,10 +121,8 @@ fn with_candle_capabilities(
             // stack (`candle-gen-face`, the InstantID/PuLID detector reused directly from kps_jobs.rs)
             // serves `kps_extract` for the Key Point Library "extract kps from this image" flow — the
             // off-Mac sibling of the native-MLX path. A job-type capability (not a generation modality),
-            // so it isn't in `registry_capabilities`; advertise it explicitly. Unlike SeedVR2, the Python
-            // InsightFace path CAN serve kps_extract, so there's NO torch-refusal gate — the candle worker
-            // claims it Python-free, with the co-resident torch worker as fallback (the Python kps path is
-            // retired wholesale in Phase 7, epic 5483).
+            // so it isn't in `registry_capabilities`; advertise it explicitly. The candle face stack is
+            // the off-Mac native path, so a build without it leaves the job queued.
             if !gpu.capabilities.contains(&WorkerCapability::KpsExtract) {
                 gpu.capabilities.push(WorkerCapability::KpsExtract);
             }
@@ -152,10 +150,8 @@ fn with_candle_capabilities(
             // `ort`/CoreML path (sc-3487) — the same RTMW detector via `pose_jobs::run_pose_detect_job`
             // with the CUDA execution provider, serving `pose_detect` for the Pose Library "create from
             // photo" flow + InstantID pose conditioning. A job-type capability (not a generation modality),
-            // so it isn't in `registry_capabilities`; advertise it explicitly. Like kps_extract — and
-            // unlike SeedVR2 — the Python rtmlib path CAN serve pose_detect, so there's NO torch-refusal
-            // gate: the candle worker claims it Python-free, with the co-resident torch worker as a
-            // fallback (the Python rtmlib path is retired wholesale in Phase 7, epic 5483).
+            // so it isn't in `registry_capabilities`; advertise it explicitly. The candle RTMW stack is
+            // the off-Mac native path, so a build without it leaves the job queued.
             if !gpu.capabilities.contains(&WorkerCapability::PoseDetect) {
                 gpu.capabilities.push(WorkerCapability::PoseDetect);
             }
@@ -164,12 +160,10 @@ fn with_candle_capabilities(
             // via `ort`/CUDA in `person_jobs` + the pure-Rust SORT/ByteTrack in `person_track`,
             // serving `person_detect` (Replace-Person candidate boxes) + `person_track` (the
             // reusable selected-person track). Job-type capabilities (not generation modalities),
-            // so they aren't in `registry_capabilities`; advertise them explicitly. Like
-            // kps_extract / pose_detect — and unlike SeedVR2 — the Python Ultralytics path CAN
-            // serve them, so there's NO torch-refusal gate: the candle worker claims them
-            // Python-free, with the co-resident torch worker as a fallback (retired wholesale in
-            // Phase 7, epic 5483). Person *segmentation* (SAM masks) is NOT ported off-Mac yet
-            // (epic 3792, sc-5062), so candle person tracks are box-only (`maskState = "missing"`).
+            // so they aren't in `registry_capabilities`; advertise them explicitly. The candle
+            // YOLO11/ByteTrack stack is the off-Mac native path, and `media_jobs::run_candle_segmenter`
+            // adds SAM3 masks to tracked people (sc-8847 / sc-8833), so off-Mac tracks are not
+            // box-only.
             for capability in [
                 WorkerCapability::PersonDetect,
                 WorkerCapability::PersonTrack,
@@ -544,7 +538,7 @@ pub(crate) async fn gpu_utilization(gpu_id: &str) -> Option<WorkerUtilizationSna
     }
     // The Apple-Silicon `mlx` worker has no nvidia-smi to query; read its
     // unified-memory + GPU load from IOKit instead (epic 3018) so the dashboard
-    // shows memory/load for it like it does for the Python `mps` worker.
+    // preserves the telemetry surface formerly supplied by the Python `mps` worker.
     #[cfg(target_os = "macos")]
     if gpu_id == "mlx" {
         return query_mlx_utilization().await;
@@ -849,18 +843,17 @@ pub(crate) fn cpu_gpu() -> DiscoveredGpu {
 /// does NOT carry the CPU utility capabilities, so downloads/imports/etc. still go to
 /// the CPU worker. `video_generate` is claimed from the video runtime onward (sc-3033);
 /// the procedural stub backs models whose real MLX path is not yet linked (Wan sc-3034,
-/// LTX+audio sc-3035), and the API-side MLX-vs-Python routing is sc-3036.
+/// LTX+audio sc-3035), and the API-side native-worker routing is sc-3036.
 ///
 /// Training (epic 3039, sc-3043/3049): the engine is always linked on macOS, so this
 /// worker can both validate plans (`lora_train`) and run real training
-/// (`lora_train_execute`) — unlike the Python worker, which advertises execute only
-/// when its torch backend is present. The API gates which `lora_train` jobs reach
+/// (`lora_train_execute`). The API gates which `lora_train` jobs reach
 /// here to the MLX-native families (`jobs_store::training_job_is_mlx_eligible`);
-/// `kolors`/`lens` and LoKr-on-Wan stay on the Python torch worker.
+/// unsupported training shapes are refused and remain queued.
 ///
 /// Dataset captioning (sc-3556): JoyCaption is linked through mlx-gen's captioner
-/// registry and runs in-process on this worker; the Python captioner remains the
-/// Windows/Linux and explicit non-MLX fallback.
+/// registry and runs in-process on this worker; other platforms require a compatible native
+/// captioner or leave the job queued.
 #[cfg(target_os = "macos")]
 pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
     let mut capabilities = vec![WorkerCapability::Gpu];
@@ -880,7 +873,7 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         // edit paths as the `character_image` reference flow — qwen/flux2/sdxl
         // edit dispatched by payload model+mode in `run_image_generate_job`. The
         // API only routes MLX-eligible edit models here (`image_job_is_mlx_eligible`);
-        // torch-only edit models stay on the Python worker.
+        // unsupported edit models are refused and remain queued.
         WorkerCapability::ImageEdit,
         // Tile-ControlNet detail refine (epic 3041, sc-3060) — the SDXL-family
         // `image_detail` job runs in-process on the engine here too.
@@ -889,24 +882,23 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         // question answering (`image_vqa`) and interleaved text-image generation
         // (`image_interleave`) run in-process via the concrete `T2iModel` (the modes the
         // `Generator` contract can't express). The API routes these here only for the
-        // SenseNova-U1 ids (`jobs_store::understanding_job_is_mlx_eligible`); off macOS the
-        // capabilities are never advertised, so the Python torch worker serves them on
-        // Windows/Linux.
+        // SenseNova-U1 ids (`jobs_store::understanding_job_is_mlx_eligible`). Off macOS the candle
+        // worker advertises the same capabilities through `with_candle_capabilities`.
         WorkerCapability::ImageVqa,
         WorkerCapability::ImageInterleave,
         // Clip-conditioning advanced video modes (epic 3040, sc-3522): extend_clip /
         // video_bridge run the LTX IC-LoRA keyframe-append path in-process. The API gates
         // these `video_extend` / `video_bridge` jobs to the LTX engines
-        // (`jobs_store::video_job_is_mlx_eligible`); a Wan extend/bridge has no IC-LoRA
-        // path and stays on the Python torch worker.
+        // (`jobs_store::video_job_is_mlx_eligible`). LTX and Wan TI2V-5B are native; 14B Wan MoE
+        // engines have no `Keyframe` path, so their extend/bridge requests are refused and remain queued.
         WorkerCapability::VideoExtend,
         WorkerCapability::VideoBridge,
         // replace_person → native Wan-VACE (epic 3040, sc-3521): the `PersonReplace`
         // job builds the masked control inputs (source clip + onnx-track mask + character
         // refs) and runs the engine `wan_vace` provider in-process — the native
         // equivalent of the torch `WanVACEPipeline` path. The API routes only
-        // MLX-eligible replace_person jobs here; non-VACE replacement + Windows/Linux
-        // keep the Python torch path.
+        // MLX-eligible replace_person jobs here; off-Mac, candle Wan-VACE/SCAIL-2 serves eligible
+        // replacements, while unsupported models are refused and remain queued.
         WorkerCapability::PersonReplace,
         // DWPose whole-body pose detection (epic 3482, sc-3487): RTMW via
         // onnxruntime/CoreML, served in-process by `pose_jobs::run_pose_detect_job`.
@@ -939,7 +931,7 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         // onnxruntime/CoreML, served in-process by `upscale_jobs::run_image_upscale_job`.
         // Replaces the Python torch Real-ESRGAN path so the Image Editor upscale tool
         // works on a Python-free Mac. Only `engine=real-esrgan` (the default) is
-        // served here; `aura-sr` stays on the Python worker (routing oracle).
+        // served here; `aura-sr` is dropped and remains queued if submitted defensively.
         WorkerCapability::ImageUpscale,
         // Dataset Doctor one-tap upscale (sc-6539): reuses the Real-ESRGAN engine to upscale flagged
         // low-resolution training items, then re-points each. Advertised wherever image_upscale is.
@@ -947,15 +939,15 @@ pub(crate) fn mlx_gpu(settings: &Settings) -> DiscoveredGpu {
         // Smart-select segmentation (epic 6087, sc-6105): native-MLX SAM3 box-prompt
         // segmentation, served in-process by `segment_jobs::run_image_segment_job` (the
         // box-PVS path of the sc-4926 SAM3 stack). The Image Editor smart-select tool's
-        // backend: a box prompt → a binary inpaint mask asset. Advertised ONLY here (no
-        // torch/candle SAM3 image path), so a segment job routes to the Mac worker by
+        // backend: a box prompt → a binary inpaint mask asset. Advertised ONLY here (there is no
+        // off-Mac standalone image-segment lane), so a segment job routes to the Mac worker by
         // construction.
         WorkerCapability::ImageSegment,
         // SeedVR2 video upscaling (epic 4811, sc-4816): native-MLX one-step super-resolution
         // (`mlx-gen-seedvr2`), served in-process by `video_jobs::run_video_upscale_job` —
         // SceneWorks' first video upscaler. Decodes the source clip, runs the temporal-chunked
         // 5D upscale, re-encodes, and passes the source audio through. The off-Mac
-        // twin is advertised by `with_candle_capabilities` (there is no torch path).
+        // twin is advertised by `with_candle_capabilities`; no other lane serves it.
         WorkerCapability::VideoUpscale,
         // Real, model-backed person detection + tracking (epic 3482, sc-3488 /
         // sc-3633/3634/3709): the native-MLX YOLO11 detector + SORT/ByteTrack tracker +
@@ -1019,7 +1011,7 @@ pub(crate) fn worker_capabilities_with_utility(
             WorkerCapability::LoraDownload,
             // Procedural detection/tracking is a preview only. Real, model-backed
             // PersonDetect/PersonTrack run on the macOS MLX worker (native
-            // YOLO11/SAM2, epic 3482) or the Python GPU worker on Windows/Linux;
+            // YOLO11/SAM2, epic 3482) or the off-Mac candle worker (YOLO11/SAM3);
             // advertising the preview capabilities here keeps the CPU placeholder
             // claimable solely for explicit `preview: true` jobs
             // (jobs_store::worker_supports_job).

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -996,7 +996,7 @@ pub(crate) async fn run_image_generate_job(
                 }
                 // No-silent-T2I (sc-5968): a strict-pose job on a candle model with NO pose lane (e.g.
                 // sdxl) must be REJECTED with a clear error, not silently rendered as plain txt2img (poses
-                // dropped) and not bounced to torch. The candle worker CLAIMS these (jobs_store
+                // dropped) and not rerouted. The candle worker CLAIMS these (jobs_store
                 // `image_job_candle_pose_reject`) precisely to fail them loudly here. SDXL identity-pose
                 // ships via InstantID; the wired candle pose families are `WIRED_CANDLE_POSE_FAMILIES`.
                 CandleImageRoute::PoseReject => {
@@ -2038,8 +2038,8 @@ include!("image_jobs/pulid.rs");
 // image detail tile-ControlNet routing.
 include!("image_jobs/detail.rs");
 
-/// Off macOS the in-process engine is unavailable; `image_detail` is served by the Python
-/// torch worker (the `mlx` worker — the only one advertising this capability — is macOS-only).
+/// Off macOS the in-process engine is unavailable; the capability is not advertised and
+/// `image_detail` remains queued (the `mlx` worker is macOS-only).
 #[cfg(not(target_os = "macos"))]
 pub(crate) async fn run_image_detail_job(
     _api: &ApiClient,

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -430,9 +430,9 @@ enum CandleImageRoute {
 /// `resolve_candle_image_route` `matches!` guard, the handler comment, and the reject error string, which
 /// had already drifted (the handler comment omitted `krea_2_turbo`). (sc-11171, F-008.)
 ///
-/// NOTE: deliberately DISTINCT from the router's `model_has_candle_pose_lane` (sceneworks-core), which
-/// omits `krea_2_turbo` so the co-resident torch worker declines krea pose jobs and candle reliably wins
-/// them — do not conflate the two lists.
+/// NOTE: deliberately DISTINCT from the router's `model_has_candle_pose_lane` (sceneworks-core),
+/// which omits `krea_2_turbo` so other GPU descriptors decline Krea pose jobs and candle reliably
+/// owns the request — do not conflate the two lists.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const WIRED_CANDLE_POSE_FAMILIES: &[&str] = &[
     "qwen_image",
@@ -4733,8 +4733,8 @@ async fn gate_with_evict_reclaim<D>(
 /// Quant + LoRA/LoKr are **descriptor-gated** (sc-5126): resolved (via the same `resolve_quant` /
 /// `resolve_adapters` the MLX path uses) only when the linked candle descriptor advertises them — i.e.
 /// for Lens (Q4/Q8 + LoRA/LoKr); the sc-3675/sc-5096 families advertise neither, so they stay dense +
-/// adapter-free exactly as before. No reference/img2img/control — those shapes fall back to the Python
-/// worker upstream (`image_request_candle_eligible`). Reached only when `backend_candle_enabled`
+/// adapter-free exactly as before. No reference/img2img/control — unsupported shapes are refused
+/// upstream and remain queued (`image_request_candle_eligible`). Reached only when `backend_candle_enabled`
 /// (default off → production routing unchanged until parity).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 async fn generate_candle_stream(

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -53,7 +53,7 @@ fn is_flux2_edit_candle_dev(model: &str) -> bool {
 
 /// FLUX.2 model ids the candle edit route accepts: the klein base 9b + true_v2 (which share the edit
 /// variant) and the dev 32B flagship (sc-7736). The klein `-kv` distill needs the reference-K/V cache
-/// port and stays on the MLX/torch path for now.
+/// port and is refused by candle for now.
 fn is_flux2_edit_candle_model(model: &str) -> bool {
     matches!(
         model,

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -76,8 +76,8 @@ fn flux_ipadapter_default_guidance(model: &str) -> f32 {
 
 /// Resolve the FLUX base (BFL snapshot) for the IP-Adapter route: an explicit `modelPath` dir
 /// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (the installed
-/// `MODEL_TABLE` turnkey by variant). `None` means the base is not present locally,
-/// so the job is not candle-runnable (falls through to torch). Mirrors `resolve_kolors_ipadapter_base`.
+/// `MODEL_TABLE` turnkey by variant). `None` means the base is not present locally, so the candle lane
+/// refuses the job and no fallback is attempted. Mirrors `resolve_kolors_ipadapter_base`.
 fn resolve_flux_ipadapter_base(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -133,8 +133,8 @@ fn pose_to_body_points(keypoints: &[crate::openpose_skeleton::Keypoint]) -> Vec<
 /// Resolve the RealVisXL (SDXL) base snapshot for InstantID: an explicit `modelPath` dir
 /// (advanced or manifest) wins, else the selected quant tier subdir of the HF cache snapshot for the
 /// manifest `repo` (default `SceneWorks/realvisxl-mlx`). The big base is staged by the normal
-/// model-download flow; `None` here means it is not present, so the job is not native-runnable
-/// (falls through to torch). An explicit `modelPath` override loads verbatim (no tier resolution) —
+/// model-download flow; `None` here means it is not present, so the native lane refuses the job and
+/// no fallback is attempted. An explicit `modelPath` override loads verbatim (no tier resolution) —
 /// it is a fully-assembled diffusers dir the caller vouches for.
 fn resolve_instantid_sdxl_base(
     request: &ImageRequest,

--- a/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_control.rs
@@ -63,7 +63,8 @@ fn is_kolors_control_model(model: &str) -> bool {
 
 /// Resolve the Kolors base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the HF
 /// cache snapshot for the manifest `repo` (default `Kwai-Kolors/Kolors-diffusers`). `None` ⇒ not present
-/// locally (the job is not candle-runnable, falls through to torch). Mirrors `resolve_kolors_ipadapter_base`.
+/// locally (the candle lane refuses the job; no fallback is attempted). Mirrors
+/// `resolve_kolors_ipadapter_base`.
 fn resolve_kolors_control_base(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -60,8 +60,8 @@ fn is_kolors_ipadapter_model(model: &str) -> bool {
 
 /// Resolve the Kolors base (diffusers) snapshot for the IP-Adapter route: an explicit `modelPath` dir
 /// (advanced or manifest) wins, else the HF cache snapshot for the manifest `repo` (default
-/// `Kwai-Kolors/Kolors-diffusers`). `None` means the base is not present locally, so the job is not
-/// candle-runnable (falls through to torch). Mirrors `resolve_sdxl_ipadapter_base`.
+/// `Kwai-Kolors/Kolors-diffusers`). `None` means the base is not present locally, so the candle lane
+/// refuses the job and no fallback is attempted. Mirrors `resolve_sdxl_ipadapter_base`.
 fn resolve_kolors_ipadapter_base(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -86,7 +86,7 @@ const PULID_CANDLE_ENGINE: &str = "candle_pulid_flux";
 /// selected quant-matrix **tier subdir** via [`standard_tier_subdir`] (sc-10103): `bf16/` when the
 /// request opts out of quant, `q8/` for Q8, else `q4/`. `candle_gen_pulid`'s `FluxRefBackbone`
 /// packed-detects whichever tier landed (or a dense BFL snapshot for a legacy `modelPath`). `None` means
-/// the base is not present locally, so the job is not candle-runnable (falls through to torch). Mirrors
+/// the base is not present locally, so the candle lane refuses the job and no fallback is attempted. Mirrors
 /// `resolve_flux_ipadapter_base` / the MLX `resolve_pulid_flux_base`.
 fn resolve_pulid_candle_base(
     request: &ImageRequest,

--- a/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_control.rs
@@ -79,7 +79,7 @@ fn is_qwen_control_model(model: &str) -> bool {
 
 /// Resolve the Qwen-Image-2512 base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) →
 /// the HF cache snapshot for the manifest `repo` (default `Qwen/Qwen-Image-2512`, sc-8350). `None` ⇒ not
-/// present locally (the job is not candle-runnable, falls through to torch). Mirrors
+/// present locally (the candle lane refuses the job; no fallback is attempted). Mirrors
 /// `resolve_kolors_ipadapter_base`.
 fn resolve_qwen_control_base(
     request: &ImageRequest,

--- a/crates/sceneworks-worker/src/image_jobs/sdxl.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl.rs
@@ -474,12 +474,10 @@ async fn generate_sdxl_advanced_stream(
 // InstantID identity-preserving character image (macOS, epic 3109 engine / sc-3345
 // integration): the production `instantid_realvisxl` model — InstantID on RealVisXL +
 // the stock SDXL IdentityNet ControlNet + the native MLX face stack (SCRFD + ArcFace),
-// all in-process with zero Python. Two modes only (torch parity): a single-identity
-// `character_image` (the reference's natural head pose) and the 11-view Character-Studio
-// angle set. Pose-library mode (`advanced.poses`) + face-restore (`advanced.faceRestore`)
-// are NOT handled here — they stay on the torch `InstantIDAdapter` (engine sc-3117 /
-// sc-3380 not yet ported), gated out by `instantid_available` so the torch worker claims
-// them. fp16 only for now (the validated envelope); Q8/Q4 ride explicit `mlxQuantize`
+// all in-process with zero Python. It serves single-identity `character_image`, the 11-view
+// Character-Studio angle set, pose-library mode (`advanced.poses`), and face restore
+// (`advanced.faceRestore`) through the native InstantID provider. fp16 only for now (the
+// validated envelope); Q8/Q4 ride explicit `mlxQuantize`
 // (unvalidated at 1024², gated by sc-3329 follow-up). The provider is the bespoke
 // `runtime_macos::providers::instantid::InstantId` (not an inventory `Generator`), so this is a dedicated
 // stream parallel to `generate_sdxl_advanced_stream`, not an MLX_MODELS row.

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -82,7 +82,7 @@ fn sdxl_edit_candle_mode(request: &ImageRequest) -> Option<SdxlEditCandleMode> {
 
 /// Resolve the SDXL base snapshot for the edit route: an explicit `modelPath` dir (advanced or manifest)
 /// wins, else the HF cache snapshot for the manifest `repo` (default by model id). `None` means the base
-/// is not present locally, so the job is not candle-runnable (falls through to torch). Mirrors
+/// is not present locally, so the candle lane refuses the job and no fallback is attempted. Mirrors
 /// `resolve_sdxl_ipadapter_base`.
 fn resolve_sdxl_edit_candle_base(
     request: &ImageRequest,

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -68,7 +68,7 @@ fn is_sdxl_ipadapter_model(model: &str) -> bool {
 /// `repo` key, and no built-in model declares one (the manifest carries `downloads[].repo` and
 /// `paths.model`, which are different keys; `resolve_model_manifest_entry` injects only `modelPath`).
 /// So this is not a fallback, it is the only branch — and after the Group-B cutover (sc-8746) it
-/// named repos the installer no longer stages, silently routing every candle IP-Adapter job to torch.
+/// named repos the installer no longer stages, leaving every candle IP-Adapter job unserved.
 ///
 /// The tier descent still applies on top: sc-10813 serves the request's q4/q8 tier via
 /// `standard_tier_subdir`, and `dense_tier_subdir` (sc-10614) takes the non-standard branch.
@@ -80,7 +80,7 @@ pub(super) fn sdxl_ipadapter_default_repo(model: &str) -> &'static str {
 
 /// Resolve the SDXL base snapshot for the IP-Adapter route: an explicit `modelPath` dir (advanced or
 /// manifest) wins, else the HF cache snapshot for the manifest `repo` (default by model id). `None`
-/// means the base is not present locally, so the job is not candle-runnable (falls through to torch).
+/// means the base is not present locally, so the candle lane refuses the job and no fallback is attempted.
 fn resolve_sdxl_ipadapter_base(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_control.rs
@@ -101,8 +101,8 @@ pub(super) fn zimage_control_base_default_repo(model: &str) -> &'static str {
 
 /// Resolve the Z-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
 /// HF cache snapshot for the manifest `repo` (default `Tongyi-MAI/Z-Image-Turbo`, or `Tongyi-MAI/Z-Image`
-/// for the base model, sc-8379). `None` ⇒ not present locally (the job is not candle-runnable, falls
-/// through to torch). Mirrors `resolve_kolors_control_base`.
+/// for the base model, sc-8379). `None` ⇒ not present locally (the candle lane refuses the job; no
+/// fallback is attempted). Mirrors `resolve_kolors_control_base`.
 pub(super) fn resolve_zimage_control_base(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
@@ -43,7 +43,8 @@ fn is_zimage_edit_candle_model(model: &str) -> bool {
 
 /// Resolve the Z-Image base (diffusers) snapshot: an explicit `modelPath` (advanced or manifest) → the
 /// HF cache snapshot for the manifest `repo` (default `Tongyi-MAI/Z-Image-Turbo`). `None` ⇒ not present
-/// locally (the job is not candle-runnable, falls through to torch). Mirrors `resolve_zimage_control_base`.
+/// locally (the candle lane refuses the job; no fallback is attempted). Mirrors
+/// `resolve_zimage_control_base`.
 pub(super) fn resolve_zimage_edit_candle_base(
     request: &ImageRequest,
     settings: &Settings,

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -9,8 +9,7 @@
 //! reuse it on any character.
 //!
 //! Native-MLX SCRFD in-process (the same `scrfd_10g` detector the InstantID face stack
-//! already runs), so the capability is Python-free on Mac (epic 3482); the Python worker
-//! keeps the InsightFace path for Windows/Linux. macOS-only here.
+//! already runs) on Mac (epic 3482), with the candle SCRFD/ArcFace stack off-Mac.
 //!
 //! Normalization mirrors the engine's centered square letterbox (`kps::letterbox`): a
 //! detected pixel `(px, py)` in a `w×h` image maps to the square-normalized point

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -133,7 +133,7 @@ use image_jobs::*;
 // sc-6501). Pure prompt-guard + post-render heuristic, compiled cross-platform so its unit tests run
 // on the Linux parity lane. sc-6610: its functions are called only from the macOS MLX generate path
 // (`image_jobs/base.rs` `generate_stream`, `#[cfg(target_os = "macos")]`) — off-Mac, Ideogram routes
-// to candle (txt2img) or the torch worker, neither of which applies the caption guard, so they read
+// to candle for eligible shapes or remains queued, and neither path applies the caption guard, so they read
 // as dead code on EVERY non-macOS build (the candle `backend-candle` lane included; the prior
 // `not(feature = "backend-candle")` carve-out wrongly assumed the candle path called them).
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
@@ -457,8 +457,8 @@ mod canny;
 mod depth;
 // DWPose pose detection via onnxruntime (epic 3482, sc-3487). On Mac the CoreML EP +
 // on the off-Mac candle GPU-worker lane the CUDA EP (sc-5496, epic 5482) run the same
-// RTMW detector in-process; on a candle-disabled box the Python rtmlib path stays the
-// Windows/Linux backend.
+// RTMW detector in-process; on a candle-disabled box the capability is not advertised and the job
+// remains queued.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -526,7 +526,7 @@ mod ort_cuda;
 // candle SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482) — the same
 // InstantID face-stack detector reused in-process for the Key Point Library "extract kps from this
 // image" capability. So the module compiles on Mac AND the candle lane; on a candle-disabled box the
-// Python InsightFace path stays the Windows/Linux backend.
+// capability is not advertised and the job remains queued.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -535,8 +535,8 @@ mod kps_jobs;
 // Image upscaling: Real-ESRGAN (epic 3482, sc-3489) RRDBNet x2/x4 via `ort`/CoreML on Mac, plus the
 // SeedVR2 one-step diffusion upscaler — native MLX on Mac (sc-4815) and the candle CUDA backend on
 // Windows (sc-5928). So the module compiles on Mac AND the Windows/CUDA candle lane; the ort/CoreML
-// Real-ESRGAN path inside stays Mac-gated (the Python torch Real-ESRGAN / AuraSR path is the
-// Windows/Linux backend), while the SeedVR2 path is backend-neutral (`crate::inference_runtime::load("seedvr2")`).
+// Real-ESRGAN path inside stays Mac-gated while the candle worker supplies the off-Mac Real-ESRGAN
+// lane, and SeedVR2 is backend-neutral (`crate::inference_runtime::load("seedvr2")`).
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -545,9 +545,8 @@ mod upscale_jobs;
 // YOLO11 person detection + selected-person ByteTrack tracking (epic 3482, sc-3488/sc-3633;
 // off-Mac candle lane sc-5498, epic 5482). Native-MLX YOLO11m on Mac, `ort`/CUDA on the off-Mac
 // candle GPU-worker lane (the pure-Rust ByteTrack in `person_track` is backend-neutral). So both
-// modules compile on Mac AND the candle lane; on a candle-disabled box the Python Ultralytics
-// path stays the Windows/Linux backend. Person *segmentation* (SAM masks) stays Mac-only
-// (`person_segment*` below) — off-Mac tracks are box-only; a candle SAM backport is epic 3792.
+// modules compile on Mac AND the candle lane; a candle-disabled off-Mac build refuses the jobs.
+// Person segmentation uses MLX SAM2/SAM3 on Mac and native candle SAM3 off-Mac.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -559,9 +558,8 @@ mod person_jobs;
 ))]
 mod person_track;
 // Native-MLX SAM2 person segmentation (epic 3704, sc-3709): the `mlx-gen-sam2`
-// box-prompt segmenter generates per-frame masks in `run_person_track`. macOS-only
-// like person_jobs (mlx-gen builds MLX from source); the Python SAM2 path stays the
-// Windows/Linux backend.
+// box-prompt segmenter generates per-frame masks in `run_person_track`. On Mac this is SAM2; off-Mac
+// the candle SAM3 seam in `media_jobs::run_candle_segmenter` supplies real masks.
 #[cfg(target_os = "macos")]
 mod person_segment;
 // SAM3 text-concept (PCS) person segmenter — the box-prompt-free upgrade of `person_segment`
@@ -571,7 +569,8 @@ mod person_segment;
 mod person_segment_sam3;
 // Smart-select image segmentation (epic 6087, sc-6105): the `image_segment` job runs SAM3
 // box-prompt segmentation in-process to produce an inpaint mask asset for the Image Editor.
-// macOS-only like its `person_segment_sam3` (SAM3) dependency; no torch/candle image-segment path.
+// macOS-only like its `person_segment_sam3` (SAM3) dependency; there is no off-Mac standalone
+// image-segment lane.
 #[cfg(target_os = "macos")]
 mod segment_jobs;
 // Off-Mac candle SAM3 text-concept person segmenter (sc-6247, epic 5482 under sc-5062) — the
@@ -907,7 +906,7 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
                 // SQLite claim contention. With busy_timeout + BEGIN IMMEDIATE in the
                 // store this should be rare, but back off (instead of hammering at the
                 // flat poll interval) and make it visible so an MLX-eligible job lost to
-                // lock contention is explained rather than silently retried into torch.
+                // lock contention is explained rather than silently losing the claim to another poller.
                 lock_failures = lock_failures.saturating_add(1);
                 let delay = retry_delay(settings.poll_seconds, lock_failures);
                 emit_event_value(
@@ -1239,16 +1238,15 @@ async fn run_utility_job(
                 .map_err(|error| ("Image edit failed.", error)),
             // Native MLX tile-ControlNet detail refine (epic 3041, sc-3060), served in-process
             // by the engine on the macOS Apple-Silicon GPU worker. Off macOS the capability is
-            // never advertised, so this arm is unreachable there (image_detail runs on torch).
+            // never advertised, so this arm is unreachable there and the job remains queued.
             JobType::ImageDetail => run_image_detail_job(api, settings, &job)
                 .await
                 .map_err(|error| ("Image detail enhancement failed.", error)),
             // SenseNova-U1 visual question answering + Document Studio interleave (epic 3180,
             // sc-3905). These bypass the `Generator` registry and call the concrete `T2iModel`
             // directly (text / text+images output the `GenerationOutput` contract can't express).
-            // The API routes them here only on Mac (`understanding_job_is_mlx_eligible`); off macOS
-            // the `image_vqa`/`image_interleave` capabilities are never advertised, so these arms
-            // are unreachable there (the Python torch worker serves them on Windows/Linux).
+            // On Mac the API routes them here through `understanding_job_is_mlx_eligible`; off-Mac
+            // the candle worker advertises the same capabilities and uses the candle handlers below.
             JobType::ImageVqa => run_vqa_job(api, settings, &job)
                 .await
                 .map_err(|error| ("Visual question answering failed.", error)),
@@ -1275,10 +1273,9 @@ async fn run_utility_job(
             // type (and `video_generate` mode=`replace_person`) shares the video handler, which
             // dispatches on `mode == "replace_person"` to the engine `wan_vace` provider — the
             // native equivalent of the torch `WanVACEPipeline` path. The API routes only
-            // MLX-eligible replace_person jobs here (`jobs_store::video_job_is_mlx_eligible`);
-            // off macOS the `person_replace` capability is never advertised, so this arm only
-            // produces a real video on the macOS MLX worker (and the Python torch path serves
-            // Windows/Linux + non-VACE replacement).
+            // MLX-eligible replace_person jobs here (`jobs_store::video_job_is_mlx_eligible`). The
+            // off-Mac candle lane serves eligible Wan-VACE/SCAIL-2 replacement; unsupported models
+            // are refused and remain queued.
             JobType::PersonReplace => run_video_generate_job(api, settings, &job)
                 .await
                 .map_err(|error| ("Person replacement failed.", error)),
@@ -1294,8 +1291,8 @@ async fn run_utility_job(
             // Native MLX LoRA/LoKr training (epic 3039, sc-3043/3049), served in-process
             // by the linked mlx-gen engine on the macOS Apple-Silicon GPU worker. The API
             // routes only MLX-native families here (jobs_store::training_job_is_mlx_eligible);
-            // kolors/lens + LoKr-on-Wan stay on the Python torch worker, which is also the
-            // Windows/Linux path. Off macOS the execute capability is never advertised.
+            // unsupported shapes are refused and remain queued for a compatible native trainer.
+            // Off macOS the execute capability is advertised only by a linked native trainer.
             JobType::LoraTrain => run_lora_train_job(api, settings, &job)
                 .await
                 .map_err(|error| ("LoRA training failed.", error)),
@@ -1310,8 +1307,8 @@ async fn run_utility_job(
                     .map_err(|error| ("ControlNet training failed.", error))
             }
             // Native MLX JoyCaption dataset captioning (epic 3550, sc-3556). The API
-            // routes only `captioner=joy_caption` jobs here; Windows/Linux and
-            // explicit non-MLX GPU choices keep the Python torch captioner fallback.
+            // routes only `captioner=joy_caption` jobs here; other captioners remain queued unless
+            // another compatible native captioner registers.
             JobType::TrainingCaption => run_training_caption_job(api, settings, &job)
                 .await
                 .map_err(|error| ("Training captioning failed.", error)),
@@ -1338,9 +1335,8 @@ async fn run_utility_job(
             // Native candle prompt refinement (epic 5095, sc-5525; consolidated onto candle-llm in sc-7404):
             // routes `prompt_refine` to the candle `core_llm::TextLlm` provider (candle-llama, resolved
             // model-first). The candle worker advertises `prompt_refine` only when `backend_candle_enabled`
-            // (engines::registry_capabilities from the registered core_llm provider); off the Windows candle
-            // build the capability is never advertised, so this arm is unreachable there and the Python torch
-            // refiner serves the job (sc-5525 keeps it as the Mac + default-installer fallback).
+            // (engines::registry_capabilities from the registered core_llm provider); without a native
+            // text provider the capability is not advertised and the job remains queued.
             JobType::PromptRefine => run_prompt_refine_job(api, settings, &job)
                 .await
                 .map_err(|error| ("Prompt refinement failed.", error)),
@@ -1371,9 +1367,8 @@ async fn run_utility_job(
             // DWPose whole-body pose detection (epic 3482, sc-3487 Mac / sc-5496 off-Mac):
             // RTMW via onnxruntime, replacing the Python rtmlib path — CoreML EP on the
             // macOS MLX worker, CUDA EP on the off-Mac candle GPU worker. Available on Mac
-            // AND the candle lane; on a candle-disabled box `PoseDetect` is never advertised
-            // by the Rust worker (the Python worker handles it), so this falls to the `_`
-            // arm there.
+            // AND the candle lane; on a candle-disabled box `PoseDetect` is never advertised, so the
+            // job remains queued and this falls to the `_` arm only if called defensively.
             #[cfg(any(
                 target_os = "macos",
                 all(not(target_os = "macos"), feature = "backend-candle")
@@ -1384,8 +1379,8 @@ async fn run_utility_job(
             // SCRFD 5-point landmark extraction (epic 4422, sc-4433): native-MLX SCRFD on Mac + the candle
             // SCRFD/ArcFace stack on the Windows/Linux candle lane (sc-5497, epic 5482), served in-process
             // for the Key Point Library. Available on Mac AND the candle lane; on a candle-disabled box
-            // `KpsExtract` is never advertised by the Rust worker (the Python InsightFace path handles it),
-            // so this falls to the `_` arm there.
+            // `KpsExtract` is never advertised, so the job remains queued and this falls to the `_` arm
+            // only if called defensively.
             #[cfg(any(
                 target_os = "macos",
                 all(not(target_os = "macos"), feature = "backend-candle")
@@ -1396,9 +1391,8 @@ async fn run_utility_job(
             // Image upscaling, served in-process by `upscale_jobs::run_image_upscale_job`: Real-ESRGAN
             // RRDBNet x2/x4 via onnxruntime/CoreML (epic 3482, sc-3489, Mac) + SeedVR2 one-step diffusion
             // (native MLX on Mac sc-4815 / candle CUDA on Windows sc-5928). Available on Mac AND the
-            // Windows/CUDA candle lane; on a plain Windows/Linux box `ImageUpscale` is never advertised by
-            // the Rust worker, so it falls to the `_` arm (Python Real-ESRGAN/AuraSR). The routing oracle
-            // refuses `engine=seedvr2` on torch and `engine=real-esrgan`/`aura-sr` on the candle worker.
+            // Windows/CUDA candle lane; on a build without either lane `ImageUpscale` is never advertised,
+            // so the job remains queued. The routing oracle admits only the engines each native lane serves.
             #[cfg(any(
                 target_os = "macos",
                 all(not(target_os = "macos"), feature = "backend-candle")

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -628,8 +628,8 @@ pub(crate) async fn run_person_detect(
 /// Run the YOLO11 person detector on a rendered frame, returning the normalized detection
 /// array (Python `run_person_detect` shape) + the device the model ran on. Available on Mac
 /// (native MLX, epic 3482 / sc-3633) AND the off-Mac candle GPU-worker lane (`ort`/CUDA,
-/// sc-5498); identical body — the platform backend is chosen inside `person_jobs`. On a
-/// candle-disabled box the Python Ultralytics path serves Windows/Linux (the stub below).
+/// sc-5498); identical body — the platform backend is chosen inside `person_jobs`. A
+/// candle-disabled off-Mac build refuses the job (the stub below).
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -695,7 +695,7 @@ async fn run_yolo11_person_detect(
 /// `ffmpeg -ss duration` accurate seek then yields no output and fails the whole track.
 /// 0.2 s clears one frame for any clip ≥ 5 fps without meaningfully moving the sample.
 /// Available on Mac AND the off-Mac candle lane, like its sole caller
-/// `assemble_real_person_track` (the Python Win/Linux path samples/extracts separately).
+/// `assemble_real_person_track`.
 #[cfg(any(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
@@ -803,9 +803,9 @@ struct PersonTrackBackend {
 /// the boxes into track identities with the pure-Rust SORT/ByteTrack tracker, resample the chosen
 /// identity onto the sample cadence (sc-3634), then fill per-frame masks with the SAM segmenter.
 ///
-/// One cfg-free orchestrator shared by the macOS (native-MLX) and off-Mac candle lanes (sc-8833);
-/// the Python Ultralytics path is the fallback on a candle-disabled box. The only per-backend seams
-/// are the `backend` descriptor (device/backend/segmenter labels) and the `run_segmenter` closure —
+/// One cfg-free orchestrator shared by the macOS (native-MLX) and off-Mac candle lanes (sc-8833).
+/// A candle-disabled off-Mac build refuses the job. The only per-backend seams are the `backend`
+/// descriptor (device/backend/segmenter labels) and the `run_segmenter` closure —
 /// every rendered frame's real device overrides `device_default`, so the default only shows through
 /// in the (unreachable) zero-frame case. The work dir is cleaned up on both the not-found error path
 /// and the success path.
@@ -1465,8 +1465,7 @@ async fn assemble_real_person_track(
 
 /// Off-Mac candle GPU-worker entry point for [`assemble_real_person_track_shared`] (sc-5498 /
 /// sc-8833): supplies the candle backend descriptor (device `cuda`, SAM3-only segmenter, sc-6247)
-/// and the candle SAM3 segmenter closure. The Python Ultralytics path is the fallback on a
-/// candle-disabled box.
+/// and the candle SAM3 segmenter closure. A candle-disabled build has no person-track lane.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 #[allow(clippy::too_many_arguments)]
 async fn assemble_real_person_track(

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -25,13 +25,12 @@
 //!    shared `decode`/`nms`/`detections_to_json` consume both backends unchanged.
 //!
 //! Available on macOS AND the off-Mac candle lane (it gates with `pose_jobs`/`kps_jobs`);
-//! on a candle-disabled box the Python Ultralytics path stays the Windows/Linux backend
-//! (the candle worker advertises `person_detect`/`person_track` while the Python path stays
-//! a co-resident fallback, retired wholesale in Phase 7, epic 5483). The MLX forward pass is
+//! on a candle-disabled box the capabilities are not advertised and the jobs remain queued. The
+//! MLX forward pass is
 //! covered by an `#[ignore]` parity test against a captured per-block reference oracle; the
-//! off-Mac `ort` lane by an `#[ignore]` GPU smoke. Person *segmentation* (SAM masks) is NOT
-//! ported here — off-Mac tracks are box-only (`maskState = "missing"`); a candle SAM backport
-//! is tracked separately (epic 3792, sc-5062).
+//! off-Mac `ort` lane by an `#[ignore]` GPU smoke. Person segmentation is orchestrated separately:
+//! MLX uses SAM2, while off-Mac `media_jobs::run_candle_segmenter` supplies SAM3 masks
+//! (sc-8847 / sc-8833), so candle tracks are not box-only.
 //!
 //! Pipeline (matched to the Ultralytics YOLO11 export — verified against the real
 //! `yolo11m.onnx` + `ultralytics.predict`):

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -11,9 +11,8 @@
 //! a mask, and a detected frame that drifts is corrected back with its ByteTrack box. The
 //! binary `L` masks are written under `person-tracks/{track_id}/masks/`.
 //!
-//! macOS-only, like `person_jobs`: `mlx-gen-sam2` builds Apple MLX from source and is
-//! meaningless off Apple Silicon. The Python SAM2 path stays the Windows/Linux backend (its
-//! per-frame quality gap is tracked in epic 3792 — backport video-SAM2 via candle-gen).
+//! This SAM2 implementation is macOS-only because `mlx-gen-sam2` builds Apple MLX from source.
+//! Off-Mac person segmentation uses the native candle SAM3 lane; there is no Python fallback.
 //!
 //! The orchestration (which span to propagate, the maskState rollup, the sidecar write) lives
 //! in `media_jobs::assemble_real_person_track`; this module owns the weight

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -13,10 +13,9 @@
 //! per clip frame, written under `person-tracks/{track_id}/masks/` by the orchestrator in
 //! `media_jobs::segment_assembly_frames` — so the replacement loader and Wan-VACE are unchanged.
 //!
-//! macOS-only, like `person_segment` / `person_jobs`: `mlx-gen-sam3` builds Apple MLX from source
-//! and is meaningless off Apple Silicon. **Cross-platform divergence (surfaced, not silent — cf.
-//! epic 3792):** the Python/torch SAM2 *box-prompt* path stays the Windows/Linux backend until a
-//! parallel SAM3 backport; only the macOS MLX worker gets the text-concept upgrade today.
+//! On macOS this module uses `mlx-gen-sam3`; off-Mac the candle worker serves the same SAM3
+//! text-concept contract through its native segmenter and returns masks. The implementation is
+//! backend-specific, but neither platform falls back to Python/torch.
 //!
 //! Unlike SAM2 (converted `.pt` → MLX), SAM3 loads the **stock `facebook/sam3` checkpoint
 //! directly** (`model.safetensors` + `tokenizer.json`); no conversion step. The model is

--- a/crates/sceneworks-worker/src/person_track.rs
+++ b/crates/sceneworks-worker/src/person_track.rs
@@ -1,7 +1,7 @@
 //! Content-based selected-person tracking (sc-3634, Slice 2 of sc-3488 / epic 3482).
 //!
-//! Ports the Python `person_adapters.py` tracking semantics to Rust, replacing the procedural
-//! `track_frames_from_detection` placeholder. The Python path runs `ultralytics yolo.track(
+//! Ports the retired Python `person_adapters.py` tracking semantics to Rust, replacing the procedural
+//! `track_frames_from_detection` placeholder. The reference used `ultralytics yolo.track(
 //! tracker="bytetrack.yaml")` — a pure algorithm (no neural net): a YOLO detector per frame plus
 //! Kalman + IoU association. Here we run the native-MLX YOLO11 detector (sc-3633) at the 2-FPS
 //! sample cadence and associate the per-frame boxes into track identities with a self-contained

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -11,9 +11,8 @@
 //! Available on macOS (CoreML EP) AND the off-Mac candle GPU-worker lane (sc-5496,
 //! epic 5482): the Windows/Linux/CUDA sibling runs the SAME RTMW detector + the SAME
 //! pure pre/post math — only the `ort` execution provider differs (CoreML on Mac, CUDA
-//! with a CPU fallback off-Mac). On a candle-disabled box the Python rtmlib path stays
-//! the Windows/Linux backend; the candle worker advertises `pose_detect` while the
-//! Python path stays a co-resident fallback (retired wholesale in Phase 7, epic 5483).
+//! with a CPU fallback off-Mac). On a candle-disabled box the capability is not advertised and the
+//! job remains queued; the candle worker is the off-Mac native `pose_detect` lane.
 //! The keypoint conversion + geometry (`wholebody_to_openpose`, `squareify`,
 //! facing/bbox) are pure and unit-tested without the onnx weights; only the
 //! onnxruntime inference is gated.

--- a/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/sdxl_base_q8_mlx_smoke.rs
@@ -7,7 +7,7 @@
 //! Purpose: this is the on-device evidence that CLOSES the stale sc-1975 Q8-on-SDXL loop. sc-1975
 //! recorded that **Apple's vendored `mlx-examples` Python Q8 recipe** produced an ALL-ZERO (degenerate)
 //! decode on SDXL base 1.0, so the manifest deferred a Q8 default. That vendored in-process MLX-SDXL
-//! adapter was RETIRED by sc-3060 (the Python worker always routes torch for SDXL now); MLX-SDXL is the
+//! adapter was RETIRED by sc-3060; MLX-SDXL is now the
 //! Rust `mlx-gen-sdxl` path, whose Q4/Q8 quantization was FIXED + MERGED by mlx-gen PR #62 (sc-2641,
 //! "SDXL Q4/Q8 quantization — both hold parity on base-1.0"). This smoke asserts the Q8 render is (a)
 //! non-degenerate (per-pixel std well above the degenerate floor) and (b) SPECIFICALLY NOT all-zero —

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -22,12 +22,12 @@
 //! (`_load_model(distill_lora=None)`) — the full base model.
 //!
 //! When neither the MLX nor the candle engine is linked (a non-macOS build with `backend-candle`
-//! off), the `image_vqa` / `image_interleave` capabilities are not advertised and the handlers are
-//! stubs that error loudly (the Python torch worker serves these modes there).
+//! off), the `image_vqa` / `image_interleave` capabilities are not advertised, jobs remain queued,
+//! and the handlers are defensive stubs that error loudly if called.
 
 use super::*;
-// The macOS (MLX) and candle (Windows/CUDA) handlers parse an `ImageRequest`; the torch-defer stub
-// doesn't.
+// The macOS (MLX) and candle (Windows/CUDA) handlers parse an `ImageRequest`; the defensive
+// no-backend stub does not.
 #[cfg(any(target_os = "macos", feature = "backend-candle"))]
 use sceneworks_core::image_request::ImageRequest;
 
@@ -348,8 +348,8 @@ fn vqa_generate(
     Ok(strip_reasoning(&answer))
 }
 
-/// Off macOS without the candle backend the in-process engine is unavailable; `image_vqa` is served
-/// by the Python torch worker (macOS runs the MLX engine; Windows/CUDA runs candle when enabled).
+/// Off macOS without the candle backend the in-process engine is unavailable; the capability is not
+/// advertised and `image_vqa` remains queued (macOS runs MLX; Windows/CUDA runs candle when enabled).
 #[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 pub(crate) async fn run_vqa_job(
     _api: &ApiClient,
@@ -819,8 +819,8 @@ fn interleave_generate(
     Ok((out.text, decoded))
 }
 
-/// Off macOS without the candle backend the in-process engine is unavailable; `image_interleave` is
-/// served by the Python torch worker (macOS runs MLX; Windows/CUDA runs candle when enabled).
+/// Off macOS without the candle backend the in-process engine is unavailable; the capability is not
+/// advertised and `image_interleave` remains queued (macOS runs MLX; Windows/CUDA runs candle when enabled).
 #[cfg(all(not(target_os = "macos"), not(feature = "backend-candle")))]
 pub(crate) async fn run_interleave_job(
     _api: &ApiClient,

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -36,8 +36,8 @@ pub struct Settings {
     /// off-Mac, so a candle build advertises them by default — no `SCENEWORKS_BACKEND_CANDLE_ENABLED`
     /// needed. A non-candle build (Mac mlx, the desktop installer with no CUDA, any CPU/Linux build
     /// without the feature) defaults `false` and links no candle crate, so this is inert there. The
-    /// env var still overrides either way (set `0` to force a candle build back onto the Python
-    /// torch fallback during a staged rollout).
+    /// env var still overrides either way (set `0` to disable native candle capabilities during a
+    /// staged rollout; unsupported jobs then remain queued).
     pub backend_candle_enabled: bool,
     /// Operator-configured directories outside the app data dir and the Hugging Face cache
     /// that may be read for model weights — typically an existing ComfyUI `models/` tree

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -188,7 +188,7 @@ fn rust_cpu_capabilities_do_not_claim_gpu_generation_jobs() {
         .iter()
         .any(|capability| capability.as_str() == "timeline_export"));
     // The CPU utility worker advertises only the procedural *preview*
-    // capabilities; real detection/tracking route to the Python GPU worker.
+    // capabilities; real detection/tracking route to the native MLX/candle worker.
     assert!(cpu_capabilities
         .iter()
         .any(|capability| capability.as_str() == "person_detect_preview"));
@@ -238,7 +238,7 @@ fn mlx_gpu_advertises_generation_capabilities_only() {
         .iter()
         .any(|capability| capability.as_str() == "image_generate"));
     // Plain Image Edit (sc-3513): without this the API's worker_supports_job would
-    // reject an `image_edit` claim and the job would silently fall back to torch.
+    // reject an `image_edit` claim and the job would remain queued.
     assert!(capabilities
         .iter()
         .any(|capability| capability.as_str() == "image_edit"));

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -19,10 +19,9 @@
 //! cross-platform. The real run executes in-process on the macOS
 //! MLX engine OR — the off-Mac cutover (sc-7817, epic 5164) — on the candle Windows/CUDA + Linux
 //! engine, for the five families with a candle trainer (`sdxl`/`z_image_turbo`/`lens`/the Krea 2 Raw
-//! 12B DiT `krea_2_raw` (sc-8614)/the Wan A14B **T2V** `wan2_2_t2v_14b`). The Python torch trainer
-//! has no Krea path at all (Krea is Rust-only — mlx or candle); it stays the fallback for everything
-//! else off-Mac with no candle trainer (Kolors, LTX, the dense Wan 5B, the Wan I2V A14B) and the
-//! cross-platform default until candle is the default off-Mac worker.
+//! 12B DiT `krea_2_raw` (sc-8614)/the Wan A14B **T2V** `wan2_2_t2v_14b`). Families without a native
+//! trainer for the active backend (Kolors, LTX, the dense Wan 5B, and Wan I2V A14B off-Mac) are
+//! refused and remain queued; there is no Python/torch training fallback.
 
 use super::*;
 use sceneworks_core::training::{TrainingPlan, TRAINING_PLAN_VERSION};
@@ -537,7 +536,8 @@ fn resolve_sample_prompts(pool: Vec<String>, count: u32) -> Vec<String> {
 /// got checkpointing in sc-5246, and the Wan A14B trainer needs it too). Scoped to exactly the
 /// candle-trainable big-DiT families: Z-Image and the Wan A14B **T2V** MoE — the same set
 /// `jobs_store::training_job_is_candle_eligible` gates the MoE to (only `wan_2_2_t2v_14b` has a candle
-/// trainer; the I2V A14B / dense 5B stay on torch). Krea 2 Raw is a 12B DiT (epic 7565 P4, sc-8614) —
+/// trainer; the I2V A14B / dense 5B are refused and remain queued). Krea 2 Raw is a 12B DiT
+/// (epic 7565 P4, sc-8614) —
 /// the same dense-backward OOM class, so it is forced too (the sc-7900 big-DiT backstop). SDXL's
 /// smaller U-Net fits a dense backward (the `candle_sdxl_real_weights` smoke trains it with
 /// checkpointing off) and Lens is small, so neither is forced — both honor the plan's value.

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -16,8 +16,7 @@
 //! the candle lane (`backend-candle`, off-Mac) — the same gate as the module. The tiling
 //! math (`tile_slices`, crop/place) is pure and unit-tested without the onnx weights;
 //! only the execution provider (`build_session`) is cfg-split. Off-Mac, Real-ESRGAN is
-//! served by the candle worker; the Python torch Real-ESRGAN path stays a co-resident
-//! fallback until Phase 7 (epic 5483) retires it.
+//! served by the candle worker.
 //!
 //! Engine scope: `engine=real-esrgan` (the default, the `ort` path above) and
 //! `engine=seedvr2` (epic 4811 / sc-4815 — the one-step diffusion super-resolution upscaler) are
@@ -26,10 +25,10 @@
 //! (single-resident engine cache — it evicts any cached image-gen engine, bounding peak memory,
 //! which matters because the SeedVR2 image path has no spatial tiling yet). It takes a target
 //! resolution (factor → `round_to_16(src × factor)`) and an optional `--softness` pre-blur.
-//! `aura-sr` (a 617M-param torch-only GigaGAN) was dropped on Mac after the sc-3668 port-or-drop
+//! `aura-sr` (a 617M-param legacy GigaGAN) was dropped on Mac after the sc-3668 port-or-drop
 //! spike and is now dropped as an offered engine off-Mac too (sc-5499): it is refused by the routing
 //! oracle (`upscale_job_is_mlx_eligible` / `upscale_job_is_candle_eligible`) and hidden in the UI,
-//! so it only runs if explicitly submitted to the Python torch worker (retired in Phase 7).
+//! so an explicit defensive submission is refused and remains queued.
 //!
 //! Tiling parity (matched to `upscalers.py:_run_tiled`):
 //!  - tile grid `tile_slices(w,h,512)`; per-tile crop padded by `tile_pad=16`
@@ -1059,7 +1058,7 @@ pub(crate) async fn run_image_upscale_job(
         // candle GPU-worker lane (sc-5499), both with a CPU fallback. The routing oracle
         // (`upscale_job_is_candle_eligible` / `upscale_job_is_mlx_eligible`) admits Real-ESRGAN on
         // both lanes; `engine=aura-sr` is refused before reaching here (defensive `engine_id` guard
-        // above), staying on the Python torch worker until Phase 7.
+        // above) and remains queued.
         update_job(
             api,
             &job.id,

--- a/crates/sceneworks-worker/src/video_jobs/wan.rs
+++ b/crates/sceneworks-worker/src/video_jobs/wan.rs
@@ -378,7 +378,7 @@ fn wan_quant_bits(request: &VideoRequest) -> Option<i64> {
 ///
 /// The video lane deliberately does NOT take epic 10721's app-wide **Q8** default (sc-10726); it keeps
 /// the pre-sc-10726 q4-first default (sc-10859). Rationale: the MLX video lane has no user Q8 lever
-/// (Video Studio's quant control is the GGUF/torch path), so a silent Q8 default gives no UI-accessible
+/// (Video Studio's quant control targets the GGUF import path), so a silent Q8 default gives no UI-accessible
 /// quality benefit and only ever surfaces as an *accidental* default when the Q8 tier landed on disk via
 /// a side lane — where it risks a video-runtime OOM at heavy res/frame counts (the install-fit clamp
 /// doesn't help: the sc-8516 budget is 1024²-image-calibrated). Q8/bf16 stay reachable on an explicit


### PR DESCRIPTION
## Summary

- replace stale Python/Torch/MPS fallback claims in Rust comments with the actual native MLX/Candle behavior or queued/refused unsupported outcome
- correct the four specifically named `gpu.rs` paths for person generation, video extend/bridge, SenseNova VQA/interleave, and SAM3 masks
- preserve valid parity, provenance, compatibility, and checkpoint-layout references

## Scope

This is a comments-only audit across 52 Rust files. No executable code, contracts, tests, or runtime behavior changed. The optional automated guard was not added because that would violate the story's comments-only scope; the equivalent guard was run during validation.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- comments-only diff guard: PASS
- targeted residual-claim scans against current routing and architecture source
- full hardware-authorized `npm run rust:check`: PASS, including Clippy, tests, Metal `nax_guard`, and final build
- fresh independent adversarial review: PASS, no required fixes

Shortcut: https://app.shortcut.com/trefry/story/14630/purge-stale-python-torch-fallback-claims-from-rust-comments
