### PR TITLE
fix(api): stabilize model catalog size estimation (sc-14800)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -996,6 +996,8 @@ pub(crate) fn create_app_with_state(
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
         model_size_cache: Arc::new(Mutex::new(ModelSizeCache::default())),
+        #[cfg(test)]
+        model_size_estimate_test_hook: Arc::new(Mutex::new(None)),
         external_lora_cache: Arc::new(Mutex::new(external_loras::ExternalLoraCache::default())),
         external_base_model_cache: Arc::new(Mutex::new(
             external_base_models::ExternalBaseModelCache::default(),

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -998,6 +998,8 @@ pub(crate) fn create_app_with_state(
         model_size_cache: Arc::new(Mutex::new(ModelSizeCache::default())),
         #[cfg(test)]
         model_size_estimate_test_hook: Arc::new(Mutex::new(None)),
+        #[cfg(test)]
+        model_size_estimate_disabled_override: Arc::new(Mutex::new(None)),
         external_lora_cache: Arc::new(Mutex::new(external_loras::ExternalLoraCache::default())),
         external_base_model_cache: Arc::new(Mutex::new(
             external_base_models::ExternalBaseModelCache::default(),

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -4381,15 +4381,23 @@ pub(crate) fn manifest_download_size_bytes(model: &Value, download: &Value) -> O
         })
 }
 
+fn model_size_estimation_disabled(_state: &AppState) -> bool {
+    #[cfg(test)]
+    if let Some(disabled) = *_state.model_size_estimate_disabled_override.lock() {
+        return disabled;
+    }
+    matches!(
+        std::env::var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE").as_deref(),
+        Ok("1" | "true" | "TRUE" | "yes" | "YES")
+    )
+}
+
 pub(crate) async fn estimate_huggingface_download_size(
     state: &AppState,
     repo: &str,
     files: &[String],
 ) -> Option<u64> {
-    if matches!(
-        std::env::var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE").as_deref(),
-        Ok("1" | "true" | "TRUE" | "yes" | "YES")
-    ) {
+    if model_size_estimation_disabled(state) {
         return None;
     }
     let cache_key = (repo.to_owned(), files.to_vec());

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -2986,21 +2986,13 @@ fn torn_tier_marker(files: &[String]) -> String {
         .unwrap_or_else(|| "incomplete: missing model components".to_owned())
 }
 
-// Build the per-variant install state for every supported download entry. A single-variant model
-// yields one entry keyed "default"; a quant-matrix model yields one per tier. Each entry's install
-// state is probed independently against the HF cache using that tier's own `files` filter, so the
-// catalog can advertise (e.g.) bf16 installed while q4 is missing.
-fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantState> {
+// Select the canonical source entry for each emitted variant. A single-variant model yields one
+// "default" entry; a quant matrix yields one per tier. Install probing and the later live-size
+// refresh share this selector so their response-array positions cannot drift.
+fn model_variant_downloads(model: &Value) -> Vec<&Value> {
     let Some(downloads) = model.get("downloads").and_then(Value::as_array) else {
         return Vec::new();
     };
-    // sc-13513: the manifest `family` selects the shared per-tier completeness predicate for the
-    // no-`model_index` MLX turnkeys (SANA/Boogu) so a torn tier reads `incomplete`, not `installed`.
-    let family = model
-        .get("family")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    let model_id = model.get("id").and_then(Value::as_str).unwrap_or_default();
     // Emitted variant keys must be unique: the single-variant case is exactly one "default", and a
     // quant matrix has one entry per distinct q4/q8/bf16 tier. Guard against a manifest that maps two
     // supported entries to the same key (unlabeled alternate sources both collapsing to "default", or
@@ -3020,6 +3012,22 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
                 .unwrap_or_else(|| "default".to_owned());
             seen_variants.insert(key)
         })
+        .collect()
+}
+
+// Build the per-variant install state for every selected download entry. Each entry is probed
+// independently against the HF cache using that tier's own `files` filter, so the catalog can
+// advertise (e.g.) bf16 installed while q4 is missing.
+fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantState> {
+    // sc-13513: the manifest `family` selects the shared per-tier completeness predicate for the
+    // no-`model_index` MLX turnkeys (SANA/Boogu) so a torn tier reads `incomplete`, not `installed`.
+    let family = model
+        .get("family")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let model_id = model.get("id").and_then(Value::as_str).unwrap_or_default();
+    model_variant_downloads(model)
+        .into_iter()
         .map(|entry| {
             let repo = entry
                 .get("repo")
@@ -3190,6 +3198,38 @@ fn apply_variant_fields(object: &mut JsonObject, data_dir: &FsPath) {
         .collect::<Vec<_>>();
     object.insert("hasVariantMatrix".to_owned(), Value::Bool(has_matrix));
     object.insert("variants".to_owned(), Value::Array(variants));
+}
+
+fn refresh_variant_download_sizes(model: &mut Value) -> Result<(), ApiError> {
+    // `apply_variant_fields` runs in the blocking install-state sweep while live HF estimation runs
+    // concurrently. Refresh only the already-built response fields after both complete: rebuilding
+    // variants here would repeat filesystem probes serially and undo the intended overlap.
+    let sizes = model_variant_downloads(model)
+        .into_iter()
+        .map(|download| {
+            manifest_download_size_bytes(model, download)
+                .or_else(|| variant_footprint_disk_bytes(download))
+        })
+        .collect::<Vec<_>>();
+    let variants = model
+        .get_mut("variants")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| ApiError::internal("Model catalog variants must be an array"))?;
+    if variants.len() != sizes.len() {
+        return Err(ApiError::internal(
+            "Model catalog variant count changed during size enrichment",
+        ));
+    }
+    for (variant, size) in variants.iter_mut().zip(sizes) {
+        let object = variant
+            .as_object_mut()
+            .ok_or_else(|| ApiError::internal("Model catalog variant must be an object"))?;
+        object.insert(
+            "downloadSizeBytes".to_owned(),
+            size.map(|value| json!(value)).unwrap_or(Value::Null),
+        );
+    }
+    Ok(())
 }
 
 /// The convert-output quant tiers present under a converted MLX dir (sc-10730), highest-fidelity first.
@@ -3486,27 +3526,29 @@ fn apply_model_catalog_size_fields(
         None if co_requisite_size_bytes > 0 => Some(co_requisite_size_bytes),
         None => None,
     };
-    let object = model
-        .as_object_mut()
-        .ok_or_else(|| ApiError::internal("Model manifest entry must be an object"))?;
-    object.insert(
-        "downloadSizeBytes".to_owned(),
-        effective_download_size_bytes
-            .map(|value| json!(value))
-            .unwrap_or(Value::Null),
-    );
-    object.insert(
-        "downloadSizeLabel".to_owned(),
-        effective_download_size_bytes
-            .map(format_bytes)
-            .map(Value::String)
-            .unwrap_or(Value::Null),
-    );
-    object.insert(
-        "downloadSizeEstimated".to_owned(),
-        Value::Bool(download_size_estimated),
-    );
-    Ok(())
+    {
+        let object = model
+            .as_object_mut()
+            .ok_or_else(|| ApiError::internal("Model manifest entry must be an object"))?;
+        object.insert(
+            "downloadSizeBytes".to_owned(),
+            effective_download_size_bytes
+                .map(|value| json!(value))
+                .unwrap_or(Value::Null),
+        );
+        object.insert(
+            "downloadSizeLabel".to_owned(),
+            effective_download_size_bytes
+                .map(format_bytes)
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        object.insert(
+            "downloadSizeEstimated".to_owned(),
+            Value::Bool(download_size_estimated),
+        );
+    }
+    refresh_variant_download_sizes(model)
 }
 
 fn apply_model_catalog_entry(

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -5,7 +5,10 @@ use sceneworks_core::credentials::normalize_host;
 use sceneworks_core::lora_family::is_hidden_file;
 
 const ALLOWED_MODEL_TYPES: &[&str] = &["image", "video", "audio", "utility"];
-const MODEL_SIZE_CACHE_LIMIT: usize = 64;
+// The shipped catalog currently has more than 64 distinct (repo, files) contexts. Keep ample
+// headroom for catalog growth so an in-order scan cannot evict the entries the next scan is about
+// to read and degrade into a zero-hit cycle.
+const MODEL_SIZE_CACHE_LIMIT: usize = 256;
 const MODEL_CATALOG_PROBE_CONCURRENCY: usize = 16;
 static MODEL_CATALOG_PROBE_PERMITS: std::sync::OnceLock<Arc<tokio::sync::Semaphore>> =
     std::sync::OnceLock::new();
@@ -13,6 +16,69 @@ static MODEL_CATALOG_PROBE_PERMITS: std::sync::OnceLock<Arc<tokio::sync::Semapho
 // negative-cached so a huggingface.co outage costs one 8s timeout per repo per
 // TTL window instead of one per catalog load (sc-4169).
 const MODEL_SIZE_NEGATIVE_TTL: Duration = Duration::from_secs(300);
+// Successful metadata can change when a repository is updated in place. Refresh it periodically
+// without making ordinary warm catalog loads depend on Hugging Face.
+const MODEL_SIZE_POSITIVE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct ModelSizeEstimateTestHook {
+    calls: Arc<std::sync::atomic::AtomicUsize>,
+    started: Arc<tokio::sync::Semaphore>,
+    release: Option<Arc<tokio::sync::Semaphore>>,
+    response: Option<u64>,
+}
+
+#[cfg(test)]
+impl ModelSizeEstimateTestHook {
+    pub(crate) fn immediate(response: Option<u64>) -> Self {
+        Self {
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            started: Arc::new(tokio::sync::Semaphore::new(0)),
+            release: None,
+            response,
+        }
+    }
+
+    pub(crate) fn blocked(response: Option<u64>) -> Self {
+        Self {
+            release: Some(Arc::new(tokio::sync::Semaphore::new(0))),
+            ..Self::immediate(response)
+        }
+    }
+
+    pub(crate) fn call_count(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    pub(crate) async fn wait_for_call(&self) {
+        self.started
+            .acquire()
+            .await
+            .expect("model-size test hook remains open")
+            .forget();
+    }
+
+    pub(crate) fn release_one(&self) {
+        self.release
+            .as_ref()
+            .expect("blocked model-size test hook")
+            .add_permits(1);
+    }
+
+    async fn request(&self) -> Option<u64> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.started.add_permits(1);
+        if let Some(release) = &self.release {
+            release
+                .acquire()
+                .await
+                .expect("model-size test hook remains open")
+                .forget();
+        }
+        self.response
+    }
+}
 
 fn validate_huggingface_repo(repo: &str) -> Result<(), ApiError> {
     let parts: Vec<_> = repo.trim().split('/').collect();
@@ -71,7 +137,7 @@ impl ModelSizeCache {
             key,
             CachedSizeEstimate {
                 size_bytes: Some(value),
-                expires_at: None,
+                expires_at: Some(std::time::Instant::now() + MODEL_SIZE_POSITIVE_TTL),
             },
         );
     }
@@ -3274,43 +3340,29 @@ fn test_delay_catalog_probe(model: &Value) {
     TEST_CATALOG_PROBES_ACTIVE.fetch_sub(1, Ordering::SeqCst);
 }
 
-fn apply_model_catalog_entry(
-    mut model: Value,
-    download_context: Option<DownloadContext>,
+fn apply_model_catalog_size_fields(
+    model: &mut Value,
+    download_context: Option<&DownloadContext>,
     download_size_bytes: Option<u64>,
-    data_dir: &FsPath,
-    user_model_ids: &std::collections::HashSet<String>,
-) -> Result<Value, ApiError> {
-    #[cfg(test)]
-    test_delay_catalog_probe(&model);
-    let fallback_size_bytes = download_context
-        .as_ref()
-        .and_then(|context| context.fallback_size_bytes);
+) -> Result<(), ApiError> {
+    let fallback_size_bytes = download_context.and_then(|context| context.fallback_size_bytes);
     let primary_size_bytes = download_size_bytes.or(fallback_size_bytes);
     let download_size_estimated = download_size_bytes.is_none() && fallback_size_bytes.is_some();
     // Co-requisites (sc-9696) install alongside the primary, so the displayed footprint must
     // include them (e.g. PiD's ~2.7 GB checkpoint + ~5.2 GB gemma-2-2b-it). Their sizes come
     // from the manifest (the live HF estimate above only sizes the primary repo).
-    let co_requisite_size_bytes: u64 = model_co_requisite_downloads(&model)
+    let co_requisite_size_bytes: u64 = model_co_requisite_downloads(model)
         .iter()
-        .filter_map(|download| manifest_download_size_bytes(&model, download))
+        .filter_map(|download| manifest_download_size_bytes(model, download))
         .sum();
     let effective_download_size_bytes = match primary_size_bytes {
         Some(primary) => Some(primary + co_requisite_size_bytes),
         None if co_requisite_size_bytes > 0 => Some(co_requisite_size_bytes),
         None => None,
     };
-    let state = install_state_for(download_context, &model, data_dir);
     let object = model
         .as_object_mut()
         .ok_or_else(|| ApiError::internal("Model manifest entry must be an object"))?;
-    let model_id = object.get("id").and_then(Value::as_str).unwrap_or_default();
-    let user_managed = user_model_ids.contains(model_id);
-    object.insert(
-        "catalogScope".to_owned(),
-        Value::String(if user_managed { "user" } else { "builtin" }.to_owned()),
-    );
-    object.insert("downloadable".to_owned(), Value::Bool(state.downloadable));
     object.insert(
         "downloadSizeBytes".to_owned(),
         effective_download_size_bytes
@@ -3328,6 +3380,28 @@ fn apply_model_catalog_entry(
         "downloadSizeEstimated".to_owned(),
         Value::Bool(download_size_estimated),
     );
+    Ok(())
+}
+
+fn apply_model_catalog_entry(
+    mut model: Value,
+    download_context: Option<DownloadContext>,
+    data_dir: &FsPath,
+    user_model_ids: &std::collections::HashSet<String>,
+) -> Result<Value, ApiError> {
+    #[cfg(test)]
+    test_delay_catalog_probe(&model);
+    let state = install_state_for(download_context, &model, data_dir);
+    let object = model
+        .as_object_mut()
+        .ok_or_else(|| ApiError::internal("Model manifest entry must be an object"))?;
+    let model_id = object.get("id").and_then(Value::as_str).unwrap_or_default();
+    let user_managed = user_model_ids.contains(model_id);
+    object.insert(
+        "catalogScope".to_owned(),
+        Value::String(if user_managed { "user" } else { "builtin" }.to_owned()),
+    );
+    object.insert("downloadable".to_owned(), Value::Bool(state.downloadable));
     object.insert(
         "installState".to_owned(),
         Value::String(
@@ -3391,7 +3465,7 @@ fn apply_model_catalog_entry(
     Ok(model)
 }
 
-type ModelCatalogWorkItem = (Value, (Option<DownloadContext>, Option<u64>));
+type ModelCatalogWorkItem = (Value, Option<DownloadContext>);
 const MODEL_SIZE_ESTIMATE_CONCURRENCY: usize = 8;
 
 async fn collect_bounded_ordered<I, T, F, Fut, R>(
@@ -3434,6 +3508,55 @@ mod model_size_concurrency_tests {
         assert_eq!(output, (0..12).collect::<Vec<_>>());
         assert_eq!(peak.load(Ordering::SeqCst), 3);
     }
+
+    #[test]
+    fn builtin_download_contexts_fit_in_size_cache() {
+        let raw = include_str!("../../../config/manifests/builtin.models.jsonc");
+        let manifest: Value = serde_json::from_str(&crate::strip_jsonc_comments(raw))
+            .expect("builtin manifest parses");
+        for (os, expected_distinct_contexts) in
+            [("macos", 81_usize), ("windows", 80), ("linux", 80)]
+        {
+            let mut keys = std::collections::HashSet::new();
+            for mut model in manifest["models"]
+                .as_array()
+                .expect("models array")
+                .iter()
+                .cloned()
+            {
+                retain_downloads_for_os(&mut model, os);
+                if let Some(context) = model_download_context(&model).expect("download context") {
+                    keys.insert((context.repo, context.files));
+                }
+            }
+            assert_eq!(
+                keys.len(),
+                expected_distinct_contexts,
+                "{os} builtin download-context count changed; reconsider cache capacity"
+            );
+            assert!(
+                keys.len() <= MODEL_SIZE_CACHE_LIMIT,
+                "{os} builtin catalog has {} distinct download contexts but cache holds only {}",
+                keys.len(),
+                MODEL_SIZE_CACHE_LIMIT
+            );
+        }
+    }
+
+    #[test]
+    fn successful_size_estimates_have_a_bounded_positive_ttl() {
+        let mut cache = ModelSizeCache::default();
+        let key = ("owner/model".to_owned(), vec!["*.safetensors".to_owned()]);
+        let before = std::time::Instant::now();
+        cache.insert(key.clone(), 1234);
+        let expires_at = cache
+            .entries
+            .get(&key)
+            .and_then(|entry| entry.expires_at)
+            .expect("successful estimate expires");
+        assert!(expires_at > before);
+        assert!(expires_at <= before + MODEL_SIZE_POSITIVE_TTL + Duration::from_secs(1));
+    }
 }
 
 fn group_model_catalog_work_items(
@@ -3442,7 +3565,7 @@ fn group_model_catalog_work_items(
     let mut groups = Vec::<Vec<ModelCatalogWorkItem>>::new();
     let mut repo_groups = HashMap::<String, usize>::new();
     for item in work_items {
-        let (_, (download_context, _)) = &item;
+        let (_, download_context) = &item;
         let repo = download_context
             .as_ref()
             .map(|context| context.repo.clone());
@@ -3458,6 +3581,37 @@ fn group_model_catalog_work_items(
         }
     }
     groups
+}
+
+async fn estimate_model_catalog_sizes(
+    state: &AppState,
+    download_contexts: &[Option<DownloadContext>],
+    enabled: bool,
+) -> HashMap<ModelSizeCacheKey, Option<u64>> {
+    if !enabled {
+        return HashMap::new();
+    }
+    let mut seen = std::collections::HashSet::new();
+    let unique = download_contexts
+        .iter()
+        .flatten()
+        .filter_map(|context| {
+            let key = (context.repo.clone(), context.files.clone());
+            seen.insert(key.clone()).then_some((key, context.clone()))
+        })
+        .collect::<Vec<_>>();
+    collect_bounded_ordered(
+        unique,
+        MODEL_SIZE_ESTIMATE_CONCURRENCY,
+        |(key, context)| async move {
+            let estimate =
+                estimate_huggingface_download_size(state, &context.repo, &context.files).await;
+            (key, estimate)
+        },
+    )
+    .await
+    .into_iter()
+    .collect()
 }
 
 async fn model_catalog_inner(
@@ -3489,25 +3643,13 @@ async fn model_catalog_inner(
         .iter()
         .map(model_download_context)
         .collect::<Result<Vec<_>, _>>()?;
-    let download_size_bytes = collect_bounded_ordered(
-        download_contexts.iter().cloned(),
-        MODEL_SIZE_ESTIMATE_CONCURRENCY,
-        |context| async move {
-            match context {
-                Some(context) if estimate_sizes => {
-                    estimate_huggingface_download_size(state, &context.repo, &context.files).await
-                }
-                _ => None,
-            }
-        },
-    )
-    .await;
+    let size_estimates = estimate_model_catalog_sizes(state, &download_contexts, estimate_sizes);
 
     let data_dir = Arc::new(state.settings.data_dir.clone());
     let user_model_ids = Arc::new(user_model_ids);
     let work_items = models
         .into_iter()
-        .zip(download_contexts.into_iter().zip(download_size_bytes))
+        .zip(download_contexts.clone())
         .collect::<Vec<_>>();
     let work_groups = group_model_catalog_work_items(work_items);
     let data_dir_for_sweep = data_dir.clone();
@@ -3520,11 +3662,10 @@ async fn model_catalog_inner(
     let catalog_sweep = run_blocking_catalog_sweep(work_groups, move |work_group| {
         work_group
             .into_iter()
-            .map(|(model, (download_context, download_size_bytes))| {
+            .map(|(model, download_context)| {
                 apply_model_catalog_entry(
                     model,
                     download_context,
-                    download_size_bytes,
                     &data_dir_for_sweep,
                     &user_model_ids_for_sweep,
                 )
@@ -3540,8 +3681,19 @@ async fn model_catalog_inner(
         let mut cache = external_base_cache.lock();
         crate::external_base_models::scan_external_base_models(&external_roots, &mut cache)
     });
-    let (models, external) = tokio::join!(catalog_sweep, external_scan);
+    let (size_estimates, models, external) =
+        tokio::join!(size_estimates, catalog_sweep, external_scan);
     let mut models = models?.into_iter().flatten().collect::<Vec<_>>();
+    for model in &mut models {
+        let context = model_download_context(model)?;
+        let live_estimate = context.as_ref().and_then(|context| {
+            size_estimates
+                .get(&(context.repo.clone(), context.files.clone()))
+                .copied()
+                .flatten()
+        });
+        apply_model_catalog_size_fields(model, context.as_ref(), live_estimate)?;
+    }
     let external = external.map_err(|err| {
         ApiError::internal(format!("external model catalog scan task failed: {err}"))
     })?;
@@ -4279,6 +4431,17 @@ pub(crate) async fn estimate_huggingface_download_size(
     let cache_key = (repo.to_owned(), files.to_vec());
     if let Some(cached) = state.model_size_cache.lock().get(&cache_key) {
         return cached;
+    }
+    #[cfg(test)]
+    let test_hook = { state.model_size_estimate_test_hook.lock().clone() };
+    #[cfg(test)]
+    if let Some(hook) = test_hook {
+        let estimate = hook.request().await;
+        match estimate {
+            Some(estimate) => state.model_size_cache.lock().insert(cache_key, estimate),
+            None => state.model_size_cache.lock().insert_failure(cache_key),
+        }
+        return estimate;
     }
     let url = format!(
         "https://huggingface.co/api/models/{}?blobs=true",

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -24,9 +24,11 @@ const MODEL_SIZE_POSITIVE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 #[derive(Clone)]
 pub(crate) struct ModelSizeEstimateTestHook {
     calls: Arc<std::sync::atomic::AtomicUsize>,
+    followers: Arc<std::sync::atomic::AtomicUsize>,
     started: Arc<tokio::sync::Semaphore>,
+    joined: Arc<tokio::sync::Semaphore>,
     release: Option<Arc<tokio::sync::Semaphore>>,
-    response: Option<u64>,
+    response: Arc<Mutex<Option<u64>>>,
 }
 
 #[cfg(test)]
@@ -34,9 +36,11 @@ impl ModelSizeEstimateTestHook {
     pub(crate) fn immediate(response: Option<u64>) -> Self {
         Self {
             calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            followers: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             started: Arc::new(tokio::sync::Semaphore::new(0)),
+            joined: Arc::new(tokio::sync::Semaphore::new(0)),
             release: None,
-            response,
+            response: Arc::new(Mutex::new(response)),
         }
     }
 
@@ -51,6 +55,10 @@ impl ModelSizeEstimateTestHook {
         self.calls.load(std::sync::atomic::Ordering::SeqCst)
     }
 
+    pub(crate) fn follower_count(&self) -> usize {
+        self.followers.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
     pub(crate) async fn wait_for_call(&self) {
         self.started
             .acquire()
@@ -59,11 +67,29 @@ impl ModelSizeEstimateTestHook {
             .forget();
     }
 
+    pub(crate) async fn wait_for_follower(&self) {
+        self.joined
+            .acquire()
+            .await
+            .expect("model-size test hook remains open")
+            .forget();
+    }
+
+    pub(crate) fn set_response(&self, response: Option<u64>) {
+        *self.response.lock() = response;
+    }
+
     pub(crate) fn release_one(&self) {
         self.release
             .as_ref()
             .expect("blocked model-size test hook")
             .add_permits(1);
+    }
+
+    fn note_follower(&self) {
+        self.followers
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.joined.add_permits(1);
     }
 
     async fn request(&self) -> Option<u64> {
@@ -76,7 +102,7 @@ impl ModelSizeEstimateTestHook {
                 .expect("model-size test hook remains open")
                 .forget();
         }
-        self.response
+        *self.response.lock()
     }
 }
 
@@ -103,9 +129,62 @@ fn validate_huggingface_repo(repo: &str) -> Result<(), ApiError> {
 pub(crate) struct ModelSizeCache {
     entries: HashMap<ModelSizeCacheKey, CachedSizeEstimate>,
     order: VecDeque<ModelSizeCacheKey>,
+    in_flight: HashMap<ModelSizeCacheKey, Arc<ModelSizeInFlight>>,
 }
 
 type ModelSizeCacheKey = (String, Vec<String>);
+
+#[derive(Debug, Clone, Copy)]
+enum ModelSizeFlightStatus {
+    Pending,
+    Complete(Option<u64>),
+    Aborted,
+}
+
+#[derive(Debug)]
+struct ModelSizeInFlight {
+    status: Mutex<ModelSizeFlightStatus>,
+    changed: tokio::sync::Notify,
+}
+
+impl ModelSizeInFlight {
+    fn pending() -> Self {
+        Self {
+            status: Mutex::new(ModelSizeFlightStatus::Pending),
+            changed: tokio::sync::Notify::new(),
+        }
+    }
+
+    async fn wait(&self) -> ModelSizeFlightStatus {
+        loop {
+            let changed = self.changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+            let status = *self.status.lock();
+            if !matches!(status, ModelSizeFlightStatus::Pending) {
+                return status;
+            }
+            changed.await;
+        }
+    }
+
+    fn complete(&self, estimate: Option<u64>) {
+        *self.status.lock() = ModelSizeFlightStatus::Complete(estimate);
+        self.changed.notify_waiters();
+    }
+
+    fn abort(&self) {
+        *self.status.lock() = ModelSizeFlightStatus::Aborted;
+        self.changed.notify_waiters();
+    }
+}
+
+enum ModelSizeLookup {
+    Cached(Option<u64>),
+    Lead(Arc<ModelSizeInFlight>),
+    Follow(Arc<ModelSizeInFlight>),
+    Unshared,
+}
 
 #[derive(Debug, Clone, Copy)]
 struct CachedSizeEstimate {
@@ -130,6 +209,52 @@ impl ModelSizeCache {
             return Some(entry.size_bytes);
         }
         None
+    }
+
+    fn lookup_or_start(&mut self, key: &ModelSizeCacheKey) -> ModelSizeLookup {
+        if let Some(cached) = self.get(key) {
+            return ModelSizeLookup::Cached(cached);
+        }
+        if let Some(in_flight) = self.in_flight.get(key) {
+            return ModelSizeLookup::Follow(in_flight.clone());
+        }
+        if self.in_flight.len() >= MODEL_SIZE_CACHE_LIMIT {
+            return ModelSizeLookup::Unshared;
+        }
+        let in_flight = Arc::new(ModelSizeInFlight::pending());
+        self.in_flight.insert(key.clone(), in_flight.clone());
+        ModelSizeLookup::Lead(in_flight)
+    }
+
+    fn finish(
+        &mut self,
+        key: &ModelSizeCacheKey,
+        in_flight: &Arc<ModelSizeInFlight>,
+        estimate: Option<u64>,
+    ) {
+        if self
+            .in_flight
+            .get(key)
+            .is_some_and(|current| Arc::ptr_eq(current, in_flight))
+        {
+            self.in_flight.remove(key);
+            match estimate {
+                Some(estimate) => self.insert(key.clone(), estimate),
+                None => self.insert_failure(key.clone()),
+            }
+        }
+        in_flight.complete(estimate);
+    }
+
+    fn abort(&mut self, key: &ModelSizeCacheKey, in_flight: &Arc<ModelSizeInFlight>) {
+        if self
+            .in_flight
+            .get(key)
+            .is_some_and(|current| Arc::ptr_eq(current, in_flight))
+        {
+            self.in_flight.remove(key);
+        }
+        in_flight.abort();
     }
 
     pub(crate) fn insert(&mut self, key: ModelSizeCacheKey, value: u64) {
@@ -174,6 +299,43 @@ impl ModelSizeCache {
     fn touch(&mut self, key: &ModelSizeCacheKey) {
         self.order.retain(|existing| existing != key);
         self.order.push_back(key.clone());
+    }
+}
+
+struct ModelSizeFlightLeader {
+    cache: Arc<Mutex<ModelSizeCache>>,
+    key: ModelSizeCacheKey,
+    in_flight: Arc<ModelSizeInFlight>,
+    finished: bool,
+}
+
+impl ModelSizeFlightLeader {
+    fn new(
+        cache: Arc<Mutex<ModelSizeCache>>,
+        key: ModelSizeCacheKey,
+        in_flight: Arc<ModelSizeInFlight>,
+    ) -> Self {
+        Self {
+            cache,
+            key,
+            in_flight,
+            finished: false,
+        }
+    }
+
+    fn finish(mut self, estimate: Option<u64>) {
+        self.cache
+            .lock()
+            .finish(&self.key, &self.in_flight, estimate);
+        self.finished = true;
+    }
+}
+
+impl Drop for ModelSizeFlightLeader {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.cache.lock().abort(&self.key, &self.in_flight);
+        }
     }
 }
 
@@ -3521,6 +3683,24 @@ mod model_size_concurrency_tests {
         assert!(expires_at > before);
         assert!(expires_at <= before + MODEL_SIZE_POSITIVE_TTL + Duration::from_secs(1));
     }
+
+    #[test]
+    fn in_flight_key_registry_is_bounded() {
+        let mut cache = ModelSizeCache::default();
+        for index in 0..MODEL_SIZE_CACHE_LIMIT {
+            let key = (format!("owner/model-{index}"), Vec::new());
+            assert!(matches!(
+                cache.lookup_or_start(&key),
+                ModelSizeLookup::Lead(_)
+            ));
+        }
+        let overflow = ("owner/overflow".to_owned(), Vec::new());
+        assert!(matches!(
+            cache.lookup_or_start(&overflow),
+            ModelSizeLookup::Unshared
+        ));
+        assert_eq!(cache.in_flight.len(), MODEL_SIZE_CACHE_LIMIT);
+    }
 }
 
 fn group_model_catalog_work_items(
@@ -4401,31 +4581,65 @@ pub(crate) async fn estimate_huggingface_download_size(
         return None;
     }
     let cache_key = (repo.to_owned(), files.to_vec());
-    if let Some(cached) = state.model_size_cache.lock().get(&cache_key) {
-        return cached;
+    loop {
+        let lookup = state.model_size_cache.lock().lookup_or_start(&cache_key);
+        match lookup {
+            ModelSizeLookup::Cached(cached) => return cached,
+            ModelSizeLookup::Follow(in_flight) => {
+                #[cfg(test)]
+                if let Some(hook) = state.model_size_estimate_test_hook.lock().clone() {
+                    hook.note_follower();
+                }
+                match in_flight.wait().await {
+                    ModelSizeFlightStatus::Complete(estimate) => return estimate,
+                    ModelSizeFlightStatus::Aborted => continue,
+                    ModelSizeFlightStatus::Pending => unreachable!("wait returns a terminal state"),
+                }
+            }
+            ModelSizeLookup::Lead(in_flight) => {
+                let leader = ModelSizeFlightLeader::new(
+                    state.model_size_cache.clone(),
+                    cache_key.clone(),
+                    in_flight,
+                );
+                let estimate = estimate_huggingface_download_size_request(state, repo, files).await;
+                leader.finish(estimate);
+                return estimate;
+            }
+            ModelSizeLookup::Unshared => {
+                let estimate = estimate_huggingface_download_size_request(state, repo, files).await;
+                match estimate {
+                    Some(estimate) => state
+                        .model_size_cache
+                        .lock()
+                        .insert(cache_key.clone(), estimate),
+                    None => state
+                        .model_size_cache
+                        .lock()
+                        .insert_failure(cache_key.clone()),
+                }
+                return estimate;
+            }
+        }
     }
+}
+
+async fn estimate_huggingface_download_size_request(
+    state: &AppState,
+    repo: &str,
+    files: &[String],
+) -> Option<u64> {
     #[cfg(test)]
     let test_hook = { state.model_size_estimate_test_hook.lock().clone() };
     #[cfg(test)]
     if let Some(hook) = test_hook {
-        let estimate = hook.request().await;
-        match estimate {
-            Some(estimate) => state.model_size_cache.lock().insert(cache_key, estimate),
-            None => state.model_size_cache.lock().insert_failure(cache_key),
-        }
-        return estimate;
+        return hook.request().await;
     }
     let url = format!(
         "https://huggingface.co/api/models/{}?blobs=true",
         quote_huggingface_repo(repo)
     );
-    let estimate =
-        estimate_huggingface_download_size_uncached(&state.http_client, &url, files).await;
-    match estimate {
-        Some(estimate) => state.model_size_cache.lock().insert(cache_key, estimate),
-        None => state.model_size_cache.lock().insert_failure(cache_key),
-    }
-    estimate
+    estimate_huggingface_download_size_uncached(&state.http_client, &url, files).await
 }
 
 pub(crate) async fn estimate_huggingface_download_size_uncached(

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -280,6 +280,8 @@ pub struct AppState {
     #[cfg(test)]
     pub(crate) model_size_estimate_test_hook:
         Arc<Mutex<Option<crate::models::ModelSizeEstimateTestHook>>>,
+    #[cfg(test)]
+    pub(crate) model_size_estimate_disabled_override: Arc<Mutex<Option<bool>>>,
     /// sc-10452 — memoized family detection for adapters scanned out of the operator's
     /// external model roots, keyed by each file's size + mtime. `lora_catalog` runs on
     /// every job-create; without this, every generation would re-parse every ComfyUI

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -277,6 +277,9 @@ pub struct AppState {
     pub(crate) manifest_cache: Arc<Mutex<ManifestCache>>,
     pub(crate) manifest_write_locks: Arc<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>>,
     pub(crate) model_size_cache: Arc<Mutex<ModelSizeCache>>,
+    #[cfg(test)]
+    pub(crate) model_size_estimate_test_hook:
+        Arc<Mutex<Option<crate::models::ModelSizeEstimateTestHook>>>,
     /// sc-10452 — memoized family detection for adapters scanned out of the operator's
     /// external model roots, keyed by each file's size + mtime. `lora_catalog` runs on
     /// every job-create; without this, every generation would re-parse every ComfyUI

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -418,6 +418,157 @@ async fn models_catalog_reuses_every_unchanged_size_estimate_on_second_load() {
 }
 
 #[tokio::test]
+async fn concurrent_models_catalog_loads_share_one_estimate_per_distinct_key() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({
+            "schemaVersion": 1,
+            "models": [
+                {
+                    "id": "single-flight-a",
+                    "name": "Single Flight A",
+                    "family": "single-flight-test",
+                    "type": "image",
+                    "downloads": [{
+                        "provider": "huggingface",
+                        "repo": "single-flight/model-a",
+                        "files": ["*.safetensors"]
+                    }]
+                },
+                {
+                    "id": "single-flight-b",
+                    "name": "Single Flight B",
+                    "family": "single-flight-test",
+                    "type": "image",
+                    "downloads": [{
+                        "provider": "huggingface",
+                        "repo": "single-flight/model-b",
+                        "files": ["*.safetensors"]
+                    }]
+                }
+            ]
+        }))
+        .expect("manifest serializes"),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(false);
+    let hook = crate::models::ModelSizeEstimateTestHook::blocked(Some(1234));
+    *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
+
+    let first = tokio::spawn(request(app.clone(), "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), async {
+        hook.wait_for_call().await;
+        hook.wait_for_call().await;
+    })
+    .await
+    .expect("both distinct estimates start");
+
+    let second = tokio::spawn(request(app, "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), async {
+        hook.wait_for_follower().await;
+        hook.wait_for_follower().await;
+    })
+    .await
+    .expect("the concurrent catalog load joins both estimates");
+    assert_eq!(hook.call_count(), 2, "one request per distinct cache key");
+    assert_eq!(hook.follower_count(), 2, "both in-flight keys are shared");
+
+    hook.release_one();
+    hook.release_one();
+    let first = first.await.expect("first catalog load joins");
+    let second = second.await.expect("second catalog load joins");
+    assert_eq!(first.0, StatusCode::OK);
+    assert_eq!(second.0, StatusCode::OK);
+    assert_eq!(second.1, first.1);
+    assert_eq!(
+        hook.call_count(),
+        2,
+        "completion must not trigger duplicate estimates"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_failed_estimate_is_shared_and_retries_after_negative_ttl_expiry() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({
+            "schemaVersion": 1,
+            "models": [{
+                "id": "single-flight-failure",
+                "name": "Single Flight Failure",
+                "family": "single-flight-test",
+                "type": "image",
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": "single-flight/failure",
+                    "files": ["*.safetensors"],
+                    "estimatedSizeBytes": 4321
+                }]
+            }]
+        }))
+        .expect("manifest serializes"),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(false);
+    let hook = crate::models::ModelSizeEstimateTestHook::blocked(None);
+    *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
+
+    let first = tokio::spawn(request(app.clone(), "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_for_call())
+        .await
+        .expect("failed estimate starts");
+    let second = tokio::spawn(request(app.clone(), "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_for_follower())
+        .await
+        .expect("concurrent failure joins the in-flight estimate");
+    hook.release_one();
+
+    let first = first.await.expect("first failed catalog load joins");
+    let second = second.await.expect("second failed catalog load joins");
+    assert_eq!(first.0, StatusCode::OK);
+    assert_eq!(second.0, StatusCode::OK);
+    assert_eq!(first.1[0]["downloadSizeBytes"], json!(4321));
+    assert_eq!(second.1, first.1);
+    assert_eq!(
+        hook.call_count(),
+        1,
+        "concurrent callers share the failed estimate"
+    );
+
+    let key = (
+        "single-flight/failure".to_owned(),
+        vec!["*.safetensors".to_owned()],
+    );
+    state
+        .model_size_cache
+        .lock()
+        .insert_failure_expiring_at(key, std::time::Instant::now());
+    hook.set_response(Some(9876));
+    hook.release_one();
+    let retry = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(retry.0, StatusCode::OK);
+    assert_eq!(retry.1[0]["downloadSizeBytes"], json!(9876));
+    assert_eq!(
+        hook.call_count(),
+        2,
+        "an expired failure must permit a fresh successful estimate"
+    );
+}
+
+#[tokio::test]
 async fn models_catalog_starts_install_sweep_before_size_estimation_completes() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -1,31 +1,6 @@
 //! rust-api catalog tests (split from tests.rs, sc-11217 F-030).
 use super::support::*;
 
-struct RestoreEnv {
-    key: &'static str,
-    value: Option<std::ffi::OsString>,
-}
-
-impl RestoreEnv {
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
-        Self {
-            key,
-            value: previous,
-        }
-    }
-}
-
-impl Drop for RestoreEnv {
-    fn drop(&mut self) {
-        match &self.value {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
-
 #[test]
 fn merge_model_manifest_entry_deep_merges_nested_blocks() {
     // The worker reads the merged manifest entry from the job payload now
@@ -381,7 +356,6 @@ async fn models_route_overlaps_slow_probes_with_bounded_fanout() {
 
 #[tokio::test]
 async fn models_catalog_reuses_every_unchanged_size_estimate_on_second_load() {
-    let _estimate_enabled = RestoreEnv::set("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "0");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
@@ -409,6 +383,7 @@ async fn models_catalog_reuses_every_unchanged_size_estimate_on_second_load() {
     write_empty_sibling_manifests(&config_dir);
     let (app, state) =
         create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(false);
     let hook = crate::models::ModelSizeEstimateTestHook::immediate(Some(1234));
     *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
 
@@ -444,7 +419,6 @@ async fn models_catalog_reuses_every_unchanged_size_estimate_on_second_load() {
 
 #[tokio::test]
 async fn models_catalog_starts_install_sweep_before_size_estimation_completes() {
-    let _estimate_enabled = RestoreEnv::set("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "0");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
@@ -472,11 +446,14 @@ async fn models_catalog_starts_install_sweep_before_size_estimation_completes() 
     crate::models::test_reset_catalog_probe_concurrency();
     let (app, state) =
         create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(false);
     let hook = crate::models::ModelSizeEstimateTestHook::blocked(Some(1234));
     *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
 
     let request_task = tokio::spawn(request(app, "GET", "/api/v1/models", Value::Null));
-    hook.wait_for_call().await;
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_for_call())
+        .await
+        .expect("size estimator starts before overlap-test deadline");
     let sweep_started_while_estimate_blocked =
         tokio::time::timeout(Duration::from_millis(150), async {
             loop {
@@ -489,7 +466,10 @@ async fn models_catalog_starts_install_sweep_before_size_estimation_completes() 
         .await
         .is_ok();
     hook.release_one();
-    let response = request_task.await.expect("models request joins");
+    let response = tokio::time::timeout(Duration::from_secs(2), request_task)
+        .await
+        .expect("models request completes before overlap-test deadline")
+        .expect("models request joins");
 
     assert_eq!(response.0, StatusCode::OK);
     assert!(
@@ -500,7 +480,6 @@ async fn models_catalog_starts_install_sweep_before_size_estimation_completes() 
 
 #[tokio::test]
 async fn models_catalog_disabled_size_estimation_skips_upstream_requests() {
-    let _disable = RestoreEnv::set("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
@@ -527,6 +506,7 @@ async fn models_catalog_disabled_size_estimation_skips_upstream_requests() {
     write_empty_sibling_manifests(&config_dir);
     let (app, state) =
         create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(true);
     let hook = crate::models::ModelSizeEstimateTestHook::immediate(Some(1234));
     *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
 

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -396,7 +396,9 @@ async fn models_catalog_reuses_every_unchanged_size_estimate_on_second_load() {
         .zip(pair[1]["name"].as_str())
         .is_some_and(|(left, right)| left < right)));
     assert!(first_models.iter().all(|model| {
-        model["downloadSizeBytes"] == json!(1234) && model["downloadSizeEstimated"] == json!(false)
+        model["downloadSizeBytes"] == json!(1234)
+            && model["downloadSizeEstimated"] == json!(false)
+            && model["variants"][0]["downloadSizeBytes"] == json!(1234)
     }));
     assert_eq!(
         hook.call_count(),
@@ -490,6 +492,73 @@ async fn concurrent_models_catalog_loads_share_one_estimate_per_distinct_key() {
         hook.call_count(),
         2,
         "completion must not trigger duplicate estimates"
+    );
+}
+
+#[tokio::test]
+async fn cancelled_size_estimate_leader_wakes_follower_to_retry() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({
+            "schemaVersion": 1,
+            "models": [{
+                "id": "single-flight-cancel",
+                "name": "Single Flight Cancel",
+                "family": "single-flight-test",
+                "type": "image",
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": "single-flight/cancel",
+                    "files": ["*.safetensors"]
+                }]
+            }]
+        }))
+        .expect("manifest serializes"),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(false);
+    let hook = crate::models::ModelSizeEstimateTestHook::blocked(Some(2468));
+    *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
+
+    let leader = tokio::spawn(request(app.clone(), "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_for_call())
+        .await
+        .expect("leader estimate starts");
+    let follower = tokio::spawn(request(app, "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_for_follower())
+        .await
+        .expect("second catalog load follows the leader");
+
+    leader.abort();
+    assert!(leader
+        .await
+        .expect_err("leader request is cancelled")
+        .is_cancelled());
+    tokio::time::timeout(Duration::from_secs(2), hook.wait_for_call())
+        .await
+        .expect("follower retries as the new leader");
+    hook.release_one();
+    let response = tokio::time::timeout(Duration::from_secs(2), follower)
+        .await
+        .expect("retry completes without a deadlock")
+        .expect("follower request joins");
+
+    assert_eq!(response.0, StatusCode::OK);
+    assert_eq!(response.1[0]["downloadSizeBytes"], json!(2468));
+    assert_eq!(
+        response.1[0]["variants"][0]["downloadSizeBytes"],
+        json!(2468)
+    );
+    assert_eq!(
+        hook.call_count(),
+        2,
+        "cancelled work is retried exactly once"
     );
 }
 

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -1,6 +1,31 @@
 //! rust-api catalog tests (split from tests.rs, sc-11217 F-030).
 use super::support::*;
 
+struct RestoreEnv {
+    key: &'static str,
+    value: Option<std::ffi::OsString>,
+}
+
+impl RestoreEnv {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self {
+            key,
+            value: previous,
+        }
+    }
+}
+
+impl Drop for RestoreEnv {
+    fn drop(&mut self) {
+        match &self.value {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 #[test]
 fn merge_model_manifest_entry_deep_merges_nested_blocks() {
     // The worker reads the merged manifest entry from the job payload now
@@ -352,6 +377,165 @@ async fn models_route_overlaps_slow_probes_with_bounded_fanout() {
         peak <= crate::models::test_catalog_probe_limit(),
         "concurrent /models requests exceeded the process-wide blocking-probe limit: {peak}"
     );
+}
+
+#[tokio::test]
+async fn models_catalog_reuses_every_unchanged_size_estimate_on_second_load() {
+    let _estimate_enabled = RestoreEnv::set("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "0");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    let models = (0..70)
+        .map(|index| {
+            json!({
+                "id": format!("cache-{index:02}"),
+                "name": format!("Cache {index:02}"),
+                "family": "cache-test",
+                "type": "image",
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": format!("cache/model-{index:02}"),
+                    "files": ["*.safetensors"]
+                }]
+            })
+        })
+        .collect::<Vec<_>>();
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({ "schemaVersion": 1, "models": models }))
+            .expect("manifest serializes"),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    let hook = crate::models::ModelSizeEstimateTestHook::immediate(Some(1234));
+    *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
+
+    let first = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(first.0, StatusCode::OK);
+    let first_models = first.1.as_array().expect("models array");
+    assert_eq!(first_models.len(), 70);
+    assert!(first_models.windows(2).all(|pair| pair[0]["name"]
+        .as_str()
+        .zip(pair[1]["name"].as_str())
+        .is_some_and(|(left, right)| left < right)));
+    assert!(first_models.iter().all(|model| {
+        model["downloadSizeBytes"] == json!(1234) && model["downloadSizeEstimated"] == json!(false)
+    }));
+    assert_eq!(
+        hook.call_count(),
+        70,
+        "first load estimates every distinct key"
+    );
+
+    let second = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(second.0, StatusCode::OK);
+    assert_eq!(
+        second.1, first.1,
+        "warm catalog output and ordering drifted"
+    );
+    assert_eq!(
+        hook.call_count(),
+        70,
+        "unchanged second load must issue no upstream size requests"
+    );
+}
+
+#[tokio::test]
+async fn models_catalog_starts_install_sweep_before_size_estimation_completes() {
+    let _estimate_enabled = RestoreEnv::set("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "0");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({
+            "schemaVersion": 1,
+            "models": [{
+                "id": "overlap",
+                "name": "Overlap",
+                "family": "overlap-test",
+                "type": "image",
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": "overlap/model",
+                    "files": ["*.safetensors"]
+                }],
+                "__testCatalogProbeDelayMs": 250
+            }]
+        }))
+        .expect("manifest serializes"),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+    crate::models::test_reset_catalog_probe_concurrency();
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    let hook = crate::models::ModelSizeEstimateTestHook::blocked(Some(1234));
+    *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
+
+    let request_task = tokio::spawn(request(app, "GET", "/api/v1/models", Value::Null));
+    hook.wait_for_call().await;
+    let sweep_started_while_estimate_blocked =
+        tokio::time::timeout(Duration::from_millis(150), async {
+            loop {
+                if crate::models::test_catalog_probe_peak() > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .is_ok();
+    hook.release_one();
+    let response = request_task.await.expect("models request joins");
+
+    assert_eq!(response.0, StatusCode::OK);
+    assert!(
+        sweep_started_while_estimate_blocked,
+        "SC-14530 install-state sweep must start before upstream size estimation completes"
+    );
+}
+
+#[tokio::test]
+async fn models_catalog_disabled_size_estimation_skips_upstream_requests() {
+    let _disable = RestoreEnv::set("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({
+            "schemaVersion": 1,
+            "models": [{
+                "id": "disabled",
+                "name": "Disabled",
+                "family": "disabled-test",
+                "type": "image",
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": "disabled/model",
+                    "files": ["*.safetensors"],
+                    "estimatedSizeBytes": 4321
+                }]
+            }]
+        }))
+        .expect("manifest serializes"),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    let hook = crate::models::ModelSizeEstimateTestHook::immediate(Some(1234));
+    *state.model_size_estimate_test_hook.lock() = Some(hook.clone());
+
+    let response = request(app, "GET", "/api/v1/models", Value::Null).await;
+
+    assert_eq!(response.0, StatusCode::OK);
+    assert_eq!(hook.call_count(), 0, "disabled mode must skip upstream");
+    assert_eq!(response.1[0]["downloadSizeBytes"], json!(4321));
+    assert_eq!(response.1[0]["downloadSizeEstimated"], json!(true));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What does this PR do?

- expands the model-size LRU from 64 to 256 entries, with regression coverage pinning the shipped distinct download-context counts at 81 on macOS and 80 on Windows/Linux
- deduplicates identical catalog size contexts and gives successful estimates a bounded six-hour TTL
- starts bounded size estimation and the existing repo-grouped SC-14530 install-state sweep together, then enriches the swept rows without changing final ordering or shared-repo receipt handling
- preserves SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE=1 behavior and manifest fallback sizes; compose/RunPod configuration remains unchanged and disabled

## Related issue

Shortcut: https://app.shortcut.com/trefry/story/14800

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- Before fix: two 70-context catalog loads made 140 mocked upstream requests; after fix they make 70 total, and cold/warm response content and ordering are identical.
- Before fix: a blocked size estimate prevented the install sweep from starting; after fix the probe starts while estimation remains blocked.
- cargo test -p sceneworks-rust-api tests::catalog:: -- --test-threads=1: 55 passed
- Hermetic cargo test -p sceneworks-rust-api -- --test-threads=1: 385 passed, 2 ignored real-tree/platform smokes
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo build -p sceneworks-rust-api

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (shared Rust API)

Live desktop/rust-api cold/warm timing was not recorded: both base and branch binaries built, but the benchmark launch was denied because it would send catalog repository metadata to Hugging Face without separate external-egress approval. No RunPod improvement is claimed.

## Checklist

- [ ] I ran npm run rust:check (the required scoped Rust API test/build plus workspace Clippy and rustfmt gates above passed)
- [ ] I ran the web lint/test/build gate (not applicable)
- [ ] I ran npm run check (not applicable)
- [x] Documentation was not required for this internal behavior fix
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change