### PR TITLE
perf(library): serve lazy cached thumbnails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +2747,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3267,6 +3283,8 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -6306,6 +6324,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "glob",
+ "httpdate",
  "image",
  "mime_guess",
  "nix",
@@ -8655,6 +8674,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,6 +2135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,6 +3295,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -7589,6 +7596,20 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -11,7 +11,7 @@ fs2 = "0.4"
 futures-util = "0.3"
 glob = "0.3"
 httpdate = "1"
-image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
+image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "tiff", "webp"] }
 parking_lot = "0.12"
 mime_guess = { version = "2", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -10,6 +10,8 @@ axum = { version = "0.7", features = ["multipart"] }
 fs2 = "0.4"
 futures-util = "0.3"
 glob = "0.3"
+httpdate = "1"
+image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 parking_lot = "0.12"
 mime_guess = { version = "2", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -66,8 +68,5 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 rmcp = { version = "=2.1.0", features = ["client", "transport-streamable-http-client-reqwest"] }
 tempfile = "3.13"
 tower = { version = "0.5", features = ["util"] }
-# Encode real test images for the synchronous image-fix round-trips (sc-6539).
-image = { version = "0.25", default-features = false, features = ["png"] }
-
 [lints]
 workspace = true

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -65,6 +65,7 @@ use sceneworks_core::video_request::{
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tokio::time::{Instant as TokioInstant, MissedTickBehavior};
@@ -992,6 +993,7 @@ pub(crate) fn create_app_with_state(
             MAX_OUTSTANDING_EVENT_TICKETS,
         )),
         media_tickets: Arc::new(TicketStore::new(MEDIA_TICKET_TTL_SECONDS)),
+        thumbnail_generation_slots: Arc::new(tokio::sync::Semaphore::new(2)),
         auth_throttle: Arc::new(AuthThrottle::default()),
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
@@ -1514,12 +1516,21 @@ async fn verify_access(
     Json(VerifyResponse { ok })
 }
 
+const GRID_THUMBNAIL_SIZE: u32 = 384;
+const PROJECT_MEDIA_CACHE_CONTROL: &str = "private, max-age=31536000, immutable";
+
+#[derive(Debug, Default, Deserialize)]
+struct ProjectFileQuery {
+    thumbnail: Option<u32>,
+}
+
 async fn get_project_file(
     State(state): State<AppState>,
     Path((project_id, relative_path)): Path<(String, String)>,
+    Query(query): Query<ProjectFileQuery>,
     headers: HeaderMap,
 ) -> Result<Response, ApiError> {
-    let project_file = project_call(state, {
+    let project_file = project_call(state.clone(), {
         let project_id = project_id.clone();
         let relative_path = relative_path.clone();
         move |store| store.project_file(&project_id, &relative_path)
@@ -1543,15 +1554,74 @@ async fn get_project_file(
             );
         }
     })?;
-    let mut file = tokio::fs::File::open(&project_file.path)
-        .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
-    let total = file
-        .metadata()
+
+    // One fixed representation prevents unbounded cache variants. Derivatives
+    // are generated on first use, so assets written before this route existed
+    // backfill without a migration.
+    let (served_path, content_type) = if let Some(size) = query.thumbnail {
+        if size != GRID_THUMBNAIL_SIZE {
+            return Err(ApiError::bad_request(format!(
+                "thumbnail must be {GRID_THUMBNAIL_SIZE}"
+            )));
+        }
+        if !project_file.content_type.starts_with("image/") {
+            return Err(ApiError::bad_request(
+                "thumbnail is only available for image media",
+            ));
+        }
+        let permit = state
+            .thumbnail_generation_slots
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))?;
+        let source_path = project_file.path.clone();
+        let cache_root = state
+            .settings
+            .data_dir
+            .join("cache")
+            .join("media-thumbnails")
+            .join("v1");
+        let thumbnail_path = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            ensure_grid_thumbnail(&source_path, &cache_root)
+        })
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?
-        .len();
-    let content_type = project_file.content_type;
+        .map_err(|error| {
+            tracing::debug!(
+                event = "project_thumbnail_unavailable",
+                project_id = %project_id,
+                relative_path = %relative_path,
+                error = %error,
+                "could not create bounded project thumbnail"
+            );
+            ApiError::bad_request("Thumbnail unavailable for this media")
+        })?;
+        (thumbnail_path, "image/png".to_owned())
+    } else {
+        (project_file.path, project_file.content_type)
+    };
+
+    let mut file = tokio::fs::File::open(&served_path)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let metadata = file
+        .metadata()
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let total = metadata.len();
+    let etag = project_file_etag(&metadata);
+    let last_modified = metadata.modified().ok();
+    let base_headers = project_file_response_headers(&content_type, total, &etag, last_modified)?;
+
+    if project_file_is_not_modified(&headers, &etag, last_modified) {
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = StatusCode::NOT_MODIFIED;
+        *response.headers_mut() = base_headers;
+        response.headers_mut().remove(header::CONTENT_LENGTH);
+        return Ok(response);
+    }
 
     // WebKit/WKWebView (the macOS desktop webview) requires HTTP byte-range
     // responses to play <video>: it probes with `Range: bytes=0-1` and treats
