### PR TITLE
sc-13643: harden worker video and media paths

### DIFF
--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -446,6 +446,15 @@ pub(crate) async fn run_person_detect_job(
 
 /// The largest seek (seconds) a person-detect frame extraction will ever accept.
 const PERSON_DETECT_MAX_TIMESTAMP_SECONDS: f64 = 3600.0;
+pub(crate) const PERSON_DETECTOR_MODEL: &str = "yolo11m";
+#[cfg(target_os = "macos")]
+pub(crate) const PERSON_DETECTOR_ADAPTER: &str = "yolo11_mlx";
+#[cfg(not(target_os = "macos"))]
+pub(crate) const PERSON_DETECTOR_ADAPTER: &str = "yolo11_ort";
+#[cfg(target_os = "macos")]
+pub(crate) const PERSON_DETECTOR_BACKEND: &str = "mlx";
+#[cfg(not(target_os = "macos"))]
+pub(crate) const PERSON_DETECTOR_BACKEND: &str = "ort";
 
 /// Clamp the requested `sourceTimestamp` into a seek that lands inside the source clip.
 ///
@@ -544,10 +553,14 @@ pub(crate) async fn run_person_detect(
                     .await?;
                     (
                         boxes,
-                        "yolo11m".to_owned(),
-                        "yolo11_mlx",
+                        PERSON_DETECTOR_MODEL.to_owned(),
+                        PERSON_DETECTOR_ADAPTER,
                         true,
-                        json!({ "backend": "mlx", "device": device, "model": "yolo11m" }),
+                        json!({
+                            "backend": PERSON_DETECTOR_BACKEND,
+                            "device": device,
+                            "model": PERSON_DETECTOR_MODEL
+                        }),
                     )
                 };
             let asset = json!({
@@ -3151,12 +3164,34 @@ pub(crate) async fn run_ffmpeg(
     run_ffmpeg_capture_stderr(args, context).await.map(|_| ())
 }
 
+/// Run FFmpeg while streaming pre-split binary chunks into stdin. The chunks are consumed one at a
+/// time, so callers can move already-owned frame buffers into the writer without concatenating or
+/// cloning a second whole-video buffer. Heartbeat, cancellation, binary resolution, stderr bounds,
+/// and kill-on-drop behavior are identical to [`run_ffmpeg`].
+pub(crate) async fn run_ffmpeg_with_stdin_chunks(
+    args: Vec<String>,
+    chunks: Vec<Vec<u8>>,
+    context: Option<FfmpegContext<'_>>,
+) -> WorkerResult<()> {
+    run_ffmpeg_capture_stderr_inner(args, context, Some(chunks))
+        .await
+        .map(|_| ())
+}
+
 /// Run FFmpeg with the shared heartbeat/cancellation lifecycle and return its stderr on success.
 /// Most callers use [`run_ffmpeg`]; media probes need FFmpeg's progress/stream metadata without
 /// introducing an `ffprobe` dependency (the desktop bundle ships only FFmpeg).
 pub(crate) async fn run_ffmpeg_capture_stderr(
     args: Vec<String>,
     context: Option<FfmpegContext<'_>>,
+) -> WorkerResult<String> {
+    run_ffmpeg_capture_stderr_inner(args, context, None).await
+}
+
+async fn run_ffmpeg_capture_stderr_inner(
+    args: Vec<String>,
+    context: Option<FfmpegContext<'_>>,
+    stdin_chunks: Option<Vec<Vec<u8>>>,
 ) -> WorkerResult<String> {
     let Some((program, arguments)) = args.split_first() else {
         return Err(WorkerError::InvalidPayload(
@@ -3178,10 +3213,17 @@ pub(crate) async fn run_ffmpeg_capture_stderr(
     // no-op for a plain binary and on every other platform.
     let resolved_program =
         sceneworks_core::media_convert::resolve_ffmpeg_program(&configured_program);
-    let mut child = Command::new(resolved_program.as_ref())
+    let mut command = Command::new(resolved_program.as_ref());
+    command
         .args(arguments)
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    if stdin_chunks.is_some() {
+        command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
+    }
+    let mut child = command
         // sc-8804 (F-003): if the heartbeat/cancel `?` below returns early (a transient POST
         // failure or a 409 stale-sweep reclaim), `child` is dropped without an explicit kill. A
         // tokio child is not reaped on drop by default, so ffmpeg would keep running and writing a
@@ -3194,6 +3236,18 @@ pub(crate) async fn run_ffmpeg_capture_stderr(
             ))
         })?;
 
+    let mut stdin_task = stdin_chunks.map(|chunks| {
+        let mut stdin = child
+            .stdin
+            .take()
+            .expect("piped FFmpeg stdin is available after spawn");
+        tokio::spawn(async move {
+            for chunk in chunks {
+                stdin.write_all(&chunk).await?;
+            }
+            stdin.shutdown().await
+        })
+    });
     let mut stderr = child.stderr.take();
     let stderr_task = tokio::spawn(async move {
         let mut bytes = Vec::new();
@@ -3210,10 +3264,25 @@ pub(crate) async fn run_ffmpeg_capture_stderr(
             tokio::select! {
                 status = child.wait() => break status?,
                 _ = interval.tick() => {
-                    heartbeat(context.api, context.settings, WorkerStatus::Busy, Some(context.job_id)).await?;
+                    if let Err(error) = heartbeat(
+                        context.api,
+                        context.settings,
+                        WorkerStatus::Busy,
+                        Some(context.job_id),
+                    ).await {
+                        if let Some(task) = stdin_task.take() {
+                            task.abort();
+                            let _ = task.await;
+                        }
+                        return Err(error);
+                    }
                     if cancel_requested_peek(context.api, context.job_id).await {
                         let _ = child.kill().await;
                         let _ = child.wait().await;
+                        if let Some(task) = stdin_task.take() {
+                            task.abort();
+                            let _ = task.await;
+                        }
                         mark_job_canceled(context.api, context.job_id, context.cancel_message).await?;
                         return Err(WorkerError::Canceled(context.cancel_message.to_owned()));
                     }
@@ -3229,7 +3298,16 @@ pub(crate) async fn run_ffmpeg_capture_stderr(
         .map_err(|error| task_join_error("ffmpeg stderr reader task", error))?;
     let stderr = String::from_utf8_lossy(&stderr);
     if status.success() {
+        if let Some(task) = stdin_task {
+            task.await
+                .map_err(|error| task_join_error("ffmpeg stdin writer task", error))?
+                .map_err(WorkerError::Io)?;
+        }
         return Ok(stderr.into_owned());
+    }
+    if let Some(task) = stdin_task {
+        task.abort();
+        let _ = task.await;
     }
     let bounded = bounded_tail(&stderr, 10, 2000);
     if bounded.trim().is_empty() {

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -777,3 +777,18 @@ fn resolve_detector_weights_env_pin_missing_errors_and_unset_falls_through() {
     );
     // `_env` restores the prior value on drop.
 }
+
+#[test]
+fn detector_provenance_matches_the_compiled_runtime() {
+    assert_eq!(crate::media_jobs::PERSON_DETECTOR_MODEL, "yolo11m");
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(crate::media_jobs::PERSON_DETECTOR_ADAPTER, "yolo11_mlx");
+        assert_eq!(crate::media_jobs::PERSON_DETECTOR_BACKEND, "mlx");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        assert_eq!(crate::media_jobs::PERSON_DETECTOR_ADAPTER, "yolo11_ort");
+        assert_eq!(crate::media_jobs::PERSON_DETECTOR_BACKEND, "ort");
+    }
+}

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -269,7 +269,10 @@ fn build_point_tracker(model_path: &Path, quant: Option<i32>) -> WorkerResult<Sa
 /// Preprocess an RGB frame to the SAM3 input tensor: resize to a 1008×1008 square (bilinear,
 /// matching the processor's fixed-square resize — *not* aspect-preserving), rescale to `[0,1]`,
 /// normalize by mean/std `0.5` to `[-1,1]`, packed NCHW `[1,3,1008,1008]` f32.
-fn input_tensor(img: &image::RgbImage) -> Array {
+fn input_tensor<I>(img: &I) -> Array
+where
+    I: image::GenericImageView<Pixel = image::Rgb<u8>>,
+{
     let resized = image::imageops::resize(
         img,
         INPUT_SIZE,
@@ -672,7 +675,7 @@ fn segment_points_on_thread(
 pub(crate) fn segment_all_persons_in_memory(
     model_path: &Path,
     tokenizer_path: &Path,
-    frames: &[image::RgbImage],
+    frames: &[gen_core::Image],
     cancel: Option<CancelFlag>,
     mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<AllPersonMasks> {
@@ -680,16 +683,29 @@ pub(crate) fn segment_all_persons_in_memory(
     let first = frames.first().ok_or_else(|| {
         WorkerError::InvalidPayload("scail2 segmentation: no frames to segment".into())
     })?;
-    let (width, height) = (first.width(), first.height());
+    let (width, height) = (first.width, first.height);
     if frames
         .iter()
-        .any(|f| f.width() != width || f.height() != height)
+        .any(|f| f.width != width || f.height != height)
     {
         return Err(WorkerError::InvalidPayload(
             "scail2 segmentation: frames are not all the same size".into(),
         ));
     }
-    let tensors: Vec<Array> = frames.iter().map(input_tensor).collect();
+    let tensors = frames
+        .iter()
+        .map(|frame| {
+            let view = image::ImageBuffer::<image::Rgb<u8>, &[u8]>::from_raw(
+                frame.width,
+                frame.height,
+                frame.pixels.as_slice(),
+            )
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload("scail2 segmentation: malformed RGB frame".into())
+            })?;
+            Ok(input_tensor(&view))
+        })
+        .collect::<WorkerResult<Vec<Array>>>()?;
 
     // Guard the cold 3.2 GB checkpoint parse + model build + quantize — the engine only observes
     // the flag once propagation starts.
@@ -808,7 +824,11 @@ mod tests {
             matches!(track, Err(WorkerError::Canceled(_))),
             "segment_track_blocking: expected Canceled, got {track:?}"
         );
-        let frames = vec![image::RgbImage::new(4, 4)];
+        let frames = vec![gen_core::Image {
+            pixels: vec![0; 4 * 4 * 3],
+            width: 4,
+            height: 4,
+        }];
         let all = segment_all_persons_in_memory(
             Path::new("/nonexistent/model.safetensors"),
             Path::new("/nonexistent/tokenizer.json"),
@@ -819,6 +839,26 @@ mod tests {
         assert!(
             matches!(all, Err(WorkerError::Canceled(_))),
             "segment_all_persons_in_memory: expected Canceled"
+        );
+    }
+
+    #[test]
+    fn in_memory_segmentation_rejects_malformed_engine_image_without_cloning() {
+        let frames = vec![gen_core::Image {
+            pixels: vec![0; 4 * 4 * 3 - 1],
+            width: 4,
+            height: 4,
+        }];
+        let result = segment_all_persons_in_memory(
+            Path::new("/nonexistent/model.safetensors"),
+            Path::new("/nonexistent/tokenizer.json"),
+            &frames,
+            None,
+            None,
+        );
+        assert!(
+            matches!(result, Err(WorkerError::InvalidPayload(ref m)) if m.contains("malformed RGB frame")),
+            "malformed borrowed frame must fail before loading weights"
         );
     }
 

--- a/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3_candle.rs
@@ -83,7 +83,10 @@ static WEIGHTS: OnceLock<Mutex<Option<Weights>>> = OnceLock::new();
 /// Preprocess an RGB frame to the SAM3 input tensor: resize to a 1008×1008 square (bilinear, fixed-
 /// square — *not* aspect-preserving), normalize by mean/std `0.5` to `[-1,1]`, packed NCHW
 /// `[1,3,1008,1008]` f32 on `device`.
-fn input_tensor(img: &image::RgbImage, device: &Device) -> WorkerResult<Tensor> {
+fn input_tensor<I>(img: &I, device: &Device) -> WorkerResult<Tensor>
+where
+    I: image::GenericImageView<Pixel = image::Rgb<u8>>,
+{
     let resized = image::imageops::resize(
         img,
         INPUT_SIZE,
@@ -239,7 +242,7 @@ pub(crate) fn segment_track_blocking(
 pub(crate) fn segment_all_persons_in_memory(
     model_path: &Path,
     tokenizer_path: &Path,
-    frames: &[image::RgbImage],
+    frames: &[gen_core::Image],
     cancel: Option<CancelFlag>,
     mut progress: Option<SegmentProgress>,
 ) -> WorkerResult<AllPersonMasks> {
@@ -247,10 +250,10 @@ pub(crate) fn segment_all_persons_in_memory(
     let first = frames.first().ok_or_else(|| {
         WorkerError::InvalidPayload("scail2 segmentation: no frames to segment".into())
     })?;
-    let (width, height) = (first.width(), first.height());
+    let (width, height) = (first.width, first.height);
     if frames
         .iter()
-        .any(|f| f.width() != width || f.height() != height)
+        .any(|f| f.width != width || f.height != height)
     {
         return Err(WorkerError::InvalidPayload(
             "scail2 segmentation: frames are not all the same size".into(),
@@ -260,7 +263,17 @@ pub(crate) fn segment_all_persons_in_memory(
     let device = default_device().map_err(|e| WorkerError::Engine(format!("sam3 device: {e}")))?;
     let tensors: Vec<Tensor> = frames
         .iter()
-        .map(|f| input_tensor(f, &device))
+        .map(|frame| {
+            let view = image::ImageBuffer::<image::Rgb<u8>, &[u8]>::from_raw(
+                frame.width,
+                frame.height,
+                frame.pixels.as_slice(),
+            )
+            .ok_or_else(|| {
+                WorkerError::InvalidPayload("scail2 segmentation: malformed RGB frame".into())
+            })?;
+            input_tensor(&view, &device)
+        })
         .collect::<WorkerResult<Vec<_>>>()?;
 
     // Guard the cold multi-GB checkpoint parse + model build — the engine only observes the flag
@@ -375,7 +388,11 @@ mod tests {
             matches!(track, Err(WorkerError::Canceled(_))),
             "segment_track_blocking: expected Canceled, got {track:?}"
         );
-        let frames = vec![image::RgbImage::new(4, 4)];
+        let frames = vec![gen_core::Image {
+            pixels: vec![0; 4 * 4 * 3],
+            width: 4,
+            height: 4,
+        }];
         let all = segment_all_persons_in_memory(
             Path::new("/nonexistent/model.safetensors"),
             Path::new("/nonexistent/tokenizer.json"),
@@ -386,6 +403,26 @@ mod tests {
         assert!(
             matches!(all, Err(WorkerError::Canceled(_))),
             "segment_all_persons_in_memory: expected Canceled"
+        );
+    }
+
+    #[test]
+    fn in_memory_segmentation_rejects_malformed_engine_image_without_cloning() {
+        let frames = vec![gen_core::Image {
+            pixels: vec![0; 4 * 4 * 3 - 1],
+            width: 4,
+            height: 4,
+        }];
+        let result = segment_all_persons_in_memory(
+            Path::new("/nonexistent/model.safetensors"),
+            Path::new("/nonexistent/tokenizer.json"),
+            &frames,
+            None,
+            None,
+        );
+        assert!(
+            matches!(result, Err(WorkerError::InvalidPayload(ref m)) if m.contains("malformed RGB frame")),
+            "malformed borrowed frame must fail before loading weights"
         );
     }
 

--- a/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/scail2_gpu_smoke.rs
@@ -45,10 +45,6 @@ fn load_rgb(path: &Path) -> Image {
     }
 }
 
-fn to_rgb_image(img: &Image) -> image::RgbImage {
-    image::RgbImage::from_raw(img.width, img.height, img.pixels.clone()).expect("rgb buffer")
-}
-
 /// Per-frame pixel std-dev, averaged — a cheap "is the clip non-degenerate" check (a NaN-clamped /
 /// all-black engine output collapses toward 0).
 fn avg_frame_std(frames: &[Image]) -> f64 {
@@ -105,11 +101,10 @@ fn scail2_candle_gpu_smoke() {
     // --- reference character + its color-coded mask (SAM3 -> the primary person painted blue) ---
     // Animation keeps the reference's world (white bg); replacement discards it (black bg).
     let reference = load_rgb(&ref_path);
-    let ref_rgb = to_rgb_image(&reference);
     let ref_masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
         &sam3_model,
         &sam3_tok,
-        std::slice::from_ref(&ref_rgb),
+        std::slice::from_ref(&reference),
         None,
         None,
     )
@@ -135,11 +130,10 @@ fn scail2_candle_gpu_smoke() {
         driving_dir.display()
     );
     let driving: Vec<Image> = paths.iter().map(|p| load_rgb(p)).collect();
-    let driving_rgb: Vec<image::RgbImage> = driving.iter().map(to_rgb_image).collect();
     let drive_masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
         &sam3_model,
         &sam3_tok,
-        &driving_rgb,
+        &driving,
         None,
         None,
     )

--- a/crates/sceneworks-worker/src/video_jobs/candle.rs
+++ b/crates/sceneworks-worker/src/video_jobs/candle.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 use super::{
     mochi::{
         ensure_mochi_bf16_present, ensure_mochi_q8_present, mochi_precheck_dir, mochi_tier_quant,
-        mochi_vram_precheck, resolve_mochi_model_dir, MOCHI_REPO,
+        mochi_vram_precheck, resolve_mochi_model_dir, validate_mochi_mode, MOCHI_REPO,
     },
     scail2::{scail2_engine_video_mode, scail2_raw_settings},
     svd::{svd_f32, svd_i32, svd_raw_settings, svd_steps, SVD_REPO},
@@ -677,6 +677,7 @@ pub(super) async fn generate_candle_video_using(
     // would be a second, drift-prone source of truth.
     let is_mochi = engine_id == "mochi_1";
     if is_mochi {
+        validate_mochi_mode(request)?;
         // Refuse a job that cannot possibly fit BEFORE paying for its tier download (sc-12373, the
         // candle half of sc-12322). Runs on a weights FLOOR — the already-present shared
         // co-requisites — so it only ever refuses when the full gate below would refuse too.
@@ -1326,18 +1327,6 @@ async fn resolve_candle_scail2_conditioning(
     let (sam_model, sam_tokenizer) =
         crate::person_segment_sam3_candle::ensure_segmenter_weights(settings, &context).await?;
 
-    // Decode the engine `Image`s to `RgbImage`s for SAM3 (it normalizes RGB internally).
-    let ref_rgb =
-        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
-            .ok_or_else(|| {
-                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
-            })?;
-    let driving_rgb: Vec<image::RgbImage> = driving
-        .iter()
-        .map(|f| image::RgbImage::from_raw(f.width, f.height, f.pixels.clone()))
-        .collect::<Option<Vec<_>>>()
-        .ok_or_else(|| WorkerError::InvalidPayload("scail2 driving frame is malformed".into()))?;
-
     // Segment + paint via the shared orchestrator (sc-8830). Animation keeps the reference's world
     // (ref bg white) and drops the driving world (driving bg black); the candle SAM3 module is the
     // off-Mac twin, whose per-frame propagate contract (sc-8972) observes the tripped cancel flag
@@ -1347,29 +1336,31 @@ async fn resolve_candle_scail2_conditioning(
         api,
         settings,
         &job.id,
-        reference,
-        driving,
         move |flag| {
             let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
                 &rm,
                 &rt,
-                std::slice::from_ref(&ref_rgb),
+                std::slice::from_ref(&reference),
                 Some(flag),
                 None,
             )?;
-            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
+            let mask =
+                crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)?;
+            Ok((reference, mask))
         },
         move |flag| {
             let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
                 &sam_model,
                 &sam_tokenizer,
-                &driving_rgb,
+                &driving,
                 Some(flag),
                 Some(Box::new(|frame, total| {
                     tracing::debug!(event = "scail2_sam3_propagate_progress", frame, total);
                 })),
             )?;
-            crate::scail2_masks::paint_driving_masks(&masks, crate::scail2_masks::BG_BLACK)
+            let masks =
+                crate::scail2_masks::paint_driving_masks(&masks, crate::scail2_masks::BG_BLACK)?;
+            Ok((driving, masks))
         },
     )
     .await
@@ -1496,11 +1487,6 @@ async fn resolve_candle_scail2_replace_conditioning(
     };
     let (sam_model, sam_tokenizer) =
         crate::person_segment_sam3_candle::ensure_segmenter_weights(settings, &context).await?;
-    let ref_rgb =
-        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
-            .ok_or_else(|| {
-                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
-            })?;
     // Heartbeat keepalive + user cancel across the cold SAM3 parse + single-frame propagate
     // (sc-8390 / sc-8807), via the shared blocking-segment helper (sc-8830); the engine's per-frame
     // propagate contract (sc-8972) observes the tripped flag between frames, beyond the coarse seams
@@ -1514,14 +1500,17 @@ async fn resolve_candle_scail2_replace_conditioning(
             let masks = crate::person_segment_sam3_candle::segment_all_persons_in_memory(
                 &sam_model,
                 &sam_tokenizer,
-                std::slice::from_ref(&ref_rgb),
+                std::slice::from_ref(&reference),
                 Some(flag),
                 None,
             )?;
-            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
+            let mask =
+                crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)?;
+            Ok((mask, reference))
         },
     )
     .await?;
+    let (ref_mask, reference) = ref_mask;
 
     let conditioning = vec![
         Conditioning::Reference {

--- a/crates/sceneworks-worker/src/video_jobs/mochi.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mochi.rs
@@ -433,10 +433,26 @@ pub(super) fn resolve_mochi_model_dir(
 /// DEFAULTS to `image_to_video` when the payload omits one, so a mode check is what keeps a
 /// conditioning-shaped Mochi job out of the route rather than letting it reach the engine's
 /// `validate_request` (or, worse, an unrelated arm of the ladder).
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle"),
+    test
+))]
+pub(super) fn validate_mochi_mode(request: &VideoRequest) -> WorkerResult<()> {
+    if request.mode == "text_to_video" {
+        Ok(())
+    } else {
+        Err(WorkerError::InvalidPayload(format!(
+            "{} supports text_to_video only; mode '{}' requires conditioning Mochi does not implement",
+            request.model, request.mode
+        )))
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub(super) fn mochi_available(request: &VideoRequest, settings: &Settings) -> bool {
     mochi_engine_id(&request.model).is_some()
-        && request.mode == "text_to_video"
+        && validate_mochi_mode(request).is_ok()
         && resolve_mochi_model_dir(settings, request).is_ok()
 }
 

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -35,7 +35,7 @@ use sceneworks_core::video_request::{
 use sceneworks_core::contracts::GenerationMetrics;
 
 use super::*;
-use crate::media_jobs::{run_ffmpeg, FfmpegContext};
+use crate::media_jobs::{run_ffmpeg, run_ffmpeg_with_stdin_chunks, FfmpegContext};
 
 /// Shared worker-level dependencies used by the engine-family modules. Keeping this
 /// list explicit prevents a family from silently inheriting newly imported parent
@@ -1026,7 +1026,7 @@ fn stub_audio_track(frame_count: u32, fps: u32) -> AudioTrack {
 // (heartbeat/cancel), so it is exercisable in tests with a real ffmpeg.
 // ---------------------------------------------------------------------------
 
-/// Write `decoded` to `media_path` as an mp4: frames → libx264, an optional 16-bit
+/// Write `decoded` to `media_path` as an mp4: raw RGB frames streamed to libx264, an optional 16-bit
 /// PCM WAV muxed as AAC (`-shortest`), then a best-effort `+faststart` remux and
 /// `.poster.jpg`. `media_path` is created (atomically renamed from a temp) only on
 /// success; all intermediates are removed regardless of outcome.
@@ -1035,21 +1035,10 @@ async fn encode_media(
     decoded: DecodedVideo,
     ctx: Option<FfmpegContext<'_>>,
 ) -> WorkerResult<()> {
-    let frames_dir = media_path.with_extension("frames");
     let enc_tmp = media_path.with_extension("enc.mp4");
     let wav_tmp = media_path.with_extension("audio.wav");
     let mux_tmp = media_path.with_extension("mux.mp4");
-    let result = encode_inner(
-        media_path,
-        decoded,
-        ctx,
-        &frames_dir,
-        &enc_tmp,
-        &wav_tmp,
-        &mux_tmp,
-    )
-    .await;
-    let _ = tokio::fs::remove_dir_all(&frames_dir).await;
+    let result = encode_inner(media_path, decoded, ctx, &enc_tmp, &wav_tmp, &mux_tmp).await;
     let _ = tokio::fs::remove_file(&enc_tmp).await;
     let _ = tokio::fs::remove_file(&wav_tmp).await;
     let _ = tokio::fs::remove_file(&mux_tmp).await;
@@ -1066,7 +1055,6 @@ async fn encode_inner(
     media_path: &Path,
     decoded: DecodedVideo,
     ctx: Option<FfmpegContext<'_>>,
-    frames_dir: &Path,
     enc_tmp: &Path,
     wav_tmp: &Path,
     mux_tmp: &Path,
@@ -1080,42 +1068,44 @@ async fn encode_inner(
         ));
     }
 
-    // 1. Write the frame sequence (blocking PNG encodes off the async runtime).
-    tokio::fs::create_dir_all(frames_dir).await?;
-    let dir = frames_dir.to_path_buf();
-    tokio::task::spawn_blocking(move || -> WorkerResult<()> {
-        for (index, frame) in frames.into_iter().enumerate() {
-            let RgbFrame {
-                width,
-                height,
-                pixels,
-            } = frame;
-            let image = image::RgbImage::from_raw(width, height, pixels).ok_or_else(|| {
-                WorkerError::InvalidPayload("video frame buffer size mismatch".to_owned())
-            })?;
-            let path = dir.join(format!("frame_{index:05}.png"));
-            image
-                .save_with_format(&path, image::ImageFormat::Png)
-                .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
+    let width = frames[0].width;
+    let height = frames[0].height;
+    let expected_bytes = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|pixels| pixels.checked_mul(3))
+        .ok_or_else(|| WorkerError::InvalidPayload("video frame dimensions overflow".to_owned()))?;
+    for frame in &frames {
+        if frame.width != width || frame.height != height {
+            return Err(WorkerError::InvalidPayload(
+                "video frames must all have the same dimensions".to_owned(),
+            ));
         }
-        Ok(())
-    })
-    .await
-    .map_err(|error| WorkerError::Io(std::io::Error::other(error)))??;
+        if frame.pixels.len() != expected_bytes {
+            return Err(WorkerError::InvalidPayload(
+                "video frame buffer size mismatch".to_owned(),
+            ));
+        }
+    }
 
-    // 2. Frames → mp4 (libx264, yuv420p — request dims are multiples of 32, so even).
-    let pattern = frames_dir.join("frame_%05d.png");
-    run_ffmpeg(
+    // 1. Stream the engine-owned RGB buffers directly into FFmpeg. This moves one existing frame
+    // buffer at a time through the pipe: no per-frame PNG encode, no multi-GB scratch tree, and no
+    // second whole-video concatenation.
+    let chunks = frames.into_iter().map(|frame| frame.pixels).collect();
+    run_ffmpeg_with_stdin_chunks(
         vec![
             "ffmpeg".to_owned(),
             "-nostdin".to_owned(),
             "-y".to_owned(),
+            "-f".to_owned(),
+            "rawvideo".to_owned(),
+            "-pix_fmt".to_owned(),
+            "rgb24".to_owned(),
+            "-video_size".to_owned(),
+            format!("{width}x{height}"),
             "-framerate".to_owned(),
             fps.to_string(),
-            "-start_number".to_owned(),
-            "0".to_owned(),
             "-i".to_owned(),
-            pattern.to_string_lossy().into_owned(),
+            "pipe:0".to_owned(),
             "-c:v".to_owned(),
             "libx264".to_owned(),
             "-pix_fmt".to_owned(),
@@ -1124,11 +1114,12 @@ async fn encode_inner(
             fps.to_string(),
             enc_tmp.to_string_lossy().into_owned(),
         ],
+        chunks,
         ctx,
     )
     .await?;
 
-    // 3. Mux the audio track (LTX) as AAC, else the video-only mp4 is the result.
+    // 2. Mux the audio track (LTX) as AAC, else the video-only mp4 is the result.
     let finished_tmp = if let Some(audio) = audio {
         write_wav_pcm16(&audio, wav_tmp)?;
         run_ffmpeg(
@@ -1155,26 +1146,22 @@ async fn encode_inner(
         enc_tmp
     };
 
-    // 4. Publish atomically, then best-effort faststart + poster (mirrors Python).
+    // 3. Publish atomically, then best-effort faststart + poster (mirrors Python).
     tokio::fs::rename(finished_tmp, media_path).await?;
     faststart_mp4(media_path).await;
     write_poster_frame(media_path).await;
     Ok(())
 }
 
-/// Peak-normalize the f32 PCM to 16-bit and write a canonical WAV. Silence (peak 0)
-/// stays silent rather than dividing by zero. `pub(crate)` so the pure-audio job path reuses it
-/// (sc-13404).
+/// Write f32 PCM to a canonical 16-bit WAV. Signals already within `[-1, 1]` retain their original
+/// amplitude; only over-range input is peak-normalized to prevent clipping. `pub(crate)` so the
+/// pure-audio job path reuses it (sc-13404).
 pub(crate) fn write_wav_pcm16(audio: &AudioTrack, path: &Path) -> WorkerResult<()> {
     let peak = audio
         .samples
         .iter()
         .fold(0.0f32, |max, &sample| max.max(sample.abs()));
-    let scale = if peak > 0.0 {
-        i16::MAX as f32 / peak
-    } else {
-        0.0
-    };
+    let scale = i16::MAX as f32 / peak.max(1.0);
     let mut pcm = Vec::with_capacity(audio.samples.len() * 2);
     for &sample in &audio.samples {
         let value = (sample * scale)
@@ -1775,16 +1762,14 @@ async fn assemble_scail2_animate_conditioning<FR, FD>(
     api: &ApiClient,
     settings: &Settings,
     job_id: &str,
-    reference: Image,
-    driving: Vec<Image>,
     segment_reference: FR,
     segment_driving: FD,
 ) -> WorkerResult<Vec<Conditioning>>
 where
-    FR: FnOnce(gen_core::CancelFlag) -> WorkerResult<Image> + Send + 'static,
-    FD: FnOnce(gen_core::CancelFlag) -> WorkerResult<Vec<Image>> + Send + 'static,
+    FR: FnOnce(gen_core::CancelFlag) -> WorkerResult<(Image, Image)> + Send + 'static,
+    FD: FnOnce(gen_core::CancelFlag) -> WorkerResult<(Vec<Image>, Vec<Image>)> + Send + 'static,
 {
-    let ref_mask = scail2_segment_blocking(
+    let (reference, ref_mask) = scail2_segment_blocking(
         api,
         settings,
         job_id,
@@ -1792,7 +1777,7 @@ where
         segment_reference,
     )
     .await?;
-    let driving_mask = scail2_segment_blocking(
+    let (driving, driving_mask) = scail2_segment_blocking(
         api,
         settings,
         job_id,

--- a/crates/sceneworks-worker/src/video_jobs/scail2.rs
+++ b/crates/sceneworks-worker/src/video_jobs/scail2.rs
@@ -331,18 +331,6 @@ pub(super) async fn resolve_scail2_conditioning(
     let (sam_model, sam_tokenizer) =
         crate::person_segment_sam3::ensure_segmenter_weights(settings, &context).await?;
 
-    // Decode the engine `Image`s to `RgbImage`s for SAM3 (it normalizes RGB internally).
-    let ref_rgb =
-        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
-            .ok_or_else(|| {
-                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
-            })?;
-    let driving_rgb: Vec<image::RgbImage> = driving
-        .iter()
-        .map(|f| image::RgbImage::from_raw(f.width, f.height, f.pixels.clone()))
-        .collect::<Option<Vec<_>>>()
-        .ok_or_else(|| WorkerError::InvalidPayload("scail2 driving frame is malformed".into()))?;
-
     // Segment + paint via the shared orchestrator (sc-8830). Animation keeps the reference's world
     // (ref bg white) and drops the driving world (driving bg black); the native SAM3 module is the
     // per-frame 1008² MLX twin.
@@ -351,29 +339,31 @@ pub(super) async fn resolve_scail2_conditioning(
         api,
         settings,
         &job.id,
-        reference,
-        driving,
         move |flag| {
             let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
                 &rm,
                 &rt,
-                std::slice::from_ref(&ref_rgb),
+                std::slice::from_ref(&reference),
                 Some(flag),
                 None,
             )?;
-            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)
+            let mask =
+                crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_WHITE)?;
+            Ok((reference, mask))
         },
         move |flag| {
             let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
                 &sam_model,
                 &sam_tokenizer,
-                &driving_rgb,
+                &driving,
                 Some(flag),
                 Some(Box::new(|frame, total| {
                     tracing::debug!(event = "scail2_sam3_propagate_progress", frame, total);
                 })),
             )?;
-            crate::scail2_masks::paint_driving_masks(&masks, crate::scail2_masks::BG_BLACK)
+            let masks =
+                crate::scail2_masks::paint_driving_masks(&masks, crate::scail2_masks::BG_BLACK)?;
+            Ok((driving, masks))
         },
     )
     .await
@@ -515,11 +505,6 @@ pub(super) async fn resolve_scail2_replace_conditioning(
     };
     let (sam_model, sam_tokenizer) =
         crate::person_segment_sam3::ensure_segmenter_weights(settings, &context).await?;
-    let ref_rgb =
-        image::RgbImage::from_raw(reference.width, reference.height, reference.pixels.clone())
-            .ok_or_else(|| {
-                WorkerError::InvalidPayload("scail2 reference image is malformed".into())
-            })?;
     // Heartbeat keepalive + user cancel across the cold SAM3 parse + single-frame propagate
     // (sc-8390 / sc-8807), via the shared blocking-segment helper (sc-8830).
     let ref_mask = scail2_segment_blocking(
@@ -531,14 +516,17 @@ pub(super) async fn resolve_scail2_replace_conditioning(
             let masks = crate::person_segment_sam3::segment_all_persons_in_memory(
                 &sam_model,
                 &sam_tokenizer,
-                std::slice::from_ref(&ref_rgb),
+                std::slice::from_ref(&reference),
                 Some(flag),
                 None,
             )?;
-            crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)
+            let mask =
+                crate::scail2_masks::paint_reference_mask(&masks, crate::scail2_masks::BG_BLACK)?;
+            Ok((mask, reference))
         },
     )
     .await?;
+    let (ref_mask, reference) = ref_mask;
 
     let conditioning = vec![
         Conditioning::Reference {

--- a/crates/sceneworks-worker/src/video_jobs/seedvr2.rs
+++ b/crates/sceneworks-worker/src/video_jobs/seedvr2.rs
@@ -80,6 +80,48 @@ const SEEDVR2_ADAPTER: &str = "mlx_seedvr2";
 ))]
 const SEEDVR2_CANCEL_MESSAGE: &str = "Video upscale canceled by user.";
 
+/// A failed post-encode step must not leave the intermediate, silent output, or derived poster
+/// behind. The API publishes the asset only after the final completion update succeeds.
+#[cfg(any(target_os = "macos", feature = "backend-candle", test))]
+pub(super) async fn cleanup_failed_seedvr2_mux(media_path: &Path, mux_tmp: &Path) {
+    let _ = tokio::fs::remove_file(mux_tmp).await;
+    let _ = tokio::fs::remove_file(media_path).await;
+    let _ = tokio::fs::remove_file(media_path.with_extension("poster.jpg")).await;
+}
+
+#[cfg(any(target_os = "macos", feature = "backend-candle", test))]
+pub(super) struct Seedvr2OutputGuard {
+    media_path: PathBuf,
+    mux_tmp: PathBuf,
+    armed: bool,
+}
+
+#[cfg(any(target_os = "macos", feature = "backend-candle", test))]
+impl Seedvr2OutputGuard {
+    pub(super) fn new(media_path: &Path, mux_tmp: &Path) -> Self {
+        Self {
+            media_path: media_path.to_path_buf(),
+            mux_tmp: mux_tmp.to_path_buf(),
+            armed: true,
+        }
+    }
+
+    pub(super) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(any(target_os = "macos", feature = "backend-candle", test))]
+impl Drop for Seedvr2OutputGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.mux_tmp);
+            let _ = std::fs::remove_file(&self.media_path);
+            let _ = std::fs::remove_file(self.media_path.with_extension("poster.jpg"));
+        }
+    }
+}
+
 /// Snap a dimension to the SeedVR2 VAE/patch stride (a multiple of 16, the engine's hard
 /// requirement), rounding to nearest and clamping to the engine's `[16, 4096]` size range.
 #[cfg(any(
@@ -1182,6 +1224,8 @@ pub(crate) async fn run_video_upscale_job(
     let _ = tokio::fs::remove_dir_all(&out_frames_dir).await;
     out_scratch.disarm();
     encode_result?;
+    let mux_tmp = media_path.with_extension("audiomux.mp4");
+    let mut output_guard = Seedvr2OutputGuard::new(&media_path, &mux_tmp);
 
     // Source-audio passthrough: remux the source's audio onto the upscaled video. `-map 1:a:0?`
     // makes audio optional, so a source with no audio yields a clean video-only file (no error);
@@ -1199,34 +1243,41 @@ pub(crate) async fn run_video_upscale_job(
         ),
     )
     .await?;
-    let mux_tmp = media_path.with_extension("audiomux.mp4");
     let ctx = FfmpegContext::new(api, settings, &job.id, SEEDVR2_CANCEL_MESSAGE);
-    run_ffmpeg(
-        vec![
-            "ffmpeg".to_owned(),
-            "-nostdin".to_owned(),
-            "-y".to_owned(),
-            "-i".to_owned(),
-            media_path.to_string_lossy().into_owned(),
-            "-i".to_owned(),
-            source_path.to_string_lossy().into_owned(),
-            "-map".to_owned(),
-            "0:v:0".to_owned(),
-            "-map".to_owned(),
-            "1:a:0?".to_owned(),
-            "-c:v".to_owned(),
-            "copy".to_owned(),
-            "-c:a".to_owned(),
-            "aac".to_owned(),
-            "-movflags".to_owned(),
-            "+faststart".to_owned(),
-            "-shortest".to_owned(),
-            mux_tmp.to_string_lossy().into_owned(),
-        ],
-        Some(ctx),
-    )
-    .await?;
-    tokio::fs::rename(&mux_tmp, &media_path).await?;
+    let mux_result: WorkerResult<()> = async {
+        run_ffmpeg(
+            vec![
+                "ffmpeg".to_owned(),
+                "-nostdin".to_owned(),
+                "-y".to_owned(),
+                "-i".to_owned(),
+                media_path.to_string_lossy().into_owned(),
+                "-i".to_owned(),
+                source_path.to_string_lossy().into_owned(),
+                "-map".to_owned(),
+                "0:v:0".to_owned(),
+                "-map".to_owned(),
+                "1:a:0?".to_owned(),
+                "-c:v".to_owned(),
+                "copy".to_owned(),
+                "-c:a".to_owned(),
+                "aac".to_owned(),
+                "-movflags".to_owned(),
+                "+faststart".to_owned(),
+                "-shortest".to_owned(),
+                mux_tmp.to_string_lossy().into_owned(),
+            ],
+            Some(ctx),
+        )
+        .await?;
+        tokio::fs::rename(&mux_tmp, &media_path).await?;
+        Ok(())
+    }
+    .await;
+    if let Err(error) = mux_result {
+        cleanup_failed_seedvr2_mux(&media_path, &mux_tmp).await;
+        return Err(error);
+    }
 
     let display_name = req
         .display_name
@@ -1269,6 +1320,13 @@ pub(crate) async fn run_video_upscale_job(
         "loras": [],
         "rawAdapterSettings": raw_settings,
         "sourceAssetId": req.source_asset_id,
+        "parents": [req.source_asset_id],
+        "extra": {
+            "isUpscaled": true,
+            "upscaledFromAssetId": req.source_asset_id,
+            "factor": factor,
+            "engine": "seedvr2",
+        },
         "timelineContext": json!({}),
     });
     let result = json!({
@@ -1304,5 +1362,6 @@ pub(crate) async fn run_video_upscale_job(
         ),
     )
     .await?;
+    output_guard.disarm();
     Ok(())
 }

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -2645,6 +2645,30 @@ fn mochi_available_is_text_to_video_only() {
     std::fs::remove_dir_all(&root).ok();
 }
 
+#[test]
+fn mochi_mode_gate_rejects_every_conditioning_shape() {
+    let mut request = request(json!({
+        "projectId": "p", "model": "mochi_1", "mode": "text_to_video", "prompt": "p"
+    }));
+    assert!(mochi::validate_mochi_mode(&request).is_ok());
+
+    for mode in [
+        "image_to_video",
+        "first_last_frame",
+        "extend_clip",
+        "video_bridge",
+        "replace_person",
+    ] {
+        request.mode = mode.to_owned();
+        let error = mochi::validate_mochi_mode(&request).expect_err("conditioning mode must fail");
+        assert!(
+            matches!(error, WorkerError::InvalidPayload(ref message)
+                if message.contains("text_to_video only") && message.contains(mode)),
+            "unexpected error for {mode}: {error:?}"
+        );
+    }
+}
+
 /// A Mochi t2v job with resolvable weights routes to `VideoRoute::Mochi` — and, critically, a
 /// Mochi job whose weights DON'T resolve must NOT silently become `VideoRoute::Stub` output:
 /// `ensure_video_engine_weights` (the sc-4176 fail-loud gate the Stub arm calls) must error.
@@ -3348,7 +3372,7 @@ fn stub_frames_differ_across_time() {
 }
 
 #[test]
-fn wav_header_is_canonical_and_peak_normalized() {
+fn wav_header_is_canonical_and_preserves_in_range_amplitude() {
     let audio = AudioTrack {
         samples: vec![0.0, 0.5, -0.25, 0.5],
         sample_rate: 48_000,
@@ -3364,13 +3388,111 @@ fn wav_header_is_canonical_and_peak_normalized() {
     assert_eq!(&bytes[36..40], b"data");
     // 4 mono 16-bit samples → 8 bytes of PCM, 44-byte header.
     assert_eq!(bytes.len(), 44 + 8);
-    // Peak (0.5) maps to i16::MAX; the matching trough (-0.25) is half-scale negative.
+    // In-range PCM retains its amplitude rather than being normalized to full scale.
     let first = i16::from_le_bytes([bytes[44], bytes[45]]);
     let peak = i16::from_le_bytes([bytes[46], bytes[47]]);
     let trough = i16::from_le_bytes([bytes[48], bytes[49]]);
     assert_eq!(first, 0);
-    assert_eq!(peak, i16::MAX);
-    assert_eq!(trough, -(i16::MAX / 2) - 1); // -0.25/0.5 * 32767, rounded
+    assert_eq!(peak, 16_384);
+    assert_eq!(trough, -8_192);
+}
+
+#[test]
+fn wav_normalizes_only_over_range_audio() {
+    let audio = AudioTrack {
+        samples: vec![2.0, -1.0],
+        sample_rate: 48_000,
+        channels: 1,
+    };
+    let dir = std::env::temp_dir().join(format!("sw_wav_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("over-range.wav");
+    write_wav_pcm16(&audio, &path).unwrap();
+    let bytes = std::fs::read(path).unwrap();
+    assert_eq!(i16::from_le_bytes([bytes[44], bytes[45]]), i16::MAX);
+    assert_eq!(i16::from_le_bytes([bytes[46], bytes[47]]), -16_384);
+}
+
+#[tokio::test]
+async fn seedvr2_failed_mux_cleanup_removes_silent_and_partial_outputs() {
+    let dir = std::env::temp_dir().join(format!("sw_seedvr2_mux_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let media_path = dir.join("upscaled.mp4");
+    let mux_tmp = dir.join("upscaled.audiomux.mp4");
+    let poster_path = media_path.with_extension("poster.jpg");
+    std::fs::write(&media_path, b"silent output").unwrap();
+    std::fs::write(&mux_tmp, b"partial mux").unwrap();
+    std::fs::write(&poster_path, b"orphaned poster").unwrap();
+
+    cleanup_failed_seedvr2_mux(&media_path, &mux_tmp).await;
+
+    assert!(!media_path.exists());
+    assert!(!mux_tmp.exists());
+    assert!(!poster_path.exists());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn seedvr2_output_guard_covers_the_full_post_encode_interval() {
+    let dir = std::env::temp_dir().join(format!("sw_seedvr2_guard_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let media_path = dir.join("upscaled.mp4");
+    let mux_tmp = dir.join("upscaled.audiomux.mp4");
+    let poster_path = media_path.with_extension("poster.jpg");
+    std::fs::write(&media_path, b"silent output").unwrap();
+    std::fs::write(&mux_tmp, b"partial mux").unwrap();
+    std::fs::write(&poster_path, b"poster").unwrap();
+
+    {
+        let _guard = Seedvr2OutputGuard::new(&media_path, &mux_tmp);
+        // Simulates any `?` after encode and before the completion update succeeds.
+    }
+
+    assert!(!media_path.exists());
+    assert!(!mux_tmp.exists());
+    assert!(!poster_path.exists());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn seedvr2_output_guard_preserves_published_outputs_after_disarm() {
+    let dir = std::env::temp_dir().join(format!("sw_seedvr2_guard_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let media_path = dir.join("upscaled.mp4");
+    let mux_tmp = dir.join("upscaled.audiomux.mp4");
+    let poster_path = media_path.with_extension("poster.jpg");
+    std::fs::write(&media_path, b"published output").unwrap();
+    std::fs::write(&mux_tmp, b"completed mux").unwrap();
+    std::fs::write(&poster_path, b"published poster").unwrap();
+
+    {
+        let mut guard = Seedvr2OutputGuard::new(&media_path, &mux_tmp);
+        guard.disarm();
+    }
+
+    assert!(media_path.exists());
+    assert!(mux_tmp.exists());
+    assert!(poster_path.exists());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn seedvr2_video_upscale_fact_records_lineage_flags() {
+    let source = include_str!("seedvr2.rs");
+    for required in [
+        "\"sourceAssetId\": req.source_asset_id",
+        "\"parents\": [req.source_asset_id]",
+        "\"extra\": {",
+        "\"isUpscaled\": true",
+        "\"upscaledFromAssetId\": req.source_asset_id",
+        "\"factor\": factor",
+        "\"engine\": \"seedvr2\"",
+    ] {
+        assert!(
+            source.contains(required),
+            "video upscale fact must contain {required}"
+        );
+    }
 }
 
 #[test]
@@ -8026,6 +8148,30 @@ async fn encode_stub_to_mp4_with_audio_and_poster() {
     assert!(!media_path.with_extension("enc.mp4").exists());
     assert!(!media_path.with_extension("audio.wav").exists());
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn encode_media_rejects_malformed_raw_frame_before_starting_ffmpeg() {
+    let dir = std::env::temp_dir().join(format!("sw_vid_bad_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let media_path = dir.join("clip.mp4");
+    let decoded = DecodedVideo {
+        frames: vec![RgbFrame {
+            width: 4,
+            height: 4,
+            pixels: vec![0; 4 * 4 * 3 - 1],
+        }],
+        fps: 24,
+        audio: None,
+    };
+
+    let error = encode_media(&media_path, decoded, None)
+        .await
+        .expect_err("malformed RGB buffer must be rejected before FFmpeg");
+
+    assert!(error.to_string().contains("frame buffer size mismatch"));
+    assert!(!media_path.exists());
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 fn ffmpeg_reachable() -> bool {

--- a/crates/sceneworks-worker/src/video_jobs/vace.rs
+++ b/crates/sceneworks-worker/src/video_jobs/vace.rs
@@ -250,24 +250,8 @@ pub(super) async fn load_source_video_frames(
             "replace_person requires a source clip (sourceClipAssetId).".to_owned(),
         )
     })?;
-    let asset = ProjectStore::new(settings.data_dir.clone(), "worker")
-        .get_asset(&request.project_id, asset_id)
-        .map_err(|error| WorkerError::InvalidPayload(format!("source clip {asset_id}: {error}")))?;
-    let rel = asset
-        .get("file")
-        .and_then(|file| file.get("path"))
-        .and_then(Value::as_str)
-        .filter(|path| !path.trim().is_empty())
-        .ok_or_else(|| {
-            WorkerError::InvalidPayload(format!("source clip {asset_id} has no media path"))
-        })?;
-    let media_path = crate::safe_project_path(project_path, rel)?;
-    if !tokio::fs::try_exists(&media_path).await? {
-        return Err(WorkerError::InvalidPayload(format!(
-            "source clip file is missing: {}",
-            media_path.display()
-        )));
-    }
+    let media_path =
+        resolve_clip_media_path(settings, &request.project_id, asset_id, project_path)?;
 
     // Sanitize the job id before it becomes a temp-dir path component (F-111): a hostile id would
     // otherwise escape `temp_dir()`. Mirrors `sw-person-track-{safe_download_dir(job.id)}` in media_jobs.
@@ -648,18 +632,8 @@ async fn generate_wan_vace_engine(
     )?;
 
     let negative_prompt = non_empty_negative_prompt(request);
-    let steps = request.advanced.get("steps").and_then(|value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-            .map(|value| value as u32)
-    });
-    let guidance = request.advanced.get("guidanceScale").and_then(|value| {
-        value
-            .as_f64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-            .map(|value| value as f32)
-    });
+    let steps = super::wan::advanced_opt_u32(request, "steps");
+    let guidance = super::wan::advanced_opt_f32(request, "guidanceScale");
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -1040,18 +1014,8 @@ pub(super) async fn generate_wan_vace_extend_bridge(
         right_anchor,
     )?;
     let negative_prompt = non_empty_negative_prompt(request);
-    let steps = request.advanced.get("steps").and_then(|value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-            .map(|value| value as u32)
-    });
-    let guidance = request.advanced.get("guidanceScale").and_then(|value| {
-        value
-            .as_f64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-            .map(|value| value as f32)
-    });
+    let steps = super::wan::advanced_opt_u32(request, "steps");
+    let guidance = super::wan::advanced_opt_f32(request, "guidanceScale");
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,


### PR DESCRIPTION
## Summary
- record the compiled person-detector backend and gate Mochi to text-to-video before backend work
- reuse shared media and advanced-setting paths; stream owned RGB frames directly to FFmpeg and borrow SCAIL-2 frames during SAM3 segmentation
- preserve in-range WAV amplitude, clean failed SeedVR2 remux outputs, and record complete video-upscale lineage

## Validation
- worker library: 1010 passed, 176 ignored
- worker all-target clippy with warnings denied
- focused malformed-frame, detector, Mochi, WAV, remux-cleanup, and lineage regressions
- cargo check and formatting/diff checks
- macOS NAX integration is environment-inconclusive locally because the sandbox exposes no Metal device; hosted NAX remains required
- off-Mac Candle cross-check is deferred to hosted CI because local cross-target cudarc requires nvcc

Shortcut: sc-13643