### PR TITLE
fix(api): close low-risk request-path findings [sc-13646]

### DIFF
--- a/.github/actions/prepare-rust-runner/action.yml
+++ b/.github/actions/prepare-rust-runner/action.yml
@@ -134,6 +134,27 @@ runs:
         }
         Write-Host "OK: $out"
 
+        # RUSTC_WRAPPER is runner-global on the self-hosted boxes. Treat it as an
+        # optional accelerator, not a build prerequisite: if an administrator
+        # removes sccache but leaves the environment variable behind, even
+        # `cargo fetch` fails before rustc can run. Clear only an unresolvable
+        # wrapper and let subsequent steps invoke the verified toolchain directly.
+        $rustcWrapper = $env:RUSTC_WRAPPER
+        if ($rustcWrapper) {
+          if ([IO.Path]::IsPathRooted($rustcWrapper)) {
+            $wrapperUsable = Test-Path -LiteralPath $rustcWrapper -PathType Leaf
+          } else {
+            $wrapperUsable = $null -ne (
+              Get-Command $rustcWrapper -CommandType Application -ErrorAction SilentlyContinue
+            )
+          }
+          if (-not $wrapperUsable) {
+            Write-Host "::warning title=Missing Rust compiler wrapper::RUSTC_WRAPPER points to '$rustcWrapper', but that executable is unavailable. Clearing it and using the verified rustc directly."
+            Add-Content -Path $env:GITHUB_ENV -Value 'RUSTC_WRAPPER='
+            Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue
+          }
+        }
+
         # Prepend the real toolchain bin so every later step's cargo/rustc/clippy resolves
         # here FIRST, ahead of the fragile .cargo\bin proxies. $GITHUB_PATH prepends, and
         # the entry survives the `call vcvars64.bat` cmd steps (vcvars only appends).

