### PR TITLE
feat(web): rebuild the Settings screen on the Page-Frame standard

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -211,7 +211,10 @@ export const viewTitles = {
   Queue: { title: "Queue", blurb: "All running and recent jobs across workers." },
   Stats: { title: "Generation Stats", blurb: "Compare runs by model, quant, settings, timing and memory." },
   Logs: { title: "Logs", blurb: "This session's activity — routing decisions, worker phases and errors." },
-  Settings: { title: "Settings", blurb: "Paths, service tokens, and detected GPU." },
+  Settings: {
+    title: "Settings",
+    blurb: "Appearance, generation defaults, storage, credentials and this machine.",
+  },
   Licenses: {
     title: "Licenses",
     blurb: "Third-party components bundled with SceneWorks and their license notices.",
@@ -2694,7 +2697,18 @@ export function App() {
         {activeView === "Library" ? <LibraryScreen /> : null}
         {activeView === "Queue" ? <QueueScreen /> : null}
         {activeView === "Models" ? <ModelManagerScreen /> : null}
-        {activeView === "Settings" ? <SettingsScreen /> : null}
+        {/* Accent + the Simple-mode default live in App state alongside the sidebar's mode
+            switch (they are not on the app context), so Settings receives them as props —
+            the same pair SimpleShell gets, writing through to the same ui-preferences store. */}
+        {activeView === "Settings" ? (
+          <SettingsScreen
+            accent={accent}
+            lockedToSimple={uiModeLocked}
+            onAccentChange={changeAccent}
+            onSimpleDefaultChange={changeSimpleUiDefault}
+            simpleDefault={simpleUiDefault}
+          />
+        ) : null}
         {activeView === "Stats" ? <StatsScreen /> : null}
         {activeView === "Logs" ? <LogsScreen /> : null}
         {activeView === "Licenses" ? <LicensesScreen /> : null}

--- a/apps/web/src/deviceSummary.js
+++ b/apps/web/src/deviceSummary.js
@@ -1,0 +1,25 @@
+// Engine + GPU summary from the live worker registry — the one signal available in every
+// deployment (desktop, Docker, remote browser). Shared by the advanced Settings screen's
+// "This machine" group and Simple Settings' Device group so both read the identical
+// derivation (Settings-page redesign handoff); it used to live in simple/SimpleSettings.jsx.
+//
+// An MLX worker means Apple Silicon unified memory; anything else is the discrete-GPU
+// (candle) lane. Unknown values read "Detecting…" rather than a fabricated placeholder.
+export function describeDevice(workers, macCapabilities) {
+  const gpuWorkers = (workers ?? []).filter((worker) => worker?.gpuId && worker.gpuId !== "cpu");
+  const mlx = gpuWorkers.find((worker) => worker.gpuId === "mlx");
+  const primary = mlx ?? gpuWorkers[0] ?? null;
+  const engine = mlx
+    ? "MLX · Apple Silicon"
+    : primary
+      ? "Candle · discrete GPU"
+      : macCapabilities?.platform === "macos"
+        ? "MLX · Apple Silicon"
+        : "Detecting…";
+  if (!primary) {
+    return { engine, gpu: "No worker connected" };
+  }
+  const totalMb = Number(primary.utilization?.memoryTotalMb);
+  const memory = Number.isFinite(totalMb) && totalMb > 0 ? ` · ${(totalMb / 1024).toFixed(0)} GB` : "";
+  return { engine, gpu: `${primary.gpuName ?? `GPU ${primary.gpuId}`}${memory}` };
+}

--- a/apps/web/src/generationQuality.js
+++ b/apps/web/src/generationQuality.js
@@ -47,6 +47,18 @@ export function generationQualityLabel(value) {
   return LABELS[value] ?? value;
 }
 
+// Chip-sized label for a quality value — [Auto, bf16, Q8, Q4]. Derived from the value rather than a
+// lookup table, so a tier added to the vocabulary still gets a sensible chip; the descriptive wording
+// above rides the chip's `title` and the line beneath it. Shared by both Settings screens (the
+// advanced one's Generation group and Simple Settings), which render the same four chips.
+export function shortQualityLabel(value) {
+  if (value === AUTO_GENERATION_QUALITY) {
+    return "Auto";
+  }
+  // bf16 is written lower-case everywhere in the product; the quant tiers are upper-case.
+  return value === "bf16" ? "bf16" : String(value).toUpperCase();
+}
+
 // The valid setting for `value` — "auto" or an explicit bf16|q8|q4 — else the "auto" default when it
 // isn't one of them. Auto is the app-wide default (epic 10721 R3): an unset/invalid preference means
 // "let the app pick the best tier that fits", not a flat q8.

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   SCHEME_LABELS,
   loadCredentials,
@@ -12,9 +12,16 @@ import {
   GENERATION_QUALITY_OPTIONS,
   generationQualityLabel,
   readDefaultGenerationQuality,
+  shortQualityLabel,
   writeDefaultGenerationQuality,
 } from "../generationQuality.js";
 import { writeClipboardText } from "../clipboard.js";
+import { WorkPanel } from "../components/WorkPanel.jsx";
+import { Icon } from "../components/Icons.jsx";
+import { ModeTabs } from "./generationStudio.jsx";
+import { ACCENTS } from "../accents.js";
+import { describeDevice } from "../deviceSummary.js";
+import { useAppContext } from "../context/AppContext.js";
 
 // The data-dir / GPU / worker / wizard / remote-access controls are desktop-only
 // (backed by Tauri commands in the shell) and are gated behind `isDesktop` so a
@@ -23,6 +30,14 @@ import { writeClipboardText } from "../clipboard.js";
 // shared ../credentials.js transport (keychain on desktop, authed REST on the
 // server / remote browser). `isDesktop`/`invoke` come from the unified runtime
 // helper (story 6).
+//
+// Settings-page redesign handoff: the screen is the Page-Frame standard (page-frame →
+// WorkPanel → .prompt-hero-top → ModeTabs, the same arrangement as Image Studio), split
+// into four tabs so it stops being one long scroll. Theme, accent, the Simple-mode
+// default and the engine/GPU readout — which previously only existed in Simple mode —
+// are surfaced here too, wired to the SAME durable stores (`PUT /api/v1/ui-preferences`
+// via App.jsx's changeTheme/changeAccent/changeSimpleUiDefault), so a change made in
+// either screen is the same change.
 
 // GPU memory cap (epic 7819). The persisted value is a fraction (0.1–0.99) of total unified
 // memory, or null/absent for "no limit". The slider works in whole percent; 100% means Off.
@@ -38,7 +53,22 @@ function bytesToGb(bytes) {
   return bytes / (1024 * 1024 * 1024);
 }
 
-export function SettingsScreen() {
+const SCHEME_OPTIONS = [
+  ["bearer", "Bearer header"],
+  ["query", "Query token"],
+];
+
+export function SettingsScreen({
+  accent,
+  onAccentChange,
+  simpleDefault = false,
+  onSimpleDefaultChange,
+  lockedToSimple = false,
+}) {
+  // theme/changeTheme and the worker registry come from the app context (the same values the
+  // topbar toggle and Simple Settings read); accent + the Simple-mode default are drilled from
+  // App.jsx, which owns them alongside the sidebar's mode switch.
+  const { theme, changeTheme, visibleWorkers = [], macCapabilities } = useAppContext();
   const [settings, setSettings] = useState(null);
   const [gpu, setGpu] = useState(null);
   const [credentials, setCredentials] = useState([]);
@@ -47,6 +77,8 @@ export function SettingsScreen() {
   const [newScheme, setNewScheme] = useState("bearer");
   const [newToken, setNewToken] = useState("");
   const [status, setStatus] = useState("");
+  // Which tab is showing. Not persisted — the screen is short-lived.
+  const [tab, setTab] = useState("appearance");
   // LAN remote access (epic 4484 stories 4/11). `remote` is the RemoteAccessStatus
   // snapshot from the shell; only fetched/rendered on desktop.
   const [remote, setRemote] = useState(null);
@@ -293,329 +325,522 @@ export function SettingsScreen() {
 
   const canSaveCredential = newHost.trim() && newToken.trim();
 
+  // Engine / GPU are read off the live worker registry — the one signal available in every
+  // deployment (desktop, Docker, remote browser), so "This machine" renders in both.
+  const device = useMemo(
+    () => describeDevice(visibleWorkers, macCapabilities),
+    [visibleWorkers, macCapabilities],
+  );
+
+  // The Server tab exists only where remote access does (the same condition that gated the old
+  // Remote-access card). When it disappears under a selected "server" tab, fall back to Appearance
+  // rather than rendering an empty panel.
+  const serverTabAvailable = Boolean(isDesktop && remote);
+  const activeTab = tab === "server" && !serverTabAvailable ? "appearance" : tab;
+  const tabOptions = [
+    ["appearance", "Appearance"],
+    ["settings", "Settings"],
+    ["device", "Device"],
+    ...(serverTabAvailable ? [["server", "Server"]] : []),
+  ];
+
+  const macGpuMemory = gpu?.platform === "macos" && Boolean(gpu?.unifiedMemoryMb);
+  const unifiedGb = macGpuMemory ? Math.round(gpu.unifiedMemoryMb / 1024) : 0;
+  const gpuTargetLabel =
+    gpuLimitPercent >= 100
+      ? "Use all available"
+      : `~${Math.round(unifiedGb * (gpuLimitPercent / 100))} GB of ${unifiedGb} GB (${gpuLimitPercent}%)`;
+
   return (
-    <div className="settings-screen">
-      {status ? <p className="settings-status">{status}</p> : null}
-
-      <section className="settings-card">
-        <h3>Generation quality</h3>
-        <p className="settings-muted">
-          The default quality tier new generations use for a model you haven’t picked a
-          tier for yet. <strong>Auto</strong> picks the highest-fidelity tier that fits this
-          machine’s memory for each model — so a small model runs at full precision and a
-          heavy one steps down to what fits. You can still pin a fixed tier here, or override
-          per model in the studio; your per-model picks are remembered.
-        </p>
-        <div className="settings-actions">
-          <label htmlFor="default-generation-quality">Default quality</label>
-          <select
-            id="default-generation-quality"
-            value={defaultQuality}
-            onChange={(event) => changeDefaultQuality(event.target.value)}
-            aria-label="Default generation quality"
-          >
-            {GENERATION_QUALITY_OPTIONS.map((value) => (
-              <option key={value} value={value}>
-                {generationQualityLabel(value)}
-              </option>
-            ))}
-          </select>
+    <section className="page-frame settings-screen">
+      <WorkPanel className="settings-work-panel">
+        <div className="prompt-hero-top">
+          <ModeTabs
+            label="Settings section"
+            options={tabOptions}
+            mode={activeTab}
+            onChange={setTab}
+          />
         </div>
-      </section>
 
-      {isDesktop ? (
-        <section className="settings-card">
-          <h3>Data directory</h3>
-          <p className="settings-value">{dataDirLabel}</p>
-          <div className="settings-actions">
-            <button type="button" onClick={changeDataDir}>
-              Change…
-            </button>
-            <button type="button" onClick={revealDataDir} disabled={!settings?.dataDir}>
-              Reveal in {gpu?.platform === "windows" ? "Explorer" : "Finder"}
-            </button>
-          </div>
-        </section>
-      ) : null}
+        {/* One status line under the tab row — the old full-width band above the panel is gone. */}
+        {status ? <p className="settings-status">{status}</p> : null}
 
-      {isDesktop && remote ? (
-        <section className="settings-card">
-          <h3>Remote access (LAN)</h3>
-          <p className="settings-muted">
-            Let another device on your local network use SceneWorks in a browser, with
-            generation running on this computer. Off by default; protected by a password
-            you set.
-          </p>
-          <p className="settings-value">
-            {remote.enabled ? "Enabled" : "Disabled"}
-            {remote.enabled && remote.url ? ` · ${remote.url}` : ""}
-          </p>
-
-          <div className="settings-actions settings-credential-form">
-            <input
-              type="password"
-              placeholder={remote.passwordSet ? "Change password" : "Set a password"}
-              value={remotePassword}
-              onChange={(event) => setRemotePassword(event.target.value)}
-              aria-label="Remote access password"
-            />
-            <button
-              type="button"
-              onClick={saveRemotePassword}
-              disabled={!remotePassword.trim()}
-            >
-              {remote.passwordSet ? "Change password" : "Set password"}
-            </button>
-            {remote.passwordSet ? (
-              <button type="button" onClick={clearRemotePassword}>
-                Clear password
-              </button>
-            ) : null}
-          </div>
-          <p className="settings-muted">
-            {remote.passwordSet
-              ? "A password is set. Remote browsers must enter it to connect."
-              : "Set a password before enabling remote access."}
-          </p>
-
-          <div className="settings-actions">
-            <label htmlFor="remote-port">Port</label>
-            <input
-              id="remote-port"
-              type="number"
-              min="1024"
-              max="65535"
-              value={remotePort}
-              onChange={(event) => setRemotePort(event.target.value)}
-              aria-label="Remote access port"
-            />
-            {remote.enabled ? (
-              <button type="button" onClick={() => applyRemoteAccess(false)}>
-                Disable remote access
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => applyRemoteAccess(true)}
-                disabled={!remote.passwordSet}
-              >
-                Enable remote access
-              </button>
-            )}
-            {remote.url ? (
-              <button type="button" onClick={copyRemoteUrl}>
-                Copy URL
-              </button>
-            ) : null}
-          </div>
-
-          {remote.url ? (
-            <p className="settings-muted">
-              Open <code>{remote.url}</code> on another device on this network.
-              {remote.lanCandidates && remote.lanCandidates.length > 1
-                ? ` Other addresses: ${remote.lanCandidates.slice(1).join(", ")}.`
-                : ""}
-            </p>
-          ) : (
-            <p className="settings-muted">
-              Couldn’t determine this computer’s LAN address — check your network
-              connection.
-            </p>
-          )}
-
-          {/* Security note + platform firewall guidance (story 11). */}
-          <p className="settings-help">
-            Trusted local networks only. Traffic uses plain HTTP, so the password and
-            your content travel unencrypted on the LAN — do not port-forward this or
-            expose it to the public internet. The URL only works for devices on the same
-            network.
-          </p>
-          {remote.enabled ? (
-            remote.platform === "windows" ? (
-              <p className="settings-help">
-                The first time SceneWorks binds the network port, Windows shows a
-                “Windows Security Alert”. Allow SceneWorks on <strong>Private</strong>{" "}
-                networks (not Public), or remote devices can’t connect. To change it
-                later: Windows Security → Firewall &amp; network protection → Allow an
-                app through firewall.
-              </p>
-            ) : (
-              <p className="settings-help">
-                The first time SceneWorks binds the network port, macOS may ask to
-                “allow incoming connections” — click Allow. To change it later: System
-                Settings → Network → Firewall.
-              </p>
-            )
-          ) : null}
-          <p className="settings-muted">
-            Changing these settings takes effect after you restart SceneWorks.
-          </p>
-        </section>
-      ) : null}
-
-      <section className="settings-card">
-        <h3>Service credentials</h3>
-        <p className="settings-muted">
-          API tokens for model &amp; LoRA downloads (Hugging Face, Civit.ai, and any
-          other authenticated source). Stored in {credentialLocation}; tokens are
-          never displayed again after saving. Changing a credential takes effect on
-          the next worker restart.
-        </p>
-        {credentials.length ? (
-          <ul className="settings-list">
-            {credentials.map((credential) => (
-              <li key={credential.host} className="settings-credential">
-                <span className="settings-value">
-                  {credential.label ? `${credential.label} — ` : ""}
-                  <code>{credential.host}</code>{" "}
-                  <span className="settings-muted">
-                    ({SCHEME_LABELS[credential.scheme] ?? credential.scheme}
-                    {credential.present ? "" : " · token missing"})
-                  </span>
-                </span>
-                <button type="button" onClick={() => removeCredential(credential.host)}>
-                  Remove
+        {activeTab === "appearance" ? (
+          <div className="settings-tab-body">
+            <div className="settings-group-title">Theme</div>
+            <div className="settings-row">
+              <span className="settings-row-title">Mode</span>
+              <div className="settings-segment" role="radiogroup" aria-label="Theme">
+                <button
+                  aria-checked={theme === "light"}
+                  className={theme === "light" ? "active" : ""}
+                  onClick={() => changeTheme("light")}
+                  role="radio"
+                  type="button"
+                >
+                  <Icon.Sun size={14} />
+                  Light
                 </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="settings-muted">No credentials saved.</p>
-        )}
-        <div className="settings-actions settings-credential-form">
-          <input
-            type="text"
-            placeholder="Host (e.g. huggingface.co)"
-            value={newHost}
-            onChange={(event) => setNewHost(event.target.value)}
-            aria-label="Credential host"
-          />
-          <input
-            type="text"
-            placeholder="Label (optional)"
-            value={newLabel}
-            onChange={(event) => setNewLabel(event.target.value)}
-            aria-label="Credential label"
-          />
-          <select
-            value={newScheme}
-            onChange={(event) => setNewScheme(event.target.value)}
-            aria-label="Authentication scheme"
-          >
-            <option value="bearer">Bearer header</option>
-            <option value="query">Query token</option>
-          </select>
-          <input
-            type="password"
-            placeholder="Token"
-            value={newToken}
-            onChange={(event) => setNewToken(event.target.value)}
-            aria-label="Credential token"
-          />
-          <button type="button" onClick={addCredential} disabled={!canSaveCredential}>
-            Save token
-          </button>
-        </div>
-      </section>
+                <button
+                  aria-checked={theme === "dark"}
+                  className={theme === "dark" ? "active" : ""}
+                  onClick={() => changeTheme("dark")}
+                  role="radio"
+                  type="button"
+                >
+                  <Icon.Moon size={14} />
+                  Dark
+                </button>
+              </div>
+            </div>
+            <div className="settings-row settings-row--top">
+              <div>
+                <div className="settings-row-title">Accent</div>
+                <div className="settings-row-sub">Recolors the whole app — chips, buttons, the mark.</div>
+              </div>
+              <div className="settings-accents" role="radiogroup" aria-label="Accent">
+                {ACCENTS.map((entry) => (
+                  <button
+                    aria-checked={accent === entry.id}
+                    aria-label={entry.name}
+                    className={
+                      accent === entry.id ? "settings-accent-swatch active" : "settings-accent-swatch"
+                    }
+                    key={entry.id}
+                    onClick={() => onAccentChange?.(entry.id)}
+                    role="radio"
+                    style={{ background: entry.swatch }}
+                    type="button"
+                  />
+                ))}
+              </div>
+            </div>
 
-      {isDesktop ? (
-        <section className="settings-card">
-          <h3>Detected GPU</h3>
-          {gpu?.devices?.length ? (
-            <ul className="settings-list">
-              {gpu.devices.map((device) => (
-                <li key={device}>{device}</li>
-              ))}
-            </ul>
-          ) : (
-            <p className="settings-muted">No accelerated GPU detected.</p>
-          )}
-          {gpu?.unifiedMemoryMb ? (
-            <p className="settings-muted">
-              Unified memory: {Math.round(gpu.unifiedMemoryMb / 1024)} GB
-              {typeof gpu.wiredLimitMb === "number"
-                ? ` · GPU cap: ${Math.round(gpu.wiredLimitMb / 1024)} GB`
-                : ""}
-            </p>
-          ) : null}
-          {gpu?.platform === "macos" && gpu?.unifiedMemoryMb ? (
-            <div className="settings-gpu-cap">
-              <label htmlFor="gpu-memory-cap">
-                GPU memory for SceneWorks:{" "}
-                {gpuLimitPercent >= 100
-                  ? "Use all available"
-                  : `~${Math.round((gpu.unifiedMemoryMb / 1024) * (gpuLimitPercent / 100))} GB of ` +
-                    `${Math.round(gpu.unifiedMemoryMb / 1024)} GB (${gpuLimitPercent}%)`}
-              </label>
-              <input
-                id="gpu-memory-cap"
-                type="range"
-                min={GPU_LIMIT_MIN_PERCENT}
-                max={100}
-                step={5}
-                value={gpuLimitPercent}
-                aria-label="GPU memory target for SceneWorks (percent of unified memory)"
-                onChange={(event) => setGpuLimitPercent(Number(event.target.value))}
-                onMouseUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
-                onKeyUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
-                onTouchEnd={(event) => commitGpuMemoryLimit(Number(event.target.value))}
-              />
-              <p className="settings-help">
-                A soft target for how much unified memory SceneWorks holds, so more stays free for the
-                rest of your system. It is not a hard limit — large models can still use more when they
-                need it. Changes apply within a couple of seconds — no restart needed.
+            <div className="work-panel-divider" />
+            <div className="settings-group-title">Simple mode</div>
+            <div className="settings-row">
+              <div>
+                <div className="settings-row-title">Use Simple mode by default</div>
+                <div className="settings-row-sub">
+                  {lockedToSimple
+                    ? "Phones always use it."
+                    : "Phones always use it; the sidebar switch overrides it for this session."}
+                </div>
+              </div>
+              <button
+                aria-checked={simpleDefault}
+                aria-label="Use Simple mode by default"
+                className={simpleDefault ? "settings-toggle on" : "settings-toggle"}
+                onClick={() => onSimpleDefaultChange?.(!simpleDefault)}
+                role="switch"
+                type="button"
+              >
+                <span />
+              </button>
+            </div>
+
+            <div className="work-panel-divider" />
+            <div className="settings-group-title">Generation</div>
+            <div>
+              <div className="settings-row-title">Default quality</div>
+              {/* SHORT labels (the tier keys) — the descriptive wording ("Auto (best that fits this
+                  Mac)") doesn't fit a 34px chip, so it rides the title attribute and the line below. */}
+              <div className="settings-chips" role="radiogroup" aria-label="Default generation quality">
+                {GENERATION_QUALITY_OPTIONS.map((value) => (
+                  <button
+                    aria-checked={defaultQuality === value}
+                    className={defaultQuality === value ? "settings-chip active" : "settings-chip"}
+                    key={value}
+                    onClick={() => changeDefaultQuality(value)}
+                    role="radio"
+                    title={generationQualityLabel(value)}
+                    type="button"
+                  >
+                    {shortQualityLabel(value)}
+                  </button>
+                ))}
+              </div>
+              <div className="settings-row-sub">{generationQualityLabel(defaultQuality)}</div>
+              <p className="settings-note settings-note--spaced">
+                The tier new generations use for a model you haven’t picked one for yet.{" "}
+                <strong>Auto</strong> takes the highest-fidelity tier that fits this machine for each
+                model. Per-model picks in a studio always win, and are remembered.
               </p>
-              {gpuTelemetry ? (
-                <p className="settings-muted">
-                  MLX memory — Active: {bytesToGb(gpuTelemetry.activeBytes).toFixed(1)} GB · Peak:{" "}
-                  {bytesToGb(gpuTelemetry.peakBytes).toFixed(1)} GB
-                  {gpuTelemetry.limitBytes
-                    ? ` · Limit: ${Math.round(bytesToGb(gpuTelemetry.limitBytes))} GB`
-                    : ""}
-                </p>
+            </div>
+          </div>
+        ) : null}
+
+        {activeTab === "settings" ? (
+          <div className="settings-tab-body">
+            {isDesktop ? (
+              <>
+                <div className="settings-group-title">Storage</div>
+                <div>
+                  <div className="settings-row-title">Data directory</div>
+                  <div className="settings-row-sub">
+                    Projects, generated assets, models and LoRAs. Moving it needs a restart.
+                  </div>
+                  <div className="settings-path">{dataDirLabel}</div>
+                  <div className="settings-button-row">
+                    <button className="settings-btn" type="button" onClick={changeDataDir}>
+                      Change…
+                    </button>
+                    <button
+                      className="settings-btn"
+                      type="button"
+                      onClick={revealDataDir}
+                      disabled={!settings?.dataDir}
+                    >
+                      Reveal in {gpu?.platform === "windows" ? "Explorer" : "Finder"}
+                    </button>
+                  </div>
+                </div>
+                <div className="work-panel-divider" />
+              </>
+            ) : null}
+
+            <div className="settings-group-title">Service credentials</div>
+            <p className="settings-note">
+              API tokens for model &amp; LoRA downloads — Hugging Face, Civit.ai, any authenticated
+              source. Stored in {credentialLocation}. Tokens are write-only: never shown again after
+              saving, and a change takes effect on the next worker restart.
+            </p>
+            {credentials.length ? (
+              <div className="settings-credential-list">
+                {credentials.map((credential) => (
+                  <div className="settings-credential" key={credential.host}>
+                    <span
+                      className={
+                        credential.present === false
+                          ? "settings-credential-glyph missing"
+                          : "settings-credential-glyph"
+                      }
+                    >
+                      {credential.present === false ? (
+                        <Icon.Warning size={18} />
+                      ) : (
+                        <Icon.Model size={18} />
+                      )}
+                    </span>
+                    <span className="settings-credential-text">
+                      <span className="settings-credential-host">{credential.host}</span>
+                      <span className="settings-credential-meta">
+                        {credential.label ? `${credential.label} · ` : ""}
+                        {SCHEME_LABELS[credential.scheme] ?? credential.scheme}
+                        {credential.present === false ? " · token missing" : " · token saved"}
+                      </span>
+                    </span>
+                    <button
+                      className="settings-btn settings-btn--quiet settings-btn--compact"
+                      type="button"
+                      onClick={() => removeCredential(credential.host)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="settings-note">No credentials saved.</p>
+            )}
+            <div className="settings-inset settings-credential-form">
+              <div className="settings-inset-title">Add a token</div>
+              <div className="settings-field-pair">
+                <input
+                  type="text"
+                  placeholder="huggingface.co"
+                  value={newHost}
+                  onChange={(event) => setNewHost(event.target.value)}
+                  aria-label="Credential host"
+                />
+                <input
+                  type="text"
+                  placeholder="Label (optional)"
+                  value={newLabel}
+                  onChange={(event) => setNewLabel(event.target.value)}
+                  aria-label="Credential label"
+                />
+              </div>
+              <div
+                className="settings-chips settings-chips--narrow"
+                role="radiogroup"
+                aria-label="Authentication scheme"
+              >
+                {SCHEME_OPTIONS.map(([value, label]) => (
+                  <button
+                    aria-checked={newScheme === value}
+                    className={newScheme === value ? "settings-chip active" : "settings-chip"}
+                    key={value}
+                    onClick={() => setNewScheme(value)}
+                    role="radio"
+                    type="button"
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <div className="settings-field-row">
+                <input
+                  className="settings-grow"
+                  type="password"
+                  placeholder="Access token"
+                  value={newToken}
+                  onChange={(event) => setNewToken(event.target.value)}
+                  aria-label="Credential token"
+                />
+                <button
+                  className="settings-btn settings-btn--primary"
+                  type="button"
+                  onClick={addCredential}
+                  disabled={!canSaveCredential}
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {activeTab === "device" ? (
+          <div className="settings-tab-body">
+            <div className="settings-group-title">This machine</div>
+            <div className="settings-kv-list">
+              <div className="settings-kv">
+                <span>Engine</span>
+                <span>{device.engine}</span>
+              </div>
+              <div className="settings-kv">
+                <span>GPU</span>
+                <span>{device.gpu}</span>
+              </div>
+              {macGpuMemory ? (
+                <div className="settings-kv">
+                  <span>Unified memory</span>
+                  <span>
+                    {unifiedGb} GB
+                    {typeof gpu.wiredLimitMb === "number"
+                      ? ` · system cap ${Math.round(gpu.wiredLimitMb / 1024)} GB`
+                      : ""}
+                  </span>
+                </div>
               ) : null}
             </div>
-          ) : null}
-          {gpu?.platform === "macos" ? (
-            <p className="settings-help">
-              On 96/128 GB Macs you can raise the GPU memory cap:{" "}
-              <code>sudo sysctl iogpu.wired_limit_mb=&lt;bytes&gt;</code>
-            </p>
-          ) : null}
-          {gpu?.platform === "windows" || gpu?.platform === "linux" ? (
-            <p className="settings-help">
-              Requires current NVIDIA drivers with CUDA support. The GPU memory target is
-              macOS-only — a discrete GPU has no per-process memory cap, so generations use
-              whatever VRAM they need.
-            </p>
-          ) : null}
-        </section>
-      ) : null}
 
-      {/* Available in both modes: desktop restarts via Tauri, a remote admin via REST
-          (epic 4484 story 12). */}
-      <section className="settings-card">
-        <h3>Inference worker</h3>
-        <div className="settings-actions">
-          <button type="button" onClick={restartWorker}>
-            Restart worker
-          </button>
-        </div>
-      </section>
+            {macGpuMemory ? (
+              <>
+                <div className="work-panel-divider" />
+                <div className="settings-group-title">GPU memory</div>
+                <div>
+                  <div className="settings-row settings-row--baseline">
+                    <div className="settings-row-title">Memory target</div>
+                    <div className="settings-readout">{gpuTargetLabel}</div>
+                  </div>
+                  <input
+                    className="settings-range"
+                    type="range"
+                    min={GPU_LIMIT_MIN_PERCENT}
+                    max={100}
+                    step={5}
+                    value={gpuLimitPercent}
+                    aria-label="GPU memory target for SceneWorks (percent of unified memory)"
+                    onChange={(event) => setGpuLimitPercent(Number(event.target.value))}
+                    onMouseUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
+                    onKeyUp={(event) => commitGpuMemoryLimit(Number(event.target.value))}
+                    onTouchEnd={(event) => commitGpuMemoryLimit(Number(event.target.value))}
+                  />
+                  <div className="settings-scale">
+                    <span>{GPU_LIMIT_MIN_PERCENT}%</span>
+                    <span>Use all available</span>
+                  </div>
+                  <p className="settings-note settings-note--spaced">
+                    A soft target for how much unified memory SceneWorks holds, so more stays free
+                    for the rest of your system. Not a hard limit — large models can still exceed it.
+                    Applies within a couple of seconds, no restart.{" "}
+                    <code>sudo sysctl iogpu.wired_limit_mb=&lt;bytes&gt;</code> raises the system cap
+                    on 96/128 GB Macs.
+                  </p>
+                  {gpuTelemetry ? (
+                    <div className="settings-inset settings-inset--spaced">
+                      <div className="settings-inset-title">Live MLX memory</div>
+                      <div className="settings-kv">
+                        <span>Active</span>
+                        <span className="settings-mono">
+                          {bytesToGb(gpuTelemetry.activeBytes).toFixed(1)} GB
+                        </span>
+                      </div>
+                      <div className="settings-kv">
+                        <span>Peak</span>
+                        <span className="settings-mono">
+                          {bytesToGb(gpuTelemetry.peakBytes).toFixed(1)} GB
+                        </span>
+                      </div>
+                      {gpuTelemetry.limitBytes ? (
+                        <div className="settings-kv">
+                          <span>Limit</span>
+                          <span className="settings-mono">
+                            {Math.round(bytesToGb(gpuTelemetry.limitBytes))} GB
+                          </span>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              </>
+            ) : null}
 
-      {isDesktop ? (
-        <section className="settings-card">
-          <h3>Setup wizard</h3>
-          <p className="settings-muted">
-            Re-open the guided setup to download more models or create another project.
-          </p>
-          <div className="settings-actions">
-            <button type="button" onClick={rerunSetupWizard}>
-              Re-run setup wizard
-            </button>
+            {gpu?.platform === "windows" || gpu?.platform === "linux" ? (
+              <p className="settings-note">
+                Requires current NVIDIA drivers with CUDA support. The GPU memory target is
+                macOS-only — a discrete GPU has no per-process memory cap, so generations use
+                whatever VRAM they need.
+              </p>
+            ) : null}
+
+            <div className="work-panel-divider" />
+            <div className="settings-group-title">Maintenance</div>
+            {/* Available in both modes: desktop restarts via Tauri, a remote admin via REST
+                (epic 4484 story 12). */}
+            <div className="settings-row">
+              <div>
+                <div className="settings-row-title">Inference worker</div>
+                <div className="settings-row-sub">
+                  Restart to pick up credential changes or clear a stuck job.
+                </div>
+              </div>
+              <button className="settings-btn" type="button" onClick={restartWorker}>
+                Restart
+              </button>
+            </div>
+            {isDesktop ? (
+              <div className="settings-row">
+                <div>
+                  <div className="settings-row-title">Setup wizard</div>
+                  <div className="settings-row-sub">
+                    Re-open the guided setup to download more models or create a project.
+                  </div>
+                </div>
+                <button className="settings-btn" type="button" onClick={rerunSetupWizard}>
+                  Re-run
+                </button>
+              </div>
+            ) : null}
           </div>
-        </section>
-      ) : null}
-    </div>
+        ) : null}
+
+        {activeTab === "server" && serverTabAvailable ? (
+          <div className="settings-tab-body">
+            <div className="settings-group-title">Remote access (LAN)</div>
+            <div className="settings-row">
+              <div>
+                <div className="settings-row-title">Let other devices on this network in</div>
+                <div className="settings-row-sub">
+                  Generation still runs on this computer. Takes effect after a restart.
+                </div>
+              </div>
+              <button
+                aria-checked={Boolean(remote.enabled)}
+                aria-label="Remote access"
+                className={remote.enabled ? "settings-toggle on" : "settings-toggle"}
+                disabled={!remote.passwordSet && !remote.enabled}
+                onClick={() => applyRemoteAccess(!remote.enabled)}
+                role="switch"
+                type="button"
+              >
+                <span />
+              </button>
+            </div>
+
+            {remote.url ? (
+              <>
+                <div className="settings-field-row">
+                  <span className="settings-url">{remote.url}</span>
+                  <button
+                    className="settings-btn settings-btn--compact"
+                    type="button"
+                    onClick={copyRemoteUrl}
+                  >
+                    <Icon.Duplicate size={14} />
+                    Copy
+                  </button>
+                </div>
+                {remote.lanCandidates && remote.lanCandidates.length > 1 ? (
+                  <div className="settings-note">
+                    Also reachable at {remote.lanCandidates.slice(1).join(", ")}
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <p className="settings-note">
+                Couldn’t determine this computer’s LAN address — check your network connection.
+              </p>
+            )}
+
+            <div className="settings-inset">
+              <div className="settings-inset-title">Access</div>
+              <div className="settings-field-row">
+                <input
+                  className="settings-grow"
+                  type="password"
+                  placeholder={remote.passwordSet ? "Change password" : "Set a password"}
+                  value={remotePassword}
+                  onChange={(event) => setRemotePassword(event.target.value)}
+                  aria-label="Remote access password"
+                />
+                <button
+                  className="settings-btn"
+                  type="button"
+                  onClick={saveRemotePassword}
+                  disabled={!remotePassword.trim()}
+                >
+                  Save
+                </button>
+                {remote.passwordSet ? (
+                  <button
+                    className="settings-btn settings-btn--quiet"
+                    type="button"
+                    onClick={clearRemotePassword}
+                  >
+                    Clear
+                  </button>
+                ) : null}
+              </div>
+              <div className="settings-field-row">
+                <span className="settings-note settings-grow">
+                  {remote.passwordSet
+                    ? "A password is set — remote browsers must enter it."
+                    : "Set a password before enabling remote access."}
+                </span>
+                <label className="settings-note" htmlFor="remote-port">
+                  Port
+                </label>
+                <input
+                  className="settings-port"
+                  id="remote-port"
+                  type="number"
+                  min="1024"
+                  max="65535"
+                  value={remotePort}
+                  onChange={(event) => setRemotePort(event.target.value)}
+                  aria-label="Remote access port"
+                />
+              </div>
+            </div>
+
+            {/* Security note + platform firewall guidance (story 11), consolidated into one notice. */}
+            <div className="settings-notice">
+              <Icon.Warning size={16} />
+              <span>
+                Trusted local networks only. Traffic is plain HTTP, so the password and your content
+                travel unencrypted — never port-forward this or expose it to the internet.{" "}
+                {remote.platform === "windows"
+                  ? "The first time SceneWorks binds the port, allow it on Private networks in the Windows Security prompt."
+                  : "The first time SceneWorks binds the port, macOS may ask to allow incoming connections — click Allow."}
+              </span>
+            </div>
+          </div>
+        ) : null}
+      </WorkPanel>
+    </section>
   );
 }

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -5,6 +5,38 @@ import { click } from "../testUtils/dom.js";
 
 // SettingsScreen computes `isDesktop` from window.__TAURI__ at module load, so we
 // set the Tauri bridge and re-import the module fresh in each test.
+//
+// The redesigned screen (Settings-page handoff) reads theme + the worker registry off the
+// app context and splits its content across four tabs, so every test mounts it inside a
+// legacy combined <AppContext.Provider> and clicks through to the tab under test.
+const APP_CONTEXT = { theme: "light", changeTheme: vi.fn(), visibleWorkers: [], macCapabilities: {} };
+
+// AppContext has to be re-imported alongside the screen after vi.resetModules(): a statically
+// imported context object is a DIFFERENT module instance from the one the freshly-imported
+// screen consumes, so its Provider wouldn't be seen and useAppContext() would throw.
+let AppContext;
+
+// Sequential on purpose: AppContext.js is a dependency of the screen, and importing both
+// concurrently races the freshly-reset module registry — the screen can end up bound to the
+// real ../api.js instead of the test's vi.doMock'd one.
+async function loadScreen() {
+  const { SettingsScreen } = await import("./SettingsScreen.jsx");
+  ({ AppContext } = await import("../context/AppContext.js"));
+  return SettingsScreen;
+}
+
+// Mount the screen inside the app context and flush the initial refresh().
+async function renderScreen(root, SettingsScreen, props = {}, context = APP_CONTEXT) {
+  await act(async () => {
+    root.render(
+      <AppContext.Provider value={context}>
+        <SettingsScreen {...props} />
+      </AppContext.Provider>,
+    );
+  });
+  await act(async () => {});
+}
+
 async function changeField(input, value) {
   await act(async () => {
     const setter = Object.getOwnPropertyDescriptor(input.constructor.prototype, "value")?.set;
@@ -14,6 +46,18 @@ async function changeField(input, value) {
     );
   });
 }
+
+// Click the tab whose label matches, so the assertions below run against its body.
+async function openTab(container, label) {
+  const tab = [...container.querySelectorAll(".mode-tab")].find(
+    (button) => button.textContent.trim() === label,
+  );
+  expect(tab, `tab "${label}"`).toBeTruthy();
+  await click(tab);
+}
+
+const buttonByText = (container, label) =>
+  [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === label);
 
 describe("SettingsScreen service credentials", () => {
   let container;
@@ -52,7 +96,7 @@ describe("SettingsScreen service credentials", () => {
     });
     window.__TAURI__ = { core: { invoke } };
     vi.resetModules();
-    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    SettingsScreen = await loadScreen();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -67,12 +111,10 @@ describe("SettingsScreen service credentials", () => {
     vi.restoreAllMocks();
   });
 
+  // Credentials live on the Settings tab.
   async function render() {
-    await act(async () => {
-      root.render(<SettingsScreen />);
-    });
-    // Flush the initial refresh() Promise.all.
-    await act(async () => {});
+    await renderScreen(root, SettingsScreen);
+    await openTab(container, "Settings");
   }
 
   it("lists a stored credential by host without exposing the token", async () => {
@@ -93,9 +135,14 @@ describe("SettingsScreen service credentials", () => {
     await render();
     await changeField(container.querySelector('[aria-label="Credential host"]'), "https://Civitai.com");
     await changeField(container.querySelector('[aria-label="Credential label"]'), "Civit.ai");
-    await changeField(container.querySelector('[aria-label="Authentication scheme"]'), "query");
+    // The scheme <select> is now a two-chip radiogroup.
+    await click(
+      [...container.querySelectorAll('[aria-label="Authentication scheme"] button')].find(
+        (chip) => chip.textContent.trim() === "Query token",
+      ),
+    );
     await changeField(container.querySelector('[aria-label="Credential token"]'), "key123");
-    await click(container.querySelector(".settings-credential-form button"));
+    await click(buttonByText(container, "Add"));
     expect(invoke).toHaveBeenCalledWith("set_credential", {
       host: "https://Civitai.com",
       label: "Civit.ai",
@@ -125,7 +172,7 @@ describe("SettingsScreen service credentials", () => {
 
     await changeField(container.querySelector('[aria-label="Credential host"]'), "huggingface.co");
     await changeField(container.querySelector('[aria-label="Credential token"]'), "hf_secret");
-    await click(container.querySelector(".settings-credential-form button"));
+    await click(buttonByText(container, "Add"));
 
     expect(container.querySelector(".settings-status").textContent).toContain(
       "Start and unlock GNOME Keyring or KWallet",
@@ -167,7 +214,7 @@ describe("SettingsScreen server (REST) mode", () => {
       API_BASE_URL: "",
       eventUrl: () => "",
     }));
-    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    SettingsScreen = await loadScreen();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -183,25 +230,25 @@ describe("SettingsScreen server (REST) mode", () => {
   });
 
   async function render() {
-    await act(async () => {
-      root.render(<SettingsScreen />);
-    });
-    await act(async () => {});
+    await renderScreen(root, SettingsScreen);
   }
 
-  it("lists credentials over REST and hides the desktop-only cards", async () => {
+  it("lists credentials over REST and hides the desktop-only groups", async () => {
     await render();
+    await openTab(container, "Settings");
     expect(apiFetch).toHaveBeenCalledWith("/api/v1/credentials", expect.anything());
     expect(container.textContent).toContain("huggingface.co");
     expect(container.textContent).not.toContain("Data directory");
-    expect(container.textContent).not.toContain("Detected GPU");
+    await openTab(container, "Device");
+    expect(container.textContent).not.toContain("GPU memory");
   });
 
   it("saves a credential via PUT to the API", async () => {
     await render();
+    await openTab(container, "Settings");
     await changeField(container.querySelector('[aria-label="Credential host"]'), "civitai.com");
     await changeField(container.querySelector('[aria-label="Credential token"]'), "key123");
-    await click(container.querySelector(".settings-credential-form button"));
+    await click(buttonByText(container, "Add"));
     expect(apiFetch).toHaveBeenCalledWith(
       "/api/v1/credentials",
       expect.anything(),
@@ -209,21 +256,20 @@ describe("SettingsScreen server (REST) mode", () => {
     );
   });
 
-  // epic 4484 stories 10/12: a remote browser hides the Tauri-only cards (including
-  // the desktop-only Remote Access controls) but keeps the inference-worker restart,
-  // which routes over REST instead of the Tauri command.
-  it("hides desktop-only cards and restarts the worker over REST", async () => {
+  // epic 4484 stories 10/12: a remote browser hides the Tauri-only groups (including
+  // the desktop-only Remote Access controls, whose whole tab disappears) but keeps the
+  // inference-worker restart, which routes over REST instead of the Tauri command.
+  it("hides desktop-only groups and restarts the worker over REST", async () => {
     await render();
-    expect(container.textContent).not.toContain("Remote access (LAN)");
+    expect(
+      [...container.querySelectorAll(".mode-tab")].map((tab) => tab.textContent.trim()),
+    ).toEqual(["Appearance", "Settings", "Device"]);
+    await openTab(container, "Settings");
     expect(container.textContent).not.toContain("Data directory");
-    expect(container.textContent).not.toContain("Detected GPU");
+    await openTab(container, "Device");
     expect(container.textContent).not.toContain("Setup wizard");
     expect(container.textContent).toContain("Inference worker");
-    const restartButton = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent.trim() === "Restart worker",
-    );
-    expect(restartButton).toBeTruthy();
-    await click(restartButton);
+    await click(buttonByText(container, "Restart"));
     expect(apiFetch).toHaveBeenCalledWith(
       "/api/v1/worker/restart",
       expect.anything(),
@@ -276,7 +322,7 @@ describe("SettingsScreen remote access (desktop)", () => {
     });
     window.__TAURI__ = { core: { invoke } };
     vi.resetModules();
-    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    SettingsScreen = await loadScreen();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -292,20 +338,17 @@ describe("SettingsScreen remote access (desktop)", () => {
   });
 
   async function render() {
-    await act(async () => {
-      root.render(<SettingsScreen />);
-    });
-    await act(async () => {});
+    await renderScreen(root, SettingsScreen);
+    await openTab(container, "Server");
   }
 
-  const button = (label) =>
-    [...container.querySelectorAll("button")].find((b) => b.textContent.trim() === label);
+  const remoteToggle = () => container.querySelector('[aria-label="Remote access"]');
 
   it("shows the section, the LAN URL, and blocks enabling without a password", async () => {
     await render();
     expect(container.textContent).toContain("Remote access (LAN)");
     expect(container.textContent).toContain("http://192.168.1.50:8787");
-    expect(button("Enable remote access").disabled).toBe(true);
+    expect(remoteToggle().disabled).toBe(true);
   });
 
   it("sets a password, then can enable remote access on the chosen port", async () => {
@@ -314,12 +357,15 @@ describe("SettingsScreen remote access (desktop)", () => {
       container.querySelector('[aria-label="Remote access password"]'),
       "lan-pass",
     );
-    await click(button("Set password"));
+    await click(buttonByText(container, "Save"));
     expect(invoke).toHaveBeenCalledWith("set_remote_access_password", { password: "lan-pass" });
-    // Re-rendered with passwordSet → the enable button is now allowed.
-    expect(button("Enable remote access").disabled).toBe(false);
-    await click(button("Enable remote access"));
+    // Re-rendered with passwordSet → the toggle is now allowed.
+    expect(remoteToggle().disabled).toBe(false);
+    await click(remoteToggle());
     expect(invoke).toHaveBeenCalledWith("set_remote_access", { enabled: true, port: 8787 });
+    // …and flipping it back disables it.
+    await click(remoteToggle());
+    expect(invoke).toHaveBeenCalledWith("set_remote_access", { enabled: false, port: 8787 });
   });
 });
 
@@ -354,7 +400,7 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
     });
     window.__TAURI__ = { core: { invoke } };
     vi.resetModules();
-    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    SettingsScreen = await loadScreen();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -369,11 +415,10 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
     vi.restoreAllMocks();
   });
 
+  // The GPU controls live on the Device tab.
   async function render() {
-    await act(async () => {
-      root.render(<SettingsScreen />);
-    });
-    await act(async () => {});
+    await renderScreen(root, SettingsScreen);
+    await openTab(container, "Device");
   }
 
   const slider = () =>
@@ -384,10 +429,17 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
   it("shows live MLX memory telemetry from the worker", async () => {
     await render();
     expect(invoke).toHaveBeenCalledWith("get_gpu_telemetry", undefined);
-    expect(container.textContent).toContain("MLX memory");
-    expect(container.textContent).toContain("Active: 20.0 GB");
-    expect(container.textContent).toContain("Peak: 40.0 GB");
-    expect(container.textContent).toContain("Limit: 64 GB");
+    expect(container.textContent).toContain("Live MLX memory");
+    expect(container.textContent).toContain("20.0 GB");
+    expect(container.textContent).toContain("40.0 GB");
+    expect(container.textContent).toContain("64 GB");
+  });
+
+  it("summarises this machine from the detected GPU and the worker registry", async () => {
+    await render();
+    expect(container.textContent).toContain("Engine");
+    expect(container.textContent).toContain("Unified memory");
+    expect(container.textContent).toContain("128 GB");
   });
 
   it("applies the GPU memory target live, without restarting the worker", async () => {
@@ -428,7 +480,7 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
       API_BASE_URL: "",
       eventUrl: () => "",
     }));
-    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    SettingsScreen = await loadScreen();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -444,32 +496,36 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
     vi.restoreAllMocks();
   });
 
+  // Default quality lives on the Appearance tab, which is the landing tab.
   async function render() {
-    await act(async () => {
-      root.render(<SettingsScreen />);
-    });
-    await act(async () => {});
+    await renderScreen(root, SettingsScreen);
   }
 
-  const qualitySelect = () =>
-    container.querySelector('[aria-label="Default generation quality"]');
+  const qualityChips = () =>
+    [...container.querySelectorAll('[aria-label="Default generation quality"] button')];
+  const selectedQuality = () =>
+    qualityChips().find((chip) => chip.getAttribute("aria-checked") === "true");
+  const chooseQuality = async (label) =>
+    click(qualityChips().find((chip) => chip.textContent.trim() === label));
 
   it("renders the control defaulting to Auto when nothing is stored (epic 10721 R3)", async () => {
     await render();
-    expect(container.textContent).toContain("Generation quality");
-    const select = qualitySelect();
-    expect(select).toBeTruthy();
-    expect(select.value).toBe("auto");
-    // Auto is offered as the first option, alongside the explicit tiers.
-    const optionValues = [...select.options].map((option) => option.value);
-    expect(optionValues).toEqual(["auto", "bf16", "q8", "q4"]);
+    expect(container.textContent).toContain("Default quality");
+    // Auto leads the row, alongside the explicit tiers.
+    expect(qualityChips().map((chip) => chip.textContent.trim())).toEqual([
+      "Auto",
+      "bf16",
+      "Q8",
+      "Q4",
+    ]);
+    expect(selectedQuality().textContent.trim()).toBe("Auto");
   });
 
   it("writes a change to the localStorage instant-paint cache and confirms it in the status line (cache path)", async () => {
     await render();
-    await changeField(qualitySelect(), "bf16");
+    await chooseQuality("bf16");
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("bf16");
-    expect(qualitySelect().value).toBe("bf16");
+    expect(selectedQuality().textContent.trim()).toBe("bf16");
     expect(container.textContent).toContain("High fidelity (bf16)");
   });
 
@@ -479,7 +535,7 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
     // durable ui-preferences store — same contract as theme/accent in App.jsx. Sending only this field
     // relies on the endpoint MERGING, so theme/accent can't be clobbered.
     await render();
-    await changeField(qualitySelect(), "q4");
+    await chooseQuality("Q4");
     expect(apiFetch).toHaveBeenCalledWith(
       "/api/v1/ui-preferences",
       "",
@@ -495,6 +551,84 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
     // here we assert the control reflects whatever the cache holds on mount.
     window.localStorage.setItem(STORAGE_KEY, "q4");
     await render();
-    expect(qualitySelect().value).toBe("q4");
+    expect(selectedQuality().textContent.trim()).toBe("Q4");
+  });
+});
+
+// The settings brought over from Simple mode (Settings-page handoff): theme, accent and the
+// Simple-mode default all write through to the SAME stores their Simple-mode counterparts use.
+describe("SettingsScreen appearance settings", () => {
+  let container;
+  let root;
+  let SettingsScreen;
+  let changeTheme;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    delete window.__TAURI__;
+    vi.resetModules();
+    vi.doMock("../api.js", () => ({
+      apiFetch: vi.fn(async () => []),
+      isAbortError: () => false,
+      API_BASE_URL: "",
+      eventUrl: () => "",
+    }));
+    SettingsScreen = await loadScreen();
+    changeTheme = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.doUnmock("../api.js");
+    vi.restoreAllMocks();
+  });
+
+  async function render(props) {
+    await renderScreen(root, SettingsScreen, props, {
+      theme: "light",
+      changeTheme,
+      visibleWorkers: [],
+      macCapabilities: {},
+    });
+  }
+
+  it("drives the app-wide theme through changeTheme", async () => {
+    await render({});
+    const dark = [...container.querySelectorAll('[aria-label="Theme"] button')].find(
+      (button) => button.textContent.trim() === "Dark",
+    );
+    await click(dark);
+    expect(changeTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("reports the selected accent and forwards a change", async () => {
+    const onAccentChange = vi.fn();
+    await render({ accent: "coral", onAccentChange });
+    const swatches = container.querySelectorAll('[aria-label="Accent"] button');
+    expect(swatches).toHaveLength(7);
+    expect(container.querySelector('[aria-label="Coral"]').getAttribute("aria-checked")).toBe("true");
+    await click(container.querySelector('[aria-label="Violet"]'));
+    expect(onAccentChange).toHaveBeenCalledWith("violet");
+  });
+
+  it("toggles the Simple-mode default", async () => {
+    const onSimpleDefaultChange = vi.fn();
+    await render({ simpleDefault: false, onSimpleDefaultChange });
+    const toggle = container.querySelector('[aria-label="Use Simple mode by default"]');
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    await click(toggle);
+    expect(onSimpleDefaultChange).toHaveBeenCalledWith(true);
+  });
+
+  it("drops the sidebar-switch sentence when the viewport locks the app to Simple", async () => {
+    await render({ lockedToSimple: true });
+    expect(container.textContent).toContain("Phones always use it.");
+    expect(container.textContent).not.toContain("the sidebar switch overrides it");
   });
 });

--- a/apps/web/src/simple/SimpleSettings.jsx
+++ b/apps/web/src/simple/SimpleSettings.jsx
@@ -4,12 +4,13 @@ import { apiFetch } from "../api.js";
 import { useAppContext } from "../context/AppContext.js";
 import { ACCENTS } from "../accents.js";
 import {
-  AUTO_GENERATION_QUALITY,
   GENERATION_QUALITY_OPTIONS,
   generationQualityLabel,
   readDefaultGenerationQuality,
+  shortQualityLabel,
   writeDefaultGenerationQuality,
 } from "../generationQuality.js";
+import { describeDevice } from "../deviceSummary.js";
 import { loadCredentials, saveCredential } from "../credentials.js";
 import { Chips } from "./studioParts.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
@@ -237,37 +238,4 @@ export function SimpleSettings({ accent, onAccentChange, simpleDefault, onSimple
       </div>
     </div>
   );
-}
-
-// Chip-sized label for a quality value — the design's [bf16, Q8, Q4] plus Auto. Derived
-// from the value rather than a lookup table, so a tier added to the vocabulary still gets a
-// sensible chip; the full descriptive wording rides the chip's title and the line beneath.
-export function shortQualityLabel(value) {
-  if (value === AUTO_GENERATION_QUALITY) {
-    return "Auto";
-  }
-  // bf16 is written lower-case everywhere in the product; the quant tiers are upper-case.
-  return value === "bf16" ? "bf16" : String(value).toUpperCase();
-}
-
-// Engine + GPU summary from the live worker registry. An MLX worker means Apple Silicon
-// unified memory; anything else is the discrete-GPU (candle) lane. Unknown values read
-// "Detecting…" rather than a fabricated placeholder.
-export function describeDevice(workers, macCapabilities) {
-  const gpuWorkers = (workers ?? []).filter((worker) => worker?.gpuId && worker.gpuId !== "cpu");
-  const mlx = gpuWorkers.find((worker) => worker.gpuId === "mlx");
-  const primary = mlx ?? gpuWorkers[0] ?? null;
-  const engine = mlx
-    ? "MLX · Apple Silicon"
-    : primary
-      ? "Candle · discrete GPU"
-      : macCapabilities?.platform === "macos"
-        ? "MLX · Apple Silicon"
-        : "Detecting…";
-  if (!primary) {
-    return { engine, gpu: "No worker connected" };
-  }
-  const totalMb = Number(primary.utilization?.memoryTotalMb);
-  const memory = Number.isFinite(totalMb) && totalMb > 0 ? ` · ${(totalMb / 1024).toFixed(0)} GB` : "";
-  return { engine, gpu: `${primary.gpuName ?? `GPU ${primary.gpuId}`}${memory}` };
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13361,78 +13361,468 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--text-muted);
 }
 
-/* Settings screen (sc-1350) */
+/* ---------- Settings screen (sc-1350; redesigned per the Settings-page handoff) ----------
+   One work-panel on the Page-Frame standard, split into four tabs (Appearance · Settings ·
+   Device · Server) that share the group / row / control vocabulary below. It mirrors the
+   Simple-mode Settings treatment (simple/simple.css `.su-*`) at the values this design
+   specifies; the classes are settings-scoped rather than shared so restyling one screen
+   can't silently restyle the other across the advanced/Simple shell boundary. */
 .settings-screen {
+  max-width: 780px;
+}
+
+/* A tab's body. Group titles, rows and dividers are all siblings on one 14px rhythm. */
+.settings-tab-body {
   display: flex;
   flex-direction: column;
-  gap: var(--gap-md, 1rem);
-  max-width: 44rem;
+  gap: var(--gap-3);
 }
 
-.settings-card {
-  background: var(--surface, #fff);
-  border: 1px solid var(--border, #e2e2e2);
-  border-radius: var(--r-lg, 12px);
-  padding: var(--pad-panel, 1rem 1.25rem);
+.settings-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-faint);
 }
 
-.settings-card h3 {
-  margin: 0 0 0.5rem;
-  font-size: 1rem;
-}
-
-.settings-value {
-  font-family: var(--font-mono, ui-monospace, Menlo, monospace);
-  font-size: 0.85rem;
-  word-break: break-all;
-}
-
-.settings-actions {
+.settings-row {
   display: flex;
-  gap: 0.5rem;
   align-items: center;
-  margin-top: 0.5rem;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.settings-actions input {
-  flex: 1 1 12rem;
-  min-width: 12rem;
-  padding: 0.4rem 0.6rem;
-  border: 1px solid var(--border, #e2e2e2);
-  border-radius: var(--r-md, 8px);
-  background: var(--surface-2, #f7f7f8);
-  color: var(--text, inherit);
+.settings-row--top {
+  align-items: flex-start;
 }
 
-.settings-muted {
-  color: var(--text-muted, #6b7280);
-  font-size: 0.85rem;
+.settings-row--baseline {
+  align-items: baseline;
 }
 
-.settings-help {
-  font-size: 0.8rem;
-  color: var(--text-muted, #6b7280);
-  margin-top: 0.5rem;
+.settings-row-title {
+  font-size: 14px;
+  font-weight: 500;
 }
 
-.settings-help code {
-  font-family: var(--font-mono, ui-monospace, Menlo, monospace);
-  background: var(--surface-2, rgba(127, 127, 127, 0.15));
-  padding: 0.1rem 0.35rem;
-  border-radius: var(--r-sm, 4px);
+.settings-row-sub {
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--text-muted);
 }
 
-.settings-list {
+.settings-note {
   margin: 0;
-  padding-left: 1.2rem;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--text-muted);
 }
 
+.settings-note--spaced {
+  margin-top: 9px;
+}
+
+.settings-note strong {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-note code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--surface-2);
+  padding: 1px 5px;
+  border-radius: var(--r-xs);
+}
+
+/* Live status of the last action (a save, a commit, or an error). One line under the tab
+   row — deliberately not the full-width band that used to sit above the panel. */
 .settings-status {
-  padding: 0.5rem 0.75rem;
-  background: var(--accent-soft, rgba(108, 140, 255, 0.12));
-  border-radius: var(--r-md, 8px);
-  font-size: 0.85rem;
+  margin: 0;
+  padding: 8px 11px;
+  border-radius: var(--r-sm);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.settings-kv-list {
+  display: grid;
+  gap: 9px;
+}
+
+.settings-kv {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.settings-kv > span:first-child {
+  color: var(--text-muted);
+}
+
+.settings-kv > span:last-child {
+  font-weight: 500;
+  text-align: right;
+}
+
+.settings-mono {
+  font-family: var(--font-mono);
+}
+
+/* Inset block for a sub-form / read-only readout inside a tab (Add a token, Access, Live
+   MLX memory). */
+.settings-inset {
+  display: grid;
+  gap: 9px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.settings-inset--spaced {
+  margin-top: 11px;
+}
+
+.settings-inset-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.settings-path {
+  margin-top: 9px;
+  padding: 9px 11px;
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.settings-button-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 9px;
+}
+
+.settings-field-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-field-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+/* The field that takes the slack in a .settings-field-row (inputs are width:100% globally). */
+.settings-grow {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-port {
+  width: 96px;
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+}
+
+.settings-url {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* --- Settings controls --- */
+
+/* Segmented control (Light / Dark). */
+.settings-segment {
+  display: inline-flex;
+  gap: 2px;
+  flex: 0 0 auto;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-2);
+}
+
+.settings-segment button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 0;
+  border-radius: var(--r-xs);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.settings-segment button.active {
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+  box-shadow: var(--shadow-sm);
+}
+
+.settings-accents {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 11px;
+  flex: 0 1 auto;
+}
+
+.settings-accent-swatch {
+  width: 30px;
+  height: 30px;
+  border: 2px solid var(--border);
+  border-radius: 9px;
+}
+
+.settings-accent-swatch.active {
+  border-color: transparent;
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 35%, transparent);
+}
+
+.settings-chips {
+  display: flex;
+  gap: 6px;
+  max-width: 320px;
+  margin-top: 9px;
+}
+
+/* The scheme selector sits inside an inset that already owns its own 9px stack gap. */
+.settings-chips--narrow {
+  max-width: 280px;
+  margin-top: 0;
+}
+
+.settings-chip {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  place-items: center;
+  height: 34px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  /* Fixed height ⇒ a wrapping label would spill out of the chip. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settings-chip.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+/* The line spelling out the selected chip sits a touch further from the row than a
+   title's own sub-line does. */
+.settings-chips + .settings-row-sub {
+  margin-top: 8px;
+}
+
+.settings-toggle {
+  position: relative;
+  width: 46px;
+  height: 27px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: var(--border-strong);
+  transition: background var(--t-fast) var(--ease-out);
+}
+
+.settings-toggle.on {
+  background: var(--accent);
+}
+
+.settings-toggle > span {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 21px;
+  height: 21px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: var(--shadow-sm);
+  transition: left var(--t-fast) var(--ease-out);
+}
+
+.settings-toggle.on > span {
+  left: 22px;
+}
+
+/* Secondary button. The global reset strips background/border/padding from <button>, so
+   every button on this screen carries a class. */
+.settings-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+  transition: background var(--t-fast) var(--ease-out), border-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.settings-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.settings-btn--compact {
+  min-height: 32px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+
+/* Removes / clears — a secondary button that warns on hover rather than shouting by default. */
+.settings-btn--quiet {
+  color: var(--text-muted);
+}
+
+.settings-btn--quiet:hover:not(:disabled) {
+  background: var(--surface);
+  border-color: color-mix(in oklch, var(--danger) 45%, var(--border));
+  color: color-mix(in oklch, var(--danger) 75%, var(--text));
+}
+
+.settings-btn--primary {
+  min-height: 38px;
+  padding: 0 15px;
+  border: 0;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-size: 13px;
+}
+
+.settings-btn--primary:hover:not(:disabled) {
+  background: var(--accent);
+}
+
+/* The global input chrome (border, surface, --control-h) would paint a box around the
+   native track; a range renders its own control. */
+.settings-range {
+  width: 100%;
+  margin-top: 11px;
+  padding: 0;
+  border: 0;
+  background: none;
+  accent-color: var(--accent);
+}
+
+.settings-scale {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+
+.settings-credential-list {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-credential {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.settings-credential-glyph {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-sm);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+/* A credential the app has recorded but whose token is gone from the keychain. */
+.settings-credential-glyph.missing {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+
+.settings-credential-text {
+  display: block;
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-credential-host {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-credential-meta {
+  display: block;
+  margin-top: 1px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.settings-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 11px 13px;
+  border: 1px solid color-mix(in oklch, var(--warn) 40%, var(--border));
+  border-radius: var(--r-md);
+  background: var(--warn-soft);
+}
+
+.settings-notice svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--warn);
+}
+
+.settings-notice span {
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-muted);
 }
 
 /*


### PR DESCRIPTION
## What does this PR do?

Rebuilds the advanced **Settings** screen per the *Settings page UI cleanup* design handoff.

Settings was the only screen not built on the `.page-frame` / `.work-panel` standard: a flat stack of `.settings-card` sections with unstyled native buttons (the global reset strips `background`/`border`/`padding`, and no `.settings-card button` rule existed), bulleted `<ul>` credential lists, and no page margin.

It is now one work-panel using the canonical `page-frame → WorkPanel → .prompt-hero-top → ModeTabs` arrangement (the same as Image Studio), split into four tabs so the page stops being one long scroll:

| Tab | Contents |
| --- | --- |
| **Appearance** | Theme, accent, Simple-mode default, default generation quality |
| **Settings** | Data directory (desktop), service credentials |
| **Device** | This machine, GPU memory (macOS), maintenance |
| **Server** | Remote access (LAN) — desktop + `remote` only |

It also brings over the four settings that previously existed **only** in Simple mode: theme, accent, the engine/GPU readout, and "Use Simple mode by default". They write to the *same* durable stores their Simple-mode counterparts use — `PUT /api/v1/ui-preferences` via App.jsx's `changeTheme` / `changeAccent` / `changeSimpleUiDefault` — so a change made in either screen is the same change. **No new endpoints.**

Every handler, Tauri `invoke` and REST call is carried over verbatim, and the desktop-vs-remote-browser gating is unchanged. The quality and auth-scheme `<select>`s become chips, the remote Enable/Disable buttons become a toggle, and the three separate security paragraphs collapse into one notice.

### Reviewer notes

- **Control styles are ported into `styles.css` under settings-scoped names rather than reusing `simple.css`'s `.su-*`.** The handoff allowed either. Roughly a quarter of the controls differ at the values this design specifies (credential row `11px`/`--surface-2` vs `13px`/`--surface`, Remove `32px` vs `28px`, the accent row right-aligns, chips cap at `320px` vs `280px`), so reuse would have been off-spec and editing `.su-*` would have restyled the Simple shell. It also keeps an advanced screen from depending on the Simple stylesheet.
- **Two helpers moved to shared modules** so both Settings screens read one derivation instead of the advanced screen importing from `simple/SimpleSettings.jsx`: `describeDevice()` → new `apps/web/src/deviceSummary.js`, `shortQualityLabel()` → `generationQuality.js`.
- **One deliberate deviation from the handoff:** the remote-access toggle is disabled on `!passwordSet && !enabled` rather than `!passwordSet` alone, so a session that somehow has remote access on without a password can still turn it off.
- **One place the mock and the prose disagreed:** the credential meta line. The README writes the suffix as `{ · token missing}` only; the mock and screenshot show `token saved` for a present credential. I followed the mock.
- The `status` line keeps its `.settings-status` class but now renders *inside* the panel under the tab row, not as a full-width band above it (the handoff offered a toast or this; `SimpleUiContext`'s toast is Simple-only).
- `viewTitles.Settings.blurb` takes the handoff's recommended copy change.
- The old `.settings-card` / `.settings-actions` / `.settings-value` / `.settings-list` / `.settings-muted` / `.settings-help` / `.settings-gpu-cap` rules are removed — grep confirms no other screen referenced them. (`.settings-bar` / `.settings-field`, the studio generation strip, are a different feature and untouched.)

`main` is merged in (it was 4 commits ahead; the merge only touched READMEs).

## Related issue

n/a — design handoff, no tracked issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

> Mostly a presentation change, but it adds four settings to this screen, so "new feature".

## How was this tested?

- `apps/web` suite: **2533 tests / 178 files pass**, re-run after the `main` merge. The Settings suite (21 tests) was rewritten for the new DOM — tab navigation, chips replacing the two `<select>`s, the remote toggle replacing Enable/Disable — with new coverage for theme, accent, the Simple-mode default, and the `lockedToSimple` copy variant.
- `npm run lint`: **0 errors**, 62 warnings — byte-identical to the `main` baseline.
- `npm run build` and `npm run check`: pass.
- Verified visually in the browser preview against all five design screenshots, in **both themes** and **both deployments** — browser/REST directly, and the desktop-only groups (Storage, GPU memory, Server, credential rows, Live MLX memory) through a throwaway page that installs a fake Tauri bridge before the module graph evaluates. No console errors; all four tabs match the mocks.

Not exercised on real hardware: this is web-UI only and the Tauri commands behind it are untouched, but the desktop groups were verified against a shimmed bridge rather than a running shell.

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed — n/a, no Rust touched
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant — n/a
- [x] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)