### PR TITLE
Fix large Parquet dataset imports

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -304,7 +304,10 @@ const DEFAULT_API_HOST: &str = "127.0.0.1";
 // person-track corrections) while shrinking the per-request ceiling ~200x. The large
 // limit is re-attached per-route ONLY to the multipart/upload endpoints below.
 const MAX_JSON_BODY_BYTES: usize = 10 * 1024 * 1024;
-const MAX_PARQUET_FINALIZE_BODY_BYTES: usize = 64 * 1024 * 1024;
+// The trusted worker may finalize up to 100k URL/caption records in one atomic
+// dataset replacement. Captions are bounded separately, but the JSON envelope can
+// still exceed the ordinary API ceiling by hundreds of megabytes.
+const MAX_PARQUET_FINALIZE_BODY_BYTES: usize = 512 * 1024 * 1024;
 const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MAX_MODEL_UPLOAD_BYTES: usize = 256 * 1024 * 1024 * 1024;
 const MAX_LORA_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;

--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -76,6 +76,23 @@ async fn parquet_import_job_queues_for_empty_dataset_and_finalizes_staged_items(
     std::fs::write(source.join("part-00000.snappy.parquet"), b"PAR1")
         .expect("placeholder shard writes");
 
+    let (status, rejected) = request(
+        app.clone(),
+        "POST",
+        &format!(
+            "/api/v1/projects/{project_id}/training/datasets/{dataset_id}/parquet-import-jobs"
+        ),
+        json!({
+            "sourcePath": source.clone(),
+            "maxItems": 100_001
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(rejected["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("100000")));
+
     let (status, job) = request(
         app.clone(),
         "POST",
@@ -84,7 +101,7 @@ async fn parquet_import_job_queues_for_empty_dataset_and_finalizes_staged_items(
         ),
         json!({
             "sourcePath": source,
-            "maxItems": 25,
+            "maxItems": 100_000,
             "minEdge": 384,
             "concurrency": 8,
             "captionIncludes": ["portrait", "person"],
@@ -96,7 +113,7 @@ async fn parquet_import_job_queues_for_empty_dataset_and_finalizes_staged_items(
     assert_eq!(job["type"], "dataset_parquet_import");
     assert_eq!(job["payload"]["urlColumn"], "URL");
     assert_eq!(job["payload"]["captionColumn"], "TEXT");
-    assert_eq!(job["payload"]["maxItems"], 25);
+    assert_eq!(job["payload"]["maxItems"], 100_000);
     assert_eq!(job["payload"]["minEdge"], 384);
     assert_eq!(job["payload"]["concurrency"], 8);
     assert_eq!(

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -488,7 +488,6 @@ pub(crate) async fn create_training_dataset_caption_job(
     Ok((StatusCode::CREATED, Json(job)))
 }
 
-const MAX_PARQUET_IMPORT_ITEMS: usize = 25_000;
 const MAX_PARQUET_IMPORT_CONCURRENCY: usize = 64;
 const MAX_PARQUET_FILTER_TERMS: usize = 32;
 const MAX_PARQUET_FILTER_TERM_CHARS: usize = 64;
@@ -496,9 +495,12 @@ const MAX_PARQUET_FILTER_TERM_CHARS: usize = 64;
 fn validate_parquet_import_request(
     payload: &DatasetParquetImportJobRequest,
 ) -> Result<std::path::PathBuf, ApiError> {
-    if payload.max_items == 0 || payload.max_items > MAX_PARQUET_IMPORT_ITEMS {
+    if payload.max_items == 0
+        || payload.max_items > sceneworks_core::contracts::MAX_DATASET_PARQUET_IMPORT_ITEMS
+    {
         return Err(ApiError::bad_request(format!(
-            "Parquet maxItems must be between 1 and {MAX_PARQUET_IMPORT_ITEMS}."
+            "Parquet maxItems must be between 1 and {}.",
+            sceneworks_core::contracts::MAX_DATASET_PARQUET_IMPORT_ITEMS
         )));
     }
     if payload.min_edge > 8192 {
@@ -653,7 +655,7 @@ pub(crate) async fn finalize_training_dataset_parquet_import(
             "Parquet import produced no usable images.",
         ));
     }
-    if payload.items.len() > MAX_PARQUET_IMPORT_ITEMS {
+    if payload.items.len() > sceneworks_core::contracts::MAX_DATASET_PARQUET_IMPORT_ITEMS {
         return Err(ApiError::bad_request(
             "Parquet import contains too many items.",
         ));

--- a/apps/web/src/App.training.test.jsx
+++ b/apps/web/src/App.training.test.jsx
@@ -224,6 +224,56 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Dataset created");
   });
 
+  it("creates an empty dataset automatically when starting a Parquet import", async () => {
+    const createDataset = vi.fn(async (payload) => ({
+      id: "dataset-parquet",
+      name: payload.name,
+      version: 1,
+      items: payload.items,
+    }));
+    const createParquetImportJob = vi.fn(async () => ({ id: "job_parquet" }));
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withTrainingDataSetsLibraryContext({
+          activeProject: { id: "project-a", name: "Project A" },
+          assets: [],
+          createDataset,
+          createParquetImportJob,
+          datasets: [],
+        }),
+      );
+    });
+
+    await changeField(field(container, "Dataset name"), "LAION Control Set");
+    const importButton = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Import Parquet",
+    );
+    expect(importButton.disabled).toBe(false);
+    await act(async () => importButton.click());
+    await changeField(field(document.body, "Parquet file or folder"), "D:\\laion2B-en-aesthetic-metadata");
+    await act(async () => {
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Start import").click();
+    });
+
+    expect(createDataset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "LAION Control Set",
+        modality: "image",
+        items: [],
+      }),
+    );
+    expect(createParquetImportJob).toHaveBeenCalledWith(
+      "dataset-parquet",
+      expect.objectContaining({
+        sourcePath: "D:\\laion2B-en-aesthetic-metadata",
+        maxItems: 1000,
+      }),
+    );
+    expect(container.textContent).toContain("Parquet import queued (job_parquet)");
+  });
+
   it("imports caption sidecars alongside images and bakes them into the saved dataset", async () => {
     const createDataset = vi.fn(async (payload) => ({
       id: "dataset-new",

--- a/apps/web/src/components/DatasetParquetImportDialog.jsx
+++ b/apps/web/src/components/DatasetParquetImportDialog.jsx
@@ -169,7 +169,7 @@ export function DatasetParquetImportDialog({ running = false, onClose, onRun }) 
           <label>
             Images to import
             <input
-              max="25000"
+              max="100000"
               min="1"
               onChange={(event) => update("maxItems", event.target.value)}
               type="number"
@@ -200,7 +200,8 @@ export function DatasetParquetImportDialog({ running = false, onClose, onRun }) 
         </div>
         <p className="dataset-parquet-hint">
           Imports are resumable. Failed or undersized URLs are skipped, so the final count may be
-          lower when the candidate window is exhausted.
+          lower when the candidate window is exhausted. Large imports can take hours and use
+          substantial disk space.
         </p>
       </form>
 

--- a/apps/web/src/components/DatasetParquetImportDialog.test.jsx
+++ b/apps/web/src/components/DatasetParquetImportDialog.test.jsx
@@ -51,6 +51,8 @@ describe("DatasetParquetImportDialog", () => {
     change(fieldByLabel("Parquet file or folder"), "D:\\laion2B-en-aesthetic-metadata");
     change(fieldByLabel("Caption category preset", "select"), "faces");
     change(fieldByLabel("Exclude any caption term"), "logo, illustration");
+    expect(fieldByLabel("Images to import").max).toBe("100000");
+    change(fieldByLabel("Images to import"), "100000");
     await act(async () => {
       document.body.querySelector('button[type="submit"]').click();
     });
@@ -60,7 +62,7 @@ describe("DatasetParquetImportDialog", () => {
       sourcePath: "D:\\laion2B-en-aesthetic-metadata",
       urlColumn: "URL",
       captionColumn: "TEXT",
-      maxItems: 1000,
+      maxItems: 100000,
       minEdge: 512,
       concurrency: 16,
       captionIncludes: ["face", "facial", "portrait", "headshot", "selfie", "close-up", "close up"],

--- a/apps/web/src/main.testSupport.jsx
+++ b/apps/web/src/main.testSupport.jsx
@@ -141,6 +141,7 @@ export function withTrainingDataSetsLibraryContext(p) {
       batchRenameTrainingDataset: p.batchRenameDataset,
       writeTrainingDatasetCaptionSidecars: p.writeCaptionSidecars,
       createTrainingDatasetCaptionJob: p.createCaptionJob,
+      createTrainingDatasetParquetImportJob: p.createParquetImportJob,
       createTrainingDatasetAnalysisJob: p.createAnalysisJob,
       createTrainingJob: p.createTrainingJob,
       trainingPresets: { presets: p.trainingPresets },

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -1282,13 +1282,18 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setDatasetError("");
     setDatasetMessage("");
     try {
-      if (!activeDataset?.id) {
-        throw new Error("Create the empty dataset before importing Parquet metadata.");
+      if (!draftName.trim()) {
+        throw new Error("Name the dataset before importing Parquet metadata.");
       }
       if (memberAssets.length) {
         throw new Error("Parquet import currently requires an empty dataset.");
       }
-      const saved = await persistDataset([], activeDataset);
+      // A new draft has no server id yet. Persist the named empty destination as part
+      // of the import action so users do not need a placeholder image or a separate save.
+      const saved = await persistDataset([], activeDataset ?? undefined);
+      if (!saved?.id) {
+        throw new Error("The empty dataset could not be created.");
+      }
       const job = await createTrainingDatasetParquetImportJob(saved.id, settings);
       setDatasetMessage(
         `Parquet import queued${job?.id ? ` (${job.id})` : ""}. Track it in the Queue, then refresh this dataset when it finishes.`,

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -115,7 +115,7 @@ export function DatasetEditorPanel({
   const [captionFilter, setCaptionFilter] = React.useState("all");
   const [parquetDialogOpen, setParquetDialogOpen] = React.useState(false);
   const [parquetImporting, setParquetImporting] = React.useState(false);
-  const parquetImportDisabled = !activeDataset?.id || memberAssets.length > 0 || parquetImporting;
+  const parquetImportDisabled = !draftName.trim() || memberAssets.length > 0 || parquetImporting;
 
   async function runParquetImport(settings) {
     if (typeof onImportParquet !== "function" || parquetImporting) return;
@@ -303,11 +303,13 @@ export function DatasetEditorPanel({
               disabled={parquetImportDisabled}
               onClick={() => setParquetDialogOpen(true)}
               title={
-                !activeDataset?.id
-                  ? "Create the empty dataset first"
+                !draftName.trim()
+                  ? "Name the dataset before importing"
                   : memberAssets.length
                     ? "Parquet import currently requires an empty dataset"
-                    : "Import URL/caption rows from local Parquet shards"
+                    : activeDataset?.id
+                      ? "Import URL/caption rows from local Parquet shards"
+                      : "Create this empty dataset and import URL/caption rows"
               }
               type="button"
             >

--- a/apps/web/src/training/datasetHelpers.js
+++ b/apps/web/src/training/datasetHelpers.js
@@ -134,19 +134,16 @@ export function datasetHealth({ activeDataset, imageAssets, selectedAssetIds }) 
 // so a chip would just repeat what the grid shows. This rule set carries only what
 // blocks Save.
 //
-// A missing name or empty selection is a `requirement` — the empty field speaks for
-// itself. `disabledItems` is the one real `error`: assets that got rejected, trashed, or
-// deleted after they were selected. Before this, that only dimmed Save and left the
-// health dot reading "Add image assets to build this dataset" — wrong, since the set is
-// full of the wrong images. The error says so.
+// A missing name is a `requirement` — the empty field speaks for itself. Empty datasets
+// are valid because Parquet import needs a persisted destination before it can materialize
+// images. `disabledItems` is the one real `error`: assets that went unavailable after
+// they were selected.
 export function datasetSaveValidation({ name, selectedAssetIds }, { health } = {}) {
   const issues = [];
   if (!name?.trim()) {
     issues.push(issue.requirement("datasetName", "Name the dataset"));
   }
-  if (!selectedAssetIds?.length) {
-    issues.push(issue.requirement("assets", "Add at least one image"));
-  } else if (health?.disabledItems > 0) {
+  if (selectedAssetIds?.length && health?.disabledItems > 0) {
     const n = health.disabledItems;
     issues.push(
       issue.error(

--- a/apps/web/src/training/datasetHelpers.test.js
+++ b/apps/web/src/training/datasetHelpers.test.js
@@ -65,8 +65,8 @@ describe("selectionAfterDuplicateRemoval (sc-6539 one-tap dedupe mapping)", () =
 });
 
 // The dataset-save gate in the app-wide vocabulary (epic 10644, sc-10648). A missing name
-// or empty selection is a silent requirement; the one thing that earns a chip is a
-// selection holding assets that went unavailable after they were picked.
+// is a silent requirement; an empty selection is valid so a Parquet import has a persisted
+// destination. The one thing that earns a chip is a selected asset that went unavailable.
 describe("datasetSaveValidation", () => {
   const whole = { name: "Kelsie", selectedAssetIds: ["a", "b"] };
   const kinds = (issues, field) => issues.filter((entry) => entry.field === field).map((entry) => entry.kind);
@@ -84,10 +84,11 @@ describe("datasetSaveValidation", () => {
     expect(summarize(issues).ready).toBe(false);
   });
 
-  it("requires at least one asset, silently", () => {
+  it("allows a named empty dataset for Parquet import", () => {
     const issues = datasetSaveValidation({ ...whole, selectedAssetIds: [] }, { health: { disabledItems: 0 } });
-    expect(kinds(issues, "assets")).toEqual(["requirement"]);
+    expect(kinds(issues, "assets")).toEqual([]);
     expect(summarize(issues).surfaced).toEqual([]);
+    expect(summarize(issues).ready).toBe(true);
   });
 
   // The one improvement this migration buys: a dead Save that used to say nothing (the
@@ -106,12 +107,10 @@ describe("datasetSaveValidation", () => {
     expect(summary.surfaced[0].message).toContain("it has been");
   });
 
-  // An empty selection is a requirement, not the disabledItems error — order matters, or a
-  // brand-new dataset would nag about "unavailable images" it doesn't have.
-  it("prefers the empty-selection requirement over the unavailable error", () => {
+  // A stale health count must not prevent creating a genuinely empty Parquet destination.
+  it("ignores unavailable counts when the selection is empty", () => {
     const issues = datasetSaveValidation({ ...whole, selectedAssetIds: [] }, { health: { disabledItems: 5 } });
-    expect(issues).toHaveLength(1);
-    expect(issues[0].kind).toBe("requirement");
+    expect(issues).toEqual([]);
   });
 
   it("tolerates a missing health context", () => {

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -449,6 +449,9 @@ string_enum! {
         // Built-in LoRA explicit download capability (sc-5944), advertised by the CPU
         // utility worker alongside model_download / lora_import.
         LoraDownload => "lora_download",
+        // LAION-style URL/caption Parquet materialization. This is a CPU utility job:
+        // it scans local metadata and downloads public images without an inference backend.
+        DatasetParquetImport => "dataset_parquet_import",
         LoraTrain => "lora_train",
         TrainingCaption => "training_caption",
         // Dataset Doctor CLIP-embedding analysis (sc-6535). Advertised only when the MLX/candle
@@ -636,6 +639,12 @@ string_enum! {
         PersonReplace => "person_replace",
     }
 }
+
+/// Maximum number of images one Parquet materialization job may add.
+///
+/// Shared by API validation and the worker clamp so a newer client cannot create
+/// a job that is accepted at submission but silently truncated at execution.
+pub const MAX_DATASET_PARQUET_IMPORT_ITEMS: usize = 100_000;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/sceneworks-worker/src/dataset_parquet_jobs.rs
+++ b/crates/sceneworks-worker/src/dataset_parquet_jobs.rs
@@ -52,7 +52,10 @@ pub(crate) async fn run_dataset_parquet_import_job(
     let url_column = required_payload_string(&job.payload, "urlColumn")?.to_owned();
     let caption_column = required_payload_string(&job.payload, "captionColumn")?.to_owned();
     let dataset_version = payload_u32(&job.payload, "datasetVersion", 0);
-    let max_items = payload_usize(&job.payload, "maxItems", 1_000).clamp(1, 25_000);
+    let max_items = payload_usize(&job.payload, "maxItems", 1_000).clamp(
+        1,
+        sceneworks_core::contracts::MAX_DATASET_PARQUET_IMPORT_ITEMS,
+    );
     let min_edge = payload_u32(&job.payload, "minEdge", 512).min(8_192);
     let concurrency = payload_usize(&job.payload, "concurrency", 16).clamp(1, 64);
     let caption_includes = normalized_filter_terms(&job.payload, "captionIncludes");

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -1044,6 +1044,9 @@ pub(crate) fn worker_capabilities_with_utility(
             // Explicit built-in LoRA download (sc-5944): fetches the catalog LoRA's HF
             // repo/file into the shared HF cache, same as model_download.
             WorkerCapability::LoraDownload,
+            // LAION-style URL/caption Parquet materialization is local metadata scanning
+            // plus bounded public image downloads, so it belongs on the CPU utility lane.
+            WorkerCapability::DatasetParquetImport,
             // Procedural detection/tracking is a preview only. Real, model-backed
             // PersonDetect/PersonTrack run on the macOS MLX worker (native
             // YOLO11/SAM2, epic 3482) or the off-Mac candle worker (YOLO11/SAM3);

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -187,6 +187,9 @@ fn rust_cpu_capabilities_do_not_claim_gpu_generation_jobs() {
     assert!(cpu_capabilities
         .iter()
         .any(|capability| capability.as_str() == "timeline_export"));
+    assert!(cpu_capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "dataset_parquet_import"));
     // The CPU utility worker advertises only the procedural *preview*
     // capabilities; real detection/tracking route to the native MLX/candle worker.
     assert!(cpu_capabilities
@@ -218,6 +221,9 @@ fn rust_cpu_capabilities_do_not_claim_gpu_generation_jobs() {
     assert!(!gpu_capabilities
         .iter()
         .any(|capability| capability.as_str() == "model_download"));
+    assert!(!gpu_capabilities
+        .iter()
+        .any(|capability| capability.as_str() == "dataset_parquet_import"));
     assert!(!gpu_capabilities
         .iter()
         .any(|capability| capability.as_str() == "image_generate"));


### PR DESCRIPTION
## Summary

- allow named empty training datasets and automatically create an empty destination when Parquet import starts from a new draft
- raise the Parquet import ceiling from 25,000 to 100,000 images across the web, API, and worker, with a shared Rust limit and a larger trusted-worker finalize envelope
- advertise `dataset_parquet_import` from the CPU utility worker so the scheduler can route the job
- add UI, API-boundary, and worker-capability regression coverage

## Root cause

The UI required at least one image before saving a dataset, while Parquet import required an already-saved empty dataset. Separately, the worker implemented the import handler but never registered the matching capability, so the API reported that no active worker supported the job. The 25,000-image ceiling was independently hard-coded in three layers.

## Impact

Users can now start a Parquet import directly from a named empty draft without adding a placeholder image. A restarted worker advertises the import capability, and production-sized imports can request up to 100,000 images.

## Validation

- `npm.cmd --prefix apps/web test` — 185 files, 2,585 tests passed
- `npm.cmd --prefix apps/web run lint`
- `cargo fmt --all -- --check`
- `cargo check -p sceneworks-core -p sceneworks-rust-api -p sceneworks-worker --offline`
- focused CPU worker capability test
- focused Rust API 100,000-item boundary and finalize test
