### PR TITLE
Harden latent review seams [sc-13653]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6312,6 +6312,7 @@ dependencies = [
  "parking_lot",
  "reqwest 0.12.28",
  "rmcp",
+ "rusqlite",
  "rust-embed",
  "sceneworks-core",
  "sceneworks-image-quality",

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -58,6 +58,9 @@ embed-web = ["dep:rust-embed", "dep:mime_guess"]
 backend-candle = ["sceneworks-worker/backend-candle"]
 
 [dev-dependencies]
+# Construct SQLite BUSY errors directly in the API error-contract test without
+# adding rusqlite to the production API dependency surface.
+rusqlite = { version = "0.32", features = ["bundled"] }
 # Real MCP streamable-HTTP client for the /mcp round-trip test (sc-10233); same
 # pinned version as crates/sceneworks-mcp — client features are additive.
 rmcp = { version = "=2.1.0", features = ["client", "transport-streamable-http-client-reqwest"] }

--- a/apps/rust-api/src/error.rs
+++ b/apps/rust-api/src/error.rs
@@ -18,6 +18,7 @@ use sceneworks_core::project_store::ProjectStoreError;
 pub(crate) struct ApiError {
     pub(crate) status: StatusCode,
     pub(crate) detail: String,
+    pub(crate) code: Option<&'static str>,
 }
 
 impl ApiError {
@@ -25,6 +26,7 @@ impl ApiError {
         Self {
             status: StatusCode::BAD_REQUEST,
             detail: detail.into(),
+            code: None,
         }
     }
 
@@ -32,6 +34,7 @@ impl ApiError {
         Self {
             status: StatusCode::UNAUTHORIZED,
             detail: detail.into(),
+            code: None,
         }
     }
 
@@ -39,6 +42,7 @@ impl ApiError {
         Self {
             status: StatusCode::FORBIDDEN,
             detail: detail.into(),
+            code: None,
         }
     }
 
@@ -46,6 +50,7 @@ impl ApiError {
         Self {
             status: StatusCode::PAYLOAD_TOO_LARGE,
             detail: detail.into(),
+            code: None,
         }
     }
 
@@ -53,6 +58,7 @@ impl ApiError {
         Self {
             status: StatusCode::CONFLICT,
             detail: detail.into(),
+            code: None,
         }
     }
 
@@ -60,20 +66,34 @@ impl ApiError {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             detail: detail.into(),
+            code: None,
+        }
+    }
+
+    fn database_locked(detail: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: detail.into(),
+            code: Some("database_locked"),
         }
     }
 }
 
 impl From<JobsStoreError> for ApiError {
     fn from(error: JobsStoreError) -> Self {
+        if error.is_database_locked() {
+            return Self::database_locked(error.to_string());
+        }
         match error {
             JobsStoreError::NotFound(_) => Self {
                 status: StatusCode::NOT_FOUND,
                 detail: "Record not found".to_owned(),
+                code: None,
             },
             JobsStoreError::InvalidStatus(status) => Self {
                 status: StatusCode::BAD_REQUEST,
                 detail: format!("Unsupported job status: {status}"),
+                code: None,
             },
             JobsStoreError::InvalidNumber(field) => {
                 Self::bad_request(format!("Invalid numeric value for {field}"))
@@ -82,6 +102,7 @@ impl From<JobsStoreError> for ApiError {
             JobsStoreError::RetryLimit { max_attempts } => Self {
                 status: StatusCode::BAD_REQUEST,
                 detail: format!("Job retry limit reached after {max_attempts} attempts."),
+                code: None,
             },
             // 409 tells the worker its report lost a race with cancel/sweep/
             // reclaim: abandon the job instead of retrying (sc-4172).
@@ -90,12 +111,14 @@ impl From<JobsStoreError> for ApiError {
                 detail: format!(
                     "Job {job_id} is already {status}; terminal jobs cannot be updated."
                 ),
+                code: None,
             },
             JobsStoreError::NotJobOwner { job_id } => Self {
                 status: StatusCode::CONFLICT,
                 detail: format!(
                     "Progress rejected: the reporting worker no longer owns job {job_id}."
                 ),
+                code: None,
             },
             other => Self::internal(other.to_string()),
         }
@@ -109,6 +132,7 @@ impl From<ProjectStoreError> for ApiError {
             ProjectStoreError::NotFound(detail) => Self {
                 status: StatusCode::NOT_FOUND,
                 detail,
+                code: None,
             },
             // A non-writable workspace folder is an environment problem, not a bad
             // request — 507 keeps the actionable, path-naming detail intact and out
@@ -117,6 +141,7 @@ impl From<ProjectStoreError> for ApiError {
             ProjectStoreError::StorageNotWritable(detail) => Self {
                 status: StatusCode::INSUFFICIENT_STORAGE,
                 detail,
+                code: None,
             },
             other => Self::internal(other.to_string()),
         }
@@ -142,6 +167,26 @@ impl IntoResponse for ApiError {
                 detail = %self.detail,
             );
         }
-        (self.status, Json(json!({ "detail": self.detail }))).into_response()
+        let body = match self.code {
+            Some(code) => json!({ "detail": self.detail, "code": code }),
+            None => json!({ "detail": self.detail }),
+        };
+        (self.status, Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_lock_maps_to_machine_readable_api_code() {
+        let sqlite = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            Some("wording is deliberately irrelevant".to_owned()),
+        );
+        let error = ApiError::from(JobsStoreError::Sqlite(sqlite));
+        assert_eq!(error.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error.code, Some("database_locked"));
     }
 }

--- a/apps/rust-api/src/events.rs
+++ b/apps/rust-api/src/events.rs
@@ -67,6 +67,7 @@ pub(crate) async fn create_event_ticket(
             .map_err(|error| ApiError {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
                 detail: format!("JSON decode error: {error}"),
+                code: None,
             })?
             .unwrap_or_default()
     };
@@ -105,6 +106,7 @@ pub(crate) async fn create_event_ticket(
                 "Too many outstanding event tickets; retry after at most \
                  {EVENT_TICKET_TTL_SECONDS} seconds"
             ),
+            code: None,
         })
 }
 

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3201,6 +3201,7 @@ fn find_timeline_item<'a>(timeline: &'a Value, item_id: &str) -> Result<&'a Valu
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Timeline item not found".to_owned(),
+            code: None,
         })
 }
 

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -37,6 +37,7 @@ pub(crate) async fn create_lora_download_job(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            code: None,
         })?;
     if lora.get("installState").and_then(Value::as_str) == Some("installed")
         && lora.get("updateAvailable").and_then(Value::as_bool) != Some(true)
@@ -152,6 +153,7 @@ pub(crate) async fn delete_lora(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            code: None,
         })?;
     let scope = query
         .scope
@@ -286,6 +288,7 @@ pub(crate) async fn update_lora(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            code: None,
         })?;
     let scope = query
         .scope
@@ -352,6 +355,7 @@ pub(crate) async fn update_lora(
     updated.map(Json).ok_or_else(|| ApiError {
         status: StatusCode::NOT_FOUND,
         detail: "LoRA has no editable manifest entry in this scope".to_owned(),
+        code: None,
     })
 }
 
@@ -376,6 +380,7 @@ pub(crate) async fn lora_embedded_tags(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            code: None,
         })?;
     let Some(installed_path) = lora
         .get("installedPath")

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -161,6 +161,7 @@ pub(crate) async fn create_model_download_job(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            code: None,
         })?;
     // Tier selection (sc-8508): an explicit `variant` installs that quant tier's download entry; an
     // absent variant installs the default tier (back-compat). A variant the model doesn't advertise
@@ -370,6 +371,7 @@ pub(crate) async fn create_model_convert_job(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            code: None,
         })?;
     let mlx = model
         .get("mlx")
@@ -487,6 +489,7 @@ pub(crate) async fn delete_model(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            code: None,
         })?;
     let manifest_path = state
         .settings
@@ -574,6 +577,7 @@ pub(crate) async fn delete_model_variant(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            code: None,
         })?;
     let data_dir = &state.settings.data_dir;
     let allowed_roots = vec![data_dir.join("models"), huggingface_hub_cache_dir(data_dir)];

