### PR TITLE
fix(worker): harden infrastructure cleanup paths [sc-13641]

### DIFF
--- a/crates/sceneworks-worker/src/credentials.rs
+++ b/crates/sceneworks-worker/src/credentials.rs
@@ -12,11 +12,22 @@ pub enum CredentialScheme {
 
 /// A per-host download credential injected via `SCENEWORKS_CREDENTIALS`, matched
 /// against LoRA/model `sourceUrl` hosts.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WorkerCredential {
     pub host: String,
     pub token: String,
     pub scheme: CredentialScheme,
+}
+
+impl fmt::Debug for WorkerCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WorkerCredential")
+            .field("host", &self.host)
+            .field("token", &"***")
+            .field("scheme", &self.scheme)
+            .finish()
+    }
 }
 
 /// Parse the `SCENEWORKS_CREDENTIALS` env value: a JSON object mapping host to

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -305,20 +305,6 @@ pub(crate) async fn ensure_cached_file_verified(
             return Ok(target.to_path_buf());
         }
     }
-    if expected_size.is_none() && target.exists() {
-        if let Some(expected) = expected_sha256 {
-            verify_file_sha256(
-                context.api,
-                context.settings,
-                context.job_id,
-                target,
-                expected,
-                label,
-            )
-            .await?;
-        }
-        return Ok(target.to_path_buf());
-    }
     if let Some(parent) = target.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -532,10 +532,25 @@ pub(crate) fn parse_f64(value: &str) -> Option<f64> {
     value.parse().ok()
 }
 