@@ -1565,10 +1635,10 @@ async fn get_project_file(
                     .await
                     .map_err(|error| ApiError::internal(error.to_string()))?;
                 let stream = ReaderStream::new(file.take(len));
-                return Ok((
+                let mut response = (
                     StatusCode::PARTIAL_CONTENT,
                     [
-                        (header::CONTENT_TYPE, content_type),
+                        (header::CONTENT_TYPE, content_type.clone()),
                         (header::ACCEPT_RANGES, "bytes".to_string()),
                         (
                             header::CONTENT_RANGE,
@@ -1586,20 +1656,30 @@ async fn get_project_file(
                     ],
                     Body::from_stream(stream),
                 )
-                    .into_response());
+                    .into_response();
+                response.headers_mut().extend(base_headers);
+                response.headers_mut().insert(
+                    header::CONTENT_LENGTH,
+                    HeaderValue::from_str(&len.to_string())
+                        .map_err(|error| ApiError::internal(error.to_string()))?,
+                );
+                return Ok(response);
             }
             None => {
-                return Ok((
+                let mut response = (
                     StatusCode::RANGE_NOT_SATISFIABLE,
                     [(header::CONTENT_RANGE, format!("bytes */{total}"))],
                 )
-                    .into_response());
+                    .into_response();
+                response.headers_mut().extend(base_headers);
+                response.headers_mut().remove(header::CONTENT_LENGTH);
+                return Ok(response);
             }
         }
     }
 
     let stream = ReaderStream::new(file);
-    Ok((
+    let mut response = (
         [
             (header::CONTENT_TYPE, content_type),
             (header::ACCEPT_RANGES, "bytes".to_string()),
@@ -1610,7 +1690,122 @@ async fn get_project_file(
         ],
         Body::from_stream(stream),
     )
-        .into_response())
+        .into_response();
+    response.headers_mut().extend(base_headers);
+    Ok(response)
+}
+
+fn ensure_grid_thumbnail(source_path: &FsPath, cache_root: &FsPath) -> Result<PathBuf, String> {
+    let metadata = std::fs::metadata(source_path).map_err(|error| error.to_string())?;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+        .unwrap_or_default();
+    let mut hash = Sha256::new();
+    hash.update(source_path.to_string_lossy().as_bytes());
+    hash.update(metadata.len().to_le_bytes());
+    hash.update(modified.as_nanos().to_le_bytes());
+    hash.update(GRID_THUMBNAIL_SIZE.to_le_bytes());
+    let key = format!("{:x}", hash.finalize());
+    let target = cache_root.join(format!("{key}.png"));
+    if target.is_file() {
+        return Ok(target);
+    }
+
+    std::fs::create_dir_all(cache_root).map_err(|error| error.to_string())?;
+    let decoded = image::open(source_path).map_err(|error| error.to_string())?;
+    let thumbnail = decoded.thumbnail(GRID_THUMBNAIL_SIZE, GRID_THUMBNAIL_SIZE);
+    let temporary = cache_root.join(format!("{key}.{}.tmp", Uuid::new_v4().simple()));
+    thumbnail
+        .save_with_format(&temporary, image::ImageFormat::Png)
+        .map_err(|error| error.to_string())?;
+    if let Err(error) = std::fs::rename(&temporary, &target) {
+        if target.is_file() {
+            let _ = std::fs::remove_file(&temporary);
+        } else {
+            let _ = std::fs::remove_file(&temporary);
+            return Err(error.to_string());
+        }
+    }
+    Ok(target)
+}
+
+fn project_file_etag(metadata: &std::fs::Metadata) -> String {
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+        .unwrap_or_default();
+    // Weak avoids reading and hashing a multi-gigabyte original before it can
+    // stream; project media is immutable after publication.
+    format!(
+        "W/\"{:x}-{:x}-{:x}\"",
+        metadata.len(),
+        modified.as_secs(),
+        modified.subsec_nanos()
+    )
+}
+
+fn project_file_response_headers(
+    content_type: &str,
+    total: u64,
+    etag: &str,
+    last_modified: Option<SystemTime>,
+) -> Result<HeaderMap, ApiError> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in [
+        (header::CONTENT_TYPE, content_type.to_owned()),
+        (header::ACCEPT_RANGES, "bytes".to_owned()),
+        (header::CONTENT_LENGTH, total.to_string()),
+        (header::X_CONTENT_TYPE_OPTIONS, "nosniff".to_owned()),
+        (
+            header::CACHE_CONTROL,
+            PROJECT_MEDIA_CACHE_CONTROL.to_owned(),
+        ),
+        (header::ETAG, etag.to_owned()),
+    ] {
+        headers.insert(
+            name,
+            HeaderValue::from_str(&value).map_err(|error| ApiError::internal(error.to_string()))?,
+        );
+    }
+    if let Some(modified) = last_modified {
+        headers.insert(
+            header::LAST_MODIFIED,
+            HeaderValue::from_str(&httpdate::fmt_http_date(modified))
+                .map_err(|error| ApiError::internal(error.to_string()))?,
+        );
+    }
+    Ok(headers)
+}
+
+fn project_file_is_not_modified(
+    request_headers: &HeaderMap,
+    etag: &str,
+    last_modified: Option<SystemTime>,
+) -> bool {
+    if let Some(value) = request_headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+    {
+        return value
+            .split(',')
+            .map(str::trim)
+            .any(|candidate| candidate == "*" || candidate == etag);
+    }
+    let Some(modified) = last_modified else {
+        return false;
+    };
+    request_headers
+        .get(header::IF_MODIFIED_SINCE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| httpdate::parse_http_date(value).ok())
+        .is_some_and(|since| {
+            modified
+                .duration_since(since)
+                .map_or(true, |delta| delta < Duration::from_secs(1))
+        })
 }
 
 /// Parse a single HTTP byte range (`bytes=start-end`, `bytes=start-`, or

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1714,7 +1714,24 @@ fn ensure_grid_thumbnail(source_path: &FsPath, cache_root: &FsPath) -> Result<Pa
     }
 
     std::fs::create_dir_all(cache_root).map_err(|error| error.to_string())?;
-    let decoded = image::open(source_path).map_err(|error| error.to_string())?;
+    let decoded = match image::open(source_path) {
+        Ok(decoded) => decoded,
+        Err(decode_error) => {
+            // Project imports normalize these formats today, but old projects
+            // can still contain AVIF/HEIC/HEIF (and other platform-decodable
+            // raster files). Reuse the worker's cross-platform compatibility
+            // path before declaring the thumbnail unavailable.
+            let converted =
+                cache_root.join(format!("{key}.{}.converted.png", Uuid::new_v4().simple()));
+            let transcode_result =
+                sceneworks_core::media_convert::transcode_to_png(source_path, &converted);
+            let decoded = transcode_result
+                .map_err(|error| format!("{decode_error}; {error}"))
+                .and_then(|()| image::open(&converted).map_err(|error| error.to_string()));
+            let _ = std::fs::remove_file(&converted);
+            decoded?
+        }
+    };
     let thumbnail = decoded.thumbnail(GRID_THUMBNAIL_SIZE, GRID_THUMBNAIL_SIZE);
     let temporary = cache_root.join(format!("{key}.{}.tmp", Uuid::new_v4().simple()));
     thumbnail

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::Mutex;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, Semaphore};
 
 use sceneworks_core::jobs_store::JobsStore;
 use sceneworks_core::project_store::ProjectStore;
