### PR TITLE
perf: add secret-safe startup timing

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -9,7 +9,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use axum::body::{to_bytes, Body};
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{
-    DefaultBodyLimit, FromRequest, Multipart, Path, Query, Request as AxumRequest, State,
+    DefaultBodyLimit, FromRequest, MatchedPath, Multipart, Path, Query, Request as AxumRequest,
+    State,
 };
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode};
 use axum::middleware::{self, Next};
@@ -889,6 +890,92 @@ fn warn_on_sweep_err(kind: &str, result: std::io::Result<usize>) {
     }
 }
 
+/// One-shot pre-bind phase timer. Startup has only four of these, and `Drop`
+/// ensures a failing phase is still visible without changing the existing error
+/// propagation.
+struct StartupPhaseTimer {
+    phase: &'static str,
+    started: Instant,
+}
+
+impl StartupPhaseTimer {
+    fn start(phase: &'static str) -> Self {
+        Self {
+            phase,
+            started: Instant::now(),
+        }
+    }
+}
+
+impl Drop for StartupPhaseTimer {
+    fn drop(&mut self) {
+        tracing::info!(
+            event = "startup_phase_duration",
+            phase = self.phase,
+            duration_ms = self.started.elapsed().as_secs_f64() * 1000.0,
+            "SceneWorks API pre-bind startup phase completed"
+        );
+    }
+}
+
+/// Return only bounded, source-owned route labels. Axum's matched path contains
+/// route parameter *names* (`:project_id`), never their values. Unknown API and
+/// MCP paths deliberately collapse to one label rather than copying a raw URI
+/// that could contain IDs, filesystem-shaped path tails, or secret-bearing query
+/// values.
+fn normalized_api_route(path: &str, matched_path: Option<&str>) -> Option<String> {
+    if path == "/mcp" || path.starts_with("/mcp/") {
+        return Some(
+            matched_path
+                .filter(|route| route.starts_with("/mcp"))
+                .unwrap_or("/mcp/<unmatched>")
+                .to_owned(),
+        );
+    }
+    if path == "/api" || path.starts_with("/api/") {
+        return Some(
+            matched_path
+                .filter(|route| route.starts_with("/api/"))
+                .unwrap_or("/api/<unmatched>")
+                .to_owned(),
+        );
+    }
+    None
+}
+
+async fn api_request_timing(request: AxumRequest, next: Next) -> Response {
+    let method = request.method().clone();
+    // `Uri::path()` excludes the query by contract. Retain it only long enough
+    // to classify API versus frontend traffic; it is never emitted.
+    let path = request.uri().path().to_owned();
+    let matched_path = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|matched| matched.as_str().to_owned());
+    let started = Instant::now();
+    let mut response = next.run(request).await;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    if let Some(route) = normalized_api_route(&path, matched_path.as_deref()) {
+        let server_timing = format!("app;dur={elapsed_ms:.3}");
+        if let Ok(value) = HeaderValue::from_str(&server_timing) {
+            response
+                .headers_mut()
+                .insert(HeaderName::from_static("server-timing"), value);
+        }
+        tracing::info!(
+            event = "api_request_duration",
+            method = %method,
+            route,
+            status = response.status().as_u16(),
+            duration_ms = elapsed_ms,
+            "SceneWorks API response completed"
+        );
+    }
+
+    response
+}
+
 pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
     Ok(create_app_with_state(settings)?.0)
 }
@@ -922,45 +1009,55 @@ pub(crate) fn create_app_with_state(
             std::fs::create_dir_all(jobs_db_parent),
         );
     }
-    // sc-8882 (F-080): a failed sweep leaves leaked multi-GB upload temps unreclaimed
-    // and was previously silent. WARN (never fatal) so the operator can investigate.
-    warn_on_sweep_err("lora", sweep_stale_lora_uploads(&settings.data_dir));
-    warn_on_sweep_err("pose", sweep_stale_pose_uploads(&settings.data_dir));
-    warn_on_sweep_err("keypoint", sweep_stale_keypoint_uploads(&settings.data_dir));
-    // sc-4204 (F-API-6): asset-import temp files (cache/uploads) had no startup sweep.
-    warn_on_sweep_err("asset", sweep_stale_asset_uploads(&settings.data_dir));
-    let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
-    jobs_store.initialize()?;
-    let purged_terminal_jobs =
-        jobs_store.purge_terminal_jobs_older_than(settings.jobs_retention_days)?;
-    tracing::info!(
-        event = "terminal_job_retention",
-        retention_days = settings.jobs_retention_days,
-        purged_terminal_jobs,
-        "applied terminal job retention"
-    );
-    let interrupted_jobs_on_startup = jobs_store.mark_interrupted_on_startup()?.len();
+    {
+        let _phase = StartupPhaseTimer::start("upload_sweeps");
+        // sc-8882 (F-080): a failed sweep leaves leaked multi-GB upload temps unreclaimed
+        // and was previously silent. WARN (never fatal) so the operator can investigate.
+        warn_on_sweep_err("lora", sweep_stale_lora_uploads(&settings.data_dir));
+        warn_on_sweep_err("pose", sweep_stale_pose_uploads(&settings.data_dir));
+        warn_on_sweep_err("keypoint", sweep_stale_keypoint_uploads(&settings.data_dir));
+        // sc-4204 (F-API-6): asset-import temp files (cache/uploads) had no startup sweep.
+        warn_on_sweep_err("asset", sweep_stale_asset_uploads(&settings.data_dir));
+    }
+    let (jobs_store, interrupted_jobs_on_startup) = {
+        let _phase = StartupPhaseTimer::start("jobs_retention_recovery");
+        let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
+        jobs_store.initialize()?;
+        let purged_terminal_jobs =
+            jobs_store.purge_terminal_jobs_older_than(settings.jobs_retention_days)?;
+        tracing::info!(
+            event = "terminal_job_retention",
+            retention_days = settings.jobs_retention_days,
+            purged_terminal_jobs,
+            "applied terminal job retention"
+        );
+        let interrupted_jobs_on_startup = jobs_store.mark_interrupted_on_startup()?.len();
+        (jobs_store, interrupted_jobs_on_startup)
+    };
     let project_store = Arc::new(ProjectStore::new(
         settings.data_dir.clone(),
         settings.app_version.clone(),
     ));
