### PR TITLE
Fix low-severity image worker review findings [sc-13642]

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -180,8 +180,7 @@ use runtime_cuda::providers::pulid::{PulidFlux, PulidFluxPaths, PulidFluxRequest
 /// `tests/fixtures/rust_migration_contracts/sidecars/asset-image.sceneworks.json`).
 const STUB_ADAPTER: &str = "procedural_preview";
 /// The adapter id recorded on assets produced by the candle (Windows/CUDA) SDXL lane (sc-3678).
-/// Used both per-asset (`generate_candle_stream`) and at the generation-set level (`adapter_id`)
-/// so the sidecar + result agree on which backend produced the image.
+/// Used by the generic candle per-asset stream and its route-derived generation-set label.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 const CANDLE_ADAPTER: &str = "candle_sdxl";
 // Shared by the MLX path and the candle Lens lane (sc-5126) — both cap a job's total LoRAs at
@@ -245,9 +244,10 @@ pub(crate) async fn run_image_generate_job(
     #[cfg(target_os = "macos")]
     let route = resolve_image_route(&request, settings);
     #[cfg(target_os = "macos")]
-    let plan = ImagePlan::with_count(
+    let plan = ImagePlan::with_count_and_adapter(
         &request,
         route.map_or(request.count, |route| route.image_count(&request, settings)) * upscale_mult,
+        route.map_or(STUB_ADAPTER, |route| route.adapter_label(&request)),
     );
     // Windows/CUDA candle lane: resolve the candle dispatch branch once and bake THAT branch's real
     // total into the plan, exactly as the macOS arm does with `resolve_image_route`. An InstantID
@@ -257,11 +257,13 @@ pub(crate) async fn run_image_generate_job(
     // (sc-5491 InstantID; sc-11171 F-009 strict-pose). `resolve_candle_image_route` returns `None` when
     // candle is disabled, so any other job (or a disabled backend) keeps `request.count`.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-    let plan = {
-        let count = resolve_candle_image_route(&request, settings)
-            .map_or(request.count, |route| route.image_count(&request, settings));
-        ImagePlan::with_count(&request, count * upscale_mult)
-    };
+    let route = resolve_candle_image_route(&request, settings);
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    let plan = ImagePlan::with_count_and_adapter(
+        &request,
+        route.map_or(request.count, |route| route.image_count(&request, settings)) * upscale_mult,
+        route.map_or(STUB_ADAPTER, |route| route.adapter_label(&request)),
+    );
     #[cfg(all(
         not(target_os = "macos"),
         not(all(not(target_os = "macos"), feature = "backend-candle"))
@@ -276,7 +278,7 @@ pub(crate) async fn run_image_generate_job(
     sceneworks_core::lora_family::validate_lora_compatibility(
         &request.loras,
         Some(plan.family.as_str()),
-        adapter_id(&request),
+        plan.adapter,
         Some(request.model.as_str()),
     )
     .map_err(WorkerError::InvalidPayload)?;
@@ -625,7 +627,7 @@ pub(crate) async fn run_image_generate_job(
     // `ImageRoute::InstantId` arm) — checked first since `instantid_realvisxl` is not an inventory
     // `is_candle_engine` id.
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-    let handled = match resolve_candle_image_route(&request, settings) {
+    let handled = match route {
         Some(route) => {
             match route {
                 // InstantID (sc-5491, epic 5480): the candle InstantID provider's bespoke path (the
@@ -1185,6 +1187,9 @@ pub(crate) struct ImagePlan {
     pub(crate) family: String,
     pub(crate) slug: String,
     pub(crate) generation_set: Value,
+    /// Backend adapter label selected by the resolved dispatch route. Keeping it in the plan makes
+    /// generation-set telemetry use the same one-time route decision as per-asset generation.
+    pub(crate) adapter: &'static str,
     /// Number of images this job produces. Usually `request.count`, but a FLUX.2 angle
     /// set is 11 and a pose set is the pose count (sc-3030) — the generation set's
     /// `count`/`expectedCount` reflect this so the gallery streams against the real
@@ -1198,11 +1203,20 @@ impl ImagePlan {
     /// effective count that differs from `request.count`).
     #[cfg(test)]
     fn new(request: &ImageRequest) -> Self {
-        Self::with_count(request, request.count)
+        Self::with_count_and_adapter(request, request.count, adapter_id(request))
     }
 
     /// Build a plan whose generation set reports `image_count` images (see the field).
     pub(crate) fn with_count(request: &ImageRequest, image_count: u32) -> Self {
+        Self::with_count_and_adapter(request, image_count, adapter_id(request))
+    }
+
+    /// Build a plan with the count and adapter label selected by the already-resolved route.
+    fn with_count_and_adapter(
+        request: &ImageRequest,
+        image_count: u32,
+        adapter: &'static str,
+    ) -> Self {
         let genset_id = format!("genset_{}", Uuid::new_v4().simple());
         let created_at = now_rfc3339();
         let family = resolve_family(request);
@@ -1223,6 +1237,7 @@ impl ImagePlan {
             family,
             slug,
             generation_set,
+            adapter,
             image_count,
         }
     }
@@ -1568,7 +1583,7 @@ fn streaming_result(plan: &ImagePlan, asset_writes: &[Value]) -> JsonObject {
     json!({
         "generationSetId": plan.genset_id,
         "expectedCount": plan.image_count,
-        "adapter": adapter_id(&plan.request),
+        "adapter": plan.adapter,
         "model": plan.request.model,
         "generationSet": plan.generation_set,
         "assetWrites": asset_writes,
@@ -1578,8 +1593,8 @@ fn streaming_result(plan: &ImagePlan, asset_writes: &[Value]) -> JsonObject {
     .expect("json! object literal")
 }
 
-/// The adapter id reported for the set (real engine on macOS for a linked family,
-/// else the procedural stub).
+/// Request-only fallback used by test plans and the backend-less stub plan. Production MLX/candle
+/// plans bind their adapter from the resolved route so bespoke IDs cannot fall through to the stub.
 fn adapter_id(request: &ImageRequest) -> &'static str {
     #[cfg(target_os = "macos")]
     if let Some(model) = mlx_model(&request.model) {

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -318,6 +318,23 @@ impl ImageRoute {
             | ImageRoute::Mlx => request.count,
         }
     }
+
+    /// The label written by this route's per-asset stream. Bespoke routes that do not map directly
+    /// to the request's registry row are named explicitly; the remaining MLX routes use the same
+    /// descriptor label their stream resolves.
+    fn adapter_label(self, request: &ImageRequest) -> &'static str {
+        match self {
+            ImageRoute::KreaControl => KREA_CONTROL_ENGINE_ID,
+            ImageRoute::KreaImported => KREA_IMPORTED_ENGINE,
+            ImageRoute::SdxlImported => SDXL_IMPORTED_ENGINE,
+            ImageRoute::InstantId => INSTANTID_ENGINE,
+            ImageRoute::PulidFlux => PULID_ADAPTER_LABEL,
+            ImageRoute::PoseControlBaseMissing | ImageRoute::PoseReject => STUB_ADAPTER,
+            _ => mlx_model(&request.model)
+                .map(|model| model.adapter_label())
+                .unwrap_or(STUB_ADAPTER),
+        }
+    }
 }
 
 /// The candle (Windows/CUDA/Linux) image engine a `run_image_generate_job` request routes to — the
@@ -463,6 +480,55 @@ impl CandleImageRoute {
             // Every other lane (plain txt2img, the edit/reference/identity/comfyui/bernini lanes, and the
             // pose-reject arms — which error before generation) produces the requested count.
             _ => request.count,
+        }
+    }
+
+    /// The exact label written by this route's per-asset stream. This is intentionally route-based:
+    /// imported/external/bespoke IDs are not present in the generic candle catalog.
+    fn adapter_label(self, request: &ImageRequest) -> &'static str {
+        match self {
+            CandleImageRoute::InstantId => INSTANTID_ENGINE,
+            CandleImageRoute::SdxlEdit => sdxl_edit_candle::SDXL_EDIT_CANDLE_ENGINE,
+            CandleImageRoute::Flux2Edit => flux2_edit_candle::FLUX2_EDIT_CANDLE_ENGINE,
+            CandleImageRoute::QwenEdit => qwen_edit_candle::QWEN_EDIT_CANDLE_ENGINE,
+            CandleImageRoute::ZimageEdit => zimage_edit_candle::ZIMAGE_EDIT_CANDLE_ENGINE,
+            CandleImageRoute::KreaEdit => krea_edit_candle::KREA_EDIT_CANDLE_ENGINE,
+            CandleImageRoute::KreaTurboOnRaw | CandleImageRoute::KreaMultiPhase => {
+                mlx_model(&request.model)
+                    .map(|model| model.adapter_label())
+                    .unwrap_or(STUB_ADAPTER)
+            }
+            CandleImageRoute::KreaImported => KREA_IMPORTED_ENGINE,
+            CandleImageRoute::SdxlImported => SDXL_IMPORTED_ENGINE,
+            CandleImageRoute::ZimageIdentity => {
+                zimage_identity_candle::ZIMAGE_IDENTITY_CANDLE_ENGINE
+            }
+            CandleImageRoute::SdxlIpAdapter => sdxl_ipadapter::SDXL_IPADAPTER_ENGINE,
+            CandleImageRoute::KolorsIpAdapter => kolors_ipadapter::KOLORS_IPADAPTER_ENGINE,
+            CandleImageRoute::FluxIpAdapter => flux_ipadapter::FLUX_IPADAPTER_ENGINE,
+            CandleImageRoute::Pulid => pulid_candle::PULID_CANDLE_ENGINE,
+            CandleImageRoute::QwenControl => qwen_control::QWEN_CONTROL_ENGINE,
+            CandleImageRoute::KolorsControl => kolors_control::KOLORS_CONTROL_ENGINE,
+            CandleImageRoute::ZimageControl => zimage_control::ZIMAGE_CTRL_ENGINE,
+            CandleImageRoute::Flux2Control => {
+                flux2_control_candle::FLUX2_CONTROL_CANDLE_ENGINE
+            }
+            CandleImageRoute::Flux1Control => {
+                flux1_control_candle::FLUX1_CONTROL_CANDLE_ENGINE
+            }
+            CandleImageRoute::KreaControl => krea_control_candle::KREA_CONTROL_ENGINE,
+            CandleImageRoute::PoseReject | CandleImageRoute::PoseControlBaseMissing => STUB_ADAPTER,
+            CandleImageRoute::ZimageComfyui => {
+                zimage_comfyui_candle::ZIMAGE_COMFYUI_CANDLE_ENGINE
+            }
+            CandleImageRoute::QwenImageComfyui => {
+                qwen_comfyui_candle::QWEN_COMFYUI_CANDLE_ENGINE
+            }
+            CandleImageRoute::Flux2Comfyui => {
+                flux2_comfyui_candle::FLUX2_COMFYUI_CANDLE_ENGINE
+            }
+            CandleImageRoute::Bernini => CANDLE_BERNINI_IMAGE_ADAPTER,
+            CandleImageRoute::CandleTxt2Img => candle_adapter_label(&request.model),
         }
     }
 }
@@ -2189,18 +2255,7 @@ fn resolve_advanced_or_manifest_u32(
     default: u32,
     range: std::ops::RangeInclusive<u32>,
 ) -> u32 {
-    let parse = |value: &Value| {
-        value
-            .as_u64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    };
-    request
-        .advanced
-        .get(key)
-        .and_then(parse)
-        .or_else(|| request.model_manifest_entry.get(key).and_then(parse))
-        .map(|value| value.clamp(*range.start() as u64, *range.end() as u64) as u32)
-        .unwrap_or(default)
+    resolve_advanced_or_manifest_u32_with(request, key, || default, range)
 }
 
 /// Resolve a float advanced knob with a manifest fallback (sc-8825). The guidance twin of
@@ -2219,17 +2274,7 @@ fn resolve_advanced_or_manifest_f32(
     default: f32,
     range: std::ops::RangeInclusive<f32>,
 ) -> f32 {
-    let manifest_default = request
-        .model_manifest_entry
-        .get(key)
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
-        .map(|value| value as f32)
-        .unwrap_or(default);
-    advanced::f32_clamped(&request.advanced, key, manifest_default, range)
+    resolve_advanced_or_manifest_f32_with(request, key, || default, range)
 }
 
 /// Closure-default twin of [`resolve_advanced_or_manifest_u32`] (sc-8825). Identical mechanism —
@@ -2239,10 +2284,8 @@ fn resolve_advanced_or_manifest_f32(
 /// (`flux_ipadapter` variant steps, `qwen_edit_candle`/`zimage_control` per-variant steps) rather than a
 /// bare constant. Every caller passes its OWN `range`/`default_fn`, so per-lane bounds stay byte-for-byte.
 ///
-/// Unlike the const twins (which have macOS-live callers in `pulid.rs`/`instantid.rs`), these variants
-/// are only *called* by the candle-exclusive lanes, so the macOS non-test lib build has no caller —
-/// hence the gate is `candle-lane OR test` (the sc-8825 unit tests exercise it on both build lanes).
 #[cfg(any(
+    target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle"),
     test
 ))]
@@ -2270,9 +2313,9 @@ fn resolve_advanced_or_manifest_u32_with(
 /// manifest `[key]` supplies the effective default (else the per-lane `default_fn` closure, evaluated
 /// only when the manifest key is absent), then [`advanced::f32_clamped`] reads `advanced[key]` (falling
 /// back to that default) and clamps to `range`. Covers `flux_ipadapter`, whose guidance fallback is a
-/// per-variant fn. Each caller passes its OWN `range`/`default_fn`. Gated `candle-lane OR test` for the
-/// same reason as the u32 twin: no macOS non-test caller, but the sc-8825 tests exercise it on both lanes.
+/// per-variant fn. Each caller passes its OWN `range`/`default_fn`.
 #[cfg(any(
+    target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle"),
     test
 ))]
@@ -2307,6 +2350,77 @@ fn resolve_advanced_or_manifest_f32_with(
 ))]
 fn uses_true_cfg(model: &ResolvedModel) -> bool {
     !model.supports_guidance() && model.supports_negative_prompt()
+}
+
+/// Apply the Ideogram placeholder recovery policy to one completed render. The renderer is injected
+/// so the MLX and candle lanes share cancellation, reseeding, retry exhaustion, and error behavior.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn recover_ideogram_placeholder<R>(
+    enabled: bool,
+    seed: i64,
+    cancel: &CancelFlag,
+    initial: (u32, u32, Vec<u8>),
+    mut render: R,
+) -> WorkerResult<(i64, u32, u32, Vec<u8>)>
+where
+    R: FnMut(i64) -> WorkerResult<(u32, u32, Vec<u8>)>,
+{
+    recover_ideogram_placeholder_with(
+        enabled,
+        crate::ideogram_caption::placeholder_recovery_retries(),
+        seed,
+        cancel,
+        initial,
+        |pixels, width, height| {
+            crate::ideogram_caption::looks_like_placeholder(pixels, width, height)
+        },
+        &mut render,
+    )
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn recover_ideogram_placeholder_with<R, P>(
+    enabled: bool,
+    retries: u32,
+    seed: i64,
+    cancel: &CancelFlag,
+    initial: (u32, u32, Vec<u8>),
+    mut is_placeholder: P,
+    mut render: R,
+) -> WorkerResult<(i64, u32, u32, Vec<u8>)>
+where
+    R: FnMut(i64) -> WorkerResult<(u32, u32, Vec<u8>)>,
+    P: FnMut(&[u8], u32, u32) -> bool,
+{
+    let (mut width, mut height, mut pixels) = initial;
+    if !enabled || !is_placeholder(&pixels, width, height) {
+        return Ok((seed, width, height, pixels));
+    }
+
+    let mut final_seed = seed;
+    for attempt in 0..retries {
+        if cancel.is_cancelled() {
+            break;
+        }
+        let retry_seed = crate::ideogram_caption::recovery_seed(seed, attempt);
+        tracing::warn!(
+            "ideogram 4 placeholder detected (seed {seed}); reseeding {retry_seed} \
+             (attempt {}/{retries})",
+            attempt + 1,
+        );
+        (width, height, pixels) = render(retry_seed)?;
+        final_seed = retry_seed;
+        if !is_placeholder(&pixels, width, height) {
+            break;
+        }
+    }
+    Ok((final_seed, width, height, pixels))
 }
 
 /// Resolve the true-CFG scale for a true-CFG family (Chroma). `None` for every other family
@@ -4442,39 +4556,19 @@ async fn generate_stream(
                         on_progress,
                     )
                 };
-                let (mut out_w, mut out_h, mut pixels) = render(seed, on_progress)?;
-                let mut final_seed = seed;
                 // Detect-and-recover safety net (sc-6501): the caption guard makes the placeholder
                 // rare, but a residual one can still occur even with a caption. Detect it via the
                 // baked-text heuristic (NOT a std/flatness check — the text lifts std to ~10) and
                 // reseed transparently, keeping the first clean render. Gated to Ideogram 4; a no-op
                 // elsewhere (and on turbo, which is CFG-free and cannot produce the placeholder).
-                if is_ideogram
-                    && crate::ideogram_caption::looks_like_placeholder(&pixels, out_w, out_h)
-                {
-                    let retries = crate::ideogram_caption::placeholder_recovery_retries();
-                    for attempt in 0..retries {
-                        if cancel.is_cancelled() {
-                            break;
-                        }
-                        let retry_seed = crate::ideogram_caption::recovery_seed(seed, attempt);
-                        tracing::warn!(
-                            "ideogram 4 placeholder detected (seed {seed}); reseeding {retry_seed} \
-                             (attempt {}/{retries})",
-                            attempt + 1,
-                        );
-                        let (rw, rh, rpixels) = render(retry_seed, on_progress)?;
-                        let recovered =
-                            !crate::ideogram_caption::looks_like_placeholder(&rpixels, rw, rh);
-                        out_w = rw;
-                        out_h = rh;
-                        pixels = rpixels;
-                        final_seed = retry_seed;
-                        if recovered {
-                            break;
-                        }
-                    }
-                }
+                let initial = render(seed, on_progress)?;
+                let (final_seed, out_w, out_h, pixels) = recover_ideogram_placeholder(
+                    is_ideogram,
+                    seed,
+                    &cancel,
+                    initial,
+                    |retry_seed| render(retry_seed, on_progress),
+                )?;
                 // Score this finished image against the cached source embedding (sc-4411). Image build +
                 // pixel clone is paid ONLY when a scorer exists (a With-Character generation) — a plain
                 // t2i / edit job has no scorer, so this is a no-op with no clone. Non-frontal → honest
@@ -4526,8 +4620,8 @@ fn is_candle_engine(model: &str) -> bool {
 }
 
 /// The per-asset `adapter` id recorded for a candle image engine (`candle_<family>`), the candle
-/// sibling of the `MODEL_TABLE` `mlx_<family>` labels. Used both per-asset (`generate_candle_stream`)
-/// and at the generation-set level (`adapter_id`) so the sidecar + result agree on the backend.
+/// sibling of the `MODEL_TABLE` `mlx_<family>` labels. Used by both the generic per-asset stream and
+/// [`CandleImageRoute::adapter_label`] so the sidecar and generation-set result agree.
 /// (sc-5099 extends this same labeling to the video + caption engines.)
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 fn candle_adapter_label(model: &str) -> &'static str {
@@ -5145,10 +5239,6 @@ async fn generate_candle_stream(
     // the one being rejected — never the rejected tier, never the picker (hidden when ≤1 tier installed).
     // Reached only on the explicit-pick / ConvRot reject below (the downtier path already rejected above
     // when nothing smaller fits), where suggesting a smaller installed tier the user could pick is apt.
-    let installed_smaller: Vec<&'static str> = installed_tier_keys(request, settings)
-        .into_iter()
-        .filter(|candidate| tier_quality_rank(candidate) < tier_quality_rank(tier))
-        .collect();
     let use_sequential = {
         match crate::vram_gate::resolve_offload(
             crate::vram_gate::fit_decision(needed, budget),
@@ -5169,6 +5259,13 @@ async fn generate_candle_stream(
                 if let Some(seq_gb) =
                     crate::vram_gate::sequential_overflow_gb(sequential_needed, budget)
                 {
+                    let installed_smaller: Vec<&'static str> =
+                        installed_tier_keys(request, settings)
+                            .into_iter()
+                            .filter(|candidate| {
+                                tier_quality_rank(candidate) < tier_quality_rank(tier)
+                            })
+                            .collect();
                     return Err(WorkerError::InvalidPayload(format!(
                         "{model} at the {tier} tier needs ~{seq} GB of VRAM even with sequential \
                          component residency (loading one component at a time), but GPU {gpu} has \
@@ -5193,6 +5290,13 @@ async fn generate_candle_stream(
                 needed_gb,
                 available_gb,
             } => {
+                let installed_smaller: Vec<&'static str> =
+                    installed_tier_keys(request, settings)
+                        .into_iter()
+                        .filter(|candidate| {
+                            tier_quality_rank(candidate) < tier_quality_rank(tier)
+                        })
+                        .collect();
                 return Err(WorkerError::InvalidPayload(format!(
                     "{model} at the {tier} tier needs ~{needed} GB of VRAM (with headroom) but GPU \
                      {gpu} has ~{available} GB available. {tail}",
@@ -5291,8 +5395,6 @@ async fn generate_candle_stream(
                         on_progress,
                     )
                 };
-                let (mut out_w, mut out_h, mut pixels) = render(seed, on_progress)?;
-                let mut final_seed = seed;
                 // Ideogram 4 placeholder detect-and-reseed (sc-6858, parity with the macOS
                 // `generate_stream` net, sc-6501): the caption guard above makes it rare, but a residual
                 // "Image blocked by safety filter" placeholder can still occur even with a caption.
@@ -5300,32 +5402,14 @@ async fn generate_candle_stream(
                 // render. Gated to Ideogram 4; a no-op for every other candle family, for turbo (CFG-free,
                 // cannot produce it), and for an edit (the output is anchored to a real source latent, so
                 // `looks_like_placeholder` returns false).
-                if is_ideogram
-                    && crate::ideogram_caption::looks_like_placeholder(&pixels, out_w, out_h)
-                {
-                    let retries = crate::ideogram_caption::placeholder_recovery_retries();
-                    for attempt in 0..retries {
-                        if cancel.is_cancelled() {
-                            break;
-                        }
-                        let retry_seed = crate::ideogram_caption::recovery_seed(seed, attempt);
-                        tracing::warn!(
-                            "ideogram 4 placeholder detected (seed {seed}); reseeding {retry_seed} \
-                             (attempt {}/{retries})",
-                            attempt + 1,
-                        );
-                        let (rw, rh, rpixels) = render(retry_seed, on_progress)?;
-                        let recovered =
-                            !crate::ideogram_caption::looks_like_placeholder(&rpixels, rw, rh);
-                        out_w = rw;
-                        out_h = rh;
-                        pixels = rpixels;
-                        final_seed = retry_seed;
-                        if recovered {
-                            break;
-                        }
-                    }
-                }
+                let initial = render(seed, on_progress)?;
+                let (final_seed, out_w, out_h, pixels) = recover_ideogram_placeholder(
+                    is_ideogram,
+                    seed,
+                    &cancel,
+                    initial,
+                    |retry_seed| render(retry_seed, on_progress),
+                )?;
                 Ok(Some((final_seed, out_w, out_h, pixels)))
             })
         },

--- a/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
@@ -27,7 +27,7 @@ use serde_json::json;
 
 /// The adapter/engine id recorded on candle ComfyUI FLUX.2-dev assets + telemetry (distinct from the
 /// registry `candle` flux2 txt2img and the `flux2_dev` edit/control lanes).
-const FLUX2_COMFYUI_CANDLE_ENGINE: &str = "candle_flux2_dev_comfyui";
+pub(super) const FLUX2_COMFYUI_CANDLE_ENGINE: &str = "candle_flux2_dev_comfyui";
 
 /// Denoise-steps fallback — the `flux2_dev` manifest default (`defaults.steps`). The UI normally
 /// supplies `advanced.steps`; this only applies when it does not. FLUX.2-dev is guidance-distilled (not

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -37,7 +37,7 @@ const FLUX2_EDIT_CANDLE_DEV_STEPS: u32 = 28;
 const FLUX2_EDIT_CANDLE_DEV_GUIDANCE: f32 = 4.0;
 /// The adapter/engine id recorded on candle FLUX.2 edit assets + telemetry (distinct from the txt2img
 /// `candle_flux2` lane). Shared by klein + dev edit (the dev variant is the same edit surface).
-const FLUX2_EDIT_CANDLE_ENGINE: &str = "candle_flux2_edit";
+pub(super) const FLUX2_EDIT_CANDLE_ENGINE: &str = "candle_flux2_edit";
 /// Cap on references fed to a single FLUX.2 edit (the multi-image picker, sc-6211): the dev edit is
 /// activation-bound, so cap at the engine's validated native fan-out. This deliberately differs from
 /// the MLX `MAX_EDIT_REFERENCES` (4): that bound is set by the 96 GB Apple-Silicon unified-memory

--- a/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux_ipadapter.rs
@@ -45,7 +45,7 @@ pub(super) const FLUX_IPADAPTER_ENCODER_REVISION: &str = "32bd64288804d66eefd0cc
 const FLUX_IPADAPTER_IP_SCALE: f32 = 0.7;
 /// The adapter/engine id recorded on candle FLUX IP-Adapter assets + telemetry (distinct from the
 /// txt2img `candle_flux` lane).
-const FLUX_IPADAPTER_ENGINE: &str = "candle_flux_ipadapter";
+pub(super) const FLUX_IPADAPTER_ENGINE: &str = "candle_flux_ipadapter";
 
 /// Model ids the candle FLUX IP-Adapter route accepts (both variants — the forked DiT injects the same
 /// XLabs adapter for each; dev embeds the guidance scalar, schnell ignores it).

--- a/crates/sceneworks-worker/src/image_jobs/instantid.rs
+++ b/crates/sceneworks-worker/src/image_jobs/instantid.rs
@@ -213,7 +213,7 @@ fn instantid_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
     // `tokenizer/` missing) now falls through to a complete sibling instead of crashing the SDXL loader
     // on the absent tokenizer. `instantid.rs` is `include!`d into the `image_jobs` module, so
     // `pick_loadable_tier` / `tier_components_present` (base.rs) are directly in scope.
-    pick_loadable_tier(&[preferred, "bf16", "q4", "q8"], &present, &tier_components_present)
+    pick_loadable_tier(&[preferred, "bf16", "q8", "q4"], &present, &tier_components_present)
         .unwrap_or_else(|| root.to_path_buf())
 }
 
@@ -1254,7 +1254,7 @@ mod instantid_tier_tests {
     /// surfaces a clear missing-weights error), and an absent turnkey resolves to the repo root.
     #[test]
     fn falls_back_when_preferred_tier_absent() {
-        // Only q8 downloaded: an unset (bf16-preferred) request falls through bf16 → q4 → q8.
+        // Only q8 downloaded: an unset (bf16-preferred) request falls through bf16 → q8.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         seed_unet(root, "q8", "diffusion_pytorch_model.safetensors");
@@ -1267,6 +1267,31 @@ mod instantid_tier_tests {
         assert_eq!(
             instantid_tier_subdir(empty.path(), &request(json!({}))),
             empty.path().to_path_buf()
+        );
+    }
+
+    #[test]
+    fn fallback_prefers_q8_over_q4_and_skips_a_torn_q8() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        seed_unet(root, "q8", "diffusion_pytorch_model.safetensors");
+        seed_unet(root, "q4", "diffusion_pytorch_model.safetensors");
+
+        assert_eq!(
+            instantid_tier_subdir(root, &request(json!({}))),
+            root.join("q8"),
+            "dense fallback should preserve the highest available fidelity"
+        );
+
+        std::fs::write(
+            root.join("q8").join("model_index.json"),
+            br#"{"unet":["diffusers","UNet2DConditionModel"],"tokenizer":["transformers","CLIPTokenizer"]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            instantid_tier_subdir(root, &request(json!({}))),
+            root.join("q4"),
+            "a q8 tier missing a model-index component must not block a complete q4 fallback"
         );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/kolors_ipadapter.rs
@@ -51,7 +51,7 @@ const KOLORS_IPADAPTER_DEFAULT_GUIDANCE: f32 = 5.0;
 const KOLORS_IPADAPTER_DEFAULT_REPO: &str = "Kwai-Kolors/Kolors-diffusers";
 /// The adapter/engine id recorded on candle Kolors IP-Adapter assets + telemetry (distinct from the
 /// txt2img `candle_kolors` lane).
-const KOLORS_IPADAPTER_ENGINE: &str = "candle_kolors_ipadapter";
+pub(super) const KOLORS_IPADAPTER_ENGINE: &str = "candle_kolors_ipadapter";
 
 /// Model ids the candle Kolors IP-Adapter route accepts.
 fn is_kolors_ipadapter_model(model: &str) -> bool {

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -54,7 +54,7 @@ const KREA_CONTROL_SCALE_CAP: f32 = 0.85;
 const KREA_CONTROL_DEFAULT_STEPS: u32 = 8;
 /// The adapter/engine id recorded on candle Krea control assets (distinct from the `candle_krea` txt2img
 /// lane).
-const KREA_CONTROL_ENGINE: &str = "candle_krea_control";
+pub(super) const KREA_CONTROL_ENGINE: &str = "candle_krea_control";
 /// The [`STRICT_CONTROL_ENGINES`] catalog id this lane validates `advanced.controlMode` against (the Krea
 /// pose-only row — `{Pose}`).
 pub(super) const KREA_CONTROL_ENGINE_ID: &str = "krea_2_turbo_control";

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
@@ -39,7 +39,7 @@ const KREA_EDIT_CANDLE_TURBO_STEPS: u32 = 8;
 const KREA_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 3.5;
 /// The adapter/engine id recorded on candle Krea edit assets + telemetry (distinct from the `candle_krea`
 /// txt2img lane — the edit is a separate surface with the required edit LoRA).
-const KREA_EDIT_CANDLE_ENGINE: &str = "candle_krea_edit";
+pub(super) const KREA_EDIT_CANDLE_ENGINE: &str = "candle_krea_edit";
 /// Reference cap — the edit LoRA's fixed-order contract: image 1 (required) + image 2 (optional), either
 /// can be a person. Swapping the
 /// order degrades results (the LoRA authors' note); more than two is off-contract.

--- a/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/pulid_candle.rs
@@ -78,7 +78,7 @@ const PULID_CANDLE_DEFAULT_GUIDANCE: f32 = 4.0;
 const PULID_CANDLE_DEFAULT_ID_WEIGHT: f32 = 1.0;
 /// The adapter/engine id recorded on candle PuLID-FLUX assets + telemetry (distinct from the macOS
 /// `mlx_pulid_flux` label and the txt2img `candle_flux` lane).
-const PULID_CANDLE_ENGINE: &str = "candle_pulid_flux";
+pub(super) const PULID_CANDLE_ENGINE: &str = "candle_pulid_flux";
 
 /// Resolve the FLUX.1-dev backbone snapshot for candle PuLID-FLUX: an explicit `modelPath` dir
 /// (advanced or manifest) wins (used verbatim — an app-managed override picks its own layout), else the

--- a/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
@@ -29,7 +29,7 @@ use serde_json::json;
 
 /// The adapter/engine id recorded on candle ComfyUI Qwen-Image assets + telemetry (distinct from the
 /// registry `candle` qwen txt2img and the `qwen_edit`/`qwen_control` lanes).
-const QWEN_COMFYUI_CANDLE_ENGINE: &str = "candle_qwen_image_comfyui";
+pub(super) const QWEN_COMFYUI_CANDLE_ENGINE: &str = "candle_qwen_image_comfyui";
 
 /// Denoise-steps fallback — the `qwen_image` manifest default (`defaults.steps`). The UI normally
 /// supplies `advanced.steps`; this only applies when it does not. Qwen-Image base is a non-distilled

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -38,7 +38,7 @@ const QWEN_EDIT_CANDLE_LIGHTNING_STEPS: u32 = 4;
 /// True-CFG guidance default.
 const QWEN_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 4.0;
 /// The adapter/engine id recorded on candle Qwen-Image-Edit assets + telemetry.
-const QWEN_EDIT_CANDLE_ENGINE: &str = "candle_qwen_edit";
+pub(super) const QWEN_EDIT_CANDLE_ENGINE: &str = "candle_qwen_edit";
 /// The SceneWorks pre-packed Qwen-Image-Edit-2511 quant-matrix turnkey (sc-8669, epic 8506): self-
 /// contained `q4/` (manifest default) + `q8/` + `bf16/` subdirs, only the transformer packed (the
 /// Qwen2.5-VL TE + VAE stay dense bf16 in every tier). Shared by all four edit ids + the Lightning
@@ -449,6 +449,7 @@ pub(super) async fn generate_candle_qwen_edit_stream(
     // This closes the candle edit-LoRA gap for the Qwen-Image-Edit family; the SDXL / FLUX.2 /
     // Z-Image candle edit engines still need an `adapters` field in candle-gen (tracked).
     adapters.extend(resolve_adapters(request, settings)?);
+    let adapter_count = adapters.len();
     let mut raw_settings =
         qwen_edit_candle_raw_settings(request, &repo, &qwen_base, steps, guidance);
     // Record the Lightning recipe for telemetry / A-B parity (matches the MLX `distillLora` key format).
@@ -549,7 +550,6 @@ pub(super) async fn generate_candle_qwen_edit_stream(
         // sc-13619: the quant picker is hidden when no alternative tier is installed. Derive advice
         // from the same forced-tier probes as the main candle lane so both reject arms name only
         // smaller tiers this installation can really load.
-        let reject_tail = vram_reject_tail_for_tier(installed_tier_keys(request, settings), tier);
         match plan {
             crate::vram_gate::LoadPlan::Sequential => {
                 tracing::info!(
@@ -570,6 +570,8 @@ pub(super) async fn generate_candle_qwen_edit_stream(
                 true
             }
             crate::vram_gate::LoadPlan::Reject => {
+                let reject_tail =
+                    vram_reject_tail_for_tier(installed_tier_keys(request, settings), tier);
                 // For the always-sequential-capable edit lane a reject is the sc-10856 second-stage
                 // sequential overflow: even staged, the measured peak won't fit the (post-reclaim) budget.
                 if let Some(seq_gb) =
@@ -614,7 +616,7 @@ pub(super) async fn generate_candle_qwen_edit_stream(
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),
         "qwen_edit",
-        0,
+        adapter_count,
         move || {
             let model = QwenEdit::load(&QwenEditPaths {
                 root: qwen_base,

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -31,7 +31,7 @@ const SDXL_EDIT_CANDLE_DEFAULT_STEPS: u32 = 30;
 const SDXL_EDIT_CANDLE_DEFAULT_GUIDANCE: f32 = 5.0;
 /// The adapter/engine id recorded on candle SDXL edit assets + telemetry (distinct from the txt2img
 /// `candle_sdxl` and the `candle_sdxl_ipadapter` lanes).
-const SDXL_EDIT_CANDLE_ENGINE: &str = "candle_sdxl_edit";
+pub(super) const SDXL_EDIT_CANDLE_ENGINE: &str = "candle_sdxl_edit";
 
 /// SDXL model ids the candle edit route accepts (the txt2img-eligible SDXL family). Must stay in
 /// lockstep with `jobs_store::routing::candle::image_request_candle_lane`'s `sdxl_edit_candle_eligible`

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_ipadapter.rs
@@ -47,7 +47,7 @@ const SDXL_IPADAPTER_DEFAULT_STEPS: u32 = 30;
 const SDXL_IPADAPTER_DEFAULT_GUIDANCE: f32 = 5.0;
 /// The adapter/engine id recorded on candle SDXL IP-Adapter assets + telemetry (distinct from the
 /// txt2img `candle_sdxl` and the `candle_instantid` lanes).
-const SDXL_IPADAPTER_ENGINE: &str = "candle_sdxl_ipadapter";
+pub(super) const SDXL_IPADAPTER_ENGINE: &str = "candle_sdxl_ipadapter";
 
 /// SDXL model ids the candle IP-Adapter route accepts (the txt2img-eligible SDXL family). Must stay
 /// in lockstep with `jobs_store::routing::candle`'s `sdxl_ipadapter_candle_eligible` guard.

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -272,6 +272,252 @@ fn streaming_result_carries_facts_for_api_persistence() {
     assert_eq!(result["generationSetId"], json!(plan.genset_id));
     assert_eq!(result["assetWrites"].as_array().map(Vec::len), Some(1));
     assert!(result.contains_key("generationSet"));
+    assert_eq!(result["adapter"], json!(plan.adapter));
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn ideogram_placeholder_recovery_handles_clean_recover_and_exhaustion() {
+    let cancel = CancelFlag::new();
+    let placeholder = |_pixels: &[u8], _width: u32, _height: u32| true;
+    let mut calls = 0;
+    let clean = recover_ideogram_placeholder_with(
+        false,
+        3,
+        7,
+        &cancel,
+        (1, 1, vec![1]),
+        placeholder,
+        |_| {
+            calls += 1;
+            Ok((1, 1, vec![0]))
+        },
+    )
+    .unwrap();
+    assert_eq!(clean, (7, 1, 1, vec![1]));
+    assert_eq!(calls, 0, "disabled recovery must not render again");
+
+    let enabled_clean = recover_ideogram_placeholder_with(
+        true,
+        3,
+        7,
+        &cancel,
+        (1, 1, vec![0]),
+        |pixels, _, _| pixels[0] == 1,
+        |_| {
+            calls += 1;
+            Ok((1, 1, vec![1]))
+        },
+    )
+    .unwrap();
+    assert_eq!(enabled_clean, (7, 1, 1, vec![0]));
+    assert_eq!(calls, 0, "an enabled clean render must not pay for a retry");
+
+    let recovered_seed = crate::ideogram_caption::recovery_seed(7, 0);
+    let recovered = recover_ideogram_placeholder_with(
+        true,
+        3,
+        7,
+        &cancel,
+        (1, 1, vec![1]),
+        |pixels, _, _| pixels[0] == 1,
+        |_| Ok((2, 2, vec![0])),
+    )
+    .unwrap();
+    assert_eq!(recovered, (recovered_seed, 2, 2, vec![0]));
+
+    let mut attempts = 0;
+    let exhausted = recover_ideogram_placeholder_with(
+        true,
+        2,
+        11,
+        &cancel,
+        (1, 1, vec![1]),
+        |pixels, _, _| pixels[0] == 1,
+        |_| {
+            attempts += 1;
+            Ok((1, 1, vec![1]))
+        },
+    )
+    .unwrap();
+    assert_eq!(attempts, 2);
+    assert_eq!(exhausted.0, crate::ideogram_caption::recovery_seed(11, 1));
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn ideogram_placeholder_recovery_honors_cancel_and_propagates_errors() {
+    let cancelled = CancelFlag::new();
+    cancelled.cancel();
+    let mut calls = 0;
+    let result = recover_ideogram_placeholder_with(
+        true,
+        3,
+        5,
+        &cancelled,
+        (1, 1, vec![1]),
+        |_, _, _| true,
+        |_| {
+            calls += 1;
+            Ok((1, 1, vec![0]))
+        },
+    )
+    .unwrap();
+    assert_eq!(result, (5, 1, 1, vec![1]));
+    assert_eq!(calls, 0);
+
+    let error = recover_ideogram_placeholder_with(
+        true,
+        1,
+        5,
+        &CancelFlag::new(),
+        (1, 1, vec![1]),
+        |_, _, _| true,
+        |_| Err(WorkerError::Engine("retry failed".to_owned())),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("retry failed"));
+}
+
+/// Mutation guard for F-061's production wiring. These paths normally require a live project,
+/// installed tier trees, and a GPU, so source-level assertions pin the exact call-site properties
+/// that pure helper tests cannot observe: one candle route decision reused by plan and dispatch,
+/// reject-only tier probes in both candle gates, and Qwen load telemetry using the resolved adapter
+/// count. Reintroducing the historical second route resolution, eager probes, or literal zero makes
+/// this test fail in the platform-neutral worker suite.
+#[test]
+fn image_review_wiring_remains_single_route_lazy_and_adapter_aware() {
+    fn between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
+        let tail = source
+            .split_once(start)
+            .unwrap_or_else(|| panic!("missing source marker {start:?}"))
+            .1;
+        tail.split_once(end)
+            .unwrap_or_else(|| panic!("missing source marker {end:?}"))
+            .0
+    }
+
+    let image_jobs = include_str!("../image_jobs.rs");
+    let run_job = between(
+        image_jobs,
+        "pub(crate) async fn run_image_generate_job(",
+        "\nasync fn generate_stub_stream(",
+    );
+    assert_eq!(
+        run_job.matches("resolve_candle_image_route(").count(),
+        1,
+        "candle route must be resolved exactly once per job"
+    );
+    let route_binding = run_job
+        .find("let route = resolve_candle_image_route")
+        .expect("one route binding");
+    let plan_use = run_job[route_binding..]
+        .find("ImagePlan::with_count_and_adapter")
+        .expect("the resolved route feeds the plan");
+    let dispatch_use = run_job[route_binding..]
+        .find("let handled = match route")
+        .expect("the same resolved route feeds dispatch");
+    assert!(
+        plan_use < dispatch_use,
+        "plan count/adapter must be bound before dispatching the same route"
+    );
+    let candle_route_wiring = &run_job[route_binding..route_binding + dispatch_use];
+    assert!(
+        candle_route_wiring.contains(
+            "route.map_or(request.count, |route| route.image_count(&request, settings))",
+        ),
+        "the resolved candle route must supply the effective image count"
+    );
+    assert!(
+        candle_route_wiring
+            .contains("route.map_or(STUB_ADAPTER, |route| route.adapter_label(&request))"),
+        "the resolved candle route must supply the adapter label"
+    );
+
+    let base = include_str!("base.rs");
+    let mlx_stream = between(
+        base,
+        "async fn generate_stream(",
+        "\nasync fn generate_candle_stream(",
+    );
+    let candle_stream = between(base, "async fn generate_candle_stream(", "\nfn lora_label(");
+    assert_eq!(
+        mlx_stream.matches("recover_ideogram_placeholder(").count(),
+        1,
+        "the MLX generation loop must use the shared placeholder recovery policy"
+    );
+    assert_eq!(
+        candle_stream
+            .matches("recover_ideogram_placeholder(")
+            .count(),
+        1,
+        "the candle generation loop must use the shared placeholder recovery policy"
+    );
+    assert_eq!(
+        candle_stream.matches("installed_tier_keys(").count(),
+        2,
+        "the generic candle lane probes tiers only in its two reject arms"
+    );
+    let sequential_reject = candle_stream
+        .find("if let Some(seq_gb) =")
+        .expect("sequential overflow reject");
+    let first_probe = candle_stream
+        .find("installed_tier_keys(")
+        .expect("sequential reject tier probe");
+    let too_big_reject = candle_stream
+        .find("FitDecision::TooBig")
+        .expect("resident reject");
+    let second_probe = candle_stream[first_probe + 1..]
+        .find("installed_tier_keys(")
+        .map(|offset| first_probe + 1 + offset)
+        .expect("resident reject tier probe");
+    assert!(
+        sequential_reject < first_probe && too_big_reject < second_probe,
+        "installed-tier walks must stay below their reject decisions"
+    );
+
+    let qwen = include_str!("qwen_edit_candle.rs");
+    let qwen_stream = qwen
+        .split_once("pub(super) async fn generate_candle_qwen_edit_stream(")
+        .expect("Qwen edit stream")
+        .1;
+    assert_eq!(
+        qwen_stream.matches("installed_tier_keys(").count(),
+        1,
+        "Qwen edit probes installed tiers only for rejection advice"
+    );
+    assert!(
+        qwen_stream
+            .find("LoadPlan::Reject")
+            .expect("Qwen reject arm")
+            < qwen_stream
+                .find("installed_tier_keys(")
+                .expect("Qwen reject tier probe"),
+        "Qwen installed-tier walk must stay inside the reject arm"
+    );
+    assert!(
+        qwen_stream.contains("let adapter_count = adapters.len();"),
+        "Qwen load telemetry must derive its adapter count from the resolved adapter stack"
+    );
+    let start_args = between(
+        qwen_stream,
+        "let (cancel, rx, blocking) = start_gen_stream(",
+        "move || {",
+    );
+    assert!(
+        start_args.contains("adapter_count,"),
+        "Qwen load telemetry must carry the complete built-in + user adapter count"
+    );
+    assert!(
+        !start_args.lines().any(|line| line.trim() == "0,"),
+        "Qwen load telemetry must never regress to a literal zero adapter count"
+    );
 }
 
 #[test]
@@ -1833,20 +2079,76 @@ fn adapter_id_reports_per_family_mlx_label() {
         adapter_id(&request(json!({ "model": "lens_turbo" }))),
         "mlx_lens"
     );
-    // Bernini still-image companion (sc-5424) IS a MODEL_TABLE row (engine `bernini`), so unlike the
-    // bespoke pulid/instantid routes `adapter_id` resolves its real per-set label.
+    // Bernini still-image companion (sc-5424) IS a MODEL_TABLE row (engine `bernini`).
     assert_eq!(
         adapter_id(&request(json!({ "model": "bernini_image" }))),
         "mlx_bernini"
     );
-    // PuLID-FLUX (sc-3344) is MLX-routed but via a BESPOKE route (not the MODEL_TABLE registry
-    // families), so `adapter_id` — which only resolves MODEL_TABLE rows — reports the stub label;
-    // the real per-asset label (`mlx_pulid_flux`) is applied in `generate_pulid_flux_stream` via
-    // `consume_gen_events`. Same shape as the InstantID bespoke route.
+    // The request-only helper remains a registry fallback. Production generation-set telemetry uses
+    // the resolved route's label, which covers bespoke IDs such as PuLID and InstantID.
     assert_eq!(
         adapter_id(&request(json!({ "model": "pulid_flux_dev" }))),
         "procedural_preview"
     );
+    assert_eq!(
+        ImageRoute::PulidFlux.adapter_label(&request(json!({ "model": "pulid_flux_dev" }))),
+        "mlx_pulid_flux"
+    );
+    assert_eq!(
+        ImageRoute::InstantId.adapter_label(&request(json!({ "model": "instantid_realvisxl" }))),
+        "mlx_instantid"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn every_generating_mlx_route_has_a_real_generation_set_adapter() {
+    let cases = [
+        (ImageRoute::ZImageControl, "z_image_turbo", "mlx_z_image"),
+        (ImageRoute::ZImageBaseControl, "z_image", "mlx_z_image"),
+        (ImageRoute::QwenControl, "qwen_image", "mlx_qwen"),
+        (ImageRoute::KolorsControl, "kolors", "mlx_kolors"),
+        (
+            ImageRoute::KreaControl,
+            "krea_2_turbo",
+            "krea_2_turbo_control",
+        ),
+        (ImageRoute::Flux1DevControl, "flux_dev", "mlx_flux"),
+        (ImageRoute::Flux2DevControl, "flux2_dev", "mlx_flux2"),
+        (ImageRoute::Flux2Edit, "flux2_klein_9b", "mlx_flux2"),
+        (ImageRoute::QwenEdit, "qwen_image_edit", "mlx_qwen"),
+        (ImageRoute::KreaEdit, "krea_2_raw", "mlx_krea"),
+        (ImageRoute::KreaTurboOnRaw, "krea_2_raw", "mlx_krea"),
+        (ImageRoute::KreaMultiPhase, "krea_2_raw", "mlx_krea"),
+        (
+            ImageRoute::KreaImported,
+            "external_krea",
+            "mlx_krea_imported",
+        ),
+        (
+            ImageRoute::SdxlImported,
+            "external_sdxl",
+            "mlx_sdxl_imported",
+        ),
+        (
+            ImageRoute::InstantId,
+            "instantid_realvisxl",
+            "mlx_instantid",
+        ),
+        (ImageRoute::PulidFlux, "pulid_flux_dev", "mlx_pulid_flux"),
+        (ImageRoute::SdxlAdvanced, "sdxl", "mlx_sdxl"),
+        (
+            ImageRoute::SensenovaEdit,
+            "sensenova_u1_8b",
+            "mlx_sensenova",
+        ),
+        (ImageRoute::Bernini, "bernini_image", "mlx_bernini"),
+        (ImageRoute::Mlx, "flux_schnell", "mlx_flux"),
+    ];
+    for (route, model, expected) in cases {
+        let label = route.adapter_label(&request(json!({ "model": model })));
+        assert_eq!(label, expected, "{route:?} must match its asset label");
+    }
 }
 
 /// The Z-Image + FLUX.1 + Qwen-Image providers included by the worker's explicit platform catalog.
@@ -6804,6 +7106,123 @@ fn candle_strict_pose_route_image_count_is_pose_set_length() {
     );
 }
 
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn every_generating_candle_route_has_a_real_generation_set_adapter() {
+    let cases = [
+        (
+            CandleImageRoute::InstantId,
+            "instantid_realvisxl",
+            "candle_instantid",
+        ),
+        (CandleImageRoute::SdxlEdit, "sdxl", "candle_sdxl_edit"),
+        (
+            CandleImageRoute::Flux2Edit,
+            "flux2_klein_9b",
+            "candle_flux2_edit",
+        ),
+        (
+            CandleImageRoute::QwenEdit,
+            "qwen_image_edit",
+            "candle_qwen_edit",
+        ),
+        (
+            CandleImageRoute::ZimageEdit,
+            "z_image_turbo",
+            "candle_zimage_edit",
+        ),
+        (CandleImageRoute::KreaEdit, "krea_2_raw", "candle_krea_edit"),
+        (CandleImageRoute::KreaTurboOnRaw, "krea_2_raw", "mlx_krea"),
+        (CandleImageRoute::KreaMultiPhase, "krea_2_raw", "mlx_krea"),
+        (
+            CandleImageRoute::KreaImported,
+            "external_krea",
+            "candle_krea_imported",
+        ),
+        (
+            CandleImageRoute::SdxlImported,
+            "external_sdxl",
+            "candle_sdxl_imported",
+        ),
+        (
+            CandleImageRoute::ZimageIdentity,
+            "z_image_turbo",
+            "candle_zimage_identity",
+        ),
+        (
+            CandleImageRoute::SdxlIpAdapter,
+            "sdxl",
+            "candle_sdxl_ipadapter",
+        ),
+        (
+            CandleImageRoute::KolorsIpAdapter,
+            "kolors",
+            "candle_kolors_ipadapter",
+        ),
+        (
+            CandleImageRoute::FluxIpAdapter,
+            "flux_dev",
+            "candle_flux_ipadapter",
+        ),
+        (
+            CandleImageRoute::Pulid,
+            "pulid_flux_dev",
+            "candle_pulid_flux",
+        ),
+        (
+            CandleImageRoute::QwenControl,
+            "qwen_image",
+            "candle_qwen_control",
+        ),
+        (
+            CandleImageRoute::KolorsControl,
+            "kolors",
+            "candle_kolors_control",
+        ),
+        (
+            CandleImageRoute::ZimageControl,
+            "z_image_turbo",
+            "candle_zimage_control",
+        ),
+        (
+            CandleImageRoute::Flux2Control,
+            "flux2_dev",
+            "candle_flux2_control",
+        ),
+        (
+            CandleImageRoute::Flux1Control,
+            "flux_dev",
+            "candle_flux1_control",
+        ),
+        (
+            CandleImageRoute::KreaControl,
+            "krea_2_turbo",
+            "candle_krea_control",
+        ),
+        (
+            CandleImageRoute::ZimageComfyui,
+            "external_zimage",
+            "candle_zimage_comfyui",
+        ),
+        (
+            CandleImageRoute::QwenImageComfyui,
+            "external_qwen",
+            "candle_qwen_image_comfyui",
+        ),
+        (
+            CandleImageRoute::Flux2Comfyui,
+            "external_flux2",
+            "candle_flux2_dev_comfyui",
+        ),
+        (CandleImageRoute::Bernini, "bernini_image", "candle_bernini"),
+        (CandleImageRoute::CandleTxt2Img, "sdxl", "candle_sdxl"),
+    ];
+    for (route, model, expected) in cases {
+        let label = route.adapter_label(&request(json!({ "model": model })));
+        assert_eq!(label, expected, "{route:?} must match its asset label");
+    }
+}
+
 // sc-10996 (epic 6562): `bernini_image` t2i / i2i route to the dedicated candle Bernini lane
 // (`CandleImageRoute::Bernini` → `generate_candle_bernini_image_stream`), NOT the generic txt2img arm
 // (the engine is `Modality::Video`, so `bernini_image` is not an `is_candle_engine` id). Routed on the
@@ -8439,7 +8858,7 @@ fn ideogram_4_headless_auto_caption_renders_real_image() {
     let cancel = CancelFlag::new();
     let enhance = PromptEnhance::default();
 
-    let render = |seed: i64| {
+    let mut render = |seed: i64| {
         generate_one(
             generator.as_ref(),
             &prompt,
@@ -8463,28 +8882,13 @@ fn ideogram_4_headless_auto_caption_renders_real_image() {
             &cancel,
             &mut |_| {},
         )
-        .expect("ideogram render from the auto-caption")
     };
     let retries = crate::ideogram_caption::placeholder_recovery_retries();
-    let (mut w, mut h, mut pixels) = render(7);
-    let mut placeholder = crate::ideogram_caption::looks_like_placeholder(&pixels, w, h);
-    let mut final_seed = 7i64;
-    for attempt in 0..retries {
-        if !placeholder {
-            break;
-        }
-        let retry_seed = crate::ideogram_caption::recovery_seed(7, attempt);
-        eprintln!(
-            "placeholder; reseeding {retry_seed} (attempt {}/{retries})",
-            attempt + 1
-        );
-        let (rw, rh, rpixels) = render(retry_seed);
-        w = rw;
-        h = rh;
-        pixels = rpixels;
-        final_seed = retry_seed;
-        placeholder = crate::ideogram_caption::looks_like_placeholder(&pixels, w, h);
-    }
+    let initial = render(7).expect("ideogram render from the auto-caption");
+    let (final_seed, w, h, pixels) =
+        recover_ideogram_placeholder(true, 7, &cancel, initial, &mut render)
+            .expect("ideogram placeholder recovery");
+    let placeholder = crate::ideogram_caption::looks_like_placeholder(&pixels, w, h);
     // Hard asserts validate THIS story's deliverable end-to-end with real weights: the 3B caption was
     // cleaned to the canonical engine form and rendered through the production Ideogram load + reseed
     // recovery, producing a correctly-sized, non-constant image.

--- a/crates/sceneworks-worker/src/image_jobs/zimage_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_comfyui_candle.rs
@@ -21,7 +21,7 @@ use serde_json::json;
 
 /// The adapter/engine id recorded on candle ComfyUI Z-Image assets + telemetry (distinct from the
 /// registry `candle_z_image` txt2img and the `candle_zimage_edit`/`_control` lanes).
-const ZIMAGE_COMFYUI_CANDLE_ENGINE: &str = "candle_zimage_comfyui";
+pub(super) const ZIMAGE_COMFYUI_CANDLE_ENGINE: &str = "candle_zimage_comfyui";
 /// Denoise-steps fallback — the Z-Image-Turbo manifest default (`z_image_turbo` `defaults.steps`). The UI
 /// normally supplies `advanced.steps`; this only applies when it does not.
 const ZIMAGE_COMFYUI_DEFAULT_STEPS: u32 = 8;

--- a/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
@@ -33,7 +33,7 @@ const ZIMAGE_EDIT_CANDLE_DEFAULT_STEPS: u32 = 4;
 pub(super) const ZIMAGE_EDIT_CANDLE_DEFAULT_REPO: &str = "Tongyi-MAI/Z-Image-Turbo";
 /// The adapter/engine id recorded on candle Z-Image edit assets + telemetry (distinct from the txt2img
 /// `candle_z_image` and the `candle_zimage_control` lanes).
-const ZIMAGE_EDIT_CANDLE_ENGINE: &str = "candle_zimage_edit";
+pub(super) const ZIMAGE_EDIT_CANDLE_ENGINE: &str = "candle_zimage_edit";
 
 /// Model ids the candle Z-Image edit route accepts: the txt2img `z_image_turbo` (in `edit_image` mode)
 /// and the dedicated `z_image_edit` id — both drive the Turbo weights' img2img path.

--- a/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_identity_candle.rs
@@ -45,7 +45,7 @@ use serde_json::json;
 
 /// The adapter/engine id recorded on candle Z-Image identity-init assets + telemetry (distinct from the
 /// txt2img `candle_z_image`, the `candle_zimage_edit`, and the `candle_zimage_control` lanes).
-const ZIMAGE_IDENTITY_CANDLE_ENGINE: &str = "candle_zimage_identity";
+pub(super) const ZIMAGE_IDENTITY_CANDLE_ENGINE: &str = "candle_zimage_identity";
 
 /// Model ids the candle Z-Image identity-init route accepts: only `z_image_turbo` (the With-Character
 /// target — the candle z-image engine is the distilled Turbo). The dedicated `z_image_edit` id is an


### PR DESCRIPTION
## Summary
- share Ideogram placeholder recovery across MLX and Candle without duplicate retries
- resolve Candle routing once and reuse it for image count, adapter telemetry, and dispatch
- make tier probes rejection-only, preserve InstantID q8 fallback, and report Qwen adapter counts
- add exhaustive route parity and mutation-sensitive regression coverage

## Validation
- independent exact-head review: APPROVE, no findings (99% confidence)
- worker: 1,051 passed, 176 ignored, 0 failed
- Mac all-target Clippy with -D warnings
- Candle cross-target check/Clippy including tests
- Linux no-backend check
- cargo fmt and git diff --check

Shortcut: sc-13642