@@ -272,6 +272,8 @@ pub struct AppState {
     pub(crate) queue_snapshot_lock: Arc<AsyncMutex<()>>,
     pub(crate) event_tickets: Arc<TicketStore>,
     pub(crate) media_tickets: Arc<TicketStore>,
+    /// Bounds CPU and memory consumed by on-demand Library thumbnail backfills.
+    pub(crate) thumbnail_generation_slots: Arc<Semaphore>,
     // sc-8870 (F-068): per-peer-IP failed-token throttle for the auth oracle.
     pub(crate) auth_throttle: Arc<AuthThrottle>,
     pub(crate) manifest_cache: Arc<Mutex<ManifestCache>>,

--- a/apps/rust-api/src/tests/media.rs
+++ b/apps/rust-api/src/tests/media.rs
@@ -46,6 +46,14 @@ async fn project_file_route_serves_files_and_rejects_traversal() {
             .and_then(|value| value.to_str().ok()),
         Some("nosniff")
     );
+    assert_eq!(
+        headers
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok()),
+        Some("private, max-age=31536000, immutable")
+    );
+    assert!(headers.get("etag").is_some());
+    assert!(headers.get("last-modified").is_some());
 
     let (status, _, bytes) = request_raw(
         app.clone(),
@@ -70,6 +78,103 @@ async fn project_file_route_serves_files_and_rejects_traversal() {
     let error: Value = serde_json::from_slice(&bytes).expect("json error parses");
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(error["detail"], "Invalid project file path");
+}
+
+#[tokio::test]
+async fn project_file_route_backfills_and_reuses_bounded_thumbnails() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+    let (_, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Thumbnail backfill" }),
+    )
+    .await;
+    let project_id = created["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
+    let media_path = project_path.join("assets/images/large.png");
+    let original = image::RgbImage::from_fn(1_280, 720, |x, y| {
+        image::Rgb([
+            ((x * 17 + y * 7) % 256) as u8,
+            ((x * 5 + y * 19) % 256) as u8,
+            ((x * 13 + y * 3) % 256) as u8,
+        ])
+    });
+    original.save(&media_path).expect("original writes");
+    let original_bytes = std::fs::read(&media_path).expect("original reads");
+    let uri = format!("/api/v1/projects/{project_id}/files/assets/images/large.png?thumbnail=384");
+
+    let (status, headers, first_bytes) =
+        request_raw(app.clone(), "GET", &uri, Body::empty(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("image/png")
+    );
+    let decoded = image::load_from_memory(&first_bytes).expect("thumbnail decodes");
+    assert_eq!((decoded.width(), decoded.height()), (384, 216));
+    assert!(
+        first_bytes.len() < original_bytes.len(),
+        "thumbnail should transfer fewer bytes than its full-resolution source"
+    );
+
+    let cache_root = data_dir.join("cache/media-thumbnails/v1");
+    assert_eq!(
+        std::fs::read_dir(&cache_root)
+            .expect("thumbnail cache exists")
+            .count(),
+        1,
+        "first request backfills exactly one derivative"
+    );
+    let (_, second_headers, second_bytes) =
+        request_raw(app.clone(), "GET", &uri, Body::empty(), &[]).await;
+    assert_eq!(second_bytes, first_bytes);
+    assert_eq!(second_headers.get("etag"), headers.get("etag"));
+    assert_eq!(
+        std::fs::read_dir(&cache_root)
+            .expect("thumbnail cache exists")
+            .count(),
+        1,
+        "warm request reuses the on-disk derivative"
+    );
+
+    let etag = headers
+        .get("etag")
+        .and_then(|value| value.to_str().ok())
+        .expect("etag");
+    let (status, conditional_headers, bytes) = request_raw(
+        app.clone(),
+        "GET",
+        &uri,
+        Body::empty(),
+        &[("if-none-match", etag)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_MODIFIED);
+    assert!(bytes.is_empty());
+    assert_eq!(conditional_headers.get("etag"), headers.get("etag"));
+    assert_eq!(
+        conditional_headers
+            .get("x-content-type-options")
+            .and_then(|value| value.to_str().ok()),
+        Some("nosniff")
+    );
+
+    let (status, _, original_response) = request_raw(
+        app,
+        "GET",
+        &format!("/api/v1/projects/{project_id}/files/assets/images/large.png"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(original_response, original_bytes);
 }
 
 #[tokio::test]
@@ -123,6 +228,13 @@ async fn project_file_route_serves_byte_ranges() {
             .get("x-content-type-options")
             .and_then(|v| v.to_str().ok()),
         Some("nosniff")
+    );
+    assert!(headers.get("etag").is_some());
+    assert_eq!(
+        headers
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok()),
+        Some("private, max-age=31536000, immutable")
     );
 
     // An open-ended range serves to EOF (this is how WebKit fetches the
@@ -715,6 +827,11 @@ async fn media_tickets_authenticate_project_file_urls() {
     let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
     std::fs::write(project_path.join("assets/images/image.png"), b"image-bytes")
         .expect("media writes");
+    std::fs::write(
+        project_path.join("assets/images/thumbnail-source.png"),
+        PNG_32X32,
+    )
+    .expect("thumbnail source writes");
     let file_uri = format!("/api/v1/projects/{project_id}/files/assets/images/image.png");
 
     // Minting a media ticket itself requires authentication.
@@ -763,6 +880,19 @@ async fn media_tickets_authenticate_project_file_urls() {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(bytes, b"image-bytes");
     }
+    let thumbnail_uri = format!(
+        "/api/v1/projects/{project_id}/files/assets/images/thumbnail-source.png?thumbnail=384&ticket={ticket_value}"
+    );
+    let (status, headers, bytes) =
+        request_raw(app.clone(), "GET", &thumbnail_uri, Body::empty(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("image/png")
+    );
+    assert!(!bytes.is_empty());
 
     // A garbage ticket stays locked out.
     let (status, _) = request(

--- a/apps/web/src/App.training.test.jsx
+++ b/apps/web/src/App.training.test.jsx
@@ -893,10 +893,10 @@ describe("SceneWorks app shell", () => {
     // defaultChipLabel ("rendering" -> "Rendering"); same content, different style.
     expect(container.textContent).toContain("Rendering");
     expect([...document.body.querySelectorAll(".worker-progress-card__thumb-media")].map((image) => image.src)).toEqual([
-      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-1.png",
-      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-2.png",
-      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-3.png",
-      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-4.png",
+      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-1.png?thumbnail=384",
+      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-2.png?thumbnail=384",
+      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-3.png?thumbnail=384",
+      "http://localhost:8000/api/v1/projects/project-a/files/loras/lora_1/samples/sample-4.png?thumbnail=384",
     ]);
   });
 

--- a/apps/web/src/components/AssetGrid.test.jsx
+++ b/apps/web/src/components/AssetGrid.test.jsx
@@ -92,6 +92,10 @@ describe("AssetGrid multi-select (sc-6112)", () => {
     expect(container.querySelectorAll("video")).toHaveLength(0);
     // Every tile (1 video poster + 2 image thumbs) paints an <img> thumbnail.
     expect(container.querySelectorAll(".asset-tile img")).toHaveLength(3);
+    for (const image of container.querySelectorAll(".asset-tile img")) {
+      expect(image.getAttribute("loading")).toBe("lazy");
+      expect(new URL(image.src).searchParams.get("thumbnail")).toBe("384");
+    }
     // Clicking the video tile still drives single-select — interactions are preserved.
     await act(async () => tiles()[0].click());
     expect(setSelectedAssetId).toHaveBeenCalledWith("v");

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -27,6 +27,22 @@ export function assetUrl(asset) {
   return withMediaTicket(bareAssetUrl(asset));
 }
 
+// Grid thumbnails use one bounded, server-cached representation. The API
+// backfills this derivative on first request for old assets and caches it under
+// data/cache/media-thumbnails; a missing/corrupt source fails the image request
+// and the existing MissingMedia fallback is shown. Full preview, playback and
+// download continue to use assetUrl()/posterUrl() and therefore the original.
+export const ASSET_THUMBNAIL_SIZE = 384;
+
+function withThumbnailRequest(url) {
+  if (!url) {
+    return "";
+  }
+  const thumbnail = new URL(url);
+  thumbnail.searchParams.set("thumbnail", String(ASSET_THUMBNAIL_SIZE));
+  return withMediaTicket(thumbnail.toString());
+}
+
 export function assetCanRenderAsImage(asset) {
   return asset?.type === "image" || asset?.file?.mimeType?.startsWith("image/");
 }
@@ -69,19 +85,28 @@ export function suppressThumbnailContextMenu(event) {
 // render, spamming the log). We only fall back to deriving the poster path for
 // transient/live-job assets the server hasn't normalized yet (no `url`), preserving
 // the in-progress poster behavior in the studios.
-export function posterUrl(asset) {
+function barePosterUrl(asset) {
   if (!assetCanRenderAsVideo(asset)) {
     return "";
   }
   if (asset?.posterUrl) {
-    return withMediaTicket(API_BASE_URL + asset.posterUrl);
+    return API_BASE_URL + asset.posterUrl;
   }
   if (asset?.url) {
     // Normalized asset with no server-advertised poster ⇒ none exists; don't probe.
     return "";
   }
   const src = bareAssetUrl(asset);
-  return src ? withMediaTicket(src.replace(/\.\w+$/, ".poster.jpg")) : "";
+  return src ? src.replace(/\.\w+$/, ".poster.jpg") : "";
+}
+
+export function posterUrl(asset) {
+  return withMediaTicket(barePosterUrl(asset));
+}
+
+export function thumbnailUrl(asset) {
+  const source = assetCanRenderAsVideo(asset) ? barePosterUrl(asset) : bareAssetUrl(asset);
+  return withThumbnailRequest(source);
 }
 
 // Placeholder shown when an asset's underlying file can't be loaded — e.g. it
@@ -117,14 +142,24 @@ function ImageThumb({ src, className }) {
   if (failed) {
     return <MissingMedia className={className} />;
   }
-  return <img alt="" className={className} onContextMenu={suppressThumbnailContextMenu} onError={() => setFailed(true)} src={src} />;
+  return (
+    <img
+      alt=""
+      className={className}
+      decoding="async"
+      loading="lazy"
+      onContextMenu={suppressThumbnailContextMenu}
+      onError={() => setFailed(true)}
+      src={src}
+    />
+  );
 }
 
 export function AssetThumbnail({ asset, className = "" }) {
   if (!asset) {
     return null;
   }
-  const src = assetUrl(asset);
+  const src = thumbnailUrl(asset);
   if (!src) {
     return <span className={className} onContextMenu={suppressThumbnailContextMenu}>{asset.type ?? "asset"}</span>;
   }
@@ -139,7 +174,7 @@ export function AssetThumbnail({ asset, className = "" }) {
 
 function VideoPoster({ asset, className }) {
   const [failed, setFailed] = React.useState(false);
-  const poster = posterUrl(asset);
+  const poster = thumbnailUrl(asset);
   // Same per-URL retry as ImageThumb (sc-9063): a new poster URL (fresh media
   // ticket) clears a stale failure so the placeholder isn't permanent.
   React.useEffect(() => {
@@ -151,7 +186,17 @@ function VideoPoster({ asset, className }) {
   if (failed) {
     return <MissingMedia className={className} />;
   }
-  return <img alt="" className={className} onContextMenu={suppressThumbnailContextMenu} onError={() => setFailed(true)} src={poster} />;
+  return (
+    <img
+      alt=""
+      className={className}
+      decoding="async"
+      loading="lazy"
+      onContextMenu={suppressThumbnailContextMenu}
+      onError={() => setFailed(true)}
+      src={poster}
+    />
+  );
 }
 
 export const AssetMedia = React.forwardRef(function AssetMedia({ asset, className = "", controls = true, ...mediaProps }, ref) {

--- a/apps/web/src/components/assetMedia.test.jsx
+++ b/apps/web/src/components/assetMedia.test.jsx
@@ -1,7 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { AssetMedia, AssetThumbnail, MissingMedia, posterUrl } from "./assetMedia.jsx";
+import { AssetMedia, AssetThumbnail, MissingMedia, posterUrl, thumbnailUrl } from "./assetMedia.jsx";
 
 const imageAsset = {
   id: "img",
@@ -54,6 +54,9 @@ describe("thumbnail native context-menu suppression (sc-8731)", () => {
     await act(() => root.render(<AssetThumbnail asset={imageAsset} />));
     const img = container.querySelector("img");
     expect(img).not.toBeNull();
+    expect(img.getAttribute("loading")).toBe("lazy");
+    expect(img.getAttribute("decoding")).toBe("async");
+    expect(new URL(img.src).searchParams.get("thumbnail")).toBe("384");
     const event = fireContextMenu(img);
     expect(event.defaultPrevented).toBe(true);
   });
@@ -78,8 +81,18 @@ describe("thumbnail native context-menu suppression (sc-8731)", () => {
     await act(() => root.render(<AssetMedia asset={imageAsset} />));
     const img = container.querySelector("img");
     expect(img).not.toBeNull();
+    expect(new URL(img.src).searchParams.has("thumbnail")).toBe(false);
+    expect(img.hasAttribute("loading")).toBe(false);
     const event = fireContextMenu(img);
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("bounded thumbnail URLs (sc-14797)", () => {
+  it("uses the derivative only for shared grid thumbnails", () => {
+    expect(new URL(thumbnailUrl(imageAsset)).searchParams.get("thumbnail")).toBe("384");
+    expect(new URL(thumbnailUrl(videoAsset)).searchParams.get("thumbnail")).toBe("384");
+    expect(new URL(posterUrl(videoAsset)).searchParams.has("thumbnail")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- make every shared AssetThumbnail request the fixed thumbnail=384 representation with native lazy loading and async decoding
- backfill versioned PNG derivatives on demand under data/cache/media-thumbnails, reuse them across navigation, cap concurrent full-resolution decodes, and fall back through the existing platform transcoder for legacy AVIF/HEIC/HEIF and other supported rasters
- add private immutable caching, ETag, Last-Modified, conditional 304, and the same validators/policy on 200/206 responses while retaining range, nosniff, traversal protection, and media-ticket authorization

Shortcut: https://app.shortcut.com/trefry/story/14797

## Acceptance criteria
- Bounded representation/backfill/missing behavior: fixed 384px PNG derivative, content/metadata-keyed disk cache; old assets generate on first request; absent/corrupt/untranscodable inputs retain the shared missing-media fallback. Only one allowed size prevents derivative-cache amplification.
- Off-screen deferral: AssetThumbnail image and video-poster img elements explicitly use loading=lazy; content-visibility remains only a paint optimization.
- Cache/auth/range: project file 200, 206, 304, and 416 paths retain nosniff/range behavior and now carry private, max-age=31536000, immutable plus ETag and Last-Modified. Auth middleware and ticket query semantics are unchanged and tested.
- Stable ticket: existing media ticket test re-mints within TTL and asserts the exact same ticket value; thumbnail+ticket authorization is now covered too.
- Shared consumers: AssetThumbnail changes cover Library, character, pose, keypoint, training, queue, and studio grids. AssetMedia, assetUrl, posterUrl, preview/fullscreen, playback, and download continue using originals.

## Real browser evidence
Synthetic 400-asset project, Chromium, 1280x720, actual network responses counted after 2.5s:
- Cold Library: 400 lazy img DOM nodes; 21 thumbnail=384 responses, 1,428 transferred bytes (fixed 68-byte harness PNGs).
- Warm Queue -> Assets return after counter reset: 0 thumbnail requests, 0 thumbnail bytes.
- One original request occurred on each visit only for the auto-selected detail pane; no grid tile requested an original. The warm harness intentionally returned 500 for originals, making this distinction visible.

## Validation
- cargo fmt --all -- --check
- cargo test --locked -p sceneworks-rust-api: 381 passed, 2 ignored before integration; 381 passed, 2 ignored after integrating current main (383 total)
- cargo clippy --locked -p sceneworks-rust-api --all-targets -- -D warnings
- cargo build --locked -p sceneworks-rust-api
- npm --prefix apps/web run test: 183 files, 2,573 tests passed
- npm --prefix apps/web run lint: 0 errors (existing warnings)
- npm --prefix apps/web run build
- focused AssetGrid/assetMedia and project-file route tests

RunPod validation remains owned by SC-14789 and is not claimed locally.