+const GPU_UTILIZATION_CACHE_AGE: Duration = Duration::from_secs(1);
+type GpuUtilizationCache =
+    tokio::sync::Mutex<HashMap<String, (Instant, Option<WorkerUtilizationSnapshot>)>>;
+
 pub(crate) async fn gpu_utilization(gpu_id: &str) -> Option<WorkerUtilizationSnapshot> {
     if gpu_id == "cpu" {
         return None;
     }
+    static CACHE: std::sync::OnceLock<GpuUtilizationCache> = std::sync::OnceLock::new();
+    cached_gpu_utilization_with(
+        gpu_id,
+        CACHE.get_or_init(|| tokio::sync::Mutex::new(HashMap::new())),
+        GPU_UTILIZATION_CACHE_AGE,
+        |gpu_id| async move { query_gpu_utilization(&gpu_id).await },
+    )
+    .await
+}
+
+async fn query_gpu_utilization(gpu_id: &str) -> Option<WorkerUtilizationSnapshot> {
     // The Apple-Silicon `mlx` worker has no nvidia-smi to query; read its
     // unified-memory + GPU load from IOKit instead (epic 3018) so the dashboard
     // preserves the telemetry surface formerly supplied by the Python `mps` worker.
@@ -548,6 +563,30 @@ pub(crate) async fn gpu_utilization(gpu_id: &str) -> Option<WorkerUtilizationSna
         .into_iter()
         .find(|gpu| gpu.id == gpu_id)
         .and_then(|gpu| gpu.utilization)
+}
+
+pub(crate) async fn cached_gpu_utilization_with<F, Fut>(
+    gpu_id: &str,
+    cache: &GpuUtilizationCache,
+    max_age: Duration,
+    query: F,
+) -> Option<WorkerUtilizationSnapshot>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: std::future::Future<Output = Option<WorkerUtilizationSnapshot>>,
+{
+    // Hold the mutex across a stale/missing probe so a heartbeat, per-job sampler,
+    // and fit-gate arriving together share one subprocess instead of stampeding.
+    // A worker process serves one GPU id, so cross-id serialization is immaterial.
+    let mut entries = cache.lock().await;
+    if let Some((sampled_at, snapshot)) = entries.get(gpu_id) {
+        if sampled_at.elapsed() < max_age {
+            return snapshot.clone();
+        }
+    }
+    let snapshot = query(gpu_id.to_owned()).await;
+    entries.insert(gpu_id.to_owned(), (Instant::now(), snapshot.clone()));
+    snapshot
 }
 
 /// Live per-GPU VRAM budget (free/total, GB) for the candle/CUDA fit-gate (epic 10765 Phase 0,

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -1720,15 +1720,6 @@ async fn ensure_ideogram_tier_present(
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn quant_int(value: &Value) -> Option<i64> {
-    if value.is_boolean() {
-        return None;
-    }
-    value
-        .as_i64()
-        .or_else(|| value.as_str()?.trim().parse().ok())
-}
-
 /// Resolve quantization: the explicit `advanced.quantTier: "nvfp4"` label → `advanced.mlxQuantize` →
 /// `manifest.mlx.quantize` → Q8 default. The engine supports Q4/Q8/NVFP4; map (<=0 → dense, <=4 → Q4,
 /// else Q8). Returns the engine quant + the effective bit count for the recipe (None = dense bf16).

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -39,6 +39,7 @@
 
 use super::*;
 use gen_core::{OffloadPolicy, Quant};
+#[cfg(test)]
 use serde_json::Value;
 
 /// Fixed transient/runtime headroom (GB) added on top of the MEASURED control-lane peak

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -326,13 +326,6 @@ pub(crate) fn incurred_peak_gb(
     Some(peak.max(0.0))
 }
 
-/// Parse a JSON float from either a number or a numeric string (mirrors [`crate::vram_gate`]'s helper).
-fn json_f64(value: &Value) -> Option<f64> {
-    value
-        .as_f64()
-        .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -687,6 +687,37 @@ struct DiscoveredGpu {
 }
 
 async fn shutdown_signal() {
+    use std::sync::OnceLock;
+    use tokio::sync::watch;
+
+    static SHUTDOWN: OnceLock<watch::Sender<bool>> = OnceLock::new();
+    let sender = SHUTDOWN.get_or_init(|| {
+        let (sender, _receiver) = watch::channel(false);
+        let signal = sender.clone();
+        tokio::spawn(async move {
+            wait_for_process_shutdown_source().await;
+            // Latch the request even if it arrives between two `select!` calls,
+            // when no receiver is currently subscribed.
+            signal.send_replace(true);
+        });
+        sender
+    });
+    let mut receiver = sender.subscribe();
+    wait_for_shutdown_latch(&mut receiver).await;
+}
+
+async fn wait_for_shutdown_latch(receiver: &mut tokio::sync::watch::Receiver<bool>) {
+    if *receiver.borrow_and_update() {
+        return;
+    }
+    while receiver.changed().await.is_ok() {
+        if *receiver.borrow_and_update() {
+            return;
+        }
+    }
+}
+
+async fn wait_for_process_shutdown_source() {
     #[cfg(unix)]
     {
         match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
@@ -727,12 +758,9 @@ async fn shutdown_signal() {
 /// (sc-11184 / F-014) — the Windows graceful-shutdown signal, standing in for the unix
 /// SIGTERM the supervisor cannot deliver per-child on Windows.
 ///
-/// `shutdown_signal()` is awaited on every worker-loop turn, so opening a fresh reader
-/// per call would risk parking a blocking thread on each turn. Instead a SINGLE
-/// background reader is started once (guarded by a `OnceLock`) and its EOF result is
-/// fanned out over a `watch` channel; every caller just subscribes. The channel latches
-/// `true` on close and stays there, so a caller that subscribes AFTER the pipe already
-/// closed still returns immediately. The reader drains stdin on std's blocking handle
+/// The process-wide shutdown source calls this once on a supervised Windows child.
+/// A SINGLE background reader is guarded by a `OnceLock`, and its EOF result is
+/// latched over a `watch` channel. The reader drains stdin on std's blocking handle
 /// inside `spawn_blocking` (rather than `tokio::io::stdin`, which needs the `io-std`
 /// feature this crate does not enable).
 #[cfg(not(unix))]

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -246,8 +246,23 @@ pub(crate) fn sequential_overflow_gb(
 /// the AppleDouble sidecar gotcha). Returns 0 if the directory is missing or holds no weights, which
 /// the gate treats as "no signal".
 pub(crate) fn sum_safetensors_bytes(dir: &Path) -> u64 {
-    fn walk(dir: &Path, total: &mut u64) {
-        let Ok(entries) = std::fs::read_dir(dir) else {
+    fn walk(
+        dir: &Path,
+        visited_dirs: &mut std::collections::HashSet<std::path::PathBuf>,
+        total: &mut u64,
+    ) {
+        // `metadata` below intentionally follows file symlinks because Hugging Face
+        // snapshots link shards into `blobs/`. Directory links are different: an
+        // operator-provided model root may contain a link/junction cycle. Canonical
+        // directory identity makes that traversal finite and also avoids double-counting
+        // an aliased subtree.
+        let Ok(canonical_dir) = std::fs::canonicalize(dir) else {
+            return;
+        };
+        if !visited_dirs.insert(canonical_dir.clone()) {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(canonical_dir) else {
             return;
         };
         for entry in entries.flatten() {
@@ -258,7 +273,7 @@ pub(crate) fn sum_safetensors_bytes(dir: &Path) -> u64 {
                 continue;
             };
             if meta.is_dir() {
-                walk(&path, total);
+                walk(&path, visited_dirs, total);
                 continue;
             }
             let name = entry.file_name();
@@ -269,7 +284,7 @@ pub(crate) fn sum_safetensors_bytes(dir: &Path) -> u64 {
         }
     }
     let mut total = 0;
-    walk(dir, &mut total);
+    walk(dir, &mut std::collections::HashSet::new(), &mut total);
     total
 }
 
@@ -1393,6 +1408,25 @@ mod tests {
         // Summing the SNAPSHOT dir follows the symlink to the 4096-byte blob and skips the `._`
         // sidecar; the `blobs/` dir is not under the snapshot, so nothing is double-counted.
         assert_eq!(sum_safetensors_bytes(&root.join("snapshots/hash")), 4096);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sum_safetensors_terminates_on_directory_symlink_cycles() {
+        use std::os::unix::fs::symlink;
+        let root = std::env::temp_dir().join(format!(
+            "mlx_fit_gate_cycle_{}_{}",
+            std::process::id(),
+            line!()
+        ));
+        let weights = root.join("weights");
+        std::fs::create_dir_all(&weights).expect("mk weights");
+        std::fs::write(weights.join("model.safetensors"), vec![0_u8; 4096]).expect("write weights");
+        symlink(&root, weights.join("cycle")).expect("create directory cycle");
+
+        assert_eq!(sum_safetensors_bytes(&root), 4096);
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/sceneworks-worker/src/payload.rs
+++ b/crates/sceneworks-worker/src/payload.rs
@@ -24,6 +24,7 @@ pub(crate) fn quant_int(value: &Value) -> Option<i64> {
 }
 
 /// Parse a JSON float from either a number or a trimmed numeric string.
+#[cfg(any(test, all(not(target_os = "macos"), feature = "backend-candle")))]
 pub(crate) fn json_f64(value: &Value) -> Option<f64> {
     value
         .as_f64()
@@ -92,7 +93,11 @@ pub(crate) fn item_f64(item: &Value, field: &str, default: f64) -> f64 {
 }
 
 pub(crate) fn value_f64(value: &Value, default: f64) -> f64 {
-    json_f64(value)
+    // Preserve the established generic payload contract: unlike the manifest/fit
+    // parser above, whitespace-padded strings are invalid and fall back.
+    value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
         .filter(|value: &f64| value.is_finite())
         .unwrap_or(default)
 }
@@ -120,5 +125,11 @@ mod tests {
         assert_eq!(json_f64(&json!(" 4.25 ")), Some(4.25));
         assert_eq!(json_f64(&json!(false)), None);
         assert_eq!(json_f64(&json!("nope")), None);
+    }
+
+    #[test]
+    fn generic_payload_float_keeps_whitespace_strings_invalid() {
+        assert_eq!(value_f64(&json!(" 4.25 "), 9.0), 9.0);
+        assert_eq!(value_f64(&json!("4.25"), 9.0), 4.25);
     }
 }

--- a/crates/sceneworks-worker/src/payload.rs
+++ b/crates/sceneworks-worker/src/payload.rs
@@ -7,6 +7,29 @@ pub(crate) fn json_size_to_u64(value: &Value) -> Option<u64> {
         .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
 }
 
+/// Parse a JSON integer from either a number or a trimmed numeric string.
+/// Booleans are deliberately rejected even though some dynamic languages treat
+/// them as integers.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+pub(crate) fn quant_int(value: &Value) -> Option<i64> {
+    if value.is_boolean() {
+        return None;
+    }
+    value
+        .as_i64()
+        .or_else(|| value.as_str()?.trim().parse().ok())
+}
+
+/// Parse a JSON float from either a number or a trimmed numeric string.
+pub(crate) fn json_f64(value: &Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse().ok())
+}
+
 pub(crate) fn required_payload_string<'a>(
     payload: &'a JsonObject,
     field: &str,
@@ -69,9 +92,33 @@ pub(crate) fn item_f64(item: &Value, field: &str, default: f64) -> f64 {
 }
 
 pub(crate) fn value_f64(value: &Value, default: f64) -> f64 {
-    value
-        .as_f64()
-        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+    json_f64(value)
         .filter(|value: &f64| value.is_finite())
         .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[cfg(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    ))]
+    #[test]
+    fn shared_integer_parser_accepts_numbers_and_trimmed_strings() {
+        assert_eq!(quant_int(&json!(8)), Some(8));
+        assert_eq!(quant_int(&json!(" 4 ")), Some(4));
+        assert_eq!(quant_int(&json!(true)), None);
+        assert_eq!(quant_int(&json!(4.5)), None);
+    }
+
+    #[test]
+    fn shared_float_parser_accepts_numbers_and_trimmed_strings() {
+        assert_eq!(json_f64(&json!(8.5)), Some(8.5));
+        assert_eq!(json_f64(&json!(" 4.25 ")), Some(4.25));
+        assert_eq!(json_f64(&json!(false)), None);
+        assert_eq!(json_f64(&json!("nope")), None);
+    }
 }

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -1,7 +1,7 @@
 //! Worker [`Settings`] and the environment-variable accessors that populate it.
 use super::*;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Settings {
     pub api_url: String,
     pub access_token: Option<String>,
@@ -54,6 +54,38 @@ pub struct Settings {
     /// single value covers generations, upscales, AND LoRA training in this process. macOS/MLX only;
     /// inert on candle/CPU builds (the cross-platform path is tracked separately as sc-7826).
     pub gpu_memory_limit_bytes: u64,
+}
+
+impl fmt::Debug for Settings {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Settings")
+            .field("api_url", &self.api_url)
+            .field("access_token", &self.access_token.as_ref().map(|_| "***"))
+            .field("data_dir", &self.data_dir)
+            .field("config_dir", &self.config_dir)
+            .field("worker_id", &self.worker_id)
+            .field("gpu_id", &self.gpu_id)
+            .field("is_child_worker", &self.is_child_worker)
+            .field("poll_seconds", &self.poll_seconds)
+            .field("heartbeat_seconds", &self.heartbeat_seconds)
+            .field("shutdown_timeout_seconds", &self.shutdown_timeout_seconds)
+            .field("huggingface_base_url", &self.huggingface_base_url)
+            .field(
+                "huggingface_token",
+                &self.huggingface_token.as_ref().map(|_| "***"),
+            )
+            .field("credentials", &self.credentials)
+            .field("max_lora_url_bytes", &self.max_lora_url_bytes)
+            .field("max_model_url_bytes", &self.max_model_url_bytes)
+            .field("allow_private_lora_urls", &self.allow_private_lora_urls)
+            .field("utility_workers", &self.utility_workers)
+            .field("backend_mlx_enabled", &self.backend_mlx_enabled)
+            .field("backend_candle_enabled", &self.backend_candle_enabled)
+            .field("external_model_roots", &self.external_model_roots)
+            .field("gpu_memory_limit_bytes", &self.gpu_memory_limit_bytes)
+            .finish()
+    }
 }
 
 impl Settings {

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -45,9 +45,9 @@ use super::downloads::{
 #[cfg(target_os = "macos")]
 use super::gpu::mlx_gpu;
 use super::gpu::{
-    cpu_gpu, cpu_worker_id, fallback_gpu, gpu_worker_id, parse_max_compute_cap,
-    parse_nvidia_smi_gpus, run_bounded_command, visible_gpu_ids, worker_capabilities_with_utility,
-    GpuDiscoveryAttempt, GpuDiscoveryFailure,
+    cached_gpu_utilization_with, cpu_gpu, cpu_worker_id, fallback_gpu, gpu_worker_id,
+    parse_max_compute_cap, parse_nvidia_smi_gpus, run_bounded_command, visible_gpu_ids,
+    worker_capabilities_with_utility, GpuDiscoveryAttempt, GpuDiscoveryFailure,
 };
 use super::media_jobs::{
     candidate_people, concat_file_contents, crossfade_duration, output_dimensions, plan_segments,
@@ -80,11 +80,11 @@ use super::{
     copy_lora_source, fresh_asset_id, heartbeat_while_blocking, import_lora_source_file_as,
     import_lora_source_path, normalize_app_managed_cache_path, now_rfc3339, parse_credentials_env,
     resolve_model_convert_output, resolve_model_import_target, safe_download_dir,
-    safe_project_path, value_f64, wan_moe_pair_filenames, write_model_download_receipt,
-    write_model_install_marker, CredentialScheme, IdleHeartbeat, JsonObject,
-    SafetensorsHeaderError, Settings, WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES,
-    DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER,
-    MODEL_CONVERSION_BACKUPS_DIR_NAME,
+    safe_project_path, value_f64, wait_for_shutdown_latch, wan_moe_pair_filenames,
+    write_model_download_receipt, write_model_install_marker, CredentialScheme, IdleHeartbeat,
+    JsonObject, SafetensorsHeaderError, Settings, WorkerCredential, WorkerError,
+    DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
+    INSTALL_MARKER, MODEL_CONVERSION_BACKUPS_DIR_NAME,
 };
 
 // HF-CLI input validation, downloaded-model family detection, atomic converted-dir finalize, and the

--- a/crates/sceneworks-worker/src/tests/credentials_and_source_url.rs
+++ b/crates/sceneworks-worker/src/tests/credentials_and_source_url.rs
@@ -27,6 +27,25 @@ fn parse_credentials_env_tolerates_invalid_json() {
 }
 
 #[test]
+fn secret_bearing_debug_output_is_redacted() {
+    let mut settings =
+        test_settings("https://huggingface.co".to_owned(), Some("hf-secret-token"));
+    settings.access_token = Some("api-secret-token".to_owned());
+    settings.credentials = vec![WorkerCredential {
+        host: "civitai.com".to_owned(),
+        token: "download-secret-token".to_owned(),
+        scheme: CredentialScheme::Bearer,
+    }];
+
+    let debug = format!("{settings:?}");
+    assert!(!debug.contains("hf-secret-token"));
+    assert!(!debug.contains("api-secret-token"));
+    assert!(!debug.contains("download-secret-token"));
+    assert!(debug.contains("***"));
+    assert!(debug.contains("civitai.com"));
+}
+
+#[test]
 fn credential_for_host_matches_case_insensitively() {
     let mut settings = test_settings("https://huggingface.co".to_owned(), None);
     settings.credentials = vec![WorkerCredential {

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -2147,3 +2147,39 @@ fn bernini_manifest_ships_the_quant_matrix() {
         assert_eq!(defaults, vec!["q4"], "{id} macOS default tier is q4");
     }
 }
+
+#[tokio::test]
+async fn utilization_cache_shares_a_fresh_probe_and_refreshes_when_stale() {
+    let cache = tokio::sync::Mutex::new(HashMap::new());
+    let probes = Arc::new(AtomicUsize::new(0));
+    let snapshot = || WorkerUtilizationSnapshot {
+        memory_total_mb: Some(24_576),
+        memory_used_mb: Some(4_096),
+        memory_free_mb: Some(20_480),
+        gpu_load_percent: Some(25.0),
+    };
+
+    for _ in 0..2 {
+        let probes = probes.clone();
+        let result = cached_gpu_utilization_with(
+            "0",
+            &cache,
+            Duration::from_secs(60),
+            move |_| async move {
+                probes.fetch_add(1, Ordering::SeqCst);
+                Some(snapshot())
+            },
+        )
+        .await;
+        assert_eq!(result, Some(snapshot()));
+    }
+    assert_eq!(probes.load(Ordering::SeqCst), 1);
+
+    let probes_for_refresh = probes.clone();
+    cached_gpu_utilization_with("0", &cache, Duration::ZERO, move |_| async move {
+        probes_for_refresh.fetch_add(1, Ordering::SeqCst);
+        Some(snapshot())
+    })
+    .await;
+    assert_eq!(probes.load(Ordering::SeqCst), 2);
+}

--- a/crates/sceneworks-worker/src/tests/media_and_paths.rs
+++ b/crates/sceneworks-worker/src/tests/media_and_paths.rs
@@ -140,6 +140,9 @@ fn path_and_error_helpers_are_bounded_and_defensive() {
 
     assert!(tail.contains("caf\u{e9}"));
     assert!(!tail.contains("line 1 "));
+    assert_eq!(tail.chars().count(), 37);
+    assert_eq!(bounded_tail("aé日", 1, 2), "é日");
+    assert_eq!(bounded_tail("aé日", 1, 0), "");
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
+++ b/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
@@ -1,4 +1,18 @@
 
+#[tokio::test]
+async fn process_shutdown_latch_survives_a_gap_without_waiters() {
+    let (sender, _receiver) = tokio::sync::watch::channel(false);
+    sender.send_replace(true);
+    let mut late_receiver = sender.subscribe();
+
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        wait_for_shutdown_latch(&mut late_receiver),
+    )
+    .await
+    .expect("a late waiter observes the already-latched shutdown");
+}
+
 /// sc-3513: the worker's `JobType::ImageEdit` dispatch arm delegates to
 /// `run_image_generate_job` — the engine keys edits on payload model+mode, not job
 /// type. Feeding an `image_edit`-typed job into the handler proves it reaches the image

--- a/crates/sceneworks-worker/src/util.rs
+++ b/crates/sceneworks-worker/src/util.rs
@@ -73,13 +73,17 @@ pub(crate) fn bounded_tail(value: &str, max_lines: usize, max_chars: usize) -> S
     let mut lines = value.lines().rev().take(max_lines).collect::<Vec<_>>();
     lines.reverse();
     let mut output = lines.join("\n");
-    if output.len() > max_chars {
-        let start = output
-            .char_indices()
-            .rev()
-            .nth(max_chars)
-            .map_or(0, |(index, _)| index);
-        output = output[start..].to_owned();
+    let char_count = output.chars().count();
+    if char_count > max_chars {
+        if max_chars == 0 {
+            output.clear();
+        } else {
+            let start = output
+                .char_indices()
+                .nth(char_count - max_chars)
+                .map_or(output.len(), |(index, _)| index);
+            output = output[start..].to_owned();
+        }
     }
     output
 }

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -751,20 +751,6 @@ fn video_weights_too_big_error(
     ))
 }
 
-/// Parse a JSON uint/int from either a number or a numeric string (mirrors base.rs `quant_int`).
-fn quant_int(value: &Value) -> Option<i64> {
-    value
-        .as_i64()
-        .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
-}
-
-/// Parse a JSON float from either a number or a numeric string.
-fn json_f64(value: &Value) -> Option<f64> {
-    value
-        .as_f64()
-        .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -21,6 +21,7 @@
 //! the wiring is in `generate_candle_stream` (image_jobs/base.rs).
 
 use super::*;
+#[cfg(test)]
 use serde_json::Value;
 
 use crate::fit_gate::BYTES_PER_GIB;


### PR DESCRIPTION
## Summary
- share one-second GPU utilization snapshots across metrics, heartbeat, and fit-gate consumers and latch shutdown signals process-wide
- consolidate numeric payload parsing, remove the unreachable cache-hit branch, and make bounded tails character-exact
- make recursive safetensors scans cycle-safe and redact worker secrets from Debug output

## Validation
- `cargo test -p sceneworks-worker --lib` (1009 passed, 176 ignored)
- `RUSTFLAGS="-D warnings" cargo check --locked -p sceneworks-worker --target x86_64-unknown-linux-gnu --no-default-features`
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Shortcut: sc-13641