### PR TITLE
fix(aux): harden MCP image and test utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6278,6 +6278,7 @@ dependencies = [
  "imageproc",
  "sceneworks-core",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -6286,6 +6287,7 @@ version = "0.8.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "futures-util",
  "http",
  "percent-encoding",
  "reqwest 0.12.28",

--- a/crates/sceneworks-image-quality/Cargo.toml
+++ b/crates/sceneworks-image-quality/Cargo.toml
@@ -19,6 +19,7 @@ image_hasher = "3"
 # Temp PNG holding ground for the transcode backstop (a valid-but-unsupported AVIF/HEIC/TIFF source
 # is converted to PNG before decode — see `decode_transcoding`).
 tempfile = "3.13"
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sceneworks-image-quality/src/lib.rs
+++ b/crates/sceneworks-image-quality/src/lib.rs
@@ -121,6 +121,15 @@ pub fn extract_tier0_scalars(path: &Path, bucket_edge: u32) -> image::ImageResul
 
 /// Extract Tier-0 scalars from an already-decoded image — the testable core, no IO.
 pub fn scalars_from_image(image: &DynamicImage, bucket_edge: u32) -> Tier0Scalars {
+    if image.width() == 0 || image.height() == 0 {
+        return Tier0Scalars {
+            blur_variance: 0.0,
+            shadow_clip: 0.0,
+            highlight_clip: 0.0,
+            well_exposed_fraction: 0.0,
+            phash: Vec::new(),
+        };
+    }
     let phash = dataset_hasher().hash_image(image).as_bytes().to_vec();
 
     // Measure sharpness + exposure on exactly what the trainer feeds in. (If the metrics below
@@ -194,7 +203,14 @@ pub fn compute_readiness(
                     extracted.push((item.item_id.clone(), scalars.clone()));
                     Some(scalars)
                 }
-                Err(_) => {
+                Err(error) => {
+                    tracing::warn!(
+                        event = "dataset_quality_image_decode_failed",
+                        itemId = %item.item_id,
+                        path = %path.display(),
+                        error = %error,
+                        "Dataset Doctor could not decode an image"
+                    );
                     decode_failed.push(item.item_id.clone());
                     None
                 }
@@ -1173,6 +1189,21 @@ mod tests {
             .find(|i| i.item_id == "broken")
             .expect("broken");
         assert!(broken.flags.iter().any(|f| f.check == QualityCheck::Decode));
+    }
+
+    #[test]
+    fn zero_dimension_image_returns_zeroed_scalars_without_crop_underflow() {
+        for image in [
+            DynamicImage::ImageRgb8(RgbImage::new(0, 4)),
+            DynamicImage::ImageRgb8(RgbImage::new(4, 0)),
+        ] {
+            let scalars = scalars_from_image(&image, 64);
+            assert_eq!(scalars.blur_variance, 0.0);
+            assert_eq!(scalars.shadow_clip, 0.0);
+            assert_eq!(scalars.highlight_clip, 0.0);
+            assert_eq!(scalars.well_exposed_fraction, 0.0);
+            assert!(scalars.phash.is_empty());
+        }
     }
 
     #[test]

--- a/crates/sceneworks-mcp/Cargo.toml
+++ b/crates/sceneworks-mcp/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 # Inline tool results: generated images come back as base64 `ImageContent` blocks
 # (sc-10234), so MCP clients can render them without another fetch.
 base64 = "0.22"
+futures-util = "0.3"
 # Read the incoming MCP request's Host header (via the `http::request::Parts` the
 # rmcp streamable-HTTP transport injects into the request extensions) so
 # get_job_result's ticket URLs point at the host the client actually used (sc-10290).
@@ -25,7 +26,7 @@ http = "1"
 # Per-segment percent-encoding of project-relative media paths before they are
 # spliced into `/files/*relative_path` URLs (sc-10279 defensive hardening).
 percent-encoding = "2.3"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 # Pinned exact (sc-10233): the official MCP Rust SDK moves fast and its
 # streamable-HTTP server surface (StreamableHttpService / tool_router macros) has
 # broken across minor bumps before — bump deliberately, with the round-trip tests.

--- a/crates/sceneworks-mcp/src/api_client.rs
+++ b/crates/sceneworks-mcp/src/api_client.rs
@@ -5,6 +5,7 @@
 //! is deliberately NO direct path into the engine/DB from the MCP server, so the
 //! tools inherit exactly the behavior (and fixes) of the routes the web UI uses.
 
+use futures_util::StreamExt;
 use serde_json::Value;
 
 /// Connect timeout for every MCP tool's API call: bounds the TCP/TLS handshake so an
@@ -147,10 +148,14 @@ impl ApiClient {
         Ok(response.json::<Value>().await?)
     }
 
-    /// GET raw bytes from `path` (project media via
-    /// `GET /api/v1/projects/:id/files/*rel`). Returns the body plus the
-    /// response `Content-Type` (parameters stripped) when the server sent one.
-    pub async fn get_bytes(&self, path: &str) -> Result<(Vec<u8>, Option<String>), ApiClientError> {
+    /// GET raw bytes from `path` without ever buffering more than `max_bytes`.
+    /// `None` means the body exceeded the cap, whether declared by Content-Length or discovered
+    /// while streaming. The response is dropped immediately in either case, aborting the download.
+    pub async fn get_bytes_bounded(
+        &self,
+        path: &str,
+        max_bytes: usize,
+    ) -> Result<(Option<Vec<u8>>, Option<String>), ApiClientError> {
         let request = self.client.get(format!("{}{}", self.base_url, path));
         let response = self.send_checked(request).await?;
         let content_type = response
@@ -159,7 +164,24 @@ impl ApiClient {
             .and_then(|value| value.to_str().ok())
             .map(|value| value.split(';').next().unwrap_or("").trim().to_owned())
             .filter(|value| !value.is_empty());
-        Ok((response.bytes().await?.to_vec(), content_type))
+        if response
+            .content_length()
+            .is_some_and(|length| length > max_bytes as u64)
+        {
+            return Ok((None, content_type));
+        }
+
+        let capacity = response.content_length().unwrap_or(0).min(max_bytes as u64) as usize;
+        let mut bytes = Vec::with_capacity(capacity);
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            if chunk.len() > max_bytes.saturating_sub(bytes.len()) {
+                return Ok((None, content_type));
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok((Some(bytes), content_type))
     }
 
     /// Attach the auth header, send, and turn any non-2xx into

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -464,14 +464,23 @@ impl SceneWorksMcp {
             let Some(media_path) = asset_media_path(asset) else {
                 continue;
             };
+            let remaining_total = MAX_INLINE_TOTAL_BYTES.saturating_sub(total_bytes);
+            let body_limit = MAX_INLINE_IMAGE_BYTES.min(remaining_total);
             let (bytes, header_mime) = self
                 .api
-                .get_bytes(&format!(
-                    "/api/v1/projects/{project_id}/files/{}",
-                    encode_media_path(&media_path)
-                ))
+                .get_bytes_bounded(
+                    &format!(
+                        "/api/v1/projects/{project_id}/files/{}",
+                        encode_media_path(&media_path)
+                    ),
+                    body_limit,
+                )
                 .await
                 .map_err(api_error)?;
+            let Some(bytes) = bytes else {
+                let link_base = self.request_link_base(&extensions);
+                return self.job_result_links(&job_id, &job, link_base).await;
+            };
             let mime_type = image_mime_type(
                 &media_path,
                 asset.pointer("/file/mimeType").and_then(Value::as_str),
@@ -484,11 +493,7 @@ impl SceneWorksMcp {
             // get_job_result ticketed-link shape (bytes downloaded so far are
             // simply dropped). The ticket links reach the same media without
             // inlining, so no result is lost.
-            total_bytes = total_bytes.saturating_add(bytes.len());
-            if bytes.len() > MAX_INLINE_IMAGE_BYTES || total_bytes > MAX_INLINE_TOTAL_BYTES {
-                let link_base = self.request_link_base(&extensions);
-                return self.job_result_links(&job_id, &job, link_base).await;
-            }
+            total_bytes += bytes.len();
             summary_assets.push(json!({
                 "id": asset.get("id").cloned().unwrap_or(Value::Null),
                 "path": &media_path,

--- a/crates/sceneworks-mcp/tests/common/mod.rs
+++ b/crates/sceneworks-mcp/tests/common/mod.rs
@@ -1,0 +1,93 @@
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use axum::Router;
+use rmcp::handler::client::ClientHandler;
+use rmcp::model::{CallToolResult, ClientInfo};
+use rmcp::service::{RoleClient, RunningService};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt;
+use sceneworks_mcp::{ApiClientConfig, JobWaitConfig};
+use serde_json::Value;
+
+pub async fn spawn(router: Router) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stub listener");
+    let addr = listener.local_addr().expect("stub addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    format!("http://{addr}")
+}
+
+#[derive(Clone, Default)]
+pub struct TestClient;
+
+impl ClientHandler for TestClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::default()
+    }
+}
+
+pub async fn connect_mcp<H>(
+    api_base: String,
+    access_token: Option<String>,
+    job_wait: JobWaitConfig,
+    handler: H,
+) -> (String, RunningService<RoleClient, H>)
+where
+    H: ClientHandler,
+{
+    let mcp_service = sceneworks_mcp::streamable_http_service_with(
+        ApiClientConfig {
+            base_url: api_base,
+            access_token,
+        },
+        job_wait,
+    );
+    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
+    );
+    let client = handler
+        .serve(transport)
+        .await
+        .expect("MCP client initializes against the mounted /mcp service");
+    (mcp_base, client)
+}
+
+pub fn fast_job_wait() -> JobWaitConfig {
+    JobWaitConfig {
+        poll_interval: Duration::from_millis(10),
+        timeout: Duration::from_secs(10),
+    }
+}
+
+pub fn call_args(value: Value) -> serde_json::Map<String, Value> {
+    value.as_object().expect("args are an object").clone()
+}
+
+/// Parse the last text block. Job-result tools append their JSON summary after resource links,
+/// while catalog tools carry a single text block, so this works for both harness families.
+pub fn result_json(result: &CallToolResult) -> Value {
+    result
+        .content
+        .iter()
+        .rev()
+        .find_map(|block| block.as_text())
+        .map(|text| serde_json::from_str(&text.text).expect("tool result text is JSON"))
+        .expect("tool result carries a text block")
+}
+
+pub fn error_text(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|block| block.as_text())
+        .map(|text| text.text.clone())
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/sceneworks-mcp/tests/generate_image_tool.rs
+++ b/crates/sceneworks-mcp/tests/generate_image_tool.rs
@@ -6,26 +6,30 @@
 //! notifications on a client-supplied progressToken, and clear errors (never a
 //! hang) for failed / canceled / stuck jobs.
 
+mod common;
+
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use std::{convert::Infallible, iter};
 
+use axum::body::{Body, Bytes};
 use axum::extract::{Path, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use futures_util::{stream, StreamExt};
 use rmcp::handler::client::ClientHandler;
 use rmcp::model::{
     CallToolRequestParams, ClientInfo, ClientRequest, Meta, NumberOrString,
     ProgressNotificationParam, ProgressToken, Request,
 };
 use rmcp::service::{NotificationContext, PeerRequestOptions, RoleClient};
-use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
-use rmcp::transport::StreamableHttpClientTransport;
-use rmcp::ServiceExt;
-use sceneworks_mcp::{ApiClientConfig, JobWaitConfig};
+use sceneworks_mcp::JobWaitConfig;
 use serde_json::{json, Value};
+
+use common::{connect_mcp, error_text, fast_job_wait, spawn};
 
 const PNG_BYTES: &[u8] = b"fake-png-payload-0001";
 const JPG_BYTES: &[u8] = b"fake-jpeg-payload-0002";
@@ -35,6 +39,7 @@ const JPG_PATH: &str = "assets/images/genset_1/img_0002.jpg";
 // generate_image must fall back to the ticketed-link response shape instead of
 // base64-inlining it.
 const LARGE_PATH: &str = "assets/images/genset_1/img_large.png";
+const CHUNKED_LARGE_PATH: &str = "assets/images/genset_1/img_chunked_large.png";
 const LARGE_IMAGE_LEN: usize = 5 * 1024 * 1024;
 const TICKET: &str = "tkt-abc123";
 
@@ -122,15 +127,31 @@ fn stub_api_router(state: StubState) -> Router {
             "/api/v1/projects/:project_id/files/*relative_path",
             get(
                 |Path((_project_id, relative_path)): Path<(String, String)>| async move {
+                    if relative_path == CHUNKED_LARGE_PATH {
+                        // No Content-Length and no end-of-stream: the client can return only by
+                        // enforcing the inline cap while consuming chunks and dropping the body.
+                        let chunks = stream::iter(
+                            iter::repeat_with(|| {
+                                Ok::<_, Infallible>(Bytes::from(vec![0x43; 1024 * 1024]))
+                            })
+                            .take(5),
+                        )
+                        .chain(stream::pending());
+                        return (
+                            [(header::CONTENT_TYPE, "image/png")],
+                            Body::from_stream(chunks),
+                        )
+                            .into_response();
+                    }
                     let (bytes, mime): (Vec<u8>, &str) = match relative_path.as_str() {
                         PNG_PATH => (PNG_BYTES.to_vec(), "image/png"),
                         JPG_PATH => (JPG_BYTES.to_vec(), "image/jpeg"),
                         LARGE_PATH => (vec![0x42u8; LARGE_IMAGE_LEN], "image/png"),
-                        _ => return Err(StatusCode::NOT_FOUND),
+                        _ => return StatusCode::NOT_FOUND.into_response(),
                     };
                     let mut headers = HeaderMap::new();
                     headers.insert(header::CONTENT_TYPE, mime.parse().unwrap());
-                    Ok((headers, bytes))
+                    (headers, bytes).into_response()
                 },
             ),
         )
@@ -140,17 +161,6 @@ fn stub_api_router(state: StubState) -> Router {
             post(|| async { Json(json!({ "ticket": TICKET, "expiresInSeconds": 600 })) }),
         )
         .with_state(state)
-}
-
-async fn spawn(router: Router) -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind stub listener");
-    let addr = listener.local_addr().expect("stub addr");
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, router).await;
-    });
-    format!("http://{addr}")
 }
 
 /// A minimal MCP client handler that records every progress notification the
@@ -195,27 +205,10 @@ async fn harness(snapshots: Vec<Value>) -> Harness {
     let polls = state.polls.clone();
     let cancels = state.cancels.clone();
     let api_base = spawn(stub_api_router(state)).await;
-    let mcp_service = sceneworks_mcp::streamable_http_service_with(
-        ApiClientConfig {
-            base_url: api_base,
-            access_token: None,
-        },
-        JobWaitConfig {
-            poll_interval: Duration::from_millis(10),
-            timeout: Duration::from_secs(10),
-        },
-    );
-    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
 
     let handler = RecordingClient::default();
     let progress = handler.progress.clone();
-    let transport = StreamableHttpClientTransport::from_config(
-        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
-    );
-    let client = handler
-        .serve(transport)
-        .await
-        .expect("MCP client initializes against the mounted /mcp service");
+    let (_, client) = connect_mcp(api_base, None, fast_job_wait(), handler).await;
     Harness {
         client,
         submitted,
@@ -241,16 +234,6 @@ fn call_with_progress_token(args: serde_json::Map<String, Value>) -> CallToolReq
         NumberOrString::String("progress-tok-1".into()),
     )));
     params
-}
-
-fn error_text(result: &rmcp::model::CallToolResult) -> String {
-    result
-        .content
-        .iter()
-        .filter_map(|block| block.as_text())
-        .map(|text| text.text.clone())
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 /// Poll `condition` until it holds, failing (never hanging) if it never does.
@@ -579,24 +562,8 @@ async fn transient_poll_failures_are_tolerated_until_the_job_completes() {
         )
         .with_state(state);
     let api_base = spawn(router).await;
-    let mcp_service = sceneworks_mcp::streamable_http_service_with(
-        ApiClientConfig {
-            base_url: api_base,
-            access_token: None,
-        },
-        JobWaitConfig {
-            poll_interval: Duration::from_millis(10),
-            timeout: Duration::from_secs(10),
-        },
-    );
-    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
-    let transport = StreamableHttpClientTransport::from_config(
-        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
-    );
-    let client = RecordingClient::default()
-        .serve(transport)
-        .await
-        .expect("MCP client initializes");
+    let (_, client) =
+        connect_mcp(api_base, None, fast_job_wait(), RecordingClient::default()).await;
 
     let result = client
         .call_tool(
@@ -632,24 +599,16 @@ async fn stuck_job_times_out_with_a_clear_error_instead_of_hanging() {
     };
     let cancels = state.cancels.clone();
     let api_base = spawn(stub_api_router(state)).await;
-    let mcp_service = sceneworks_mcp::streamable_http_service_with(
-        ApiClientConfig {
-            base_url: api_base,
-            access_token: None,
-        },
+    let (_, client) = connect_mcp(
+        api_base,
+        None,
         JobWaitConfig {
             poll_interval: Duration::from_millis(10),
             timeout: Duration::from_millis(100),
         },
-    );
-    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
-    let transport = StreamableHttpClientTransport::from_config(
-        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
-    );
-    let client = RecordingClient::default()
-        .serve(transport)
-        .await
-        .expect("MCP client initializes");
+        RecordingClient::default(),
+    )
+    .await;
 
     let result = client
         .call_tool(
@@ -800,6 +759,47 @@ async fn oversize_result_falls_back_to_ticketed_links() {
     assert!(summary["assets"][0]["url"]
         .as_str()
         .is_some_and(|url| url.contains(&format!("?ticket={TICKET}"))));
+
+    let _ = harness.client.cancel().await;
+}
+
+#[tokio::test]
+async fn chunked_oversize_result_aborts_without_waiting_for_end_of_stream() {
+    let harness = harness(vec![snapshot(
+        "completed",
+        1.0,
+        "completed",
+        json!({ "result": { "assets": [
+            image_asset("asset_chunked", CHUNKED_LARGE_PATH, "image/png")
+        ] } }),
+    )])
+    .await;
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        harness.client.call_tool(
+            CallToolRequestParams::new("generate_image").with_arguments(generate_args(json!({}))),
+        ),
+    )
+    .await
+    .expect("bounded reader aborts the never-ending body once it crosses the cap")
+    .expect("generate_image succeeds");
+
+    assert_ne!(result.is_error, Some(true), "unexpected error: {result:?}");
+    assert!(
+        !result
+            .content
+            .iter()
+            .any(|block| block.as_image().is_some()),
+        "an over-cap chunked result must not inline bytes: {result:?}"
+    );
+    let links: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|block| block.as_resource_link())
+        .collect();
+    assert_eq!(links.len(), 1, "one ticketed link: {result:?}");
+    assert!(links[0].uri.contains(&format!("?ticket={TICKET}")));
 
     let _ = harness.client.cancel().await;
 }

--- a/crates/sceneworks-mcp/tests/mcp_roundtrip.rs
+++ b/crates/sceneworks-mcp/tests/mcp_roundtrip.rs
@@ -5,15 +5,17 @@
 //! session handshake, tool discovery, catalog calls, the `X-SceneWorks-Token`
 //! header on the upstream API call, and error surfacing on an upstream 401.
 
+mod common;
+
 use axum::extract::Query;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::get;
 use axum::{Json, Router};
-use rmcp::model::{CallToolRequestParams, ClientInfo};
-use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
-use rmcp::transport::StreamableHttpClientTransport;
-use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use sceneworks_mcp::JobWaitConfig;
 use serde_json::{json, Value};
+
+use common::{call_args, connect_mcp, result_json, spawn, TestClient};
 
 const STUB_TOKEN: &str = "test-secret-token";
 
@@ -86,49 +88,14 @@ fn stub_api_router() -> Router {
         )
 }
 
-async fn spawn(router: Router) -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind stub listener");
-    let addr = listener.local_addr().expect("stub addr");
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, router).await;
-    });
-    format!("http://{addr}")
-}
-
 /// Spin up stub API + mounted MCP service, return a connected MCP client.
 async fn connect_client(
     access_token: Option<String>,
-) -> rmcp::service::RunningService<rmcp::RoleClient, ClientInfo> {
+) -> rmcp::service::RunningService<rmcp::RoleClient, TestClient> {
     let api_base = spawn(stub_api_router()).await;
-    let mcp_service = sceneworks_mcp::streamable_http_service(sceneworks_mcp::ApiClientConfig {
-        base_url: api_base,
-        access_token,
-    });
-    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
-
-    let transport = StreamableHttpClientTransport::from_config(
-        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
-    );
-    ClientInfo::default()
-        .serve(transport)
+    connect_mcp(api_base, access_token, JobWaitConfig::default(), TestClient)
         .await
-        .expect("MCP client initializes against the mounted /mcp service")
-}
-
-fn content_json(result: &rmcp::model::CallToolResult) -> Value {
-    let text = result
-        .content
-        .first()
-        .and_then(|block| block.as_text())
-        .map(|text| text.text.as_str())
-        .expect("tool result has one text content block");
-    serde_json::from_str(text).expect("tool content is JSON")
-}
-
-fn call_args(value: Value) -> serde_json::Map<String, Value> {
-    value.as_object().expect("args are an object").clone()
+        .1
 }
 
 #[tokio::test]
