### PR TITLE
fix: close post-review addendum gaps (sc-13842)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1780,6 +1780,24 @@ mod download_receipt_tests {
     // real HF cache when HF_HOME is set. Serialize on the same `HF_ENV_LOCK`; never add a second lock.
     use crate::tests::support::isolate_hf_cache;
 
+    fn builtin_models_entry(model_id: &str) -> Value {
+        let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+            .iter()
+            .find(|(name, _)| *name == "builtin.models.jsonc")
+            .map(|(_, contents)| *contents)
+            .expect("builtin.models.jsonc present");
+        let manifest: Value =
+            serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
+                .expect("builtin.models.jsonc parses");
+        manifest["models"]
+            .as_array()
+            .expect("models array")
+            .iter()
+            .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
+            .cloned()
+            .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
+    }
+
     #[test]
     fn multi_repo_marker_filters_nested_receipts_by_requested_repo() {
         let temp = tempfile::tempdir().unwrap();
@@ -2209,24 +2227,6 @@ mod download_receipt_tests {
     #[test]
     fn mmaudio_install_state_gates_on_all_five_component_co_requisites() {
         let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
-        fn builtin_models_entry(model_id: &str) -> Value {
-            let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
-                .iter()
-                .find(|(name, _)| *name == "builtin.models.jsonc")
-                .map(|(_, contents)| *contents)
-                .expect("builtin.models.jsonc present");
-            let manifest: Value =
-                serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
-                    .expect("builtin.models.jsonc parses");
-            manifest["models"]
-                .as_array()
-                .expect("models array")
-                .iter()
-                .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
-                .cloned()
-                .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
-        }
-
         for model_id in ["mmaudio_small_16k", "mmaudio_large_44k"] {
             let temp = tempfile::tempdir().unwrap();
             let data_dir = temp.path();
@@ -2306,24 +2306,6 @@ mod download_receipt_tests {
     #[test]
     fn moss_tts_install_state_gates_on_the_codec_co_requisite() {
         let _env = isolate_hf_cache(); // seed/resolve under the tempdir, never a dev's real HF cache (sc-13835)
-        fn builtin_models_entry(model_id: &str) -> Value {
-            let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
-                .iter()
-                .find(|(name, _)| *name == "builtin.models.jsonc")
-                .map(|(_, contents)| *contents)
-                .expect("builtin.models.jsonc present");
-            let manifest: Value =
-                serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
-                    .expect("builtin.models.jsonc parses");
-            manifest["models"]
-                .as_array()
-                .expect("models array")
-                .iter()
-                .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
-                .cloned()
-                .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
-        }
-
         for model_id in ["moss_ttsd_v05", "moss_tts_realtime"] {
             let temp = tempfile::tempdir().unwrap();
             let data_dir = temp.path();
@@ -2419,24 +2401,6 @@ mod download_receipt_tests {
     #[test]
     fn sdxl_shared_components_are_candle_only_and_gate_install_state_off_macos() {
         use std::collections::BTreeSet;
-
-        fn builtin_models_entry(model_id: &str) -> Value {
-            let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
-                .iter()
-                .find(|(name, _)| *name == "builtin.models.jsonc")
-                .map(|(_, contents)| *contents)
-                .expect("builtin.models.jsonc present");
-            let manifest: Value =
-                serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
-                    .expect("builtin.models.jsonc parses");
-            manifest["models"]
-                .as_array()
-                .expect("models array")
-                .iter()
-                .find(|entry| entry.get("id").and_then(Value::as_str) == Some(model_id))
-                .cloned()
-                .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
-        }
 
         let want: BTreeSet<String> = ["tokenizer_clip_l", "tokenizer_clip_bigg", "vae_fp16_fix"]
             .iter()

--- a/apps/rust-api/src/saved_voices.rs
+++ b/apps/rust-api/src/saved_voices.rs
@@ -22,6 +22,16 @@ fn map_voice_embed_error(error: VoiceEmbedError) -> ApiError {
     }
 }
 
+fn validated_dedup_threshold(value: Option<f32>) -> Result<f32, ApiError> {
+    let threshold = value.unwrap_or(DEFAULT_VOICE_DEDUP_THRESHOLD);
+    if !threshold.is_finite() || !(0.0..=1.0).contains(&threshold) {
+        return Err(ApiError::bad_request(
+            "dedupThreshold must be a finite number between 0 and 1",
+        ));
+    }
+    Ok(threshold)
+}
+
 pub(crate) async fn list_saved_voices(
     State(state): State<AppState>,
     Path(project_id): Path<String>,
@@ -46,9 +56,7 @@ pub(crate) async fn create_saved_voice(
             "A reference audio asset id is required",
         ));
     }
-    let threshold = payload
-        .dedup_threshold
-        .unwrap_or(DEFAULT_VOICE_DEDUP_THRESHOLD);
+    let threshold = validated_dedup_threshold(payload.dedup_threshold)?;
 
     // 1. Resolve the reference clip to an absolute on-disk path (blocking store call).
     let wav_path = project_call(state.clone(), {
@@ -107,4 +115,23 @@ pub(crate) async fn delete_saved_voice(
         })
         .await?,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_threshold_accepts_default_and_closed_unit_interval_only() {
+        assert_eq!(
+            validated_dedup_threshold(None).expect("default threshold"),
+            DEFAULT_VOICE_DEDUP_THRESHOLD
+        );
+        assert_eq!(validated_dedup_threshold(Some(0.0)).unwrap(), 0.0);
+        assert_eq!(validated_dedup_threshold(Some(1.0)).unwrap(), 1.0);
+
+        for invalid in [-0.01, 1.01, f32::NAN, f32::INFINITY] {
+            assert!(validated_dedup_threshold(Some(invalid)).is_err());
+        }
+    }
 }

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -1450,6 +1450,80 @@ async fn worker_can_register_claim_and_complete_job_through_http() {
     assert_eq!(queue["workers"][0]["status"], "idle");
 }
 
+/// sc-13842: the audio streaming pump may have a Running progress POST already in flight when the
+/// cancel watcher commits terminal Canceled. Hold that nonterminal report immediately before the
+/// authoritative store transition, let Canceled win, then prove the delayed report receives 409
+/// and cannot resurrect the terminal row.
+#[tokio::test]
+async fn in_flight_running_progress_cannot_resurrect_a_canceled_job() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    let (status, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "image_detail",
+            "projectId": "project-1",
+            "payload": { "prompt": "streaming race" },
+            "requestedGpu": "auto"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let job_id = created["id"].as_str().expect("job id").to_owned();
+    claim_job_as_worker(&app, &job_id, "stream-worker", &["image_detail"]).await;
+
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    *state.progress_before_accept_once.lock() = Some(barrier.clone());
+    let progress_app = app.clone();
+    let progress_job_id = job_id.clone();
+    let progress = tokio::spawn(async move {
+        request(
+            progress_app,
+            "POST",
+            &format!("/api/v1/jobs/{progress_job_id}/progress"),
+            json!({
+                "status": "running",
+                "stage": "generating",
+                "progress": 0.5,
+                "message": "Streaming audio…",
+                "workerId": "stream-worker"
+            }),
+        )
+        .await
+    });
+
+    barrier.wait().await;
+    let (cancel_status, canceled) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/progress"),
+        json!({
+            "status": "canceled",
+            "stage": "canceled",
+            "progress": 1,
+            "message": "Canceled by user.",
+            "workerId": "stream-worker"
+        }),
+    )
+    .await;
+    assert_eq!(cancel_status, StatusCode::OK);
+    assert_eq!(canceled["status"], "canceled");
+    barrier.wait().await;
+
+    let (progress_status, _) = progress.await.expect("progress request joins");
+    assert_eq!(
+        progress_status,
+        StatusCode::CONFLICT,
+        "a nonterminal progress report accepted after cancellation must receive 409"
+    );
+    let (status, job) = request(app, "GET", &format!("/api/v1/jobs/{job_id}"), Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(job["status"], "canceled");
+}
+
 #[tokio::test]
 async fn authenticated_lan_caller_cannot_mutate_an_unclaimed_job_without_worker_id() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/web/src/hooks/useSavedVoices.js
+++ b/apps/web/src/hooks/useSavedVoices.js
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
 
 // Owns the project's Voice Clone "saved voices" roster + its create/delete mutations (sc-13517).
 // A saved voice is a named pointer to a library audio reference clip (plus its Chatterbox-VE speaker
@@ -10,6 +11,12 @@ import { apiFetch, isAbortError } from "../api.js";
 // across App's SSE-driven re-renders (mirrors the sc-4194 note in useCharacters/useModelsAndLoras).
 export function useSavedVoices({ token, activeProject, activeProjectRef, setError }) {
   const [savedVoices, setSavedVoices] = useState([]);
+
+  const isCurrentVoiceRequest = useCallback(
+    (projectId) =>
+      isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId),
+    [activeProjectRef],
+  );
 
   const refreshSavedVoices = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
@@ -24,17 +31,17 @@ export function useSavedVoices({ token, activeProject, activeProjectRef, setErro
         );
         // Drop a stale response for a project the user already switched away from
         // (mirrors refreshCharacters' guard).
-        if (activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
+        if (!isCurrentVoiceRequest(projectId)) {
           return;
         }
         setSavedVoices(Array.isArray(items) ? items : []);
         setError("");
       } catch (err) {
-        if (isAbortError(err)) return;
+        if (isAbortError(err) || !isCurrentVoiceRequest(projectId)) return;
         setError(err.message);
       }
     },
-    [token, activeProject, activeProjectRef, setError],
+    [token, activeProject, isCurrentVoiceRequest, setError],
   );
 
   // Register a saved voice: the backend resolves the reference clip, computes its embedding, runs
@@ -46,15 +53,19 @@ export function useSavedVoices({ token, activeProject, activeProjectRef, setErro
         setError("Create or open a project first.");
         return null;
       }
+      const projectId = activeProject.id;
       try {
         const created = await apiFetch(
-          `/api/v1/projects/${activeProject.id}/voices`,
+          `/api/v1/projects/${projectId}/voices`,
           token,
           {
             method: "POST",
             body: JSON.stringify({ name, referenceAudioAssetId }),
           },
         );
+        if (!isCurrentVoiceRequest(projectId)) {
+          return null;
+        }
         setSavedVoices((items) => [
           created,
           ...items.filter((item) => item.id !== created.id),
@@ -62,11 +73,12 @@ export function useSavedVoices({ token, activeProject, activeProjectRef, setErro
         setError("");
         return created;
       } catch (err) {
+        if (!isCurrentVoiceRequest(projectId)) return null;
         setError(err.message);
         return null;
       }
     },
-    [token, activeProject, setError],
+    [token, activeProject, isCurrentVoiceRequest, setError],
   );
 
   const deleteSavedVoice = useCallback(
@@ -75,21 +87,26 @@ export function useSavedVoices({ token, activeProject, activeProjectRef, setErro
         setError("Create or open a project first.");
         return null;
       }
+      const projectId = activeProject.id;
       try {
         await apiFetch(
-          `/api/v1/projects/${activeProject.id}/voices/${encodeURIComponent(voiceId)}`,
+          `/api/v1/projects/${projectId}/voices/${encodeURIComponent(voiceId)}`,
           token,
           { method: "DELETE" },
         );
+        if (!isCurrentVoiceRequest(projectId)) {
+          return null;
+        }
         setSavedVoices((items) => items.filter((item) => item.id !== voiceId));
         setError("");
         return { id: voiceId, status: "deleted" };
       } catch (err) {
+        if (!isCurrentVoiceRequest(projectId)) return null;
         setError(err.message);
         return null;
       }
     },
-    [token, activeProject, setError],
+    [token, activeProject, isCurrentVoiceRequest, setError],
   );
 
   return {

--- a/apps/web/src/hooks/useSavedVoices.test.jsx
+++ b/apps/web/src/hooks/useSavedVoices.test.jsx
@@ -1,0 +1,152 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock("../api.js", async (importOriginal) => ({
+  ...(await importOriginal()),
+  apiFetch: apiFetchMock,
+}));
+
+import { useSavedVoices } from "./useSavedVoices.js";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useSavedVoices project scoping", () => {
+  let container;
+  let root;
+  let latest;
+  let projectRef;
+  let setError;
+
+  function Harness({ project }) {
+    latest = useSavedVoices({
+      token: "token",
+      activeProject: project,
+      activeProjectRef: projectRef,
+      setError,
+    });
+    return null;
+  }
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    apiFetchMock.mockReset();
+    setError = vi.fn();
+    projectRef = { current: { id: "project_a" } };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<Harness project={{ id: "project_a" }} />);
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("splices a created voice when the project remains active", async () => {
+    const created = { id: "voice_a", name: "Narrator" };
+    apiFetchMock.mockResolvedValue(created);
+
+    let result;
+    await act(async () => {
+      result = await latest.createSavedVoice({
+        name: "Narrator",
+        referenceAudioAssetId: "asset_a",
+      });
+    });
+
+    expect(result).toBe(created);
+    expect(latest.savedVoices).toEqual([created]);
+    expect(setError).toHaveBeenLastCalledWith("");
+  });
+
+  it("drops a successful create response after switching projects", async () => {
+    const request = deferred();
+    apiFetchMock.mockReturnValue(request.promise);
+    const pending = latest.createSavedVoice({
+      name: "Old project voice",
+      referenceAudioAssetId: "asset_a",
+    });
+
+    projectRef.current = { id: "project_b" };
+    await act(async () => {
+      root.render(<Harness project={{ id: "project_b" }} />);
+      latest.setSavedVoices([{ id: "voice_b", name: "Current project voice" }]);
+    });
+
+    let result;
+    await act(async () => {
+      request.resolve({ id: "voice_a", name: "Old project voice" });
+      result = await pending;
+    });
+
+    expect(result).toBeNull();
+    expect(latest.savedVoices).toEqual([{ id: "voice_b", name: "Current project voice" }]);
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it("drops a create error after switching projects", async () => {
+    const request = deferred();
+    apiFetchMock.mockReturnValue(request.promise);
+    const pending = latest.createSavedVoice({
+      name: "Old project voice",
+      referenceAudioAssetId: "asset_a",
+    });
+
+    projectRef.current = { id: "project_b" };
+    await act(async () => {
+      root.render(<Harness project={{ id: "project_b" }} />);
+    });
+    let result;
+    await act(async () => {
+      request.reject(new Error("old project failed"));
+      result = await pending;
+    });
+
+    expect(result).toBeNull();
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it("does not delete a same-id voice from the project selected after the request began", async () => {
+    const request = deferred();
+    apiFetchMock.mockReturnValue(request.promise);
+    const pending = latest.deleteSavedVoice("voice_shared");
+
+    projectRef.current = { id: "project_b" };
+    await act(async () => {
+      root.render(<Harness project={{ id: "project_b" }} />);
+      latest.setSavedVoices([{ id: "voice_shared", name: "Project B voice" }]);
+    });
+    await act(async () => {
+      request.resolve({});
+      await pending;
+    });
+
+    expect(latest.savedVoices).toEqual([{ id: "voice_shared", name: "Project B voice" }]);
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it("reports a delete failure while the originating project remains active", async () => {
+    apiFetchMock.mockRejectedValue(new Error("delete failed"));
+
+    let result;
+    await act(async () => {
+      result = await latest.deleteSavedVoice("voice_a");
+    });
+
+    expect(result).toBeNull();
+    expect(setError).toHaveBeenLastCalledWith("delete failed");
+  });
+});

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { appConfirm } from "../appConfirm.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { AdvancedSection } from "../components/AdvancedSection.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
@@ -274,6 +275,8 @@ export function AudioStudio() {
   // selected reference clip, an in-flight guard, and the post-register notice (dedup warning / info).
   const [savedVoiceName, setSavedVoiceName] = useState("");
   const [registeringVoice, setRegisteringVoice] = useState(false);
+  const [deletingVoiceId, setDeletingVoiceId] = useState("");
+  const deletingVoiceRef = useRef("");
   const [savedVoiceNotice, setSavedVoiceNotice] = useState(null);
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   const [guideOpen, setGuideOpen] = useState(false);
@@ -456,9 +459,26 @@ export function AudioStudio() {
   }
 
   async function handleDeleteSavedVoice(voice) {
-    if (!deleteSavedVoice) return;
-    await deleteSavedVoice(voice.id);
-    setSavedVoiceNotice(null);
+    if (!deleteSavedVoice || deletingVoiceRef.current) return;
+    deletingVoiceRef.current = voice.id;
+    setDeletingVoiceId(voice.id);
+    try {
+      const proceed = await appConfirm({
+        title: "Delete saved voice?",
+        message: `Permanently delete “${voice.name}” from this project’s saved voices? This cannot be undone.`,
+        confirmLabel: "Delete permanently",
+        cancelLabel: "Cancel",
+        tone: "danger",
+      });
+      if (!proceed) return;
+      const deleted = await deleteSavedVoice(voice.id);
+      if (deleted) {
+        setSavedVoiceNotice(null);
+      }
+    } finally {
+      deletingVoiceRef.current = "";
+      setDeletingVoiceId("");
+    }
   }
 
   // Segmented-script editor handlers (sc-13676). Each edits a single { speaker, text } turn; the
@@ -666,6 +686,7 @@ export function AudioStudio() {
           // fixed voice bank; it maps the per-segment [S1]/[S2] labels to its own voices. The prompt is
           // left empty; the script carries the text. The worker passes the script to the generator and
           // the gen-core floor gates it on supports_multi_speaker / maxSpeakers (never a hardcoded id).
+          payload.prompt = "";
           payload.script = scriptSegmentsForSubmit(script);
         } else {
           // Single-voice Speech (Kokoro) ships a voice bank; omitted when unset so it falls back to af_heart.
@@ -1156,6 +1177,7 @@ export function AudioStudio() {
                             type="button"
                             className="saved-voice-delete"
                             aria-label={`Delete saved voice ${voice.name}`}
+                            disabled={Boolean(deletingVoiceId)}
                             title="Delete saved voice"
                             onClick={() => handleDeleteSavedVoice(voice)}
                           >

--- a/apps/web/src/screens/AudioStudio.test.jsx
+++ b/apps/web/src/screens/AudioStudio.test.jsx
@@ -2,6 +2,12 @@ import React, { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
 
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", async (importOriginal) => ({
+  ...(await importOriginal()),
+  appConfirm: appConfirmMock,
+}));
+
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -14,6 +20,19 @@ import { AppContext } from "../context/AppContext.js";
 import { AudioStudio } from "./AudioStudio.jsx";
 import { KEEP_ALIVE_VIEWS, navSections, viewTitles } from "../App.jsx";
 import { PROMPT_REFINE_MODEL_ID } from "../constants.js";
+
+beforeEach(() => {
+  appConfirmMock.mockReset();
+  appConfirmMock.mockResolvedValue(true);
+});
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 // Fixture audio models mirroring the seeded `type:"audio"` catalog entries (constants.js). Each
 // carries only the `audio` sub-block the eligibility predicates + UI read — voices (speech),
@@ -1718,7 +1737,7 @@ describe("AudioStudio register-a-voice (sc-13517)", () => {
     expect(notice.textContent).toContain("Brand New Voice");
   });
 
-  it("deletes a saved voice via its delete affordance", async () => {
+  it("confirms before deleting a saved voice", async () => {
     const savedVoices = [{ id: "voice_a", name: "Narrator", referenceAudioAssetId: "ref-voice-1" }];
     const deleteSavedVoice = vi.fn(async () => ({ id: "voice_a", status: "deleted" }));
     await render(
@@ -1731,7 +1750,53 @@ describe("AudioStudio register-a-voice (sc-13517)", () => {
     );
     await click(modeTab(container, "Voice Clone"));
     await click(container.querySelector(".saved-voice-delete"));
+    expect(appConfirmMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tone: "danger", confirmLabel: "Delete permanently" }),
+    );
     expect(deleteSavedVoice).toHaveBeenCalledWith("voice_a");
+  });
+
+  it("keeps a saved voice when permanent deletion is canceled", async () => {
+    appConfirmMock.mockResolvedValueOnce(false);
+    const savedVoices = [{ id: "voice_a", name: "Narrator", referenceAudioAssetId: "ref-voice-1" }];
+    const deleteSavedVoice = vi.fn();
+    await render(
+      baseContext({
+        assets: [referenceAsset],
+        savedVoices,
+        createSavedVoice: vi.fn(),
+        deleteSavedVoice,
+      }),
+    );
+    await click(modeTab(container, "Voice Clone"));
+    await click(container.querySelector(".saved-voice-delete"));
+
+    expect(appConfirmMock).toHaveBeenCalledOnce();
+    expect(deleteSavedVoice).not.toHaveBeenCalled();
+  });
+
+  it("guards a saved-voice delete while the mutation is in flight", async () => {
+    const deletion = deferred();
+    const savedVoices = [{ id: "voice_a", name: "Narrator", referenceAudioAssetId: "ref-voice-1" }];
+    const deleteSavedVoice = vi.fn(() => deletion.promise);
+    await render(
+      baseContext({
+        assets: [referenceAsset],
+        savedVoices,
+        createSavedVoice: vi.fn(),
+        deleteSavedVoice,
+      }),
+    );
+    await click(modeTab(container, "Voice Clone"));
+    const deleteButton = container.querySelector(".saved-voice-delete");
+    await click(deleteButton);
+
+    expect(deleteSavedVoice).toHaveBeenCalledOnce();
+    expect(deleteButton.disabled).toBe(true);
+    deleteButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(deleteSavedVoice).toHaveBeenCalledOnce();
+
+    await act(async () => deletion.resolve({ id: "voice_a", status: "deleted" }));
   });
 });
 
@@ -1924,6 +1989,7 @@ describe("AudioStudio multi-speaker reveal (sc-13676)", () => {
       { text: "Hello, how are you today?", speaker: "S1" },
       { text: "I'm doing great, thanks for asking!", speaker: "S2" },
     ]);
+    expect(payload.prompt).toBe("");
     // A multi-speaker model ships no voice bank, so no `voice` is sent.
     expect(payload.voice).toBeUndefined();
     expect(rememberLocalGenerationJob).toHaveBeenCalledWith("audio", job);

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -7467,7 +7467,7 @@ mod tests {
                 crate::voice_store::SavedVoiceCreateInput {
                     name: "Narrator".to_owned(),
                     reference_audio_asset_id: asset_id.clone(),
-                    embedding: vec![0.1, 0.2, 0.3, 0.4],
+                    embedding: vec![0.1; crate::voice_store::VOICE_EMBEDDING_DIM],
                 },
                 crate::voice_store::DEFAULT_VOICE_DEDUP_THRESHOLD,
             )
@@ -7557,7 +7557,7 @@ mod tests {
                 crate::voice_store::SavedVoiceCreateInput {
                     name: "Narrator".to_owned(),
                     reference_audio_asset_id: "asset_ref".to_owned(),
-                    embedding: vec![0.5, 0.5, 0.5],
+                    embedding: vec![0.5; crate::voice_store::VOICE_EMBEDDING_DIM],
                 },
                 crate::voice_store::DEFAULT_VOICE_DEDUP_THRESHOLD,
             )

--- a/crates/sceneworks-core/src/voice_store.rs
+++ b/crates/sceneworks-core/src/voice_store.rs
@@ -158,9 +158,19 @@ impl SavedVoiceStore {
                 "Invalid reference audio asset id".to_owned(),
             ));
         }
-        if input.embedding.is_empty() {
+        if input.embedding.len() != VOICE_EMBEDDING_DIM {
+            return Err(ProjectStoreError::BadRequest(format!(
+                "Voice embedding must contain exactly {VOICE_EMBEDDING_DIM} values"
+            )));
+        }
+        if input.embedding.iter().any(|value| !value.is_finite()) {
             return Err(ProjectStoreError::BadRequest(
-                "Voice embedding must not be empty".to_owned(),
+                "Voice embedding values must be finite".to_owned(),
+            ));
+        }
+        if !dedup_threshold.is_finite() || !(0.0..=1.0).contains(&dedup_threshold) {
+            return Err(ProjectStoreError::BadRequest(
+                "Voice dedup threshold must be between 0 and 1".to_owned(),
             ));
         }
 
@@ -276,6 +286,12 @@ mod tests {
         let connection = Connection::open_in_memory().expect("in-memory db");
         apply_voice_migrations(&connection).expect("voice migration runs");
         connection
+    }
+
+    fn valid_embedding(axis: usize) -> Vec<f32> {
+        let mut embedding = vec![0.0; VOICE_EMBEDDING_DIM];
+        embedding[axis] = 1.0;
+        embedding
     }
 
     /// The store's public delegating layer opens the real project.db; the unit tests here drive the
@@ -397,7 +413,7 @@ mod tests {
                 SavedVoiceCreateInput {
                     name: "Narrator".to_owned(),
                     reference_audio_asset_id: "asset_ref_1".to_owned(),
-                    embedding: vec![0.9, 0.1, 0.2, 0.05, 0.3],
+                    embedding: valid_embedding(0),
                 },
                 DEFAULT_VOICE_DEDUP_THRESHOLD,
             )
@@ -414,7 +430,11 @@ mod tests {
                 SavedVoiceCreateInput {
                     name: "Narrator (again)".to_owned(),
                     reference_audio_asset_id: "asset_ref_2".to_owned(),
-                    embedding: vec![0.901, 0.099, 0.2, 0.05, 0.301],
+                    embedding: {
+                        let mut embedding = valid_embedding(0);
+                        embedding[1] = 0.01;
+                        embedding
+                    },
                 },
                 DEFAULT_VOICE_DEDUP_THRESHOLD,
             )
@@ -429,7 +449,7 @@ mod tests {
                 SavedVoiceCreateInput {
                     name: "Villain".to_owned(),
                     reference_audio_asset_id: "asset_ref_3".to_owned(),
-                    embedding: vec![-0.2, 0.8, -0.6, 0.7, -0.9],
+                    embedding: valid_embedding(1),
                 },
                 DEFAULT_VOICE_DEDUP_THRESHOLD,
             )
@@ -479,5 +499,56 @@ mod tests {
                 DEFAULT_VOICE_DEDUP_THRESHOLD,
             )
             .is_err());
+    }
+
+    #[test]
+    fn create_requires_a_finite_256_value_embedding_and_bounded_threshold() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let store = SavedVoiceStore::new(temp.path());
+        let create = |embedding: Vec<f32>, threshold| {
+            store.create_saved_voice(
+                "project_1",
+                SavedVoiceCreateInput {
+                    name: "Narrator".to_owned(),
+                    reference_audio_asset_id: "asset_ref".to_owned(),
+                    embedding,
+                },
+                threshold,
+            )
+        };
+
+        for invalid in [
+            vec![0.0; VOICE_EMBEDDING_DIM - 1],
+            vec![0.0; VOICE_EMBEDDING_DIM + 1],
+        ] {
+            assert!(matches!(
+                create(invalid, DEFAULT_VOICE_DEDUP_THRESHOLD),
+                Err(ProjectStoreError::BadRequest(message))
+                    if message.contains("exactly 256 values")
+            ));
+        }
+
+        let mut non_finite = valid_embedding(0);
+        non_finite[1] = f32::NAN;
+        assert!(matches!(
+            create(non_finite, DEFAULT_VOICE_DEDUP_THRESHOLD),
+            Err(ProjectStoreError::BadRequest(message))
+                if message == "Voice embedding values must be finite"
+        ));
+
+        for threshold in [-0.01, 1.01, f32::NAN] {
+            assert!(matches!(
+                create(valid_embedding(0), threshold),
+                Err(ProjectStoreError::BadRequest(message))
+                    if message == "Voice dedup threshold must be between 0 and 1"
+            ));
+        }
+
+        for threshold in [0.0, 1.0, DEFAULT_VOICE_DEDUP_THRESHOLD] {
+            assert!(
+                create(valid_embedding(0), threshold).is_ok(),
+                "threshold {threshold} should be accepted"
+            );
+        }
     }
 }

--- a/crates/sceneworks-worker/src/audio_jobs.rs
+++ b/crates/sceneworks-worker/src/audio_jobs.rs
@@ -786,9 +786,11 @@ async fn run_audio_synthesis_using(
     // Concurrent incremental-progress pump (sc-13675): posts a Running/Generating job update as each
     // streamed chunk arrives so the UI reflects the stream. It runs ALONGSIDE
     // `run_blocking_with_heartbeat` (which owns worker heartbeats + the cancel watcher on a DIFFERENT
-    // endpoint). It stops the instant the shared cancel flag is tripped, so it can never post a Running
-    // status after the watcher writes the terminal `Canceled` (no cancel/heartbeat regression), and it
-    // ends when synthesis closes the channel. Non-streaming synthesis never sends, so the pump exits
+    // endpoint). The cancel check stops new attempts once the shared flag is observed, but cancellation
+    // can still serialize while an already-started progress POST is awaiting the API. That race is safe
+    // because jobs_store transactionally rejects any nonterminal write after `Canceled`; the resulting
+    // 409 is deliberately ignored here because synthesis must not depend on its progress sink. The pump
+    // ends when synthesis closes the channel. Non-streaming synthesis never sends, so it exits
     // immediately with zero posts, leaving those modes untouched.
     let pump = {
         let api = api.clone();

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2694,9 +2694,9 @@ fn resolve_sdxl_components(
         crate::model_jobs::resolve_co_requisites(&descriptor, &manifest_value, settings)?;
     let mut take = |id: &str| -> WorkerResult<WeightsSource> {
         components.remove(id).ok_or_else(|| {
-            WorkerError::InvalidPayload(format!(
-                "SDXL requires the '{id}' component, but its catalog entry declares no matching \
-                 `coRequisite` download — the model manifest entry is misconfigured"
+            WorkerError::Engine(format!(
+                "the registered candle SDXL descriptor does not advertise its required '{id}' \
+                 component — the SceneWorks inference runtime pin is incompatible with this worker"
             ))
         })
     };

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1641,8 +1641,16 @@ pub(crate) fn huggingface_pinned_snapshot_dir(
     // seam, `resolve_co_requisites` / `resolve_optional_component`), which is unvalidated over the LAN
     // jobs API (epic 4484). A `..`/absolute revision would otherwise join OUTSIDE `snapshots/` — a dir
     // that passes `is_dir()` and, on Windows, gets its symlinks rewritten to hardlinks by
-    // `materialize_snapshot_hardlinks`. A pinned revision is a single 40-hex commit component, so
-    // confine it with `safe_join`; a traversal value yields `None` ("not installed") (sc-13583).
+    // `materialize_snapshot_hardlinks`. A pinned revision is exactly one lowercase 40-hex commit
+    // component. Enforce that runtime contract before confinement because the manifest schema is not
+    // authoritative for the copy embedded in an untrusted job payload (sc-13842 / sc-13583).
+    if revision.len() != 40
+        || !revision
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return None;
+    }
     let dir = safe_join(
         &huggingface_repo_cache_path(data_dir, repo)?.join("snapshots"),
         revision,
@@ -1755,11 +1763,74 @@ pub(crate) fn resolve_co_requisites(
                 }
                 gen_core::WeightsSource::File(path)
             }
-            _ => gen_core::WeightsSource::Dir(snapshot),
+            [] => gen_core::WeightsSource::Dir(snapshot),
+            _ => {
+                // Multi-file components are staged as directories because providers join their own
+                // internal paths, but the pre-load all-or-nothing contract still requires every
+                // manifest-declared file or pattern to be present.
+                for file in &files {
+                    if !snapshot_contains_declared_file(&snapshot, file)? {
+                        return Err(WorkerError::InvalidPayload(format!(
+                            "{model_id}: the '{component_id}' component file {repo}/{file} is missing \
+                             from the cached snapshot — reinstall {model_id} to repair it"
+                        )));
+                    }
+                }
+                gen_core::WeightsSource::Dir(snapshot)
+            }
         };
         components.insert(component_id.to_owned(), source);
     }
     Ok(components)
+}
+
+fn snapshot_contains_declared_file(snapshot: &Path, declared: &str) -> WorkerResult<bool> {
+    if !declared.contains(['*', '?', '[']) {
+        return Ok(safe_join(snapshot, declared)?.is_file());
+    }
+    let relative = Path::new(declared);
+    if relative.is_absolute()
+        || relative.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(WorkerError::InvalidPayload(format!(
+            "model component file pattern `{declared}` must stay within its cached snapshot"
+        )));
+    }
+    let pattern = glob::Pattern::new(declared).map_err(|error| {
+        WorkerError::InvalidPayload(format!(
+            "invalid model component file pattern `{declared}`: {error}"
+        ))
+    })?;
+    Ok(snapshot_tree_contains(snapshot, &|path| {
+        path.strip_prefix(snapshot)
+            .is_ok_and(|relative| pattern.matches_path(relative))
+    }))
+}
+
+fn snapshot_tree_contains(dir: &Path, predicate: &impl Fn(&Path) -> bool) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_dir() => {
+                if snapshot_tree_contains(&path, predicate) {
+                    return true;
+                }
+            }
+            Ok(_) if predicate(&path) => return true,
+            Ok(_) | Err(_) => {}
+        }
+    }
+    false
 }
 
 /// Resolve an OPTIONAL, on-demand model component the caller stages only for specific requests — the
@@ -1979,7 +2050,7 @@ fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathB
     // empty/torn one, not dummy fixture weights from real ones.
     if let Ok(rev) = std::fs::read_to_string(repo_dir.join("refs").join("main")) {
         let candidate = snapshots.join(rev.trim());
-        if snapshot_file_count(&candidate) > 0 {
+        if snapshot_has_any_file(&candidate) {
             return Some(candidate);
         }
     }
@@ -1994,6 +2065,13 @@ fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathB
         .filter(|(count, _)| *count > 0)
         .max_by_key(|(count, _)| *count)
         .map(|(_, path)| path)
+}
+
+/// Short-circuiting presence probe for the hot `refs/main` path. Unlike
+/// [`snapshot_file_count`], it stops at the first file instead of walking a large snapshot tree on
+/// every model resolve.
+fn snapshot_has_any_file(dir: &Path) -> bool {
+    snapshot_tree_contains(dir, &|_| true)
 }
 
 /// Recursively count regular files under `dir` (symlinks counted as files — HF snapshots link into
@@ -4256,6 +4334,64 @@ mod co_requisite_tests {
             None,
             "a `..` revision must not resolve to a dir outside snapshots/"
         );
+        for invalid in [
+            "abc123",
+            "5BB1F6EE58E50C3B8D408BC82A6D3740C2DB6E18",
+            "5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e1g",
+        ] {
+            assert_eq!(
+                huggingface_pinned_snapshot_dir(data_dir.path(), repo, invalid),
+                None,
+                "a pinned revision must be exactly 40 lowercase hex characters: {invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_co_requisites_rejects_a_torn_multi_file_component() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let repo = "owner/multi-component";
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        stage_snapshot_file(data_dir.path(), repo, revision, "weights/a.bin");
+        let descriptor = gen_core::ModelDescriptor {
+            id: "multi_model",
+            family: "multi",
+            backend: "candle",
+            modality: gen_core::Modality::Audio,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &["bundle"],
+        };
+        let manifest = json!({
+            "id": "multi_model",
+            "downloads": [{
+                "provider": "huggingface",
+                "repo": repo,
+                "revision": revision,
+                "coRequisite": true,
+                "componentId": "bundle",
+                "files": ["weights/a.bin", "weights/b.bin"]
+            }]
+        });
+        let settings = settings_at(data_dir.path().to_path_buf());
+
+        let error = resolve_co_requisites(&descriptor, &manifest, &settings)
+            .expect_err("a missing member makes the component incomplete");
+        assert!(
+            matches!(error, WorkerError::InvalidPayload(ref message) if message.contains("weights/b.bin")),
+            "the repair error must identify the missing member, got {error:?}"
+        );
+
+        stage_snapshot_file(data_dir.path(), repo, revision, "weights/b.bin");
+        assert!(
+            matches!(
+                resolve_co_requisites(&descriptor, &manifest, &settings)
+                    .expect("the complete component resolves")
+                    .get("bundle"),
+                Some(gen_core::WeightsSource::Dir(path)) if path.ends_with(revision)
+            ),
+            "a complete multi-file component stages its snapshot root"
+        );
     }
 
     /// sc-13583 (co-requisite seam): a single-entry `files: ["<../.. path>"]` in the payload
@@ -4688,11 +4824,32 @@ mod co_requisite_tests {
         for &(model_id, family, repo, revision, file) in MOSS_CODEC_SNAPSHOTS {
             let _env = isolate_hf_cache();
             let data_dir = tempfile::tempdir().expect("temp data dir");
-            stage_snapshot_file(data_dir.path(), repo, revision, file);
+            let manifest = builtin_manifest_entry(model_id);
+            let codec_download = manifest["downloads"]
+                .as_array()
+                .expect("downloads array")
+                .iter()
+                .find(|download| {
+                    download.get("componentId").and_then(Value::as_str) == Some("codec")
+                })
+                .expect("codec co-requisite");
+            let declared_files: Vec<&str> = codec_download["files"]
+                .as_array()
+                .expect("codec files")
+                .iter()
+                .filter_map(Value::as_str)
+                .collect();
+            assert!(
+                declared_files.contains(&file),
+                "{model_id}: fixture anchor must remain in the live codec file set"
+            );
+            for declared in declared_files {
+                stage_snapshot_file(data_dir.path(), repo, revision, declared);
+            }
 
             let components = resolve_co_requisites(
                 &moss_descriptor(model_id, family),
-                &builtin_manifest_entry(model_id),
+                &manifest,
                 &settings_at(data_dir.path().to_path_buf()),
             )
             .unwrap_or_else(|error| {


### PR DESCRIPTION
## Summary
- harden saved-voice project scoping, deletion, embedding shape, and dedup threshold validation
- make streaming cancellation ordering truthful and prove terminal jobs reject late Running updates
- harden model snapshot pins, multi-file co-requisites, refs/main probing, and SDXL pin-skew errors
- consolidate duplicated builtin manifest test helpers

## Validation
- independent exact-head review: APPROVE, no findings, 99% confidence
- full web suite: 2,579 passed
- targeted web suite: 66 passed; lint: 0 errors; production build passed
- worker co-requisite suite: 16 passed
- core voice-store suite: 7 passed
- Rust API terminal-race, threshold, and manifest install-state tests passed
- strict macOS clippy passed
- canonical Linux/Candle worker clippy plus rust-api check passed under -D warnings
- cargo fmt and git diff --check passed

Shortcut: sc-13842