-    // Reserved global pose library (epic 2282): created up front so its assets
-    // endpoint returns [] (not 404) before any pose is saved. Best-effort.
-    if let Err(error) = project_store.ensure_global_poses_project() {
-        tracing::error!(
-            event = "ensure_global_poses_project_failed",
-            error = %error,
-            "could not ensure global pose library project"
-        );
-    }
-    // Reserved global Key Point Library (epic 4422): created up front so its assets +
-    // collections endpoints return seeded data before any preset is saved. Best-effort.
-    if let Err(error) = project_store.ensure_global_keypoints_project() {
-        tracing::error!(
-            event = "ensure_global_keypoints_project_failed",
-            error = %error,
-            "could not ensure global keypoint library project"
-        );
+    {
+        let _phase = StartupPhaseTimer::start("reserved_project_initialization");
+        // Reserved global pose library (epic 2282): created up front so its assets
+        // endpoint returns [] (not 404) before any pose is saved. Best-effort.
+        if let Err(error) = project_store.ensure_global_poses_project() {
+            tracing::error!(
+                event = "ensure_global_poses_project_failed",
+                error = %error,
+                "could not ensure global pose library project"
+            );
+        }
+        // Reserved global Key Point Library (epic 4422): created up front so its assets +
+        // collections endpoints return seeded data before any preset is saved. Best-effort.
+        if let Err(error) = project_store.ensure_global_keypoints_project() {
+            tracing::error!(
+                event = "ensure_global_keypoints_project_failed",
+                error = %error,
+                "could not ensure global keypoint library project"
+            );
+        }
     }
     // Startup data-integrity pass: drop index rows for assets whose media was
     // purged from disk but whose row/sidecar lingered, so the Library never fetches
@@ -968,18 +1065,21 @@ pub(crate) fn create_app_with_state(
     // Runs before the server binds, so the first `list_assets` is already clean.
     // Best-effort and non-fatal — a failure just leaves the stale rows for next
     // startup; the sidecars are untouched, so nothing is lost.
-    match project_store.prune_all_orphaned_assets() {
-        Ok(0) => {}
-        Ok(pruned) => tracing::info!(
-            event = "orphaned_assets_pruned",
-            count = pruned,
-            "pruned purged-but-referenced assets from project registries at startup"
-        ),
-        Err(error) => tracing::warn!(
-            event = "orphaned_assets_prune_failed",
-            error = %error,
-            "startup orphaned-asset prune failed; the Library may still request purged media"
-        ),
+    {
+        let _phase = StartupPhaseTimer::start("orphaned_asset_maintenance");
+        match project_store.prune_all_orphaned_assets() {
+            Ok(0) => {}
+            Ok(pruned) => tracing::info!(
+                event = "orphaned_assets_pruned",
+                count = pruned,
+                "pruned purged-but-referenced assets from project registries at startup"
+            ),
+            Err(error) => tracing::warn!(
+                event = "orphaned_assets_prune_failed",
+                error = %error,
+                "startup orphaned-asset prune failed; the Library may still request purged media"
+            ),
+        }
     }
     let state = AppState {
         settings,
@@ -1445,7 +1545,10 @@ pub(crate) fn create_app_with_state(
         // model/lora import routes above).
         .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
         .layer(middleware::from_fn_with_state(state, access_control))
-        .layer(cors);
+        .layer(cors)
+        // Outermost so auth failures, CORS responses, and handler responses are
+        // all timed. Non-API frontend traffic is ignored by the middleware.
+        .layer(middleware::from_fn(api_request_timing));
     Ok((router, returned_state))
 }
 

--- a/apps/rust-api/src/tests/server.rs
+++ b/apps/rust-api/src/tests/server.rs
@@ -8,6 +8,71 @@ fn default_api_host_is_loopback() {
     assert!(ip.is_loopback(), "default API host must be loopback");
 }
 
+#[test]
+fn api_timing_route_labels_exclude_ids_queries_and_unknown_path_tails() {
+    let matched = normalized_api_route(
+        "/api/v1/projects/project-secret/assets/asset-secret",
+        Some("/api/v1/projects/:project_id/assets/:asset_id"),
+    );
+    assert_eq!(
+        matched.as_deref(),
+        Some("/api/v1/projects/:project_id/assets/:asset_id")
+    );
+    assert!(!matched
+        .as_deref()
+        .expect("API route is timed")
+        .contains("secret"));
+
+    // Middleware receives `Uri::path()`, never the query, and unknown paths
+    // collapse instead of echoing their potentially sensitive tail.
+    assert_eq!(
+        normalized_api_route("/api/v1/unknown/access-token-value", None).as_deref(),
+        Some("/api/<unmatched>")
+    );
+    assert_eq!(
+        normalized_api_route("/mcp/private-client-id", None).as_deref(),
+        Some("/mcp/<unmatched>")
+    );
+    assert_eq!(normalized_api_route("/assets/index.js", None), None);
+}
+
+#[tokio::test]
+async fn api_timing_adds_numeric_server_timing_to_success_and_error_responses() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (status, headers, _) = request_raw(
+        app.clone(),
+        "GET",
+        "/api/v1/access?ticket=never-echo",
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let timing = headers
+        .get("server-timing")
+        .and_then(|value| value.to_str().ok())
+        .expect("API success exposes Server-Timing");
+    assert!(timing.starts_with("app;dur="));
+    assert!(timing["app;dur=".len()..].parse::<f64>().is_ok());
+    assert!(!timing.contains("ticket"));
+
+    let (status, headers, _) = request_raw(
+        app,
+        "GET",
+        "/api/v1/not-a-route/private-value",
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(
+        headers.contains_key("server-timing"),
+        "fallback API responses are timed too"
+    );
+}
+
 /// F-003 / sc-11159: the enqueue gate must reject a path-unsafe `model` id (traversal /
 /// separators / absolute), since it flows verbatim into the worker's asset filename. A
 /// plain single-component id — including an uncatalogued one the stub lane serves — is

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -17,9 +17,9 @@ pub(crate) use crate::workers::person_readiness_from_workers;
 pub(crate) use crate::{
     create_app, create_app_with_state, huggingface_repo_cache_path, inject_converted_model_path,
     inprocess_utility_worker_id, inprocess_worker_gpu_id, lora_artifact_paths,
-    merge_model_manifest_entry, mlx_catalog_status, open_bind_override_enabled,
-    parse_inprocess_utility_worker_count, safe_download_dir, seed_mode_for_config_dir,
-    serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
+    merge_model_manifest_entry, mlx_catalog_status, normalized_api_route,
+    open_bind_override_enabled, parse_inprocess_utility_worker_count, safe_download_dir,
+    seed_mode_for_config_dir, serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
     sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before, sweep_stale_uploads,
     validate_model_id, Settings, WorkerCapability, WorkerSnapshot, WorkerStatus,
     API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1096,19 +1096,6 @@ export function App() {
     }
   }, [activeProject]);
 
-  // The request settle mark is recorded before its state update; this layout
-  // effect then runs on the resulting commit, identifying the first render in
-  // which the Assets surface can consume the selected project's catalog.
-  useLayoutEffect(() => {
-    if (
-      activeView === "Library" &&
-      activeProject &&
-      loadedAssetsProjectId === activeProject.id
-    ) {
-      recordStartupMark("assets-ready-render");
-    }
-  }, [activeProject, activeView, loadedAssetsProjectId]);
-
   useEffect(() => {
     localGenerationJobIdsRef.current = localGenerationJobIds;
   }, [localGenerationJobIds]);
@@ -2357,6 +2344,9 @@ export function App() {
     queueTimelineVideoJob,
     // Assets / library (sc-1651 Phase B batch 1)
     assets,
+    assetsReady: Boolean(
+      activeProject && loadedAssetsProjectId === activeProject.id
+    ),
     selectedAsset,
     // The RAW selection id (null when nothing is explicitly selected). Studios need it
     // to tell an explicit user selection apart from `selectedAsset`'s assets[0] fallback
@@ -2517,7 +2507,7 @@ export function App() {
     activeProject, mediaAssets, openPreview, sendAssetToImage, sendAssetToVideo,
     activeTimeline, timelines, selectedTimelineId, setSelectedTimelineId, setActiveTimeline, isActiveTimelineDirty,
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
-    assets, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
+    assets, loadedAssetsProjectId, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobAction, clearCompletedJobs, cancelPendingJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
     projectFilter, setProjectFilter, projects,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "./api.js";
+import {
+  beginAssetRequest,
+  recordStartupMark,
+  settleAssetRequest,
+} from "./startupTiming.js";
 import { CREATE_JOB_DEFINITIONS, makeCreateJob } from "./createJob.js";
 import { pollJobToCompletion } from "./pollJob.js";
 import { AccentPicker } from "./components/AccentPicker.jsx";
@@ -1075,9 +1080,34 @@ export function App() {
     setVisitedKeepAliveViews((prev) => (prev.has(activeView) ? prev : new Set(prev).add(activeView)));
   }, [activeView]);
 
+  // Passive effects run after React commits the state batch from refreshData.
+  // Keep this before the active-project effect so the marks reflect the commit
+  // order that unlocks the project-scoped catalog request below.
+  useEffect(() => {
+    if (projectsLoaded) {
+      recordStartupMark("projects-committed");
+    }
+  }, [projectsLoaded, projects]);
+
   useEffect(() => {
     activeProjectRef.current = activeProject;
+    if (activeProject) {
+      recordStartupMark("active-project-selected");
+    }
   }, [activeProject]);
+
+  // The request settle mark is recorded before its state update; this layout
+  // effect then runs on the resulting commit, identifying the first render in
+  // which the Assets surface can consume the selected project's catalog.
+  useLayoutEffect(() => {
+    if (
+      activeView === "Library" &&
+      activeProject &&
+      loadedAssetsProjectId === activeProject.id
+    ) {
+      recordStartupMark("assets-ready-render");
+    }
+  }, [activeProject, activeView, loadedAssetsProjectId]);
 
   useEffect(() => {
     localGenerationJobIdsRef.current = localGenerationJobIds;
@@ -1457,6 +1487,7 @@ export function App() {
     if (!isCurrentProjectRequest(activeProject?.id ?? null, projectId)) {
       return;
     }
+    const timingStartedAt = beginAssetRequest();
     try {
       const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token, { signal });
       // sc-8858: an SSE-triggered refresh for the just-active project can resolve
@@ -1473,6 +1504,8 @@ export function App() {
     } catch (err) {
       if (isAbortError(err)) return;
       setError(err.message);
+    } finally {
+      settleAssetRequest(timingStartedAt);
     }
   }
 

--- a/apps/web/src/App.simpleUi.test.jsx
+++ b/apps/web/src/App.simpleUi.test.jsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./main.jsx";
 import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
 import { click } from "./testUtils/dom.js";
+import { resetStartupTimingForTests } from "./startupTiming.js";
 
 // Simple UI ⇄ full workspace switching at the App level (design handoff).
 //
@@ -53,6 +54,8 @@ describe("App — Simple/Advanced shell switching", () => {
   afterEach(async () => {
     await act(async () => root?.unmount());
     container.remove();
+    resetStartupTimingForTests();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -69,6 +72,32 @@ describe("App — Simple/Advanced shell switching", () => {
     expect(container.querySelector("main.app")).toBeTruthy();
     expect(container.querySelector(".workspace")).toBeTruthy();
     expect(container.querySelector(".su-root")).toBeNull();
+  });
+
+  it("records Assets ready only after the advanced Library surface commits", async () => {
+    let now = 0;
+    const mark = vi.fn();
+    vi.stubGlobal("performance", {
+      clearMarks: vi.fn(),
+      clearMeasures: vi.fn(),
+      mark,
+      measure: vi.fn(),
+      now: () => ++now,
+    });
+    resetStartupTimingForTests();
+
+    await renderApp();
+
+    expect(mark.mock.calls.map(([name]) => name)).toEqual([
+      "sceneworks.access-resolved",
+      "sceneworks.media-authorization-settled",
+      "sceneworks.projects-committed",
+      "sceneworks.active-project-selected",
+      "sceneworks.asset-request-start",
+      "sceneworks.asset-request-settled",
+      "sceneworks.assets-ready-render",
+    ]);
+    expect(container.querySelector(".workspace")).toBeTruthy();
   });
 
   it("adds the Simple/Advanced switch to the workspace sidebar, on Advanced", async () => {

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { apiFetch, setMediaTicket } from "../api.js";
 import { isDesktop as isDesktopShell } from "../runtime.js";
 import { readAccessToken, storeAccessToken, clearAccessToken } from "../accessToken.js";
+import { recordStartupMark } from "../startupTiming.js";
 
 // Owns the remote-access gate (epic 4484): the /api/v1/access probe, the host
 // password (= API token), the login-gate draft/error, and the media-ticket mint
@@ -71,6 +72,7 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
     }
     if (!access.authRequired) {
       setMediaTicket("");
+      recordStartupMark("media-authorization-settled");
       setMediaReady(true);
       return undefined;
     }
@@ -87,6 +89,7 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
           return;
         }
         setMediaTicket(response.ticket);
+        recordStartupMark("media-authorization-settled");
         setMediaReady(true);
         setMediaTicketFailed(false);
         dismissNoticeKind("media-ticket");
@@ -97,6 +100,7 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
         if (closed) {
           return;
         }
+        recordStartupMark("media-authorization-settled");
         setMediaTicketFailed(true);
         pushNotice(
           "media-ticket",
@@ -140,6 +144,7 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
           return;
         }
         setAccess(result);
+        recordStartupMark("access-resolved");
         setAccessResolved(true);
         dismissNoticeKind("access-probe");
       } catch (err) {

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -2,7 +2,10 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.jsx";
 import { ErrorBoundary } from "./components/ErrorBoundary.jsx";
+import { recordStartupMark } from "./startupTiming.js";
 import "./styles.css";
+
+recordStartupMark("bootstrap-start");
 
 const rootElement = typeof document === "undefined" ? null : document.getElementById("root");
 if (rootElement) {

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -2,10 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.jsx";
 import { ErrorBoundary } from "./components/ErrorBoundary.jsx";
-import { recordStartupMark } from "./startupTiming.js";
 import "./styles.css";
-
-recordStartupMark("bootstrap-start");
 
 const rootElement = typeof document === "undefined" ? null : document.getElementById("root");
 if (rootElement) {

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 import { AssetBatchModal, AssetSelectionBar, useAssetBatch } from "../assetBatch.jsx";
 import { foldUpscaledAssetVariants } from "../assetVariants.js";
 import { AssetDetail, AssetGrid, emptyTrash } from "../components/assetPanels.jsx";
@@ -6,6 +6,7 @@ import { useAudioTakePlayer } from "../components/audioTakeParts.jsx";
 import { isLibraryAsset, terminalStatuses } from "../constants.js";
 import { useAppContext } from "../context/AppContext.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
+import { recordStartupMark } from "../startupTiming.js";
 
 // Free-text Library search across an asset's display name, prompt, and tags.
 // Case-insensitive substring match; an empty needle matches everything so callers
@@ -24,6 +25,7 @@ export function LibraryScreen() {
   const {
     activeProject,
     assets,
+    assetsReady = false,
     jobs = [],
     imageModels = [],
     createVqaJob,
@@ -42,6 +44,11 @@ export function LibraryScreen() {
     updateAssetTags,
     audioModels = [],
   } = useAppContext();
+  useLayoutEffect(() => {
+    if (assetsReady) {
+      recordStartupMark("assets-ready-render");
+    }
+  }, [assetsReady]);
   // Shared multi-select + batch toolbar (selection state, fan-out, Discard/Move).
   const batch = useAssetBatch();
   // ONE audio transport for the screen (sc-14391): the grid tiles and the detail stage drive

--- a/apps/web/src/simple/SimpleAssets.jsx
+++ b/apps/web/src/simple/SimpleAssets.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useLayoutEffect, useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { AssetThumbnail, assetCanRenderAsAudio, assetCanRenderAsVideo } from "../components/assetMedia.jsx";
 import { useAppContext } from "../context/AppContext.js";
@@ -8,6 +8,7 @@ import { assetMatchesSearch } from "../screens/LibraryScreen.jsx";
 import { assetGridColumns } from "./breakpoint.js";
 import { SimpleAudioTile } from "./simpleAudioParts.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
+import { recordStartupMark } from "../startupTiming.js";
 
 // Simple Assets (design handoff): search + type pills + a responsive thumbnail grid.
 // Reuses the Library screen's own hygiene rules so the two views can't disagree about
@@ -22,10 +23,16 @@ const FILTERS = [
 ];
 
 export function SimpleAssets() {
-  const { assets = [] } = useAppContext();
+  const { assets = [], assetsReady = false } = useAppContext();
   const { breakpoint, openPreview, loadedTakeId } = useSimpleUi();
   const [filter, setFilter] = useState("all");
   const [query, setQuery] = useState("");
+
+  useLayoutEffect(() => {
+    if (assetsReady) {
+      recordStartupMark("assets-ready-render");
+    }
+  }, [assetsReady]);
 
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppContext } from "../context/AppContext.js";
 import { SimpleShell } from "./SimpleShell.jsx";
 import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+import { resetStartupTimingForTests } from "../startupTiming.js";
 
 // The Simple shell mounts inside App's providers and reads everything through them, so a
 // single legacy <AppContext.Provider> is enough to drive it in isolation (see AppContext's
@@ -121,6 +122,8 @@ describe("SimpleShell", () => {
 
   afterEach(async () => {
     await unmountRoot(root, container);
+    resetStartupTimingForTests();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -140,6 +143,27 @@ describe("SimpleShell", () => {
     expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Queue");
     await click(navButton(container, "Licenses"));
     expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Licenses");
+  });
+
+  it("records Assets ready only when the Simple Assets surface mounts", async () => {
+    const mark = vi.fn();
+    vi.stubGlobal("performance", {
+      clearMarks: vi.fn(),
+      clearMeasures: vi.fn(),
+      mark,
+      measure: vi.fn(),
+      now: () => 1,
+    });
+    resetStartupTimingForTests();
+
+    await renderShell(root, baseContext({ assetsReady: true }));
+    expect(mark).not.toHaveBeenCalled();
+
+    await click(navButton(container, "Assets"));
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Assets");
+    expect(mark.mock.calls.map(([name]) => name)).toEqual([
+      "sceneworks.assets-ready-render",
+    ]);
   });
 
   it("shows the live queue count as a nav badge and drops it when nothing is pending", async () => {

--- a/apps/web/src/startupEntry.test.js
+++ b/apps/web/src/startupEntry.test.js
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { renderThemeInit } from "./accentIds.js";
+import accentsSource from "./accents.js?raw";
+import indexSource from "../index.html?raw";
+import mainSource from "./main.jsx?raw";
+import startupTimingSource from "./startupTiming.js?raw";
+import templateSource from "./theme-init.template.js?raw";
+
+afterEach(() => {
+  delete globalThis.__SCENEWORKS_BOOTSTRAP_TIMING_STARTED__;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("startup timing entry", () => {
+  it("marks bootstrap in the blocking pre-paint entry before the ESM graph", () => {
+    const prePaintEntry = indexSource.indexOf('<script src="/theme-init.js"></script>');
+    const moduleEntry = indexSource.indexOf(
+      '<script type="module" src="/src/main.jsx"></script>',
+    );
+    const bootstrapMark = templateSource.indexOf(
+      'timing.mark("sceneworks.bootstrap-start")',
+    );
+    const firstAppRead = templateSource.indexOf("window.localStorage");
+
+    expect(prePaintEntry).toBeGreaterThan(-1);
+    expect(moduleEntry).toBeGreaterThan(prePaintEntry);
+    expect(bootstrapMark).toBeGreaterThan(-1);
+    expect(firstAppRead).toBeGreaterThan(bootstrapMark);
+    expect(mainSource).not.toContain('recordStartupMark("bootstrap-start")');
+    expect(startupTimingSource).toContain(
+      "globalThis.__SCENEWORKS_BOOTSTRAP_TIMING_STARTED__ === true",
+    );
+  });
+
+  it("executes the generated bootstrap mark before application storage reads", () => {
+    const events = [];
+    vi.stubGlobal("performance", {
+      clearMarks: vi.fn(),
+      mark: vi.fn((name) => events.push(`mark:${name}`)),
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation((key) => {
+      events.push(`storage:${key}`);
+      return null;
+    });
+
+    const generated = renderThemeInit(templateSource, accentsSource);
+    Function(generated)();
+
+    expect(events[0]).toBe("mark:sceneworks.bootstrap-start");
+    expect(events.some((event) => event.startsWith("storage:"))).toBe(true);
+    expect(globalThis.__SCENEWORKS_BOOTSTRAP_TIMING_STARTED__).toBe(true);
+  });
+});

--- a/apps/web/src/startupTiming.js
+++ b/apps/web/src/startupTiming.js
@@ -15,6 +15,10 @@ export const STARTUP_MARK_ORDER = Object.freeze([
 
 const startupOnce = new Set();
 let lastStartupIndex = -1;
+if (globalThis.__SCENEWORKS_BOOTSTRAP_TIMING_STARTED__ === true) {
+  startupOnce.add("bootstrap-start");
+  lastStartupIndex = STARTUP_MARK_ORDER.indexOf("bootstrap-start");
+}
 const STARTUP_MEASURE_NAMES = [
   ...STARTUP_MARK_ORDER.slice(1).map(
     (name, index) => `${STARTUP_MARK_ORDER[index]}-to-${name}`,

--- a/apps/web/src/startupTiming.js
+++ b/apps/web/src/startupTiming.js
@@ -1,0 +1,125 @@
+// Secret-safe, bounded startup timing. These names describe lifecycle phases
+// only; no project, asset, URL, prompt, token, or path value is ever attached.
+const PREFIX = "sceneworks.";
+
+export const STARTUP_MARK_ORDER = Object.freeze([
+  "bootstrap-start",
+  "access-resolved",
+  "media-authorization-settled",
+  "projects-committed",
+  "active-project-selected",
+  "asset-request-start",
+  "asset-request-settled",
+  "assets-ready-render",
+]);
+
+const startupOnce = new Set();
+let lastStartupIndex = -1;
+const STARTUP_MEASURE_NAMES = [
+  ...STARTUP_MARK_ORDER.slice(1).map(
+    (name, index) => `${STARTUP_MARK_ORDER[index]}-to-${name}`,
+  ),
+  "bootstrap-to-assets-ready-render",
+  "asset-request",
+];
+
+function timingApi() {
+  const api = globalThis.performance;
+  return api && typeof api.mark === "function" ? api : null;
+}
+
+function boundedMark(name) {
+  const api = timingApi();
+  if (!api) return false;
+  const fullName = `${PREFIX}${name}`;
+  api.clearMarks?.(fullName);
+  api.mark(fullName);
+  return true;
+}
+
+function boundedMeasure(name, start, end) {
+  const api = timingApi();
+  if (!api || typeof api.measure !== "function") return;
+  const fullName = `${PREFIX}${name}`;
+  api.clearMeasures?.(fullName);
+  try {
+    if (typeof start === "number" && typeof end === "number") {
+      api.measure(fullName, { start, end });
+    } else {
+      api.measure(fullName, start, end);
+    }
+  } catch {
+    // Timing must never affect startup. Older WebViews can expose `mark` while
+    // lacking modern `measure` overloads.
+  }
+}
+
+export function recordStartupMark(name) {
+  if (!STARTUP_MARK_ORDER.includes(name) || startupOnce.has(name)) return false;
+  const index = STARTUP_MARK_ORDER.indexOf(name);
+  if (index < lastStartupIndex) return false;
+  if (!boundedMark(name)) return false;
+  startupOnce.add(name);
+  lastStartupIndex = index;
+
+  const previous = STARTUP_MARK_ORDER[index - 1];
+  if (previous && startupOnce.has(previous)) {
+    boundedMeasure(
+      `${previous}-to-${name}`,
+      `${PREFIX}${previous}`,
+      `${PREFIX}${name}`,
+    );
+  }
+  if (name === "assets-ready-render") {
+    boundedMeasure(
+      "asset-request-settled-to-assets-ready-render",
+      `${PREFIX}asset-request-settled`,
+      `${PREFIX}assets-ready-render`,
+    );
+    if (startupOnce.has("bootstrap-start")) {
+      boundedMeasure(
+        "bootstrap-to-assets-ready-render",
+        `${PREFIX}bootstrap-start`,
+        `${PREFIX}assets-ready-render`,
+      );
+    }
+  }
+  return true;
+}
+
+export function beginAssetRequest() {
+  const api = timingApi();
+  const startedAt = typeof api?.now === "function" ? api.now() : Date.now();
+  boundedMark("asset-request-start");
+  if (startupOnce.has("active-project-selected")) {
+    boundedMeasure(
+      "active-project-selected-to-asset-request-start",
+      `${PREFIX}active-project-selected`,
+      `${PREFIX}asset-request-start`,
+    );
+  }
+  return startedAt;
+}
+
+export function settleAssetRequest(startedAt) {
+  const api = timingApi();
+  const settledAt = typeof api?.now === "function" ? api.now() : Date.now();
+  boundedMark("asset-request-settled");
+  boundedMeasure("asset-request", startedAt, settledAt);
+}
+
+// Test-only reset for this module's one-shot bookkeeping. It intentionally
+// clears only SceneWorks-owned marks. Tests provide an isolated Performance API,
+// so clearing measures cannot affect a real browser navigation.
+export function resetStartupTimingForTests() {
+  startupOnce.clear();
+  lastStartupIndex = -1;
+  const api = timingApi();
+  if (!api) return;
+  for (const name of STARTUP_MARK_ORDER) {
+    api.clearMarks?.(`${PREFIX}${name}`);
+  }
+  for (const name of STARTUP_MEASURE_NAMES) {
+    api.clearMeasures?.(`${PREFIX}${name}`);
+  }
+}

--- a/apps/web/src/startupTiming.test.js
+++ b/apps/web/src/startupTiming.test.js
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  STARTUP_MARK_ORDER,
+  beginAssetRequest,
+  recordStartupMark,
+  resetStartupTimingForTests,
+  settleAssetRequest,
+} from "./startupTiming.js";
+
+function fakePerformance() {
+  let now = 10;
+  return {
+    mark: vi.fn(),
+    measure: vi.fn(),
+    clearMarks: vi.fn(),
+    clearMeasures: vi.fn(),
+    now: vi.fn(() => ++now),
+  };
+}
+
+const originalPerformance = globalThis.performance;
+
+afterEach(() => {
+  resetStartupTimingForTests();
+  Object.defineProperty(globalThis, "performance", {
+    configurable: true,
+    value: originalPerformance,
+  });
+});
+
+describe("startup timing", () => {
+  it("records the expected readiness order without secret-bearing detail", () => {
+    const performance = fakePerformance();
+    Object.defineProperty(globalThis, "performance", { configurable: true, value: performance });
+
+    for (const mark of STARTUP_MARK_ORDER.slice(0, 5)) {
+      expect(recordStartupMark(mark)).toBe(true);
+    }
+    const requestStarted = beginAssetRequest();
+    settleAssetRequest(requestStarted);
+    expect(recordStartupMark("assets-ready-render")).toBe(true);
+
+    expect(performance.mark.mock.calls.map(([name]) => name)).toEqual(
+      STARTUP_MARK_ORDER.map((name) => `sceneworks.${name}`),
+    );
+    expect(performance.mark.mock.calls.flat().join(" ")).not.toMatch(
+      /token|ticket|project-\d|prompt|query/i,
+    );
+  });
+
+  it("keeps one mark and one measure per name when asset refreshes repeat", () => {
+    const performance = fakePerformance();
+    Object.defineProperty(globalThis, "performance", { configurable: true, value: performance });
+
+    for (let index = 0; index < 20; index += 1) {
+      const started = beginAssetRequest();
+      settleAssetRequest(started);
+    }
+
+    expect(performance.clearMarks).toHaveBeenCalledTimes(40);
+    expect(performance.clearMeasures).toHaveBeenCalledTimes(20);
+    expect(performance.measure).toHaveBeenCalledTimes(20);
+    expect(new Set(performance.measure.mock.calls.map(([name]) => name))).toEqual(
+      new Set(["sceneworks.asset-request"]),
+    );
+  });
+
+  it("rejects lifecycle marks that would make readiness order move backwards", () => {
+    const performance = fakePerformance();
+    Object.defineProperty(globalThis, "performance", { configurable: true, value: performance });
+
+    expect(recordStartupMark("access-resolved")).toBe(true);
+    expect(recordStartupMark("projects-committed")).toBe(true);
+    expect(recordStartupMark("media-authorization-settled")).toBe(false);
+    expect(performance.mark.mock.calls.map(([name]) => name)).toEqual([
+      "sceneworks.access-resolved",
+      "sceneworks.projects-committed",
+    ]);
+  });
+
+  it("is inert when the Performance Timeline API is unavailable", () => {
+    Object.defineProperty(globalThis, "performance", { configurable: true, value: undefined });
+
+    expect(() => {
+      recordStartupMark("bootstrap-start");
+      settleAssetRequest(beginAssetRequest());
+    }).not.toThrow();
+  });
+});

--- a/apps/web/src/theme-init.template.js
+++ b/apps/web/src/theme-init.template.js
@@ -6,6 +6,21 @@
 //
 // Applied before first paint to avoid a theme/accent flash. Kept as an external
 // script (not inline) so the served CSP can use a strict script-src 'self'.
+//
+// This is also the tiny, parser-blocking bootstrap entry for startup timing.
+// It executes before /src/main.jsx is requested/evaluated, so this first
+// operation includes the whole ESM graph's fetch, parse, and evaluation cost.
+try {
+  const timing = window.performance;
+  if (timing && typeof timing.mark === "function") {
+    timing.clearMarks?.("sceneworks.bootstrap-start");
+    timing.mark("sceneworks.bootstrap-start");
+    globalThis.__SCENEWORKS_BOOTSTRAP_TIMING_STARTED__ = true;
+  }
+} catch {
+  // Timing must never affect bootstrap.
+}
+
 try {
   const root = document.documentElement;
 

--- a/docs/deploy-runpod.md
+++ b/docs/deploy-runpod.md
@@ -392,6 +392,10 @@ take well over an hour on a cold hosted runner.
 
 ## Optional: validate the RunPod proxy
 
+For a page-load performance capture that separates API server work, proxy/body
+transfer, and client readiness without recording secrets, follow the
+[startup and page-load timing procedure](startup-performance-capture.md).
+
 The repository probe checks authenticated job events, SSE heartbeats, and a
 large multipart upload through the real RunPod HTTPS proxy. Keep a representative
 image or video of at least 100 MiB available.

--- a/docs/startup-performance-capture.md
+++ b/docs/startup-performance-capture.md
@@ -28,11 +28,13 @@ fixed phases:
 - `reserved_project_initialization`
 - `orphaned_asset_maintenance`
 
-The web app records fixed `sceneworks.*` marks for bootstrap start, access
-resolution, media authorization settlement, projects committed, active project
-selection, asset request start/settle, and the first Assets-ready render.
-Repeated asset refreshes clear and reuse the same entries. Startup marks are
-one-shot, so the browser retains a fixed, bounded set.
+The parser-blocking pre-paint entry records `sceneworks.bootstrap-start` before
+the application module graph is fetched/evaluated. The web app then records
+fixed marks for access resolution, media authorization settlement, projects
+committed, active project selection, asset request start/settle, and the first
+commit of the actual Advanced Library or Simple Assets surface with a settled
+catalog. Repeated asset refreshes clear and reuse the same entries. Startup
+marks are one-shot, so the browser retains a fixed, bounded set.
 
 ## RunPod capture procedure
 

--- a/docs/startup-performance-capture.md
+++ b/docs/startup-performance-capture.md
@@ -1,0 +1,133 @@
+# Startup and page-load timing capture
+
+SceneWorks exposes a small, secret-safe timing surface for separating API work,
+response transfer, and browser readiness. It is diagnostic telemetry in the
+existing process log and browser Performance Timeline; it does not send data to
+an external service.
+
+## What is recorded
+
+API responses emit an `api_request_duration` log event with only:
+
+- the HTTP method;
+- Axum's normalized route template, such as
+  `/api/v1/projects/:project_id/assets`;
+- the response status; and
+- server duration in milliseconds.
+
+Unknown API paths collapse to `/api/<unmatched>` and MCP paths collapse to
+`/mcp/<unmatched>`. Raw URLs, query strings, IDs, tokens, media tickets,
+prompts, names, and filesystem paths are never timing fields. Every API
+response also carries `Server-Timing: app;dur=<milliseconds>`.
+
+Before binding the listener, the API emits `startup_phase_duration` for these
+fixed phases:
+
+- `upload_sweeps`
+- `jobs_retention_recovery`
+- `reserved_project_initialization`
+- `orphaned_asset_maintenance`
+
+The web app records fixed `sceneworks.*` marks for bootstrap start, access
+resolution, media authorization settlement, projects committed, active project
+selection, asset request start/settle, and the first Assets-ready render.
+Repeated asset refreshes clear and reuse the same entries. Startup marks are
+one-shot, so the browser retains a fixed, bounded set.
+
+## RunPod capture procedure
+
+Use an immutable image tag or digest and record it with the Pod's GPU type,
+region, volume state (cold or warm), browser version, and UTC capture time.
+Never paste a Pod URL, access token, media ticket, project name, or full browser
+network export into a ticket.
+
+1. Start the Pod and save only `startup_phase_duration` log events. Copy the
+   `phase` and `duration_ms` fields; omit unrelated log fields.
+2. Open the RunPod proxy URL in a private browser window, start a Performance
+   recording, authenticate normally, and wait until Assets renders.
+3. In DevTools Console, run the sanitizing snippet below. It returns fixed mark
+   names and allow-listed route templates only; it never returns resource URLs
+   or query strings.
+4. Repeat at least five cold browser loads. Use a fresh private window for each
+   cold load. Keep cold-volume and warm-volume samples in separate tables.
+5. Attach the sanitized tables to the Shortcut story before comparing any
+   optimization result.
+
+```js
+const routeLabel = (pathname) => {
+  if (pathname === "/api/v1/access") return pathname;
+  if (pathname === "/api/v1/files/ticket") return pathname;
+  if (pathname === "/api/v1/projects") return pathname;
+  if (/^\/api\/v1\/projects\/[^/]+\/assets$/.test(pathname)) {
+    return "/api/v1/projects/:project_id/assets";
+  }
+  return pathname.startsWith("/api/") ? "/api/<other>" : null;
+};
+
+const marks = performance
+  .getEntriesByType("mark")
+  .filter(({ name }) => name.startsWith("sceneworks."))
+  .map(({ name, startTime }) => ({
+    mark: name,
+    millisecondsFromNavigation: Number(startTime.toFixed(3)),
+  }));
+
+const requests = performance
+  .getEntriesByType("resource")
+  .map((entry) => ({ entry, route: routeLabel(new URL(entry.name).pathname) }))
+  .filter(({ route }) => route)
+  .map(({ entry, route }) => {
+    const server =
+      entry.serverTiming.find(({ name }) => name === "app")?.duration ?? null;
+    return {
+      route,
+      totalMs: Number(entry.duration.toFixed(3)),
+      serverMs: server === null ? null : Number(server.toFixed(3)),
+      transferMs: Number((entry.responseEnd - entry.responseStart).toFixed(3)),
+      proxyNetworkAndQueueMs:
+        server === null
+          ? null
+          : Number(
+              Math.max(0, entry.responseStart - entry.requestStart - server).toFixed(3),
+            ),
+    };
+  });
+
+({ marks, requests });
+```
+
+Interpret the columns as follows:
+
+- `serverMs` is application processing through response-header creation,
+  reported by the API's `Server-Timing` header.
+- `transferMs` is first response byte through final response byte and therefore
+  includes proxy-to-browser body transfer.
+- `proxyNetworkAndQueueMs` is an approximation of the remaining request wait
+  outside the app. TLS, RunPod proxying, scheduling, and network latency are
+  included, so do not label it server work.
+- Client readiness is the delta from `sceneworks.bootstrap-start` to the
+  relevant fixed mark, especially `sceneworks.assets-ready-render`.
+
+For a same-origin RunPod deployment, `serverTiming` is available directly.
+If it is absent, retain `serverMs: null` rather than estimating server time from
+the resource duration; correlate the normalized API log event instead.
+
+## Local pre-optimization evidence (not RunPod)
+
+Captured 2026-07-25 on a Windows development host from an unoptimized Rust
+debug build, loopback HTTP, no authentication, empty temporary data/config
+directories, and ten sequential PowerShell requests per route:
+
+| Normalized route | Samples | Total median (min-max) | Server median (min-max) |
+| --- | ---: | ---: | ---: |
+| `/api/v1/access` | 10 | 23.973 ms (23.372-24.940) | 0.138 ms (0.131-0.342) |
+| `/api/v1/projects` | 10 | 22.188 ms (16.045-28.163) | 0.959 ms (0.878-1.094) |
+
+The total includes substantial PowerShell `Invoke-WebRequest` overhead and is
+not a browser transfer measurement. This local harness did not exercise the
+RunPod proxy, TLS, a populated network volume, authentication, bundle loading,
+or a real browser render. Its purpose is to prove that the server and
+end-to-end values can be separated without secrets; it must not be used as the
+RunPod performance baseline or compared directly with downstream RunPod
+optimization results. The focused client timing test separately proves the
+expected mark ordering and bounded repeated-asset behavior.


### PR DESCRIPTION
## What does this PR do?

Adds secret-safe, low-overhead startup/page-load timing for SC-14782:

- logs normalized Axum route templates, method, status, and server duration for every API/MCP response, and exposes the numeric duration through `Server-Timing`;
- emits fixed pre-bind durations for upload sweeps, jobs retention/recovery, reserved projects, and orphaned-asset maintenance;
- records bounded browser marks/measures from bootstrap through the first Assets-ready render, including repeated asset request timing;
- documents a sanitized RunPod capture that separates application time, transfer time, proxy/network wait, and client readiness;
- records an explicitly local-only pre-optimization baseline, also attached to the Shortcut story.

Timing labels never include raw URLs, query strings, IDs, tokens, tickets, prompts, names, or filesystem paths. Unknown routes collapse to fixed labels.

## Related issue

[SC-14782](https://app.shortcut.com/trefry/story/14782)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [x] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [ ] macOS (Apple Silicon / MLX)
- [x] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

Validation:

- `cargo test -p sceneworks-rust-api --lib` — 380 passed, 2 ignored
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build -p sceneworks-rust-api`
- `npm --prefix apps/web run lint` — 0 errors; 62 pre-existing warnings
- `npm --prefix apps/web test` — 2,576 passed
- `npm --prefix apps/web run build`
- focused client timing/auth tests — 37 passed
- focused API timing/redaction tests — 2 passed

Local baseline caveat: Windows debug/loopback/PowerShell only, not RunPod or browser-comparable. The real RunPod procedure is in `docs/startup-performance-capture.md`.

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [ ] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant
- [x] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [x] My PR is focused on a single logical change