--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -255,7 +255,7 @@ pub(crate) struct AssetMoveToCharacterBody {
 pub(crate) async fn move_asset_to_character(
     State(state): State<AppState>,
     Path((project_id, asset_id)): Path<(String, String)>,
-    Json(body): Json<AssetMoveToCharacterBody>,
+    ApiJson(body): ApiJson<AssetMoveToCharacterBody>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     Ok(Json(
         project_call(state, move |store| {

--- a/apps/rust-api/src/face_likeness.rs
+++ b/apps/rust-api/src/face_likeness.rs
@@ -30,9 +30,15 @@ pub(crate) async fn create_face_likeness_compare_job(
     // Resolve both assets to confined on-disk paths up front so an invalid id is a clean 400 (the
     // worker re-resolves + re-confines independently; this is fail-fast UX, not the sole guard).
     let project_path = project_path_for_id(state.clone(), project_id).await?;
-    resolve_project_asset_path(state.clone(), project_id, source_asset_id, &project_path).await?;
-    resolve_project_asset_path(state.clone(), project_id, candidate_asset_id, &project_path)
+    resolve_project_confined_asset_path(state.clone(), project_id, source_asset_id, &project_path)
         .await?;
+    resolve_project_confined_asset_path(
+        state.clone(),
+        project_id,
+        candidate_asset_id,
+        &project_path,
+    )
+    .await?;
 
     let mut job_payload = JsonObject::new();
     job_payload.insert("projectId".to_owned(), Value::String(project_id.to_owned()));
@@ -55,43 +61,4 @@ pub(crate) async fn create_face_likeness_compare_job(
     )
     .await?;
     Ok((StatusCode::CREATED, Json(job)))
-}
-
-/// Resolve a project asset id to an absolute, project-confined on-disk path. Mirrors the worker's
-/// `load_reference_image` / the prompt-refine `resolve_image_caption_path`: read the asset record's
-/// relative `file.path`, join it under the project directory using only `Normal` components (rejecting
-/// `..`/absolute traversal), and confirm the file exists. Returns a 400 for a missing/garbled record or
-/// a path that escapes the project root.
-async fn resolve_project_asset_path(
-    state: AppState,
-    project_id: &str,
-    asset_id: &str,
-    project_path: &std::path::Path,
-) -> Result<(), ApiError> {
-    let project_id_owned = project_id.to_owned();
-    let asset_id_owned = asset_id.to_owned();
-    let asset = project_call(state, move |store| {
-        store.get_asset(&project_id_owned, &asset_id_owned)
-    })
-    .await?;
-    let rel = asset
-        .get("file")
-        .and_then(|file| file.get("path"))
-        .and_then(Value::as_str)
-        .ok_or_else(|| ApiError::bad_request("Asset has no file path"))?;
-    let mut path = project_path.to_path_buf();
-    for component in std::path::Path::new(rel).components() {
-        match component {
-            std::path::Component::Normal(value) => path.push(value),
-            _ => {
-                return Err(ApiError::bad_request(
-                    "Asset path must stay inside the project directory",
-                ))
-            }
-        }
-    }
-    if !path.exists() {
-        return Err(ApiError::bad_request("Asset image not found on disk"));
-    }
-    Ok(())
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -17,7 +17,7 @@ use axum::response::sse::{Event, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, patch, post, put};
 use axum::{Json, Router};
-use futures_util::future::join_all;
+use futures_util::{future::join_all, stream};
 use parking_lot::Mutex;
 use sceneworks_core::contracts::{
     CancelPendingJobsRequest, CancelPendingJobsResponse, ClaimRequest, ClaimResponse,
@@ -203,7 +203,7 @@ mod manifest_entity;
 mod recipe_presets;
 use recipe_presets::{
     create_recipe_preset, delete_recipe_preset, duplicate_recipe_preset, get_recipe_preset,
-    list_recipe_presets, preset_lora_id, preset_lora_weight, preset_prompt, recipe_preset_catalog,
+    list_recipe_presets, preset_lora_id, preset_lora_weight, preset_prompt,
     recipe_preset_catalog_with, recipe_preset_loras, serialize_preset_lora,
     stamp_recipe_preset_used, update_recipe_preset,
 };
@@ -1926,6 +1926,39 @@ async fn project_path_for_id(state: AppState, project_id: &str) -> Result<PathBu
     Ok(PathBuf::from(project.path))
 }
 
+/// Resolve a project asset record to an on-disk path without allowing absolute
+/// paths or traversal outside the owning project.
+async fn resolve_project_confined_asset_path(
+    state: AppState,
+    project_id: &str,
+    asset_id: &str,
+    project_path: &FsPath,
+) -> Result<PathBuf, ApiError> {
+    let project_id = project_id.to_owned();
+    let asset_id = asset_id.to_owned();
+    let asset = project_call(state, move |store| store.get_asset(&project_id, &asset_id)).await?;
+    let relative_path = asset
+        .get("file")
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::bad_request("Asset has no file path"))?;
+    let mut resolved = project_path.to_path_buf();
+    for component in FsPath::new(relative_path).components() {
+        match component {
+            std::path::Component::Normal(value) => resolved.push(value),
+            _ => {
+                return Err(ApiError::bad_request(
+                    "Asset path must stay inside the project directory",
+                ))
+            }
+        }
+    }
+    if !resolved.exists() {
+        return Err(ApiError::bad_request("Asset file not found on disk"));
+    }
+    Ok(resolved)
+}
+
 fn model_lora_families(model: &Value) -> Vec<String> {
     families_from_value_chain(
         model,
@@ -1976,9 +2009,10 @@ async fn catalog_delete_warnings(
     kind: &str,
     id: &str,
     project_id: Option<&str>,
+    catalogs: Option<&JobCatalogSnapshot>,
 ) -> Result<Vec<String>, ApiError> {
     let mut warnings = Vec::new();
-    let presets = recipe_preset_catalog(state, project_id).await?;
+    let presets = recipe_preset_catalog_with(state, project_id, catalogs).await?;
     let preset_names = presets
         .iter()
         .filter(|preset| match kind {

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -243,7 +243,8 @@ pub(crate) async fn delete_lora(
         ));
     }
     let warnings =
-        catalog_delete_warnings(&state, "lora", &lora_id, query.project_id.as_deref()).await?;
+        catalog_delete_warnings(&state, "lora", &lora_id, query.project_id.as_deref(), None)
+            .await?;
     let policy = if removed_entry.is_some() {
         "Removed the LoRA registry entry and SceneWorks-owned local LoRA files."
     } else {
@@ -866,15 +867,21 @@ pub(crate) async fn queue_lora_import_job(
     } else {
         allowed_source_roots
     };
-    if let Some(local_source) = payload.source_path.as_deref() {
-        validate_lora_import_source_path(local_source, &source_roots)?;
-        // A paired Wan A14B MoE upload (sc-1991) carries a second low-noise file;
-        // validate it against the same upload root here. The high/low_noise filenames
-        // are assigned once the family-scoped target name is known, below.
-        if let Some(secondary_source_path) = payload.secondary_source_path.as_deref() {
-            validate_lora_import_source_path(secondary_source_path, &source_roots)?;
-        }
-        let detected = detect_family_from_local_path(local_source)?;
+    if let Some(local_source) = payload.source_path.clone() {
+        let secondary_source = payload.secondary_source_path.clone();
+        let (local_source, detected) = tokio::task::spawn_blocking(move || {
+            validate_lora_import_source_path(&local_source, &source_roots)?;
+            // A paired Wan A14B MoE upload (sc-1991) carries a second low-noise
+            // file; validate it against the same upload root.
+            if let Some(secondary_source) = secondary_source.as_deref() {
+                validate_lora_import_source_path(secondary_source, &source_roots)?;
+            }
+            detect_family_from_local_path(&local_source).map(|detected| (local_source, detected))
+        })
+        .await
+        .map_err(|error| {
+            ApiError::internal(format!("LoRA import inspection task failed: {error}"))
+        })??;
         payload.family = reconcile_lora_family(
             payload.family.take(),
             detected,
@@ -897,8 +904,17 @@ pub(crate) async fn queue_lora_import_job(
     // *different* family, with an honest message instead of stacking two adapters the
     // header inspector would arbitrate non-deterministically. Same-family re-imports
     // (the folder's existing file matches) are still allowed.
-    if let Some(family) = payload.family.as_deref() {
-        if let Some(existing) = conflicting_folder_family(&target_dir, family)? {
+    if let Some(family) = payload.family.clone() {
+        let target_dir_for_inspection = target_dir.clone();
+        let family_for_inspection = family.clone();
+        let existing = tokio::task::spawn_blocking(move || {
+            conflicting_folder_family(&target_dir_for_inspection, &family_for_inspection)
+        })
+        .await
+        .map_err(|error| {
+            ApiError::internal(format!("LoRA target inspection task failed: {error}"))
+        })??;
+        if let Some(existing) = existing {
             return Err(ApiError::bad_request(format!(
                 "The folder for LoRA '{lora_id}' already contains a {existing} LoRA. \
                  Import this {family} LoRA under a different name so each family keeps its own folder."

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -477,10 +477,13 @@ pub(crate) async fn delete_model(
     Query(query): Query<CatalogDeleteQuery>,
 ) -> Result<Json<Value>, ApiError> {
     let permanent = query.permanent.unwrap_or(false);
-    let catalog = model_catalog(&state).await?;
-    let model = catalog
-        .into_iter()
+    let catalogs = JobCatalogSnapshot::default();
+    let model = catalogs
+        .models(&state)
+        .await?
+        .iter()
         .find(|item| item.get("id").and_then(Value::as_str) == Some(model_id.as_str()))
+        .cloned()
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
@@ -528,7 +531,8 @@ pub(crate) async fn delete_model(
             "Built-in model catalog entries are read-only unless local files are installed",
         ));
     }
-    let warnings = catalog_delete_warnings(&state, "model", &model_id, None).await?;
+    let warnings =
+        catalog_delete_warnings(&state, "model", &model_id, None, Some(&catalogs)).await?;
     let policy = if removed_entry.is_some() {
         "Removed the model registry entry and SceneWorks-owned local model files."
     } else {
@@ -1103,20 +1107,25 @@ pub(crate) async fn queue_model_import_job(
         .join("user.models.jsonc");
     let source_path_rel = format!("models/imports/{target_name}");
     let allowed_source_roots = vec![state.settings.data_dir.join("models")];
-    if let Some(source_path) = payload.source_path.as_deref() {
+    if let Some(source_path) = payload.source_path.clone() {
         let allowed_source_roots = if payload.uploaded_source_path {
             vec![state.settings.data_dir.join("cache").join("model-uploads")]
         } else {
             allowed_source_roots
         };
-        validate_lora_import_source_path(source_path, &allowed_source_roots)?;
-        // Compatibility gate (sc-14019): refuse — synchronously, with the detector's typed reason —
-        // any staged/local base checkpoint whose (family, component, quant) has no loader today.
-        // Runs AFTER confinement above; it never widens the allowed roots. Repo/URL imports (no file
-        // on disk yet) are gated by the worker over the downloaded bytes instead.
-        import_source_supported(FsPath::new(source_path))?;
-        let detected =
-            detect_model_family(FsPath::new(source_path)).map_err(model_family_inspection_error)?;
+        let (source_path, detected) = tokio::task::spawn_blocking(move || {
+            validate_lora_import_source_path(&source_path, &allowed_source_roots)?;
+            // Compatibility gate (sc-14019): refuse, with the detector's typed
+            // reason, any local checkpoint whose shape has no loader today.
+            import_source_supported(FsPath::new(&source_path))?;
+            let detected = detect_model_family(FsPath::new(&source_path))
+                .map_err(model_family_inspection_error)?;
+            Ok::<_, ApiError>((source_path, detected))
+        })
+        .await
+        .map_err(|error| {
+            ApiError::internal(format!("Model import inspection task failed: {error}"))
+        })??;
         payload.family = reconcile_model_family(
             payload.family.take(),
             detected,
@@ -3379,6 +3388,49 @@ fn apply_model_catalog_entry(
 }
 
 type ModelCatalogWorkItem = (Value, (Option<DownloadContext>, Option<u64>));
+const MODEL_SIZE_ESTIMATE_CONCURRENCY: usize = 8;
+
+async fn collect_bounded_ordered<I, T, F, Fut, R>(
+    items: I,
+    concurrency: usize,
+    operation: F,
+) -> Vec<R>
+where
+    I: IntoIterator<Item = T>,
+    F: FnMut(T) -> Fut,
+    Fut: std::future::Future<Output = R>,
+{
+    let pending = futures_util::StreamExt::map(stream::iter(items), operation);
+    let bounded = futures_util::StreamExt::buffered(pending, concurrency.max(1));
+    futures_util::StreamExt::collect(bounded).await
+}
+
+#[cfg(test)]
+mod model_size_concurrency_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn bounded_collection_caps_concurrency_and_preserves_order() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let output = collect_bounded_ordered(0..12, 3, |value| {
+            let active = active.clone();
+            let peak = peak.clone();
+            async move {
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(current, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                value
+            }
+        })
+        .await;
+
+        assert_eq!(output, (0..12).collect::<Vec<_>>());
+        assert_eq!(peak.load(Ordering::SeqCst), 3);
+    }
+}
 
 fn group_model_catalog_work_items(
     work_items: Vec<ModelCatalogWorkItem>,
@@ -3433,14 +3485,18 @@ async fn model_catalog_inner(
         .iter()
         .map(model_download_context)
         .collect::<Result<Vec<_>, _>>()?;
-    let download_size_bytes = join_all(download_contexts.iter().map(|context| async move {
-        match context {
-            Some(context) if estimate_sizes => {
-                estimate_huggingface_download_size(state, &context.repo, &context.files).await
+    let download_size_bytes = collect_bounded_ordered(
+        download_contexts.iter().cloned(),
+        MODEL_SIZE_ESTIMATE_CONCURRENCY,
+        |context| async move {
+            match context {
+                Some(context) if estimate_sizes => {
+                    estimate_huggingface_download_size(state, &context.repo, &context.files).await
+                }
+                _ => None,
             }
-            _ => None,
-        }
-    }))
+        },
+    )
     .await;
 
     let data_dir = Arc::new(state.settings.data_dir.clone());

--- a/apps/rust-api/src/prompts.rs
+++ b/apps/rust-api/src/prompts.rs
@@ -185,30 +185,7 @@ async fn resolve_image_caption_path(
     asset_id: &str,
 ) -> Result<String, ApiError> {
     let project_path = project_path_for_id(state.clone(), project_id).await?;
-    let project_id_owned = project_id.to_owned();
-    let asset_id_owned = asset_id.to_owned();
-    let asset = project_call(state, move |store| {
-        store.get_asset(&project_id_owned, &asset_id_owned)
-    })
-    .await?;
-    let rel = asset
-        .get("file")
-        .and_then(|file| file.get("path"))
-        .and_then(Value::as_str)
-        .ok_or_else(|| ApiError::bad_request("Reference asset has no file path"))?;
-    let mut path = project_path;
-    for component in std::path::Path::new(rel).components() {
-        match component {
-            std::path::Component::Normal(value) => path.push(value),
-            _ => {
-                return Err(ApiError::bad_request(
-                    "Reference asset path must stay inside the project directory",
-                ))
-            }
-        }
-    }
-    if !path.exists() {
-        return Err(ApiError::bad_request("Reference image not found on disk"));
-    }
+    let path =
+        resolve_project_confined_asset_path(state, project_id, asset_id, &project_path).await?;
     Ok(path.display().to_string())
 }

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -2959,6 +2959,7 @@ async fn catalog_delete_routes_remove_manifest_entries_and_owned_artifacts() {
     let app = create_app(test_settings(&temp_dir)).expect("app creates");
     // permanent=true keeps the assertions deterministic (the default move-to-OS-trash
     // path depends on the host having a usable recycle bin/trash).
+    crate::test_reset_catalog_build_counters();
     let (model_status, model_delete) = request(
         app.clone(),
         "DELETE",
@@ -2969,6 +2970,11 @@ async fn catalog_delete_routes_remove_manifest_entries_and_owned_artifacts() {
     assert_eq!(model_status, StatusCode::OK);
     assert_eq!(model_delete["removedManifestEntry"], true);
     assert_eq!(model_delete["removedLocalArtifacts"], true);
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        1,
+        "one delete request must assemble the model catalog only once"
+    );
     assert!(model_delete["warnings"][0]
         .as_str()
         .is_some_and(|warning| warning.contains("Moody")));

--- a/apps/rust-api/src/tests/projects.rs
+++ b/apps/rust-api/src/tests/projects.rs
@@ -506,3 +506,22 @@ async fn character_studio_routes_manage_references_loras_and_test_jobs() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(archived.as_array().unwrap().len(), 1);
 }
+
+#[tokio::test]
+async fn move_asset_to_character_uses_the_shaped_json_error_contract() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, _, body) = request_raw(
+        app,
+        "POST",
+        "/api/v1/projects/project-1/assets/asset-1/move-to-character",
+        Body::from(r#"{"characterId":"#),
+        &[("content-type", "application/json")],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    let body: Value = serde_json::from_slice(&body).expect("json error body");
+    assert_eq!(body["detail"][0]["type"], "json_invalid");
+    assert_eq!(body["detail"][0]["loc"], json!(["body", 0]));
+}

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -19,6 +19,17 @@ test("Windows workflows watch the local Rust runner action", async () => {
   }
 });
 
+test("Windows runner prep falls back when its optional rustc wrapper is missing", async () => {
+  const action = await source(".github/actions/prepare-rust-runner/action.yml");
+  assert.match(action, /\$rustcWrapper = \$env:RUSTC_WRAPPER/);
+  assert.match(action, /Test-Path -LiteralPath \$rustcWrapper -PathType Leaf/);
+  assert.match(action, /Get-Command \$rustcWrapper -CommandType Application/);
+  assert.match(
+    action,
+    /Add-Content -Path \$env:GITHUB_ENV -Value 'RUSTC_WRAPPER='/,
+  );
+});
+
 test("Docker relevance gate paginates and checks for truncated file lists", async () => {
   const workflow = await source(".github/workflows/check.yml");
   assert.match(workflow, /gh api --paginate/);


### PR DESCRIPTION
## Summary
- move local model and LoRA filesystem/header inspection off async runtime threads
- centralize project-confined asset resolution and bound concurrent Hugging Face size estimates
- reuse one request-scoped model catalog during deletion and restore the shaped JSON error contract

## Validation
- cargo test -p sceneworks-rust-api --lib (372 passed, 1 ignored)
- cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings
- cargo fmt --all -- --check
- focused concurrency, delete-catalog, shaped-JSON, and image-caption tests
- git diff --check

Shortcut: sc-13646