### PR TITLE
perf(assets): remove row-scaled clean-list I/O (sc-14799)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6244,6 +6244,7 @@ version = "0.8.0"
 dependencies = [
  "directories",
  "getrandom 0.3.4",
+ "image",
  "imagesize",
  "libc",
  "mime_guess",
@@ -6252,6 +6253,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6245,6 +6245,7 @@ dependencies = [
  "directories",
  "getrandom 0.3.4",
  "imagesize",
+ "libc",
  "mime_guess",
  "parking_lot",
  "rusqlite",

--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -32,6 +32,7 @@ pub(crate) async fn list_assets(
         timeline_reads = filesystem_operations.timeline_reads,
         character_reads = filesystem_operations.character_reads,
         poster_stats = filesystem_operations.poster_stats,
+        poster_reads = filesystem_operations.poster_reads,
         index_marker_reads = filesystem_operations.index_marker_reads,
         index_marker_writes = filesystem_operations.index_marker_writes,
         index_marker_removes = filesystem_operations.index_marker_removes,
@@ -83,6 +84,34 @@ pub(crate) async fn get_asset(
     Ok(Json(
         project_call(state, move |store| store.get_asset(&project_id, &asset_id)).await?,
     ))
+}
+
+pub(crate) async fn get_asset_poster(
+    State(state): State<AppState>,
+    Path((project_id, asset_id, poster_sha256)): Path<(String, String, String)>,
+) -> Result<Response, ApiError> {
+    let poster = project_call(state, move |store| {
+        store.get_asset_poster(&project_id, &asset_id, &poster_sha256)
+    })
+    .await?;
+    let length = poster.bytes.len().to_string();
+    Ok((
+        [
+            (header::CONTENT_TYPE, "image/jpeg".to_owned()),
+            (header::CONTENT_LENGTH, length),
+            (
+                header::CACHE_CONTROL,
+                "private, max-age=31536000, immutable".to_owned(),
+            ),
+            (header::ETAG, format!("\"{}\"", poster.sha256)),
+            (
+                HeaderName::from_static("x-content-type-options"),
+                "nosniff".to_owned(),
+            ),
+        ],
+        poster.bytes,
+    )
+        .into_response())
 }
 
 pub(crate) async fn import_asset(

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -100,7 +100,7 @@ mod projects;
 use projects::{create_project, get_project, list_projects, reindex_project_endpoint};
 mod assets;
 use assets::{
-    delete_asset, get_asset, import_asset, list_assets, move_asset_to_character,
+    delete_asset, get_asset, get_asset_poster, import_asset, list_assets, move_asset_to_character,
     move_asset_to_library, purge_asset, sweep_stale_asset_uploads, update_asset_status,
     update_asset_tags, write_upload_field_to_dir, write_upload_field_to_temp_file,
 };
@@ -1078,6 +1078,10 @@ pub(crate) fn create_app_with_state(
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id",
             get(get_asset).delete(delete_asset),
+        )
+        .route(
+            "/api/v1/projects/:project_id/assets/:asset_id/poster/:poster_sha256",
+            get(get_asset_poster),
         )
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id/purge",

--- a/apps/rust-api/src/tests/projects.rs
+++ b/apps/rust-api/src/tests/projects.rs
@@ -1,6 +1,14 @@
 //! rust-api projects tests (split from tests.rs, sc-11217 F-030).
 use super::support::*;
 
+fn jpeg_fixture(rgb: [u8; 3]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut bytes, 90)
+        .encode(&rgb, 1, 1, image::ExtendedColorType::Rgb8)
+        .expect("test JPEG encodes");
+    bytes
+}
+
 #[tokio::test]
 async fn advertised_asset_poster_route_serves_the_indexed_blob() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -8,11 +16,13 @@ async fn advertised_asset_poster_route_serves_the_indexed_blob() {
     let store =
         sceneworks_core::project_store::ProjectStore::new(&settings.data_dir, "test-version");
     let project = store.create_project("Poster endpoint").unwrap();
+    let other_project = store.create_project("Other poster endpoint").unwrap();
     let project_path = std::path::PathBuf::from(&project.path);
     let media = project_path.join("assets/videos/set/video.mp4");
+    let poster_bytes = jpeg_fixture([21, 43, 65]);
     std::fs::create_dir_all(media.parent().unwrap()).unwrap();
     std::fs::write(&media, b"video").unwrap();
-    std::fs::write(media.with_extension("poster.jpg"), b"poster-http").unwrap();
+    std::fs::write(media.with_extension("poster.jpg"), &poster_bytes).unwrap();
     store
         .persist_generated_asset(
             &project.id,
@@ -51,18 +61,35 @@ async fn advertised_asset_poster_route_serves_the_indexed_blob() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(headers["content-type"], "image/jpeg");
     assert_eq!(headers["x-content-type-options"], "nosniff");
-    assert_eq!(bytes, b"poster-http");
+    assert_eq!(bytes, poster_bytes);
 
     let wrong_url = poster_url
         .rsplit_once('/')
         .map(|(prefix, _)| format!("{prefix}/{}", "0".repeat(64)))
         .unwrap();
     assert_eq!(
-        request_raw(app, "GET", &wrong_url, Body::empty(), &[])
+        request_raw(app.clone(), "GET", &wrong_url, Body::empty(), &[])
             .await
             .0,
         StatusCode::NOT_FOUND,
         "a valid-shaped digest cannot select bytes from a different indexed version"
+    );
+
+    let wrong_project_url = poster_url.replacen(&project.id, &other_project.id, 1);
+    assert_eq!(
+        request_raw(app.clone(), "GET", &wrong_project_url, Body::empty(), &[])
+            .await
+            .0,
+        StatusCode::NOT_FOUND,
+        "a digest is scoped to the authoritative project"
+    );
+    let wrong_asset_url = poster_url.replacen("/assets/video/", "/assets/another-video/", 1);
+    assert_eq!(
+        request_raw(app, "GET", &wrong_asset_url, Body::empty(), &[])
+            .await
+            .0,
+        StatusCode::NOT_FOUND,
+        "a digest is scoped to the authoritative asset row"
     );
 }
 

--- a/apps/rust-api/src/tests/projects.rs
+++ b/apps/rust-api/src/tests/projects.rs
@@ -2,6 +2,71 @@
 use super::support::*;
 
 #[tokio::test]
+async fn advertised_asset_poster_route_serves_the_indexed_blob() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let store =
+        sceneworks_core::project_store::ProjectStore::new(&settings.data_dir, "test-version");
+    let project = store.create_project("Poster endpoint").unwrap();
+    let project_path = std::path::PathBuf::from(&project.path);
+    let media = project_path.join("assets/videos/set/video.mp4");
+    std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+    std::fs::write(&media, b"video").unwrap();
+    std::fs::write(media.with_extension("poster.jpg"), b"poster-http").unwrap();
+    store
+        .persist_generated_asset(
+            &project.id,
+            "job",
+            "set",
+            &json!({
+                "assetId": "video",
+                "mediaPath": "assets/videos/set/video.mp4",
+                "mimeType": "video/mp4",
+                "type": "video",
+                "displayName": "Video",
+                "createdAt": "2026-05-25T00:00:00Z",
+                "mode": "image_to_video",
+                "model": "wan",
+                "adapter": "wan",
+                "prompt": "x",
+            }),
+        )
+        .unwrap();
+
+    let app = create_app(settings).expect("app creates");
+    let (status, listed) = request(
+        app.clone(),
+        "GET",
+        &format!(
+            "/api/v1/projects/{}/assets?includeRejected=true&includeTrashed=true",
+            project.id
+        ),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let poster_url = listed[0]["posterUrl"].as_str().unwrap();
+    let (status, headers, bytes) =
+        request_raw(app.clone(), "GET", poster_url, Body::empty(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["content-type"], "image/jpeg");
+    assert_eq!(headers["x-content-type-options"], "nosniff");
+    assert_eq!(bytes, b"poster-http");
+
+    let wrong_url = poster_url
+        .rsplit_once('/')
+        .map(|(prefix, _)| format!("{prefix}/{}", "0".repeat(64)))
+        .unwrap();
+    assert_eq!(
+        request_raw(app, "GET", &wrong_url, Body::empty(), &[])
+            .await
+            .0,
+        StatusCode::NOT_FOUND,
+        "a valid-shaped digest cannot select bytes from a different indexed version"
+    );
+}
+
+#[tokio::test]
 async fn project_and_asset_routes_persist_contract_state() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let app = create_app(test_settings(&temp_dir)).expect("app creates");

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -15,14 +15,18 @@ serde_json = "1.0"
 mime_guess = "2.0"
 url = "2.5"
 # sc-6531 (Dataset Doctor): read image dimensions from the header without a full decode.
-# `imagesize` is pure-Rust and pulls in NO native image-codec build (libdav1d/nasm/meson),
-# keeping core decode-free and correct on the Windows candle lane — same reason
-# `media_convert` shells out to sips/ffmpeg instead of linking the `image` crate.
+# `imagesize` reads dataset dimensions without decoding. The poster verifier
+# below enables only the pure-Rust JPEG codec, avoiding native AVIF dependencies
+# (libdav1d/nasm/meson) that would break the Windows candle lane.
 imagesize = "0.13"
+# Indexed video posters are served as image/jpeg, so indexing fully decodes the
+# bounded payload instead of trusting the sibling `.poster.jpg` filename.
+image = { version = "0.25", default-features = false, features = ["jpeg"] }
 # sc-6531: SHA-256 of stored bytes = exact-duplicate key + the cache key for Tier-1
 # embeddings (epic 6529 §6.3). Pinned to the workspace's existing 0.10 line (worker + desktop)
 # so no new locked version appears.
 sha2 = "0.10"
+subtle = "2.6"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 # Purge sends asset media/sidecars to the OS trash (recoverable) instead of unlinking.

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -33,6 +33,9 @@ trash = { workspace = true }
 # cache uses volume + file index to distinguish atomic replacement.
 winapi-util = "0.1"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3.13"
 

--- a/crates/sceneworks-core/examples/assets_list_benchmark.rs
+++ b/crates/sceneworks-core/examples/assets_list_benchmark.rs
@@ -25,7 +25,7 @@ fn report(
         "{label}: assets={assets} elapsed_ms={:.3} fs_total={} registry_opens={} \
          registry_metadata_reads={} registry_content_reads={} path_stats={} directory_scans={} \
          sidecar_reads={} generation_set_reads={} timeline_reads={} character_reads={} \
-         poster_stats={} index_marker_reads={} index_marker_writes={} index_marker_removes={} \
+         poster_stats={} poster_reads={} index_marker_reads={} index_marker_writes={} index_marker_removes={} \
          directory_create_calls={} db_opens={}",
         elapsed.as_secs_f64() * 1_000.0,
         operations.total(),
@@ -39,6 +39,7 @@ fn report(
         operations.timeline_reads,
         operations.character_reads,
         operations.poster_stats,
+        operations.poster_reads,
         operations.index_marker_reads,
         operations.index_marker_writes,
         operations.index_marker_removes,
@@ -69,6 +70,7 @@ fn run(store: ProjectStore, project_id: &str, iterations: usize) {
         warm_operations.timeline_reads += operations.timeline_reads;
         warm_operations.character_reads += operations.character_reads;
         warm_operations.poster_stats += operations.poster_stats;
+        warm_operations.poster_reads += operations.poster_reads;
         warm_operations.index_marker_reads += operations.index_marker_reads;
         warm_operations.index_marker_writes += operations.index_marker_writes;
         warm_operations.index_marker_removes += operations.index_marker_removes;
@@ -91,6 +93,7 @@ fn run(store: ProjectStore, project_id: &str, iterations: usize) {
             timeline_reads: warm_operations.timeline_reads / iterations as u64,
             character_reads: warm_operations.character_reads / iterations as u64,
             poster_stats: warm_operations.poster_stats / iterations as u64,
+            poster_reads: warm_operations.poster_reads / iterations as u64,
             index_marker_reads: warm_operations.index_marker_reads / iterations as u64,
             index_marker_writes: warm_operations.index_marker_writes / iterations as u64,
             index_marker_removes: warm_operations.index_marker_removes / iterations as u64,

--- a/crates/sceneworks-core/examples/assets_list_benchmark.rs
+++ b/crates/sceneworks-core/examples/assets_list_benchmark.rs
@@ -110,20 +110,42 @@ fn synthetic(asset_count: usize, iterations: usize) {
     let project = store
         .create_project("Synthetic asset-list benchmark")
         .expect("synthetic project creates");
+    let project_path = PathBuf::from(&project.path);
     for index in 0..asset_count {
         let asset_id = format!("asset_{index:08}");
+        let generation_set_id = format!("set_{index:08}");
+        store
+            .write_generation_set(
+                &project.id,
+                "benchmark-job",
+                &json!({
+                    "id": generation_set_id,
+                    "mode": "image_to_video",
+                    "model": "benchmark",
+                    "prompt": "benchmark",
+                    "createdAt": "2026-07-25T00:00:00Z",
+                }),
+                None,
+            )
+            .expect("synthetic generation set persists");
+        let media_path = format!("assets/videos/{generation_set_id}/{asset_id}.mp4");
+        let poster_path = project_path.join(&media_path).with_extension("poster.jpg");
+        std::fs::create_dir_all(poster_path.parent().expect("poster parent"))
+            .expect("poster directory creates");
+        std::fs::write(&poster_path, b"benchmark-poster").expect("poster writes");
         store
             .persist_generated_asset(
                 &project.id,
                 "benchmark-job",
-                "shared-set",
+                &generation_set_id,
                 &json!({
                     "assetId": asset_id,
-                    "mediaPath": format!("assets/images/shared-set/{asset_id}.png"),
-                    "mimeType": "image/png",
+                    "mediaPath": media_path,
+                    "mimeType": "video/mp4",
+                    "type": "video",
                     "displayName": format!("Asset {index}"),
                     "createdAt": format!("2026-07-25T00:00:00Z-{index:08}"),
-                    "mode": "text_to_image",
+                    "mode": "image_to_video",
                     "model": "benchmark",
                     "adapter": "benchmark",
                     "prompt": "benchmark",
@@ -131,7 +153,10 @@ fn synthetic(asset_count: usize, iterations: usize) {
             )
             .expect("synthetic asset persists");
     }
-    println!("storage=synthetic-local path={}", data_dir.display());
+    println!(
+        "storage=synthetic-local-distinct-video-sets path={}",
+        data_dir.display()
+    );
     // Seed through one store, then report the first call through a genuinely
     // fresh registry cache. This still does not evict the operating-system cache.
     run(

--- a/crates/sceneworks-core/examples/assets_list_benchmark.rs
+++ b/crates/sceneworks-core/examples/assets_list_benchmark.rs
@@ -4,6 +4,14 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use sceneworks_core::project_store::{AssetListFilesystemOperations, AssetScope, ProjectStore};
 use serde_json::json;
 
+fn jpeg_fixture() -> Vec<u8> {
+    let mut bytes = Vec::new();
+    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut bytes, 90)
+        .encode(&[32, 64, 96], 1, 1, image::ExtendedColorType::Rgb8)
+        .expect("benchmark JPEG encodes");
+    bytes
+}
+
 fn list_once(
     store: &ProjectStore,
     project_id: &str,
@@ -135,7 +143,7 @@ fn synthetic(asset_count: usize, iterations: usize) {
         let poster_path = project_path.join(&media_path).with_extension("poster.jpg");
         std::fs::create_dir_all(poster_path.parent().expect("poster parent"))
             .expect("poster directory creates");
-        std::fs::write(&poster_path, b"benchmark-poster").expect("poster writes");
+        std::fs::write(&poster_path, jpeg_fixture()).expect("poster writes");
         store
             .persist_generated_asset(
                 &project.id,

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -1,6 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use rusqlite::{params, Connection, OptionalExtension, Row};
@@ -17,8 +18,7 @@ use crate::store_util::{
 };
 
 pub(crate) const ASSET_SIDECAR_PATTERN: &str = "*.sceneworks.json";
-const INDEXED_POSTERS_DIR: &str = "assets/posters";
-const INDEXED_POSTER_SUFFIX: &str = ".poster.jpg";
+const MAX_INDEXED_POSTER_BYTES: u64 = 16 * 1024 * 1024;
 
 pub(crate) const ASSET_FOLDERS: &[&str] = &[
     "assets/images",
@@ -35,6 +35,11 @@ pub(crate) const ASSET_FOLDERS: &[&str] = &[
 pub(crate) struct AssetRecord {
     pub(crate) file_path: Option<String>,
     pub(crate) sidecar_path: Option<String>,
+}
+
+struct IndexedPoster {
+    bytes: Vec<u8>,
+    sha256: String,
 }
 
 pub(crate) fn sidecar_content_fingerprint(
@@ -112,13 +117,13 @@ pub(crate) fn index_asset_on_connection(
     sidecar_path: Option<&Path>,
 ) -> ProjectStoreResult<()> {
     let mut indexed_asset = asset.clone();
-    hydrate_asset(
+    let indexed_poster = hydrate_asset(
         project_id,
         project_path,
         &mut indexed_asset,
         &mut GenerationSetCache::default(),
+        true,
     )?;
-    materialize_indexed_poster(project_id, project_path, &mut indexed_asset)?;
     let sidecar_rel = match sidecar_path {
         Some(path) => Some(relative_string(project_path, path)?),
         None => None,
@@ -129,92 +134,8 @@ pub(crate) fn index_asset_on_connection(
         &indexed_asset,
         sidecar_rel.as_deref(),
         sidecar_fingerprint,
+        indexed_poster.as_ref(),
     )
-}
-
-/// Materialize an advertised video poster into one managed, flat directory.
-///
-/// Keeping indexed posters flat lets the clean list path verify every row's
-/// poster presence with one directory snapshot instead of one stat per video.
-/// The URL is always assembled from the authoritative route/store project id,
-/// never the mutable `projectId` carried by an imported sidecar.
-fn materialize_indexed_poster(
-    project_id: &str,
-    project_path: &Path,
-    asset: &mut Value,
-) -> ProjectStoreResult<()> {
-    let asset_id = asset
-        .get("id")
-        .and_then(Value::as_str)
-        .filter(|id| is_safe_id(id));
-    let source_poster = asset
-        .pointer("/file/path")
-        .and_then(Value::as_str)
-        .filter(|_| asset.get("type").and_then(Value::as_str) == Some("video"))
-        .filter(|path| is_safe_relative_path(path))
-        .map(|path| Path::new(&path.replace('\\', "/")).with_extension("poster.jpg"));
-
-    let Some((asset_id, source_poster)) = asset_id.zip(source_poster) else {
-        if let Some(object) = asset.as_object_mut() {
-            object.remove("posterUrl");
-        }
-        return Ok(());
-    };
-    let poster_rel =
-        Path::new(INDEXED_POSTERS_DIR).join(format!("{asset_id}{INDEXED_POSTER_SUFFIX}"));
-    let poster_path = project_path.join(&poster_rel);
-    let source_path = project_path.join(source_poster);
-    if source_path.is_file() {
-        if let Some(parent) = poster_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::copy(&source_path, &poster_path)?;
-    }
-
-    let poster_url = poster_path.is_file().then(|| {
-        format!(
-            "/api/v1/projects/{project_id}/files/{}",
-            poster_rel.to_string_lossy().replace('\\', "/")
-        )
-    });
-    if let Some(object) = asset.as_object_mut() {
-        object.remove("posterUrl");
-        if let Some(poster_url) = poster_url {
-            object.insert("posterUrl".to_owned(), Value::String(poster_url));
-        }
-    }
-    Ok(())
-}
-
-/// Snapshot the managed poster directory once for an ordinary asset list.
-///
-/// Directory enumeration (including entry type) is one shared logical
-/// operation. It deliberately replaces N per-video `stat` calls.
-pub(crate) fn indexed_poster_ids(project_path: &Path) -> ProjectStoreResult<HashSet<String>> {
-    record_asset_list_filesystem_operation(AssetListFilesystemOperation::DirectoryScan);
-    let entries = match fs::read_dir(project_path.join(INDEXED_POSTERS_DIR)) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashSet::new()),
-        Err(error) => return Err(error.into()),
-    };
-    let mut poster_ids = HashSet::new();
-    for entry in entries {
-        let entry = entry?;
-        if !entry.file_type()?.is_file() {
-            continue;
-        }
-        let Some(asset_id) = entry
-            .file_name()
-            .to_str()
-            .and_then(|name| name.strip_suffix(INDEXED_POSTER_SUFFIX))
-            .filter(|id| is_safe_id(id))
-            .map(str::to_owned)
-        else {
-            continue;
-        };
-        poster_ids.insert(asset_id);
-    }
-    Ok(poster_ids)
 }
 
 pub(crate) fn row_to_asset_record(row: &Row<'_>) -> rusqlite::Result<AssetRecord> {
@@ -315,12 +236,14 @@ pub(crate) fn normalize_asset(
     project_path: &Path,
     sidecar_path: &Path,
 ) -> ProjectStoreResult<Value> {
-    normalize_asset_cached(
+    let mut asset = normalize_asset_cached(
         project_id,
         project_path,
         sidecar_path,
         &mut GenerationSetCache::default(),
-    )
+    )?;
+    attach_indexed_poster_url(project_id, project_path, &mut asset)?;
+    Ok(asset)
 }
 
 /// Like [`normalize_asset`] but resolves the embedded `generationSet` through a
@@ -334,7 +257,7 @@ pub(crate) fn normalize_asset_cached(
 ) -> ProjectStoreResult<Value> {
     record_asset_list_filesystem_operation(AssetListFilesystemOperation::SidecarRead);
     let mut asset = read_json(sidecar_path)?;
-    hydrate_asset(project_id, project_path, &mut asset, generation_sets)?;
+    hydrate_asset(project_id, project_path, &mut asset, generation_sets, false)?;
     let sidecar_rel = relative_string(project_path, sidecar_path)?;
     if let Some(object) = asset.as_object_mut() {
         object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));
@@ -347,7 +270,8 @@ fn hydrate_asset(
     project_path: &Path,
     asset: &mut Value,
     generation_sets: &mut GenerationSetCache,
-) -> ProjectStoreResult<()> {
+    index_poster: bool,
+) -> ProjectStoreResult<Option<IndexedPoster>> {
     // Guarantee every API response carries an `origin`, even for legacy sidecars
     // written before the field existed (sc-2024).
     let origin = asset_origin(asset);
@@ -357,30 +281,13 @@ fn hydrate_asset(
             .entry("origin".to_owned())
             .or_insert_with(|| Value::String(origin));
     }
-    if let Some(path) = asset.pointer("/file/path").and_then(Value::as_str) {
+    let indexed_poster = if let Some(path) = asset.pointer("/file/path").and_then(Value::as_str) {
         let normalized_path = path.replace('\\', "/");
-        // A generated/rendered video carries a sibling `<name>.poster.jpg` (worker
-        // frame-0 extract) that the web UI shows in place of the <video>'s own first
-        // frame — WKWebView won't paint it. Advertise a `posterUrl` ONLY when that
-        // file actually exists on disk, so the client never requests a poster a video
-        // doesn't have — an imported clip, or a generation where ffmpeg was
-        // unavailable — which would otherwise 404 on every render (sc-10468).
-        // Indexing subsequently materializes this poster into the flat managed
-        // poster directory. Ordinary lists snapshot that directory once, so
-        // out-of-band deletion of an advertised poster is visible immediately
-        // without restoring N per-video stats (sc-14799).
-        let poster_url = (asset.get("type").and_then(Value::as_str) == Some("video"))
-            .then(|| Path::new(&normalized_path).with_extension("poster.jpg"))
-            .filter(|poster_rel| {
-                record_asset_list_filesystem_operation(AssetListFilesystemOperation::PosterStat);
-                project_path.join(poster_rel).is_file()
-            })
-            .map(|poster_rel| {
-                format!(
-                    "/api/v1/projects/{project_id}/files/{}",
-                    poster_rel.to_string_lossy().replace('\\', "/")
-                )
-            });
+        let indexed_poster = if index_poster {
+            read_indexed_poster(project_path, asset)?
+        } else {
+            None
+        };
         if let Some(object) = asset.as_object_mut() {
             object.insert(
                 "url".to_owned(),
@@ -389,11 +296,26 @@ fn hydrate_asset(
                 )),
             );
             object.remove("posterUrl");
-            if let Some(poster_url) = poster_url {
-                object.insert("posterUrl".to_owned(), Value::String(poster_url));
+            if let (Some(asset_id), Some(poster)) = (
+                object.get("id").and_then(Value::as_str),
+                indexed_poster.as_ref(),
+            ) {
+                object.insert(
+                    "posterUrl".to_owned(),
+                    Value::String(format!(
+                        "/api/v1/projects/{project_id}/assets/{asset_id}/poster/{}",
+                        poster.sha256
+                    )),
+                );
             }
         }
-    }
+        indexed_poster
+    } else {
+        if let Some(object) = asset.as_object_mut() {
+            object.remove("posterUrl");
+        }
+        None
+    };
     // The id comes from the on-disk sidecar and is joined into the
     // generation-sets read path below; skip anything that isn't a plain id so a
     // tampered sidecar can't pull JSON from outside the project into API
@@ -425,15 +347,168 @@ fn hydrate_asset(
     } else if let Some(object) = asset.as_object_mut() {
         object.remove("generationSet");
     }
+    Ok(indexed_poster)
+}
+
+fn attach_indexed_poster_url(
+    project_id: &str,
+    project_path: &Path,
+    asset: &mut Value,
+) -> ProjectStoreResult<()> {
+    let Some(asset_id) = asset
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| is_safe_id(id))
+        .map(str::to_owned)
+    else {
+        return Ok(());
+    };
+    let Ok(connection) = Connection::open(project_path.join("project.db")) else {
+        return Ok(());
+    };
+    let Ok(poster_sha256) = connection
+        .query_row(
+            "select poster_sha256 from assets where id = ?1 and poster_bytes is not null",
+            params![asset_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+    else {
+        return Ok(());
+    };
+    if let Some(object) = asset.as_object_mut() {
+        object.remove("posterUrl");
+        if let Some(poster_sha256) = poster_sha256.flatten() {
+            object.insert(
+                "posterUrl".to_owned(),
+                Value::String(format!(
+                    "/api/v1/projects/{project_id}/assets/{asset_id}/poster/{poster_sha256}"
+                )),
+            );
+        }
+    }
     Ok(())
+}
+
+/// Read a generated sibling poster for DB-backed serving.
+///
+/// Every path component is inspected without following links, the resolved
+/// source must remain below the canonical project root, and the final open uses
+/// the platform's no-follow flag. Unsafe, missing, unreadable, or oversized
+/// posters are treated as absent so indexing atomically clears any prior blob.
+fn read_indexed_poster(
+    project_path: &Path,
+    asset: &Value,
+) -> ProjectStoreResult<Option<IndexedPoster>> {
+    if asset.get("type").and_then(Value::as_str) != Some("video") {
+        return Ok(None);
+    }
+    let Some(asset_id) = asset
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| is_safe_id(id))
+    else {
+        return Ok(None);
+    };
+    let Some(media_path) = asset
+        .pointer("/file/path")
+        .and_then(Value::as_str)
+        .filter(|path| is_safe_relative_path(path))
+    else {
+        return Ok(None);
+    };
+    let poster_rel = Path::new(media_path).with_extension("poster.jpg");
+    if !poster_rel
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Ok(None);
+    }
+
+    record_asset_list_filesystem_operation(AssetListFilesystemOperation::PosterStat);
+    let Ok(root) = fs::canonicalize(project_path) else {
+        return Ok(None);
+    };
+    let mut target = root.clone();
+    for component in poster_rel.components() {
+        let Component::Normal(component) = component else {
+            return Ok(None);
+        };
+        target.push(component);
+        let Ok(metadata) = fs::symlink_metadata(&target) else {
+            return Ok(None);
+        };
+        if metadata.file_type().is_symlink() {
+            return Ok(None);
+        }
+    }
+    let Ok(canonical_target) = fs::canonicalize(&target) else {
+        return Ok(None);
+    };
+    if !canonical_target.starts_with(&root) {
+        return Ok(None);
+    }
+
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // FILE_FLAG_OPEN_REPARSE_POINT: a raced symlink is opened as the link
+        // itself and rejected by the regular-file check below.
+        options.custom_flags(0x0020_0000);
+    }
+    let Ok(file) = options.open(&canonical_target) else {
+        return Ok(None);
+    };
+    let Ok(metadata) = file.metadata() else {
+        return Ok(None);
+    };
+    if !metadata.is_file() || metadata.len() > MAX_INDEXED_POSTER_BYTES {
+        return Ok(None);
+    }
+    // Revalidate the lexical source after the no-follow open. This catches a
+    // component swapped to a reparse point/symlink between the first walk and
+    // opening before any bytes are copied into SQLite.
+    let mut revalidated = root.clone();
+    for component in poster_rel.components() {
+        let Component::Normal(component) = component else {
+            return Ok(None);
+        };
+        revalidated.push(component);
+        let Ok(metadata) = fs::symlink_metadata(&revalidated) else {
+            return Ok(None);
+        };
+        if metadata.file_type().is_symlink() {
+            return Ok(None);
+        }
+    }
+    if fs::canonicalize(&revalidated).ok().as_ref() != Some(&canonical_target) {
+        return Ok(None);
+    }
+
+    record_asset_list_filesystem_operation(AssetListFilesystemOperation::PosterRead);
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_INDEXED_POSTER_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_INDEXED_POSTER_BYTES {
+        return Ok(None);
+    }
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    debug_assert!(is_safe_id(asset_id));
+    Ok(Some(IndexedPoster { bytes, sha256 }))
 }
 
 /// Return an already-hydrated asset envelope stored in project.db.
 ///
-/// Filesystem-derived fields (`generationSet` and `posterUrl`) are materialized
-/// when the row is indexed. Poster presence is separately reconciled from one
-/// shared managed-directory snapshot by the caller. SceneWorks-owned mutations
-/// update the index before returning, while out-of-band sidecar or
+/// Filesystem-derived fields (`generationSet` and DB-backed `posterUrl`) are
+/// materialized when the row is indexed. SceneWorks-owned mutations update the
+/// index before returning, while out-of-band sidecar, source-poster, or
 /// generation-set edits require an explicit project reindex.
 pub(crate) fn hydrate_indexed_asset_cached(
     _project_id: &str,
@@ -444,11 +519,12 @@ pub(crate) fn hydrate_indexed_asset_cached(
     Ok(asset)
 }
 
-pub(crate) fn upsert_asset_row(
+fn upsert_asset_row(
     connection: &Connection,
     asset: &Value,
     sidecar_rel: Option<&str>,
     sidecar_fingerprint: Option<(u64, Option<String>, String)>,
+    indexed_poster: Option<&IndexedPoster>,
 ) -> ProjectStoreResult<()> {
     let status = asset.get("status").unwrap_or(&Value::Null);
     connection.execute(
@@ -457,8 +533,9 @@ pub(crate) fn upsert_asset_row(
           id, type, display_name, file_path, generation_set_id, created_at,
           favorite, rating, rejected, trashed, sidecar_path, origin,
           asset_json, source_asset_id, upscaled_from_asset_id,
-          sidecar_size, sidecar_modified_ns, sidecar_sha256
-        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+          sidecar_size, sidecar_modified_ns, sidecar_sha256,
+          poster_bytes, poster_sha256
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
         ",
         params![
             required_str(asset, "id")?,
@@ -502,6 +579,8 @@ pub(crate) fn upsert_asset_row(
                 .as_ref()
                 .and_then(|value| value.1.clone()),
             sidecar_fingerprint.map(|value| value.2),
+            indexed_poster.map(|poster| poster.bytes.as_slice()),
+            indexed_poster.map(|poster| poster.sha256.as_str()),
         ],
     )?;
     Ok(())

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -12,10 +12,13 @@ use crate::project_store::{
     ProjectStoreResult,
 };
 use crate::store_util::{
-    is_safe_id, optional_bool, optional_str, optional_u64, read_json, relative_string,
+    is_safe_id, is_safe_relative_path, optional_bool, optional_str, optional_u64, read_json,
+    relative_string,
 };
 
 pub(crate) const ASSET_SIDECAR_PATTERN: &str = "*.sceneworks.json";
+const INDEXED_POSTERS_DIR: &str = "assets/posters";
+const INDEXED_POSTER_SUFFIX: &str = ".poster.jpg";
 
 pub(crate) const ASSET_FOLDERS: &[&str] = &[
     "assets/images",
@@ -103,29 +106,19 @@ pub(crate) fn find_asset_sidecar_path_on_connection(
 /// its absolute path. Shared by both stores (sc-4272 / F-CORE-12).
 pub(crate) fn index_asset_on_connection(
     connection: &Connection,
+    project_id: &str,
     project_path: &Path,
     asset: &Value,
     sidecar_path: Option<&Path>,
 ) -> ProjectStoreResult<()> {
     let mut indexed_asset = asset.clone();
-    let project_id = indexed_asset
-        .get("projectId")
-        .and_then(Value::as_str)
-        .map(str::to_owned)
-        .or_else(|| {
-            read_json(&project_path.join("project.json"))
-                .ok()?
-                .get("id")?
-                .as_str()
-                .map(str::to_owned)
-        })
-        .ok_or_else(|| ProjectStoreError::BadRequest("Missing project id".to_owned()))?;
     hydrate_asset(
-        &project_id,
+        project_id,
         project_path,
         &mut indexed_asset,
         &mut GenerationSetCache::default(),
     )?;
+    materialize_indexed_poster(project_id, project_path, &mut indexed_asset)?;
     let sidecar_rel = match sidecar_path {
         Some(path) => Some(relative_string(project_path, path)?),
         None => None,
@@ -137,6 +130,91 @@ pub(crate) fn index_asset_on_connection(
         sidecar_rel.as_deref(),
         sidecar_fingerprint,
     )
+}
+
+/// Materialize an advertised video poster into one managed, flat directory.
+///
+/// Keeping indexed posters flat lets the clean list path verify every row's
+/// poster presence with one directory snapshot instead of one stat per video.
+/// The URL is always assembled from the authoritative route/store project id,
+/// never the mutable `projectId` carried by an imported sidecar.
+fn materialize_indexed_poster(
+    project_id: &str,
+    project_path: &Path,
+    asset: &mut Value,
+) -> ProjectStoreResult<()> {
+    let asset_id = asset
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| is_safe_id(id));
+    let source_poster = asset
+        .pointer("/file/path")
+        .and_then(Value::as_str)
+        .filter(|_| asset.get("type").and_then(Value::as_str) == Some("video"))
+        .filter(|path| is_safe_relative_path(path))
+        .map(|path| Path::new(&path.replace('\\', "/")).with_extension("poster.jpg"));
+
+    let Some((asset_id, source_poster)) = asset_id.zip(source_poster) else {
+        if let Some(object) = asset.as_object_mut() {
+            object.remove("posterUrl");
+        }
+        return Ok(());
+    };
+    let poster_rel =
+        Path::new(INDEXED_POSTERS_DIR).join(format!("{asset_id}{INDEXED_POSTER_SUFFIX}"));
+    let poster_path = project_path.join(&poster_rel);
+    let source_path = project_path.join(source_poster);
+    if source_path.is_file() {
+        if let Some(parent) = poster_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&source_path, &poster_path)?;
+    }
+
+    let poster_url = poster_path.is_file().then(|| {
+        format!(
+            "/api/v1/projects/{project_id}/files/{}",
+            poster_rel.to_string_lossy().replace('\\', "/")
+        )
+    });
+    if let Some(object) = asset.as_object_mut() {
+        object.remove("posterUrl");
+        if let Some(poster_url) = poster_url {
+            object.insert("posterUrl".to_owned(), Value::String(poster_url));
+        }
+    }
+    Ok(())
+}
+
+/// Snapshot the managed poster directory once for an ordinary asset list.
+///
+/// Directory enumeration (including entry type) is one shared logical
+/// operation. It deliberately replaces N per-video `stat` calls.
+pub(crate) fn indexed_poster_ids(project_path: &Path) -> ProjectStoreResult<HashSet<String>> {
+    record_asset_list_filesystem_operation(AssetListFilesystemOperation::DirectoryScan);
+    let entries = match fs::read_dir(project_path.join(INDEXED_POSTERS_DIR)) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashSet::new()),
+        Err(error) => return Err(error.into()),
+    };
+    let mut poster_ids = HashSet::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let Some(asset_id) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.strip_suffix(INDEXED_POSTER_SUFFIX))
+            .filter(|id| is_safe_id(id))
+            .map(str::to_owned)
+        else {
+            continue;
+        };
+        poster_ids.insert(asset_id);
+    }
+    Ok(poster_ids)
 }
 
 pub(crate) fn row_to_asset_record(row: &Row<'_>) -> rusqlite::Result<AssetRecord> {
@@ -274,6 +352,7 @@ fn hydrate_asset(
     // written before the field existed (sc-2024).
     let origin = asset_origin(asset);
     if let Some(object) = asset.as_object_mut() {
+        object.insert("projectId".to_owned(), Value::String(project_id.to_owned()));
         object
             .entry("origin".to_owned())
             .or_insert_with(|| Value::String(origin));
@@ -286,9 +365,10 @@ fn hydrate_asset(
         // file actually exists on disk, so the client never requests a poster a video
         // doesn't have — an imported clip, or a generation where ffmpeg was
         // unavailable — which would otherwise 404 on every render (sc-10468).
-        // The result is persisted in the indexed envelope. SceneWorks-owned writes
-        // refresh it before returning; out-of-band poster changes use the explicit
-        // reindex contract shared with sidecars and generation sets (sc-14799).
+        // Indexing subsequently materializes this poster into the flat managed
+        // poster directory. Ordinary lists snapshot that directory once, so
+        // out-of-band deletion of an advertised poster is visible immediately
+        // without restoring N per-video stats (sc-14799).
         let poster_url = (asset.get("type").and_then(Value::as_str) == Some("video"))
             .then(|| Path::new(&normalized_path).with_extension("poster.jpg"))
             .filter(|poster_rel| {
@@ -351,10 +431,10 @@ fn hydrate_asset(
 /// Return an already-hydrated asset envelope stored in project.db.
 ///
 /// Filesystem-derived fields (`generationSet` and `posterUrl`) are materialized
-/// when the row is indexed. Keeping this clean-list path pure is the SC-14799
-/// consistency contract: SceneWorks-owned mutations update the index before
-/// returning, while out-of-band sidecar, generation-set, media, or poster edits
-/// require an explicit project reindex.
+/// when the row is indexed. Poster presence is separately reconciled from one
+/// shared managed-directory snapshot by the caller. SceneWorks-owned mutations
+/// update the index before returning, while out-of-band sidecar or
+/// generation-set edits require an explicit project reindex.
 pub(crate) fn hydrate_indexed_asset_cached(
     _project_id: &str,
     _project_path: &Path,

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::Read;
+use std::io::{Cursor, Read};
 use std::path::{Component, Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
+use image::{ImageFormat, ImageReader};
 use rusqlite::{params, Connection, OptionalExtension, Row};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -19,6 +20,8 @@ use crate::store_util::{
 
 pub(crate) const ASSET_SIDECAR_PATTERN: &str = "*.sceneworks.json";
 const MAX_INDEXED_POSTER_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_INDEXED_POSTER_DIMENSION: u32 = 16_384;
+const MAX_INDEXED_POSTER_DECODE_BYTES: u64 = 128 * 1024 * 1024;
 
 pub(crate) const ASSET_FOLDERS: &[&str] = &[
     "assets/images",
@@ -394,8 +397,10 @@ fn attach_indexed_poster_url(
 ///
 /// Every path component is inspected without following links, the resolved
 /// source must remain below the canonical project root, and the final open uses
-/// the platform's no-follow flag. Unsafe, missing, unreadable, or oversized
-/// posters are treated as absent so indexing atomically clears any prior blob.
+/// the platform's no-follow flag. The bounded payload must also fully decode as
+/// JPEG; the `.poster.jpg` filename is never treated as proof of MIME. Unsafe,
+/// missing, unreadable, malformed, or oversized posters are treated as absent
+/// so indexing atomically clears any prior blob.
 fn read_indexed_poster(
     project_path: &Path,
     asset: &Value,
@@ -497,6 +502,15 @@ fn read_indexed_poster(
     file.take(MAX_INDEXED_POSTER_BYTES + 1)
         .read_to_end(&mut bytes)?;
     if bytes.len() as u64 > MAX_INDEXED_POSTER_BYTES {
+        return Ok(None);
+    }
+    let mut reader = ImageReader::with_format(Cursor::new(bytes.as_slice()), ImageFormat::Jpeg);
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_INDEXED_POSTER_DIMENSION);
+    limits.max_image_height = Some(MAX_INDEXED_POSTER_DIMENSION);
+    limits.max_alloc = Some(MAX_INDEXED_POSTER_DECODE_BYTES);
+    reader.limits(limits);
+    if reader.decode().is_err() {
         return Ok(None);
     }
     let sha256 = format!("{:x}", Sha256::digest(&bytes));

--- a/crates/sceneworks-core/src/asset_index.rs
+++ b/crates/sceneworks-core/src/asset_index.rs
@@ -107,6 +107,25 @@ pub(crate) fn index_asset_on_connection(
     asset: &Value,
     sidecar_path: Option<&Path>,
 ) -> ProjectStoreResult<()> {
+    let mut indexed_asset = asset.clone();
+    let project_id = indexed_asset
+        .get("projectId")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            read_json(&project_path.join("project.json"))
+                .ok()?
+                .get("id")?
+                .as_str()
+                .map(str::to_owned)
+        })
+        .ok_or_else(|| ProjectStoreError::BadRequest("Missing project id".to_owned()))?;
+    hydrate_asset(
+        &project_id,
+        project_path,
+        &mut indexed_asset,
+        &mut GenerationSetCache::default(),
+    )?;
     let sidecar_rel = match sidecar_path {
         Some(path) => Some(relative_string(project_path, path)?),
         None => None,
@@ -114,7 +133,7 @@ pub(crate) fn index_asset_on_connection(
     let sidecar_fingerprint = sidecar_path.and_then(|path| sidecar_content_fingerprint(path).ok());
     upsert_asset_row(
         connection,
-        asset,
+        &indexed_asset,
         sidecar_rel.as_deref(),
         sidecar_fingerprint,
     )
@@ -266,8 +285,10 @@ fn hydrate_asset(
         // frame — WKWebView won't paint it. Advertise a `posterUrl` ONLY when that
         // file actually exists on disk, so the client never requests a poster a video
         // doesn't have — an imported clip, or a generation where ffmpeg was
-        // unavailable — which would otherwise 404 on every render (sc-10468). Resolved
-        // at read time so it reflects the real on-disk state; images never have one.
+        // unavailable — which would otherwise 404 on every render (sc-10468).
+        // The result is persisted in the indexed envelope. SceneWorks-owned writes
+        // refresh it before returning; out-of-band poster changes use the explicit
+        // reindex contract shared with sidecars and generation sets (sc-14799).
         let poster_url = (asset.get("type").and_then(Value::as_str) == Some("video"))
             .then(|| Path::new(&normalized_path).with_extension("poster.jpg"))
             .filter(|poster_rel| {
@@ -287,6 +308,7 @@ fn hydrate_asset(
                     "/api/v1/projects/{project_id}/files/{normalized_path}"
                 )),
             );
+            object.remove("posterUrl");
             if let Some(poster_url) = poster_url {
                 object.insert("posterUrl".to_owned(), Value::String(poster_url));
             }
@@ -317,26 +339,28 @@ fn hydrate_asset(
             if let Some(object) = asset.as_object_mut() {
                 object.insert("generationSet".to_owned(), generation_set);
             }
+        } else if let Some(object) = asset.as_object_mut() {
+            object.remove("generationSet");
         }
+    } else if let Some(object) = asset.as_object_mut() {
+        object.remove("generationSet");
     }
     Ok(())
 }
 
-/// Hydrate a normalized asset envelope already stored in project.db.
+/// Return an already-hydrated asset envelope stored in project.db.
+///
+/// Filesystem-derived fields (`generationSet` and `posterUrl`) are materialized
+/// when the row is indexed. Keeping this clean-list path pure is the SC-14799
+/// consistency contract: SceneWorks-owned mutations update the index before
+/// returning, while out-of-band sidecar, generation-set, media, or poster edits
+/// require an explicit project reindex.
 pub(crate) fn hydrate_indexed_asset_cached(
-    project_id: &str,
-    project_path: &Path,
-    mut asset: Value,
-    generation_sets: &mut GenerationSetCache,
+    _project_id: &str,
+    _project_path: &Path,
+    asset: Value,
+    _generation_sets: &mut GenerationSetCache,
 ) -> ProjectStoreResult<Value> {
-    let sidecar_rel = asset
-        .get("sidecarPath")
-        .and_then(Value::as_str)
-        .map(str::to_owned);
-    hydrate_asset(project_id, project_path, &mut asset, generation_sets)?;
-    if let (Some(object), Some(sidecar_rel)) = (asset.as_object_mut(), sidecar_rel) {
-        object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));
-    }
     Ok(asset)
 }
 

--- a/crates/sceneworks-core/src/character_store.rs
+++ b/crates/sceneworks-core/src/character_store.rs
@@ -321,6 +321,7 @@ impl<'a> CharacterStore<'a> {
         let transaction = connection.transaction()?;
         update_asset_character_link(
             &transaction,
+            project_id,
             &self.project_path,
             character_id,
             &reference,
@@ -401,6 +402,7 @@ impl<'a> CharacterStore<'a> {
         let transaction = connection.transaction()?;
         update_asset_character_link(
             &transaction,
+            project_id,
             &self.project_path,
             character_id,
             reference,
@@ -437,6 +439,7 @@ impl<'a> CharacterStore<'a> {
         let transaction = connection.transaction()?;
         update_asset_character_link(
             &transaction,
+            project_id,
             &self.project_path,
             character_id,
             reference,
@@ -1239,6 +1242,7 @@ fn character_asset_summary(
 
 fn update_asset_character_link(
     connection: &Connection,
+    project_id: &str,
     project_path: &Path,
     character_id: &str,
     reference: &Value,
@@ -1297,7 +1301,13 @@ fn update_asset_character_link(
     }
     metadata.insert("characterReferences".to_owned(), Value::Array(links));
     write_json(&sidecar_path, &asset)?;
-    index_asset_on_connection(connection, project_path, &asset, Some(&sidecar_path))
+    index_asset_on_connection(
+        connection,
+        project_id,
+        project_path,
+        &asset,
+        Some(&sidecar_path),
+    )
 }
 
 fn remove_asset_references_from_character(

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1308,13 +1308,15 @@ impl ProjectStore {
     /// List assets and return the complete request-scoped filesystem-operation
     /// inventory used by performance tests, benchmarks, and API observability.
     ///
-    /// The indexed `asset_json` envelope is authoritative on this clean path.
-    /// SceneWorks-owned mutations update the sidecar and index before returning.
-    /// Tools that edit sidecars out of band must call
+    /// The indexed `asset_json` envelope is authoritative on this clean path,
+    /// including its embedded generation set and poster presence. SceneWorks-owned
+    /// mutations update the sidecar and index before returning. Tools that edit
+    /// sidecars, generation-set JSON, media, or poster files out of band must call
     /// [`Self::reindex_project`] (the REST equivalent is
     /// `POST /api/v1/projects/:project_id/reindex`) before expecting those edits
-    /// in listings. This explicit contract includes same-size rewrites and edits
-    /// that preserve timestamps; list requests do not inspect or hash sidecars.
+    /// in listings. This explicit contract includes deletion, same-size rewrites,
+    /// and edits that preserve timestamps; list requests do not inspect or hash
+    /// any per-row files.
     pub fn list_assets_with_filesystem_operations(
         &self,
         project_id: &str,
@@ -1341,13 +1343,10 @@ impl ProjectStore {
         #[cfg(test)]
         run_ensure_ready_before_lock_hook(&project_path);
         let _project_guard = lock_project_files(&project_path);
-        ensure_project_db_ready(&project_path)?;
-        let total = {
-            let connection = connect_project_db(&project_path)?;
-            connection.query_row("select count(*) from assets", [], |row| {
-                row.get::<_, i64>(0)
-            })?
-        };
+        let mut connection = connect_project_db_ready_locked(&project_path)?;
+        let total = connection.query_row("select count(*) from assets", [], |row| {
+            row.get::<_, i64>(0)
+        })?;
         // Pre-migration projects (created before the `sidecar_path` column /
         // asset index existed) surface as EMPTY libraries even though their
         // assets are still on disk as `.sceneworks.json` sidecars (V-4). The
@@ -1359,9 +1358,9 @@ impl ProjectStore {
         // holds (possibly empty), which is strictly better than an error.
         if total == 0 && project_has_sidecars(&project_path) {
             let _ = reindex_project_path(&project_path, false);
+            connection = connect_project_db(&project_path)?;
         }
 
-        let connection = connect_project_db(&project_path)?;
         // The Library view hides Character Studio test outputs (sc-2024). Rows
         // with a null origin (should not occur after the schema-bump reindex)
         // fail open and stay visible.
@@ -2612,9 +2611,56 @@ impl ProjectStore {
                 object.insert("recipe".to_owned(), recipe);
             }
         }
+        let index_mutation = AssetIndexMutation::begin(&project_path)?;
         let dir = project_path.join("generation-sets");
         fs::create_dir_all(&dir)?;
         write_json(&dir.join(format!("{id}.json")), &record)?;
+        maybe_fail_asset_index_db_mutation()?;
+        let mut connection = connect_project_db(&project_path)?;
+        let transaction = connection.transaction()?;
+        apply_project_migrations(&transaction)?;
+        transaction.execute(
+            "
+            insert or replace into generation_sets (id, mode, model, prompt, created_at, job_id)
+            values (?1, ?2, ?3, ?4, ?5, ?6)
+            ",
+            params![
+                id,
+                optional_str(&record, "mode").unwrap_or("unknown"),
+                optional_str(&record, "model").unwrap_or("unknown"),
+                optional_str(&record, "prompt").unwrap_or(""),
+                optional_str(&record, "createdAt").unwrap_or(""),
+                optional_str(&record, "jobId"),
+            ],
+        )?;
+        let indexed_assets = {
+            let mut statement = transaction
+                .prepare("select id, asset_json from assets where generation_set_id = ?1")?;
+            let rows = statement
+                .query_map(params![id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            rows
+        };
+        for (asset_id, asset_json) in indexed_assets {
+            let Some(asset_json) = asset_json else {
+                continue;
+            };
+            let Ok(mut asset) = serde_json::from_str::<Value>(&asset_json) else {
+                continue;
+            };
+            let Some(object) = asset.as_object_mut() else {
+                continue;
+            };
+            object.insert("generationSet".to_owned(), record.clone());
+            transaction.execute(
+                "update assets set asset_json = ?1 where id = ?2",
+                params![serde_json::to_string(&asset)?, asset_id],
+            )?;
+        }
+        transaction.commit()?;
+        index_mutation.commit();
         Ok(())
     }
 
@@ -3194,7 +3240,13 @@ struct ReindexCounts {
 /// registry). The bump lets existing DBs pick up the new table through the gated
 /// migration; the table is DB-authoritative (no sidecar), so the reindex the bump
 /// triggers — which only clears the sidecar-rebuilt tables — leaves it intact.
-const PROJECT_SCHEMA_VERSION: i64 = 6;
+///
+/// v6: sc-14787 — rebuilt indexed asset envelopes for the authoritative clean
+/// path and its durable dirty-marker repair contract.
+///
+/// v7: sc-14799 — materializes generation-set and poster hydration in each
+/// indexed asset envelope, removing per-row filesystem reads from clean lists.
+const PROJECT_SCHEMA_VERSION: i64 = 7;
 const ASSET_INDEX_VERSION_KEY: &str = "assetIndexVersion";
 const ASSET_INDEX_DIRTY_MARKER: &str = ".asset-index-dirty";
 
@@ -3466,6 +3518,16 @@ pub fn ensure_project_db_ready(project_path: &Path) -> ProjectStoreResult<()> {
     // serialized project operation. Mutation guards use the same reentrant lock,
     // so a list cannot repair and clear the marker owned by an in-flight write.
     let _project_guard = lock_project_files(project_path);
+    connect_project_db_ready_locked(project_path).map(drop)
+}
+
+/// Return one ready connection while the caller holds the project lock.
+///
+/// The clean path keeps and reuses the connection opened for migrations/index
+/// readiness, so an asset list performs one `project.db` open. A version bump or
+/// dirty-marker repair rebuilds transactionally and then opens the rebuilt DB;
+/// repair is intentionally outside the clean-path operation-count contract.
+fn connect_project_db_ready_locked(project_path: &Path) -> ProjectStoreResult<Connection> {
     let connection = connect_project_db(project_path)?;
     apply_project_migrations(&connection)?;
     let indexed_version = connection
@@ -3475,7 +3537,6 @@ pub fn ensure_project_db_ready(project_path: &Path) -> ProjectStoreResult<()> {
             |row| row.get::<_, String>(0),
         )
         .optional()?;
-    drop(connection);
     // The schema stamp and the derived-data rebuild are separate operations.
     // Record completion only in the rebuild transaction so a failed reindex is
     // retried even though PRAGMA user_version already reached this version.
@@ -3483,13 +3544,15 @@ pub fn ensure_project_db_ready(project_path: &Path) -> ProjectStoreResult<()> {
         && !current_thread_owns_asset_index_mutation(project_path);
     if indexed_version.as_deref() != Some(&PROJECT_SCHEMA_VERSION.to_string()) || asset_index_dirty
     {
+        drop(connection);
         // Legacy/version-bump rebuilds continue to recover sidecars even when
         // their media is temporarily unavailable. Only dirty-mutation repair
         // prunes missing-media rows before clearing the marker, closing the
         // partial-purge resurrection window.
         reindex_project_path(project_path, asset_index_dirty)?;
+        return connect_project_db(project_path);
     }
-    Ok(())
+    Ok(connection)
 }
 
 /// sc-10117: heal upscale-variant lineage on inline-upscaled asset sidecars.
@@ -5781,7 +5844,7 @@ mod tests {
     /// alongside a deliberate schema change — and when you do, you MUST bump
     /// `PROJECT_SCHEMA_VERSION` so the `user_version=` line below changes too.
     const EXPECTED_PROJECT_DB_SCHEMA: &str = concat!(
-        "user_version=6\n",
+        "user_version=7\n",
         "table assets: id TEXT notnull=0 default=NULL pk=1, type TEXT notnull=1 default=NULL pk=0, display_name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, generation_set_id TEXT notnull=0 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, favorite INTEGER notnull=1 default=0 pk=0, rating INTEGER notnull=1 default=0 pk=0, rejected INTEGER notnull=1 default=0 pk=0, trashed INTEGER notnull=1 default=0 pk=0, sidecar_path TEXT notnull=0 default=NULL pk=0, origin TEXT notnull=0 default=NULL pk=0, asset_json TEXT notnull=0 default=NULL pk=0, source_asset_id TEXT notnull=0 default=NULL pk=0, upscaled_from_asset_id TEXT notnull=0 default=NULL pk=0, sidecar_size INTEGER notnull=0 default=NULL pk=0, sidecar_modified_ns TEXT notnull=0 default=NULL pk=0, sidecar_sha256 TEXT notnull=0 default=NULL pk=0\n",
         "table character_looks: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, description TEXT notnull=1 default='' pk=0, approved_reference_ids TEXT notnull=1 default='[]' pk=0, recipe_settings TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table character_loras: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, lora_id TEXT notnull=0 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, source_path TEXT notnull=0 default=NULL pk=0, project_path TEXT notnull=0 default=NULL pk=0, copied_into_project INTEGER notnull=1 default=0 pk=0, category TEXT notnull=1 default='character' pk=0, scope TEXT notnull=1 default='project' pk=0, trigger_words TEXT notnull=1 default='[]' pk=0, default_weight REAL notnull=1 default=1.0 pk=0, compatibility TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
@@ -6928,28 +6991,179 @@ mod tests {
     }
 
     #[test]
-    fn list_assets_many_clean_rows_reads_no_sidecar_content() {
+    fn list_assets_external_generation_set_edit_requires_explicit_reindex() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Indexed generation set").unwrap();
+        store
+            .write_generation_set(
+                &project.id,
+                "job-1",
+                &json!({
+                    "id": "set",
+                    "mode": "text_to_image",
+                    "model": "benchmark",
+                    "prompt": "Before",
+                    "createdAt": "2026-05-25T00:00:00Z",
+                }),
+                None,
+            )
+            .unwrap();
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "set",
+                &json!({
+                    "assetId": "asset_cached",
+                    "mediaPath": "assets/images/set/asset_cached.png",
+                    "mimeType": "image/png",
+                    "displayName": "Cached",
+                    "createdAt": "2026-05-25T00:00:00Z",
+                    "mode": "text_to_image",
+                    "model": "benchmark",
+                    "adapter": "benchmark",
+                    "prompt": "Before",
+                }),
+            )
+            .unwrap();
+
+        let project_path = store.find_project_path(&project.id).unwrap();
+        std::fs::write(
+            project_path.join("assets/images/set/asset_cached.png"),
+            b"png",
+        )
+        .unwrap();
+        let generation_set_path = project_path.join("generation-sets/set.json");
+        let mut generation_set = read_json(&generation_set_path).unwrap();
+        generation_set["prompt"] = json!("After!");
+        write_json(&generation_set_path, &generation_set).unwrap();
+
+        let (listed, operations) = store
+            .list_assets_with_filesystem_operations(&project.id, false, false, AssetScope::All)
+            .unwrap();
+        assert_eq!(listed[0]["generationSet"]["prompt"], json!("Before"));
+        assert_eq!(
+            operations.generation_set_reads, 0,
+            "clean listing serves the indexed generation set"
+        );
+
+        store.reindex_project(&project.id).unwrap();
+        let listed = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .unwrap();
+        assert_eq!(
+            listed[0]["generationSet"]["prompt"],
+            json!("After!"),
+            "explicit reindex refreshes externally edited generation-set JSON"
+        );
+    }
+
+    #[test]
+    fn write_generation_set_refreshes_indexed_assets_before_returning() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Generation set mutation").unwrap();
+        let generation_set = |prompt: &str| {
+            json!({
+                "id": "set",
+                "mode": "text_to_image",
+                "model": "benchmark",
+                "prompt": prompt,
+                "createdAt": "2026-05-25T00:00:00Z",
+            })
+        };
+        store
+            .write_generation_set(&project.id, "job-1", &generation_set("Before"), None)
+            .unwrap();
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "set",
+                &json!({
+                    "assetId": "asset_cached",
+                    "mediaPath": "assets/images/set/asset_cached.png",
+                    "mimeType": "image/png",
+                    "displayName": "Cached",
+                    "createdAt": "2026-05-25T00:00:00Z",
+                    "mode": "text_to_image",
+                    "model": "benchmark",
+                    "adapter": "benchmark",
+                    "prompt": "Before",
+                }),
+            )
+            .unwrap();
+
+        store
+            .write_generation_set(&project.id, "job-1", &generation_set("After!"), None)
+            .unwrap();
+        let (listed, operations) = store
+            .list_assets_with_filesystem_operations(&project.id, false, false, AssetScope::All)
+            .unwrap();
+        assert_eq!(listed[0]["generationSet"]["prompt"], json!("After!"));
+        assert_eq!(operations.generation_set_reads, 0);
+    }
+
+    #[test]
+    fn list_assets_many_clean_rows_has_constant_filesystem_operations() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
         let project = store.create_project("Many indexed assets").unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let mut one_row_operations = None;
         for index in 0..128 {
             let asset_id = format!("asset_{index:03}");
+            let generation_set_id = format!("set_{index:03}");
+            store
+                .write_generation_set(
+                    &project.id,
+                    "job-1",
+                    &json!({
+                        "id": generation_set_id,
+                        "mode": "image_to_video",
+                        "model": "benchmark",
+                        "prompt": "indexed",
+                        "createdAt": "2026-05-25T00:00:00Z",
+                    }),
+                    None,
+                )
+                .unwrap();
+            let media_rel = format!("assets/videos/{generation_set_id}/{asset_id}.mp4");
+            let poster_path = project_path.join(&media_rel).with_extension("poster.jpg");
+            std::fs::create_dir_all(poster_path.parent().unwrap()).unwrap();
+            std::fs::write(&poster_path, b"poster").unwrap();
             let fact = json!({
                 "assetId": asset_id,
-                "mediaPath": format!("assets/images/shared/{asset_id}.png"),
-                "mimeType": "image/png",
+                "mediaPath": media_rel,
+                "mimeType": "video/mp4",
+                "type": "video",
                 "displayName": format!("Asset {index:03}"),
                 "createdAt": format!("2026-05-25T00:{:02}:{:02}Z", index / 60, index % 60),
-                "mode": "text_to_image",
-                "model": "z_image_turbo",
-                "adapter": "z_image_diffusers",
+                "mode": "image_to_video",
+                "model": "benchmark",
+                "adapter": "benchmark",
                 "prompt": "indexed",
             });
             store
-                .persist_generated_asset(&project.id, "job-1", "shared", &fact)
+                .persist_generated_asset(&project.id, "job-1", &generation_set_id, &fact)
                 .unwrap();
+            if index == 0 {
+                one_row_operations = Some(
+                    store
+                        .list_assets_with_filesystem_operations(
+                            &project.id,
+                            false,
+                            false,
+                            AssetScope::All,
+                        )
+                        .unwrap()
+                        .1,
+                );
+            }
         }
 
+        let one_row_operations = one_row_operations.unwrap();
         let (assets, operations) = store
             .list_assets_with_filesystem_operations(&project.id, false, false, AssetScope::All)
             .unwrap();
@@ -6958,15 +7172,9 @@ mod tests {
             operations.sidecar_reads, 0,
             "clean indexed listing must not read or hash one sidecar per row"
         );
-        assert_eq!(
-            operations.generation_set_reads, 1,
-            "the shared generation set remains deduplicated within the request"
-        );
-        assert_eq!(operations.poster_stats, 0, "images do not probe posters");
-        assert!(
-            operations.db_opens > 0,
-            "DB opens stay visible in the total"
-        );
+        assert_eq!(operations.generation_set_reads, 0);
+        assert_eq!(operations.poster_stats, 0);
+        assert_eq!(operations.db_opens, 1);
         assert_eq!(operations.registry_opens, 1);
         assert_eq!(operations.registry_metadata_reads, 1);
         assert!(operations.path_stats >= 1);
@@ -6974,7 +7182,11 @@ mod tests {
         assert_eq!(operations.index_marker_reads, 1);
         assert_eq!(operations.index_marker_writes, 0);
         assert_eq!(operations.index_marker_removes, 0);
-        assert!(operations.total() >= 10);
+        assert_eq!(
+            operations.total(),
+            one_row_operations.total(),
+            "clean-list filesystem work must be independent of returned row count"
+        );
     }
 
     #[test]
@@ -7634,22 +7846,35 @@ mod tests {
                 "prompt": "x",
             })
         };
+        // The worker writes the media and best-effort poster before reporting the
+        // completed asset fact. Only `withposter` has that sibling when indexed.
+        let poster_path = project_path.join("assets/videos/genset/withposter.poster.jpg");
+        std::fs::create_dir_all(poster_path.parent().unwrap()).expect("video dir");
+        std::fs::write(&poster_path, b"jpg-bytes").expect("write poster");
+        std::fs::write(
+            project_path.join("assets/videos/genset/withposter.mp4"),
+            b"video",
+        )
+        .expect("write video");
+        std::fs::write(
+            project_path.join("assets/videos/genset/noposter.mp4"),
+            b"video",
+        )
+        .expect("write video");
         store
             .persist_generated_asset(&project.id, "job-1", "genset", &video_fact("withposter"))
             .expect("withposter persists");
         store
             .persist_generated_asset(&project.id, "job-1", "genset", &video_fact("noposter"))
             .expect("noposter persists");
-        // Only `withposter` has its `<name>.poster.jpg` sibling on disk.
-        std::fs::write(
-            project_path.join("assets/videos/genset/withposter.poster.jpg"),
-            b"jpg-bytes",
-        )
-        .expect("write poster");
 
-        let assets = store
-            .list_assets(&project.id, true, true, AssetScope::All)
+        let (assets, operations) = store
+            .list_assets_with_filesystem_operations(&project.id, true, true, AssetScope::All)
             .expect("list");
+        assert_eq!(
+            operations.poster_stats, 0,
+            "poster presence is served from the indexed envelope"
+        );
         let by_id = |id: &str| {
             assets
                 .iter()
@@ -7667,6 +7892,22 @@ mod tests {
         assert!(
             by_id("noposter").get("posterUrl").is_none(),
             "no posterUrl is advertised when the poster file is absent"
+        );
+
+        std::fs::remove_file(&poster_path).expect("external poster removal");
+        store
+            .reindex_project(&project.id)
+            .expect("explicit reindex");
+        let assets = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .expect("list after reindex");
+        assert!(
+            assets
+                .iter()
+                .find(|asset| asset["id"] == "withposter")
+                .and_then(|asset| asset.get("posterUrl"))
+                .is_none(),
+            "reindex never advertises a poster that no longer exists"
         );
     }
 

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -7,7 +7,6 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-#[cfg(windows)]
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -16,6 +15,7 @@ use parking_lot::{Mutex, ReentrantMutexGuard};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use subtle::ConstantTimeEq;
 
 use crate::asset_index::{
     asset_origin, asset_sidecars, find_asset_sidecar_path_on_connection,
@@ -2922,25 +2922,38 @@ impl ProjectStore {
         let project_path = self.find_project_path(project_id)?;
         let _project_guard = lock_project_files(&project_path);
         let connection = connect_project_db_ready_locked(&project_path)?;
-        connection
+        let poster = connection
             .query_row(
                 "
                 select poster_bytes, poster_sha256
                   from assets
                  where id = ?1
-                   and poster_sha256 = ?2
                    and poster_bytes is not null
                 ",
-                params![asset_id, poster_sha256],
-                |row| {
-                    Ok(AssetPoster {
-                        bytes: row.get(0)?,
-                        sha256: row.get(1)?,
-                    })
-                },
+                params![asset_id],
+                |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Option<String>>(1)?)),
             )
             .optional()?
-            .ok_or_else(|| ProjectStoreError::NotFound("Poster not found".to_owned()))
+            .ok_or_else(|| ProjectStoreError::NotFound("Poster not found".to_owned()))?;
+        let (bytes, Some(stored_sha256)) = poster else {
+            return Err(ProjectStoreError::NotFound("Poster not found".to_owned()));
+        };
+        let recomputed_sha256 = format!("{:x}", Sha256::digest(&bytes));
+        let stored_matches_bytes: bool = stored_sha256
+            .as_bytes()
+            .ct_eq(recomputed_sha256.as_bytes())
+            .into();
+        let request_matches_bytes: bool = poster_sha256
+            .as_bytes()
+            .ct_eq(recomputed_sha256.as_bytes())
+            .into();
+        if !stored_matches_bytes || !request_matches_bytes {
+            return Err(ProjectStoreError::NotFound("Poster not found".to_owned()));
+        }
+        Ok(AssetPoster {
+            bytes,
+            sha256: stored_sha256,
+        })
     }
 
     pub fn index_asset_sidecar(
@@ -5630,6 +5643,14 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    fn jpeg_fixture(rgb: [u8; 3]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut bytes, 90)
+            .encode(&rgb, 1, 1, image::ExtendedColorType::Rgb8)
+            .expect("test JPEG encodes");
+        bytes
+    }
+
     #[cfg(unix)]
     fn create_file_symlink(source: &Path, destination: &Path) -> std::io::Result<()> {
         std::os::unix::fs::symlink(source, destination)
@@ -7347,7 +7368,11 @@ mod tests {
             let media_rel = format!("assets/videos/{generation_set_id}/{asset_id}.mp4");
             let poster_path = project_path.join(&media_rel).with_extension("poster.jpg");
             std::fs::create_dir_all(poster_path.parent().unwrap()).unwrap();
-            std::fs::write(&poster_path, b"poster").unwrap();
+            std::fs::write(
+                &poster_path,
+                jpeg_fixture([index as u8, (index * 2) as u8, (index * 3) as u8]),
+            )
+            .unwrap();
             let fact = json!({
                 "assetId": asset_id,
                 "mediaPath": media_rel,
@@ -8076,8 +8101,9 @@ mod tests {
         // The worker writes the media and best-effort poster before reporting the
         // completed asset fact. Only `withposter` has that sibling when indexed.
         let poster_path = project_path.join("assets/videos/genset/withposter.poster.jpg");
+        let poster_bytes = jpeg_fixture([12, 34, 56]);
         std::fs::create_dir_all(poster_path.parent().unwrap()).expect("video dir");
-        std::fs::write(&poster_path, b"jpg-bytes").expect("write poster");
+        std::fs::write(&poster_path, &poster_bytes).expect("write poster");
         std::fs::write(
             project_path.join("assets/videos/genset/withposter.mp4"),
             b"video",
@@ -8118,7 +8144,7 @@ mod tests {
                 .get_asset_poster(&project.id, "withposter", poster_sha256)
                 .expect("advertised poster resolves")
                 .bytes,
-            b"jpg-bytes"
+            poster_bytes
         );
         assert!(
             by_id("noposter").get("posterUrl").is_none(),
@@ -8146,7 +8172,7 @@ mod tests {
                 .get_asset_poster(&project.id, "withposter", poster_sha256)
                 .expect("DB-backed poster survives source deletion")
                 .bytes,
-            b"jpg-bytes"
+            poster_bytes
         );
 
         store
@@ -8170,6 +8196,116 @@ mod tests {
     }
 
     #[test]
+    fn indexed_poster_rejects_malformed_and_oversized_jpeg_payloads() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Poster validation").unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let fact = |id: &str| {
+            json!({
+                "assetId": id,
+                "mediaPath": format!("assets/videos/set/{id}.mp4"),
+                "mimeType": "video/mp4",
+                "type": "video",
+                "displayName": id,
+                "createdAt": "2026-05-25T00:00:00Z",
+                "mode": "image_to_video",
+                "model": "wan",
+                "adapter": "wan",
+                "prompt": "x",
+            })
+        };
+
+        for id in ["malformed", "oversized"] {
+            let media = project_path.join(format!("assets/videos/set/{id}.mp4"));
+            std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+            std::fs::write(&media, b"video").unwrap();
+            let payload = if id == "malformed" {
+                vec![0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, b'J', b'F', b'I', b'F']
+            } else {
+                vec![0u8; 16 * 1024 * 1024 + 1]
+            };
+            std::fs::write(media.with_extension("poster.jpg"), payload).unwrap();
+            store
+                .persist_generated_asset(&project.id, "job", "set", &fact(id))
+                .unwrap();
+        }
+
+        let listed = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap();
+        assert_eq!(listed.len(), 2);
+        assert!(
+            listed.iter().all(|asset| asset.get("posterUrl").is_none()),
+            "neither JPEG-looking malformed bytes nor an oversized file may be advertised"
+        );
+    }
+
+    #[test]
+    fn get_asset_poster_fails_closed_when_indexed_blob_or_digest_is_tampered() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Poster integrity").unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let media = project_path.join("assets/videos/set/integrity.mp4");
+        let original = jpeg_fixture([1, 2, 3]);
+        std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+        std::fs::write(&media, b"video").unwrap();
+        std::fs::write(media.with_extension("poster.jpg"), &original).unwrap();
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job",
+                "set",
+                &json!({
+                    "assetId": "integrity",
+                    "mediaPath": "assets/videos/set/integrity.mp4",
+                    "mimeType": "video/mp4",
+                    "type": "video",
+                    "displayName": "Integrity",
+                    "createdAt": "2026-05-25T00:00:00Z",
+                    "mode": "image_to_video",
+                    "model": "wan",
+                    "adapter": "wan",
+                    "prompt": "x",
+                }),
+            )
+            .unwrap();
+        let advertised_sha = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap()[0]["posterUrl"]
+            .as_str()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap()
+            .to_owned();
+        let connection = Connection::open(project_path.join("project.db")).unwrap();
+
+        connection
+            .execute(
+                "update assets set poster_bytes = ?1 where id = 'integrity'",
+                params![jpeg_fixture([9, 8, 7])],
+            )
+            .unwrap();
+        assert!(matches!(
+            store.get_asset_poster(&project.id, "integrity", &advertised_sha),
+            Err(ProjectStoreError::NotFound(_))
+        ));
+
+        connection
+            .execute(
+                "update assets set poster_bytes = ?1, poster_sha256 = ?2 where id = 'integrity'",
+                params![original, "0".repeat(64)],
+            )
+            .unwrap();
+        assert!(matches!(
+            store.get_asset_poster(&project.id, "integrity", &advertised_sha),
+            Err(ProjectStoreError::NotFound(_))
+        ));
+    }
+
+    #[test]
     fn indexed_poster_rejects_symlink_sources_and_never_writes_a_poster_destination() {
         let temp_dir = tempfile::tempdir().unwrap();
         let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
@@ -8179,7 +8315,8 @@ mod tests {
         std::fs::create_dir_all(&video_dir).unwrap();
         std::fs::write(video_dir.join("linked.mp4"), b"video").unwrap();
         let outside_poster = temp_dir.path().join("outside-secret.jpg");
-        std::fs::write(&outside_poster, b"outside-secret").unwrap();
+        let outside_bytes = jpeg_fixture([11, 22, 33]);
+        std::fs::write(&outside_poster, &outside_bytes).unwrap();
         let linked_poster = video_dir.join("linked.poster.jpg");
         if let Err(error) = create_file_symlink(&outside_poster, &linked_poster) {
             eprintln!("symlink privilege unavailable; skipping symlink fixture: {error}");
@@ -8206,7 +8343,7 @@ mod tests {
             .list_assets(&project.id, true, true, AssetScope::All)
             .unwrap();
         assert!(listed[0].get("posterUrl").is_none());
-        assert_eq!(std::fs::read(&outside_poster).unwrap(), b"outside-secret");
+        assert_eq!(std::fs::read(&outside_poster).unwrap(), outside_bytes);
 
         let outside_destination = temp_dir.path().join("outside-destination");
         std::fs::create_dir_all(&outside_destination).unwrap();
@@ -8218,7 +8355,8 @@ mod tests {
             return;
         }
         std::fs::write(video_dir.join("contained.mp4"), b"video").unwrap();
-        std::fs::write(video_dir.join("contained.poster.jpg"), b"contained").unwrap();
+        let contained_bytes = jpeg_fixture([44, 55, 66]);
+        std::fs::write(video_dir.join("contained.poster.jpg"), &contained_bytes).unwrap();
         store
             .persist_generated_asset(&project.id, "job", "set", &fact("contained"))
             .unwrap();
@@ -8245,7 +8383,7 @@ mod tests {
                 .get_asset_poster(&project.id, "contained", sha)
                 .unwrap()
                 .bytes,
-            b"contained"
+            contained_bytes
         );
     }
 
@@ -8257,9 +8395,11 @@ mod tests {
         let project_path = store.find_project_path(&project.id).unwrap();
         let media = project_path.join("assets/videos/set/reused.mp4");
         let poster = media.with_extension("poster.jpg");
+        let poster_a = jpeg_fixture([10, 20, 30]);
+        let poster_b = jpeg_fixture([40, 50, 60]);
         std::fs::create_dir_all(media.parent().unwrap()).unwrap();
         std::fs::write(&media, b"video-a").unwrap();
-        std::fs::write(&poster, b"poster-a").unwrap();
+        std::fs::write(&poster, &poster_a).unwrap();
         let fact = json!({
             "assetId": "reused",
             "mediaPath": "assets/videos/set/reused.mp4",
@@ -8298,7 +8438,7 @@ mod tests {
             Err(ProjectStoreError::NotFound(_))
         ));
 
-        std::fs::write(&poster, b"poster-b").unwrap();
+        std::fs::write(&poster, &poster_b).unwrap();
         store
             .persist_generated_asset(&project.id, "job", "set", &fact)
             .unwrap();
@@ -8317,7 +8457,7 @@ mod tests {
                 .get_asset_poster(&project.id, "reused", new_sha)
                 .unwrap()
                 .bytes,
-            b"poster-b"
+            poster_b
         );
     }
 
@@ -8347,7 +8487,7 @@ mod tests {
             let poster = media.with_extension("poster.jpg");
             std::fs::create_dir_all(media.parent().unwrap()).unwrap();
             std::fs::write(&media, b"old-video").unwrap();
-            std::fs::write(&poster, b"old-poster").unwrap();
+            std::fs::write(&poster, jpeg_fixture([70, 80, 90])).unwrap();
             store
                 .persist_generated_asset(&project.id, "job", "set", &fact(lifecycle))
                 .unwrap();
@@ -8398,15 +8538,15 @@ mod tests {
         let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
         let project = store.create_project("Duplicate ids").unwrap();
         let project_path = store.find_project_path(&project.id).unwrap();
-        for (folder, file, poster_bytes) in [
-            ("a", "first", b"poster-a".as_slice()),
-            ("b", "second", b"poster-b".as_slice()),
+        for (folder, file, poster_rgb) in [
+            ("a", "first", [101, 102, 103]),
+            ("b", "second", [201, 202, 203]),
         ] {
             let media_rel = format!("assets/videos/{folder}/{file}.mp4");
             let media = project_path.join(&media_rel);
             std::fs::create_dir_all(media.parent().unwrap()).unwrap();
             std::fs::write(&media, b"video").unwrap();
-            std::fs::write(media.with_extension("poster.jpg"), poster_bytes).unwrap();
+            std::fs::write(media.with_extension("poster.jpg"), jpeg_fixture(poster_rgb)).unwrap();
             let asset = build_generated_asset_sidecar(
                 &project.id,
                 "job",
@@ -8434,9 +8574,9 @@ mod tests {
         assert_eq!(listed.len(), 1);
         let media_path = listed[0]["file"]["path"].as_str().unwrap();
         let expected = if media_path.contains("/a/") {
-            b"poster-a".as_slice()
+            jpeg_fixture([101, 102, 103])
         } else {
-            b"poster-b".as_slice()
+            jpeg_fixture([201, 202, 203])
         };
         let sha = listed[0]["posterUrl"]
             .as_str()
@@ -8462,9 +8602,11 @@ mod tests {
         let project_path = store.find_project_path(&project.id).unwrap();
         let media = project_path.join("assets/videos/set/repaired.mp4");
         let poster = media.with_extension("poster.jpg");
+        let before = jpeg_fixture([3, 4, 5]);
+        let after = jpeg_fixture([6, 7, 8]);
         std::fs::create_dir_all(media.parent().unwrap()).unwrap();
         std::fs::write(&media, b"video").unwrap();
-        std::fs::write(&poster, b"poster-before").unwrap();
+        std::fs::write(&poster, &before).unwrap();
         let fact = json!({
             "assetId": "repaired",
             "mediaPath": "assets/videos/set/repaired.mp4",
@@ -8490,7 +8632,7 @@ mod tests {
             .unwrap()
             .to_owned();
 
-        std::fs::write(&poster, b"poster-after").unwrap();
+        std::fs::write(&poster, &after).unwrap();
         fail_next_asset_index_db_mutation();
         assert!(store
             .update_asset_status(
@@ -8519,7 +8661,7 @@ mod tests {
                 .get_asset_poster(&project.id, "repaired", new_sha)
                 .unwrap()
                 .bytes,
-            b"poster-after"
+            after
         );
         assert!(matches!(
             store.get_asset_poster(&project.id, "repaired", &old_sha),

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -19,7 +19,8 @@ use serde_json::{json, Map, Value};
 
 use crate::asset_index::{
     asset_origin, asset_sidecars, find_asset_sidecar_path_on_connection,
-    hydrate_indexed_asset_cached, index_asset_on_connection, normalize_asset, GenerationSetCache,
+    hydrate_indexed_asset_cached, index_asset_on_connection, indexed_poster_ids, normalize_asset,
+    GenerationSetCache,
 };
 use crate::character_store::{
     apply_character_migrations, clear_character_tables, reindex_characters_on_connection,
@@ -55,6 +56,7 @@ pub const PROJECT_FOLDERS: &[&str] = &[
     "assets/renders",
     "assets/documents",
     "assets/poses",
+    "assets/posters",
     "characters",
     "generation-sets",
     "loras",
@@ -1055,7 +1057,7 @@ impl ProjectStore {
 
     pub fn reindex_project(&self, project_id: &str) -> ProjectStoreResult<ReindexResult> {
         let (project_path, _project_guard) = self.lock_project(project_id)?;
-        let counts = reindex_project_path(&project_path, true)?;
+        let counts = reindex_project_path(project_id, &project_path, true)?;
         Ok(ReindexResult {
             project_id: project_id.to_owned(),
             assets: counts.assets,
@@ -1309,14 +1311,15 @@ impl ProjectStore {
     /// inventory used by performance tests, benchmarks, and API observability.
     ///
     /// The indexed `asset_json` envelope is authoritative on this clean path,
-    /// including its embedded generation set and poster presence. SceneWorks-owned
+    /// including its embedded generation set. Poster URLs are reconciled against
+    /// one shared snapshot of the managed poster directory. SceneWorks-owned
     /// mutations update the sidecar and index before returning. Tools that edit
-    /// sidecars, generation-set JSON, media, or poster files out of band must call
+    /// sidecars or generation-set JSON out of band must call
     /// [`Self::reindex_project`] (the REST equivalent is
     /// `POST /api/v1/projects/:project_id/reindex`) before expecting those edits
     /// in listings. This explicit contract includes deletion, same-size rewrites,
-    /// and edits that preserve timestamps; list requests do not inspect or hash
-    /// any per-row files.
+    /// and edits that preserve timestamps. Deletion of an advertised managed
+    /// poster is visible on the next ordinary list without a reindex.
     pub fn list_assets_with_filesystem_operations(
         &self,
         project_id: &str,
@@ -1357,7 +1360,7 @@ impl ProjectStore {
         // the listing — fail open and return whatever the table currently
         // holds (possibly empty), which is strictly better than an error.
         if total == 0 && project_has_sidecars(&project_path) {
-            let _ = reindex_project_path(&project_path, false);
+            let _ = reindex_project_path(project_id, &project_path, false);
             connection = connect_project_db(&project_path)?;
         }
 
@@ -1392,6 +1395,7 @@ impl ProjectStore {
             )?
             .collect::<Result<Vec<_>, _>>()?;
         drop(statement);
+        let indexed_posters = indexed_poster_ids(&project_path)?;
         // HashSet dedup (was an O(n²) Vec linear scan) and a per-call
         // generation-set cache so a set's JSON is read once, not once per asset
         // in it (sc-4270 / F-CORE-10).
@@ -1413,7 +1417,7 @@ impl ProjectStore {
                     object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));
                 }
             }
-            let Ok(asset) = hydrate_indexed_asset_cached(
+            let Ok(mut asset) = hydrate_indexed_asset_cached(
                 project_id,
                 &project_path,
                 asset,
@@ -1421,6 +1425,11 @@ impl ProjectStore {
             ) else {
                 continue;
             };
+            if asset.get("posterUrl").is_some() && !indexed_posters.contains(&row_id) {
+                if let Some(object) = asset.as_object_mut() {
+                    object.remove("posterUrl");
+                }
+            }
             if seen_asset_ids.insert(row_id) {
                 assets.push(asset);
             }
@@ -1925,7 +1934,7 @@ impl ProjectStore {
         }
         let sidecar_path = media_path.with_extension("sceneworks.json");
         write_json(&sidecar_path, &asset)?;
-        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        index_asset(project_id, &project_path, &asset, Some(&sidecar_path))?;
         index_mutation.commit();
         normalize_asset(project_id, &project_path, &sidecar_path)
     }
@@ -1981,7 +1990,7 @@ impl ProjectStore {
             &recipes_dir.join(format!("{asset_id}.recipe.json")),
             &asset["recipe"],
         )?;
-        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        index_asset(project_id, &project_path, &asset, Some(&sidecar_path))?;
         index_mutation.commit();
         Ok(asset)
     }
@@ -2144,7 +2153,12 @@ impl ProjectStore {
         });
         let sidecar_path = media_path.with_extension("sceneworks.json");
         write_json(&sidecar_path, &asset)?;
-        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        index_asset(
+            GLOBAL_POSES_PROJECT_ID,
+            &project_path,
+            &asset,
+            Some(&sidecar_path),
+        )?;
         index_mutation.commit();
         normalize_asset(GLOBAL_POSES_PROJECT_ID, &project_path, &sidecar_path)
     }
@@ -2293,7 +2307,12 @@ impl ProjectStore {
         });
         let sidecar_path = media_path.with_extension("sceneworks.json");
         write_json(&sidecar_path, &asset)?;
-        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        index_asset(
+            GLOBAL_KEYPOINTS_PROJECT_ID,
+            &project_path,
+            &asset,
+            Some(&sidecar_path),
+        )?;
         index_mutation.commit();
         normalize_asset(GLOBAL_KEYPOINTS_PROJECT_ID, &project_path, &sidecar_path)
     }
@@ -2702,7 +2721,7 @@ impl ProjectStore {
         }
         let index_mutation = AssetIndexMutation::begin(&project_path)?;
         write_json(&sidecar_path, &asset)?;
-        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        index_asset(project_id, &project_path, &asset, Some(&sidecar_path))?;
         index_mutation.commit();
         normalize_asset(project_id, &project_path, &sidecar_path)
     }
@@ -2726,7 +2745,7 @@ impl ProjectStore {
         );
         let index_mutation = AssetIndexMutation::begin(&project_path)?;
         write_json(&sidecar_path, &asset)?;
-        index_asset(&project_path, &asset, Some(&sidecar_path))?;
+        index_asset(project_id, &project_path, &asset, Some(&sidecar_path))?;
         index_mutation.commit();
         normalize_asset(project_id, &project_path, &sidecar_path)
     }
@@ -2784,7 +2803,7 @@ impl ProjectStore {
                 }
             }
             write_json(&sidecar_path, &asset)?;
-            index_asset(&project_path, &asset, Some(&sidecar_path))?;
+            index_asset(project_id, &project_path, &asset, Some(&sidecar_path))?;
             // Drop the asset from every character's references[] (character sidecars + index).
             character_store.remove_asset_references(&member_id)?;
             moved.push(normalize_asset(project_id, &project_path, &sidecar_path)?);
@@ -2865,7 +2884,7 @@ impl ProjectStore {
                 );
             }
             write_json(&sidecar_path, &asset)?;
-            index_asset(&project_path, &asset, Some(&sidecar_path))?;
+            index_asset(project_id, &project_path, &asset, Some(&sidecar_path))?;
             // Leave no curated membership behind: the move detaches the asset from every
             // character's references[] (including the target's — the Approved set is
             // hand-curated and a bulk move must not populate it).
@@ -2890,7 +2909,7 @@ impl ProjectStore {
         let (project_path, _project_guard) = self.lock_project(project_id)?;
         let asset = read_json(sidecar_path)?;
         let index_mutation = AssetIndexMutation::begin(&project_path)?;
-        index_asset(&project_path, &asset, Some(sidecar_path))?;
+        index_asset(project_id, &project_path, &asset, Some(sidecar_path))?;
         index_mutation.commit();
         Ok(())
     }
@@ -2932,7 +2951,7 @@ impl ProjectStore {
                 .join(format!("{asset_id}.recipe.json")),
             recipe,
         )?;
-        index_asset(&project_path, asset, Some(sidecar_path))?;
+        index_asset(project_id, &project_path, asset, Some(sidecar_path))?;
         index_mutation.commit();
         Ok(())
     }
@@ -2990,7 +3009,12 @@ impl ProjectStore {
         if sidecar_path != trashed_sidecar_path {
             fs::remove_file(&sidecar_path).ok();
         }
-        index_asset(&project_path, &asset, Some(&trashed_sidecar_path))?;
+        index_asset(
+            project_id,
+            &project_path,
+            &asset,
+            Some(&trashed_sidecar_path),
+        )?;
         index_mutation.commit();
         Ok(AssetMutationResult {
             id: asset_id.to_owned(),
@@ -3549,7 +3573,8 @@ fn connect_project_db_ready_locked(project_path: &Path) -> ProjectStoreResult<Co
         // their media is temporarily unavailable. Only dirty-mutation repair
         // prunes missing-media rows before clearing the marker, closing the
         // partial-purge resurrection window.
-        reindex_project_path(project_path, asset_index_dirty)?;
+        let project_id = read_project_summary(project_path)?.id;
+        reindex_project_path(&project_id, project_path, asset_index_dirty)?;
         return connect_project_db(project_path);
     }
     Ok(connection)
@@ -3716,6 +3741,7 @@ fn upscale_lineage_group(project_path: &Path, asset_id: &str) -> Vec<String> {
 }
 
 fn reindex_project_path(
+    project_id: &str,
     project_path: &Path,
     prune_orphans: bool,
 ) -> ProjectStoreResult<ReindexCounts> {
@@ -3742,7 +3768,13 @@ fn reindex_project_path(
         if asset.get("id").is_none() || asset.pointer("/file/path").is_none() {
             continue;
         }
-        index_asset_on_connection(&transaction, project_path, &asset, Some(&sidecar_path))?;
+        index_asset_on_connection(
+            &transaction,
+            project_id,
+            project_path,
+            &asset,
+            Some(&sidecar_path),
+        )?;
         counts.assets += 1;
     }
 
@@ -5003,6 +5035,7 @@ fn write_user_collections(project_path: &Path, collections: &[Value]) -> Project
 }
 
 fn index_asset(
+    project_id: &str,
     project_path: &Path,
     asset: &Value,
     sidecar_path: Option<&Path>,
@@ -5022,7 +5055,13 @@ fn index_asset(
     let mut connection = connect_project_db(project_path)?;
     let transaction = connection.transaction()?;
     apply_project_migrations(&transaction)?;
-    index_asset_on_connection(&transaction, project_path, asset, Some(&sidecar_path))?;
+    index_asset_on_connection(
+        &transaction,
+        project_id,
+        project_path,
+        asset,
+        Some(&sidecar_path),
+    )?;
     transaction.commit()?;
     Ok(())
 }
@@ -6991,6 +7030,60 @@ mod tests {
     }
 
     #[test]
+    fn reindex_uses_authoritative_project_id_for_asset_urls() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Imported sidecar").unwrap();
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job-1",
+                "set",
+                &json!({
+                    "assetId": "asset_imported",
+                    "mediaPath": "assets/images/set/asset_imported.png",
+                    "mimeType": "image/png",
+                    "displayName": "Imported",
+                    "createdAt": "2026-05-25T00:00:00Z",
+                    "mode": "text_to_image",
+                    "model": "benchmark",
+                    "adapter": "benchmark",
+                    "prompt": "imported",
+                }),
+            )
+            .unwrap();
+
+        let project_path = store.find_project_path(&project.id).unwrap();
+        std::fs::write(
+            project_path.join("assets/images/set/asset_imported.png"),
+            b"png",
+        )
+        .unwrap();
+        let sidecar = project_path.join("assets/images/set/asset_imported.sceneworks.json");
+        let mut asset = read_json(&sidecar).unwrap();
+        asset["projectId"] = json!("project_from_another_machine");
+        write_json(&sidecar, &asset).unwrap();
+
+        store.reindex_project(&project.id).unwrap();
+        let listed = store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .unwrap();
+        assert_eq!(
+            listed[0]["url"],
+            json!(format!(
+                "/api/v1/projects/{}/files/assets/images/set/asset_imported.png",
+                project.id
+            )),
+            "mutable imported sidecar metadata must not select the URL project"
+        );
+        assert_eq!(
+            listed[0]["projectId"],
+            json!(project.id),
+            "the indexed envelope also reports its authoritative current project"
+        );
+    }
+
+    #[test]
     fn list_assets_external_generation_set_edit_requires_explicit_reindex() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
@@ -7178,7 +7271,10 @@ mod tests {
         assert_eq!(operations.registry_opens, 1);
         assert_eq!(operations.registry_metadata_reads, 1);
         assert!(operations.path_stats >= 1);
-        assert_eq!(operations.directory_scans, 0);
+        assert_eq!(
+            operations.directory_scans, 1,
+            "one shared managed-poster snapshot replaces per-video stats"
+        );
         assert_eq!(operations.index_marker_reads, 1);
         assert_eq!(operations.index_marker_writes, 0);
         assert_eq!(operations.index_marker_removes, 0);
@@ -7884,7 +7980,7 @@ mod tests {
         assert_eq!(
             by_id("withposter")["posterUrl"],
             json!(format!(
-                "/api/v1/projects/{}/files/assets/videos/genset/withposter.poster.jpg",
+                "/api/v1/projects/{}/files/assets/posters/withposter.poster.jpg",
                 project.id
             )),
             "posterUrl is advertised when the poster file exists"
@@ -7894,20 +7990,24 @@ mod tests {
             "no posterUrl is advertised when the poster file is absent"
         );
 
-        std::fs::remove_file(&poster_path).expect("external poster removal");
-        store
-            .reindex_project(&project.id)
-            .expect("explicit reindex");
-        let assets = store
-            .list_assets(&project.id, true, true, AssetScope::All)
-            .expect("list after reindex");
+        let advertised_poster_path = project_path.join("assets/posters/withposter.poster.jpg");
+        assert!(
+            advertised_poster_path.is_file(),
+            "indexing materializes the advertised managed poster"
+        );
+        std::fs::remove_file(&advertised_poster_path).expect("external poster removal");
+        let (assets, operations) = store
+            .list_assets_with_filesystem_operations(&project.id, true, true, AssetScope::All)
+            .expect("ordinary list after removal");
+        assert_eq!(operations.poster_stats, 0);
+        assert_eq!(operations.directory_scans, 1);
         assert!(
             assets
                 .iter()
                 .find(|asset| asset["id"] == "withposter")
                 .and_then(|asset| asset.get("posterUrl"))
                 .is_none(),
-            "reindex never advertises a poster that no longer exists"
+            "ordinary list never advertises a managed poster that was deleted"
         );
     }
 

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -19,8 +19,7 @@ use serde_json::{json, Map, Value};
 
 use crate::asset_index::{
     asset_origin, asset_sidecars, find_asset_sidecar_path_on_connection,
-    hydrate_indexed_asset_cached, index_asset_on_connection, indexed_poster_ids, normalize_asset,
-    GenerationSetCache,
+    hydrate_indexed_asset_cached, index_asset_on_connection, normalize_asset, GenerationSetCache,
 };
 use crate::character_store::{
     apply_character_migrations, clear_character_tables, reindex_characters_on_connection,
@@ -56,7 +55,6 @@ pub const PROJECT_FOLDERS: &[&str] = &[
     "assets/renders",
     "assets/documents",
     "assets/poses",
-    "assets/posters",
     "characters",
     "generation-sets",
     "loras",
@@ -216,6 +214,12 @@ pub struct AssetMutationResult {
     pub status: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetPoster {
+    pub bytes: Vec<u8>,
+    pub sha256: String,
+}
+
 /// Which assets a listing should include (sc-2024). `All` is the historical
 /// behaviour used by Image/Video studios, the Editor, and the per-character
 /// gallery. `Library` is the Asset Library view, which excludes Character Studio
@@ -246,6 +250,7 @@ pub struct AssetListFilesystemOperations {
     pub timeline_reads: u64,
     pub character_reads: u64,
     pub poster_stats: u64,
+    pub poster_reads: u64,
     pub index_marker_reads: u64,
     pub index_marker_writes: u64,
     pub index_marker_removes: u64,
@@ -265,6 +270,7 @@ impl AssetListFilesystemOperations {
             + self.timeline_reads
             + self.character_reads
             + self.poster_stats
+            + self.poster_reads
             + self.index_marker_reads
             + self.index_marker_writes
             + self.index_marker_removes
@@ -285,6 +291,7 @@ pub(crate) enum AssetListFilesystemOperation {
     TimelineRead,
     CharacterRead,
     PosterStat,
+    PosterRead,
     IndexMarkerRead,
     IndexMarkerWrite,
     IndexMarkerRemove,
@@ -320,6 +327,7 @@ pub(crate) fn record_asset_list_filesystem_operation(operation: AssetListFilesys
             AssetListFilesystemOperation::TimelineRead => operations.timeline_reads += 1,
             AssetListFilesystemOperation::CharacterRead => operations.character_reads += 1,
             AssetListFilesystemOperation::PosterStat => operations.poster_stats += 1,
+            AssetListFilesystemOperation::PosterRead => operations.poster_reads += 1,
             AssetListFilesystemOperation::IndexMarkerRead => operations.index_marker_reads += 1,
             AssetListFilesystemOperation::IndexMarkerWrite => operations.index_marker_writes += 1,
             AssetListFilesystemOperation::IndexMarkerRemove => {
@@ -1311,15 +1319,15 @@ impl ProjectStore {
     /// inventory used by performance tests, benchmarks, and API observability.
     ///
     /// The indexed `asset_json` envelope is authoritative on this clean path,
-    /// including its embedded generation set. Poster URLs are reconciled against
-    /// one shared snapshot of the managed poster directory. SceneWorks-owned
-    /// mutations update the sidecar and index before returning. Tools that edit
+    /// including its embedded generation set and DB-backed poster URL.
+    /// SceneWorks-owned mutations update the sidecar and index before returning.
+    /// Tools that edit
     /// sidecars or generation-set JSON out of band must call
     /// [`Self::reindex_project`] (the REST equivalent is
     /// `POST /api/v1/projects/:project_id/reindex`) before expecting those edits
     /// in listings. This explicit contract includes deletion, same-size rewrites,
-    /// and edits that preserve timestamps. Deletion of an advertised managed
-    /// poster is visible on the next ordinary list without a reindex.
+    /// and edits that preserve timestamps. Advertised posters are served from
+    /// the same indexed DB row, so list requests do no poster filesystem work.
     pub fn list_assets_with_filesystem_operations(
         &self,
         project_id: &str,
@@ -1395,7 +1403,6 @@ impl ProjectStore {
             )?
             .collect::<Result<Vec<_>, _>>()?;
         drop(statement);
-        let indexed_posters = indexed_poster_ids(&project_path)?;
         // HashSet dedup (was an O(n²) Vec linear scan) and a per-call
         // generation-set cache so a set's JSON is read once, not once per asset
         // in it (sc-4270 / F-CORE-10).
@@ -1417,7 +1424,7 @@ impl ProjectStore {
                     object.insert("sidecarPath".to_owned(), Value::String(sidecar_rel));
                 }
             }
-            let Ok(mut asset) = hydrate_indexed_asset_cached(
+            let Ok(asset) = hydrate_indexed_asset_cached(
                 project_id,
                 &project_path,
                 asset,
@@ -1425,11 +1432,6 @@ impl ProjectStore {
             ) else {
                 continue;
             };
-            if asset.get("posterUrl").is_some() && !indexed_posters.contains(&row_id) {
-                if let Some(object) = asset.as_object_mut() {
-                    object.remove("posterUrl");
-                }
-            }
             if seen_asset_ids.insert(row_id) {
                 assets.push(asset);
             }
@@ -2901,6 +2903,46 @@ impl ProjectStore {
         normalize_asset(project_id, &project_path, &sidecar_path)
     }
 
+    pub fn get_asset_poster(
+        &self,
+        project_id: &str,
+        asset_id: &str,
+        poster_sha256: &str,
+    ) -> ProjectStoreResult<AssetPoster> {
+        if !is_safe_id(asset_id)
+            || poster_sha256.len() != 64
+            || !poster_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(ProjectStoreError::BadRequest(
+                "Invalid indexed poster id".to_owned(),
+            ));
+        }
+        let project_path = self.find_project_path(project_id)?;
+        let _project_guard = lock_project_files(&project_path);
+        let connection = connect_project_db_ready_locked(&project_path)?;
+        connection
+            .query_row(
+                "
+                select poster_bytes, poster_sha256
+                  from assets
+                 where id = ?1
+                   and poster_sha256 = ?2
+                   and poster_bytes is not null
+                ",
+                params![asset_id, poster_sha256],
+                |row| {
+                    Ok(AssetPoster {
+                        bytes: row.get(0)?,
+                        sha256: row.get(1)?,
+                    })
+                },
+            )
+            .optional()?
+            .ok_or_else(|| ProjectStoreError::NotFound("Poster not found".to_owned()))
+    }
+
     pub fn index_asset_sidecar(
         &self,
         project_id: &str,
@@ -2990,6 +3032,7 @@ impl ProjectStore {
         let index_mutation = AssetIndexMutation::begin(&project_path)?;
         let trash_dir = project_path.join("trash").join(asset_id);
         fs::create_dir_all(&trash_dir)?;
+        remove_sibling_poster_no_symlinks(&project_path, &media_rel)?;
         if media_path.exists() && media_path.is_file() {
             let trashed_media_path = trash_dir.join(media_path.file_name().ok_or_else(|| {
                 ProjectStoreError::BadRequest("Invalid asset media path".to_owned())
@@ -3035,12 +3078,11 @@ impl ProjectStore {
         let (project_path, _project_guard) = self.lock_project(project_id)?;
         let sidecar_path = self.find_asset_sidecar(&project_path, asset_id)?;
         let asset = read_json(&sidecar_path)?;
-        let media_path = project_path.join(
-            asset
-                .pointer("/file/path")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-        );
+        let media_rel = asset
+            .pointer("/file/path")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let media_path = project_path.join(media_rel);
         let trash_dir = project_path.join("trash");
         let asset_trash_dir = sidecar_path
             .parent()
@@ -3066,6 +3108,7 @@ impl ProjectStore {
                 targets
             };
             let index_mutation = AssetIndexMutation::begin(&project_path)?;
+            remove_sibling_poster_no_symlinks(&project_path, media_rel)?;
             if !targets.is_empty() && trash::delete_all(&targets).is_err() {
                 // The trash API does not guarantee an atomic multi-target operation.
                 // Keep the marker so the next read repairs any partial deletion before
@@ -3085,6 +3128,7 @@ impl ProjectStore {
             });
         }
         let index_mutation = AssetIndexMutation::begin(&project_path)?;
+        remove_sibling_poster_no_symlinks(&project_path, media_rel)?;
         CharacterStore::new(&self.data_dir, project_path.clone())
             .remove_asset_references(asset_id)?;
         if media_path.exists() && media_path.is_file() {
@@ -3270,7 +3314,10 @@ struct ReindexCounts {
 ///
 /// v7: sc-14799 — materializes generation-set and poster hydration in each
 /// indexed asset envelope, removing per-row filesystem reads from clean lists.
-const PROJECT_SCHEMA_VERSION: i64 = 7;
+///
+/// v8: sc-14799 review convergence stores poster bytes and their digest in
+/// `project.db`, so advertised posters need no clean-list filesystem scan.
+const PROJECT_SCHEMA_VERSION: i64 = 8;
 const ASSET_INDEX_VERSION_KEY: &str = "assetIndexVersion";
 const ASSET_INDEX_DIRTY_MARKER: &str = ".asset-index-dirty";
 
@@ -3519,6 +3566,8 @@ pub fn apply_project_migrations(connection: &Connection) -> ProjectStoreResult<(
     ensure_column(connection, "assets", "sidecar_size", "integer")?;
     ensure_column(connection, "assets", "sidecar_modified_ns", "text")?;
     ensure_column(connection, "assets", "sidecar_sha256", "text")?;
+    ensure_column(connection, "assets", "poster_bytes", "blob")?;
+    ensure_column(connection, "assets", "poster_sha256", "text")?;
     connection.execute_batch(
         "
         create index if not exists idx_assets_source_asset
@@ -5088,6 +5137,56 @@ fn purge_asset_record(project_path: &Path, asset_id: &str) -> ProjectStoreResult
     Ok(())
 }
 
+/// Remove a source sibling poster without ever traversing a symlinked parent.
+///
+/// Poster bytes are already durable in `project.db`; this lifecycle cleanup
+/// prevents a purged/orphaned id reused at the same media path from inheriting
+/// its predecessor's source poster.
+fn remove_sibling_poster_no_symlinks(
+    project_path: &Path,
+    media_rel: &str,
+) -> ProjectStoreResult<()> {
+    if !is_safe_relative_path(media_rel) {
+        return Ok(());
+    }
+    let poster_rel = Path::new(media_rel).with_extension("poster.jpg");
+    let root = fs::canonicalize(project_path)?;
+    let mut target = root.clone();
+    let components = poster_rel.components().collect::<Vec<_>>();
+    for component in components.iter().take(components.len().saturating_sub(1)) {
+        let std::path::Component::Normal(component) = component else {
+            return Ok(());
+        };
+        target.push(component);
+        let Ok(metadata) = fs::symlink_metadata(&target) else {
+            return Ok(());
+        };
+        if metadata.file_type().is_symlink() {
+            return Ok(());
+        }
+    }
+    let Some(std::path::Component::Normal(file_name)) = components.last() else {
+        return Ok(());
+    };
+    target.push(file_name);
+    let Ok(metadata) = fs::symlink_metadata(&target) else {
+        return Ok(());
+    };
+    if metadata.is_dir() {
+        return Ok(());
+    }
+    if !metadata.file_type().is_symlink() {
+        let Ok(canonical_target) = fs::canonicalize(&target) else {
+            return Ok(());
+        };
+        if !canonical_target.starts_with(&root) {
+            return Ok(());
+        }
+    }
+    fs::remove_file(target)?;
+    Ok(())
+}
+
 /// Sidecars of pruned "purged-but-referenced" assets are moved here, out of the
 /// folders `asset_sidecars` scans, so a rebuild can't resurrect them. A dotdir so
 /// it reads as internal state, not user content.
@@ -5103,8 +5202,8 @@ fn prune_orphaned_asset_rows(project_path: &Path) -> ProjectStoreResult<usize> {
     let mut connection = connect_project_db(project_path)?;
     let transaction = connection.transaction()?;
     apply_project_migrations(&transaction)?;
-    // (asset id, orphaned sidecar to quarantine) for every row whose media is gone.
-    let orphans: Vec<(String, Option<PathBuf>)> = {
+    // (asset id, media path, orphaned sidecar to quarantine) for every row whose media is gone.
+    let orphans: Vec<(String, String, Option<PathBuf>)> = {
         let mut statement =
             transaction.prepare("select id, file_path, sidecar_path from assets")?;
         let rows = statement.query_map([], |row| {
@@ -5138,11 +5237,11 @@ fn prune_orphaned_asset_rows(project_path: &Path) -> ProjectStoreResult<usize> {
                         .with_extension("sceneworks.json");
                     derived.exists().then_some(derived)
                 });
-            orphans.push((asset_id, sidecar));
+            orphans.push((asset_id, file_rel, sidecar));
         }
         orphans
     };
-    for (asset_id, _) in &orphans {
+    for (asset_id, _, _) in &orphans {
         transaction.execute("delete from assets where id = ?1", params![asset_id])?;
     }
     transaction.commit()?;
@@ -5154,8 +5253,11 @@ fn prune_orphaned_asset_rows(project_path: &Path) -> ProjectStoreResult<usize> {
     // deleted) so the recipe metadata stays recoverable. Report a move failure after
     // attempting every orphan so dirty repair keeps its marker and retries instead
     // of clearing it while a resurrectable sidecar remains in the scanned tree.
-    let mut quarantine_error = None;
-    for (asset_id, sidecar) in &orphans {
+    let mut cleanup_error = None;
+    for (asset_id, media_rel, sidecar) in &orphans {
+        if let Err(error) = remove_sibling_poster_no_symlinks(project_path, media_rel) {
+            cleanup_error.get_or_insert(error);
+        }
         let Some(sidecar) = sidecar else {
             continue;
         };
@@ -5167,11 +5269,11 @@ fn prune_orphaned_asset_rows(project_path: &Path) -> ProjectStoreResult<usize> {
                 error = %error,
                 "could not move orphaned sidecar out of the asset tree; repair remains pending"
             );
-            quarantine_error.get_or_insert(error);
+            cleanup_error.get_or_insert(ProjectStoreError::Io(error));
         }
     }
-    if let Some(error) = quarantine_error {
-        return Err(ProjectStoreError::Io(error));
+    if let Some(error) = cleanup_error {
+        return Err(error);
     }
     Ok(orphans.len())
 }
@@ -5528,6 +5630,26 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    #[cfg(unix)]
+    fn create_file_symlink(source: &Path, destination: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(source, destination)
+    }
+
+    #[cfg(windows)]
+    fn create_file_symlink(source: &Path, destination: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(source, destination)
+    }
+
+    #[cfg(unix)]
+    fn create_dir_symlink(source: &Path, destination: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(source, destination)
+    }
+
+    #[cfg(windows)]
+    fn create_dir_symlink(source: &Path, destination: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_dir(source, destination)
+    }
+
     #[test]
     fn recent_project_registry_cache_reuses_reads_and_invalidates_on_external_change() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
@@ -5883,8 +6005,8 @@ mod tests {
     /// alongside a deliberate schema change — and when you do, you MUST bump
     /// `PROJECT_SCHEMA_VERSION` so the `user_version=` line below changes too.
     const EXPECTED_PROJECT_DB_SCHEMA: &str = concat!(
-        "user_version=7\n",
-        "table assets: id TEXT notnull=0 default=NULL pk=1, type TEXT notnull=1 default=NULL pk=0, display_name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, generation_set_id TEXT notnull=0 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, favorite INTEGER notnull=1 default=0 pk=0, rating INTEGER notnull=1 default=0 pk=0, rejected INTEGER notnull=1 default=0 pk=0, trashed INTEGER notnull=1 default=0 pk=0, sidecar_path TEXT notnull=0 default=NULL pk=0, origin TEXT notnull=0 default=NULL pk=0, asset_json TEXT notnull=0 default=NULL pk=0, source_asset_id TEXT notnull=0 default=NULL pk=0, upscaled_from_asset_id TEXT notnull=0 default=NULL pk=0, sidecar_size INTEGER notnull=0 default=NULL pk=0, sidecar_modified_ns TEXT notnull=0 default=NULL pk=0, sidecar_sha256 TEXT notnull=0 default=NULL pk=0\n",
+        "user_version=8\n",
+        "table assets: id TEXT notnull=0 default=NULL pk=1, type TEXT notnull=1 default=NULL pk=0, display_name TEXT notnull=1 default=NULL pk=0, file_path TEXT notnull=1 default=NULL pk=0, generation_set_id TEXT notnull=0 default=NULL pk=0, created_at TEXT notnull=1 default=NULL pk=0, favorite INTEGER notnull=1 default=0 pk=0, rating INTEGER notnull=1 default=0 pk=0, rejected INTEGER notnull=1 default=0 pk=0, trashed INTEGER notnull=1 default=0 pk=0, sidecar_path TEXT notnull=0 default=NULL pk=0, origin TEXT notnull=0 default=NULL pk=0, asset_json TEXT notnull=0 default=NULL pk=0, source_asset_id TEXT notnull=0 default=NULL pk=0, upscaled_from_asset_id TEXT notnull=0 default=NULL pk=0, sidecar_size INTEGER notnull=0 default=NULL pk=0, sidecar_modified_ns TEXT notnull=0 default=NULL pk=0, sidecar_sha256 TEXT notnull=0 default=NULL pk=0, poster_bytes BLOB notnull=0 default=NULL pk=0, poster_sha256 TEXT notnull=0 default=NULL pk=0\n",
         "table character_looks: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, description TEXT notnull=1 default='' pk=0, approved_reference_ids TEXT notnull=1 default='[]' pk=0, recipe_settings TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table character_loras: id TEXT notnull=0 default=NULL pk=1, character_id TEXT notnull=1 default=NULL pk=0, lora_id TEXT notnull=0 default=NULL pk=0, name TEXT notnull=1 default=NULL pk=0, source_path TEXT notnull=0 default=NULL pk=0, project_path TEXT notnull=0 default=NULL pk=0, copied_into_project INTEGER notnull=1 default=0 pk=0, category TEXT notnull=1 default='character' pk=0, scope TEXT notnull=1 default='project' pk=0, trigger_words TEXT notnull=1 default='[]' pk=0, default_weight REAL notnull=1 default=1.0 pk=0, compatibility TEXT notnull=1 default='{}' pk=0, created_at TEXT notnull=1 default=NULL pk=0, updated_at TEXT notnull=1 default=NULL pk=0\n",
         "table character_references: character_id TEXT notnull=1 default=NULL pk=1, asset_id TEXT notnull=1 default=NULL pk=2, approved INTEGER notnull=1 default=0 pk=0, role TEXT notnull=1 default='reference' pk=0, notes TEXT notnull=1 default='' pk=0, added_at TEXT notnull=1 default=NULL pk=0, approved_at TEXT notnull=0 default=NULL pk=0\n",
@@ -7267,14 +7389,12 @@ mod tests {
         );
         assert_eq!(operations.generation_set_reads, 0);
         assert_eq!(operations.poster_stats, 0);
+        assert_eq!(operations.poster_reads, 0);
         assert_eq!(operations.db_opens, 1);
         assert_eq!(operations.registry_opens, 1);
         assert_eq!(operations.registry_metadata_reads, 1);
         assert!(operations.path_stats >= 1);
-        assert_eq!(
-            operations.directory_scans, 1,
-            "one shared managed-poster snapshot replaces per-video stats"
-        );
+        assert_eq!(operations.directory_scans, 0);
         assert_eq!(operations.index_marker_reads, 1);
         assert_eq!(operations.index_marker_writes, 0);
         assert_eq!(operations.index_marker_removes, 0);
@@ -7282,6 +7402,17 @@ mod tests {
             operations.total(),
             one_row_operations.total(),
             "clean-list filesystem work must be independent of returned row count"
+        );
+        let list_source = include_str!("project_store.rs")
+            .split_once("fn list_assets_filtered(")
+            .unwrap()
+            .1
+            .split_once("pub fn list_saved_voices(")
+            .unwrap()
+            .0;
+        assert!(
+            !list_source.contains("read_dir") && !list_source.contains("file_type"),
+            "the clean-list implementation must not hide poster enumeration behind one counter"
         );
     }
 
@@ -7977,38 +8108,424 @@ mod tests {
                 .find(|asset| asset["id"] == id)
                 .unwrap_or_else(|| panic!("asset {id} present"))
         };
+        let poster_url = by_id("withposter")["posterUrl"]
+            .as_str()
+            .expect("poster URL");
+        let poster_sha256 = poster_url.rsplit('/').next().expect("poster digest");
+        assert_eq!(poster_sha256.len(), 64);
         assert_eq!(
-            by_id("withposter")["posterUrl"],
-            json!(format!(
-                "/api/v1/projects/{}/files/assets/posters/withposter.poster.jpg",
-                project.id
-            )),
-            "posterUrl is advertised when the poster file exists"
+            store
+                .get_asset_poster(&project.id, "withposter", poster_sha256)
+                .expect("advertised poster resolves")
+                .bytes,
+            b"jpg-bytes"
         );
         assert!(
             by_id("noposter").get("posterUrl").is_none(),
             "no posterUrl is advertised when the poster file is absent"
         );
 
-        let advertised_poster_path = project_path.join("assets/posters/withposter.poster.jpg");
-        assert!(
-            advertised_poster_path.is_file(),
-            "indexing materializes the advertised managed poster"
-        );
-        std::fs::remove_file(&advertised_poster_path).expect("external poster removal");
+        std::fs::remove_file(&poster_path).expect("external source poster removal");
         let (assets, operations) = store
             .list_assets_with_filesystem_operations(&project.id, true, true, AssetScope::All)
             .expect("ordinary list after removal");
         assert_eq!(operations.poster_stats, 0);
-        assert_eq!(operations.directory_scans, 1);
+        assert_eq!(operations.poster_reads, 0);
+        assert_eq!(operations.directory_scans, 0);
+        assert_eq!(
+            assets
+                .iter()
+                .find(|asset| asset["id"] == "withposter")
+                .and_then(|asset| asset.get("posterUrl"))
+                .and_then(Value::as_str),
+            Some(poster_url),
+            "source deletion cannot invalidate the DB-backed advertised URL"
+        );
+        assert_eq!(
+            store
+                .get_asset_poster(&project.id, "withposter", poster_sha256)
+                .expect("DB-backed poster survives source deletion")
+                .bytes,
+            b"jpg-bytes"
+        );
+
+        store
+            .reindex_project(&project.id)
+            .expect("explicit reindex");
+        let assets = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .expect("list after reindex");
         assert!(
             assets
                 .iter()
                 .find(|asset| asset["id"] == "withposter")
                 .and_then(|asset| asset.get("posterUrl"))
                 .is_none(),
-            "ordinary list never advertises a managed poster that was deleted"
+            "reindex atomically clears the URL and blob when its source is gone"
         );
+        assert!(matches!(
+            store.get_asset_poster(&project.id, "withposter", poster_sha256),
+            Err(ProjectStoreError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn indexed_poster_rejects_symlink_sources_and_never_writes_a_poster_destination() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Poster symlinks").unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let video_dir = project_path.join("assets/videos/set");
+        std::fs::create_dir_all(&video_dir).unwrap();
+        std::fs::write(video_dir.join("linked.mp4"), b"video").unwrap();
+        let outside_poster = temp_dir.path().join("outside-secret.jpg");
+        std::fs::write(&outside_poster, b"outside-secret").unwrap();
+        let linked_poster = video_dir.join("linked.poster.jpg");
+        if let Err(error) = create_file_symlink(&outside_poster, &linked_poster) {
+            eprintln!("symlink privilege unavailable; skipping symlink fixture: {error}");
+            return;
+        }
+        let fact = |id: &str| {
+            json!({
+                "assetId": id,
+                "mediaPath": format!("assets/videos/set/{id}.mp4"),
+                "mimeType": "video/mp4",
+                "type": "video",
+                "displayName": id,
+                "createdAt": "2026-05-25T00:00:00Z",
+                "mode": "image_to_video",
+                "model": "wan",
+                "adapter": "wan",
+                "prompt": "x",
+            })
+        };
+        store
+            .persist_generated_asset(&project.id, "job", "set", &fact("linked"))
+            .unwrap();
+        let listed = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap();
+        assert!(listed[0].get("posterUrl").is_none());
+        assert_eq!(std::fs::read(&outside_poster).unwrap(), b"outside-secret");
+
+        let outside_destination = temp_dir.path().join("outside-destination");
+        std::fs::create_dir_all(&outside_destination).unwrap();
+        let destination_link = project_path.join("assets/posters");
+        if let Err(error) = create_dir_symlink(&outside_destination, &destination_link) {
+            eprintln!(
+                "directory symlink privilege unavailable; skipping destination fixture: {error}"
+            );
+            return;
+        }
+        std::fs::write(video_dir.join("contained.mp4"), b"video").unwrap();
+        std::fs::write(video_dir.join("contained.poster.jpg"), b"contained").unwrap();
+        store
+            .persist_generated_asset(&project.id, "job", "set", &fact("contained"))
+            .unwrap();
+        assert_eq!(
+            std::fs::read_dir(&outside_destination).unwrap().count(),
+            0,
+            "DB-backed indexing performs no poster destination filesystem writes"
+        );
+        let listed = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap();
+        let contained = listed
+            .iter()
+            .find(|asset| asset["id"] == "contained")
+            .unwrap();
+        let sha = contained["posterUrl"]
+            .as_str()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap();
+        assert_eq!(
+            store
+                .get_asset_poster(&project.id, "contained", sha)
+                .unwrap()
+                .bytes,
+            b"contained"
+        );
+    }
+
+    #[test]
+    fn same_id_overwrite_atomically_clears_and_replaces_poster_blob() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Poster overwrite").unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let media = project_path.join("assets/videos/set/reused.mp4");
+        let poster = media.with_extension("poster.jpg");
+        std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+        std::fs::write(&media, b"video-a").unwrap();
+        std::fs::write(&poster, b"poster-a").unwrap();
+        let fact = json!({
+            "assetId": "reused",
+            "mediaPath": "assets/videos/set/reused.mp4",
+            "mimeType": "video/mp4",
+            "type": "video",
+            "displayName": "Reused",
+            "createdAt": "2026-05-25T00:00:00Z",
+            "mode": "image_to_video",
+            "model": "wan",
+            "adapter": "wan",
+            "prompt": "x",
+        });
+        store
+            .persist_generated_asset(&project.id, "job", "set", &fact)
+            .unwrap();
+        let old_url = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap()[0]["posterUrl"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        let old_sha = old_url.rsplit('/').next().unwrap().to_owned();
+
+        std::fs::remove_file(&poster).unwrap();
+        std::fs::write(&media, b"video-b").unwrap();
+        store
+            .persist_generated_asset(&project.id, "job", "set", &fact)
+            .unwrap();
+        assert!(store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap()[0]
+            .get("posterUrl")
+            .is_none());
+        assert!(matches!(
+            store.get_asset_poster(&project.id, "reused", &old_sha),
+            Err(ProjectStoreError::NotFound(_))
+        ));
+
+        std::fs::write(&poster, b"poster-b").unwrap();
+        store
+            .persist_generated_asset(&project.id, "job", "set", &fact)
+            .unwrap();
+        let listed = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap();
+        let new_sha = listed[0]["posterUrl"]
+            .as_str()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap();
+        assert_ne!(new_sha, old_sha);
+        assert_eq!(
+            store
+                .get_asset_poster(&project.id, "reused", new_sha)
+                .unwrap()
+                .bytes,
+            b"poster-b"
+        );
+    }
+
+    #[test]
+    fn purge_and_orphan_cleanup_prevent_poster_inheritance_on_id_reuse() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let fact = |id: &str| {
+            json!({
+                "assetId": id,
+                "mediaPath": format!("assets/videos/set/{id}.mp4"),
+                "mimeType": "video/mp4",
+                "type": "video",
+                "displayName": id,
+                "createdAt": "2026-05-25T00:00:00Z",
+                "mode": "image_to_video",
+                "model": "wan",
+                "adapter": "wan",
+                "prompt": "x",
+            })
+        };
+
+        for lifecycle in ["purge", "orphan"] {
+            let project = store.create_project(lifecycle).unwrap();
+            let project_path = store.find_project_path(&project.id).unwrap();
+            let media = project_path.join(format!("assets/videos/set/{lifecycle}.mp4"));
+            let poster = media.with_extension("poster.jpg");
+            std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+            std::fs::write(&media, b"old-video").unwrap();
+            std::fs::write(&poster, b"old-poster").unwrap();
+            store
+                .persist_generated_asset(&project.id, "job", "set", &fact(lifecycle))
+                .unwrap();
+            let old_sha = store
+                .list_assets(&project.id, true, true, AssetScope::All)
+                .unwrap()[0]["posterUrl"]
+                .as_str()
+                .unwrap()
+                .rsplit('/')
+                .next()
+                .unwrap()
+                .to_owned();
+
+            if lifecycle == "purge" {
+                store.purge_asset(&project.id, lifecycle, true).unwrap();
+            } else {
+                std::fs::remove_file(&media).unwrap();
+                assert_eq!(store.prune_orphaned_assets(&project.id).unwrap(), 1);
+            }
+            assert!(
+                !poster.exists(),
+                "{lifecycle} removes the old source poster"
+            );
+            assert!(matches!(
+                store.get_asset_poster(&project.id, lifecycle, &old_sha),
+                Err(ProjectStoreError::NotFound(_))
+            ));
+
+            std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+            std::fs::write(&media, b"new-video-without-poster").unwrap();
+            store
+                .persist_generated_asset(&project.id, "job", "set", &fact(lifecycle))
+                .unwrap();
+            assert!(
+                store
+                    .list_assets(&project.id, true, true, AssetScope::All)
+                    .unwrap()[0]
+                    .get("posterUrl")
+                    .is_none(),
+                "{lifecycle} id reuse cannot inherit the predecessor poster"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_sidecar_ids_keep_envelope_and_poster_blob_from_one_winner() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Duplicate ids").unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        for (folder, file, poster_bytes) in [
+            ("a", "first", b"poster-a".as_slice()),
+            ("b", "second", b"poster-b".as_slice()),
+        ] {
+            let media_rel = format!("assets/videos/{folder}/{file}.mp4");
+            let media = project_path.join(&media_rel);
+            std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+            std::fs::write(&media, b"video").unwrap();
+            std::fs::write(media.with_extension("poster.jpg"), poster_bytes).unwrap();
+            let asset = build_generated_asset_sidecar(
+                &project.id,
+                "job",
+                "set",
+                &json!({
+                    "assetId": "duplicate",
+                    "mediaPath": media_rel,
+                    "mimeType": "video/mp4",
+                    "type": "video",
+                    "displayName": file,
+                    "createdAt": "2026-05-25T00:00:00Z",
+                    "mode": "image_to_video",
+                    "model": "wan",
+                    "adapter": "wan",
+                    "prompt": "x",
+                }),
+            );
+            write_json(&media.with_extension("sceneworks.json"), &asset).unwrap();
+        }
+
+        store.reindex_project(&project.id).unwrap();
+        let listed = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        let media_path = listed[0]["file"]["path"].as_str().unwrap();
+        let expected = if media_path.contains("/a/") {
+            b"poster-a".as_slice()
+        } else {
+            b"poster-b".as_slice()
+        };
+        let sha = listed[0]["posterUrl"]
+            .as_str()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap();
+        assert_eq!(
+            store
+                .get_asset_poster(&project.id, "duplicate", sha)
+                .unwrap()
+                .bytes,
+            expected,
+            "the URL, envelope file path, and blob are replaced in one row transaction"
+        );
+    }
+
+    #[test]
+    fn dirty_marker_repair_reconciles_poster_blob_after_db_failure() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Poster repair").unwrap();
+        let project_path = store.find_project_path(&project.id).unwrap();
+        let media = project_path.join("assets/videos/set/repaired.mp4");
+        let poster = media.with_extension("poster.jpg");
+        std::fs::create_dir_all(media.parent().unwrap()).unwrap();
+        std::fs::write(&media, b"video").unwrap();
+        std::fs::write(&poster, b"poster-before").unwrap();
+        let fact = json!({
+            "assetId": "repaired",
+            "mediaPath": "assets/videos/set/repaired.mp4",
+            "mimeType": "video/mp4",
+            "type": "video",
+            "displayName": "Repaired",
+            "createdAt": "2026-05-25T00:00:00Z",
+            "mode": "image_to_video",
+            "model": "wan",
+            "adapter": "wan",
+            "prompt": "x",
+        });
+        store
+            .persist_generated_asset(&project.id, "job", "set", &fact)
+            .unwrap();
+        let old_sha = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap()[0]["posterUrl"]
+            .as_str()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap()
+            .to_owned();
+
+        std::fs::write(&poster, b"poster-after").unwrap();
+        fail_next_asset_index_db_mutation();
+        assert!(store
+            .update_asset_status(
+                &project.id,
+                "repaired",
+                AssetStatusPatch {
+                    favorite: Some(true),
+                    ..AssetStatusPatch::default()
+                },
+            )
+            .is_err());
+        assert!(project_path.join(ASSET_INDEX_DIRTY_MARKER).exists());
+        let listed = store
+            .list_assets(&project.id, true, true, AssetScope::All)
+            .unwrap();
+        assert_eq!(listed[0]["status"]["favorite"], true);
+        let new_sha = listed[0]["posterUrl"]
+            .as_str()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap();
+        assert_ne!(new_sha, old_sha);
+        assert_eq!(
+            store
+                .get_asset_poster(&project.id, "repaired", new_sha)
+                .unwrap()
+                .bytes,
+            b"poster-after"
+        );
+        assert!(matches!(
+            store.get_asset_poster(&project.id, "repaired", &old_sha),
+            Err(ProjectStoreError::NotFound(_))
+        ));
+        assert!(!project_path.join(ASSET_INDEX_DIRTY_MARKER).exists());
     }
 
     #[test]

--- a/docs/performance/assets-list-index.md
+++ b/docs/performance/assets-list-index.md
@@ -2,9 +2,10 @@
 
 `ProjectStore::list_assets` serves the normalized `asset_json` envelope stored
 in each project's `project.db`. That envelope includes filesystem-derived
-generation-set hydration and video-poster presence, so a clean list does not
-read or stat a per-row file. SceneWorks-owned asset mutations write the sidecar
-and update the indexed envelope before returning, so the next list sees them
+generation-set hydration. Indexed video posters are copied to the flat managed
+`assets/posters` directory, which a clean list snapshots once; no per-row file
+is read or statted. SceneWorks-owned asset mutations write the sidecar and
+update the indexed envelope before returning, so the next list sees them
 immediately. A durable `.asset-index-dirty` marker spans the filesystem write
 and separate SQLite transaction. If either fails or the process exits between
 them, the next indexed read rebuilds from disk before serving data. Marker
@@ -15,9 +16,9 @@ and index through the same guarded core operation.
 
 ## Out-of-band filesystem edits
 
-Direct edits to `*.sceneworks.json`, `generation-sets/*.json`, media, or sibling
-`*.poster.jpg` files are supported through explicit reconciliation. After
-editing those files, call:
+Direct edits to `*.sceneworks.json`, `generation-sets/*.json`, media, or source
+sibling `*.poster.jpg` files are supported through explicit reconciliation.
+After editing those files, call:
 
 ```text
 POST /api/v1/projects/<project-id>/reindex
@@ -25,13 +26,22 @@ POST /api/v1/projects/<project-id>/reindex
 
 or use `ProjectStore::reindex_project`. Until reindex completes, list responses
 continue to use the last indexed envelope, including its embedded generation
-set and poster-presence decision. Reindex reads the current files, so this
-contract also covers deletions, same-size rewrites, and edits made by tools that
-preserve file timestamps. A corrupt sidecar is skipped during reindex; a corrupt
-indexed envelope is skipped during listing without preventing healthy assets
-from loading. Here "corrupt sidecar" means unreadable or invalid JSON; a
-parseable sidecar that violates the asset schema can make reindex fail so the
-dirty marker remains and the prior DB transaction stays intact for retry.
+set. Reindex reads the current source files, so this contract also covers
+deletions, same-size rewrites, and edits made by tools that preserve file
+timestamps.
+
+Poster presence has a narrower freshness contract. Indexing copies an existing
+source sibling poster to `assets/posters/<asset-id>.poster.jpg` and advertises
+that managed path. Deleting the advertised managed file is visible on the next
+ordinary list: its URL is suppressed without a reindex. Adding, replacing, or
+deleting only the source sibling still requires reindexing to refresh the
+managed copy.
+
+A corrupt sidecar is skipped during reindex; a corrupt indexed envelope is
+skipped during listing without preventing healthy assets from loading. Here
+"corrupt sidecar" means unreadable or invalid JSON; a parseable sidecar that
+violates the asset schema can make reindex fail so the dirty marker remains and
+the prior DB transaction stays intact for retry.
 
 ## SQLite connection and journal policy
 
@@ -56,7 +66,10 @@ character JSON reads, poster stats, dirty-marker reads/writes/removes,
 directory-create calls, and DB opens. `fs_total` is the sum of those categories.
 Counts are logical calls made by the SceneWorks asset-list/reconciliation code;
 they do not claim to expose hidden syscalls inside SQLite, the standard library,
-or the operating system.
+or the operating system. In particular, the managed-poster snapshot is one
+logical directory scan per list, but its enumeration bytes and CPU grow with
+the number of managed posters. Benchmark wall time therefore remains necessary
+alongside the constant logical-operation count, especially on network volumes.
 
 ```shell
 cargo run --release -p sceneworks-core --example assets_list_benchmark -- synthetic 1000 10
@@ -105,8 +118,8 @@ evicted cold-cache measurement:
 
 ```text
 storage=synthetic-local-distinct-video-sets path=<temporary local directory>
-first-call: assets=500 elapsed_ms=8.305 fs_total=10 registry_opens=2 registry_metadata_reads=2 registry_content_reads=2 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
-steady-state-average(10): assets=500 elapsed_ms=7.994 fs_total=7 registry_opens=1 registry_metadata_reads=1 registry_content_reads=1 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+first-call: assets=500 elapsed_ms=9.384 fs_total=11 registry_opens=2 registry_metadata_reads=2 registry_content_reads=2 path_stats=1 directory_scans=1 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+steady-state-average(10): assets=500 elapsed_ms=8.418 fs_total=8 registry_opens=1 registry_metadata_reads=1 registry_content_reads=1 path_stats=1 directory_scans=1 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
 ```
 
 The implementation environment had no mounted network volume or RunPod access,

--- a/docs/performance/assets-list-index.md
+++ b/docs/performance/assets-list-index.md
@@ -35,11 +35,15 @@ timestamps.
 At indexing time, a source sibling poster is accepted only when its relative
 path is safe, every component is non-symlink, canonical resolution remains
 inside the project, the final open uses the platform no-follow flag, and the
-file is at most 16 MiB. Its bytes and digest are committed atomically with the
-envelope. Missing or rejected sources commit a null blob and no URL, clearing
-any previous value for the same asset id. Adding, replacing, or deleting only
-the source sibling requires reindexing; until then the advertised DB-backed URL
-continues to resolve independently of that source file.
+file is at most 16 MiB. The bounded payload must fully decode as JPEG under
+dimension and allocation limits; its filename alone never determines MIME.
+Verified bytes and their digest are committed atomically with the envelope.
+Missing or rejected sources commit a null blob and no URL, clearing any previous
+value for the same asset id. Adding, replacing, or deleting only the source
+sibling requires reindexing; until then the advertised DB-backed URL continues
+to resolve independently of that source file. The serving path recomputes the
+blob digest and constant-time compares it with both the stored and requested
+digests, failing closed if a DB row is inconsistent.
 
 A corrupt sidecar is skipped during reindex; a corrupt indexed envelope is
 skipped during listing without preventing healthy assets from loading. Here
@@ -131,8 +135,8 @@ evicted cold-cache measurement:
 
 ```text
 storage=synthetic-local-distinct-video-sets path=<temporary local directory>
-first-call: assets=500 elapsed_ms=7.552 fs_total=10 registry_opens=2 registry_metadata_reads=2 registry_content_reads=2 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 poster_reads=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
-steady-state-average(10): assets=500 elapsed_ms=7.366 fs_total=7 registry_opens=1 registry_metadata_reads=1 registry_content_reads=1 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 poster_reads=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+first-call: assets=500 elapsed_ms=11.716 fs_total=10 registry_opens=2 registry_metadata_reads=2 registry_content_reads=2 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 poster_reads=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+steady-state-average(10): assets=500 elapsed_ms=11.533 fs_total=7 registry_opens=1 registry_metadata_reads=1 registry_content_reads=1 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 poster_reads=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
 ```
 
 The implementation environment had no mounted network volume or RunPod access,

--- a/docs/performance/assets-list-index.md
+++ b/docs/performance/assets-list-index.md
@@ -2,13 +2,15 @@
 
 `ProjectStore::list_assets` serves the normalized `asset_json` envelope stored
 in each project's `project.db`. That envelope includes filesystem-derived
-generation-set hydration. Indexed video posters are copied to the flat managed
-`assets/posters` directory, which a clean list snapshots once; no per-row file
-is read or statted. SceneWorks-owned asset mutations write the sidecar and
-update the indexed envelope before returning, so the next list sees them
-immediately. A durable `.asset-index-dirty` marker spans the filesystem write
-and separate SQLite transaction. If either fails or the process exits between
-them, the next indexed read rebuilds from disk before serving data. Marker
+generation-set hydration plus a content-addressed `posterUrl`. Poster bytes and
+their SHA-256 digest live in the same indexed asset row, and the dedicated
+poster endpoint serves that blob. A clean list therefore performs no poster
+filesystem read, stat, or directory enumeration. SceneWorks-owned asset
+mutations write the sidecar and update the indexed envelope before returning,
+so the next list sees them immediately. A durable `.asset-index-dirty` marker
+spans the filesystem write and separate SQLite transaction. If either fails or
+the process exits between them, the next indexed read rebuilds from disk before
+serving data. Marker
 inspection, repair, orphan pruning, and marker clear share the same reentrant
 per-project lock as the owning mutation, so a concurrent list cannot clear an
 in-flight writer's marker. Native frame/render workers persist sidecar, recipe,
@@ -30,12 +32,14 @@ set. Reindex reads the current source files, so this contract also covers
 deletions, same-size rewrites, and edits made by tools that preserve file
 timestamps.
 
-Poster presence has a narrower freshness contract. Indexing copies an existing
-source sibling poster to `assets/posters/<asset-id>.poster.jpg` and advertises
-that managed path. Deleting the advertised managed file is visible on the next
-ordinary list: its URL is suppressed without a reindex. Adding, replacing, or
-deleting only the source sibling still requires reindexing to refresh the
-managed copy.
+At indexing time, a source sibling poster is accepted only when its relative
+path is safe, every component is non-symlink, canonical resolution remains
+inside the project, the final open uses the platform no-follow flag, and the
+file is at most 16 MiB. Its bytes and digest are committed atomically with the
+envelope. Missing or rejected sources commit a null blob and no URL, clearing
+any previous value for the same asset id. Adding, replacing, or deleting only
+the source sibling requires reindexing; until then the advertised DB-backed URL
+continues to resolve independently of that source file.
 
 A corrupt sidecar is skipped during reindex; a corrupt indexed envelope is
 skipped during listing without preventing healthy assets from loading. Here
@@ -57,19 +61,28 @@ would also retain handles to removable or remounted project paths and complicate
 the existing project-file lock/repair lifecycle. One connection per request
 removes the redundant opens without narrowing the supported storage contract.
 
+Schema v8 stores one poster blob per video asset. This deliberately trades
+project DB size (and rollback-journal write volume during poster updates) for
+zero poster filesystem work on ordinary lists and an authoritative serving
+endpoint. Each blob is capped at 16 MiB. The list query selects `asset_json` but
+not `poster_bytes`, so SQLite does not materialize blob contents while listing;
+the poster endpoint reads one requested blob. The version-bump rebuild reads
+existing sibling posters once. Purge/orphan lifecycle cleanup removes safe
+source siblings so later reuse of an id/path cannot inherit old poster content.
+
 ## Benchmark harness
 
 The harness records asset count, elapsed time, and one per-request logical
 filesystem-call inventory. It covers registry opens/metadata/content reads,
 path stats, directory scans, asset-sidecar, generation-set, timeline, and
-character JSON reads, poster stats, dirty-marker reads/writes/removes,
+character JSON reads, poster stats/reads, dirty-marker reads/writes/removes,
 directory-create calls, and DB opens. `fs_total` is the sum of those categories.
 Counts are logical calls made by the SceneWorks asset-list/reconciliation code;
 they do not claim to expose hidden syscalls inside SQLite, the standard library,
-or the operating system. In particular, the managed-poster snapshot is one
-logical directory scan per list, but its enumeration bytes and CPU grow with
-the number of managed posters. Benchmark wall time therefore remains necessary
-alongside the constant logical-operation count, especially on network volumes.
+or the operating system. The SC-14799 regression additionally pins zero clean
+list directory scans and statically rejects `read_dir`/`file_type` calls in the
+list implementation, so entry enumeration cannot be collapsed into one
+false-green logical operation.
 
 ```shell
 cargo run --release -p sceneworks-core --example assets_list_benchmark -- synthetic 1000 10
@@ -118,8 +131,8 @@ evicted cold-cache measurement:
 
 ```text
 storage=synthetic-local-distinct-video-sets path=<temporary local directory>
-first-call: assets=500 elapsed_ms=9.384 fs_total=11 registry_opens=2 registry_metadata_reads=2 registry_content_reads=2 path_stats=1 directory_scans=1 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
-steady-state-average(10): assets=500 elapsed_ms=8.418 fs_total=8 registry_opens=1 registry_metadata_reads=1 registry_content_reads=1 path_stats=1 directory_scans=1 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+first-call: assets=500 elapsed_ms=7.552 fs_total=10 registry_opens=2 registry_metadata_reads=2 registry_content_reads=2 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 poster_reads=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+steady-state-average(10): assets=500 elapsed_ms=7.366 fs_total=7 registry_opens=1 registry_metadata_reads=1 registry_content_reads=1 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 poster_reads=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
 ```
 
 The implementation environment had no mounted network volume or RunPod access,

--- a/docs/performance/assets-list-index.md
+++ b/docs/performance/assets-list-index.md
@@ -1,34 +1,51 @@
 # Indexed asset-list performance and reconciliation
 
 `ProjectStore::list_assets` serves the normalized `asset_json` envelope stored
-in each project's `project.db`. A clean list does not read or hash asset
-sidecars. SceneWorks-owned asset mutations write the sidecar and update the
-indexed envelope before returning, so the next list sees them immediately. A
-durable `.asset-index-dirty` marker spans the filesystem write and separate
-SQLite transaction. If either fails or the process exits between them, the next
-indexed read rebuilds from disk before serving data. Marker inspection, repair,
-orphan pruning, and marker clear share the same reentrant per-project lock as
-the owning mutation, so a concurrent list cannot clear an in-flight writer's
-marker. Native frame/render workers persist sidecar, recipe, and index through
-the same guarded core operation.
+in each project's `project.db`. That envelope includes filesystem-derived
+generation-set hydration and video-poster presence, so a clean list does not
+read or stat a per-row file. SceneWorks-owned asset mutations write the sidecar
+and update the indexed envelope before returning, so the next list sees them
+immediately. A durable `.asset-index-dirty` marker spans the filesystem write
+and separate SQLite transaction. If either fails or the process exits between
+them, the next indexed read rebuilds from disk before serving data. Marker
+inspection, repair, orphan pruning, and marker clear share the same reentrant
+per-project lock as the owning mutation, so a concurrent list cannot clear an
+in-flight writer's marker. Native frame/render workers persist sidecar, recipe,
+and index through the same guarded core operation.
 
-## Out-of-band sidecar edits
+## Out-of-band filesystem edits
 
-Direct edits to `*.sceneworks.json` files are supported through explicit
-reconciliation. After editing sidecars, call:
+Direct edits to `*.sceneworks.json`, `generation-sets/*.json`, media, or sibling
+`*.poster.jpg` files are supported through explicit reconciliation. After
+editing those files, call:
 
 ```text
 POST /api/v1/projects/<project-id>/reindex
 ```
 
 or use `ProjectStore::reindex_project`. Until reindex completes, list responses
-continue to use the last indexed envelope. Reindex reads the sidecar contents,
-so this contract also covers same-size rewrites and edits made by tools that
+continue to use the last indexed envelope, including its embedded generation
+set and poster-presence decision. Reindex reads the current files, so this
+contract also covers deletions, same-size rewrites, and edits made by tools that
 preserve file timestamps. A corrupt sidecar is skipped during reindex; a corrupt
 indexed envelope is skipped during listing without preventing healthy assets
 from loading. Here "corrupt sidecar" means unreadable or invalid JSON; a
 parseable sidecar that violates the asset schema can make reindex fail so the
 dirty marker remains and the prior DB transaction stays intact for retry.
+
+## SQLite connection and journal policy
+
+A clean asset-list request opens `project.db` once and reuses that connection
+for migration/index-readiness checks, the legacy empty-index check, and the
+asset query. Repair paths may open again after a transactional rebuild.
+
+`project.db` deliberately remains in SQLite's rollback-journal mode rather than
+enabling WAL. SceneWorks supports projects on mounted network volumes, while
+SQLite's [WAL design](https://www.sqlite.org/wal.html) requires same-host shared
+memory and explicitly does not support network filesystems. A per-project pool
+would also retain handles to removable or remounted project paths and complicate
+the existing project-file lock/repair lifecycle. One connection per request
+removes the redundant opens without narrowing the supported storage contract.
 
 ## Benchmark harness
 
@@ -77,3 +94,22 @@ steady-state-average(10): assets=500 elapsed_ms=4.721 fs_total=12 registry_opens
 A populated RunPod network volume was not available in the implementation
 environment. Run the existing-project command on RunPod before final rollout;
 do not treat the local SSD result as network-volume evidence.
+
+## SC-14799 validation record
+
+Windows local SSD, release build, 500 synthetic indexed video assets with 500
+distinct generation sets and 500 existing posters, 10 steady-state iterations.
+This deliberately reproduces the formerly row-scaled generation-set-read and
+poster-stat workload. It is first-call versus steady-state evidence, not an
+evicted cold-cache measurement:
+
+```text
+storage=synthetic-local-distinct-video-sets path=<temporary local directory>
+first-call: assets=500 elapsed_ms=8.305 fs_total=10 registry_opens=2 registry_metadata_reads=2 registry_content_reads=2 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+steady-state-average(10): assets=500 elapsed_ms=7.994 fs_total=7 registry_opens=1 registry_metadata_reads=1 registry_content_reads=1 path_stats=1 directory_scans=0 sidecar_reads=0 generation_set_reads=0 timeline_reads=0 character_reads=0 poster_stats=0 index_marker_reads=1 index_marker_writes=0 index_marker_removes=0 directory_create_calls=1 db_opens=1
+```
+
+The implementation environment had no mounted network volume or RunPod access,
+so no network-volume wall-time claim is recorded here. SC-14789 owns the
+populated-volume run; use the `existing` command above there and attach its
+first-call/steady-state output before final rollout.


### PR DESCRIPTION
## Summary

- materialize generation-set hydration in the indexed asset envelope so clean lists perform no per-row generation-set reads
- store video poster bytes and SHA-256 digests atomically in schema-v8 `project.db` asset rows and serve them through a content-addressed API endpoint
- remove managed poster-directory copies and all clean-list poster enumeration, stats, and reads
- reject symlink/reparse-point, escaping, unreadable, malformed, and oversized poster sources; bounded poster payloads must fully decode as JPEG before indexing
- recompute the served blob digest and constant-time compare it with both the stored and requested digests, failing closed on row inconsistency
- reconcile poster lifecycle across overwrite, trash/purge, orphan repair, duplicate sidecar IDs, dirty-marker recovery, and ID/path reuse
- derive indexed URLs and returned `projectId` only from the authoritative route/store/reindex project id, never mutable imported sidecar metadata
- reuse one ready `project.db` connection for readiness, legacy-empty check, and the asset query; retain rollback journals for mounted-network-volume compatibility

## Acceptance criteria

- Clean-list inventory: 1-row and 128-row video listings have equal `total()`, with `sidecar_reads=0`, `generation_set_reads=0`, `poster_stats=0`, `poster_reads=0`, `directory_scans=0`, and `db_opens=1`.
- Enumeration guard: the regression statically rejects `read_dir`/`file_type` in the clean-list implementation so a row-scaled scan cannot be hidden behind one logical counter.
- Poster ingestion: indexing safely reads at most 16 MiB, fully decodes JPEG under dimension/allocation limits, and commits verified bytes, digest, and `asset_json` in one SQLite transaction. Filename alone never determines MIME.
- Poster serving: the content-addressed endpoint reads the exact authoritative asset row, recomputes SHA-256, and constant-time compares recomputed/stored/requested digests. Wrong digest, wrong project, wrong asset, and tampered row all fail closed.
- Freshness: adding, replacing, or deleting only a source sibling poster requires explicit reindex. Until then the indexed URL remains resolvable from the DB. Reindex clears missing/rejected sources atomically.
- Lifecycle: regressions cover real JPEG fixtures, malformed and oversized payloads, symlink sources and legacy destinations, same-ID clear/replace, purge and orphan reuse, duplicate sidecar IDs, and dirty-marker repair after a DB failure.
- Project identity: normal writes, character-reference writes, explicit reindex, legacy auto-reindex, and dirty repair pass an authoritative project id into hydration. A mismatched imported sidecar regression proves the current project owns the returned URL/envelope.
- SQLite tradeoff: one poster blob per video increases DB and rollback-journal write volume, bounded to 16 MiB each. Listing selects `asset_json` without materializing blobs. WAL remains unsuitable for mounted network filesystems SceneWorks supports.
- Benchmark: Windows local SSD release run with real JPEG fixtures, 500 videos / 500 distinct generation sets / 500 posters: first 11.716 ms (`fs_total=10`), steady 11.533 ms (`fs_total=7`); both have zero directory scans, generation reads, poster stats, and poster reads, with one DB open. Network/RunPod evidence remains assigned to SC-14789.

## Codex evidence

- `cargo fmt --all -- --check`
- `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets -- -D warnings`
- `cargo test -p sceneworks-core` — main suite 611 passed, 1 ignored; integration and doc suites passed
- all 8 poster regressions passed, including malformed/oversized validation and tampered-row integrity; constant-inventory and API project/asset scoping regressions passed
- `cargo test -p sceneworks-rust-api` — 381 passed, 2 ignored; one known unrelated Windows process-liveness test fails in this sandbox (`freshly spawned parent reads as dead`)
- `cargo build -p sceneworks-core -p sceneworks-rust-api`
- `cargo run --release -p sceneworks-core --example assets_list_benchmark -- synthetic 500 10`
- `git diff --check`

Shortcut: https://app.shortcut.com/trefry/story/14799