--- a/apps/rust-api/src/prompt_batches.rs
+++ b/apps/rust-api/src/prompt_batches.rs
@@ -325,6 +325,7 @@ fn prompt_batch_not_found() -> ApiError {
     ApiError {
         status: StatusCode::NOT_FOUND,
         detail: "Prompt batch not found".to_owned(),
+        code: None,
     }
 }
 

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -573,6 +573,7 @@ pub(crate) fn recipe_preset_not_found() -> ApiError {
     ApiError {
         status: StatusCode::NOT_FOUND,
         detail: "Recipe preset not found".to_owned(),
+        code: None,
     }
 }
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -85,6 +85,7 @@ import {
   readStoredTheme,
 } from "./appHelpers.js";
 import {
+  applySuccessfulProjectRefresh,
   hasVisibleLocalFailureForView,
   isCurrentProjectRequest,
   reconcileSelectedAssetId,
@@ -546,13 +547,13 @@ export function App() {
   // Same persistence contract as theme: instant localStorage cache + durable
   // server copy. The PUT sends only the changed field, so the endpoint must
   // MERGE partial updates (theme writes already rely on this).
-  const changeAccent = (next) => {
+  const changeAccent = useCallback((next) => {
     setAccent(next);
     apiFetch("/api/v1/ui-preferences", "", {
       method: "PUT",
       body: JSON.stringify({ accent: next }),
     }).catch(() => {});
-  };
+  }, []);
   // Simple UI (design handoff). `simpleUiDefault` is the persisted "Use Simple UI by
   // default" preference — same durable contract as theme/accent (server copy in
   // ui-preferences.json + a localStorage instant-paint cache), because the desktop
@@ -1415,10 +1416,8 @@ export function App() {
     fetchInitial("Mac capabilities", "/api/v1/capabilities/mac", DEFAULT_MAC_CAPABILITIES, true)
       .then((result) => setMacCapabilities(result.value ?? DEFAULT_MAC_CAPABILITIES))
       .catch(() => {});
-    const projectItems = projectsResult.value;
-    setProjects(projectItems);
+    applySuccessfulProjectRefresh(projectsResult, setProjects, setActiveProject);
     setProjectsLoaded(true);
-    setActiveProject((current) => current ?? projectItems[0] ?? null);
     setJobs((current) => mergeFreshJobs(current, jobsResult.value));
     setWorkers(workersResult.value.sort(sortWorkers));
     setQueueSummary(null);

--- a/apps/web/src/appStateHelpers.js
+++ b/apps/web/src/appStateHelpers.js
@@ -26,3 +26,16 @@ export function reconcileSelectedAssetId(items, currentId) {
 export function isCurrentProjectRequest(activeProjectId, requestedProjectId) {
   return activeProjectId === requestedProjectId;
 }
+
+export function reconcileActiveProject(projects, current) {
+  if (!current) return projects[0] ?? null;
+  return projects.find((project) => project.id === current.id) ?? projects[0] ?? null;
+}
+
+export function applySuccessfulProjectRefresh(result, setProjects, setActiveProject) {
+  if (result.error) return false;
+  const projects = result.value;
+  setProjects(projects);
+  setActiveProject((current) => reconcileActiveProject(projects, current));
+  return true;
+}

--- a/apps/web/src/appStateHelpers.test.js
+++ b/apps/web/src/appStateHelpers.test.js
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import appSource from "./App.jsx?raw";
 import {
+  applySuccessfulProjectRefresh,
   hasVisibleLocalFailureForView,
   isCurrentProjectRequest,
+  reconcileActiveProject,
   reconcileSelectedAssetId,
 } from "./appStateHelpers.js";
 
@@ -86,5 +88,62 @@ describe("isCurrentProjectRequest", () => {
       "isCurrentProjectRequest(activeProject?.id ?? null, projectId)",
     );
     expect(refreshStart).not.toContain("activeProjectRef.current");
+  });
+});
+
+describe("reconcileActiveProject", () => {
+  const refreshed = [
+    { id: "project-a", name: "A refreshed", updatedAt: "new" },
+    { id: "project-b", name: "B" },
+  ];
+
+  it("replaces a selected project's stale snapshot with the refreshed object", () => {
+    expect(reconcileActiveProject(refreshed, { id: "project-a", name: "A stale" })).toBe(
+      refreshed[0],
+    );
+  });
+
+  it("selects the first current project when the old selection disappeared", () => {
+    expect(reconcileActiveProject(refreshed, { id: "deleted" })).toBe(refreshed[0]);
+    expect(reconcileActiveProject([], { id: "deleted" })).toBeNull();
+  });
+});
+
+describe("applySuccessfulProjectRefresh", () => {
+  it("retains the current project list and selection when the projects request fails", () => {
+    let projectWrites = 0;
+    let activeProjectWrites = 0;
+    const applied = applySuccessfulProjectRefresh(
+      { value: [], error: "Projects: offline" },
+      () => {
+        projectWrites += 1;
+      },
+      () => {
+        activeProjectWrites += 1;
+      },
+    );
+
+    expect(applied).toBe(false);
+    expect(projectWrites).toBe(0);
+    expect(activeProjectWrites).toBe(0);
+  });
+
+  it("updates both list and selected snapshot after a successful projects request", () => {
+    const refreshed = [{ id: "project-a", name: "A refreshed" }];
+    let writtenProjects = null;
+    let activeUpdater = null;
+    const applied = applySuccessfulProjectRefresh(
+      { value: refreshed, error: "" },
+      (projects) => {
+        writtenProjects = projects;
+      },
+      (updater) => {
+        activeUpdater = updater;
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(writtenProjects).toBe(refreshed);
+    expect(activeUpdater({ id: "project-a", name: "A stale" })).toBe(refreshed[0]);
   });
 });

--- a/apps/web/src/batchOps.js
+++ b/apps/web/src/batchOps.js
@@ -118,8 +118,8 @@ export function batchItemStatusForItem(item, jobs, observedJobs) {
   return batchItemStatus(item.jobId, jobs, observedJobs);
 }
 
-// The completed result asset for a batch item (the worker returns it on `result.assets[0]`),
-// or null while pending / on failure.
+// The completed result asset for a batch item (the API exposes persisted worker asset writes on
+// `result.assets[0]`), or null while pending / on failure.
 export function batchItemResultAsset(jobId, jobs) {
   const job = (jobs ?? []).find((item) => item.id === jobId);
   if (!job || job.status !== "completed") return null;

--- a/apps/web/src/components/Modal.jsx
+++ b/apps/web/src/components/Modal.jsx
@@ -1,6 +1,22 @@
 import React, { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function focusableChildren(dialog) {
+  return [...dialog.querySelectorAll(FOCUSABLE_SELECTOR)].filter(
+    (element) => !element.hidden && element.getAttribute("aria-hidden") !== "true",
+  );
+}
+
 // Shared modal primitive: a backdrop that closes on outside mousedown, a
 // role="dialog" container that closes on Escape, and focus moved into the
 // dialog on mount. Extracted so every overlay behaves consistently for
@@ -19,7 +35,13 @@ export function Modal({ children, onClose, className, labelledBy, label }) {
   const dialogRef = useRef(null);
 
   useEffect(() => {
+    const previousFocus = document.activeElement;
     dialogRef.current?.focus();
+    return () => {
+      if (previousFocus?.isConnected && typeof previousFocus.focus === "function") {
+        previousFocus.focus();
+      }
+    };
   }, []);
 
   const overlay = (
@@ -36,6 +58,37 @@ export function Modal({ children, onClose, className, labelledBy, label }) {
           if (event.key === "Escape") {
             event.preventDefault();
             onClose();
+            return;
+          }
+          if (event.key === "Tab") {
+            const dialog = dialogRef.current;
+            if (!dialog) return;
+            const focusable = focusableChildren(dialog);
+            if (focusable.length === 0) {
+              event.preventDefault();
+              dialog.focus();
+              return;
+            }
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const focusIsOnContainer = document.activeElement === dialog;
+            if (
+              event.shiftKey &&
+              (document.activeElement === first ||
+                focusIsOnContainer ||
+                !dialog.contains(document.activeElement))
+            ) {
+              event.preventDefault();
+              last.focus();
+            } else if (
+              !event.shiftKey &&
+              (document.activeElement === last ||
+                focusIsOnContainer ||
+                !dialog.contains(document.activeElement))
+            ) {
+              event.preventDefault();
+              first.focus();
+            }
           }
         }}
         onMouseDown={(event) => event.stopPropagation()}

--- a/apps/web/src/components/Modal.test.jsx
+++ b/apps/web/src/components/Modal.test.jsx
@@ -1,0 +1,80 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Modal } from "./Modal.jsx";
+
+describe("Modal keyboard focus", () => {
+  let container;
+  let root;
+  let opener;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    opener = document.createElement("button");
+    opener.textContent = "Open";
+    document.body.appendChild(opener);
+    opener.focus();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    opener.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("traps Tab within the dialog and restores the opener on unmount", async () => {
+    await act(async () => {
+      root.render(
+        <Modal label="Test dialog" onClose={() => {}} className="test-modal">
+          <button>First</button>
+          <a href="/inside">Middle</a>
+          <button>Last</button>
+        </Modal>,
+      );
+    });
+
+    const dialog = document.body.querySelector(".test-modal");
+    const [first, , last] = dialog.querySelectorAll("button, a");
+    expect(document.activeElement).toBe(dialog);
+
+    await act(async () => {
+      dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    });
+    expect(document.activeElement).toBe(first);
+
+    last.focus();
+    await act(async () => {
+      last.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    });
+    expect(document.activeElement).toBe(first);
+
+    await act(async () => {
+      first.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }),
+      );
+    });
+    expect(document.activeElement).toBe(last);
+
+    await act(async () => root.render(<div />));
+    expect(document.activeElement).toBe(opener);
+  });
+
+  it("keeps focus on the dialog when it has no focusable children", async () => {
+    await act(async () => {
+      root.render(
+        <Modal label="Empty dialog" onClose={() => {}} className="empty-modal">
+          <p>Nothing interactive</p>
+        </Modal>,
+      );
+    });
+    const dialog = document.body.querySelector(".empty-modal");
+    await act(async () => {
+      dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    });
+    expect(document.activeElement).toBe(dialog);
+  });
+});

--- a/apps/web/src/components/editor/MediaBin.jsx
+++ b/apps/web/src/components/editor/MediaBin.jsx
@@ -1,7 +1,9 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AssetThumbnail, assetCanRenderAsImage } from "../assetMedia.jsx";
 import { Icon } from "../Icons.jsx";
 import { isAiAsset } from "./editorUtils.js";
+
+const MEDIA_PAGE_SIZE = 60;
 
 // The left media bin (design 2a, epic 12798). Two tabs: "Media" (video + still assets
 // you drop onto the timeline) and "Assets" (the full project media library for preview).
@@ -9,11 +11,17 @@ import { isAiAsset } from "./editorUtils.js";
 // AI-generated assets (derived from origin/recipe, mirroring the LikenessBadge overlay).
 export function MediaBin({ assets = [], onAddToTrack, onPreview }) {
   const [tab, setTab] = useState("media");
+  const [visibleCount, setVisibleCount] = useState(MEDIA_PAGE_SIZE);
 
   const clipAssets = assets.filter(
     (asset) => asset.type === "video" || asset.file?.mimeType?.startsWith("video/") || assetCanRenderAsImage(asset),
   );
   const shown = tab === "media" ? clipAssets : assets;
+  const visible = shown.slice(0, visibleCount);
+
+  useEffect(() => {
+    setVisibleCount(MEDIA_PAGE_SIZE);
+  }, [tab]);
 
   function handleClick(asset) {
     if (tab === "media") {
@@ -37,7 +45,7 @@ export function MediaBin({ assets = [], onAddToTrack, onPreview }) {
         {shown.length === 0 ? (
           <div className="ve-bin-empty">No media</div>
         ) : (
-          shown.slice(0, 60).map((asset) => (
+          visible.map((asset) => (
             <button
               className="ve-bin-item"
               key={asset.id}
@@ -56,6 +64,21 @@ export function MediaBin({ assets = [], onAddToTrack, onPreview }) {
           ))
         )}
       </div>
+      {shown.length > MEDIA_PAGE_SIZE ? (
+        <div className="ve-bin-more">
+          <span aria-live="polite">
+            Showing {visible.length} of {shown.length}
+          </span>
+          {visible.length < shown.length ? (
+            <button
+              onClick={() => setVisibleCount((count) => count + MEDIA_PAGE_SIZE)}
+              type="button"
+            >
+              Show more
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/editor/editorThumbnails.test.jsx
+++ b/apps/web/src/components/editor/editorThumbnails.test.jsx
@@ -46,6 +46,26 @@ describe("editor thumbnail surfaces (sc-13632)", () => {
     expect(onAddToTrack).toHaveBeenCalledWith(videoAsset);
   });
 
+  it("makes the MediaBin cap visible and lets users reveal the remaining assets", async () => {
+    const assets = Array.from({ length: 61 }, (_, index) => ({
+      ...videoAsset,
+      id: `video-${index}`,
+      displayName: `Clip ${index}`,
+    }));
+    await act(() => root.render(<MediaBin assets={assets} />));
+
+    expect(container.querySelectorAll(".ve-bin-item")).toHaveLength(60);
+    expect(container.textContent).toContain("Showing 60 of 61");
+
+    const showMore = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Show more",
+    );
+    await act(() => showMore.click());
+
+    expect(container.querySelectorAll(".ve-bin-item")).toHaveLength(61);
+    expect(container.textContent).toContain("Showing 61 of 61");
+  });
+
   it("renders video posters in StoryboardStrip without mounting full video media", async () => {
     const clip = {
       id: "clip-1",

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   SCHEME_LABELS,
   loadCredentials,
@@ -98,6 +98,7 @@ export function SettingsScreen({
   // origin-keyed localStorage. Seeded here from the cache (App.jsx re-primes it from the server on launch);
   // q8 by default.
   const [defaultQuality, setDefaultQuality] = useState(readDefaultGenerationQuality);
+  const defaultQualityRequest = useRef(0);
 
   const refresh = useCallback(async () => {
     try {
@@ -218,14 +219,29 @@ export function SettingsScreen({
   // 127.0.0.1:<port> origin changes each launch, wiping origin-keyed localStorage). Same contract as
   // theme/accent in App.jsx — the endpoint MERGES, so sending only this field can't disturb theme/accent.
   // Token is "" because ui-preferences is a public route (like /health); mirrors App.jsx's PUT.
-  function changeDefaultQuality(value) {
+  async function changeDefaultQuality(value) {
+    const request = defaultQualityRequest.current + 1;
+    defaultQualityRequest.current = request;
+    const previous = defaultQuality;
     const next = writeDefaultGenerationQuality(value);
     setDefaultQuality(next);
-    apiFetch("/api/v1/ui-preferences", "", {
-      method: "PUT",
-      body: JSON.stringify({ defaultGenerationQuality: next }),
-    }).catch(() => {});
-    setStatus(`Default generation quality set to ${generationQualityLabel(next)}.`);
+    try {
+      await apiFetch("/api/v1/ui-preferences", "", {
+        method: "PUT",
+        body: JSON.stringify({ defaultGenerationQuality: next }),
+      });
+      if (defaultQualityRequest.current === request) {
+        setStatus(`Default generation quality set to ${generationQualityLabel(next)}.`);
+      }
+    } catch (error) {
+      // An older request may finish after a newer click. Only the latest operation owns the
+      // optimistic cache/state; a stale failure must not roll back a newer successful choice.
+      if (defaultQualityRequest.current === request) {
+        writeDefaultGenerationQuality(previous);
+        setDefaultQuality(previous);
+        setStatus(`Could not save default generation quality: ${String(error)}`);
+      }
+    }
   }
 
   async function restartWorker() {

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -546,6 +546,50 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
     );
   });
 
+  it("rolls back the optimistic cache and reports a failed durable preference write", async () => {
+    apiFetch.mockImplementation(async (path, _token, options) => {
+      if (path === "/api/v1/ui-preferences" && options?.method === "PUT") {
+        throw new Error("disk full");
+      }
+      return [];
+    });
+    await render();
+    await chooseQuality("Q4");
+    expect(selectedQuality().textContent.trim()).toBe("Auto");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("auto");
+    expect(container.textContent).toContain("Could not save default generation quality");
+    expect(container.textContent).not.toContain("Default generation quality set to");
+  });
+
+  it("does not let an older failed PUT roll back a newer successful quality choice", async () => {
+    const writes = [];
+    apiFetch.mockImplementation((path, _token, options) => {
+      if (path === "/api/v1/ui-preferences" && options?.method === "PUT") {
+        return new Promise((resolve, reject) => writes.push({ resolve, reject }));
+      }
+      return Promise.resolve([]);
+    });
+    await render();
+
+    await chooseQuality("Q4");
+    await chooseQuality("bf16");
+    expect(writes).toHaveLength(2);
+
+    await act(async () => {
+      writes[1].resolve({});
+      await Promise.resolve();
+    });
+    await act(async () => {
+      writes[0].reject(new Error("older disk failure"));
+      await Promise.resolve();
+    });
+
+    expect(selectedQuality().textContent.trim()).toBe("bf16");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("bf16");
+    expect(container.textContent).toContain("Default generation quality set to High fidelity (bf16)");
+    expect(container.textContent).not.toContain("older disk failure");
+  });
+
   it("seeds the control from the instant-paint cache on mount (cache round-trip)", async () => {
     // App.jsx re-primes this cache from the durable server copy on launch (covered in App.shell.test.jsx);
     // here we assert the control reflects whatever the cache holds on mount.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -10094,6 +10094,18 @@ details[open] > summary.lora-scope-group-heading::before,
   text-align: center;
   padding: 20px 0;
 }
+.ve-bin-more {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  color: var(--text-faint);
+  display: flex;
+  font-size: 11px;
+  justify-content: space-between;
+  padding: 8px 10px;
+}
+.ve-bin-more button {
+  min-height: 28px;
+}
 .ve-bin-item {
   position: relative;
   aspect-ratio: 16 / 10;

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -235,6 +235,22 @@ impl std::fmt::Display for JobsStoreError {
 
 impl std::error::Error for JobsStoreError {}
 
+impl JobsStoreError {
+    /// Machine-readable SQLite lock classification for the API/worker retry seam. Do not make
+    /// callers parse rusqlite's rendered wording: SQLite exposes both BUSY and LOCKED as stable
+    /// result codes, while their human messages are not an API contract.
+    pub fn is_database_locked(&self) -> bool {
+        matches!(
+            self,
+            Self::Sqlite(error)
+                if matches!(
+                    error.sqlite_error_code(),
+                    Some(rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked)
+                )
+        )
+    }
+}
+
 impl From<std::io::Error> for JobsStoreError {
     fn from(error: std::io::Error) -> Self {
         Self::Io(error)
@@ -449,6 +465,8 @@ impl JobsStore {
               on jobs(status, created_at);
             create index if not exists idx_jobs_project_created
               on jobs(project_id, created_at);
+            create index if not exists idx_jobs_created
+              on jobs(created_at);
             create index if not exists idx_jobs_assigned_gpu_status
               on jobs(assigned_gpu, status);
             create index if not exists idx_jobs_worker_status
@@ -598,6 +616,8 @@ impl JobsStore {
                where 0;
             create unique index if not exists idx_genmetrics_history_job
               on generation_metrics_history(job_id);
+            create index if not exists idx_genmetrics_history_created
+              on generation_metrics_history(j_created_at);
             ",
         )?;
         transaction.commit()?;
@@ -1827,10 +1847,9 @@ impl JobsStore {
     /// queued past the grace window when no live candle worker exists, terminal with
     /// `candle_unavailable` — so a deployment can fail loudly instead of queuing forever.
     ///
-    /// "Live candle worker" = a worker advertising the `candle` marker capability that is not
-    /// offline and has a heartbeat within `grace_seconds` (the marker is a fixed JSON string in
-    /// `capabilities_json`, matched as a substring — the candle worker runs on a real CUDA gpu
-    /// index, not the `mlx` sentinel, so it can't be matched by `gpu_id`; see [`worker_is_candle`]).
+    /// "Live candle worker" = a worker advertising the exact `candle` marker capability that is not
+    /// offline and has a heartbeat within `grace_seconds`. Capabilities are decoded through the same
+    /// typed parser as [`row_to_worker`], rather than substring-matching JSON.
     /// While one exists (even merely busy) this is a no-op and candle-eligible jobs wait, so a
     /// transient candle crash the supervisor restarts inside the window never fails a job. Off
     /// (`!candle_required`) it returns immediately, leaving normal capability routing unaffected.
@@ -1854,20 +1873,21 @@ impl JobsStore {
         // A live candle worker means candle-eligible jobs should wait for it — it may simply be
         // busy. Only when none has checked in within the window do we treat candle as unavailable
         // and fail the stranded jobs.
-        let live_candle_worker = transaction
-            .query_row(
+        let live_candle_worker = {
+            let mut statement = transaction.prepare(
                 "
-                select 1 from workers
+                select capabilities_json from workers
                  where status != 'offline'
                    and last_seen_at >= ?1
-                   and capabilities_json like '%\"candle\"%'
-                 limit 1
                 ",
-                params![cutoff],
-                |_row| Ok(()),
-            )
-            .optional()?
-            .is_some();
+            )?;
+            let capabilities = statement
+                .query_map(params![cutoff], |row| row.get::<_, String>(0))?
+                .collect::<Result<Vec<_>, _>>()?;
+            capabilities
+                .iter()
+                .any(|encoded| encoded_worker_has_capability(encoded, "candle"))
+        };
         if live_candle_worker {
             return Ok(Vec::new());
         }
@@ -3158,6 +3178,12 @@ where
     value
         .and_then(|text| serde_json::from_str::<Vec<T>>(text).ok())
         .unwrap_or_default()
+}
+
+fn encoded_worker_has_capability(encoded: &str, expected: &str) -> bool {
+    loads_vec::<WorkerCapability>(Some(encoded))
+        .iter()
+        .any(|capability| capability.as_str() == expected)
 }
 
 fn loads_optional<T>(value: Option<&str>) -> Option<T>

--- a/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
@@ -75,6 +75,22 @@ const CANDLE_CAPS: &[&str] = &["gpu", "image_generate", "image_edit", "candle"];
 const TORCH_CAPS: &[&str] = &["gpu", "image_generate", "image_edit", "image_detail"];
 
 #[test]
+fn candle_marker_detection_parses_exact_capability_membership() {
+    assert!(encoded_worker_has_capability(
+        r#"["gpu","image_generate","candle"]"#,
+        "candle"
+    ));
+    assert!(!encoded_worker_has_capability(
+        r#"["gpu","image_generate","not-candle"]"#,
+        "candle"
+    ));
+    assert!(!encoded_worker_has_capability(
+        r#"{"capabilities":["candle"]}"#,
+        "candle"
+    ));
+}
+
+#[test]
 fn candle_pose_model_catalog_matches_control_routes() {
     let mut routed = candle_pose_route_models();
     routed.sort_unstable();

--- a/crates/sceneworks-core/src/jobs_store/tests/connection_pool_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/connection_pool_tests.rs
@@ -70,3 +70,30 @@ fn write_connection_is_reused_across_calls() {
         "the connection-scoped temp table persists → same long-lived connection reused"
     );
 }
+
+#[test]
+fn generation_stats_created_at_sort_keys_are_indexed() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let store = JobsStore::new(dir.path().join("jobs.db"));
+    store.initialize().expect("store initializes");
+    let connection = store.open_connection().expect("read connection");
+
+    let index_exists = |table: &str, index: &str| {
+        let mut statement = connection
+            .prepare(&format!("pragma index_list({table})"))
+            .expect("index list prepares");
+        statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("index list reads")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("index names decode")
+            .iter()
+            .any(|name| name == index)
+    };
+
+    assert!(index_exists("jobs", "idx_jobs_created"));
+    assert!(index_exists(
+        "generation_metrics_history",
+        "idx_genmetrics_history_created"
+    ));
+}

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1158,6 +1158,17 @@ impl ProjectStore {
         include_trashed: bool,
         scope: AssetScope,
     ) -> ProjectStoreResult<Vec<Value>> {
+        self.list_assets_filtered(project_id, include_rejected, include_trashed, scope, None)
+    }
+
+    fn list_assets_filtered(
+        &self,
+        project_id: &str,
+        include_rejected: bool,
+        include_trashed: bool,
+        scope: AssetScope,
+        asset_type: Option<&str>,
+    ) -> ProjectStoreResult<Vec<Value>> {
         let project_path = self.find_project_path(project_id)?;
         ensure_project_db_ready(&project_path)?;
         let total = {
@@ -1194,21 +1205,25 @@ impl ProjectStore {
               from assets
              where (?1 or rejected = 0)
                and (?2 or trashed = 0)
+               and (?3 is null or type = ?3)
                {origin_filter}
              order by created_at desc
             "
         ))?;
         let rows = statement
-            .query_map(params![include_rejected, include_trashed], |row| {
-                Ok((
-                    row.get::<_, Option<String>>(0)?,
-                    row.get::<_, Option<String>>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                    row.get::<_, Option<u64>>(3)?,
-                    row.get::<_, Option<String>>(4)?,
-                    row.get::<_, Option<String>>(5)?,
-                ))
-            })?
+            .query_map(
+                params![include_rejected, include_trashed, asset_type],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, Option<u64>>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                    ))
+                },
+            )?
             .collect::<Result<Vec<_>, _>>()?;
         drop(statement);
         // HashSet dedup (was an O(n²) Vec linear scan) and a per-call
@@ -2195,13 +2210,14 @@ impl ProjectStore {
 
     fn list_user_keypoint_presets(&self) -> ProjectStoreResult<Vec<Value>> {
         self.ensure_global_keypoints_project()?;
-        let assets =
-            self.list_assets(GLOBAL_KEYPOINTS_PROJECT_ID, false, false, AssetScope::All)?;
-        Ok(assets
-            .iter()
-            .filter(|asset| asset.get("type").and_then(Value::as_str) == Some("keypoint"))
-            .map(keypoint_asset_to_preset)
-            .collect())
+        let assets = self.list_assets_filtered(
+            GLOBAL_KEYPOINTS_PROJECT_ID,
+            false,
+            false,
+            AssetScope::All,
+            Some("keypoint"),
+        )?;
+        Ok(assets.iter().map(keypoint_asset_to_preset).collect())
     }
 
     /// The set of preset ids a collection may reference: the built-in ids + the user's stored
@@ -7903,6 +7919,34 @@ mod tests {
             [0.43, 0.53],
             [0.58, 0.53]
         ])
+    }
+
+    #[test]
+    fn keypoint_reads_keep_the_asset_type_filter_at_the_sql_seam() {
+        let source = include_str!("project_store.rs");
+        let list = source
+            .split_once("fn list_assets_filtered(")
+            .expect("filtered asset query")
+            .1
+            .split_once("pub fn get_asset(")
+            .expect("end of asset listing")
+            .0;
+        assert!(
+            list.contains("and (?3 is null or type = ?3)"),
+            "the shared asset reader must push its optional type filter into SQLite"
+        );
+        let keypoints = source
+            .split_once("fn list_user_keypoint_presets(")
+            .expect("keypoint reader")
+            .1
+            .split_once("fn known_preset_ids(")
+            .expect("end of keypoint reader")
+            .0;
+        assert!(keypoints.contains("Some(\"keypoint\")"));
+        assert!(
+            !keypoints.contains(".filter("),
+            "keypoint reads must not fetch every asset and filter in Rust"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/session_log.rs
+++ b/crates/sceneworks-core/src/session_log.rs
@@ -193,9 +193,11 @@ fn redact_json_marker_value(output: String, key: &str) -> String {
 }
 
 fn redact_marker_value(mut output: String, marker: &str, terminators: &[char]) -> String {
+    // ASCII case folding preserves UTF-8 byte offsets. Keep one parallel search buffer and update
+    // only each replacement span instead of allocating/lowercasing the full line per occurrence.
+    let mut lowered = output.to_ascii_lowercase();
     let mut search_from = 0;
     loop {
-        let lowered = output.to_ascii_lowercase();
         let Some(relative_start) = lowered[search_from..].find(marker) else {
             return output;
         };
@@ -217,14 +219,15 @@ fn redact_marker_value(mut output: String, marker: &str, terminators: &[char]) -
             continue;
         }
         output.replace_range(value_start..value_end, "[REDACTED]");
+        lowered.replace_range(value_start..value_end, "[redacted]");
         search_from = value_start + "[REDACTED]".len();
     }
 }
 
 fn redact_authorization_header(mut output: String) -> String {
+    let mut lowered = output.to_ascii_lowercase();
     let mut search_from = 0;
     loop {
-        let lowered = output.to_ascii_lowercase();
         let Some(relative_start) = lowered[search_from..].find("authorization:") else {
             return output;
         };
@@ -263,6 +266,7 @@ fn redact_authorization_header(mut output: String) -> String {
             continue;
         }
         output.replace_range(value_start..value_end, "[REDACTED]");
+        lowered.replace_range(value_start..value_end, "[redacted]");
         search_from = value_start + "[REDACTED]".len();
     }
 }

--- a/crates/sceneworks-worker/src/api_client.rs
+++ b/crates/sceneworks-worker/src/api_client.rs
@@ -76,11 +76,27 @@ where
 {
     let status = response.status();
     if !status.is_success() {
-        let detail = response
+        let body = response
             .text()
             .await
             .unwrap_or_else(|_| "request failed".to_owned());
-        return Err(WorkerError::Api { status, detail });
+        let envelope = serde_json::from_str::<Value>(&body).ok();
+        let detail = envelope
+            .as_ref()
+            .and_then(|value| value.get("detail"))
+            .and_then(Value::as_str)
+            .unwrap_or(&body)
+            .to_owned();
+        let code = envelope
+            .as_ref()
+            .and_then(|value| value.get("code"))
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        return Err(WorkerError::Api {
+            status,
+            detail,
+            code,
+        });
     }
     Ok(response.json::<T>().await?)
 }

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -50,6 +50,7 @@ fn classify_audio_synthesis_error(context: &str, error: gen_core::Error) -> Work
 struct AudioRequest {
     project_id: String,
     model: String,
+    model_provided: bool,
     prompt: String,
     voice: Option<String>,
     language: Option<String>,
@@ -95,8 +96,9 @@ struct AudioRequest {
     /// path. `None` ⇒ an ordinary Speech/SFX/Music generation.
     reference_audio_asset_id: Option<String>,
     /// Voice Clone base TTS model id (the "content" generator whose speech OpenVoice re-timbres). The API
-    /// injects its manifest entry as `baseModelManifestEntry`. Defaults to Kokoro (`kokoro_82m`).
+    /// injects its manifest entry as `baseModelManifestEntry`.
     base_model: String,
+    base_model_provided: bool,
     /// Voice Clone match strength — overrides OpenVoice V2's posterior-sampling temperature τ (rides
     /// `AudioTransformRequest::strength`). `None` ⇒ the converter's own default (τ = 0.3).
     match_strength: Option<f32>,
@@ -178,9 +180,12 @@ impl AudioRequest {
                 .filter(|value| !value.is_empty())
                 .map(str::to_owned)
         };
+        let model = string("model");
+        let base_model = string("baseModel");
         Self {
             project_id: string("projectId").unwrap_or_default(),
-            model: string("model").unwrap_or_else(|| "kokoro_82m".to_owned()),
+            model_provided: model.is_some(),
+            model: model.unwrap_or_else(|| "kokoro_82m".to_owned()),
             prompt: payload
                 .get("prompt")
                 .and_then(Value::as_str)
@@ -233,7 +238,8 @@ impl AudioRequest {
                 .and_then(Value::as_f64)
                 .map(|value| value as f32),
             reference_audio_asset_id: string("referenceAudioAssetId"),
-            base_model: string("baseModel").unwrap_or_else(|| "kokoro_82m".to_owned()),
+            base_model_provided: base_model.is_some(),
+            base_model: base_model.unwrap_or_else(|| "kokoro_82m".to_owned()),
             match_strength: payload
                 .get("matchStrength")
                 .and_then(Value::as_f64)
@@ -405,6 +411,9 @@ fn audio_preflight(request: &AudioRequest) -> WorkerResult<()> {
         return Err(WorkerError::InvalidPayload(
             "projectId is required.".to_owned(),
         ));
+    }
+    if !request.model_provided {
+        return Err(WorkerError::InvalidPayload("model is required.".to_owned()));
     }
     // A single-voice request needs a prompt; a multi-speaker request (sc-13676) carries its text in
     // the `script` instead, so one of the two must be present. `script` is `None` for every
@@ -882,6 +891,11 @@ fn resolve_voice_clone_plan(
     request: &AudioRequest,
     project_path: &Path,
 ) -> WorkerResult<VoiceClonePlan> {
+    if !request.base_model_provided {
+        return Err(WorkerError::InvalidPayload(
+            "baseModel is required for converter-based voice cloning.".to_owned(),
+        ));
+    }
     let base_model_dir = resolve_audio_model_dir_for(
         settings,
         &request.base_model_manifest_entry,
@@ -1625,6 +1639,14 @@ mod tests {
         assert!(audio_preflight(&no_project).is_err());
         let no_prompt = AudioRequest::from_payload(&payload(json!({ "prompt": "   " })));
         assert!(audio_preflight(&no_prompt).is_err());
+
+        let mut no_model_payload = payload(json!({}));
+        no_model_payload.remove("model");
+        let no_model = AudioRequest::from_payload(&no_model_payload);
+        assert!(matches!(
+            audio_preflight(&no_model),
+            Err(WorkerError::InvalidPayload(message)) if message == "model is required."
+        ));
     }
 
     #[test]
@@ -1969,13 +1991,24 @@ mod tests {
         assert!(request.is_voice_clone());
         assert_eq!(request.mode(), "voice_clone");
 
-        // A base model defaults to Kokoro when the payload omits it.
+        // Parsing retains the legacy value for replay helpers, but the converter-plan resolver rejects
+        // the omission so a direct worker payload can never silently select Kokoro.
         let defaulted = AudioRequest::from_payload(&payload(json!({
             "model": "openvoice_v2",
             "referenceAudioAssetId": "ref-voice-1",
         })));
         assert_eq!(defaulted.base_model, "kokoro_82m");
         assert!(defaulted.is_voice_clone());
+        assert!(audio_preflight(&defaulted).is_ok());
+        assert!(matches!(
+            resolve_voice_clone_plan(
+                &Settings::from_env(),
+                &defaulted,
+                Path::new("/unused-project"),
+            ),
+            Err(WorkerError::InvalidPayload(message))
+                if message == "baseModel is required for converter-based voice cloning."
+        ));
 
         // No reference ⇒ an ordinary (non-voice-clone) run: a blank/whitespace id does not route.
         let none = AudioRequest::from_payload(&payload(json!({ "model": "kokoro_82m" })));
@@ -2056,6 +2089,7 @@ mod tests {
             "referenceAudioAssetId": "ref-voice-1",
             "seed": 9,
         })));
+        assert!(audio_preflight(&request).is_ok());
         let plan = AudioPlan::new(&request, Path::new("/tmp/project"));
         let fact = audio_asset_fact(
             &plan, &request, 24_000, 1, 4.0, /* native_clone */ true,

--- a/crates/sceneworks-worker/src/error.rs
+++ b/crates/sceneworks-worker/src/error.rs
@@ -7,7 +7,11 @@ pub enum WorkerError {
     Io(std::io::Error),
     Json(serde_json::Error),
     ProjectStore(ProjectStoreError),
-    Api { status: StatusCode, detail: String },
+    Api {
+        status: StatusCode,
+        detail: String,
+        code: Option<String>,
+    },
     InvalidPayload(String),
     Engine(String),
     Canceled(String),
@@ -20,7 +24,14 @@ impl fmt::Display for WorkerError {
             Self::Io(error) => write!(formatter, "{error}"),
             Self::Json(error) => write!(formatter, "{error}"),
             Self::ProjectStore(error) => write!(formatter, "{error}"),
-            Self::Api { status, detail } => write!(formatter, "API {status}: {detail}"),
+            Self::Api {
+                status,
+                detail,
+                code,
+            } => match code {
+                Some(code) => write!(formatter, "API {status} ({code}): {detail}"),
+                None => write!(formatter, "API {status}: {detail}"),
+            },
             Self::InvalidPayload(detail) => formatter.write_str(detail),
             Self::Engine(detail) => formatter.write_str(detail),
             Self::Canceled(detail) => formatter.write_str(detail),

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -58,6 +58,14 @@ use uuid::Uuid;
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod advanced;
 mod api_client;
+// Shared one-child PNG persistence for upscale (Mac + candle) and smart-select (Mac).
+// Keep the include site on the callers' superset so the neither-backend lane does not
+// compile an otherwise dead helper.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+mod single_child_asset;
 // Lazy, on-demand download-credential pull from the macOS desktop credential socket
 // (sc-5891). Compiles on all targets; the socket I/O is `cfg(unix)` and inert unless
 // the desktop injects `SCENEWORKS_CRED_IPC_*`, so server/Docker/Windows are unaffected.
@@ -1056,14 +1064,14 @@ async fn run_job_with_shutdown(
     JobOutcome::ShutdownDuringJob
 }
 
-/// True when an error ultimately stems from SQLite reporting the jobs database as locked.
-/// The claim travels worker→API→store, so a lock surfaces as an `Api { detail }` whose
-/// message embeds the SQLite text; match on the rendered string rather than a typed variant.
+/// True when the API reports SQLite's typed BUSY/LOCKED class for the jobs database.
 fn is_database_locked(error: &WorkerError) -> bool {
-    error
-        .to_string()
-        .to_ascii_lowercase()
-        .contains("database is locked")
+    matches!(
+        error,
+        WorkerError::Api {
+            code: Some(code), ..
+        } if code == "database_locked"
+    )
 }
 
 async fn register_worker_with_retry(

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1060,6 +1060,13 @@ enum Sd3Variant {
     Medium,
 }
 
+fn unknown_converter_error(model_id: &str, converter: &str) -> ConvertPlanError {
+    ConvertPlanError {
+        message: "Unknown MLX converter.",
+        detail: format!("Unrecognized mlx.converter '{converter}' for {model_id}."),
+    }
+}
+
 /// Resolve the native [`ConvertPlan`] for a convert job from its `converter` discriminator, or a
 /// [`ConvertPlanError`] naming why it can't proceed (missing source file, base model not installed,
 /// unknown converter, …). Split out of [`run_model_convert_job`] (sc-8921, F-119): the converter-arm
@@ -1086,10 +1093,7 @@ async fn resolve_convert_plan(
     // the exact drift that shipped as sc-10573 (`ltx_video` handled here but missing from the gate).
     // The empty ("" = no converter configured) case still falls through to its own arm below.
     if !converter.is_empty() && !NATIVE_CONVERTERS.contains(&converter) {
-        return Ok(Err(ConvertPlanError {
-            message: "Unknown MLX converter.",
-            detail: format!("Unrecognized mlx.converter '{converter}' for {model_id}."),
-        }));
+        return Ok(Err(unknown_converter_error(model_id, converter)));
     }
     let plan = match converter {
         "flux2_klein_diffusers" => {
@@ -1255,10 +1259,9 @@ async fn resolve_convert_plan(
             }));
         }
         other => {
-            return Ok(Err(ConvertPlanError {
-                message: "Unknown MLX converter.",
-                detail: format!("Unrecognized mlx.converter '{other}' for {model_id}."),
-            }));
+            // The registry precheck above makes this defensive arm unreachable for production
+            // inputs. Keep one shared error constructor so the guard and fallback cannot drift.
+            return Ok(Err(unknown_converter_error(model_id, other)));
         }
     };
     Ok(Ok(plan))
@@ -1827,112 +1830,143 @@ pub(crate) fn huggingface_receipt_weights_dir(
     variant: Option<&str>,
 ) -> Option<PathBuf> {
     let models_dir = data_dir.join("models");
-    let mut markers = Vec::new();
-    markers.push(
-        models_dir
-            .join(safe_download_dir(repo))
-            .join(INSTALL_MARKER),
-    );
+    let repo_marker = models_dir
+        .join(safe_download_dir(repo))
+        .join(INSTALL_MARKER);
+    let mut targeted = vec![repo_marker];
     if let Some(model_id) = model_id {
-        markers.push(
+        targeted.push(
             models_dir
                 .join(safe_download_dir(model_id))
                 .join(INSTALL_MARKER),
         );
     }
-    if let Ok(entries) = std::fs::read_dir(&models_dir) {
-        markers.extend(
-            entries
-                .flatten()
-                .map(|entry| entry.path().join(INSTALL_MARKER)),
-        );
-    }
-    markers.sort();
-    markers.dedup();
+    targeted.dedup();
 
-    for marker in markers {
-        let Ok(bytes) = std::fs::read(marker) else {
-            continue;
-        };
-        let Ok(top) = serde_json::from_slice::<Value>(&bytes) else {
-            continue;
-        };
-        let receipts = top
-            .get("receipts")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_else(|| vec![top]);
-        for receipt in receipts {
-            if receipt.get("repo").and_then(Value::as_str) != Some(repo) {
-                continue;
-            }
-            if let Some(model_id) = model_id {
-                if receipt
-                    .get("modelId")
-                    .and_then(Value::as_str)
-                    .is_some_and(|id| id != model_id)
-                {
-                    continue;
-                }
-            }
-            if let Some(variant) = variant {
-                if receipt.get("variant").and_then(Value::as_str) != Some(variant) {
-                    continue;
-                }
-            }
-            let files = receipt
-                .get("resolvedFiles")
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-                .filter_map(Value::as_str)
-                .collect::<Vec<_>>();
-            if files.is_empty() {
-                continue;
-            }
-            let repo_dir = huggingface_repo_cache_path(data_dir, repo)?;
-            let snapshots = repo_dir.join("snapshots");
-            let Ok(snapshot_entries) = std::fs::read_dir(&snapshots) else {
-                continue;
-            };
-            let recorded_revision = receipt
-                .get("snapshotRevision")
-                .and_then(Value::as_str)
-                .map(str::trim)
-                .filter(|revision| !revision.is_empty());
-            let matching = snapshot_entries
-                .flatten()
-                .map(|entry| entry.path())
-                .filter(|snapshot| {
-                    snapshot.is_dir() && files.iter().all(|file| snapshot.join(file).is_file())
-                })
-                .filter(|snapshot| {
-                    recorded_revision.map_or(true, |revision| {
-                        snapshot.file_name().and_then(|name| name.to_str()) == Some(revision)
-                    })
-                })
-                .collect::<Vec<_>>();
-            // Schema-v2 receipts written before snapshotRevision are accepted only when their exact
-            // file set identifies one revision unambiguously. Never guess by filesystem order.
-            if recorded_revision.is_none() && matching.len() != 1 {
-                continue;
-            }
-            if let Some(snapshot) = matching.into_iter().next() {
-                // Tier receipts are self-contained below a tier directory.  Only descend when every
-                // file belongs to that same recorded tier; otherwise return the snapshot root for a
-                // single-variant/whole-repo install.
-                if let Some(variant) = receipt.get("variant").and_then(Value::as_str) {
-                    let tier = snapshot.join(variant);
-                    let prefix = format!("{variant}/");
-                    if files.iter().all(|file| file.starts_with(&prefix)) && tier.is_dir() {
-                        return Some(tier);
-                    }
-                }
-                return Some(snapshot);
-            }
+    // The repo/model marker is the overwhelmingly common path. Resolve it before walking every
+    // installed model directory; a targeted hit makes this lookup O(1) in the catalog size.
+    for marker in &targeted {
+        if let Some(weights_dir) =
+            receipt_weights_dir_from_marker(data_dir, marker, repo, model_id, variant)
+        {
+            return Some(weights_dir);
+        }
+    }
+
+    let entries = std::fs::read_dir(&models_dir).ok()?;
+    for marker in entries
+        .flatten()
+        .map(|entry| entry.path().join(INSTALL_MARKER))
+        .filter(|marker| !targeted.contains(marker))
+    {
+        if let Some(weights_dir) =
+            receipt_weights_dir_from_marker(data_dir, &marker, repo, model_id, variant)
+        {
+            return Some(weights_dir);
         }
     }
     None
+}
+
+#[cfg(any(target_os = "macos", feature = "backend-candle", test))]
+fn receipt_weights_dir_from_marker(
+    data_dir: &Path,
+    marker: &Path,
+    repo: &str,
+    model_id: Option<&str>,
+    variant: Option<&str>,
+) -> Option<PathBuf> {
+    #[cfg(test)]
+    RECEIPT_MARKERS_READ.with(|count| count.set(count.get() + 1));
+    let bytes = std::fs::read(marker).ok()?;
+    let top = serde_json::from_slice::<Value>(&bytes).ok()?;
+    let receipts = top
+        .get("receipts")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_else(|| vec![top]);
+    for receipt in receipts {
+        if receipt.get("repo").and_then(Value::as_str) != Some(repo) {
+            continue;
+        }
+        if let Some(model_id) = model_id {
+            if receipt
+                .get("modelId")
+                .and_then(Value::as_str)
+                .is_some_and(|id| id != model_id)
+            {
+                continue;
+            }
+        }
+        if let Some(variant) = variant {
+            if receipt.get("variant").and_then(Value::as_str) != Some(variant) {
+                continue;
+            }
+        }
+        let files = receipt
+            .get("resolvedFiles")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+        if files.is_empty() {
+            continue;
+        }
+        let repo_dir = huggingface_repo_cache_path(data_dir, repo)?;
+        let snapshots = repo_dir.join("snapshots");
+        let snapshot_entries = std::fs::read_dir(&snapshots).ok()?;
+        let recorded_revision = receipt
+            .get("snapshotRevision")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|revision| !revision.is_empty());
+        let matching = snapshot_entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|snapshot| {
+                snapshot.is_dir() && files.iter().all(|file| snapshot.join(file).is_file())
+            })
+            .filter(|snapshot| {
+                recorded_revision.map_or(true, |revision| {
+                    snapshot.file_name().and_then(|name| name.to_str()) == Some(revision)
+                })
+            })
+            .collect::<Vec<_>>();
+        // Schema-v2 receipts written before snapshotRevision are accepted only when their exact
+        // file set identifies one revision unambiguously. Never guess by filesystem order.
+        if recorded_revision.is_none() && matching.len() != 1 {
+            continue;
+        }
+        if let Some(snapshot) = matching.into_iter().next() {
+            // Tier receipts are self-contained below a tier directory. Only descend when every
+            // file belongs to that same recorded tier; otherwise return the snapshot root.
+            if let Some(variant) = receipt.get("variant").and_then(Value::as_str) {
+                let tier = snapshot.join(variant);
+                let prefix = format!("{variant}/");
+                if files.iter().all(|file| file.starts_with(&prefix)) && tier.is_dir() {
+                    return Some(tier);
+                }
+            }
+            return Some(snapshot);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+thread_local! {
+    static RECEIPT_MARKERS_READ: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_receipt_markers_read() {
+    RECEIPT_MARKERS_READ.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn receipt_markers_read() -> usize {
+    RECEIPT_MARKERS_READ.with(std::cell::Cell::get)
 }
 
 fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathBuf> {

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -287,7 +287,9 @@ fn decode(
     let channels = shape[1].max(0) as usize; // 84 = 4 box + 80 classes
     let anchors = shape[2].max(0) as usize; // 8400
     if channels < 5 {
-        return Ok(Vec::new());
+        return Err(WorkerError::Engine(format!(
+            "yolo11m output has {channels} channels, expected at least 5 (box + person score)"
+        )));
     }
     if data.len() < channels.saturating_mul(anchors) {
         return Err(WorkerError::Engine(format!(

--- a/crates/sceneworks-worker/src/person_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/person_jobs/tests.rs
@@ -97,11 +97,12 @@ fn decode_rejects_malformed_output_shape_and_length() {
         matches!(short, Err(WorkerError::Engine(_))),
         "truncated data buffer must be rejected, got {short:?}"
     );
-    // channels < 5 (no person class channel) is a benign "nothing to decode", not an error.
+    // channels < 5 means this is not the detector head we pinned. Treating it as no detections
+    // would hide a mis-pinned export as "no people found".
     let no_person = decode(&[0.0; 8], &[1, 4, 2], &lb, 0.25, 640, 640);
     assert!(
-        matches!(no_person, Ok(ref v) if v.is_empty()),
-        "channels<5 → empty, got {no_person:?}"
+        matches!(no_person, Err(WorkerError::Engine(_))),
+        "channels<5 must be rejected, got {no_person:?}"
     );
 }
 

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -204,13 +204,16 @@ fn yolox_preprocess(img: &RgbImage) -> (Vec<f32>, f32) {
 /// return an `Engine` error instead (sc-8904).
 fn yolox_decode(dets: &[f32], shape: &[i64], ratio: f32) -> WorkerResult<Vec<Box4>> {
     let mut out = Vec::new();
-    if shape.last().copied() != Some(5) {
-        return Ok(out);
-    }
     if shape.len() < 2 {
         return Err(WorkerError::Engine(format!(
             "yolox output rank {} < 2 (expected (…, N, 5))",
             shape.len()
+        )));
+    }
+    if shape.last().copied() != Some(5) {
+        return Err(WorkerError::Engine(format!(
+            "yolox output last dimension {:?}, expected 5 for embedded-NMS detections",
+            shape.last()
         )));
     }
     let n = shape[1].max(0) as usize;
@@ -289,15 +292,20 @@ fn pose_decode(
     simcc_x: &[f32],
     sx_shape: &[i64],
     simcc_y: &[f32],
-    cx: f32,
-    cy: f32,
-    sw: f32,
-    sh: f32,
+    sy_shape: &[i64],
+    crop: (f32, f32, f32, f32),
 ) -> WorkerResult<Vec<[f32; 3]>> {
+    let (cx, cy, sw, sh) = crop;
     if sx_shape.len() < 3 {
         return Err(WorkerError::Engine(format!(
             "rtmw simcc_x rank {} < 3 (expected (1, K, Wx))",
             sx_shape.len()
+        )));
+    }
+    if sy_shape.len() < 3 {
+        return Err(WorkerError::Engine(format!(
+            "rtmw simcc_y rank {} < 3 (expected (1, K, Wy))",
+            sy_shape.len()
         )));
     }
     let k = sx_shape[1].max(0) as usize;
@@ -307,7 +315,18 @@ fn pose_decode(
             "rtmw simcc_x has 0 keypoints".to_owned(),
         ));
     }
-    let wy = simcc_y.len() / k;
+    let y_k = sy_shape[1].max(0) as usize;
+    if y_k != k {
+        return Err(WorkerError::Engine(format!(
+            "rtmw simcc keypoint dimensions disagree: x reports {k}, y reports {y_k}"
+        )));
+    }
+    let wy = sy_shape[2].max(0) as usize;
+    if wx == 0 || wy == 0 {
+        return Err(WorkerError::Engine(format!(
+            "rtmw simcc bins must be non-zero (Wx={wx}, Wy={wy})"
+        )));
+    }
     if simcc_x.len() < k.saturating_mul(wx) || simcc_y.len() < k.saturating_mul(wy) {
         return Err(WorkerError::Engine(format!(
             "rtmw simcc buffers too short: x has {} (needs {}), y has {} (needs {})",
@@ -611,10 +630,8 @@ impl Detector {
                 &pout[xi].1,
                 &pout[xi].0,
                 &pout[yi].1,
-                cx,
-                cy,
-                sw,
-                sh,
+                &pout[yi].0,
+                (cx, cy, sw, sh),
             )?);
         }
         Ok(people)

--- a/crates/sceneworks-worker/src/pose_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/pose_jobs/tests.rs
@@ -110,10 +110,11 @@ fn yolox_decode_embedded_nms_branch() {
     assert_eq!(boxes.len(), 1);
     assert!(approx(boxes[0].x1, 20.0, 1e-6));
     assert!(approx(boxes[0].y2, 80.0, 1e-6));
-    // non-NMS shape (last dim != 5) -> empty (we only ship the embedded-NMS export)
-    assert!(yolox_decode(&[0.0; 85], &[1, 1, 85], 1.0)
-        .expect("non-5 last dim is a benign empty")
-        .is_empty());
+    // A non-NMS head is a mis-pinned export, not a valid "no people" response.
+    assert!(matches!(
+        yolox_decode(&[0.0; 85], &[1, 1, 85], 1.0),
+        Err(WorkerError::Engine(_))
+    ));
 }
 
 #[test]
@@ -140,8 +141,14 @@ fn pose_decode_argmax_and_rescale() {
     sy[2] = 7.0;
     // crop geometry: center (50,60), scale (PW, PH) so px = (loc/2)/PW*PW + x0.
     let (cx, cy, sw, sh) = (50.0f32, 60.0f32, PW as f32, PH as f32);
-    let kp = pose_decode(&sx, &[1, k as i64, wx as i64], &sy, cx, cy, sw, sh)
-        .expect("valid simcc decodes");
+    let kp = pose_decode(
+        &sx,
+        &[1, k as i64, wx as i64],
+        &sy,
+        &[1, k as i64, wy as i64],
+        (cx, cy, sw, sh),
+    )
+    .expect("valid simcc decodes");
     assert_eq!(kp.len(), 1);
     // x: loc 2 -> 2/2=1 ; (1)/PW*sw + (cx - sw/2) = 1 + (50 - PW/2)
     let x0 = cx - sw / 2.0;
@@ -156,8 +163,14 @@ fn pose_decode_argmax_and_rescale() {
 fn pose_decode_negative_value_marks_missing() {
     let sx = vec![-1.0f32; 4];
     let sy = vec![-1.0f32; 4];
-    let kp = pose_decode(&sx, &[1, 1, 4], &sy, 50.0, 60.0, PW as f32, PH as f32)
-        .expect("valid simcc decodes");
+    let kp = pose_decode(
+        &sx,
+        &[1, 1, 4],
+        &sy,
+        &[1, 1, 4],
+        (50.0, 60.0, PW as f32, PH as f32),
+    )
+    .expect("valid simcc decodes");
     // val <= 0 -> loc (-1,-1) -> negative rescaled coords, score <= 0
     assert!(kp[0][2] <= 0.0);
 }
@@ -165,17 +178,47 @@ fn pose_decode_negative_value_marks_missing() {
 #[test]
 fn pose_decode_rejects_malformed_simcc() {
     // Rank < 3 simcc_x shape → Engine error, not an OOB panic on sx_shape[2] (F-102).
-    let rank2 = pose_decode(&[0.0; 4], &[1, 4], &[0.0; 4], 0.0, 0.0, 1.0, 1.0);
+    let rank2 = pose_decode(
+        &[0.0; 4],
+        &[1, 4],
+        &[0.0; 4],
+        &[1, 1, 4],
+        (0.0, 0.0, 1.0, 1.0),
+    );
     assert!(
         matches!(rank2, Err(WorkerError::Engine(_))),
         "rank-2 simcc_x must be rejected, got {rank2:?}"
     );
     // Well-formed rank but simcc_x is shorter than K*Wx → Engine error.
-    let short = pose_decode(&[0.0; 2], &[1, 2, 4], &[0.0; 8], 0.0, 0.0, 1.0, 1.0);
+    let short = pose_decode(
+        &[0.0; 2],
+        &[1, 2, 4],
+        &[0.0; 8],
+        &[1, 2, 4],
+        (0.0, 0.0, 1.0, 1.0),
+    );
     assert!(
         matches!(short, Err(WorkerError::Engine(_))),
         "truncated simcc_x must be rejected, got {short:?}"
     );
+    // A well-sized Y buffer cannot override the reported shape. A mismatched K or a truncated
+    // buffer relative to Wy must fail rather than manufacturing Wy from len/K.
+    let mismatched_k = pose_decode(
+        &[0.0; 8],
+        &[1, 2, 4],
+        &[0.0; 12],
+        &[1, 3, 4],
+        (0.0, 0.0, 1.0, 1.0),
+    );
+    assert!(matches!(mismatched_k, Err(WorkerError::Engine(_))));
+    let short_y = pose_decode(
+        &[0.0; 8],
+        &[1, 2, 4],
+        &[0.0; 6],
+        &[1, 2, 4],
+        (0.0, 0.0, 1.0, 1.0),
+    );
+    assert!(matches!(short_y, Err(WorkerError::Engine(_))));
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -26,9 +26,10 @@ use crate::downloads::DownloadContext;
 use crate::person_segment_sam3::{
     ensure_segmenter_weights, segment_box_blocking, segment_points_blocking,
 };
+use crate::single_child_asset::{write_single_child_asset, SingleChildAssetSpec};
 use crate::{
-    fresh_asset_id, heartbeat, now_rfc3339, progress_payload, run_blocking_with_heartbeat,
-    task_join_error, update_job, ApiClient, Settings, WorkerError, WorkerResult,
+    heartbeat, progress_payload, run_blocking_with_heartbeat, update_job, ApiClient, Settings,
+    WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -346,91 +347,56 @@ pub(crate) async fn run_image_segment_job(
     let mask_image = image::GrayImage::from_raw(src_w, src_h, mask)
         .ok_or_else(|| WorkerError::Engine("smart-select mask buffer size mismatch".to_owned()))?;
 
-    // Write exactly one child asset (the mask PNG) with lineage back to the source, mirroring the
-    // upscale/detail asset-write shape so the API materializes it into `result.assets`.
-    let created_at = now_rfc3339();
-    let generation_set_id = format!("genset_{}", uuid::Uuid::new_v4().simple());
-    let asset_id = fresh_asset_id();
-    let date = &created_at[..10];
-    let suffix: String = asset_id.chars().skip(6).take(8).collect();
-    let filename = format!("{date}_mask_{suffix}.png");
-    let media_rel = format!("assets/images/{generation_set_id}/{filename}");
-    let media_path = project_path.join(&media_rel);
-    if let Some(parent) = media_path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    let tmp_path = media_path.with_extension("tmp.png");
-    // Encode the mask PNG off the async runtime thread (sc-8909 / F-107) so the blocking encode never
-    // stalls the heartbeat.
-    let encode_tmp = tmp_path.clone();
-    tokio::task::spawn_blocking(move || {
-        mask_image
-            .save_with_format(&encode_tmp, image::ImageFormat::Png)
-            .map_err(|e| WorkerError::Io(std::io::Error::other(e)))
-    })
-    .await
-    .map_err(|e| task_join_error("smart-select mask encode task", e))??;
-    tokio::fs::rename(&tmp_path, &media_path)
-        .await
-        .inspect_err(|_| {
-            let _ = std::fs::remove_file(&tmp_path);
-        })?;
-
     let source_name = payload
         .get("displayName")
         .and_then(Value::as_str)
         .map(str::to_owned)
         .or(source_display)
         .unwrap_or_else(|| "Image".to_owned());
-    let fact = json!({
-        "assetId": asset_id,
-        "mediaPath": media_rel,
-        "mimeType": "image/png",
-        "type": "image",
-        "width": src_w,
-        "height": src_h,
-        "normalizedWidth": src_w,
-        "normalizedHeight": src_h,
-        "count": 1,
-        "seed": 0,
-        "displayName": format!("{source_name} (mask)"),
-        "createdAt": created_at.clone(),
-        "mode": "image_segment",
-        "model": "sam3",
-        "adapter": "sam3",
-        "prompt": "",
-        "negativePrompt": "",
-        "loras": [],
-        "stylePreset": "",
-        "sourceAssetId": source_asset_id,
-        "rawAdapterSettings": {
-            "segment": segment_settings,
+    let result = write_single_child_asset(
+        &project_path,
+        image::DynamicImage::ImageLuma8(mask_image),
+        SingleChildAssetSpec {
+            filename_stem: "mask",
+            mode: "image_segment",
+            model: "sam3",
+            adapter: "sam3",
+            encode_label: "smart-select mask encode task",
         },
-        "parents": [source_asset_id],
-        "extra": {
-            "isMask": true,
-            "maskOfAssetId": source_asset_id,
+        |write| {
+            json!({
+                "assetId": write.asset_id,
+                "mediaPath": write.media_path,
+                "mimeType": "image/png",
+                "type": "image",
+                "width": src_w,
+                "height": src_h,
+                "normalizedWidth": src_w,
+                "normalizedHeight": src_h,
+                "count": 1,
+                "seed": 0,
+                "displayName": format!("{source_name} (mask)"),
+                "createdAt": write.created_at,
+                "mode": "image_segment",
+                "model": "sam3",
+                "adapter": "sam3",
+                "prompt": "",
+                "negativePrompt": "",
+                "loras": [],
+                "stylePreset": "",
+                "sourceAssetId": source_asset_id,
+                "rawAdapterSettings": {
+                    "segment": segment_settings,
+                },
+                "parents": [source_asset_id],
+                "extra": {
+                    "isMask": true,
+                    "maskOfAssetId": source_asset_id,
+                },
+            })
         },
-    });
-    let generation_set = json!({
-        "id": generation_set_id,
-        "mode": "image_segment",
-        "model": "sam3",
-        "prompt": "",
-        "negativePrompt": "",
-        "count": 1,
-        "createdAt": created_at,
-    });
-    let mut result = JsonObject::new();
-    result.insert(
-        "generationSetId".to_owned(),
-        Value::String(generation_set_id),
-    );
-    result.insert("expectedCount".to_owned(), json!(1));
-    result.insert("adapter".to_owned(), Value::String("sam3".to_owned()));
-    result.insert("model".to_owned(), Value::String("sam3".to_owned()));
-    result.insert("generationSet".to_owned(), generation_set);
-    result.insert("assetWrites".to_owned(), Value::Array(vec![fact]));
+    )
+    .await?;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/single_child_asset.rs
+++ b/crates/sceneworks-worker/src/single_child_asset.rs
@@ -1,0 +1,140 @@
+use std::path::Path;
+
+use image::DynamicImage;
+use serde_json::{json, Value};
+
+use crate::{fresh_asset_id, now_rfc3339, task_join_error, JsonObject, WorkerError, WorkerResult};
+
+pub(crate) struct SingleChildAssetWrite {
+    pub asset_id: String,
+    pub generation_set_id: String,
+    pub created_at: String,
+    pub media_path: String,
+}
+
+pub(crate) struct SingleChildAssetSpec<'a> {
+    pub filename_stem: &'a str,
+    pub mode: &'a str,
+    pub model: &'a str,
+    pub adapter: &'a str,
+    pub encode_label: &'a str,
+}
+
+/// Persist one PNG child and build the common one-asset generation result. Upscale and smart-select
+/// supply only their domain-specific fact fields; atomic temp-file encoding, ids, generation-set
+/// metadata, and the API result envelope stay identical.
+pub(crate) async fn write_single_child_asset<F>(
+    project_path: &Path,
+    image: DynamicImage,
+    spec: SingleChildAssetSpec<'_>,
+    build_fact: F,
+) -> WorkerResult<JsonObject>
+where
+    F: FnOnce(&SingleChildAssetWrite) -> Value,
+{
+    let created_at = now_rfc3339();
+    let generation_set_id = format!("genset_{}", uuid::Uuid::new_v4().simple());
+    let asset_id = fresh_asset_id();
+    let date = &created_at[..10];
+    let suffix: String = asset_id.chars().skip(6).take(8).collect();
+    let filename = format!("{date}_{}_{suffix}.png", spec.filename_stem);
+    let media_path = format!("assets/images/{generation_set_id}/{filename}");
+    let absolute_path = project_path.join(&media_path);
+    if let Some(parent) = absolute_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp_path = absolute_path.with_extension("tmp.png");
+    let encode_tmp = tmp_path.clone();
+    tokio::task::spawn_blocking(move || {
+        image
+            .save_with_format(&encode_tmp, image::ImageFormat::Png)
+            .map_err(|error| WorkerError::Io(std::io::Error::other(error)))
+    })
+    .await
+    .map_err(|error| task_join_error(spec.encode_label, error))??;
+    tokio::fs::rename(&tmp_path, &absolute_path)
+        .await
+        .inspect_err(|_| {
+            let _ = std::fs::remove_file(&tmp_path);
+        })?;
+
+    let write = SingleChildAssetWrite {
+        asset_id,
+        generation_set_id: generation_set_id.clone(),
+        created_at: created_at.clone(),
+        media_path,
+    };
+    let generation_set = json!({
+        "id": generation_set_id,
+        "mode": spec.mode,
+        "model": spec.model,
+        "prompt": "",
+        "negativePrompt": "",
+        "count": 1,
+        "createdAt": created_at,
+    });
+    let mut result = JsonObject::new();
+    result.insert(
+        "generationSetId".to_owned(),
+        Value::String(write.generation_set_id.clone()),
+    );
+    result.insert("expectedCount".to_owned(), json!(1));
+    result.insert("adapter".to_owned(), Value::String(spec.adapter.to_owned()));
+    result.insert("model".to_owned(), Value::String(spec.model.to_owned()));
+    result.insert("generationSet".to_owned(), generation_set);
+    result.insert(
+        "assetWrites".to_owned(),
+        Value::Array(vec![build_fact(&write)]),
+    );
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn writes_one_png_and_builds_the_shared_result_envelope() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let image =
+            DynamicImage::ImageLuma8(image::GrayImage::from_pixel(1, 1, image::Luma([255])));
+        let result = write_single_child_asset(
+            dir.path(),
+            image,
+            SingleChildAssetSpec {
+                filename_stem: "mask",
+                mode: "image_segment",
+                model: "sam3",
+                adapter: "sam3",
+                encode_label: "test encode",
+            },
+            |write| {
+                json!({
+                    "assetId": write.asset_id,
+                    "mediaPath": write.media_path,
+                    "createdAt": write.created_at,
+                })
+            },
+        )
+        .await
+        .expect("child writes");
+
+        assert_eq!(result["expectedCount"], json!(1));
+        assert_eq!(result["adapter"], "sam3");
+        assert_eq!(
+            result["generationSetId"], result["generationSet"]["id"],
+            "one id feeds result and generation set"
+        );
+        let relative = result["assetWrites"][0]["mediaPath"]
+            .as_str()
+            .expect("media path");
+        assert!(dir.path().join(relative).is_file());
+        assert_eq!(
+            image::open(dir.path().join(relative))
+                .expect("saved png decodes")
+                .color(),
+            image::ColorType::L8,
+            "mask encoding remains grayscale"
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -62,8 +62,8 @@ use super::model_jobs::{
     check_downloaded_model_family, derived_tokenizer_overlay,
     downloaded_model_detection_io_error_is_inconclusive, finalize_converted_dir,
     finalize_converted_dir_with_test_hook, huggingface_receipt_weights_dir,
-    overlay_derived_tokenizer, recover_stranded_model_conversions, validate_hf_download_inputs,
-    DownloadFamilyCheck,
+    overlay_derived_tokenizer, receipt_markers_read, recover_stranded_model_conversions,
+    reset_receipt_markers_read, validate_hf_download_inputs, DownloadFamilyCheck,
 };
 // `terminating_signal` is only exercised by a `#[cfg(unix)]` test (signal-death
 // attribution is uncatchable and only observable on Unix), so gate the import to
@@ -78,13 +78,13 @@ use super::supervisor::{
 use super::{
     allow_pattern_matches, bounded_tail, cancel_requested_peek, cleanup_uploaded_import_source,
     copy_lora_source, fresh_asset_id, heartbeat_while_blocking, import_lora_source_file_as,
-    import_lora_source_path, normalize_app_managed_cache_path, now_rfc3339, parse_credentials_env,
-    resolve_model_convert_output, resolve_model_import_target, safe_download_dir,
-    safe_project_path, value_f64, wait_for_shutdown_latch, wan_moe_pair_filenames,
-    write_model_download_receipt, write_model_install_marker, CredentialScheme, IdleHeartbeat,
-    JsonObject, SafetensorsHeaderError, Settings, WorkerCredential, WorkerError,
-    DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
-    INSTALL_MARKER, MODEL_CONVERSION_BACKUPS_DIR_NAME,
+    import_lora_source_path, is_database_locked, normalize_app_managed_cache_path, now_rfc3339,
+    parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
+    safe_download_dir, safe_project_path, value_f64, wait_for_shutdown_latch,
+    wan_moe_pair_filenames, write_model_download_receipt, write_model_install_marker,
+    CredentialScheme, IdleHeartbeat, JsonObject, SafetensorsHeaderError, Settings,
+    WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
+    DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER, MODEL_CONVERSION_BACKUPS_DIR_NAME,
 };
 
 // HF-CLI input validation, downloaded-model family detection, atomic converted-dir finalize, and the

--- a/crates/sceneworks-worker/src/tests/hf_and_family.rs
+++ b/crates/sceneworks-worker/src/tests/hf_and_family.rs
@@ -1123,9 +1123,23 @@ fn stale_receipt_resolves_exact_old_quant_tier_after_manifest_rename() {
             "resolvedFiles": ["q4/transformer/old-1.safetensors", "q4/transformer/old-2.safetensors", "q4/config.json"]
         })).unwrap(),
     ).unwrap();
+    for index in 0..20 {
+        let unrelated = root
+            .path()
+            .join("models")
+            .join(format!("unrelated-{index}"));
+        std::fs::create_dir_all(&unrelated).unwrap();
+        std::fs::write(unrelated.join(INSTALL_MARKER), b"{}").unwrap();
+    }
 
+    reset_receipt_markers_read();
     let resolved = huggingface_receipt_weights_dir(root.path(), repo, Some("model-id"), Some("q4"));
     assert_eq!(resolved, Some(snapshot.join("q4")));
+    assert_eq!(
+        receipt_markers_read(),
+        1,
+        "a targeted receipt hit must return before scanning unrelated install markers"
+    );
     assert!(!snapshot.join("q4/transformer/new-name.safetensors").exists());
 }
 

--- a/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
+++ b/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
@@ -752,3 +752,22 @@ async fn receipt_writer_preserves_primary_and_corequisite_default_entries() {
     assert!(receipts.iter().any(|entry| entry["modelId"] == "other-model" && entry["resolvedFiles"] == json!(["other.safetensors"])));
     assert!(receipts.iter().any(|entry| entry["variant"] == "q4" && entry["resolvedFiles"] == json!(["q4/model.safetensors"])));
 }
+#[test]
+fn database_lock_retry_uses_only_the_machine_readable_api_code() {
+    let typed = WorkerError::Api {
+        status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        detail: "wording may change".to_owned(),
+        code: Some("database_locked".to_owned()),
+    };
+    assert!(is_database_locked(&typed));
+
+    let wording_only = WorkerError::Api {
+        status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        detail: "database is locked".to_owned(),
+        code: None,
+    };
+    assert!(
+        !is_database_locked(&wording_only),
+        "rendered wording must never be the retry contract"
+    );
+}

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -43,6 +43,7 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use crate::generator_cache::with_cached_generator;
+use crate::single_child_asset::{write_single_child_asset, SingleChildAssetSpec};
 use crate::util::resolve_env_file_pin;
 use gen_core::{
     CancelFlag, Conditioning, GenerationOutput, GenerationRequest, Image as GenImage, LoadSpec,
@@ -61,8 +62,8 @@ use ort::value::Tensor;
 use serde_json::{json, Value};
 
 use crate::{
-    fresh_asset_id, heartbeat, now_rfc3339, progress_payload, resolve_dataset_item_path,
-    safe_project_path, task_join_error, update_job, ApiClient, Settings, WorkerError, WorkerResult,
+    heartbeat, progress_payload, resolve_dataset_item_path, safe_project_path, task_join_error,
+    update_job, ApiClient, Settings, WorkerError, WorkerResult,
 };
 use sceneworks_core::contracts::{JobSnapshot, JobStatus, JsonObject, ProgressStage, WorkerStatus};
 use sceneworks_core::project_store::ProjectStore;
@@ -1109,36 +1110,6 @@ pub(crate) async fn run_image_upscale_job(
     };
     let (out_w, out_h) = (upscaled.width(), upscaled.height());
 
-    // write exactly one child asset with lineage back to the source (mirrors
-    // image_adapters.run_image_upscale).
-    let created_at = now_rfc3339();
-    let generation_set_id = format!("genset_{}", uuid::Uuid::new_v4().simple());
-    let asset_id = fresh_asset_id();
-    let date = &created_at[..10];
-    // filename suffix = asset_id[6:14] (the 8 hex chars after "asset_")
-    let suffix: String = asset_id.chars().skip(6).take(8).collect();
-    let filename = format!("{date}_upscaled_x{factor}_{suffix}.png");
-    let media_rel = format!("assets/images/{generation_set_id}/{filename}");
-    let media_path = project_path.join(&media_rel);
-    if let Some(parent) = media_path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    let tmp_path = media_path.with_extension("tmp.png");
-    // Encode the upscaled PNG off the async runtime thread (sc-8909 / F-107).
-    let encode_tmp = tmp_path.clone();
-    tokio::task::spawn_blocking(move || {
-        upscaled
-            .save_with_format(&encode_tmp, image::ImageFormat::Png)
-            .map_err(|e| WorkerError::Io(std::io::Error::other(e)))
-    })
-    .await
-    .map_err(|e| task_join_error("upscale encode task", e))??;
-    tokio::fs::rename(&tmp_path, &media_path)
-        .await
-        .inspect_err(|_| {
-            let _ = std::fs::remove_file(&tmp_path);
-        })?;
-
     let source_name = payload
         .get("displayName")
         .and_then(Value::as_str)
@@ -1165,55 +1136,50 @@ pub(crate) async fn run_image_upscale_job(
         // upscale result reveals whether the hardware EP ran or it fell back to CPU (sc-8923).
         upscale_settings["device"] = json!(device);
     }
-    let fact = json!({
-        "assetId": asset_id,
-        "mediaPath": media_rel,
-        "mimeType": "image/png",
-        "type": "image",
-        "width": out_w,
-        "height": out_h,
-        "normalizedWidth": out_w,
-        "normalizedHeight": out_h,
-        "count": 1,
-        "seed": seed,
-        "displayName": format!("{source_name} ({factor}x upscaled)"),
-        "createdAt": created_at.clone(),
-        "mode": "image_upscale",
-        "model": engine_id,
-        "adapter": engine_id,
-        "prompt": "",
-        "negativePrompt": "",
-        "loras": [],
-        "stylePreset": "",
-        "sourceAssetId": source_asset_id,
-        "rawAdapterSettings": { "upscale": upscale_settings },
-        "parents": [source_asset_id],
-        "extra": {
-            "isUpscaled": true,
-            "upscaledFromAssetId": source_asset_id,
-            "factor": factor,
-            "engine": engine_id,
+    let result = write_single_child_asset(
+        &project_path,
+        image::DynamicImage::ImageRgb8(upscaled),
+        SingleChildAssetSpec {
+            filename_stem: &format!("upscaled_x{factor}"),
+            mode: "image_upscale",
+            model: engine_id,
+            adapter: engine_id,
+            encode_label: "upscale encode task",
         },
-    });
-    let generation_set = json!({
-        "id": generation_set_id,
-        "mode": "image_upscale",
-        "model": engine_id,
-        "prompt": "",
-        "negativePrompt": "",
-        "count": 1,
-        "createdAt": created_at,
-    });
-    let mut result = JsonObject::new();
-    result.insert(
-        "generationSetId".to_owned(),
-        Value::String(generation_set_id),
-    );
-    result.insert("expectedCount".to_owned(), json!(1));
-    result.insert("adapter".to_owned(), Value::String(engine_id.to_owned()));
-    result.insert("model".to_owned(), Value::String(engine_id.to_owned()));
-    result.insert("generationSet".to_owned(), generation_set);
-    result.insert("assetWrites".to_owned(), Value::Array(vec![fact]));
+        |write| {
+            json!({
+                "assetId": write.asset_id,
+                "mediaPath": write.media_path,
+                "mimeType": "image/png",
+                "type": "image",
+                "width": out_w,
+                "height": out_h,
+                "normalizedWidth": out_w,
+                "normalizedHeight": out_h,
+                "count": 1,
+                "seed": seed,
+                "displayName": format!("{source_name} ({factor}x upscaled)"),
+                "createdAt": write.created_at,
+                "mode": "image_upscale",
+                "model": engine_id,
+                "adapter": engine_id,
+                "prompt": "",
+                "negativePrompt": "",
+                "loras": [],
+                "stylePreset": "",
+                "sourceAssetId": source_asset_id,
+                "rawAdapterSettings": { "upscale": upscale_settings },
+                "parents": [source_asset_id],
+                "extra": {
+                    "isUpscaled": true,
+                    "upscaledFromAssetId": source_asset_id,
+                    "factor": factor,
+                    "engine": engine_id,
+                },
+            })
+        },
+    )
+    .await?;
 
     update_job(
         api,

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -33,8 +33,10 @@ embedded manifest, in ``crates/sceneworks-worker/src/engines.rs`` (the tests
 
 from __future__ import annotations
 
+import copy
 import json
 import re
+from functools import lru_cache
 from pathlib import Path
 
 import jsonschema
@@ -156,9 +158,35 @@ def _strip_jsonc_comments(body: str) -> str:
     return "".join(result)
 
 
-def _load_builtin_models_manifest() -> dict:
-    raw = MANIFEST_PATH.read_text(encoding="utf-8")
+@lru_cache(maxsize=None)
+def _cached_jsonc(path: Path) -> dict:
+    raw = path.read_text(encoding="utf-8")
     return json.loads(_strip_jsonc_comments(raw))
+
+
+@lru_cache(maxsize=None)
+def _cached_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_builtin_models_manifest() -> dict:
+    return copy.deepcopy(_cached_jsonc(MANIFEST_PATH))
+
+
+def _load_schema(path: Path) -> dict:
+    return copy.deepcopy(_cached_json(path))
+
+
+def test_cached_manifest_and_schema_loaders_return_isolated_copies():
+    first_manifest = _load_builtin_models_manifest()
+    original_id = first_manifest["models"][0]["id"]
+    first_manifest["models"][0]["id"] = "mutated"
+    assert _load_builtin_models_manifest()["models"][0]["id"] == original_id
+
+    first_schema = _load_schema(SCHEMA_PATH)
+    original_type = first_schema["type"]
+    first_schema["type"] = "mutated"
+    assert _load_schema(SCHEMA_PATH)["type"] == original_type
 
 
 def test_mage_flow_generation_family_is_pinned_and_complete():
@@ -546,7 +574,7 @@ def test_manifest_model_path_is_only_an_optional_override():
 def test_builtin_models_manifest_satisfies_authoring_schema():
     """sc-12338: the builtin catalog's $schema is an enforced CI contract."""
     manifest = _load_builtin_models_manifest()
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     jsonschema.Draft202012Validator.check_schema(schema)
     errors = sorted(
         jsonschema.Draft202012Validator(schema).iter_errors(manifest),
@@ -562,7 +590,7 @@ def test_builtin_schema_rejects_an_unknown_closed_model_key():
     """Mutation guard: a typo/decorative builtin key must make the CI gate fail."""
     manifest = _load_builtin_models_manifest()
     manifest["models"][0]["recommendded"] = True
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
     assert any("recommendded" in error.message for error in errors)
 
@@ -611,7 +639,7 @@ def _sample_audio_model_entry() -> dict:
 def test_schema_accepts_audio_type_and_audio_sub_block():
     """sc-13401: a `type: "audio"` entry with a populated `audio` sub-block
     validates against the authoring schema (the new sibling of mlx/candle)."""
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     jsonschema.Draft202012Validator.check_schema(schema)
     manifest = {"schemaVersion": 1, "models": [_sample_audio_model_entry()]}
     errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
@@ -624,7 +652,7 @@ def test_schema_accepts_audio_type_and_audio_sub_block():
 def test_schema_rejects_unknown_field_under_audio_sub_block():
     """Mutation guard: the `audio` block is additionalProperties:false, so a typo
     / undeclared field under it must fail validation."""
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     entry = _sample_audio_model_entry()
     entry["audio"]["bogusField"] = True
     manifest = {"schemaVersion": 1, "models": [entry]}
@@ -636,7 +664,7 @@ def test_schema_rejects_unknown_field_under_audio_sub_block():
 
 def test_schema_rejects_audio_voice_without_id():
     """A voice object requires `id` so the picker always has a backend key."""
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     entry = _sample_audio_model_entry()
     entry["audio"]["voices"] = [{"label": "No Id", "gender": "female"}]
     manifest = {"schemaVersion": 1, "models": [entry]}
@@ -661,7 +689,7 @@ def test_schema_rejects_audio_voice_without_id():
 def test_schema_rejects_unknown_model_type():
     """Negative control: the `type` enum still rejects an out-of-set value even
     after `audio` was added, so the enum is not accidentally open."""
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     entry = _sample_audio_model_entry()
     entry["type"] = "hologram"
     manifest = {"schemaVersion": 1, "models": [entry]}
@@ -890,7 +918,7 @@ def test_schema_pins_download_revision_to_a_40hex_sha():
     (the F-029 pin authority), accepting a valid SHA and rejecting a branch/tag/
     short/uppercase/wrong-length value via the `pattern` keyword.
     """
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     jsonschema.Draft202012Validator.check_schema(schema)
     validator = jsonschema.Draft202012Validator(schema)
 
@@ -926,7 +954,7 @@ def test_schema_accepts_a_component_id_on_a_corequisite_download():
     authoring schema constrains it to lowercase snake_case (same shape as a descriptor id), accepting
     a valid id and rejecting capitals / hyphens / a leading digit / empty via the `pattern` keyword.
     """
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     jsonschema.Draft202012Validator.check_schema(schema)
     validator = jsonschema.Draft202012Validator(schema)
 
@@ -970,7 +998,7 @@ def test_schema_rejects_a_component_id_on_a_non_corequisite_download():
     by the `a_required_component_with_no_matching_component_id_is_a_manifest_error` unit test in
     crates/sceneworks-worker/src/model_jobs.rs).
     """
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     jsonschema.Draft202012Validator.check_schema(schema)
     validator = jsonschema.Draft202012Validator(schema)
 
@@ -1041,7 +1069,7 @@ def test_manifest_constraint_contract_registry_is_complete_and_live():
     to reject requests, which is materially different from an accidental dead key.
     """
     manifest = _load_builtin_models_manifest()
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = _load_schema(SCHEMA_PATH)
     model_properties = schema["properties"]["models"]["items"]["properties"]
 
     declared: set[str] = set()
@@ -1477,14 +1505,14 @@ RECIPE_PRESET_SCHEMA_PATH = ROOT / "packages" / "schemas" / "recipe-preset.schem
 
 def _load_jsonc(path: Path) -> dict:
     """Generalization of `_load_builtin_models_manifest` for the sibling catalogs."""
-    return json.loads(_strip_jsonc_comments(path.read_text(encoding="utf-8")))
+    return copy.deepcopy(_cached_jsonc(path))
 
 
 def _schema_errors(manifest: dict, schema_path: Path) -> list:
     """Validate `manifest` against the schema at `schema_path`, returning the
     (path-sorted) validation errors. Also asserts the schema itself is a legal
     Draft 2020-12 document (a broken schema is a silent all-pass otherwise)."""
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_schema(schema_path)
     jsonschema.Draft202012Validator.check_schema(schema)
     return sorted(
         jsonschema.Draft202012Validator(schema).iter_errors(manifest),

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import copy
 import json
 import os
 import re
@@ -8,6 +9,7 @@ import sqlite3
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -64,7 +66,7 @@ def write_updated_snapshots() -> None:
     # Note: because this merge preserves all pre-existing labels, intentionally
     # REMOVING a snapshot must be done by editing snapshots.json manually — a
     # filtered UPDATE_SNAPSHOTS run will never delete stale entries.
-    merged = snapshots()
+    merged = dict(snapshots())
     merged.update(UPDATED_SNAPSHOTS)
     SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
     SNAPSHOT_PATH.write_text(
@@ -288,17 +290,57 @@ def contract_runtimes(tmp_path):
 
 
 def normalize_contract(value: Any, roots: tuple[Path, ...], path: str = "$") -> Any:
+    return _normalize_contract(value, roots, path, {}, {})
+
+
+def _normalize_contract(
+    value: Any,
+    roots: tuple[Path, ...],
+    path: str,
+    normalized_ids: dict[tuple[str, str], str],
+    id_counts: dict[str, int],
+) -> Any:
     if isinstance(value, dict):
-        return {key: normalize_contract(item, roots, f"{path}.{key}") for key, item in sorted(value.items())}
+        return {
+            key: _normalize_contract(
+                item,
+                roots,
+                f"{path}.{key}",
+                normalized_ids,
+                id_counts,
+            )
+            for key, item in sorted(value.items())
+        }
     if isinstance(value, list):
-        return [normalize_contract(item, roots, f"{path}[{index}]") for index, item in enumerate(value)]
+        return [
+            _normalize_contract(
+                item,
+                roots,
+                f"{path}[{index}]",
+                normalized_ids,
+                id_counts,
+            )
+            for index, item in enumerate(value)
+        ]
     if isinstance(value, str):
         normalized = value.replace("\\", "/")
         for root in roots:
             normalized = normalized.replace(str(root).replace("\\", "/"), "<runtime-root>")
         normalized = TIMESTAMP_RE.sub("<timestamp>", normalized)
         normalized = UPLOAD_SUFFIX_RE.sub(r"\1-<upload-suffix>", normalized)
-        normalized = PREFIXED_ID_RE.sub(lambda match: f"{match.group(1)}_fixture", normalized)
+
+        def normalize_id(match: re.Match[str]) -> str:
+            prefix = match.group(1)
+            original = match.group(0)
+            key = (prefix, original)
+            if key not in normalized_ids:
+                ordinal = id_counts.get(prefix, 0) + 1
+                id_counts[prefix] = ordinal
+                suffix = "" if ordinal == 1 else f"_{ordinal}"
+                normalized_ids[key] = f"{prefix}_fixture{suffix}"
+            return normalized_ids[key]
+
+        normalized = PREFIXED_ID_RE.sub(normalize_id, normalized)
         normalized = CLAIM_WORKER_RE.sub("claim-worker-fixture", normalized)
         # The exact JSON parser wording/offset is intentionally ignored; the
         # stable contract is the 422 envelope.
@@ -312,6 +354,24 @@ def normalize_contract(value: Any, roots: tuple[Path, ...], path: str = "$") -> 
     if path.endswith(".loc[1]") and isinstance(value, int):
         return "<json-error-offset>"
     return value
+
+
+def test_normalize_contract_preserves_distinct_id_relationships():
+    normalized = normalize_contract(
+        {
+            "assets": [
+                {"id": "asset_aaaaaaaa", "projectId": "project_11111111"},
+                {"id": "asset_bbbbbbbb", "projectId": "project_11111111"},
+            ],
+            "selectedAssetId": "asset_aaaaaaaa",
+        },
+        (),
+    )
+
+    assert normalized["assets"][0]["id"] == "asset_fixture"
+    assert normalized["assets"][1]["id"] == "asset_fixture_2"
+    assert normalized["selectedAssetId"] == "asset_fixture"
+    assert {asset["projectId"] for asset in normalized["assets"]} == {"project_fixture"}
 
 
 def diff_values(left: Any, right: Any, path: str = "$") -> list[str]:
@@ -371,10 +431,21 @@ def assert_runtime_consistency(
     return normalized_baseline
 
 
-def snapshots() -> dict[str, Any]:
-    if not SNAPSHOT_PATH.exists():
+@lru_cache(maxsize=None)
+def _cached_snapshots(path: Path) -> dict[str, Any]:
+    if not path.exists():
         return {}
-    return json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def snapshots() -> dict[str, Any]:
+    return copy.deepcopy(_cached_snapshots(SNAPSHOT_PATH))
+
+
+def test_cached_snapshots_are_isolated_between_callers():
+    first = snapshots()
+    first["mutation-probe"] = True
+    assert "mutation-probe" not in snapshots()
 
 
 def assert_snapshot(label: str, normalized_value: Any) -> None:


### PR DESCRIPTION
## Summary
- resolve all 17 current-main latent robustness observations across detector validation, typed lock/capability contracts, asset persistence, receipt lookup, database queries, UI state, accessibility, and parity fixtures
- preserve explicitly revalidated nonissues and narrow the implementation to live defects
- add regression coverage for shape failures, lock classification, exact capability membership, persistence races, project refresh failures, focus containment, pagination, indexes, and fixture isolation

## Validation
- core: 599 passed, 1 ignored
- worker: 1,053 passed, 176 ignored
- rust-api: 395 passed, 3 ignored
- web: 2,572 passed
- strict native Clippy, Linux neither-backend Clippy, Candle worker/API typecheck, rustfmt, root checks, web lint/build, and diff checks pass
- changed Python cache and ID-normalization contracts: 3 passed

Independent exact-head review approved commit 204a157f53680529e1ad5dba60589db74ee3f4c9 with no findings.

Shortcut: https://app.shortcut.com/trefry/story/13653