### PR TITLE
fix: close residual low review clusters (sc-13652)

### DIFF
--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -888,13 +888,17 @@ pub fn reset_setup() -> Result<(), String> {
 /// Generic folder picker for the splash storage step (workspace + HF cache
 /// pickers). Returns the chosen absolute path, or `None` if the dialog was
 /// dismissed.
-#[tauri::command]
-pub async fn choose_folder(app: AppHandle) -> Option<String> {
+fn pick_folder(app: &AppHandle) -> Option<String> {
     app.dialog()
         .file()
         .blocking_pick_folder()
         .and_then(|file| file.into_path().ok())
         .map(|path| path.to_string_lossy().into_owned())
+}
+
+#[tauri::command]
+pub async fn choose_folder(app: AppHandle) -> Option<String> {
+    pick_folder(&app)
 }
 
 #[tauri::command]
@@ -907,11 +911,7 @@ pub fn set_data_dir(path: String) -> Result<AppSettings, String> {
 
 #[tauri::command]
 pub async fn choose_data_dir(app: AppHandle) -> Option<String> {
-    app.dialog()
-        .file()
-        .blocking_pick_folder()
-        .and_then(|file| file.into_path().ok())
-        .map(|path| path.to_string_lossy().into_owned())
+    pick_folder(&app)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -581,11 +581,16 @@ fn append_log(path: &Path, line: &str) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(mut file) = std::fs::OpenOptions::new()
+    let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
-    {
+        .ok();
+    append_log_with_handle(path, line, file.as_mut());
+}
+
+fn append_log_with_handle(path: &Path, line: &str, file: Option<&mut std::fs::File>) {
+    if let Some(file) = file {
         let _ = file.write_all(line.as_bytes());
         let _ = file.flush();
     }
@@ -1663,25 +1668,39 @@ fn supervise_worker(
                 continue;
             }
             let started = Instant::now();
+            // Keep one append handle for this worker lifetime. Stdout/stderr can
+            // emit thousands of events per generation; reopening the same file
+            // for every chunk needlessly hits the filesystem hot path.
+            let mut log_file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path)
+                .ok();
             loop {
                 match tauri::async_runtime::block_on(events.recv()) {
                     Some(CommandEvent::Stdout(bytes)) | Some(CommandEvent::Stderr(bytes)) => {
-                        append_log(&log_path, &String::from_utf8_lossy(&bytes));
+                        append_log_with_handle(
+                            &log_path,
+                            &String::from_utf8_lossy(&bytes),
+                            log_file.as_mut(),
+                        );
                     }
                     Some(CommandEvent::Terminated(payload)) => {
-                        append_log(
+                        append_log_with_handle(
                             &log_path,
                             &format!(
                                 "[desktop] {label} worker terminated: code={:?} signal={:?}\n",
                                 payload.code, payload.signal
                             ),
+                            log_file.as_mut(),
                         );
                         break;
                     }
                     Some(CommandEvent::Error(error)) => {
-                        append_log(
+                        append_log_with_handle(
                             &log_path,
                             &format!("[desktop] {label} worker error: {error}\n"),
+                            log_file.as_mut(),
                         );
                         break;
                     }

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -159,11 +159,12 @@ pub(crate) fn validate_vqa_job(payload: &VqaJobRequest) -> Result<(), ApiError> 
         return Err(ApiError::bad_request("sourceAssetId is required"));
     }
     let question = payload.question.trim();
-    if question.is_empty() || question.chars().count() > 4000 {
-        return Err(ApiError::bad_request(
-            "question must be between 1 and 4000 characters",
-        ));
+    if question.is_empty() || question.chars().count() > MAX_PROMPT_CHARS {
+        return Err(ApiError::bad_request(format!(
+            "question must be between 1 and {MAX_PROMPT_CHARS} characters"
+        )));
     }
+    validate_prompt_extras("", &payload.advanced)?;
     if !(16..=2048).contains(&payload.max_new_tokens) {
         return Err(ApiError::bad_request(
             "maxNewTokens must be between 16 and 2048",
@@ -198,11 +199,12 @@ pub(crate) fn validate_interleave_job(payload: &InterleaveJobRequest) -> Result<
     if payload.project_id.is_empty() {
         return Err(ApiError::bad_request("projectId is required"));
     }
-    if payload.prompt.trim().is_empty() || payload.prompt.chars().count() > 4000 {
-        return Err(ApiError::bad_request(
-            "prompt must be between 1 and 4000 characters",
-        ));
+    if payload.prompt.trim().is_empty() || payload.prompt.chars().count() > MAX_PROMPT_CHARS {
+        return Err(ApiError::bad_request(format!(
+            "prompt must be between 1 and {MAX_PROMPT_CHARS} characters"
+        )));
     }
+    validate_prompt_extras("", &payload.advanced)?;
     // Upstream interleave_gen caps the run at 10 generated images.
     if !(1..=10).contains(&payload.max_images) {
         return Err(ApiError::bad_request("maxImages must be between 1 and 10"));

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2939,6 +2939,12 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
         ));
     }
     validate_prompt_extras(&payload.negative_prompt, &payload.advanced)?;
+    if payload.loras.len() > sceneworks_core::lora_family::MAX_JOB_LORAS {
+        return Err(ApiError::bad_request(format!(
+            "loras must contain at most {} entries",
+            sceneworks_core::lora_family::MAX_JOB_LORAS
+        )));
+    }
     if ![
         "text_to_image",
         "edit_image",
@@ -2977,10 +2983,10 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
 }
 
 fn validate_character_test_job(payload: &CharacterTestRequest) -> Result<(), ApiError> {
-    if payload.prompt.is_empty() || payload.prompt.chars().count() > 4000 {
-        return Err(ApiError::bad_request(
-            "prompt must be between 1 and 4000 characters",
-        ));
+    if payload.prompt.is_empty() || payload.prompt.chars().count() > MAX_PROMPT_CHARS {
+        return Err(ApiError::bad_request(format!(
+            "prompt must be between 1 and {MAX_PROMPT_CHARS} characters"
+        )));
     }
     if !(1..=8).contains(&payload.count) {
         return Err(ApiError::bad_request("count must be between 1 and 8"));
@@ -3001,6 +3007,12 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         ));
     }
     validate_prompt_extras(&payload.negative_prompt, &payload.advanced)?;
+    if payload.loras.len() > sceneworks_core::lora_family::MAX_JOB_LORAS {
+        return Err(ApiError::bad_request(format!(
+            "loras must contain at most {} entries",
+            sceneworks_core::lora_family::MAX_JOB_LORAS
+        )));
+    }
     if ![
         "image_to_video",
         "text_to_video",

--- a/apps/rust-api/src/manifest.rs
+++ b/apps/rust-api/src/manifest.rs
@@ -314,8 +314,12 @@ pub(crate) fn metadata_modified_ns(metadata: &std::fs::Metadata) -> u128 {
 
 pub(crate) fn merge_entries_by_id(builtin: Vec<Value>, user: Vec<Value>) -> Vec<Value> {
     let mut entries = Vec::<Value>::new();
+    let mut indexes = HashMap::<String, usize>::new();
     for entry in builtin {
-        if entry.get("id").and_then(Value::as_str).is_some() {
+        if let Some(id) = entry.get("id").and_then(Value::as_str) {
+            // Preserve the existing first-match override behavior for a malformed
+            // manifest containing duplicate built-in ids.
+            indexes.entry(id.to_owned()).or_insert(entries.len());
             entries.push(entry);
         }
     }
@@ -323,12 +327,10 @@ pub(crate) fn merge_entries_by_id(builtin: Vec<Value>, user: Vec<Value>) -> Vec<
         let Some(id) = entry.get("id").and_then(Value::as_str) else {
             continue;
         };
-        if let Some(existing) = entries
-            .iter_mut()
-            .find(|existing| existing.get("id").and_then(Value::as_str) == Some(id))
-        {
-            merge_object(existing, entry);
+        if let Some(index) = indexes.get(id).copied() {
+            merge_object(&mut entries[index], entry);
         } else {
+            indexes.insert(id.to_owned(), entries.len());
             entries.push(entry);
         }
     }

--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -90,14 +90,6 @@ fn load_preferences(path: &std::path::Path) -> UiPreferences {
         .unwrap_or_default()
 }
 
-fn save_preferences(path: &std::path::Path, prefs: &UiPreferences) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let body = serde_json::to_string_pretty(prefs)?;
-    std::fs::write(path, body)
-}
-
 /// The valid stored theme for `input`, or `None` if it isn't one we recognize.
 fn normalize_theme(input: Option<&str>) -> Option<String> {
     match input.map(str::trim) {
@@ -151,22 +143,34 @@ pub(crate) async fn get_ui_preferences(
 ) -> Result<Json<UiPreferences>, ApiError> {
     // sc-4202 (F-API-3): keep the preferences-file read off the async executor.
     let path = preferences_path(&state);
-    let prefs = tokio::task::spawn_blocking(move || {
-        let mut prefs = load_preferences(&path);
+    let lock = manifest_write_lock(&state, &path);
+    let _guard = lock.lock().await;
+    let load_path = path.clone();
+    let (mut prefs, migrated_body) = tokio::task::spawn_blocking(move || {
+        let mut prefs = load_preferences(&load_path);
         // One-time migration (epic 10721 R3): flip a stored `q8` (the old forced default, predating the
         // `auto` option) to `auto` and persist — see `migrate_quality_to_auto`. Only writes on a change.
         if migrate_quality_to_auto(&mut prefs) {
-            let _ = save_preferences(&path, &prefs);
+            let body = serde_json::to_string_pretty(&prefs).ok();
+            return (prefs, body);
         }
-        // Always hand the web a concrete value to seed (`auto` when unset/invalid), so the durable
-        // value survives a desktop relaunch even before the user changes it.
-        prefs.default_generation_quality = Some(normalize_generation_quality(
-            prefs.default_generation_quality.as_deref(),
-        ));
-        prefs
+        (prefs, None)
     })
     .await
     .map_err(|err| ApiError::internal(format!("UI preferences load task failed: {err}")))?;
+    if let Some(body) = migrated_body {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|error| {
+                ApiError::internal(format!("Failed to create preferences directory: {error}"))
+            })?;
+        }
+        write_manifest_atomic(&path, &body).await?;
+    }
+    // Always hand the web a concrete value to seed (`auto` when unset/invalid), so the durable
+    // value survives a desktop relaunch even before the user changes it.
+    prefs.default_generation_quality = Some(normalize_generation_quality(
+        prefs.default_generation_quality.as_deref(),
+    ));
     Ok(Json(prefs))
 }
 
@@ -179,8 +183,11 @@ pub(crate) async fn set_ui_preferences(
     // sc-4202 (F-API-3): the read-modify-write of the preferences file runs on the
     // blocking pool so it can't stall a tokio worker thread.
     let path = preferences_path(&state);
-    let prefs = tokio::task::spawn_blocking(move || -> std::io::Result<UiPreferences> {
-        let mut prefs = load_preferences(&path);
+    let lock = manifest_write_lock(&state, &path);
+    let _guard = lock.lock().await;
+    let load_path = path.clone();
+    let (prefs, body) = tokio::task::spawn_blocking(move || -> Result<_, serde_json::Error> {
+        let mut prefs = load_preferences(&load_path);
         if let Some(theme) = normalize_theme(payload.theme.as_deref()) {
             prefs.theme = Some(theme);
         }
@@ -209,12 +216,18 @@ pub(crate) async fn set_ui_preferences(
         if let Some(per_model_tier) = payload.per_model_tier {
             prefs.per_model_tier = Some(per_model_tier);
         }
-        save_preferences(&path, &prefs)?;
-        Ok(prefs)
+        let body = serde_json::to_string_pretty(&prefs)?;
+        Ok((prefs, body))
     })
     .await
     .map_err(|err| ApiError::internal(format!("UI preferences save task failed: {err}")))?
-    .map_err(|error| ApiError::internal(format!("Failed to save UI preferences: {error}")))?;
+    .map_err(|error| ApiError::internal(format!("Failed to encode UI preferences: {error}")))?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            ApiError::internal(format!("Failed to create preferences directory: {error}"))
+        })?;
+    }
+    write_manifest_atomic(&path, &body).await?;
     Ok(Json(prefs))
 }
 

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -9,7 +9,7 @@ import globals from "globals";
 // enables the high-signal rules:
 //   - no-undef        → would have caught F-WEB-1 (modelLoraFamilies) and F-WEB-5
 //   - no-unused-vars  → flags dead imports
-//   - react-hooks/rules-of-hooks (error) and exhaustive-deps (warn; the codebase
+//   - react-hooks/rules-of-hooks and exhaustive-deps (errors; the codebase
 //     carries intentional eslint-disable-next-line exhaustive-deps comments).
 export default [
   {
@@ -34,7 +34,7 @@ export default [
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-hooks/exhaustive-deps": "warn",
+      "react-hooks/exhaustive-deps": "error",
       // Without these, no-unused-vars treats JSX-only-used identifiers as unused:
       // jsx-uses-vars covers components rendered as <Foo/>; jsx-uses-react covers the
       // `React` import that the test files need (vitest uses the classic JSX runtime,

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -440,8 +440,10 @@ export function App() {
   // Scope project data during render, not in a passive effect. On A → B (or A
   // → no project), B's first render therefore cannot observe A's assets or raw
   // selection while B's catalog request is still pending.
-  const assets =
-    loadedAssetsProjectId === activeProject?.id ? loadedAssets : [];
+  const assets = useMemo(
+    () => (loadedAssetsProjectId === activeProject?.id ? loadedAssets : []),
+    [activeProject?.id, loadedAssets, loadedAssetsProjectId],
+  );
   const selectedAssetId =
     loadedAssetsProjectId === activeProject?.id ? storedSelectedAssetId : null;
   const [projectFilter, setProjectFilter] = useState("all");
@@ -475,10 +477,10 @@ export function App() {
     );
     setPreviewAsset(asset);
   }, []);
-  const closePreview = () => {
+  const closePreview = useCallback(() => {
     setPreviewScopeIds(null);
     setPreviewAsset(null);
-  };
+  }, []);
   const [studioLaunch, setStudioLaunch] = useState(null);
   // sc-8730: the launch channel INTO the Image Editor canvas (crop/upscale/refine
   // screen, activeView === "ImageEditor"). Mirrors studioLaunch but targets the
@@ -1330,6 +1332,8 @@ export function App() {
     refreshPersonTracksRef.current?.(activeProject.id, { signal });
     refreshTimelinesRef.current?.(activeProject.id, { signal });
     return () => controller.abort();
+    // Project identity owns this refresh; project-object churn must not restart every catalog request.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeProject?.id, ready, token]);
 
   // sc-11231 (F-037): useJobEvents captures whichever callback existed at subscribe time
@@ -1573,7 +1577,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token, activeProject, requestedGpu],
+    [token, activeProject?.id, activeProject?.name, requestedGpu, setError],
   );
 
   const createImageJob = useMemo(
@@ -1981,7 +1985,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
   );
 
   const updateAssetTags = useCallback(
@@ -1997,7 +2001,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
   );
 
   // A move endpoint returns the whole moved upscale-fold group (sc-10205) as an
@@ -2027,7 +2031,7 @@ export function App() {
         throw err;
       }
     },
-    [token, mergeMovedAssets],
+    [token, mergeMovedAssets, setError],
   );
 
   // Move an asset into a character's assets (sc-10200): the true-move twin of
@@ -2051,7 +2055,7 @@ export function App() {
         throw err;
       }
     },
-    [token, mergeMovedAssets],
+    [token, mergeMovedAssets, setError],
   );
 
   const deleteAsset = useCallback(
@@ -2068,7 +2072,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
   );
 
   const purgeAsset = useCallback(
@@ -2099,7 +2103,34 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
+  );
+  const deletePreviewAsset = useCallback(
+    async (asset) => {
+      const { previous, next } = previewNavigation;
+      const target =
+        previewDirectionRef.current === "previous" ? previous ?? next : next ?? previous;
+      await deleteAsset(asset);
+      if (target) {
+        setPreviewAsset(target);
+      } else {
+        closePreview();
+      }
+    },
+    [closePreview, deleteAsset, previewNavigation],
+  );
+  const previewAssetInDirection = useCallback((asset, direction) => {
+    if (direction) {
+      previewDirectionRef.current = direction;
+    }
+    setPreviewAsset(asset);
+  }, []);
+  const purgePreviewAsset = useCallback(
+    async (asset) => {
+      await purgeAsset(asset);
+      closePreview();
+    },
+    [closePreview, purgeAsset],
   );
   // Keep the ref current for the App-level scratch-op survivor (sc-8850), which purges
   // from the SSE/sweep path without re-subscribing. Published from a post-commit effect
@@ -2148,7 +2179,7 @@ export function App() {
         return null;
       }
     },
-    [token, activeProject],
+    [activeProject, setError, token],
   );
 
   const jobAction = useCallback(
@@ -2166,7 +2197,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
   );
 
   // Clear completed items from the queue (issue #1556 / sc-12231). The server
@@ -2192,7 +2223,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
   );
 
   // Cancel every pending (not-yet-started) item in the queue (sc-13448). The server
@@ -2218,7 +2249,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
   );
 
   // Clear a single completed item from the queue (issue #1556 / sc-12231) — the
@@ -2237,7 +2268,7 @@ export function App() {
         setError(err.message);
       }
     },
-    [token],
+    [setError, token],
   );
 
   const titleInfo = viewTitles[activeView] ?? { title: activeView, blurb: "" };
@@ -2807,39 +2838,16 @@ export function App() {
       {previewedAsset ? (
         <FullscreenPreview
           asset={previewedAsset}
-          deleteAsset={async (asset) => {
-            // Stay in the preview and advance to the neighbour in the direction
-            // the user was scrolling (falling back to the other side, then to
-            // closing once nothing is left).
-            const { previous, next } = previewNavigation;
-            const target =
-              previewDirectionRef.current === "previous" ? previous ?? next : next ?? previous;
-            await deleteAsset(asset);
-            // Advance within the launch collection; close (and drop the scope)
-            // once it is exhausted.
-            if (target) {
-              setPreviewAsset(target);
-            } else {
-              closePreview();
-            }
-          }}
+          deleteAsset={deletePreviewAsset}
           nextAsset={previewNavigation.next}
           onClose={closePreview}
           onEditImage={sendAssetToImageEditor}
           onEditInStudio={sendAssetToImageEdit}
-          onPreviewAsset={(asset, direction) => {
-            if (direction) {
-              previewDirectionRef.current = direction;
-            }
-            setPreviewAsset(asset);
-          }}
+          onPreviewAsset={previewAssetInDirection}
           onUseRecipe={sendAssetRecipeToStudio}
           previousAsset={previewNavigation.previous}
           sourceAsset={previewSourceAsset}
-          purgeAsset={async (asset) => {
-            await purgeAsset(asset);
-            closePreview();
-          }}
+          purgeAsset={purgePreviewAsset}
           updateAssetStatus={updateAssetStatus}
         />
       ) : null}

--- a/apps/web/src/App.preview.test.jsx
+++ b/apps/web/src/App.preview.test.jsx
@@ -223,6 +223,28 @@ describe("SceneWorks app shell", () => {
     });
 
     expect(document.body.querySelector(".preview-modal img").getAttribute("src")).toContain("original.png");
+
+    const refreshedOriginal = { ...original };
+    const refreshedUpscaled = { ...upscaled };
+    refreshedUpscaled.variants = {
+      original: refreshedOriginal,
+      upscaled: refreshedUpscaled,
+    };
+    await act(async () => {
+      root.render(
+        <FullscreenPreview
+          asset={refreshedUpscaled}
+          deleteAsset={noop}
+          nextAsset={null}
+          onClose={noop}
+          onPreviewAsset={noop}
+          previousAsset={null}
+          purgeAsset={noop}
+          updateAssetStatus={noop}
+        />,
+      );
+    });
+    expect(document.body.querySelector(".preview-modal img").getAttribute("src")).toContain("original.png");
   });
 
   it("toggles a side-by-side Original↔Edited compare for edits with a resolvable source", async () => {

--- a/apps/web/src/App.videoRecipe.test.jsx
+++ b/apps/web/src/App.videoRecipe.test.jsx
@@ -467,4 +467,46 @@ describe("video recipe replay (sc-12324)", () => {
     // while also adopting the replayed clip as its own source clip.
     expect(activeMode()).toBe("First → Last");
   });
+
+  it("does not replay a persistent asset launch when the asset catalog refreshes", async () => {
+    const asset = {
+      id: "asset-image",
+      type: "image",
+      displayName: "Source",
+      file: { path: "source.png" },
+    };
+    const context = {
+      assets: [asset],
+      selectedAsset: asset,
+      selectedAssetId: asset.id,
+      studioLaunch: {
+        id: "launch-asset",
+        view: "Video",
+        assetId: asset.id,
+        mode: "image_to_video",
+      },
+    };
+    await launch(context);
+    expect(activeMode()).toBe("Image → Video");
+
+    await act(async () => {
+      [...document.body.querySelectorAll(".mode-tab")]
+        .find((button) => button.textContent.trim() === "Text → Video")
+        .click();
+    });
+    expect(activeMode()).toBe("Text → Video");
+
+    await act(async () => {
+      const refreshedAsset = { ...asset };
+      root.render(
+        renderStudio({
+          ...context,
+          assets: [refreshedAsset],
+          selectedAsset: refreshedAsset,
+        }),
+      );
+    });
+    await settle();
+    expect(activeMode()).toBe("Text → Video");
+  });
 });

--- a/apps/web/src/components/ReferenceCaptionPicker.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.jsx
@@ -16,6 +16,7 @@ import React, { useEffect, useState } from "react";
 import { AssetPickerField, ImageEditSourcePickerField } from "./AssetPicker.jsx";
 import { assetUrl } from "./assetMedia.jsx";
 import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
+import { probeImageDimensions } from "../imageDimensions.js";
 
 export default function ReferenceCaptionPicker({
   // Run the vision job for the picked asset and resolve to a result (the parent parses:
@@ -66,20 +67,6 @@ export default function ReferenceCaptionPicker({
     .filter((id) => id && id !== referenceAssetId)
     .slice(0, Math.max(0, moodBoardMax - 1));
 
-  // Feed the uploaded image's natural dimensions to the sc-8109 auto-preset seam.
-  function reportReferenceDimensions(asset) {
-    if (typeof onReferenceImageLoaded !== "function" || !asset) return;
-    const src = assetUrl(asset);
-    if (!src || typeof Image === "undefined") return;
-    const probe = new Image();
-    probe.onload = () => {
-      if (probe.naturalWidth && probe.naturalHeight) {
-        onReferenceImageLoaded(probe.naturalWidth, probe.naturalHeight);
-      }
-    };
-    probe.src = src;
-  }
-
   function handleReferenceChange(assetId) {
     setReferenceAssetId(assetId);
     setError("");
@@ -91,11 +78,10 @@ export default function ReferenceCaptionPicker({
   // the id and the list re-runs once the asset resolves, covering select / import / drag / character
   // paths uniformly.
   useEffect(() => {
-    if (!referenceAssetId) return;
+    if (!referenceAssetId) return undefined;
     const asset = referenceAssets.find((item) => item.id === referenceAssetId);
-    if (asset) reportReferenceDimensions(asset);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [referenceAssetId, referenceAssets]);
+    return probeImageDimensions(asset && assetUrl(asset), onReferenceImageLoaded);
+  }, [onReferenceImageLoaded, referenceAssetId, referenceAssets]);
 
   async function handleCaption() {
     if (typeof onCaption !== "function" || !referenceAssetId || busy) return;

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -103,7 +103,7 @@ export async function emptyTrash(trashedAssets, purgeAsset) {
     return;
   }
   for (const asset of items) {
-    // eslint-disable-next-line no-await-in-loop -- sequential keeps state updates predictable
+    // Sequential awaits keep state updates predictable.
     await purgeAsset(asset);
   }
 }
@@ -869,7 +869,7 @@ function PreviewContextMenu({ x, y, items, submenu, onClose }) {
   );
 }
 
-export function FullscreenPreview({
+function FullscreenPreviewComponent({
   asset,
   deleteAsset,
   nextAsset,
@@ -887,6 +887,8 @@ export function FullscreenPreview({
   const [variantMode, setVariantMode] = React.useState("upscaled");
   React.useEffect(() => {
     setVariantMode(asset.variants?.upscaled ? "upscaled" : "original");
+    // Variant identity controls reset; catalog object refreshes must preserve the user's mode.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [asset.id, asset.variants?.upscaled?.id]);
   const displayedAsset = hasUpscaleVariants ? asset.variants[variantMode] : asset;
 
@@ -1321,3 +1323,5 @@ export function FullscreenPreview({
     </Modal>
   );
 }
+
+export const FullscreenPreview = React.memo(FullscreenPreviewComponent);

--- a/apps/web/src/components/editor/useEditorGeneration.js
+++ b/apps/web/src/components/editor/useEditorGeneration.js
@@ -113,13 +113,20 @@ export function useEditorGeneration({ context }) {
   const durationOptions = selectedModel?.limits?.durations ?? DURATION_FALLBACK;
   const samplerOptions = useMemo(() => samplerOptionsFromModel(selectedModel, null), [selectedModel]);
   const schedulerOptions = useMemo(() => schedulerOptionsFromModel(selectedModel, null), [selectedModel]);
-  const tierPickerOpts = { convRotEligible: false, nvfp4Eligible: false, defaultQuality: EDITOR_DEFAULT_TIER };
-  const availableTiers = useMemo(() => installedTiers(selectedModel, tierPickerOpts), [selectedModel]);
+  const tierPickerOpts = useMemo(
+    () => ({
+      convRotEligible: false,
+      nvfp4Eligible: false,
+      defaultQuality: EDITOR_DEFAULT_TIER,
+    }),
+    [],
+  );
+  const availableTiers = useMemo(() => installedTiers(selectedModel, tierPickerOpts), [selectedModel, tierPickerOpts]);
   // Full display set + option list with un-downloaded tiers disabled — same show-all/disable-unavailable
   // rule as the studios. `availableTiers` stays the SELECTABLE set; the picker shows when there is more
   // than one POSSIBLE tier and at least one is installed.
-  const possibleTiers = useMemo(() => allPossibleTiers(selectedModel, tierPickerOpts), [selectedModel]);
-  const tierPickerItems = useMemo(() => tierPickerOptions(selectedModel, tierPickerOpts), [selectedModel]);
+  const possibleTiers = useMemo(() => allPossibleTiers(selectedModel, tierPickerOpts), [selectedModel, tierPickerOpts]);
+  const tierPickerItems = useMemo(() => tierPickerOptions(selectedModel, tierPickerOpts), [selectedModel, tierPickerOpts]);
   // Only an installed tier can be selected; disabled chips are shown for discoverability, never picked.
   const selectTier = (tier) => {
     if (availableTiers.includes(tier)) {

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -339,7 +339,7 @@ export function useGenerationStudio({
           presetMatchesWorkflow(preset, mode) &&
           presetMatchesModel(preset, selectedModel, models),
       ),
-    [mode, presets, selectedModel?.id, models],
+    [presets, mode, selectedModel, models],
   );
   // General (model-agnostic) presets are available on every model in every mode.
   const availableGeneralPresets = useMemo(
@@ -399,7 +399,7 @@ export function useGenerationStudio({
       const next = ids.filter((id) => availableGeneralPresets.some((preset) => preset.id === id));
       return next.length === ids.length ? ids : next;
     });
-  }, [presets.length, availableGeneralKey]);
+  }, [presets.length, availableGeneralKey, availableGeneralPresets]);
 
   // Add/remove a general preset from the stack. Toggling never touches the model, mode, or
   // the LoRA picker — general presets carry none of those. Composition into the prompt is
@@ -448,7 +448,7 @@ export function useGenerationStudio({
   // stale progress card never lingers.
   const localJobs = useMemo(
     () => selectStackedJobs(trackedLocalJobs, (job) => resultVisible(job) || completedWaitExpired(job)),
-    [trackedLocalJobs, resultVisible, completedWaitExpired, resultFallbackTick],
+    [trackedLocalJobs, resultVisible, completedWaitExpired],
   );
 
   // ---- LoRA selection (sc-4196: shared by Image + Video studios) ----
@@ -497,14 +497,14 @@ export function useGenerationStudio({
       return;
     }
     setSelectedLoraIds((ids) => ids.filter((id) => compatibleLoras.some((lora) => lora.id === id)));
-  }, [loras.length, selectedModel, compatibleLoraKey]);
+  }, [loras.length, selectedModel, compatibleLoraKey, compatibleLoras]);
   // Auto-open the advanced panel when an incompatible LoRA is selected so the
   // generate-blocking warning is visible.
   useEffect(() => {
     if (selectedLoraValidationResult.incompatible.length && !advancedOpen) {
       setAdvancedOpen(true);
     }
-  }, [advancedOpen, selectedLoraValidationResult.incompatible.length]);
+  }, [advancedOpen, selectedLoraValidationResult.incompatible.length, setAdvancedOpen]);
 
   function toggleLora(lora) {
     setSelectedLoraIds((ids) => {

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -382,7 +382,7 @@ export function useJobEvents({
       }
       setQueueSummary(summary);
       if (Array.isArray(summary.workers)) {
-        setWorkers(summary.workers.sort(sortWorkers));
+        setWorkers([...summary.workers].sort(sortWorkers));
       }
     }
 

--- a/apps/web/src/hooks/usePresets.js
+++ b/apps/web/src/hooks/usePresets.js
@@ -1,130 +1,18 @@
-import { useCallback, useState } from "react";
-import { apiFetch, isAbortError } from "../api.js";
-import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { useScopedCrudList } from "./useScopedCrudList.js";
 
-// Owns the recipe-preset list plus its scoped refresh/create/update/duplicate/delete
-// mutations. Extracted from App.jsx (sc-1651). Behavior unchanged — token, the active
-// project, and error reporting are passed in. App's bulk refreshData still seeds the
-// list via the returned setPresets (same React setter identity), and the project-load
-// effect calls refreshCharacters/refreshPresets exactly as before.
-export function usePresets({ token, activeProject, activeProjectRef, setError }) {
-  const [presets, setPresets] = useState([]);
-
-  const isCurrentPresetRequest = useCallback(
-    (projectId) =>
-      !projectId ||
-      isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId),
-    [activeProjectRef],
-  );
-
-  // sc-4194: actions wrapped in useCallback so their identity is stable across
-  // App's SSE-driven re-renders, enabling appContextValue to memoize.
-  const refreshPresets = useCallback(
-    async (projectId = activeProject?.id, { signal } = {}) => {
-      try {
-        const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-        const items = await apiFetch(`/api/v1/recipe-presets${query}`, token, { signal });
-        if (!isCurrentPresetRequest(projectId)) return [];
-        setPresets(items);
-        setError("");
-        return items;
-      } catch (err) {
-        if (isAbortError(err)) return [];
-        if (!isCurrentPresetRequest(projectId)) return [];
-        setError(err.message);
-        return [];
-      }
-    },
-    [token, activeProject, isCurrentPresetRequest, setError],
-  );
-
-  const presetQuery = useCallback(
-    (scope = null) => {
-      const params = new URLSearchParams();
-      if (scope) {
-        params.set("scope", scope);
-      }
-      if (scope === "project" && activeProject?.id) {
-        params.set("projectId", activeProject.id);
-      }
-      const value = params.toString();
-      return value ? `?${value}` : "";
-    },
-    [activeProject],
-  );
-
-  const createPreset = useCallback(
-    async (payload) => {
-      if (payload.scope === "project" && !activeProject) {
-        throw new Error("Create or open a project first.");
-      }
-      const created = await apiFetch(`/api/v1/recipe-presets${presetQuery(payload.scope)}`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      // Refresh the caller's current catalog view even when the mutation itself
-      // targets a global preset: a project view contains both global and project
-      // presets. Capture the id so a later project switch can suppress this refetch.
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentPresetRequest(projectId)) {
-        await refreshPresets(projectId);
-      }
-      return created;
-    },
-    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
-  );
-
-  const updatePreset = useCallback(
-    async (presetId, payload, scope = payload.scope) => {
-      const updated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
-        method: "PATCH",
-        body: JSON.stringify(payload),
-      });
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentPresetRequest(projectId)) {
-        await refreshPresets(projectId);
-      }
-      return updated;
-    },
-    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
-  );
-
-  const duplicatePreset = useCallback(
-    async (presetId, scope = null) => {
-      const duplicated = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}/duplicate${presetQuery(scope)}`, token, {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentPresetRequest(projectId)) {
-        await refreshPresets(projectId);
-      }
-      return duplicated;
-    },
-    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
-  );
-
-  const deletePreset = useCallback(
-    async (presetId, scope = null) => {
-      const archived = await apiFetch(`/api/v1/recipe-presets/${encodeURIComponent(presetId)}${presetQuery(scope)}`, token, {
-        method: "DELETE",
-      });
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentPresetRequest(projectId)) {
-        await refreshPresets(projectId);
-      }
-      return archived;
-    },
-    [token, activeProject, isCurrentPresetRequest, presetQuery, refreshPresets],
-  );
-
+export function usePresets(options) {
+  const catalog = useScopedCrudList({
+    ...options,
+    resourcePath: "/api/v1/recipe-presets",
+    projectRequiredMessage: "Create or open a project first.",
+  });
   return {
-    presets,
-    setPresets,
-    refreshPresets,
-    createPreset,
-    updatePreset,
-    duplicatePreset,
-    deletePreset,
+    presets: catalog.items,
+    setPresets: catalog.setItems,
+    refreshPresets: catalog.refresh,
+    createPreset: catalog.create,
+    updatePreset: catalog.update,
+    duplicatePreset: catalog.duplicate,
+    deletePreset: catalog.remove,
   };
 }

--- a/apps/web/src/hooks/usePromptBatches.js
+++ b/apps/web/src/hooks/usePromptBatches.js
@@ -1,132 +1,18 @@
-import { useCallback, useState } from "react";
-import { apiFetch, isAbortError } from "../api.js";
-import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { useScopedCrudList } from "./useScopedCrudList.js";
 
-// Owns the prompt-batch list plus its scoped refresh/create/update/duplicate/delete
-// mutations (sc-9954, epic 9952). A direct sibling of usePresets — same scoping and
-// error handling — against the /api/v1/prompt-batches routes. Batches carry prompt
-// templates + variable definitions, not a generation recipe, so there is no
-// model/workflow filtering here.
-export function usePromptBatches({ token, activeProject, activeProjectRef, setError }) {
-  const [promptBatches, setPromptBatches] = useState([]);
-
-  const isCurrentBatchRequest = useCallback(
-    (projectId) =>
-      !projectId ||
-      isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId),
-    [activeProjectRef],
-  );
-
-  const refreshPromptBatches = useCallback(
-    async (projectId = activeProject?.id, { signal } = {}) => {
-      try {
-        const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-        const items = await apiFetch(`/api/v1/prompt-batches${query}`, token, { signal });
-        if (!isCurrentBatchRequest(projectId)) return [];
-        setPromptBatches(items);
-        setError("");
-        return items;
-      } catch (err) {
-        if (isAbortError(err)) return [];
-        if (!isCurrentBatchRequest(projectId)) return [];
-        setError(err.message);
-        return [];
-      }
-    },
-    [token, activeProject, isCurrentBatchRequest, setError],
-  );
-
-  const batchQuery = useCallback(
-    (scope = null) => {
-      const params = new URLSearchParams();
-      if (scope) {
-        params.set("scope", scope);
-      }
-      if (scope === "project" && activeProject?.id) {
-        params.set("projectId", activeProject.id);
-      }
-      const value = params.toString();
-      return value ? `?${value}` : "";
-    },
-    [activeProject],
-  );
-
-  const createPromptBatch = useCallback(
-    async (payload) => {
-      if (payload.scope === "project" && !activeProject) {
-        throw new Error("Create or open a project first.");
-      }
-      const created = await apiFetch(`/api/v1/prompt-batches${batchQuery(payload.scope)}`, token, {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-      // Refresh the caller's current catalog view even when the mutation itself
-      // targets a global batch: a project view contains both global and project
-      // batches. Capture the id so a later project switch can suppress this refetch.
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentBatchRequest(projectId)) {
-        await refreshPromptBatches(projectId);
-      }
-      return created;
-    },
-    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
-  );
-
-  const updatePromptBatch = useCallback(
-    async (batchId, payload, scope = payload.scope) => {
-      const updated = await apiFetch(
-        `/api/v1/prompt-batches/${encodeURIComponent(batchId)}${batchQuery(scope)}`,
-        token,
-        { method: "PATCH", body: JSON.stringify(payload) },
-      );
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentBatchRequest(projectId)) {
-        await refreshPromptBatches(projectId);
-      }
-      return updated;
-    },
-    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
-  );
-
-  const duplicatePromptBatch = useCallback(
-    async (batchId, scope = null) => {
-      const duplicated = await apiFetch(
-        `/api/v1/prompt-batches/${encodeURIComponent(batchId)}/duplicate${batchQuery(scope)}`,
-        token,
-        { method: "POST", body: JSON.stringify({}) },
-      );
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentBatchRequest(projectId)) {
-        await refreshPromptBatches(projectId);
-      }
-      return duplicated;
-    },
-    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
-  );
-
-  const deletePromptBatch = useCallback(
-    async (batchId, scope = null) => {
-      const archived = await apiFetch(
-        `/api/v1/prompt-batches/${encodeURIComponent(batchId)}${batchQuery(scope)}`,
-        token,
-        { method: "DELETE" },
-      );
-      const projectId = activeProject?.id ?? null;
-      if (isCurrentBatchRequest(projectId)) {
-        await refreshPromptBatches(projectId);
-      }
-      return archived;
-    },
-    [token, activeProject, batchQuery, isCurrentBatchRequest, refreshPromptBatches],
-  );
-
+export function usePromptBatches(options) {
+  const catalog = useScopedCrudList({
+    ...options,
+    resourcePath: "/api/v1/prompt-batches",
+    projectRequiredMessage: "Create or open a project first.",
+  });
   return {
-    promptBatches,
-    setPromptBatches,
-    refreshPromptBatches,
-    createPromptBatch,
-    updatePromptBatch,
-    duplicatePromptBatch,
-    deletePromptBatch,
+    promptBatches: catalog.items,
+    setPromptBatches: catalog.setItems,
+    refreshPromptBatches: catalog.refresh,
+    createPromptBatch: catalog.create,
+    updatePromptBatch: catalog.update,
+    duplicatePromptBatch: catalog.duplicate,
+    deletePromptBatch: catalog.remove,
   };
 }

--- a/apps/web/src/hooks/useScopedCrudList.js
+++ b/apps/web/src/hooks/useScopedCrudList.js
@@ -1,0 +1,116 @@
+import { useCallback, useState } from "react";
+import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
+
+// Shared global/project-scoped catalog mutations. Recipe presets and prompt
+// batches intentionally expose different domain names, but their request,
+// stale-project suppression, refresh and error behavior are one contract.
+export function useScopedCrudList({
+  token,
+  activeProject,
+  activeProjectRef,
+  setError,
+  resourcePath,
+  projectRequiredMessage,
+}) {
+  const [items, setItems] = useState([]);
+
+  const isCurrentRequest = useCallback(
+    (projectId) =>
+      !projectId ||
+      isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId),
+    [activeProjectRef],
+  );
+
+  const refresh = useCallback(
+    async (projectId = activeProject?.id, { signal } = {}) => {
+      try {
+        const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+        const next = await apiFetch(`${resourcePath}${query}`, token, { signal });
+        if (!isCurrentRequest(projectId)) return [];
+        setItems(next);
+        setError("");
+        return next;
+      } catch (error) {
+        if (isAbortError(error) || !isCurrentRequest(projectId)) return [];
+        setError(error.message);
+        return [];
+      }
+    },
+    [activeProject, isCurrentRequest, resourcePath, setError, token],
+  );
+
+  const scopeQuery = useCallback(
+    (scope = null) => {
+      const params = new URLSearchParams();
+      if (scope) params.set("scope", scope);
+      if (scope === "project" && activeProject?.id) {
+        params.set("projectId", activeProject.id);
+      }
+      const value = params.toString();
+      return value ? `?${value}` : "";
+    },
+    [activeProject],
+  );
+
+  const refreshCurrent = useCallback(async () => {
+    const projectId = activeProject?.id ?? null;
+    if (isCurrentRequest(projectId)) await refresh(projectId);
+  }, [activeProject, isCurrentRequest, refresh]);
+
+  const create = useCallback(
+    async (payload) => {
+      if (payload.scope === "project" && !activeProject) {
+        throw new Error(projectRequiredMessage);
+      }
+      const created = await apiFetch(`${resourcePath}${scopeQuery(payload.scope)}`, token, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      await refreshCurrent();
+      return created;
+    },
+    [activeProject, projectRequiredMessage, refreshCurrent, resourcePath, scopeQuery, token],
+  );
+
+  const update = useCallback(
+    async (id, payload, scope = payload.scope) => {
+      const updated = await apiFetch(
+        `${resourcePath}/${encodeURIComponent(id)}${scopeQuery(scope)}`,
+        token,
+        { method: "PATCH", body: JSON.stringify(payload) },
+      );
+      await refreshCurrent();
+      return updated;
+    },
+    [refreshCurrent, resourcePath, scopeQuery, token],
+  );
+
+  const duplicate = useCallback(
+    async (id, scope = null) => {
+      const duplicated = await apiFetch(
+        `${resourcePath}/${encodeURIComponent(id)}/duplicate${scopeQuery(scope)}`,
+        token,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+      await refreshCurrent();
+      return duplicated;
+    },
+    [refreshCurrent, resourcePath, scopeQuery, token],
+  );
+
+  const remove = useCallback(
+    async (id, scope = null) => {
+      const removed = await apiFetch(
+        `${resourcePath}/${encodeURIComponent(id)}${scopeQuery(scope)}`,
+        token,
+        { method: "DELETE" },
+      );
+      await refreshCurrent();
+      return removed;
+    },
+    [refreshCurrent, resourcePath, scopeQuery, token],
+  );
+
+  return { items, setItems, refresh, create, update, duplicate, remove };
+}

--- a/apps/web/src/imageDimensions.js
+++ b/apps/web/src/imageDimensions.js
@@ -1,0 +1,21 @@
+// Start a cancel-safe natural-dimension probe. Cleanup detaches handlers and
+// releases the pending image request so a stale selection cannot update state.
+export function probeImageDimensions(src, onDimensions) {
+  if (!src || typeof Image === "undefined" || typeof onDimensions !== "function") {
+    return () => {};
+  }
+  let active = true;
+  const image = new Image();
+  image.onload = () => {
+    if (active && image.naturalWidth && image.naturalHeight) {
+      onDimensions(image.naturalWidth, image.naturalHeight);
+    }
+  };
+  image.src = src;
+  return () => {
+    active = false;
+    image.onload = null;
+    image.onerror = null;
+    image.src = "";
+  };
+}

--- a/apps/web/src/imageDimensions.test.js
+++ b/apps/web/src/imageDimensions.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeImageDimensions } from "./imageDimensions.js";
+
+describe("probeImageDimensions", () => {
+  it("reports natural dimensions and cleanup suppresses stale loads", () => {
+    const OriginalImage = globalThis.Image;
+    const probes = [];
+    globalThis.Image = class {
+      constructor() {
+        this.naturalWidth = 640;
+        this.naturalHeight = 480;
+        probes.push(this);
+      }
+    };
+    try {
+      const onDimensions = vi.fn();
+      const cleanup = probeImageDimensions("/asset.png", onDimensions);
+      probes[0].onload();
+      expect(onDimensions).toHaveBeenCalledWith(640, 480);
+
+      cleanup();
+      expect(probes[0].src).toBe("");
+      expect(probes[0].onload).toBeNull();
+    } finally {
+      globalThis.Image = OriginalImage;
+    }
+  });
+});

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -335,8 +335,17 @@ export function AudioStudio() {
 
   // The selected model's audio capabilities — the single source every field below reads from. Never
   // hardcoded: an absent sub-block simply hides the dependent control.
-  const audio = selectedModel?.audio && typeof selectedModel.audio === "object" ? selectedModel.audio : {};
-  const voices = Array.isArray(audio.voices) ? audio.voices : [];
+  const audio = useMemo(
+    () =>
+      selectedModel?.audio && typeof selectedModel.audio === "object"
+        ? selectedModel.audio
+        : {},
+    [selectedModel?.audio],
+  );
+  const voices = useMemo(
+    () => (Array.isArray(audio.voices) ? audio.voices : []),
+    [audio],
+  );
   const languages = Array.isArray(audio.languages) ? audio.languages : [];
   const editModes = Array.isArray(audio.editModes) ? audio.editModes : [];
   const sampleRates = Array.isArray(audio.sampleRates) ? audio.sampleRates : [];

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -272,7 +272,11 @@ export function CharacterStudio() {
   // sc-2022: datasets the dataset backend reports as owned by this character,
   // and the character's own images (same match the Dataset editor's Character
   // tab uses) that a new dataset would be seeded from.
-  const datasetsForProject = trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [];
+  const datasetsForProject = useMemo(
+    () =>
+      trainingDatasetsProjectId === activeProject?.id ? trainingDatasets : [],
+    [activeProject?.id, trainingDatasets, trainingDatasetsProjectId],
+  );
   const characterDatasets = useMemo(
     () => datasetsForProject.filter((dataset) => dataset.characterId === selectedCharacter?.id),
     [datasetsForProject, selectedCharacter?.id],
@@ -285,7 +289,7 @@ export function CharacterStudio() {
       selectedCharacter
         ? imageAssets.filter((asset) => assetMatchesCharacter(asset, selectedCharacter.id, selectedCharacter))
         : [],
-    [imageAssets, selectedCharacter?.id],
+    [imageAssets, selectedCharacter],
   );
   const characterImageAssetIds = useMemo(
     () => characterReferenceCandidates.map((asset) => asset.id),
@@ -408,7 +412,7 @@ export function CharacterStudio() {
       draft: serverDraft,
       loraEdits: serverLoraEdits,
     };
-  }, [selectedCharacter?.id, selectedCharacter?.updatedAt]);
+  }, [selectedCharacter, testLookId]);
 
   useEffect(() => {
     if (!macImageModels.some((item) => item.id === testModel)) {

--- a/apps/web/src/screens/EditorScreen.test.jsx
+++ b/apps/web/src/screens/EditorScreen.test.jsx
@@ -351,6 +351,25 @@ describe("EditorScreen keep-alive keydown gating (sc-13589)", () => {
     expect(setActiveTimeline.mock.calls[0][0].tracks[0].items).toHaveLength(0);
   });
 
+  it("undo restores the pre-commit timeline snapshot", () => {
+    const { setActiveTimeline } = renderEditor(true);
+    selectClipAndPressDelete();
+    act(() => {
+      window.dispatchEvent(
+        new window.KeyboardEvent("keydown", {
+          key: "z",
+          code: "KeyZ",
+          metaKey: true,
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(setActiveTimeline).toHaveBeenCalledTimes(2);
+    expect(setActiveTimeline.mock.calls[1][0].tracks[0].items).toHaveLength(1);
+    expect(setActiveTimeline.mock.calls[1][0].tracks[0].items[0].id).toBe("item_1");
+  });
+
   it("ignores Delete while the editor is HIDDEN under keep-alive", () => {
     const { setActiveTimeline } = renderEditor(false);
     selectClipAndPressDelete();

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -1151,6 +1151,7 @@ export function ImageEditor() {
   // handlers (a checkpoint captures the pre-operation stack; restore reuses the
   // live decoded images for unchanged layers and revokes the URLs it drops).
   const workingRef = useRef(null);
+  const mountedRef = useRef(false);
   // Live mirrors of the snapshot-relevant state so a synchronous checkpoint can
   // capture the pre-operation state without stale-closure surprises.
   const editsRef = useRef(edits);
@@ -1299,8 +1300,15 @@ export function ImageEditor() {
     return () => observer.disconnect();
   }, []);
 
-  // Revoke every live layer's object URL when the editor unmounts.
-  useEffect(() => () => revokeLayerUrls(workingRef.current?.layers), []);
+  // Revoke every live layer's object URL when the editor unmounts and mark
+  // in-flight terminal-result decodes as stale.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      revokeLayerUrls(workingRef.current?.layers);
+    };
+  }, []);
 
   const fitToView = useCallback(() => {
     if (!working || !stageSize.width || !stageSize.height) return;
@@ -2493,6 +2501,10 @@ export function ImageEditor() {
         if (!res.ok) throw new Error(`Failed to load result (${res.status})`);
         const blob = await res.blob();
         const prepared = await blobToEditorImage(blob);
+        if (!mountedRef.current) {
+          URL.revokeObjectURL(prepared.objectUrl);
+          return;
+        }
         checkpoint();
         // Active-layer op (same-size edit / detail) → write the result back into the
         // target layer, preserving the rest of the stack; document op (upscale /
@@ -2518,7 +2530,9 @@ export function ImageEditor() {
         if (edit) setEdits((prev) => [...prev, edit]);
         setDirty(true);
       } catch (err) {
-        setStatus({ loading: false, error: err.message || "The operation failed." });
+        if (mountedRef.current) {
+          setStatus({ loading: false, error: err.message || "The operation failed." });
+        }
       } finally {
         // Hand the purge to App (sc-8850): it owns the scratch registry, so it purges the
         // scratch + mask + result assets through the single survivor path. This also drops

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -169,6 +169,7 @@ import {
   macModelFeatureBlock,
 } from "../macGating.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
+import { probeImageDimensions } from "../imageDimensions.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 import {
   availableUpscaleEngines as upscaleEnginesForPlatform,
@@ -613,13 +614,13 @@ export function ImageStudio() {
     setMode(nextMode);
   }
 
-  function handleUpscaleEngineChange(nextEngine) {
+  const handleUpscaleEngineChange = useCallback((nextEngine) => {
     setUpscaleEngine(nextEngine);
     const factors = upscaleFactorsForEngine(nextEngine);
     if (!factors.includes(upscaleFactor)) {
       setUpscaleFactor(factors[0]);
     }
-  }
+  }, [upscaleFactor]);
 
   // Engines offered in the picker; AuraSR is dropped on every platform (sc-3668 / sc-5499).
   const availableUpscaleEngines = upscaleEnginesForPlatform(macCapabilities);
@@ -640,7 +641,7 @@ export function ImageStudio() {
     if (usePid && upscaleEnabled) {
       setUsePid(false);
     }
-  }, [usePid, upscaleEnabled]);
+  }, [usePid, upscaleEnabled, setUsePid]);
 
   useEffect(() => {
     if (mode === "edit_image" && selectedAssetEditableSourceId) {
@@ -677,7 +678,7 @@ export function ImageStudio() {
     if (launchRequest.mode === "edit_image" && selectedAssetEditableSourceId) {
       setSourceAssetId(selectedAssetEditableSourceId);
     }
-  }, [launchRequest?.id, selectedAsset?.id, selectedAssetEditableSourceId]);
+  }, [launchRequest, selectedAsset?.id, selectedAssetEditableSourceId]);
 
   // Mac UI gating (sc-3486): on a Mac in MLX-required mode, hide torch-only models from the
   // picker so the user can't select something that would only error. Inert elsewhere.
@@ -834,7 +835,7 @@ export function ImageStudio() {
   // size changes so the user always re-confirms against the current count.
   useEffect(() => {
     setBatchConfirmPending(false);
-  }, [batchTotal]);
+  }, [batchTotal, setBatchConfirmPending]);
   // Whether the model exposes its built-in prompt upsampler ("Enhance prompt" toggle) — FLUX.2-dev.
   const promptEnhance = Boolean(selectedModel?.ui?.promptEnhance);
   // Whether the model ships a packed default + a hosted full-precision bf16 build, exposing the
@@ -1031,6 +1032,8 @@ export function ImageStudio() {
     // Clear a stale overlay pick so an id trained for a different backbone can't leak into a submit
     // (sc-10165 B4); the picker re-fetches for the new backbone.
     setControlOverlayId(null);
+    // Model identity owns this reset; a catalog refresh must not erase in-progress tuning.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model]);
   // sc-12034: On a FRESH mount (no restored snapshot) whose model catalog arrives AFTER mount, the
   // reset effect above ran once with an empty `ui` (the catalog hadn't surfaced the model yet) and
@@ -1064,7 +1067,7 @@ export function ImageStudio() {
     setTrueCfgScale(typeof ui.variationStrength?.default === "number" ? ui.variationStrength.default : 4.0);
     setControlScale(typeof ui.controlScale?.default === "number" ? ui.controlScale.default : null);
     setTextStyleGain(typeof ui.textStyleGain?.default === "number" ? ui.textStyleGain.default : 1.0);
-  }, [model, imageModels]);
+  }, [model, imageModels, setControlScale]);
   // Approved reference images for the selected character (the IP-Adapter identity
   // source). Resolve the full asset from the catalog so thumbnails render even when
   // the character payload only carries assetIds.
@@ -1167,20 +1170,7 @@ export function ImageStudio() {
     if (!img2imgReferenceAssetId) return;
     const asset = editImageAssets.find((item) => item.id === img2imgReferenceAssetId);
     const src = asset && assetUrl(asset);
-    if (!src || typeof Image === "undefined") return;
-    let cancelled = false;
-    const probe = new Image();
-    probe.onload = () => {
-      if (!cancelled && probe.naturalWidth && probe.naturalHeight) {
-        onReferenceImageLoaded(probe.naturalWidth, probe.naturalHeight);
-      }
-    };
-    probe.src = src;
-    return () => {
-      cancelled = true;
-      probe.onload = null;
-      probe.src = "";
-    };
+    return probeImageDimensions(src, onReferenceImageLoaded);
   }, [img2imgReferenceAssetId, editImageAssets, onReferenceImageLoaded]);
   // Sampler / scheduler menus declared by the model, gated to the ACTIVE backend
   // (epic 7114 P5): `macGatingActive` is the worker `mlx_required` master switch, so
@@ -1459,7 +1449,7 @@ export function ImageStudio() {
       setModel(launchRequest.presetModel);
     }
     setSelectedPresetId(launchRequest.presetId);
-  }, [launchRequest?.id]);
+  }, [launchRequest, setSelectedPresetId]);
   // A general-preset launch (epic 11949): toggle it into the stack without touching the model
   // or mode. The chip is available in every studio, so a Video-bound user can re-add it there.
   useEffect(() => {
@@ -1576,6 +1566,9 @@ export function ImageStudio() {
     if (typeof upscale?.softness === "number") {
       setUpscaleSoftness(upscale.softness);
     }
+  // The launch id owns this one-shot hydration. Including the local values this
+  // effect sets would replay a launch while applying that launch.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [launchRequest?.id]);
   const [dropdownWidth, dropdownHeight] = resolution.split("x").map((value) => Number(value));
   // A non-empty Width/Height override wins for that axis; empty falls back to the Aspect

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -670,7 +670,13 @@ export function ModelManagerScreen() {
   // FLUX.2 [klein] has family "flux2-klein" yet accepts "flux2" LoRAs. The import
   // validator + generation-time matcher both key off loraCompatibility.families,
   // so the dropdown must too, or the user picks a family the backend rejects.
-  const families = Array.from(new Set(models.flatMap((model) => modelLoraFamilies(model)).filter(Boolean))).sort();
+  const families = useMemo(
+    () =>
+      Array.from(
+        new Set(models.flatMap((model) => modelLoraFamilies(model)).filter(Boolean)),
+      ).sort(),
+    [models],
+  );
   const familiesKey = families.join("|");
   const [familyFilter, setFamilyFilter] = useState("all");
   const [importingLora, setImportingLora] = useState(false);
@@ -800,11 +806,11 @@ export function ModelManagerScreen() {
     if (familyFilter !== "all" && !families.includes(familyFilter)) {
       setFamilyFilter("all");
     }
-  }, [familiesKey, familyFilter]);
+  }, [families, familiesKey, familyFilter]);
 
   useEffect(() => {
     setImportForm((current) => (current.family && !families.includes(current.family) ? { ...current, family: "" } : current));
-  }, [familiesKey]);
+  }, [families, familiesKey]);
 
   // The base model + low-noise slot only apply to wan-video imports; clear them
   // when the family changes away so a stale baseModel can't ride along.

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -394,6 +394,8 @@ export function PresetManagerScreen() {
       setSelectedPresetId("");
       setEditing(false);
     }
+    // Catalog refreshes replace preset objects; identity alone controls selection validity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [presets, selectedPreset?.id]);
 
   useEffect(() => {
@@ -404,7 +406,9 @@ export function PresetManagerScreen() {
     setForm(next);
     setBaseline(next);
     setMessage({ tone: "neutral", text: "" });
-  }, [selectedPreset?.id, editing]);
+    // Hydrate only on edit/preset identity changes; model/preset object refreshes must not erase edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editing, selectedPreset?.id]);
 
   // Model drives Workflow, not the other way round: when the chosen model can't serve the
   // current segment, fall back to the first one it does serve.
@@ -415,6 +419,8 @@ export function PresetManagerScreen() {
     if (!segmentAvailable(selectedModel, activeSegment) && segments.length) {
       setForm((current) => ({ ...current, segment: segments[0].key }));
     }
+    // Model identity and segment keys fully describe this correction without catalog object churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editing, selectedModel?.id, activeSegment.key, segments.length]);
 
   function updateField(field, value) {

--- a/apps/web/src/screens/PresetManagerScreen.test.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.test.jsx
@@ -537,5 +537,27 @@ describe("PresetManagerScreen", () => {
       expect(field(container, "Name").value).toBe("Edited Name");
       expect(pill()).toContain("Unsaved changes");
     });
+
+    it("preserves a dirty form when catalogs refresh with new object identities", async () => {
+      const context = await render();
+      await editCard("Cinematic Portrait");
+      await changeField(field(container, "Name"), "In-progress name");
+
+      await act(async () => {
+        root.render(
+          withAppContext(
+            {
+              ...context,
+              presets: context.presets.map((preset) => ({ ...preset })),
+              imageModels: context.imageModels.map((model) => ({ ...model })),
+            },
+            <PresetManagerScreen />,
+          ),
+        );
+      });
+
+      expect(field(container, "Name").value).toBe("In-progress name");
+      expect(pill()).toContain("Unsaved changes");
+    });
   });
 });

--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -186,6 +186,8 @@ function PersonTrackCorrections({ track, sourceClip, saveTrackCorrections }) {
       setDrafts(seeded);
       setFrameIndex((current) => (current < frames.length ? current : 0));
     }
+    // Stable track/correction identities avoid reseeding dirty drafts on catalog object refresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [track?.id, correctionsSignature, frames.length]);
 
   useEffect(() => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -342,8 +342,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const updateDataset = updateTrainingDataset;
   const batchRenameDataset = batchRenameTrainingDataset;
   const createCaptionJob = createTrainingDatasetCaptionJob;
-  const trainingPresets = trainingPresetsCatalog?.presets ?? [];
-  const trainingTargets = trainingTargetsCatalog?.targets ?? [];
+  const trainingPresets = useMemo(
+    () => trainingPresetsCatalog?.presets ?? [],
+    [trainingPresetsCatalog?.presets],
+  );
+  const trainingTargets = useMemo(
+    () => trainingTargetsCatalog?.targets ?? [],
+    [trainingTargetsCatalog?.targets],
+  );
   const [activeDataset, setActiveDataset] = useState(null);
   const [datasetError, setDatasetError] = useState("");
   const [datasetMessage, setDatasetMessage] = useState("");
@@ -353,6 +359,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [uploadedDatasetAssets, setUploadedDatasetAssets] = useState([]);
   const [savingDataset, setSavingDataset] = useState(false);
+  const openDatasetRef = useRef(null);
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
   // Dataset Doctor readiness report (sc-6534), fetched server-side over the saved
   // dataset. `null` until the first fetch resolves; the loading flag keeps badges in
@@ -744,8 +751,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
       return;
     }
     if (studioLaunch.datasetId !== selectedDatasetId) {
-      openDataset(studioLaunch.datasetId);
+      openDatasetRef.current?.(studioLaunch.datasetId);
     }
+    // A persistent launch is one-shot by launch id; selection changes must not reopen the old dataset.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasetLibraryMode, studioLaunch?.id]);
 
   useEffect(() => {
@@ -814,6 +823,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setConfigError("");
     setConfigTriggerFollowsCaptions(true);
     setConfigPromptsFollowTrigger(true);
+    // Dataset/target identities own hydration; background object refreshes must preserve edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeDataset?.id, selectedTarget?.id, trainingPresets]);
 
   useEffect(() => {
@@ -828,6 +839,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
       return { ...current, triggerWord: nextTriggerPhrase };
     });
     setConfigSnapshot(null);
+    // Target identity is sufficient; catalog object refreshes must not invalidate the draft.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [captionTriggerWords, configTriggerFollowsCaptions, selectedTarget?.id]);
 
   // Keep the sample-prompts draft in sync with the trigger phrase until the user
@@ -859,6 +872,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
       }
       return { ...current, requestedGpu: gpuOptions[0] ?? "" };
     });
+    // The stable key captures the complete option set without array-identity churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gpuOptionsKey]);
 
   // Live mirror of the unsaved-draft flag so imperative guards (the project-switch guard
@@ -931,6 +946,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setBusyDatasetId("");
     }
   }
+  openDatasetRef.current = openDataset;
 
   // Drops a member (or an unavailable/orphaned id) from the dataset selection.
   function removeUnavailableAsset(assetId) {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -532,6 +532,8 @@ export function VideoStudio() {
     if (selectedAsset.type === "video") {
       setSourceClipAssetId(selectedAsset.id);
     }
+    // Asset object refreshes must not replay a user-selection transition.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedAssetId, selectedAsset?.id, selectedAsset?.type]);
 
   useEffect(() => {
@@ -574,6 +576,8 @@ export function VideoStudio() {
     if (selectedAsset?.type === "image" || selectedAsset?.type === "frame") {
       setSourceAssetId(selectedAsset.id);
     }
+    // A persistent launch is applied once per launch/asset identity, not on catalog object refresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [launchRequest?.id, selectedAsset?.id, selectedAsset?.type]);
 
   // Restore-time validation of the persisted asset selections (sc-11964). The snapshot seeds
@@ -627,6 +631,8 @@ export function VideoStudio() {
       const options = selectedModel.limits?.fps ?? [24, 25, 30];
       return options.includes(Number(current)) ? current : selectedModel.defaults?.fps ?? options[0];
     });
+    // Reconcile defaults only when model identity changes, not on catalog object refresh.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedModel?.id]);
 
   // I2V: when the user picks a source image (or first/last frame) after mount,
@@ -649,6 +655,8 @@ export function VideoStudio() {
     if (!width || !height) return;
     const match = pickClosestResolution(width, height, selectedModel?.limits?.resolutions);
     if (match) setResolution(match);
+    // Source/model identities drive this probe; an unrelated asset catalog refresh does not.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [i2vSourceAssetId, mode, selectedModel?.id, assets]);
 
   // sc-12324: replay a recorded recipe — the viewer's "Use this recipe" on a video asset. Restores
@@ -1025,7 +1033,16 @@ export function VideoStudio() {
   const promptless = Boolean(selectedModel?.promptless);
   const [width, height] = resolution.split("x").map((value) => Number(value));
   const durationOptions = selectedModel?.limits?.durations ?? [4, 6, 8, 10];
-  const resolutionOptions = selectedModel?.limits?.resolutions ?? ["768x512", "640x640", "1280x720", "720x1280"];
+  const resolutionOptions = useMemo(
+    () =>
+      selectedModel?.limits?.resolutions ?? [
+        "768x512",
+        "640x640",
+        "1280x720",
+        "720x1280",
+      ],
+    [selectedModel?.limits?.resolutions],
+  );
 
   // Effective inputs once the general-preset stack folds in (epic 11949); drives the live
   // preview and (Phase 5) the client-authoritative submit.

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -533,9 +533,15 @@ export function CharacterGenerationPanel({
   // sc-2003: multi-backbone picker. `models` is the full list of capable backbones
   // (manifest order); `model` is the resolved default (kept for back-compat with the
   // pre-picker callers). The local state below tracks the user's pick.
-  const availableModels = Array.isArray(models) && models.length > 0
-    ? models
-    : (model ? [model] : []);
+  const availableModels = React.useMemo(
+    () =>
+      Array.isArray(models) && models.length > 0
+        ? models
+        : model
+          ? [model]
+          : [],
+    [model, models],
+  );
   const [selectedModelId, setSelectedModelId] = React.useState(
     model?.id ?? availableModels[0]?.id ?? "",
   );
@@ -579,7 +585,9 @@ export function CharacterGenerationPanel({
   React.useEffect(() => {
     setPrompt(mode.seedPrompt(selectedCharacter));
     setStatus("");
-  }, [characterId, selectedCharacter?.name, selectedCharacter?.description]);
+    // Only fields consumed by seedPrompt should reset a user's in-progress prompt.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [characterId, selectedCharacter?.name, selectedCharacter?.description, mode]);
   // Reset the picker selection when the available models change (e.g. a new
   // manifest load) so a stale id doesn't lock the panel.
   React.useEffect(() => {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -552,6 +552,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "revision": "bb2bc9893b3c49ae96c813350775f791a2e8bc80",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -569,6 +570,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "revision": "bb2bc9893b3c49ae96c813350775f791a2e8bc80",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 10998523666,
@@ -577,6 +579,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "revision": "bb2bc9893b3c49ae96c813350775f791a2e8bc80",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 20538406851,
@@ -704,6 +707,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-mlx",
+          "revision": "c74f74c2ad193294fc9ff3f8a5be71daa00d22ab",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -718,6 +722,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-mlx",
+          "revision": "c74f74c2ad193294fc9ff3f8a5be71daa00d22ab",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 10996438540,
@@ -726,6 +731,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-mlx",
+          "revision": "c74f74c2ad193294fc9ff3f8a5be71daa00d22ab",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 20538412852,
@@ -820,6 +826,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "revision": "bb2bc9893b3c49ae96c813350775f791a2e8bc80",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -831,6 +838,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "revision": "bb2bc9893b3c49ae96c813350775f791a2e8bc80",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 10998523666,
@@ -839,6 +847,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/z-image-turbo-mlx",
+          "revision": "bb2bc9893b3c49ae96c813350775f791a2e8bc80",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 20538406851,
@@ -901,6 +910,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-mlx",
+          "revision": "8080a4171f1c8b7fca6c30491eafbe6ffab754bf",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -910,6 +920,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-mlx",
+          "revision": "8080a4171f1c8b7fca6c30491eafbe6ffab754bf",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 38583632655,
@@ -918,6 +929,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-mlx",
+          "revision": "8080a4171f1c8b7fca6c30491eafbe6ffab754bf",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 57731960832,
@@ -937,6 +949,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-2512-fun-controlnet-union",
+          "revision": "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
           "coRequisite": true,
           "required": "soft",
           "files": ["q4/model.safetensors"],
@@ -946,6 +959,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-2512-fun-controlnet-union",
+          "revision": "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
           "coRequisite": true,
           "required": "soft",
           "files": ["q8/model.safetensors"],
@@ -955,6 +969,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-2512-fun-controlnet-union",
+          "revision": "a061fbc42a4744d6a7ec206370fbd3a37d4a7cca",
           "coRequisite": true,
           "required": "soft",
           "files": ["bf16/model.safetensors"],
@@ -1085,6 +1100,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "revision": "0dfbf3a018bcee42d77de14494c35f97a7531def",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -1094,6 +1110,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "revision": "0dfbf3a018bcee42d77de14494c35f97a7531def",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 38583632655,
@@ -1102,6 +1119,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "revision": "0dfbf3a018bcee42d77de14494c35f97a7531def",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 57731960832,
@@ -1223,6 +1241,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "revision": "0dfbf3a018bcee42d77de14494c35f97a7531def",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -1232,6 +1251,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "revision": "0dfbf3a018bcee42d77de14494c35f97a7531def",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 38583632655,
@@ -1240,6 +1260,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/qwen-image-edit-2511-mlx",
+          "revision": "0dfbf3a018bcee42d77de14494c35f97a7531def",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 57731960832,
@@ -1388,6 +1409,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-mlx",
+          "revision": "4e1349c1962950eee328c69537904631ebc64283",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -1398,6 +1420,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-mlx",
+          "revision": "4e1349c1962950eee328c69537904631ebc64283",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos", "windows", "linux"],
@@ -1407,6 +1430,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-mlx",
+          "revision": "4e1349c1962950eee328c69537904631ebc64283",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos", "windows", "linux"],
@@ -1427,6 +1451,7 @@
           // tracks independently of the MLX inference tiers (sc-8508).
           "provider": "huggingface",
           "repo": "SceneWorks/Lens",
+          "revision": "5c5521d4417a3cae55816929ece69319d1e7712a",
           "variant": "training",
           "files": [],
           "platforms": ["macos", "windows", "linux"],
@@ -1515,6 +1540,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-turbo-mlx",
+          "revision": "d3f485c320039595cff16d4f686a5f9378714f25",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -1532,6 +1558,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-turbo-mlx",
+          "revision": "d3f485c320039595cff16d4f686a5f9378714f25",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos", "windows", "linux"],
@@ -1541,6 +1568,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/lens-turbo-mlx",
+          "revision": "d3f485c320039595cff16d4f686a5f9378714f25",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos", "windows", "linux"],
@@ -1643,6 +1671,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-mlx",
+          "revision": "b6206ea2e888198418b92f3bed31f5506c6183f9",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -1652,6 +1681,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-mlx",
+          "revision": "b6206ea2e888198418b92f3bed31f5506c6183f9",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19927870461,
@@ -1660,6 +1690,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-mlx",
+          "revision": "b6206ea2e888198418b92f3bed31f5506c6183f9",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 35121691427,
@@ -1796,6 +1827,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-mlx",
+          "revision": "9c2f476b136ff146691fc7c792e46c8a8df6a10b",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -1805,6 +1837,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-mlx",
+          "revision": "9c2f476b136ff146691fc7c792e46c8a8df6a10b",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19927923905,
@@ -1813,6 +1846,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-mlx",
+          "revision": "9c2f476b136ff146691fc7c792e46c8a8df6a10b",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 35121744859,
@@ -1916,6 +1950,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-mlx",
+          "revision": "34f24bc8195f601cb90cb207acd4233eb7d0e2d3",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -1925,6 +1960,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-mlx",
+          "revision": "34f24bc8195f601cb90cb207acd4233eb7d0e2d3",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19927776248,
@@ -1933,6 +1969,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-mlx",
+          "revision": "34f24bc8195f601cb90cb207acd4233eb7d0e2d3",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 35121597119,
@@ -2037,6 +2074,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-fast-mlx",
+          "revision": "d432225e00e5b6f59a86602e237876c9298b3a77",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -2046,6 +2084,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-fast-mlx",
+          "revision": "d432225e00e5b6f59a86602e237876c9298b3a77",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19927870497,
@@ -2054,6 +2093,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-fast-mlx",
+          "revision": "d432225e00e5b6f59a86602e237876c9298b3a77",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 35121579949,
@@ -2181,6 +2221,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx",
+          "revision": "33d42d2e3b2c3dce102f8982d173c98ef361d098",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -2190,6 +2231,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx",
+          "revision": "33d42d2e3b2c3dce102f8982d173c98ef361d098",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19927924235,
@@ -2198,6 +2240,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v2-fast-mlx",
+          "revision": "33d42d2e3b2c3dce102f8982d173c98ef361d098",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 35121633249,
@@ -2310,6 +2353,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx",
+          "revision": "660506e94bf0b0898476949f9e661dc58611d70f",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -2319,6 +2363,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx",
+          "revision": "660506e94bf0b0898476949f9e661dc58611d70f",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19927776291,
@@ -2327,6 +2372,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sensenova-u1-8b-infographic-v3-fast-mlx",
+          "revision": "660506e94bf0b0898476949f9e661dc58611d70f",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 35121485601,
@@ -2435,6 +2481,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-schnell-mlx",
+          "revision": "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -2444,6 +2491,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-schnell-mlx",
+          "revision": "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 17999175703,
@@ -2452,6 +2500,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-schnell-mlx",
+          "revision": "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 33725923002,
@@ -2540,6 +2589,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "revision": "323fd12d79f78ad444e882e8d8e871914584f2b9",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -2549,6 +2599,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "revision": "323fd12d79f78ad444e882e8d8e871914584f2b9",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 18010071290,
@@ -2557,6 +2608,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "revision": "323fd12d79f78ad444e882e8d8e871914584f2b9",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 33746402173,
@@ -2705,6 +2757,7 @@
           // (previously off-Mac gracefully fell back to q4).
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
+          "revision": "a3095855b8819dc0d6b067cb1354aaa7da189ff8",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -2722,6 +2775,7 @@
           // generation-time on-demand fetch — never a Models-page-installable variant.)
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
+          "revision": "a3095855b8819dc0d6b067cb1354aaa7da189ff8",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos", "windows", "linux"],
@@ -2745,6 +2799,7 @@
           // turnkey; `candle_ideogram_repo` stays retired.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
+          "revision": "2e8fb610109bf0db195344cc424df98b301d3cad",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos", "windows", "linux"],
@@ -2876,6 +2931,7 @@
           // entry (the retired `candle_ideogram_repo` target) is removed.
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
+          "revision": "a3095855b8819dc0d6b067cb1354aaa7da189ff8",
           "variant": "q4",
           "default": true,
           "files": ["q4/*", "q4/turbo_lora.safetensors"],
@@ -2890,6 +2946,7 @@
           // so off-Mac gets the real q4/q8 A-B picker. Size includes the ~0.85 GB LoRA (turbo uses it).
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4-mlx",
+          "revision": "a3095855b8819dc0d6b067cb1354aaa7da189ff8",
           "variant": "q8",
           "files": ["q8/*", "q8/turbo_lora.safetensors"],
           "platforms": ["macos", "windows", "linux"],
@@ -2911,6 +2968,7 @@
           // a large-card tier (see the candle VRAM block). (Base q4/q8 come from the `-mlx` turnkey.)
           "provider": "huggingface",
           "repo": "SceneWorks/ideogram-4",
+          "revision": "2e8fb610109bf0db195344cc424df98b301d3cad",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos", "windows", "linux"],
@@ -3021,6 +3079,7 @@
           // multi-tier picker as macOS (previously off-Mac resolved only the shipped Q8 default).
           "provider": "huggingface",
           "repo": "SceneWorks/boogu-image-mlx",
+          "revision": "a459e614d408bfdf57089c32cc3da706f5a017de",
           "files": ["base/transformer/*", "base/mllm/*", "base/vae/*"],
           "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 23380234752
@@ -3134,6 +3193,7 @@
           // `candle_boogu_repo` target) is removed.
           "provider": "huggingface",
           "repo": "SceneWorks/boogu-image-mlx",
+          "revision": "a459e614d408bfdf57089c32cc3da706f5a017de",
           "files": ["turbo/transformer/*", "turbo/mllm/*", "turbo/vae/*"],
           "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 23380234586
@@ -3247,6 +3307,7 @@
           // target) is removed.
           "provider": "huggingface",
           "repo": "SceneWorks/boogu-image-mlx",
+          "revision": "a459e614d408bfdf57089c32cc3da706f5a017de",
           "files": ["edit/transformer/*", "edit/mllm/*", "edit/vae/*"],
           "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 23380234314
@@ -3343,6 +3404,7 @@
           // 20,554,619,613 B = transformer 14.57 + text_encoder 5.47 + vae 0.48 GB; rounded up).
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-mlx",
+          "revision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
           // sc-9300: the per-tier `variant` keys make Krea 2 a proper variant matrix (like the
           // standard-tier models) so `/models` emits a `variants[]` entry per tier and the studio tier
           // picker (`quantTier.js`) can toggle installed tiers. q8 is the shipped default.
@@ -3364,6 +3426,7 @@
           // selectable via advanced mlxQuantize<=4 (sc-8508/8509). Same complete-root shape as q8.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-mlx",
+          "revision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
           "variant": "q4",
           "files": [
             "q4/transformer/*",
@@ -3382,6 +3445,7 @@
           // via advanced mlxQuantize<=0 (sc-8508/8509). Mirror of the dense `krea/Krea-2-Turbo` tree.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-mlx",
+          "revision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
           "variant": "bf16",
           "files": [
             "bf16/transformer/*",
@@ -3414,6 +3478,7 @@
           // global co-requisite. `platforms` OMITS macos so the Mac picker never lists this tier.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-turbo-int8-convrot",
+          "revision": "b25730586dceb84efdc8286df586ba47103dba3f",
           "variant": "int8-convrot",
           "files": ["krea2_turbo_int8_convrot.safetensors"],
           "platforms": ["windows", "linux"],
@@ -3663,6 +3728,7 @@
           // model_index.json). MEASURED q8 download 20,554,619,432 B. q8 is the shipped default.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-raw-mlx",
+          "revision": "b88090c79762ba34b1de23a892da239eb76962e4",
           "variant": "q8",
           "default": true,
           "files": [
@@ -3681,6 +3747,7 @@
           // complete-root shape as q8. MEASURED 12,488,709,625 B.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-raw-mlx",
+          "revision": "b88090c79762ba34b1de23a892da239eb76962e4",
           "variant": "q4",
           "files": [
             "q4/transformer/*",
@@ -3699,6 +3766,7 @@
           // tier is ALSO the Krea 2 LoRA training base (the trainer reads `bf16/`). MEASURED 35,678,121,657 B.
           "provider": "huggingface",
           "repo": "SceneWorks/krea-2-raw-mlx",
+          "revision": "b88090c79762ba34b1de23a892da239eb76962e4",
           "variant": "bf16",
           "files": [
             "bf16/transformer/*",
@@ -3865,6 +3933,7 @@
           // (`DENSE_TE_TIER_MODELS`). Replaces the old gated 49 GiB whole-repo + load-time quantize.
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "revision": "1d36c68041725a14c76566cdf6cea4270b264b03",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -3874,6 +3943,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "revision": "1d36c68041725a14c76566cdf6cea4270b264b03",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 26100000000,
@@ -3884,6 +3954,7 @@
           // per-variant tracking (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-mlx",
+          "revision": "1d36c68041725a14c76566cdf6cea4270b264b03",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 34600000000,
@@ -4024,6 +4095,7 @@
           // load via `DENSE_TE_TIER_MODELS`). Replaces the old gated whole-repo + load-time quantize.
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "revision": "fc6579b25dcb7e1bce85dd27cb9b901312110bab",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4033,6 +4105,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "revision": "fc6579b25dcb7e1bce85dd27cb9b901312110bab",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 26100000000,
@@ -4041,6 +4114,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-klein-9b-kv-mlx",
+          "revision": "fc6579b25dcb7e1bce85dd27cb9b901312110bab",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 34600000000,
@@ -4250,6 +4324,7 @@
           // bf16 tier added separately. q8/ is a second entry (tier selection: epic 8506 sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-dev-mlx",
+          "revision": "0c9b86f4d91eeaec3db11bcc9cc0e4c006faed74",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4259,6 +4334,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-dev-mlx",
+          "revision": "0c9b86f4d91eeaec3db11bcc9cc0e4c006faed74",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 55000000000,
@@ -4271,6 +4347,7 @@
           // generates; 256² fits a 128 GB box, production 1024² wants >128 GB).
           "provider": "huggingface",
           "repo": "SceneWorks/flux2-dev-mlx",
+          "revision": "0c9b86f4d91eeaec3db11bcc9cc0e4c006faed74",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 113000000000,
@@ -4435,6 +4512,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-hd-mlx",
+          "revision": "9d99afe1ebca67032476756bc70d4a7152bc1bd5",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4444,6 +4522,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-hd-mlx",
+          "revision": "9d99afe1ebca67032476756bc70d4a7152bc1bd5",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19424564251,
@@ -4452,6 +4531,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-hd-mlx",
+          "revision": "9d99afe1ebca67032476756bc70d4a7152bc1bd5",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 27493363692,
@@ -4522,6 +4602,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-base-mlx",
+          "revision": "e7330dda29d00ffdeeb719b28e92ee74cff0884c",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4531,6 +4612,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-base-mlx",
+          "revision": "e7330dda29d00ffdeeb719b28e92ee74cff0884c",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19424563899,
@@ -4539,6 +4621,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-base-mlx",
+          "revision": "e7330dda29d00ffdeeb719b28e92ee74cff0884c",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 27493363362,
@@ -4609,6 +4692,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-flash-mlx",
+          "revision": "6a9cb6178709559461506bf247f708d0d1008d00",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4618,6 +4702,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-flash-mlx",
+          "revision": "6a9cb6178709559461506bf247f708d0d1008d00",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 19424564095,
@@ -4626,6 +4711,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/chroma1-flash-mlx",
+          "revision": "6a9cb6178709559461506bf247f708d0d1008d00",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 27493363732,
@@ -4699,6 +4785,7 @@
           // bf16-only cross-cutting caveat is tracked separately across Group-B.
           "provider": "huggingface",
           "repo": "SceneWorks/kolors-mlx",
+          "revision": "aadbd49f53b66a33ef1be09384eac409cbc44061",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4708,6 +4795,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/kolors-mlx",
+          "revision": "aadbd49f53b66a33ef1be09384eac409cbc44061",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 10363817984,
@@ -4716,6 +4804,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/kolors-mlx",
+          "revision": "aadbd49f53b66a33ef1be09384eac409cbc44061",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 17821597696,
@@ -4808,6 +4897,7 @@
           // separate entries (tier selection: sc-8508/8509). Sizes are the measured on-disk totals.
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-mlx",
+          "revision": "0cf819d00d30d296cee58e02c59b0daa5b8ede89",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4817,6 +4907,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-mlx",
+          "revision": "0cf819d00d30d296cee58e02c59b0daa5b8ede89",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 31248461824,
@@ -4827,6 +4918,7 @@
           // Selectable via per-variant tracking (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-mlx",
+          "revision": "0cf819d00d30d296cee58e02c59b0daa5b8ede89",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 38789746688,
@@ -4936,6 +5028,7 @@
           // quantized). Replaces the gated download + install-time convert. Sizes = measured on-disk.
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "revision": "e9166f4632ec64f74d560be3ac778d346f89a364",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -4945,6 +5038,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "revision": "e9166f4632ec64f74d560be3ac778d346f89a364",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 31239405568,
@@ -4954,6 +5048,7 @@
           // bf16/ — the dense diffusers tree (sharded transformer), max-fidelity tier (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-large-turbo-mlx",
+          "revision": "e9166f4632ec64f74d560be3ac778d346f89a364",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 38789746688,
@@ -5049,6 +5144,7 @@
           // (the dense T5-XXL TE dominates even the small backbone, so the tiers are close in size).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-medium-mlx",
+          "revision": "5413e962bb326db248be2026a93b147c323392b6",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -5058,6 +5154,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-medium-mlx",
+          "revision": "5413e962bb326db248be2026a93b147c323392b6",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 25334730752,
@@ -5067,6 +5164,7 @@
           // bf16/ — the dense diffusers tree, max-fidelity tier (sc-8508/8509).
           "provider": "huggingface",
           "repo": "SceneWorks/sd3.5-medium-mlx",
+          "revision": "5413e962bb326db248be2026a93b147c323392b6",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 27436347392,
@@ -5185,6 +5283,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_1600M_1024px_mlx",
+          "revision": "ac421696dd6eb0b41f446f4c45a53ccc057d82a1",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -5195,6 +5294,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_1600M_1024px_mlx",
+          "revision": "ac421696dd6eb0b41f446f4c45a53ccc057d82a1",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -5204,6 +5304,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_1600M_1024px_mlx",
+          "revision": "ac421696dd6eb0b41f446f4c45a53ccc057d82a1",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -5347,6 +5448,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+          "revision": "0b0d18484cac2fb515e76d25a09a5911ae4ab58e",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -5357,6 +5459,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+          "revision": "0b0d18484cac2fb515e76d25a09a5911ae4ab58e",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -5366,6 +5469,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Sana_Sprint_1.6B_1024px_mlx",
+          "revision": "0b0d18484cac2fb515e76d25a09a5911ae4ab58e",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -5803,6 +5907,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sdxl-base-mlx",
+          "revision": "36699bb8a6353e61c920e3bf19f0e6f8e4151c55",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -5812,6 +5917,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sdxl-base-mlx",
+          "revision": "36699bb8a6353e61c920e3bf19f0e6f8e4151c55",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 4177386896,
@@ -5826,6 +5932,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/sdxl-base-mlx",
+          "revision": "36699bb8a6353e61c920e3bf19f0e6f8e4151c55",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 6941187536,
@@ -5982,6 +6089,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-mlx",
+          "revision": "e40202d63baef826c7df95a639a811698c1178d2",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -5991,6 +6099,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-mlx",
+          "revision": "e40202d63baef826c7df95a639a811698c1178d2",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 5385840183,
@@ -5999,6 +6108,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-mlx",
+          "revision": "e40202d63baef826c7df95a639a811698c1178d2",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108692804,
@@ -6130,6 +6240,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-lightning-mlx",
+          "revision": "c09fd586989bdc3c658d4acd03e8ae81677ade8e",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -6139,6 +6250,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-lightning-mlx",
+          "revision": "c09fd586989bdc3c658d4acd03e8ae81677ade8e",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 5385843729,
@@ -6147,6 +6259,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-lightning-mlx",
+          "revision": "c09fd586989bdc3c658d4acd03e8ae81677ade8e",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108692804,
@@ -6256,6 +6369,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/illustrious-xl-v1-mlx",
+          "revision": "c5a92a902dd4e6ee99c2a57981ecf66209905dd1",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -6265,6 +6379,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/illustrious-xl-v1-mlx",
+          "revision": "c5a92a902dd4e6ee99c2a57981ecf66209905dd1",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 5385646417,
@@ -6273,6 +6388,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/illustrious-xl-v1-mlx",
+          "revision": "c5a92a902dd4e6ee99c2a57981ecf66209905dd1",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108498305,
@@ -6384,6 +6500,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/illustrious-xl-v2-mlx",
+          "revision": "7c5c8b2bb75a8f38a7365e70bdf84d38d6204473",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -6393,6 +6510,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/illustrious-xl-v2-mlx",
+          "revision": "7c5c8b2bb75a8f38a7365e70bdf84d38d6204473",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 5385646137,
@@ -6401,6 +6519,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/illustrious-xl-v2-mlx",
+          "revision": "7c5c8b2bb75a8f38a7365e70bdf84d38d6204473",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 7108498177,
@@ -6522,6 +6641,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-mlx",
+          "revision": "e40202d63baef826c7df95a639a811698c1178d2",
           "variant": "bf16",
           "default": true,
           "files": ["bf16/*"],
@@ -6531,6 +6651,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-mlx",
+          "revision": "e40202d63baef826c7df95a639a811698c1178d2",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 5385840183,
@@ -6539,6 +6660,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/realvisxl-mlx",
+          "revision": "e40202d63baef826c7df95a639a811698c1178d2",
           "variant": "q4",
           "files": ["q4/*"],
           "estimatedSizeBytes": 3911656467,
@@ -6712,6 +6834,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "revision": "323fd12d79f78ad444e882e8d8e871914584f2b9",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -6721,6 +6844,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "revision": "323fd12d79f78ad444e882e8d8e871914584f2b9",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 18010071290,
@@ -6729,6 +6853,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/flux1-dev-mlx",
+          "revision": "323fd12d79f78ad444e882e8d8e871914584f2b9",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 33746402173,
@@ -6861,6 +6986,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -6871,6 +6997,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -6880,6 +7007,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -7210,6 +7338,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
+          "revision": "bb1b055249614cf9d7cf4373fbdbc184b77dee88",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -7222,6 +7351,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
+          "revision": "bb1b055249614cf9d7cf4373fbdbc184b77dee88",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -7231,6 +7361,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-ti2v-5b-mlx",
+          "revision": "bb1b055249614cf9d7cf4373fbdbc184b77dee88",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -7248,6 +7379,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-ti2v-5b-candle",
+          "revision": "9b173dc8660334a87a11e67de58939afe68f8cb2",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -7258,6 +7390,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-ti2v-5b-candle",
+          "revision": "9b173dc8660334a87a11e67de58939afe68f8cb2",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["windows", "linux"],
@@ -7481,6 +7614,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
+          "revision": "991eb255c544bbb2e1f1e07da4355c2f0a5337b7",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -7496,6 +7630,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
+          "revision": "991eb255c544bbb2e1f1e07da4355c2f0a5337b7",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -7505,6 +7640,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-t2v-a14b-mlx",
+          "revision": "991eb255c544bbb2e1f1e07da4355c2f0a5337b7",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -7519,6 +7655,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-t2v-a14b-candle",
+          "revision": "da1909b66b360e1ea8cdeb3e39e40dca172cfa32",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -7529,6 +7666,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-t2v-a14b-candle",
+          "revision": "da1909b66b360e1ea8cdeb3e39e40dca172cfa32",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["windows", "linux"],
@@ -7746,6 +7884,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-i2v-a14b-mlx",
+          "revision": "c6c786170031eccc3a1fac0f98f1ad4ff988271e",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -7760,6 +7899,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-i2v-a14b-mlx",
+          "revision": "c6c786170031eccc3a1fac0f98f1ad4ff988271e",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -7769,6 +7909,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-i2v-a14b-mlx",
+          "revision": "c6c786170031eccc3a1fac0f98f1ad4ff988271e",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -7783,6 +7924,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-i2v-a14b-candle",
+          "revision": "d01bf1ea995c01a5bc545cefb977a320c9cb9fd0",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -7793,6 +7935,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/wan2.2-i2v-a14b-candle",
+          "revision": "d01bf1ea995c01a5bc545cefb977a320c9cb9fd0",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["windows", "linux"],
@@ -8094,6 +8237,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
+          "revision": "533d688f16c8f33dc832890c1e16c11921a2019a",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -8105,6 +8249,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
+          "revision": "533d688f16c8f33dc832890c1e16c11921a2019a",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -8115,6 +8260,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
+          "revision": "533d688f16c8f33dc832890c1e16c11921a2019a",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -8138,6 +8284,7 @@
           // is a follow-up). Size is the bf16 tier estimate (candle loads the converted tree dense).
           "provider": "huggingface",
           "repo": "SceneWorks/bernini",
+          "revision": "f9f95e0ff3d7940664ab8163ebf71bf0c8018b27",
           "files": [],
           "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 87591990679
@@ -8255,6 +8402,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
+          "revision": "533d688f16c8f33dc832890c1e16c11921a2019a",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -8265,6 +8413,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
+          "revision": "533d688f16c8f33dc832890c1e16c11921a2019a",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -8274,6 +8423,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/bernini-mlx",
+          "revision": "533d688f16c8f33dc832890c1e16c11921a2019a",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -8290,6 +8440,7 @@
           // (HF cache dedupes). Loads dense today (off-Mac packed-tier select is a follow-up).
           "provider": "huggingface",
           "repo": "SceneWorks/bernini",
+          "revision": "f9f95e0ff3d7940664ab8163ebf71bf0c8018b27",
           "files": [],
           "platforms": ["windows", "linux"],
           "estimatedSizeBytes": 87591990679
@@ -8388,6 +8539,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/scail2-mlx",
+          "revision": "ce88cfdb1008f395e9c820e525e6db7b6695f7b3",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -8400,6 +8552,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/scail2-mlx",
+          "revision": "ce88cfdb1008f395e9c820e525e6db7b6695f7b3",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -8409,6 +8562,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/scail2-mlx",
+          "revision": "ce88cfdb1008f395e9c820e525e6db7b6695f7b3",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],
@@ -8888,6 +9042,7 @@
           // the weights. Converted losslessly from nvidia/PiD's model_ema_bf16.pth (sc-7843 converter).
           "provider": "huggingface",
           "repo": "SceneWorks/pid-qwenimage",
+          "revision": "4aeb783a9d3037b75275c42d35d84210c89cb044",
           "files": [],
           "estimatedSizeBytes": 5525193754
         },
@@ -8898,6 +9053,7 @@
           // mirror's LICENSE (Gemma Terms) + Prohibited Use Policy + NOTICE alongside the weights.
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          "revision": "684c553b5b41a1c835989d89f62f585e6269a7de",
           // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
           // Model Manager downloads both, and the entry only reports installed once both are cached
           // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD
@@ -8967,6 +9123,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/pid-flux",
+          "revision": "6d5c1f1049e863f1757f68fd81c6bc850a95609d",
           // Whole-repo download (empty `files`): fetches BOTH the 4K-tuned `2kto4k` student AND the
           // 2K-tuned `res2k` student (`pid_flux_2k.safetensors`, sc-10056) the 2K output tier prefers.
           // Size ≈ 2× the single 2.72 GB student.
@@ -8976,6 +9133,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          "revision": "684c553b5b41a1c835989d89f62f585e6269a7de",
           // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
           // Model Manager downloads both, and the entry only reports installed once both are cached
           // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD
@@ -9044,6 +9202,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/pid-flux2",
+          "revision": "900de3a7114cbdd8551274ba7773014d934ceca8",
           // Whole-repo download (empty `files`): fetches BOTH the 4K-tuned `2kto4k` student AND the
           // 2K-tuned `res2k` student (`pid_flux2_2k.safetensors`, sc-10056) the 2K output tier prefers.
           // Size ≈ 2× the single 2.73 GB student.
@@ -9053,6 +9212,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          "revision": "684c553b5b41a1c835989d89f62f585e6269a7de",
           // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
           // Model Manager downloads both, and the entry only reports installed once both are cached
           // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD
@@ -9121,12 +9281,14 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/pid-sdxl",
+          "revision": "70b494831561dc2c181f04a7f057260b8785419a",
           "files": [],
           "estimatedSizeBytes": 2724634940
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/gemma-2-2b-it",
+          "revision": "684c553b5b41a1c835989d89f62f585e6269a7de",
           // Co-requisite (sc-9696): fetched ALONGSIDE the PiD checkpoint, not an alternate to it.
           // Model Manager downloads both, and the entry only reports installed once both are cached
           // (else `resolve_pid_weights` silently no-ops to the native VAE). Shared across all four PiD

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -687,10 +687,6 @@ mod tests {
     /// pin its `revision` instead. Kept in lockstep with the identical Python audit
     /// allowlist in tests/test_builtin_manifest_audit.py.
     const COREQUISITE_REVISION_MIGRATION_PENDING: &[(&str, &str)] = &[
-        (
-            "qwen_image",
-            "SceneWorks/qwen-image-2512-fun-controlnet-union",
-        ),
         // ("ltx_2_3", "SceneWorks/ltx-2.3-mlx") pinned in sc-13683 (the gemma coRequisite now carries the
         // full 40-hex LTX_BUNDLE_REVISION), so its migration row was removed here + in the Python twin.
         (
@@ -699,10 +695,6 @@ mod tests {
         ),
         ("wan_2_2_t2v_14b", "lightx2v/Wan2.2-Lightning"),
         ("wan_2_2_i2v_14b", "lightx2v/Wan2.2-Lightning"),
-        ("pid_qwenimage", "SceneWorks/gemma-2-2b-it"),
-        ("pid_flux", "SceneWorks/gemma-2-2b-it"),
-        ("pid_flux2", "SceneWorks/gemma-2-2b-it"),
-        ("pid_sdxl", "SceneWorks/gemma-2-2b-it"),
     ];
 
     /// Every `(model_id, repo)` co-requisite pair in the live manifest that is NOT

--- a/crates/sceneworks-core/src/lora_url.rs
+++ b/crates/sceneworks-core/src/lora_url.rs
@@ -121,13 +121,21 @@ pub fn validate_public_ip(address: IpAddr) -> Result<(), LoraUrlError> {
 }
 
 fn blocked_ipv4(address: Ipv4Addr) -> bool {
+    let [a, b, c, _] = address.octets();
     address.is_private()
         || address.is_loopback()
         || address.is_link_local()
         || address.is_broadcast()
         || address.is_documentation()
-        || address.octets()[0] == 0
-        || address.octets()[0] >= 224
+        || a == 0
+        || a >= 224
+        // RFC 6598 shared address space.
+        || (a == 100 && (64..=127).contains(&b))
+        // IETF protocol assignments and the deprecated 6to4 relay anycast.
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 192 && b == 88 && c == 99)
+        // RFC 2544 benchmark networks.
+        || (a == 198 && (18..=19).contains(&b))
 }
 
 fn blocked_ipv6(address: Ipv6Addr) -> bool {
@@ -209,5 +217,29 @@ mod tests {
             parse_lora_source_url("https://example.com/style.safetensors%00.txt").unwrap_err(),
             LoraUrlError::UnsafeFilename
         );
+    }
+
+    #[test]
+    fn validate_public_ip_blocks_reserved_ipv4_ranges() {
+        for blocked in [
+            "100.64.0.1",
+            "100.127.255.254",
+            "192.0.0.1",
+            "192.88.99.1",
+            "198.18.0.1",
+            "198.19.255.254",
+        ] {
+            assert_eq!(
+                validate_public_ip(blocked.parse().expect("valid IP")),
+                Err(LoraUrlError::BlockedHost),
+                "{blocked} must be blocked"
+            );
+        }
+        for public in ["100.63.255.254", "100.128.0.1", "192.0.1.1", "198.20.0.1"] {
+            assert!(
+                validate_public_ip(public.parse().expect("valid IP")).is_ok(),
+                "{public} must remain allowed"
+            );
+        }
     }
 }

--- a/crates/sceneworks-core/src/session_log.rs
+++ b/crates/sceneworks-core/src/session_log.rs
@@ -165,31 +165,84 @@ impl SessionLog {
 const VALUE_TERMINATORS: &[char] = &['&', '"', '\'', ' ', '\t', '<', '>', ',', '}'];
 
 fn redact_secrets(line: &str) -> String {
-    // Query / flag shapes: `token=…`, `access_token=…`, `api_key=…`.
-    let line = redact_marker_value(line.to_owned(), "token=", VALUE_TERMINATORS);
-    let line = redact_marker_value(line, "access_token=", VALUE_TERMINATORS);
-    let line = redact_marker_value(line, "api_key=", VALUE_TERMINATORS);
-    // JSON object shapes: `"token":"…"`, `"access_token":"…"`, `"api_key":"…"`.
-    // The marker consumes through the value-opening quote so the redaction span
-    // starts at the secret and stops at the closing quote (a terminator). This
-    // catches secrets a `key=value` marker never would (F-072).
-    let line = redact_json_marker_value(line, "token");
-    let line = redact_json_marker_value(line, "access_token");
-    let line = redact_json_marker_value(line, "api_key");
+    // Cover query, CLI, JSON and YAML-style key/value shapes, including whitespace
+    // around the delimiter. Secret-bearing callers are inconsistent about whether
+    // they spell API key with an underscore, so both common forms are included.
+    let mut line = line.to_owned();
+    for key in [
+        "token",
+        "access_token",
+        "api_key",
+        "apikey",
+        "secret",
+        "password",
+    ] {
+        line = redact_key_value(line, key);
+    }
     // Bearer credential, in both `Bearer abc` and `"Bearer abc"` forms.
     let line = redact_marker_value(line, "bearer ", VALUE_TERMINATORS);
     redact_authorization_header(line)
 }
 
-/// Redact the value of a `"<key>":"` JSON pair. The marker matches through the
-/// opening quote of the value so `redact_marker_value` starts replacing at the
-/// secret itself and stops at the closing quote (in `VALUE_TERMINATORS`).
-fn redact_json_marker_value(output: String, key: &str) -> String {
-    // Tolerate the whitespace serializers put around the colon: `"key": "val"`.
-    let marker_no_space = format!("\"{key}\":\"");
-    let marker_space = format!("\"{key}\": \"");
-    let output = redact_marker_value(output, &marker_no_space, VALUE_TERMINATORS);
-    redact_marker_value(output, &marker_space, VALUE_TERMINATORS)
+fn redact_key_value(mut output: String, key: &str) -> String {
+    let mut lowered = output.to_ascii_lowercase();
+    let mut search_from = 0;
+    while let Some(relative_start) = lowered[search_from..].find(key) {
+        let start = search_from + relative_start;
+        let end = start + key.len();
+        let boundary_before = start == 0
+            || !lowered.as_bytes()[start - 1].is_ascii_alphanumeric()
+                && lowered.as_bytes()[start - 1] != b'_';
+        let mut cursor = end;
+        if cursor < output.len() && output.as_bytes()[cursor] == b'"' {
+            cursor += 1;
+        }
+        while cursor < output.len() && matches!(output.as_bytes()[cursor], b' ' | b'\t') {
+            cursor += 1;
+        }
+        let delimiter = output.as_bytes().get(cursor).copied();
+        if !boundary_before || !matches!(delimiter, Some(b'=') | Some(b':')) {
+            search_from = end;
+            continue;
+        }
+        cursor += 1;
+        while cursor < output.len() && matches!(output.as_bytes()[cursor], b' ' | b'\t') {
+            cursor += 1;
+        }
+        let quote = output
+            .as_bytes()
+            .get(cursor)
+            .copied()
+            .filter(|value| matches!(value, b'"' | b'\''));
+        if quote.is_some() {
+            cursor += 1;
+        }
+        let value_start = cursor;
+        let value_end = if let Some(quote) = quote {
+            output[value_start..]
+                .bytes()
+                .position(|value| value == quote)
+                .map(|offset| value_start + offset)
+                .unwrap_or(output.len())
+        } else {
+            output[value_start..]
+                .char_indices()
+                .find_map(|(index, character)| {
+                    VALUE_TERMINATORS
+                        .contains(&character)
+                        .then_some(value_start + index)
+                })
+                .unwrap_or(output.len())
+        };
+        if value_end == value_start {
+            search_from = value_start;
+            continue;
+        }
+        output.replace_range(value_start..value_end, "[REDACTED]");
+        lowered.replace_range(value_start..value_end, "[redacted]");
+        search_from = value_start + "[REDACTED]".len();
+    }
+    output
 }
 
 fn redact_marker_value(mut output: String, marker: &str, terminators: &[char]) -> String {
@@ -558,6 +611,25 @@ mod tests {
             event.get("token").and_then(Value::as_str),
             Some("[REDACTED]")
         );
+    }
+
+    #[test]
+    fn redacts_whitespace_tolerant_yaml_and_secret_key_variants() {
+        let log = SessionLog::with_capacity(8);
+        log.push_line("worker", "token : yaml-secret keep: visible");
+        log.push_line("worker", "password: pass-word");
+        log.push_line("worker", "apikey : \"sk-abc\" keep=value");
+        log.push_line("worker", "secret=hidden&x=1");
+        let entries = log.query(&LogQuery::default());
+        for secret in ["yaml-secret", "pass-word", "sk-abc", "hidden"] {
+            assert!(
+                entries.iter().all(|entry| !entry.raw.contains(secret)),
+                "{secret} must be redacted: {entries:?}"
+            );
+        }
+        assert!(entries[0].raw.contains("keep: visible"));
+        assert!(entries[2].raw.contains("keep=value"));
+        assert!(entries[3].raw.contains("x=1"));
     }
 
     #[test]

--- a/crates/sceneworks-image-quality/src/lib.rs
+++ b/crates/sceneworks-image-quality/src/lib.rs
@@ -12,7 +12,7 @@
 //! soft, which is the correct signal). The perceptual hash is taken on the full image — it
 //! self-normalizes by downscaling internally. See `docs/sc-6530/dataset-doctor-metrics.md`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use image::{imageops::FilterType, DynamicImage, GrayImage, Luma, RgbImage};
@@ -136,12 +136,12 @@ pub fn scalars_from_image(image: &DynamicImage, bucket_edge: u32) -> Tier0Scalar
     // change meaning, bump `sceneworks_core::dataset_quality::TIER0_METRICS_VERSION` so persisted
     // caches recompute instead of being judged under the old definition.)
     let trainer_gray = trainer_grayscale(image, bucket_edge.max(1));
-    let (shadow_clip, highlight_clip) = exposure_clip(&trainer_gray);
+    let (shadow_clip, highlight_clip, well_exposed_fraction) = exposure_fractions(&trainer_gray);
     Tier0Scalars {
         blur_variance: tile_peak_focus(&trainer_gray),
         shadow_clip,
         highlight_clip,
-        well_exposed_fraction: well_exposed_fraction(&trainer_gray),
+        well_exposed_fraction,
         phash,
     }
 }
@@ -192,7 +192,7 @@ pub fn compute_readiness(
 ) -> (DatasetReadinessReport, Vec<(String, Tier0Scalars)>) {
     let mut inputs = Vec::with_capacity(items.len());
     let mut extracted = Vec::new();
-    let mut decode_failed = Vec::new();
+    let mut decode_failed = HashSet::new();
 
     for item in items {
         let scalars = if let Some(cached) = &item.cached_scalars {
@@ -211,7 +211,7 @@ pub fn compute_readiness(
                         error = %error,
                         "Dataset Doctor could not decode an image"
                     );
-                    decode_failed.push(item.item_id.clone());
+                    decode_failed.insert(item.item_id.clone());
                     None
                 }
             }
@@ -396,7 +396,8 @@ fn response_tile_variance(
     let mut sum_sq = 0.0_f64;
     for y in y0..(y0 + h) {
         for x in x0..(x0 + w) {
-            let value = f64::from(response.get_pixel(x, y)[0]);
+            let index = (u64::from(y) * u64::from(response.width()) + u64::from(x)) as usize;
+            let value = f64::from(response.as_raw()[index]);
             sum += value;
             sum_sq += value * value;
             count += 1.0;
@@ -449,30 +450,15 @@ fn percentile(values: &mut [f64], p: f64) -> f64 {
     values[rank.min(values.len() - 1)]
 }
 
-/// Fraction of pixels sitting in a healthy midtone band — neither crushed toward black nor blown
-/// toward white (sc-8563). Distinguishes an intentional low-key frame (a lit subject on a dark
-/// backdrop: high `shadow_clip` *and* a healthy well-exposed band) from a genuinely under/over-
-/// exposed one (little to nothing in the band). In `[0, 1]`.
-fn well_exposed_fraction(gray: &GrayImage) -> f64 {
+/// Compute both histogram tails and the healthy midtone share in one pixel pass.
+fn exposure_fractions(gray: &GrayImage) -> (f64, f64, f64) {
     let total = u64::from(gray.width()) * u64::from(gray.height());
     if total == 0 {
-        return 0.0;
-    }
-    let healthy = gray
-        .pixels()
-        .filter(|pixel| (WELL_EXPOSED_LOW..=WELL_EXPOSED_HIGH).contains(&pixel[0]))
-        .count() as f64;
-    healthy / total as f64
-}
-
-/// Fraction of pixels crushed to black and blown to white (luma histogram tails).
-fn exposure_clip(gray: &GrayImage) -> (f64, f64) {
-    let total = u64::from(gray.width()) * u64::from(gray.height());
-    if total == 0 {
-        return (0.0, 0.0);
+        return (0.0, 0.0, 0.0);
     }
     let mut shadow = 0_u64;
     let mut highlight = 0_u64;
+    let mut healthy = 0_u64;
     for pixel in gray.pixels() {
         if pixel[0] <= SHADOW_CUTOFF {
             shadow += 1;
@@ -480,10 +466,14 @@ fn exposure_clip(gray: &GrayImage) -> (f64, f64) {
         if pixel[0] >= HIGHLIGHT_CUTOFF {
             highlight += 1;
         }
+        if (WELL_EXPOSED_LOW..=WELL_EXPOSED_HIGH).contains(&pixel[0]) {
+            healthy += 1;
+        }
     }
     (
         shadow as f64 / total as f64,
         highlight as f64 / total as f64,
+        healthy as f64 / total as f64,
     )
 }
 

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -42,11 +42,14 @@ use serde_json::{json, Map, Value};
 
 use crate::api_client::{ApiClient, ApiClientError};
 
-/// How many consecutive `GET /api/v1/jobs/:id` failures the blocking poll loop
-/// tolerates before giving up (sc-10279). A single network blip / brief API
-/// restart must not throw away a possibly-20-minute render that is still running
-/// server-side; only a sustained failure streak surfaces as an error.
-const MAX_CONSECUTIVE_POLL_ERRORS: u32 = 5;
+/// How long a continuous `GET /api/v1/jobs/:id` outage is tolerated. Counting
+/// failures made tolerance accidentally depend on the configured poll cadence:
+/// a faster poller abandoned the same server outage much sooner.
+const MAX_POLL_OUTAGE: Duration = Duration::from_secs(15);
+
+fn poll_outage_exceeded(outage_started: tokio::time::Instant, now: tokio::time::Instant) -> bool {
+    now.duration_since(outage_started) >= MAX_POLL_OUTAGE
+}
 
 /// F-041 (sc-11236) — inline-payload caps for `generate_image`. The tool
 /// base64-inlines every produced image into the JSON-RPC tool result. base64
@@ -349,7 +352,7 @@ impl SceneWorksMcp {
         reporter.report(&submitted).await;
 
         let started = tokio::time::Instant::now();
-        let mut consecutive_poll_errors: u32 = 0;
+        let mut poll_outage_started: Option<tokio::time::Instant> = None;
         let job = loop {
             // Cooperative cancellation (sc-10276): rmcp cancels `ctx.ct` when the
             // client sends `notifications/cancelled` (it does NOT abort the tool
@@ -380,12 +383,13 @@ impl SceneWorksMcp {
                 .await
             {
                 Ok(job) => {
-                    consecutive_poll_errors = 0;
+                    poll_outage_started = None;
                     job
                 }
                 Err(error) => {
-                    consecutive_poll_errors += 1;
-                    if consecutive_poll_errors >= MAX_CONSECUTIVE_POLL_ERRORS {
+                    let now = tokio::time::Instant::now();
+                    let outage_started = *poll_outage_started.get_or_insert(now);
+                    if poll_outage_exceeded(outage_started, now) {
                         return Err(api_error(error));
                     }
                     if started.elapsed() >= self.job_wait.timeout {
@@ -1963,6 +1967,16 @@ mod tests {
         let c = JobWaitConfig::clamped(Duration::from_secs(10), Duration::from_secs(3));
         assert_eq!(c.poll_interval, Duration::from_secs(10));
         assert_eq!(c.timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn poll_outage_tolerance_is_elapsed_time_based() {
+        let started = tokio::time::Instant::now();
+        assert!(!poll_outage_exceeded(
+            started,
+            started + MAX_POLL_OUTAGE - Duration::from_millis(1)
+        ));
+        assert!(poll_outage_exceeded(started, started + MAX_POLL_OUTAGE));
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/asset_media.rs
+++ b/crates/sceneworks-worker/src/asset_media.rs
@@ -1,0 +1,84 @@
+use std::path::{Component, Path, PathBuf};
+
+use sceneworks_core::project_store::ProjectStore;
+
+pub(crate) struct ResolvedAssetMedia {
+    pub path: PathBuf,
+    pub display_name: Option<String>,
+}
+
+fn lexically_confined_media_path(project_path: &Path, relative: &str) -> Option<PathBuf> {
+    let mut path = project_path.to_path_buf();
+    for component in Path::new(relative).components() {
+        match component {
+            Component::Normal(value) => path.push(value),
+            _ => return None,
+        }
+    }
+    Some(path)
+}
+
+fn confined_media_path(project_path: &Path, relative: &str) -> Option<PathBuf> {
+    let project_path = project_path.canonicalize().ok()?;
+    let media_path = lexically_confined_media_path(&project_path, relative)?
+        .canonicalize()
+        .ok()?;
+    (media_path.starts_with(&project_path) && media_path.is_file()).then_some(media_path)
+}
+
+/// Resolve an asset sidecar's project-relative media path without accepting root,
+/// prefix, `.` or `..` components or symlinks that escape the canonical project
+/// root. Segment, upscale, and pose all consume the same contract, so confinement
+/// must not drift between separate copies.
+pub(crate) fn resolve_asset_media(
+    store: &ProjectStore,
+    project_id: &str,
+    asset_id: &str,
+    project_path: &Path,
+) -> Option<ResolvedAssetMedia> {
+    let asset = store.get_asset(project_id, asset_id).ok()?;
+    let relative = asset.get("file")?.get("path")?.as_str()?;
+    let path = confined_media_path(project_path, relative)?;
+    Some(ResolvedAssetMedia {
+        path,
+        display_name: asset
+            .get("displayName")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confines_asset_media_paths_to_normal_components() {
+        let root = Path::new("/projects/example.sceneworks");
+        assert_eq!(
+            lexically_confined_media_path(root, "assets/images/source.png"),
+            Some(root.join("assets/images/source.png"))
+        );
+        assert_eq!(lexically_confined_media_path(root, "../secret"), None);
+        assert_eq!(lexically_confined_media_path(root, "/tmp/secret"), None);
+        assert_eq!(
+            lexically_confined_media_path(root, "./assets/source.png"),
+            None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_media_that_escapes_the_project() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("project.sceneworks");
+        let outside = temp.path().join("outside.png");
+        std::fs::create_dir(&project).expect("project dir");
+        std::fs::write(&outside, b"not actually an image").expect("outside file");
+        symlink(&outside, project.join("linked.png")).expect("symlink");
+
+        assert_eq!(confined_media_path(&project, "linked.png"), None);
+    }
+}

--- a/crates/sceneworks-worker/src/bernini_tier_build.rs
+++ b/crates/sceneworks-worker/src/bernini_tier_build.rs
@@ -45,6 +45,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::smoke_support::{report_tier, QUANT_TIERS};
 use mlx_rs::Array;
 
 /// The runtime files that make a Bernini tier subdir COMPLETE for the load path (mirrors
@@ -67,9 +68,6 @@ const TIER_FILES: &[&str] = &[
     "mllm/tokenizer.json",
 ];
 
-/// The two quantized tiers to derive from the bf16 tier: `(subdir, bits)`.
-const QUANT_TIERS: &[(&str, i32)] = &[("q8", 8), ("q4", 4)];
-
 /// The quant group size — the canonical mflux/reference default the load path
 /// (`WanModelConfig::from_config_json` / `QwenVlTextConfig::from_config_json`) reconstructs. Matches
 /// the Wan A14B renderer experts, so the two halves pack at the same group.
@@ -88,23 +86,6 @@ const RENDERER_EXPERTS: &[&str] = &[
 /// config gates `WanTransformer::from_weights`.
 const PLANNER_CONFIG: &str = "qwen2_5_vl_config.json";
 const RENDERER_CONFIG: &str = "config.json";
-
-/// Recursively sum the byte size of every file under `dir` (the on-disk size of a built tier).
-fn dir_size_bytes(dir: &Path) -> u64 {
-    let mut total = 0;
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return 0;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            total += dir_size_bytes(&path);
-        } else if let Ok(meta) = path.metadata() {
-            total += meta.len();
-        }
-    }
-    total
-}
 
 /// Recursively copy a directory tree (following symlinks to real files, like the HF cache blobs).
 fn copy_tree(src: &Path, dst: &Path) {
@@ -135,15 +116,6 @@ fn assert_tier_complete(out_dir: &Path, tier: &str) {
             "built {tier} tier is missing {file}"
         );
     }
-}
-
-/// Print the machine-readable `[[TIER]]` line for backfilling the manifest sizes.
-fn report_tier(tier: &str, out_dir: &Path) {
-    let size = dir_size_bytes(out_dir);
-    eprintln!(
-        "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
-        out_dir.display()
-    );
 }
 
 /// Load a bf16 safetensors map, apply `quantize` to it, materialize, and save to `out`.

--- a/crates/sceneworks-worker/src/caption_jobs.rs
+++ b/crates/sceneworks-worker/src/caption_jobs.rs
@@ -84,6 +84,17 @@ struct CaptionedItem {
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
+fn caption_destination(payload: &JsonObject) -> WorkerResult<(String, String)> {
+    Ok((
+        required_payload_string(payload, "projectId")?.to_owned(),
+        required_payload_string(payload, "datasetId")?.to_owned(),
+    ))
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 pub(crate) async fn run_training_caption_job(
     api: &ApiClient,
     settings: &Settings,
@@ -101,6 +112,10 @@ pub(crate) async fn run_training_caption_job(
         ));
     }
 
+    // Validate the persistence destination before reserving the GPU or loading weights.
+    // These fields used to be checked only after inference had completed, wasting a full
+    // caption run for a request that could never save its results.
+    let (project_id, dataset_id) = caption_destination(&job.payload)?;
     let items = caption_items(settings, &job.payload)?;
     if items.is_empty() {
         return Err(WorkerError::InvalidPayload(
@@ -380,8 +395,6 @@ pub(crate) async fn run_training_caption_job(
         ),
     )
     .await?;
-    let project_id = required_payload_string(&job.payload, "projectId")?;
-    let dataset_id = required_payload_string(&job.payload, "datasetId")?;
     let sidecars: Value = api
         .post_json(
             &format!(
@@ -400,7 +413,7 @@ pub(crate) async fn run_training_caption_job(
             &format!("Created captions for {} training item(s).", items.len()),
             Some(caption_result(
                 &model_name_or_path,
-                dataset_id,
+                &dataset_id,
                 items.len(),
                 sidecars,
             )),
@@ -775,6 +788,19 @@ mod tests {
         assert_eq!(options.sampling.temperature, 0.5);
         assert_eq!(options.sampling.top_p, 0.8);
         assert_eq!(options.sampling.max_new_tokens, 128);
+    }
+
+    #[test]
+    fn caption_destination_rejects_missing_ids_before_inference() {
+        let complete = serde_json::Map::from_iter([
+            ("projectId".to_owned(), json!("project-1")),
+            ("datasetId".to_owned(), json!("dataset-1")),
+        ]);
+        assert_eq!(
+            caption_destination(&complete).expect("destination"),
+            ("project-1".to_owned(), "dataset-1".to_owned())
+        );
+        assert!(caption_destination(&serde_json::Map::new()).is_err());
     }
 
     // ── sc-11189 (F-016): per-step token-progress coalescing (ported from the refine path) ────────

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -1,5 +1,17 @@
 use super::*;
 
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn extend_capabilities_unique(
+    target: &mut Vec<WorkerCapability>,
+    capabilities: impl IntoIterator<Item = WorkerCapability>,
+) {
+    for capability in capabilities {
+        if !target.contains(&capability) {
+            target.push(capability);
+        }
+    }
+}
+
 pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
     let requested_gpu_id = settings.gpu_id.as_str();
     if requested_gpu_id == "cpu" {
@@ -68,11 +80,7 @@ fn with_candle_capabilities(
     if settings.backend_candle_enabled && gpu.capabilities.contains(&WorkerCapability::Gpu) {
         let derived = crate::engines::registry_capabilities(settings);
         if !derived.is_empty() {
-            for capability in derived {
-                if !gpu.capabilities.contains(&capability) {
-                    gpu.capabilities.push(capability);
-                }
-            }
+            extend_capabilities_unique(&mut gpu.capabilities, derived);
             // Plain Image Edit (sc-5487, epic 5480): the distinct `image_edit` job type
             // (`mode == "edit_image"` + `sourceAssetId`, epic 2427) runs the bespoke candle edit lanes
             // (SdxlEdit / Flux2Edit / QwenEdit) via `run_image_generate_job`, which dispatches by payload
@@ -82,23 +90,20 @@ fn with_candle_capabilities(
             // API enforce-fails it `candle_unsupported`. The routing gate confines the claim to the
             // candle-eligible edit models (`image_job_is_candle_eligible`); unsupported edit models
             // are refused and remain queued.
-            if !gpu.capabilities.contains(&WorkerCapability::ImageEdit) {
-                gpu.capabilities.push(WorkerCapability::ImageEdit);
-            }
+            extend_capabilities_unique(&mut gpu.capabilities, [WorkerCapability::ImageEdit]);
             // SenseNova-U1 VQA + Document-Studio interleave (sc-5501) run off the `Generator`
             // registry via the concrete candle `T2iModel::{vqa, interleave_gen}` (their text /
             // text+image output the neutral contract can't express), so they are NOT in
             // `registry_capabilities`. Advertise them explicitly — the candle SenseNova provider is
             // owned by `runtime-cuda`, and the routing gate confines them to the
             // SenseNova-U1 ids (`understanding_job_is_mlx_eligible`).
-            for capability in [
-                WorkerCapability::ImageVqa,
-                WorkerCapability::ImageInterleave,
-            ] {
-                if !gpu.capabilities.contains(&capability) {
-                    gpu.capabilities.push(capability);
-                }
-            }
+            extend_capabilities_unique(
+                &mut gpu.capabilities,
+                [
+                    WorkerCapability::ImageVqa,
+                    WorkerCapability::ImageInterleave,
+                ],
+            );
             // Image + video upscaling (sc-5928 SeedVR2 + sc-5499 Real-ESRGAN, epic 4811 / epic 5482):
             // off-Mac the candle worker serves `image_upscale` for BOTH Real-ESRGAN (`ort`/CUDA in
             // `upscale_jobs`, the off-Mac sibling of the Mac CoreML path — sc-5499) and SeedVR2
@@ -108,53 +113,44 @@ fn with_candle_capabilities(
             // routing gate (`upscale_job_is_candle_eligible` / `video_upscale_job_is_candle_eligible`)
             // admits Real-ESRGAN + SeedVR2; only `aura-sr` has no candle path (dropped as an offered
             // engine, sc-3668 / sc-5499) and remains queued if submitted defensively.
-            for capability in [
-                WorkerCapability::ImageUpscale,
-                WorkerCapability::VideoUpscale,
-                WorkerCapability::DatasetUpscale,
-            ] {
-                if !gpu.capabilities.contains(&capability) {
-                    gpu.capabilities.push(capability);
-                }
-            }
+            extend_capabilities_unique(
+                &mut gpu.capabilities,
+                [
+                    WorkerCapability::ImageUpscale,
+                    WorkerCapability::VideoUpscale,
+                    WorkerCapability::DatasetUpscale,
+                ],
+            );
             // SCRFD 5-point face-landmark extraction (sc-5497, epic 5482): the candle SCRFD/ArcFace face
             // stack (`candle-gen-face`, the InstantID/PuLID detector reused directly from kps_jobs.rs)
             // serves `kps_extract` for the Key Point Library "extract kps from this image" flow — the
             // off-Mac sibling of the native-MLX path. A job-type capability (not a generation modality),
             // so it isn't in `registry_capabilities`; advertise it explicitly. The candle face stack is
             // the off-Mac native path, so a build without it leaves the job queued.
-            if !gpu.capabilities.contains(&WorkerCapability::KpsExtract) {
-                gpu.capabilities.push(WorkerCapability::KpsExtract);
-            }
+            extend_capabilities_unique(&mut gpu.capabilities, [WorkerCapability::KpsExtract]);
             // Dataset Doctor face pass (sc-6538): the off-Mac sibling of the macOS face stack — the
             // candle SCRFD/ArcFace stack (`candle-gen-face`, reused from kps_jobs.rs) embeds the largest
             // face of each Person-dataset image. A job-type capability (not a generation modality), so
             // it isn't in `registry_capabilities`; advertise it explicitly, like kps_extract.
-            if !gpu
-                .capabilities
-                .contains(&WorkerCapability::DatasetFaceAnalysis)
-            {
-                gpu.capabilities.push(WorkerCapability::DatasetFaceAnalysis);
-            }
+            extend_capabilities_unique(
+                &mut gpu.capabilities,
+                [WorkerCapability::DatasetFaceAnalysis],
+            );
             // On-demand face-likeness compare (sc-4415): the off-Mac sibling of the macOS face stack —
             // the candle SCRFD/ArcFace stack scores a candidate asset against a source identity
             // reference. A job-type capability (not a generation modality), so it isn't in
             // `registry_capabilities`; advertise it explicitly, like dataset_face_analysis.
-            if !gpu
-                .capabilities
-                .contains(&WorkerCapability::FaceLikenessCompare)
-            {
-                gpu.capabilities.push(WorkerCapability::FaceLikenessCompare);
-            }
+            extend_capabilities_unique(
+                &mut gpu.capabilities,
+                [WorkerCapability::FaceLikenessCompare],
+            );
             // DWPose whole-body pose detection (sc-5496, epic 5482): the off-Mac sibling of the macOS
             // `ort`/CoreML path (sc-3487) — the same RTMW detector via `pose_jobs::run_pose_detect_job`
             // with the CUDA execution provider, serving `pose_detect` for the Pose Library "create from
             // photo" flow + InstantID pose conditioning. A job-type capability (not a generation modality),
             // so it isn't in `registry_capabilities`; advertise it explicitly. The candle RTMW stack is
             // the off-Mac native path, so a build without it leaves the job queued.
-            if !gpu.capabilities.contains(&WorkerCapability::PoseDetect) {
-                gpu.capabilities.push(WorkerCapability::PoseDetect);
-            }
+            extend_capabilities_unique(&mut gpu.capabilities, [WorkerCapability::PoseDetect]);
             // YOLO11 person detection + selected-person ByteTrack tracking (sc-5498, epic 5482):
             // the off-Mac sibling of the macOS native-MLX path (sc-3633/sc-3634) — `yolo11m.onnx`
             // via `ort`/CUDA in `person_jobs` + the pure-Rust SORT/ByteTrack in `person_track`,
@@ -164,24 +160,24 @@ fn with_candle_capabilities(
             // YOLO11/ByteTrack stack is the off-Mac native path, and `media_jobs::run_candle_segmenter`
             // adds SAM3 masks to tracked people (sc-8847 / sc-8833), so off-Mac tracks are not
             // box-only.
-            for capability in [
-                WorkerCapability::PersonDetect,
-                WorkerCapability::PersonTrack,
-            ] {
-                if !gpu.capabilities.contains(&capability) {
-                    gpu.capabilities.push(capability);
-                }
-            }
+            extend_capabilities_unique(
+                &mut gpu.capabilities,
+                [
+                    WorkerCapability::PersonDetect,
+                    WorkerCapability::PersonTrack,
+                ],
+            );
             // Pure audio synthesis (SceneWorks Audio Studio, epic 13400 / sc-13404): audio is
             // candle-native on every platform, and `runtime-cuda` ships the same audio lane default-on
             // as `runtime-macos` — so the off-Mac candle worker serves `audio_generate` too when the
             // lane is linked (`inference_runtime::audio()`). Advertised explicitly like the mlx worker's
             // carve-out (the audio generators live in a separate registry from the media graph
             // `registry_capabilities` iterates); a build without the lane never advertises it.
-            if crate::inference_runtime::audio().is_some()
-                && !gpu.capabilities.contains(&WorkerCapability::AudioGenerate)
-            {
-                gpu.capabilities.push(WorkerCapability::AudioGenerate);
+            if crate::inference_runtime::audio().is_some() {
+                extend_capabilities_unique(
+                    &mut gpu.capabilities,
+                    [WorkerCapability::AudioGenerate],
+                );
             }
             // The lane marker the routing gate keys off (mirrors the existing `nvidia` marker).
             gpu.capabilities

--- a/crates/sceneworks-worker/src/image_sampling.rs
+++ b/crates/sceneworks-worker/src/image_sampling.rs
@@ -1,0 +1,49 @@
+use image::RgbImage;
+
+/// Bilinearly sample all three RGB channels with one neighbor fetch. Callers may
+/// reorder the returned channels for BGR model inputs without re-reading pixels.
+#[inline]
+pub(crate) fn sample_rgb_bilinear(image: &RgbImage, x: f32, y: f32, border: f32) -> [f32; 3] {
+    let (width, height) = (image.width() as i64, image.height() as i64);
+    let x0 = x.floor() as i64;
+    let y0 = y.floor() as i64;
+    let fx = x - x0 as f32;
+    let fy = y - y0 as f32;
+    let get = |xi: i64, yi: i64| -> [f32; 3] {
+        if xi < 0 || yi < 0 || xi >= width || yi >= height {
+            [border; 3]
+        } else {
+            image.get_pixel(xi as u32, yi as u32).0.map(f32::from)
+        }
+    };
+    let [v00, v10, v01, v11] = [
+        get(x0, y0),
+        get(x0 + 1, y0),
+        get(x0, y0 + 1),
+        get(x0 + 1, y0 + 1),
+    ];
+    std::array::from_fn(|channel| {
+        let top = v00[channel] * (1.0 - fx) + v10[channel] * fx;
+        let bottom = v01[channel] * (1.0 - fx) + v11[channel] * fx;
+        top * (1.0 - fy) + bottom * fy
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{Rgb, RgbImage};
+
+    #[test]
+    fn samples_all_channels_with_shared_geometry() {
+        let image = RgbImage::from_fn(2, 2, |x, y| {
+            let base = (x + y * 2) as u8 * 30;
+            Rgb([base, base + 10, base + 20])
+        });
+        assert_eq!(
+            sample_rgb_bilinear(&image, 0.5, 0.5, 0.0),
+            [45.0, 55.0, 65.0]
+        );
+        assert_eq!(sample_rgb_bilinear(&image, -1.0, -1.0, 7.0), [7.0; 3]);
+    }
+}

--- a/crates/sceneworks-worker/src/kps_jobs.rs
+++ b/crates/sceneworks-worker/src/kps_jobs.rs
@@ -186,7 +186,12 @@ impl KpsExtraction {
 /// `pose_jobs::DETECTOR` / `person_segment_sam3::WEIGHTS` (poison-recovery: a poisoned lock drops the
 /// cached value and rebuilds). macOS only; `Weights` is the MLX weight container.
 #[cfg(target_os = "macos")]
-static WEIGHTS: OnceLock<Mutex<Option<Weights>>> = OnceLock::new();
+static WEIGHTS: OnceLock<Mutex<Option<(PathBuf, Weights)>>> = OnceLock::new();
+
+#[cfg(any(target_os = "macos", test))]
+fn cached_path_matches<T>(cached: Option<&(PathBuf, T)>, path: &Path) -> bool {
+    cached.map(|(cached_path, _)| cached_path.as_path()) == Some(path)
+}
 
 thread_local! {
     /// The built [`Scrfd`] detector cached per blocking thread, keyed by weight path (sc-8910 /
@@ -235,12 +240,13 @@ fn detect_largest_kps(scrfd_path: &Path, image: &Image) -> WorkerResult<KpsExtra
                     *guard = None;
                     guard
                 });
-                if guard.is_none() {
-                    *guard = Some(Weights::from_file(scrfd_path).map_err(|error| {
+                if !cached_path_matches(guard.as_ref(), scrfd_path) {
+                    let weights = Weights::from_file(scrfd_path).map_err(|error| {
                         WorkerError::Engine(format!("SCRFD weights {scrfd_path:?}: {error}"))
-                    })?);
+                    })?;
+                    *guard = Some((scrfd_path.to_path_buf(), weights));
                 }
-                let scrfd = Scrfd::from_weights(guard.as_ref().expect("weights loaded"))
+                let scrfd = Scrfd::from_weights(&guard.as_ref().expect("weights loaded").1)
                     .map_err(|error| WorkerError::Engine(format!("SCRFD load: {error}")))?;
                 *cell.borrow_mut() = Some((scrfd_path.to_path_buf(), scrfd));
             }
@@ -477,6 +483,19 @@ pub(crate) async fn run_kps_extract_job(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn weights_cache_identity_includes_the_resolved_path() {
+        let cached = (PathBuf::from("/weights/a.safetensors"), "weights");
+        assert!(cached_path_matches(
+            Some(&cached),
+            Path::new("/weights/a.safetensors")
+        ));
+        assert!(!cached_path_matches(
+            Some(&cached),
+            Path::new("/weights/b.safetensors")
+        ));
+    }
 
     /// A queued `kps_extract` job carrying `payload` (mirrors `jobs_store`'s test constructor).
     fn kps_job(payload: Value) -> JobSnapshot {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -58,6 +58,16 @@ use uuid::Uuid;
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod advanced;
 mod api_client;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+mod asset_media;
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+mod image_sampling;
 // Shared one-child PNG persistence for upscale (Mac + candle) and smart-select (Mac).
 // Keep the include site on the callers' superset so the neither-backend lane does not
 // compile an otherwise dead helper.

--- a/crates/sceneworks-worker/src/manifest.rs
+++ b/crates/sceneworks-worker/src/manifest.rs
@@ -203,7 +203,10 @@ pub(crate) async fn write_json_value(path: &Path, value: &Value) -> WorkerResult
             .and_then(|extension| extension.to_str())
             .unwrap_or("json")
     ));
-    tokio::fs::write(&tmp_path, output).await?;
+    let mut file = tokio::fs::File::create(&tmp_path).await?;
+    file.write_all(&output).await?;
+    file.sync_all().await?;
+    drop(file);
     tokio::fs::rename(tmp_path, path).await?;
     Ok(())
 }

--- a/crates/sceneworks-worker/src/person_jobs.rs
+++ b/crates/sceneworks-worker/src/person_jobs.rs
@@ -48,6 +48,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
+use crate::image_sampling::sample_rgb_bilinear;
 use image::RgbImage;
 use serde_json::{json, Value};
 
@@ -172,31 +173,6 @@ impl Letterbox {
     }
 }
 
-/// Bilinear sample of an RGB channel (0=R,1=G,2=B) at (x,y); out-of-bounds → `border`.
-/// cv2 INTER_LINEAR half-pixel convention is applied by the caller.
-#[inline]
-fn sample_rgb(img: &RgbImage, x: f32, y: f32, c: usize, border: f32) -> f32 {
-    let (w, h) = (img.width() as i64, img.height() as i64);
-    let x0 = x.floor() as i64;
-    let y0 = y.floor() as i64;
-    let fx = x - x0 as f32;
-    let fy = y - y0 as f32;
-    let get = |xi: i64, yi: i64| -> f32 {
-        if xi < 0 || yi < 0 || xi >= w || yi >= h {
-            border
-        } else {
-            img.get_pixel(xi as u32, yi as u32)[c] as f32
-        }
-    };
-    let v00 = get(x0, y0);
-    let v10 = get(x0 + 1, y0);
-    let v01 = get(x0, y0 + 1);
-    let v11 = get(x0 + 1, y0 + 1);
-    let top = v00 * (1.0 - fx) + v10 * fx;
-    let bot = v01 * (1.0 - fx) + v11 * fx;
-    top * (1.0 - fy) + bot * fy
-}
-
 /// Destination layout for the shared letterbox preprocessor: NHWC (the layout
 /// `runtime_macos::media::nn::conv2d` expects, macOS) or NCHW (the `yolo11m.onnx` export expects,
 /// off-Mac). The two backends' letterbox + cv2 half-pixel sampling are byte-identical;
@@ -247,15 +223,14 @@ fn preprocess_letterbox(img: &RgbImage, layout: InputLayout) -> (Vec<f32>, Lette
         for dx in 0..new_w {
             let src_x = (dx as f32 + 0.5) * sx - 0.5;
             let x = dx + pad_x;
-            for c in 0..3 {
-                let v = sample_rgb(
-                    img,
-                    src_x.clamp(0.0, w - 1.0),
-                    src_y.clamp(0.0, h - 1.0),
-                    c,
-                    0.0,
-                );
-                buf[layout.index(x, y, c)] = v / 255.0;
+            let rgb = sample_rgb_bilinear(
+                img,
+                src_x.clamp(0.0, w - 1.0),
+                src_y.clamp(0.0, h - 1.0),
+                0.0,
+            );
+            for (channel, value) in rgb.into_iter().enumerate() {
+                buf[layout.index(x, y, channel)] = value / 255.0;
             }
         }
     }

--- a/crates/sceneworks-worker/src/person_segment.rs
+++ b/crates/sceneworks-worker/src/person_segment.rs
@@ -132,6 +132,9 @@ pub(crate) fn box_norm_to_pixels(
 pub(crate) fn mask_box_coverage(pixels: &[u8], box_norm: BoxNorm, width: u32, height: u32) -> f64 {
     let [x1, y1, x2, y2] = box_norm_to_pixels(box_norm, width, height);
     let (w, h) = (width as usize, height as usize);
+    if pixels.len() != w.saturating_mul(h) {
+        return 0.0;
+    }
     let (mut fg, mut inside) = (0u64, 0u64);
     for y in 0..h {
         for x in 0..w {
@@ -479,6 +482,11 @@ mod tests {
         assert_eq!(
             mask_box_coverage(&[0u8; 100], (0.0, 0.0, 1.0, 1.0), w, h),
             0.0
+        );
+        assert_eq!(
+            mask_box_coverage(&pixels[..99], (0.0, 0.0, 1.0, 1.0), w, h),
+            0.0,
+            "malformed masks must not index past their buffer"
         );
         // A box over the left half of the block → ~half the foreground inside.
         let half = mask_box_coverage(&pixels, (0.0, 0.0, 0.4, 1.0), w, h);

--- a/crates/sceneworks-worker/src/pose_jobs.rs
+++ b/crates/sceneworks-worker/src/pose_jobs.rs
@@ -28,7 +28,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+use crate::asset_media::resolve_asset_media;
 use crate::downloads::{ensure_cached_file, verify_file_sha256, DownloadContext};
+use crate::image_sampling::sample_rgb_bilinear;
 use image::RgbImage;
 #[cfg(not(target_os = "macos"))]
 use ort::execution_providers::CUDAExecutionProvider;
@@ -133,32 +135,6 @@ const COCO_TO_OPENPOSE: [(usize, usize); 17] = [
 // pure detector math (ported from the spike crate; unit-tested without weights)
 // ---------------------------------------------------------------------------
 
-/// Bilinear sample of a BGR channel from an RgbImage; out-of-bounds → `border`.
-/// `c` is the BGR channel index (0=B,1=G,2=R); RgbImage stores RGB so we remap.
-#[inline]
-fn sample_bgr(img: &RgbImage, x: f32, y: f32, c: usize, border: f32) -> f32 {
-    let (w, h) = (img.width() as i64, img.height() as i64);
-    let x0 = x.floor() as i64;
-    let y0 = y.floor() as i64;
-    let fx = x - x0 as f32;
-    let fy = y - y0 as f32;
-    let rgb_c = [2usize, 1, 0][c];
-    let get = |xi: i64, yi: i64| -> f32 {
-        if xi < 0 || yi < 0 || xi >= w || yi >= h {
-            border
-        } else {
-            img.get_pixel(xi as u32, yi as u32)[rgb_c] as f32
-        }
-    };
-    let v00 = get(x0, y0);
-    let v10 = get(x0 + 1, y0);
-    let v01 = get(x0, y0 + 1);
-    let v11 = get(x0 + 1, y0 + 1);
-    let top = v00 * (1.0 - fx) + v10 * fx;
-    let bot = v01 * (1.0 - fx) + v11 * fx;
-    top * (1.0 - fy) + bot * fy
-}
-
 #[derive(Clone, Copy)]
 struct Box4 {
     x1: f32,
@@ -181,14 +157,13 @@ fn yolox_preprocess(img: &RgbImage) -> (Vec<f32>, f32) {
             let src_y = (dy as f32 + 0.5) * sy - 0.5; // cv2 INTER_LINEAR half-pixel
             for dx in 0..new_w {
                 let src_x = (dx as f32 + 0.5) * sx - 0.5;
-                let v = sample_bgr(
+                let rgb = sample_rgb_bilinear(
                     img,
                     src_x.clamp(0.0, w - 1.0),
                     src_y.clamp(0.0, h - 1.0),
-                    c,
                     0.0,
                 );
-                chw[plane + dy * DET + dx] = v;
+                chw[plane + dy * DET + dx] = rgb[2 - c];
             }
         }
     }
@@ -261,7 +236,8 @@ fn pose_preprocess(img: &RgbImage, b: &Box4) -> (Vec<f32>, f32, f32, f32, f32) {
             let src_y = y0 + dy as f32 * sh / PH as f32; // affine inverse (no half-pixel)
             for dx in 0..PW {
                 let src_x = x0 + dx as f32 * sw / PW as f32;
-                chw[plane + dy * PW + dx] = (sample_bgr(img, src_x, src_y, c, 0.0) - m) / sd;
+                let rgb = sample_rgb_bilinear(img, src_x, src_y, 0.0);
+                chw[plane + dy * PW + dx] = (rgb[2 - c] - m) / sd;
             }
         }
     }
@@ -1013,12 +989,12 @@ fn resolve_source(
     }
     // asset id resolved against the originating project (Create tab sends ids)
     if let (Some(id), Some(pid), Some(proj)) = (&asset_id, project_id, project_path) {
-        if let Some(path) = resolve_asset_path(store, pid, id, proj) {
+        if let Some(asset) = resolve_asset_media(store, pid, id, proj) {
             return Ok(PoseSource {
                 asset_id,
-                display_name,
+                display_name: display_name.or(asset.display_name),
                 temp,
-                path: Some(path),
+                path: Some(asset.path),
             });
         }
     }
@@ -1059,25 +1035,6 @@ fn join_project_relative(project_path: &Path, raw: &str) -> Option<PathBuf> {
         }
     }
     Some(path)
-}
-
-fn resolve_asset_path(
-    store: &ProjectStore,
-    project_id: &str,
-    asset_id: &str,
-    project_path: &Path,
-) -> Option<PathBuf> {
-    let asset = store.get_asset(project_id, asset_id).ok()?;
-    let rel = asset.get("file")?.get("path")?.as_str()?;
-    let mut path = project_path.to_path_buf();
-    for component in Path::new(rel).components() {
-        if let std::path::Component::Normal(value) = component {
-            path.push(value);
-        } else {
-            return None;
-        }
-    }
-    path.exists().then_some(path)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sceneworks-worker/src/prompt_refine_jobs.rs
+++ b/crates/sceneworks-worker/src/prompt_refine_jobs.rs
@@ -848,13 +848,18 @@ pub(crate) async fn run_prompt_refine_job(
                     .to_owned(),
             ));
         }
-        let mut refs = Vec::with_capacity(paths.len());
-        for path in &paths {
-            let safe_path =
-                normalize_app_managed_model_path(settings, path, "Vision reference image")?;
-            refs.push(load_caption_image_ref(&safe_path)?);
-        }
-        refs
+        let safe_paths = paths
+            .iter()
+            .map(|path| normalize_app_managed_model_path(settings, path, "Vision reference image"))
+            .collect::<WorkerResult<Vec<_>>>()?;
+        tokio::task::spawn_blocking(move || {
+            safe_paths
+                .iter()
+                .map(|path| load_caption_image_ref(path))
+                .collect::<WorkerResult<Vec<_>>>()
+        })
+        .await
+        .map_err(|error| task_join_error("vision reference image decode", error))??
     } else {
         Vec::new()
     };

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -18,10 +18,11 @@
 //! by the MLX worker (`gpu.rs mlx_gpu`), so a segment job never routes off-Mac. There is no
 //! torch/candle SAM3 image path yet (a Windows/Linux backport is tracked separately).
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde_json::{json, Value};
 
+use crate::asset_media::resolve_asset_media;
 use crate::downloads::DownloadContext;
 use crate::person_segment_sam3::{
     ensure_segmenter_weights, segment_box_blocking, segment_points_blocking,
@@ -38,34 +39,6 @@ use sceneworks_core::project_store::ProjectStore;
 /// test): keep an instance when `σ(logit)·σ(presence) > THRESHOLD`, binarize its mask at `σ > MASK`.
 const SEGMENT_THRESHOLD: f32 = 0.5;
 const SEGMENT_MASK_THRESHOLD: f32 = 0.5;
-
-/// Resolve a `sourceAssetId` to its on-disk media path + the asset's `displayName` via the project
-/// sidecar (mirrors `upscale_jobs::resolve_source` / `image_adapters.find_asset_media_path`).
-fn resolve_source(
-    store: &ProjectStore,
-    project_id: &str,
-    asset_id: &str,
-    project_path: &Path,
-) -> Option<(PathBuf, Option<String>)> {
-    let asset = store.get_asset(project_id, asset_id).ok()?;
-    let rel = asset.get("file")?.get("path")?.as_str()?;
-    let mut path = project_path.to_path_buf();
-    for component in Path::new(rel).components() {
-        if let std::path::Component::Normal(value) = component {
-            path.push(value);
-        } else {
-            return None;
-        }
-    }
-    if !path.exists() {
-        return None;
-    }
-    let display = asset
-        .get("displayName")
-        .and_then(Value::as_str)
-        .map(str::to_owned);
-    Some((path, display))
-}
 
 /// Parse `payload.box` (the box prompt in source-image pixel coords). Accepts either the canonical
 /// 4-array `[x1, y1, x2, y2]` or an `{x, y, width, height}` object (the editor's rect shape), so the
@@ -226,12 +199,14 @@ pub(crate) async fn run_image_segment_job(
         .get_project(&project_id)
         .map_err(|e| WorkerError::InvalidPayload(format!("project not found: {e}")))?;
     let project_path = PathBuf::from(project.path);
-    let (source_path, source_display) =
-        resolve_source(&store, &project_id, &source_asset_id, &project_path).ok_or_else(|| {
+    let source = resolve_asset_media(&store, &project_id, &source_asset_id, &project_path)
+        .ok_or_else(|| {
             WorkerError::InvalidPayload(format!(
                 "Source image asset not found or missing: {source_asset_id}."
             ))
         })?;
+    let source_path = source.path;
+    let source_display = source.display_name;
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/smoke_support.rs
+++ b/crates/sceneworks-worker/src/smoke_support.rs
@@ -19,6 +19,35 @@ use std::path::Path;
 
 use gen_core::Image;
 
+#[cfg(target_os = "macos")]
+pub(crate) const QUANT_TIERS: &[(&str, i32)] = &[("q8", 8), ("q4", 4)];
+
+#[cfg(target_os = "macos")]
+pub(crate) fn tier_dir_size_bytes(dir: &Path) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += tier_dir_size_bytes(&path);
+        } else if let Ok(metadata) = path.metadata() {
+            total += metadata.len();
+        }
+    }
+    total
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn report_tier(tier: &str, out_dir: &Path) {
+    let size = tier_dir_size_bytes(out_dir);
+    eprintln!(
+        "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
+        out_dir.display()
+    );
+}
+
 /// General degenerate-decode floor for the mean per-pixel std-dev sanity check (sc-9838, F-122).
 ///
 /// This is the model-agnostic "is the decode alive?" guard: a NaN / all-black / flat collapse pulls

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -41,6 +41,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+use crate::asset_media::resolve_asset_media;
 use crate::downloads::{ensure_hf_cached_file, DownloadContext};
 use crate::generator_cache::with_cached_generator;
 use crate::single_child_asset::{write_single_child_asset, SingleChildAssetSpec};
@@ -858,38 +859,6 @@ where
 }
 
 // ---------------------------------------------------------------------------
-// source resolution (mirrors image_adapters.find_asset_media_path / _source_display_name)
-// ---------------------------------------------------------------------------
-
-/// Resolve a `sourceAssetId` to its on-disk media path (native resolution) + the
-/// asset's `displayName`, via the project sidecar — mirrors `find_asset_media_path`.
-fn resolve_source(
-    store: &ProjectStore,
-    project_id: &str,
-    asset_id: &str,
-    project_path: &Path,
-) -> Option<(PathBuf, Option<String>)> {
-    let asset = store.get_asset(project_id, asset_id).ok()?;
-    let rel = asset.get("file")?.get("path")?.as_str()?;
-    let mut path = project_path.to_path_buf();
-    for component in Path::new(rel).components() {
-        if let std::path::Component::Normal(value) = component {
-            path.push(value);
-        } else {
-            return None;
-        }
-    }
-    if !path.exists() {
-        return None;
-    }
-    let display = asset
-        .get("displayName")
-        .and_then(Value::as_str)
-        .map(str::to_owned);
-    Some((path, display))
-}
-
-// ---------------------------------------------------------------------------
 // job handler
 // ---------------------------------------------------------------------------
 
@@ -987,12 +956,14 @@ pub(crate) async fn run_image_upscale_job(
         .get_project(&project_id)
         .map_err(|e| WorkerError::InvalidPayload(format!("project not found: {e}")))?;
     let project_path = PathBuf::from(project.path);
-    let (source_path, source_display) =
-        resolve_source(&store, &project_id, &source_asset_id, &project_path).ok_or_else(|| {
+    let source = resolve_asset_media(&store, &project_id, &source_asset_id, &project_path)
+        .ok_or_else(|| {
             WorkerError::InvalidPayload(format!(
                 "Source image asset not found or missing: {source_asset_id}."
             ))
         })?;
+    let source_path = source.path;
+    let source_display = source.display_name;
 
     // Decode the source off the async runtime thread (sc-8909 / F-107): the full read + decode is
     // blocking and would otherwise stall the heartbeat before the upscale even starts.

--- a/crates/sceneworks-worker/src/wan_i2v_14b_tier_build.rs
+++ b/crates/sceneworks-worker/src/wan_i2v_14b_tier_build.rs
@@ -28,6 +28,7 @@
 //! Each tier prints a `[[TIER]] {json}` line (tier, dir, diskSizeBytes) so the manifest
 //! `estimatedSizeBytes`/`footprint.diskSizeBytes` can be backfilled with the exact hosted sizes.
 
+use crate::smoke_support::report_tier;
 use std::path::{Path, PathBuf};
 
 /// The three tiers to build: `(subdir, Option<(bits, group_size)>)`. bf16 is dense (`None`); q8/q4
@@ -35,23 +36,6 @@ use std::path::{Path, PathBuf};
 /// same group `WanModelConfig::from_config_json` assumes and the load path reconstructs).
 const TIERS: &[(&str, Option<(i32, i32)>)] =
     &[("bf16", None), ("q8", Some((8, 64))), ("q4", Some((4, 64)))];
-
-/// Recursively sum the byte size of every file under `dir` (the on-disk size of a built tier).
-fn dir_size_bytes(dir: &Path) -> u64 {
-    let mut total = 0;
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return 0;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            total += dir_size_bytes(&path);
-        } else if let Ok(meta) = path.metadata() {
-            total += meta.len();
-        }
-    }
-    total
-}
 
 /// Resolve the `tokenizer.json` to copy into each tier: the explicit env override, then
 /// `<native>/tokenizer.json`, then the native `google/umt5-xxl/tokenizer.json` (where the upstream
@@ -157,12 +141,7 @@ fn wan_i2v_14b_build_tiers() {
                 "built {tier} tier is missing {file}"
             );
         }
-        let size = dir_size_bytes(&out_dir);
-        // Machine-readable line for backfilling the manifest sizes.
-        eprintln!(
-            "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
-            out_dir.display()
-        );
+        report_tier(tier, &out_dir);
     }
     eprintln!(
         "done — upload the tier subdirs:\n  hf upload SceneWorks/wan2.2-i2v-a14b-mlx {} --include 'bf16/*' 'q8/*' 'q4/*'",

--- a/crates/sceneworks-worker/src/wan_t2v_14b_tier_build.rs
+++ b/crates/sceneworks-worker/src/wan_t2v_14b_tier_build.rs
@@ -26,6 +26,7 @@
 //! Each tier prints a `[[TIER]] {json}` line (tier, dir, diskSizeBytes) so the manifest
 //! `estimatedSizeBytes`/`footprint.diskSizeBytes` can be backfilled with the exact hosted sizes.
 
+use crate::smoke_support::report_tier;
 use std::path::{Path, PathBuf};
 
 /// The three tiers to build: `(subdir, Option<(bits, group_size)>)`. bf16 is dense (`None`); q8/q4
@@ -33,23 +34,6 @@ use std::path::{Path, PathBuf};
 /// same group `WanModelConfig::from_config_json` assumes and the load path reconstructs).
 const TIERS: &[(&str, Option<(i32, i32)>)] =
     &[("bf16", None), ("q8", Some((8, 64))), ("q4", Some((4, 64)))];
-
-/// Recursively sum the byte size of every file under `dir` (the on-disk size of a built tier).
-fn dir_size_bytes(dir: &Path) -> u64 {
-    let mut total = 0;
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return 0;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            total += dir_size_bytes(&path);
-        } else if let Ok(meta) = path.metadata() {
-            total += meta.len();
-        }
-    }
-    total
-}
 
 /// Resolve the `tokenizer.json` to copy into each tier: the explicit env override, then
 /// `<native>/tokenizer.json`, then the cached `SceneWorks/wan2.2-t2v-a14b-mlx` turnkey's
@@ -149,12 +133,7 @@ fn wan_t2v_14b_build_tiers() {
                 "built {tier} tier is missing {file}"
             );
         }
-        let size = dir_size_bytes(&out_dir);
-        // Machine-readable line for backfilling the manifest sizes.
-        eprintln!(
-            "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
-            out_dir.display()
-        );
+        report_tier(tier, &out_dir);
     }
     eprintln!(
         "done — upload the tier subdirs:\n  hf upload SceneWorks/wan2.2-t2v-a14b-mlx {} --include 'bf16/*' 'q8/*' 'q4/*'",

--- a/crates/sceneworks-worker/src/wan_ti2v_5b_tier_build.rs
+++ b/crates/sceneworks-worker/src/wan_ti2v_5b_tier_build.rs
@@ -39,6 +39,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::smoke_support::{report_tier, QUANT_TIERS};
 use mlx_rs::Array;
 
 /// The five files that make a TI2V-5B tier subdir COMPLETE for the load path
@@ -52,29 +53,8 @@ const TIER_FILES: &[&str] = &[
     "config.json",
 ];
 
-/// The two quantized tiers to derive from the bf16 output: `(subdir, bits)`. Group 64 (the canonical
-/// Wan/mflux default the load path `WanModelConfig::from_config_json` assumes and reconstructs).
-const QUANT_TIERS: &[(&str, i32)] = &[("q8", 8), ("q4", 4)];
-
 /// The Wan transformer quant group size (mflux/reference default; matches the A14B tiers).
 const GROUP_SIZE: i32 = 64;
-
-/// Recursively sum the byte size of every file under `dir` (the on-disk size of a built tier).
-fn dir_size_bytes(dir: &Path) -> u64 {
-    let mut total = 0;
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return 0;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            total += dir_size_bytes(&path);
-        } else if let Ok(meta) = path.metadata() {
-            total += meta.len();
-        }
-    }
-    total
-}
 
 /// Resolve the `tokenizer.json` to copy into each tier: the explicit env override, then
 /// `<native>/tokenizer.json`, then the native `google/umt5-xxl/tokenizer.json` (where the upstream
@@ -128,15 +108,6 @@ fn assert_tier_complete(out_dir: &Path, tier: &str) {
             "built {tier} tier is missing {file}"
         );
     }
-}
-
-/// Print the machine-readable `[[TIER]]` line for backfilling the manifest sizes.
-fn report_tier(tier: &str, out_dir: &Path) {
-    let size = dir_size_bytes(out_dir);
-    eprintln!(
-        "[[TIER]] {{\"tier\":\"{tier}\",\"dir\":\"{}\",\"diskSizeBytes\":{size}}}",
-        out_dir.display()
-    );
 }
 
 /// Derive a quantized tier (`q8`/`q4`) from the already-built dense `bf16/` tier: quantize the DiT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,11 +79,11 @@ services:
       HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
       # "Refine my prompt" (sc-2041 / sc-5500) runs in-process on the candle TextLlm
       # provider and downloads on demand. Optionally override the default model repo.
       PROMPT_REFINE_MODEL: ${PROMPT_REFINE_MODEL:-}
       PROMPT_REFINE_MAX_NEW_TOKENS: ${PROMPT_REFINE_MAX_NEW_TOKENS:-512}
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
       - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
@@ -131,7 +131,6 @@ services:
       HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
       HF_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
       HUGGINGFACE_HUB_CACHE: ${SCENEWORKS_HUGGINGFACE_HUB_CACHE:-/sceneworks/data/cache/huggingface/hub}
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
     volumes:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
       - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
@@ -139,15 +138,6 @@ services:
     depends_on:
       api:
         condition: service_healthy
-    # Keep GPU visibility available for explicit Rust GPU auto mode.
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-
   web:
     build:
       context: .

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -47,7 +47,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id"],
+        "required": ["id", "name", "family"],
         "additionalProperties": false,
         "properties": {
           "id": {

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -124,7 +124,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "name", "type"],
+        "required": ["id", "name", "family", "type"],
         "additionalProperties": false,
         "allOf": [
           {

--- a/scripts/spike_lokr_roundtrip.py
+++ b/scripts/spike_lokr_roundtrip.py
@@ -124,17 +124,25 @@ def run(kind):
             "reload_match": reload_match, "delta": delta_vs_base}
 
 
-lokr = run("lokr")
-lora = run("lora")
+def main():
+    lokr = run("lokr")
+    lora = run("lora")
 
-print("\n===== SUMMARY =====")
-print(f"  LoRA  params={lora['params']:,}  bytes={lora['bytes']:,}")
-print(f"  LoKr  params={lokr['params']:,}  bytes={lokr['bytes']:,}")
-ratio = lora["bytes"] / max(lokr["bytes"], 1)
-print(f"  LoKr is {ratio:.2f}x smaller on disk than LoRA at r={RANK}")
-print(f"  LoKr inference-reload OK: {lokr['reload_match']}   LoRA inference-reload OK: {lora['reload_match']}")
-print("\n  Why load_lora_weights() can't consume LoKr:")
-print(f"    LoRA keys look like:  {lora['keys'][0]}")
-print(f"    LoKr keys look like:  {lokr['keys'][0]}")
-print("    diffusers' converter expects lora_A/lora_B (or kohya lora_down/lora_up);")
-print("    LoKr emits lokr_w1/lokr_w2/lokr_t2 -> unrecognized -> must use PEFT injection.")
+    print("\n===== SUMMARY =====")
+    print(f"  LoRA  params={lora['params']:,}  bytes={lora['bytes']:,}")
+    print(f"  LoKr  params={lokr['params']:,}  bytes={lokr['bytes']:,}")
+    ratio = lora["bytes"] / max(lokr["bytes"], 1)
+    print(f"  LoKr is {ratio:.2f}x smaller on disk than LoRA at r={RANK}")
+    print(
+        "  LoKr inference-reload OK: "
+        f"{lokr['reload_match']}   LoRA inference-reload OK: {lora['reload_match']}"
+    )
+    print("\n  Why load_lora_weights() can't consume LoKr:")
+    print(f"    LoRA keys look like:  {lora['keys'][0]}")
+    print(f"    LoKr keys look like:  {lokr['keys'][0]}")
+    print("    diffusers' converter expects lora_A/lora_B (or kohya lora_down/lora_up);")
+    print("    LoKr emits lokr_w1/lokr_w2/lokr_t2 -> unrecognized -> must use PEFT injection.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/rust_api_harness.py
+++ b/tests/rust_api_harness.py
@@ -11,7 +11,7 @@ of truth for those fixtures so they can't diverge again.
 from __future__ import annotations
 
 import json
-import socket
+import re
 import subprocess
 import threading
 import time
@@ -30,11 +30,28 @@ PNG_1X1 = (
 )
 
 
-def free_port() -> int:
-    """Bind an ephemeral loopback port and hand back its number for the API."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+LISTENING_ADDRESS_RE = re.compile(
+    r"""api_listening.*?address(?:\\?["']?\s*[:=]\s*\\?["']?)"""
+    r"""(?P<address>\[[0-9a-fA-F:]+\]|[0-9.]+):(?P<port>[0-9]+)"""
+)
+
+
+def listening_url_from_log(log: str) -> str | None:
+    """Extract the API's authoritative port-0 bound address from tracing output."""
+    match = LISTENING_ADDRESS_RE.search(log)
+    if not match:
+        return None
+    host = match.group("address")
+    if host in {"0.0.0.0", "[::]"}:
+        host = "127.0.0.1"
+    return f"http://{host}:{match.group('port')}"
+
+
+def enable_api_listening_log(env: dict[str, str]) -> None:
+    """Keep the authoritative port-0 event visible under restrictive ambient logs."""
+    directive = "sceneworks_rust_api::server=info"
+    ambient = env.get("RUST_LOG", "").strip()
+    env["RUST_LOG"] = f"{ambient},{directive}" if ambient else directive
 
 
 def safetensors_bytes() -> bytes:
@@ -60,11 +77,10 @@ class SpawnedProcess:
     fills (~64 KB) -- the test then hangs until its deadline and is mis-reported
     as "job did not reach status" rather than the real cause.
 
-    This wrapper sends ``stdout`` to ``DEVNULL`` (the previous code captured it
-    but never read it) and drains ``stderr`` on a background daemon thread into an
-    in-memory buffer, so the child can always make progress. ``stderr_text()``
-    returns everything captured so far for failure messages, preserving the
-    stderr-on-early-exit debuggability the callers relied on.
+    This wrapper drains both ``stdout`` and ``stderr`` on background daemon
+    threads into one in-memory buffer, so the child can always make progress.
+    SceneWorks tracing writes to stdout, while compiler/process failures use
+    stderr; port discovery and diagnostics therefore need both streams.
 
     It delegates the small slice of the ``Popen`` surface the tests use
     (``poll``/``returncode``/``terminate``/``wait``/``kill``) so it drops in for
@@ -75,13 +91,22 @@ class SpawnedProcess:
         self._popen = popen
         self._chunks: list[str] = []
         self._lock = threading.Lock()
-        self._thread = threading.Thread(
-            target=self._drain, name="spawned-stderr-drain", daemon=True
-        )
-        self._thread.start()
+        self._threads = [
+            threading.Thread(
+                target=self._drain,
+                args=(stream,),
+                name=f"spawned-{name}-drain",
+                daemon=True,
+            )
+            for name, stream in (
+                ("stdout", self._popen.stdout),
+                ("stderr", self._popen.stderr),
+            )
+        ]
+        for thread in self._threads:
+            thread.start()
 
-    def _drain(self) -> None:
-        stream = self._popen.stderr
+    def _drain(self, stream) -> None:
         if stream is None:
             return
         # Iterating a text-mode pipe yields lines until EOF (child exit/close),
@@ -91,13 +116,28 @@ class SpawnedProcess:
                 self._chunks.append(line)
 
     def stderr_text(self) -> str:
-        """Return the child's captured stderr. If the child has already exited,
-        wait briefly for the drain thread to consume the final buffered bytes so
-        the failure message is complete."""
+        """Return the child's captured output. If the child has already exited,
+        wait briefly for both drain threads to consume their final buffered bytes."""
         if self._popen.poll() is not None:
-            self._thread.join(timeout=5)
+            for thread in self._threads:
+                thread.join(timeout=5)
         with self._lock:
             return "".join(self._chunks)
+
+    def wait_for_listening_url(self, timeout_seconds: float = 30.0) -> str:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if url := listening_url_from_log(self.stderr_text()):
+                return url
+            if self.poll() is not None:
+                raise AssertionError(
+                    f"Rust API exited early with code {self.returncode}: {self.stderr_text()}"
+                )
+            time.sleep(0.05)
+        raise AssertionError(
+            "Rust API did not report its bound address within "
+            f"{timeout_seconds:.0f}s: {self.stderr_text()}"
+        )
 
     # -- Popen delegation (only what the tests touch) ------------------------
     def poll(self) -> int | None:
@@ -120,15 +160,14 @@ class SpawnedProcess:
 def spawn_process(command, *, cwd, env) -> SpawnedProcess:
     """Spawn an API/worker binary with non-blocking pipe handling (F-042).
 
-    ``stdout`` is discarded to ``DEVNULL`` (it was captured but never read) and
-    ``stderr`` is drained by a background thread -- neither can fill and block the
-    child, so a chatty binary can no longer hang the test. Returns a
+    ``stdout`` and ``stderr`` are drained by background threads -- neither can
+    fill and block the child, so a chatty binary can no longer hang the test. Returns a
     :class:`SpawnedProcess` that stands in for the old raw ``Popen`` handle."""
     popen = subprocess.Popen(
         command,
         cwd=cwd,
         env=env,
-        stdout=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -14,10 +14,7 @@ self-contained readers are inlined below rather than imported from
 ``scene_worker``, which would re-couple these audits to the retired worker):
 
   * ``_strip_jsonc_comments`` + ``_load_builtin_models_manifest`` parse the file
-    to a dict for the capability / UI-wiring audits.
-  * ``_manifest_brace_walker`` walks balanced braces so a URL containing ``//``
-    inside an entry doesn't trip a naive comment strip; used by the per-model
-    ``mlx`` block audits.
+    to a dict for every capability, UI-wiring, and per-model ``mlx`` audit.
 
 The three character_image ENGINE-WIRING guards that used to live here additionally
 cross-referenced the retired Python worker's ``MODEL_TARGETS`` table via a lazy
@@ -604,6 +601,7 @@ def _sample_audio_model_entry() -> dict:
     return {
         "id": "sample_audio_speech",
         "name": "Sample Audio Speech",
+        "family": "sample_audio",
         "type": "audio",
         # `audio` is a picker (non-utility) type, so the schema now requires a
         # `ui.promptGuide` with a title/path (sc-13783, reconciled with
@@ -647,6 +645,26 @@ def test_schema_accepts_audio_type_and_audio_sub_block():
         f"- {'.'.join(map(str, error.absolute_path)) or '<root>'}: {error.message}"
         for error in errors
     )
+
+
+def test_model_schema_requires_entry_identity():
+    """Every model entry carries the id, display name, family, and type used by
+    routing and catalog consumers."""
+    schema = _load_schema(SCHEMA_PATH)
+    for field in ("id", "name", "family", "type"):
+        entry = _sample_audio_model_entry()
+        del entry[field]
+        errors = list(
+            jsonschema.Draft202012Validator(schema).iter_errors(
+                {"schemaVersion": 1, "models": [entry]}
+            )
+        )
+        assert any(
+            error.validator == "required"
+            and field in error.validator_value
+            and list(error.absolute_path) == ["models", 0]
+            for error in errors
+        ), f"a model entry without `{field}` must be rejected by the entry identity contract"
 
 
 def test_schema_rejects_unknown_field_under_audio_sub_block():
@@ -820,16 +838,11 @@ _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 # crates/sceneworks-core/src/builtin_manifests.rs.
 _COREQUISITE_REVISION_MIGRATION_PENDING: frozenset[tuple[str, str]] = frozenset(
     {
-        ("qwen_image", "SceneWorks/qwen-image-2512-fun-controlnet-union"),
         # ("ltx_2_3", "SceneWorks/ltx-2.3-mlx") pinned in sc-13683 (the gemma coRequisite now carries
         # the full 40-hex LTX_BUNDLE_REVISION); removed here + in the Rust twin to keep both green.
         ("ltx_2_3_eros", "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments"),
         ("wan_2_2_t2v_14b", "lightx2v/Wan2.2-Lightning"),
         ("wan_2_2_i2v_14b", "lightx2v/Wan2.2-Lightning"),
-        ("pid_qwenimage", "SceneWorks/gemma-2-2b-it"),
-        ("pid_flux", "SceneWorks/gemma-2-2b-it"),
-        ("pid_flux2", "SceneWorks/gemma-2-2b-it"),
-        ("pid_sdxl", "SceneWorks/gemma-2-2b-it"),
     }
 )
 
@@ -861,6 +874,20 @@ def test_corequisite_downloads_pin_a_full_sha_revision():
         "co-requisite downloads must pin a 40-hex commit SHA (F-029, sc-13659); these are "
         f"unpinned and NOT tracked for the sc-13591 migration: {sorted(unexpected)}"
     )
+
+
+def test_first_party_downloads_pin_a_full_sha_revision():
+    """SceneWorks controls these repositories, so the shipped catalog must never
+    silently move an installed artifact when a repository's main branch changes."""
+    gaps = []
+    for model in _load_builtin_models_manifest()["models"]:
+        for download in model.get("downloads", []):
+            repo = download.get("repo", "")
+            if repo.startswith("SceneWorks/") and not _FULL_SHA_RE.fullmatch(
+                download.get("revision", "")
+            ):
+                gaps.append((model["id"], repo, download.get("variant")))
+    assert not gaps, f"first-party downloads must pin immutable revisions: {gaps}"
 
 
 def test_corequisite_revision_migration_allowlist_has_no_stale_entries():
@@ -899,6 +926,7 @@ def _model_entry_with_download(download: dict) -> dict:
     return {
         "id": "sample_pinned_model",
         "name": "Sample Pinned Model",
+        "family": "sample",
         "type": "image",
         # `image` is a picker (non-utility) type, so the schema now requires a
         # `ui.promptGuide` with a title/path (sc-13783, reconciled with
@@ -1133,46 +1161,8 @@ def test_manifest_constraint_contract_registry_is_complete_and_live():
             )
 
 
-def _manifest_brace_walker():
-    # Helper for the mlx-block manifest tests. Returns (raw, find_entry_block,
-    # find_mlx_block) that walk balanced braces so a URL containing `//` (in
-    # the entry text) doesn't trip a naive jsonc strip.
-    raw = MANIFEST_PATH.read_text(encoding="utf-8")
-
-    def find_balanced_block(start_index: int) -> str:
-        depth = 0
-        for index in range(start_index, len(raw)):
-            ch = raw[index]
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    return raw[start_index : index + 1]
-        raise AssertionError(f"unterminated brace block from index {start_index}")
-
-    def find_entry_block(model_id: str) -> str:
-        anchor = raw.index(f'"id": "{model_id}"')
-        start = raw.rfind("{", 0, anchor)
-        assert start != -1, f"entry start brace for {model_id} not found"
-        return find_balanced_block(start)
-
-    def find_mlx_block(entry_block: str) -> str:
-        match = re.search(r'"mlx"\s*:\s*\{', entry_block)
-        assert match, "entry block has no mlx block"
-        # Resolve the entry block's position in the raw manifest, then walk
-        # balanced braces from the actual opening brace so nested limits {...}
-        # are captured (Qwen carries a sampler/scheduler limits override, FLUX
-        # does not).
-        entry_start = raw.index(entry_block)
-        mlx_open = entry_start + match.end() - 1
-        return find_balanced_block(mlx_open)
-
-    return raw, find_entry_block, find_mlx_block
-
-
 # ---------------------------------------------------------------------------
-# Per-model `mlx` block structural audits (pure manifest; brace-walker based).
+# Per-model `mlx` block structural audits (parsed JSONC manifest).
 # Extracted from tests/test_worker_image_adapters.py (sc-8861 / F-059).
 # ---------------------------------------------------------------------------
 
@@ -1181,17 +1171,14 @@ def test_flux_manifest_has_mlx_block():
     # Manifest-driven auto-dispatch + Model Manager memory tier (sc-1970).
     # The Rust API owns the canonical jsonc parser; here we just confirm both
     # FLUX entries carry an `mlx` block and the contents look right.
-    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
+    models = {model["id"]: model for model in _load_builtin_models_manifest()["models"]}
 
     for model_id in ("flux_schnell", "flux_dev"):
-        block = find_entry_block(model_id)
-        mlx_block = find_mlx_block(block)
-        quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
-        mem_match = re.search(r'"minMemoryGb"\s*:\s*(\d+)', mlx_block)
-        assert quant_match and int(quant_match.group(1)) in {3, 4, 5, 6, 8}, (
+        mlx = models[model_id]["mlx"]
+        assert mlx["quantize"] in {3, 4, 5, 6, 8}, (
             f"{model_id} mlx.quantize must be a supported quant level (sc-1970)"
         )
-        assert mem_match and int(mem_match.group(1)) > 0, (
+        assert mlx["minMemoryGb"] > 0, (
             f"{model_id} mlx.minMemoryGb must be a positive int (sc-1970)"
         )
 
@@ -1201,24 +1188,25 @@ def test_qwen_image_manifest_has_mlx_block():
     # override (mflux's loop is sealed on "linear" — match the wan_2_2
     # precedent of restricting the menu to default-only when the MLX path is
     # the active backend, epic 1753 §14).
-    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
-    block = find_entry_block("qwen_image")
-    mlx_block = find_mlx_block(block)
-    quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
-    mem_match = re.search(r'"minMemoryGb"\s*:\s*(\d+)', mlx_block)
-    assert quant_match and int(quant_match.group(1)) in {3, 4, 5, 6, 8}, (
+    model = next(
+        model
+        for model in _load_builtin_models_manifest()["models"]
+        if model["id"] == "qwen_image"
+    )
+    mlx = model["mlx"]
+    assert mlx["quantize"] in {3, 4, 5, 6, 8}, (
         "qwen_image mlx.quantize must be a supported quant level (sc-1972)"
     )
-    assert mem_match and int(mem_match.group(1)) > 0, (
+    assert mlx["minMemoryGb"] > 0, (
         "qwen_image mlx.minMemoryGb must be a positive int (sc-1972)"
     )
     # MLX sampler/scheduler menu (epic 7114 P5, sc-7126): the native MLX engine now
     # routes through the unified curated sampler/scheduler framework (the old mflux
     # linear-only loop is gone), so the mlx block advertises the curated menu.
-    assert '"dpmpp_2m"' in mlx_block and '"uni_pc"' in mlx_block, (
+    assert {"dpmpp_2m", "uni_pc"} <= set(mlx["limits"]["samplers"]), (
         "qwen_image mlx must advertise the curated sampler menu (epic 7114)"
     )
-    assert '"sgm_uniform"' in mlx_block, (
+    assert "sgm_uniform" in mlx["limits"]["schedulers"], (
         "qwen_image mlx must advertise the curated scheduler menu (epic 7114)"
     )
 
@@ -1226,47 +1214,45 @@ def test_qwen_image_manifest_has_mlx_block():
 def test_flux2_true_v2_manifest_install_time_conversion():
     # sc-2235: the entry must declare the install-time conversion contract the
     # Rust convert job + adapter rely on.
-    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
-    block = find_entry_block("flux2_klein_9b_true_v2")
-    assert '"macOnly": true' in block
-    assert '"adapter": "mlx_flux2"' in block
+    model = next(
+        model
+        for model in _load_builtin_models_manifest()["models"]
+        if model["id"] == "flux2_klein_9b_true_v2"
+    )
+    assert model["macOnly"] is True
+    assert model["adapter"] == "mlx_flux2"
     # Only the bf16 single-file is pulled (not the whole 73 GB repo).
-    assert "Flux2-Klein-9B-True-v2-bf16.safetensors" in block
+    assert model["downloads"][0]["files"] == ["Flux2-Klein-9B-True-v2-bf16.safetensors"]
     # Undistilled defaults differ from the 4-step distill.
-    assert re.search(r'"steps"\s*:\s*24', block)
-
-    mlx_block = find_mlx_block(block)
-    assert '"requiresConversion": true' in mlx_block
-    assert '"converter": "flux2_klein_diffusers"' in mlx_block
-    assert '"convertSourceRepo": "wikeeyang/Flux2-Klein-9B-True-V2"' in mlx_block
-    assert '"convertBaseRepo": "black-forest-labs/FLUX.2-klein-9B"' in mlx_block
-    assert re.search(r'"quantize"\s*:\s*8', mlx_block)
+    assert model["defaults"]["steps"] == 24
+    mlx = model["mlx"]
+    assert mlx["requiresConversion"] is True
+    assert mlx["converter"] == "flux2_klein_diffusers"
+    assert mlx["convertSourceRepo"] == "wikeeyang/Flux2-Klein-9B-True-V2"
+    assert mlx["convertBaseRepo"] == "black-forest-labs/FLUX.2-klein-9B"
+    assert mlx["quantize"] == 8
 
 
 def test_flux2_klein_manifest_entries_present():
     # Both flux2_klein_9b and flux2_klein_9b_kv must be present in the
     # builtin manifest with the expected adapter + family + mlx block.
-    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
+    models = {model["id"]: model for model in _load_builtin_models_manifest()["models"]}
     # Both ids expose the same capability set: -kv is no longer gated to
     # character_image only — it runs plain txt2img on par with the base 9B,
     # the cache just doesn't engage without a reference (sc-2173).
     for model_id in ("flux2_klein_9b", "flux2_klein_9b_kv"):
-        block = find_entry_block(model_id)
-        assert '"adapter": "mlx_flux2"' in block, model_id
-        assert '"family": "flux2-klein"' in block, model_id
-        assert '"macOnly": true' in block, model_id
+        model = models[model_id]
+        assert model["adapter"] == "mlx_flux2", model_id
+        assert model["family"] == "flux2-klein", model_id
+        assert model["macOnly"] is True, model_id
         # sc-8711 (epic 8506): re-hosted as a public, ungated SceneWorks MLX quant-matrix
         # turnkey (q4/q8/bf16), so the entry is `gated: false` with no credentialHost — the
         # FLUX Non-Commercial LICENSE.md travels with the weights.
-        assert '"gated": false' in block, model_id
-        mlx_block = find_mlx_block(block)
-        quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
-        assert quant_match is not None, f"{model_id}: mlx.quantize missing"
+        assert model["gated"] is False, model_id
         # quantize records the DEFAULT tier (q4); the load Quant is forced to None so the
         # dense bf16 Qwen3 TE is preserved (DENSE_TE_TIER_MODELS).
-        assert int(quant_match.group(1)) == 4, f"{model_id}: default tier should be q4 (sc-8711)"
-        assert '"text_to_image"' in block, model_id
-        assert '"character_image"' in block, model_id
+        assert model["mlx"]["quantize"] == 4, f"{model_id}: default tier should be q4 (sc-8711)"
+        assert {"text_to_image", "character_image"} <= set(model["capabilities"]), model_id
 
 
 def test_z_image_turbo_manifest_has_mlx_block():
@@ -1274,23 +1260,24 @@ def test_z_image_turbo_manifest_has_mlx_block():
     # override (mflux's loop is sealed on "linear" — match the wan_2_2 /
     # qwen_image precedents of restricting the menu to default-only when the
     # MLX path is the active backend, epic 1753 §14).
-    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
-    block = find_entry_block("z_image_turbo")
-    mlx_block = find_mlx_block(block)
-    quant_match = re.search(r'"quantize"\s*:\s*(\d+)', mlx_block)
-    mem_match = re.search(r'"minMemoryGb"\s*:\s*(\d+)', mlx_block)
-    assert quant_match and int(quant_match.group(1)) in {3, 4, 5, 6, 8}, (
+    model = next(
+        model
+        for model in _load_builtin_models_manifest()["models"]
+        if model["id"] == "z_image_turbo"
+    )
+    mlx = model["mlx"]
+    assert mlx["quantize"] in {3, 4, 5, 6, 8}, (
         "z_image_turbo mlx.quantize must be a supported quant level (sc-2145)"
     )
-    assert mem_match and int(mem_match.group(1)) > 0, (
+    assert mlx["minMemoryGb"] > 0, (
         "z_image_turbo mlx.minMemoryGb must be a positive int (sc-2145)"
     )
     # epic 7114 P5 (sc-7126): the native MLX engine adopted the unified curated
     # sampler/scheduler framework, so the mflux linear-only restriction is gone.
-    assert '"dpmpp_2m"' in mlx_block and '"uni_pc"' in mlx_block, (
+    assert {"dpmpp_2m", "uni_pc"} <= set(mlx["limits"]["samplers"]), (
         "z_image_turbo mlx must advertise the curated sampler menu (epic 7114)"
     )
-    assert '"sgm_uniform"' in mlx_block, (
+    assert "sgm_uniform" in mlx["limits"]["schedulers"], (
         "z_image_turbo mlx must advertise the curated scheduler menu (epic 7114)"
     )
 
@@ -1424,11 +1411,12 @@ def test_sdxl_manifest_has_mlx_block():
     # sdxl carries an mlx block (no `limits` override here — the MLX SDXL schedule
     # matches the torch EulerDiscrete default, and there's no per-model sampler menu
     # in the sdxl manifest entry to limit).
-    _, find_entry_block, find_mlx_block = _manifest_brace_walker()
-    block = find_entry_block("sdxl")
-    mlx_block = find_mlx_block(block)
-    mem_match = re.search(r'"minMemoryGb"\s*:\s*(\d+)', mlx_block)
-    assert mem_match and int(mem_match.group(1)) > 0, (
+    model = next(
+        model
+        for model in _load_builtin_models_manifest()["models"]
+        if model["id"] == "sdxl"
+    )
+    assert model["mlx"]["minMemoryGb"] > 0, (
         "sdxl mlx.minMemoryGb must be a positive int"
     )
 
@@ -1554,20 +1542,19 @@ def test_builtin_loras_manifest_satisfies_authoring_schema():
     assert not errors, "builtin.loras.jsonc violates lora-manifest.schema.json:\n" + _format_errors(errors)
 
 
-def test_lora_schema_requires_entry_id():
-    """A LoRA entry must carry `id` (the picker / job payloads / compatibility
-    checks all key on it). Discriminate on the `required` keyword + its value so a
-    schema revert dropping `required:[id]` goes red rather than passing on an
-    unrelated error."""
-    entry = _sample_lora_entry()
-    del entry["id"]
-    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
-    assert any(
-        error.validator == "required"
-        and error.validator_value == ["id"]
-        and list(error.absolute_path) == ["loras", 0]
-        for error in errors
-    ), "a LoRA entry without `id` must be rejected by the entry's required:['id']"
+def test_lora_schema_requires_entry_identity():
+    """Every LoRA entry carries the complete identity consumed by catalog and
+    compatibility paths: id, display name, and normalized family."""
+    for field in ("id", "name", "family"):
+        entry = _sample_lora_entry()
+        del entry[field]
+        errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+        assert any(
+            error.validator == "required"
+            and field in error.validator_value
+            and list(error.absolute_path) == ["loras", 0]
+            for error in errors
+        ), f"a LoRA entry without `{field}` must be rejected by the entry identity contract"
 
 
 def test_lora_schema_rejects_a_typod_source_key():

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -21,7 +21,7 @@ import pytest
 # between this file and test_rust_api_worker_smoke.py.
 from rust_api_harness import (
     PNG_1X1,
-    free_port,
+    enable_api_listening_log,
     safetensors_bytes,
     spawn_process,
     wait_for_health,
@@ -188,19 +188,18 @@ class ServerApiHarness:
         self.root = root
         self.runtime = "rust"
         write_contract_manifests(root / "config")
-        port = free_port()
-        self.base_url = f"http://127.0.0.1:{port}"
         env = os.environ.copy()
         env.update(
             {
                 "SCENEWORKS_API_HOST": "127.0.0.1",
-                "SCENEWORKS_API_PORT": str(port),
+                "SCENEWORKS_API_PORT": "0",
                 "SCENEWORKS_DATA_DIR": str(root / "data"),
                 "SCENEWORKS_CONFIG_DIR": str(root / "config"),
                 "SCENEWORKS_JOBS_DB_PATH": str(root / "data" / "cache" / "jobs.db"),
                 "SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE": "1",
             }
         )
+        enable_api_listening_log(env)
         rust_binary = os.getenv("SCENEWORKS_RUST_API_BINARY")
         command = (
             [rust_binary]
@@ -208,6 +207,7 @@ class ServerApiHarness:
             else ["cargo", "run", "-q", "-p", "sceneworks-rust-api"]
         )
         self.process = spawn_process(command, cwd=ROOT, env=env)
+        self.base_url = self.process.wait_for_listening_url()
         wait_for_health(self.base_url, self.process, "rust")
         self.client = httpx.Client(base_url=self.base_url, timeout=10)
 

--- a/tests/test_rust_api_harness.py
+++ b/tests/test_rust_api_harness.py
@@ -1,0 +1,23 @@
+from rust_api_harness import enable_api_listening_log, listening_url_from_log
+
+
+def test_listening_url_from_text_and_json_tracing_output():
+    assert (
+        listening_url_from_log(
+            "INFO sceneworks_rust_api: SceneWorks API listening "
+            "event=\"api_listening\" address=127.0.0.1:43125"
+        )
+        == "http://127.0.0.1:43125"
+    )
+    assert (
+        listening_url_from_log(
+            '{"event":"api_listening","address":"127.0.0.1:51234"}'
+        )
+        == "http://127.0.0.1:51234"
+    )
+
+
+def test_api_listening_event_survives_restrictive_ambient_logging():
+    env = {"RUST_LOG": "warn"}
+    enable_api_listening_log(env)
+    assert env["RUST_LOG"] == "warn,sceneworks_rust_api::server=info"

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -21,8 +21,8 @@ from conftest import require_tool
 # file and test_rust_api_contract_snapshots.py.
 from rust_api_harness import (
     PNG_1X1,
+    enable_api_listening_log,
     SpawnedProcess,
-    free_port,
     minimal_safetensors as _minimal_safetensors,
     spawn_process,
     wait_for_health,
@@ -248,21 +248,21 @@ def rust_api(tmp_path):
         "SCENEWORKS_RUST_API_BINARY", "sceneworks-rust-api", "the Rust API smoke test"
     )
 
-    port = free_port()
-    base_url = f"http://127.0.0.1:{port}"
     env = os.environ.copy()
     env.update(
         {
             "SCENEWORKS_API_HOST": "127.0.0.1",
-            "SCENEWORKS_API_PORT": str(port),
+            "SCENEWORKS_API_PORT": "0",
             "SCENEWORKS_DATA_DIR": str(tmp_path / "data"),
             "SCENEWORKS_CONFIG_DIR": str(tmp_path / "config"),
             "SCENEWORKS_JOBS_DB_PATH": str(tmp_path / "cache" / "jobs.db"),
             "SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE": "1",
         }
     )
+    enable_api_listening_log(env)
     process = spawn_process(command, cwd=ROOT, env=env)
     try:
+        base_url = process.wait_for_listening_url()
         wait_for_health(base_url, process)
         yield base_url
     finally:


### PR DESCRIPTION
## Summary
- close the exact-current F-052 through F-060 residuals after all superseding dependency PRs
- consolidate confined media resolution, sampling, CRUD hooks, manifest writes, preference updates, input validation, and platform helpers
- harden redaction, SSRF ranges, model revision pinning, dynamic-port test harnesses, React refresh behavior, and schema identity contracts

## Validation
- Web ESLint with zero warnings, production build, 185 files / 2,583 tests
- Native Rust all-target clippy with -D warnings; core 603, API 398, worker 1,058, MCP 38, image-quality 30 passing tests
- Linux no-Candle cross-target clippy; Linux Candle worker clippy and API typecheck
- Scaffold, compose, manifest, and harness contract checks
- Independent adversarial review, all five findings fixed, follow-up review clean

## Environment notes
- Docker Desktop daemon was stopped locally; equivalent installed-target no-Candle cross-clippy passed
- macOS Trash and one API-managed utility-worker smoke are sandbox-constrained; hosted CI is authoritative for those paths

Shortcut: https://app.shortcut.com/trefry/story/13652/review-low-prior-review-2026-07-12-low-clusters-f-052-f-060-all-still-open