@@ -155,7 +122,7 @@ async fn mcp_client_lists_tools_and_calls_catalog_tools() {
         .expect("list_projects succeeds");
     assert_ne!(result.is_error, Some(true));
     assert_eq!(
-        content_json(&result),
+        result_json(&result),
         json!([{ "id": "p1", "name": "My Film", "createdAt": "2026-07-07T00:00:00Z" }])
     );
 
@@ -165,7 +132,7 @@ async fn mcp_client_lists_tools_and_calls_catalog_tools() {
         .await
         .expect("list_models succeeds");
     assert_ne!(result.is_error, Some(true));
-    let models = content_json(&result);
+    let models = result_json(&result);
     assert_eq!(models[0]["id"], "z_image_turbo");
     assert_eq!(models[0]["defaults"]["steps"], 8);
     assert_eq!(models[0]["resolutions"], json!(["1024x1024"]));
@@ -183,7 +150,7 @@ async fn mcp_client_lists_tools_and_calls_catalog_tools() {
         .await
         .expect("list_loras succeeds");
     assert_ne!(result.is_error, Some(true));
-    let loras = content_json(&result);
+    let loras = result_json(&result);
     assert_eq!(loras[0]["id"], "lora-for-sdxl");
     assert_eq!(loras[0]["compatibleFamilies"], json!(["sdxl"]));
 

--- a/crates/sceneworks-mcp/tests/video_job_tools.rs
+++ b/crates/sceneworks-mcp/tests/video_job_tools.rs
@@ -8,20 +8,18 @@
 //! the job error, a completed job hands back a ticketed URL another machine
 //! can fetch, and the tools stay generic across image jobs.
 
+mod common;
+
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use rmcp::handler::client::ClientHandler;
-use rmcp::model::{CallToolRequestParams, ClientInfo};
-use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
-use rmcp::transport::StreamableHttpClientTransport;
-use rmcp::ServiceExt;
-use sceneworks_mcp::{ApiClientConfig, JobWaitConfig};
+use rmcp::model::CallToolRequestParams;
 use serde_json::{json, Value};
+
+use common::{connect_mcp, error_text, fast_job_wait, result_json, spawn, TestClient};
 
 const TICKET: &str = "tkt0123456789abcdef";
 const VIDEO_PATH: &str = "assets/videos/genset_1/clip_0001.mp4";
@@ -113,26 +111,6 @@ fn stub_api_router(state: StubState) -> Router {
         .with_state(state)
 }
 
-async fn spawn(router: Router) -> String {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind stub listener");
-    let addr = listener.local_addr().expect("stub addr");
-    tokio::spawn(async move {
-        let _ = axum::serve(listener, router).await;
-    });
-    format!("http://{addr}")
-}
-
-#[derive(Clone, Default)]
-struct TestClient;
-
-impl ClientHandler for TestClient {
-    fn get_info(&self) -> ClientInfo {
-        ClientInfo::default()
-    }
-}
-
 struct Harness {
     client: rmcp::service::RunningService<rmcp::service::RoleClient, TestClient>,
     submitted: Arc<Mutex<Vec<Value>>>,
@@ -155,24 +133,7 @@ async fn harness(snapshots: Vec<Value>) -> Harness {
     let submitted = state.submitted.clone();
     let tickets_minted = state.tickets_minted.clone();
     let api_base = spawn(stub_api_router(state)).await;
-    let mcp_service = sceneworks_mcp::streamable_http_service_with(
-        ApiClientConfig {
-            base_url: api_base,
-            access_token: None,
-        },
-        JobWaitConfig {
-            poll_interval: Duration::from_millis(10),
-            timeout: Duration::from_secs(10),
-        },
-    );
-    let mcp_base = spawn(Router::new().nest_service("/mcp", mcp_service)).await;
-    let transport = StreamableHttpClientTransport::from_config(
-        StreamableHttpClientTransportConfig::with_uri(format!("{mcp_base}/mcp")),
-    );
-    let client = TestClient
-        .serve(transport)
-        .await
-        .expect("MCP client initializes against the mounted /mcp service");
+    let (mcp_base, client) = connect_mcp(api_base, None, fast_job_wait(), TestClient).await;
     Harness {
         client,
         submitted,
@@ -183,26 +144,6 @@ async fn harness(snapshots: Vec<Value>) -> Harness {
 
 /// The JSON payload of a tool result (its text content blocks parsed as JSON;
 /// the last one wins — get_job_result appends the summary block last).
-fn result_json(result: &rmcp::model::CallToolResult) -> Value {
-    result
-        .content
-        .iter()
-        .rev()
-        .find_map(|block| block.as_text())
-        .map(|text| serde_json::from_str(&text.text).expect("tool result text is JSON"))
-        .expect("tool result carries a text block")
-}
-
-fn error_text(result: &rmcp::model::CallToolResult) -> String {
-    result
-        .content
-        .iter()
-        .filter_map(|block| block.as_text())
-        .map(|text| text.text.clone())
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 #[tokio::test]
 async fn submit_video_job_returns_job_id_and_initial_snapshot() {
     let harness = harness(vec![]).await;

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --strict-markers
 markers =
     parity: runs the Rust API against isolated temp data and compares wire contracts to snapshots
     e2e: drives a job end to end through the Rust API binary via a pure-HTTP worker client (procedural adapter, no model weights)

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -666,7 +666,11 @@ def test_schema_rejects_unknown_model_type():
     entry["type"] = "hologram"
     manifest = {"schemaVersion": 1, "models": [entry]}
     errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
-    assert any("hologram" in error.message or "enum" in error.message for error in errors)
+    assert any(
+        error.validator == "enum"
+        and list(error.absolute_path) == ["models", 0, "type"]
+        for error in errors
+    ), "the model type must fail the enum validator exactly at models/0/type"
 
 
 # The seeded audio catalog (sc-13402, epic 13400). Each id is a live candle-audio

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 import shutil
 import subprocess
@@ -230,6 +231,15 @@ def wait_for_job_status(base_url: str, job_id: str, status: str, process: Spawne
             raise AssertionError(f"Job reached terminal status {last_job['status']}: {last_job}")
         time.sleep(0.25)
     raise AssertionError(f"Job did not reach {status}: {last_job}")
+
+
+def assert_claimed_by(completed: dict, base_worker_id: str) -> None:
+    """The supervisor gives each CPU utility child a strict, base-derived worker id."""
+    actual = completed["workerId"]
+    pattern = rf"{re.escape(base_worker_id)}-cpu(?:-[1-9][0-9]*)?"
+    assert re.fullmatch(pattern, actual), (
+        f"{actual!r} is not a CPU utility child of {base_worker_id!r}"
+    )
 
 
 @pytest.fixture()
@@ -526,9 +536,7 @@ def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(ru
 
         completed = wait_for_job_status(rust_api, job["id"], "completed", worker)
 
-        # The supervisor spawns per-device child workers (e.g. <id>-cpu-2), so the
-        # configured WORKER_ID is a prefix of the claiming worker's id.
-        assert completed["workerId"].startswith("rust-worker-smoke")
+        assert_claimed_by(completed, "rust-worker-smoke")
         assert completed["result"]["repo"] is None
         assert completed["result"]["path"].endswith("smoke_lora")
         assert (
@@ -654,15 +662,16 @@ def test_rust_worker_completes_ffmpeg_frame_and_timeline_jobs_against_rust_api_b
         track_job.raise_for_status()
         track_completed = wait_for_job_status(rust_api, track_job.json()["id"], "completed", worker)
 
-        assert frame_completed["workerId"] == "rust-ffmpeg-smoke"
+        assert_claimed_by(frame_completed, "rust-ffmpeg-smoke")
         assert frame_completed["result"]["assets"][0]["type"] == "frame"
         assert frame_completed["result"]["assets"][0]["recipe"]["mode"] == "frame_extract"
-        assert export_completed["workerId"] == "rust-ffmpeg-smoke"
+        assert_claimed_by(export_completed, "rust-ffmpeg-smoke")
         assert export_completed["result"]["assets"][0]["type"] == "render"
         assert export_completed["result"]["assets"][0]["file"]["mimeType"] == "video/mp4"
-        assert {job["workerId"] for job in detection_completed} == {"rust-ffmpeg-smoke"}
+        for completed in detection_completed:
+            assert_claimed_by(completed, "rust-ffmpeg-smoke")
         assert all(job["result"]["detections"] for job in detection_completed)
-        assert track_completed["workerId"] == "rust-ffmpeg-smoke"
+        assert_claimed_by(track_completed, "rust-ffmpeg-smoke")
         assert track_completed["result"]["track"]["recipe"]["mode"] == "person_track"
     finally:
         worker.terminate()


### PR DESCRIPTION
## Summary
- bound MCP image downloads while streaming and abort over-cap bodies
- handle zero-dimension images safely and preserve decode diagnostics
- consolidate MCP test harnesses and tighten pytest/manifest/worker assertions

## Validation
- cargo test -p sceneworks-mcp --tests
- cargo clippy -p sceneworks-mcp --all-targets -- -D warnings
- cargo test -p sceneworks-image-quality
- cargo clippy -p sceneworks-image-quality --all-targets -- -D warnings
- python -m pytest -q tests/test_builtin_manifest_audit.py
- python -m pytest --collect-only -q tests/test_rust_api_worker_smoke.py
- cargo fmt --all -- --check
- git diff --check

Shortcut: sc-13651