### PR TITLE
Refresh datasets after Parquet imports

### DIFF
--- a/apps/web/src/App.training.test.jsx
+++ b/apps/web/src/App.training.test.jsx
@@ -274,6 +274,64 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Parquet import queued (job_parquet)");
   });
 
+  it("reloads the open dataset when a Parquet import completes", async () => {
+    let imported = false;
+    const loadDataset = vi.fn(async () => ({
+      id: "dataset-parquet",
+      name: "LAION Control Set",
+      version: imported ? 2 : 1,
+      items: imported
+        ? [{
+            id: "pq_1",
+            path: "images/pq_1.jpg",
+            displayName: "pq_1.jpg",
+            caption: { text: "a portrait", source: "imported", triggerWords: [] },
+          }]
+        : [],
+    }));
+    const refreshDatasets = vi.fn(async () => []);
+    const context = (jobs) =>
+      withTrainingDataSetsLibraryContext({
+        activeProject: { id: "project-a", name: "Project A" },
+        assets: [],
+        datasets: [{ id: "dataset-parquet", name: "LAION Control Set", modality: "image", itemCount: imported ? 1 : 0 }],
+        jobs,
+        loadDataset,
+        onRefreshDatasets: refreshDatasets,
+      });
+
+    root = createRoot(container);
+    await act(async () => root.render(context([])));
+    await act(async () => document.body.querySelector(".compact-selector-pill").click());
+    await act(async () => {
+      [...document.body.querySelectorAll(".compact-selector-item")]
+        .find((button) => button.textContent.includes("LAION Control Set"))
+        .click();
+    });
+    await settle();
+    expect(document.body.querySelectorAll(".training-caption-card")).toHaveLength(0);
+
+    imported = true;
+    await act(async () => {
+      root.render(
+        context([{
+          id: "job_parquet",
+          type: "dataset_parquet_import",
+          status: "completed",
+          projectId: "project-a",
+          payload: { datasetId: "dataset-parquet" },
+          result: { datasetId: "dataset-parquet", importedItemCount: 1 },
+        }]),
+      );
+    });
+    await settle();
+
+    expect(refreshDatasets).toHaveBeenCalledWith();
+    expect(loadDataset).toHaveBeenCalledTimes(2);
+    expect(document.body.querySelectorAll(".training-caption-card")).toHaveLength(1);
+    expect(container.textContent).toContain("Parquet import completed with 1 image.");
+  });
+
   it("imports caption sidecars alongside images and bakes them into the saved dataset", async () => {
     const createDataset = vi.fn(async (payload) => ({
       id: "dataset-new",

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -335,7 +335,6 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const datasetsError = trainingDatasetsError;
   const loadingDatasets = loadingTrainingDatasets;
   const onPreview = setPreviewAsset;
-  const onRefreshDatasets = () => refreshTrainingDatasets(activeProject?.id);
   const uploadDatasetItem = uploadTrainingDatasetItem ?? ((file) => importAssetRaw(file, { throwOnError: true }));
   const loadDataset = loadTrainingDataset;
   const createDataset = createTrainingDataset;
@@ -360,6 +359,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
   const [uploadedDatasetAssets, setUploadedDatasetAssets] = useState([]);
   const [savingDataset, setSavingDataset] = useState(false);
   const openDatasetRef = useRef(null);
+  const handledParquetImportJobsRef = useRef(new Set());
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
   // Dataset Doctor readiness report (sc-6534), fetched server-side over the saved
   // dataset. `null` until the first fetch resolves; the loading flag keeps badges in
@@ -479,6 +479,18 @@ export function TrainingStudio({ mode = "training" } = {}) {
       selectedAssetIds.length !== originalAssetIds.length ||
       selectedAssetIds.some((id, index) => id !== originalAssetIds[index]) ||
       captionsDirty);
+  const completedParquetImport = useMemo(
+    () =>
+      jobs.find(
+        (job) =>
+          job.type === "dataset_parquet_import" &&
+          job.status === "completed" &&
+          job.payload?.datasetId === activeDataset?.id,
+      ) ?? null,
+    [jobs, activeDataset?.id],
+  );
+  const completedParquetImportId = completedParquetImport?.id ?? "";
+  const completedParquetImportCount = completedParquetImport?.result?.importedItemCount;
   // Unsaved work the destructive-transition guards protect (sc-11970): an edited saved
   // dataset (dirty) OR a brand-new dataset the user has started building (name / members /
   // character) but not yet saved. A new draft isn't "dirty" (no baseline), but discarding
@@ -940,13 +952,75 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
       setAssociatedCharacterId(dataset?.characterId ?? "");
       setSelectedDatasetId(dataset?.id ?? datasetId);
+      return dataset;
     } catch (err) {
       setDatasetError(err.message);
+      return null;
     } finally {
       setBusyDatasetId("");
     }
   }
   openDatasetRef.current = openDataset;
+
+  async function onRefreshDatasets() {
+    await refreshTrainingDatasets(activeProject?.id);
+    if (!activeDataset?.id || dirty) {
+      return;
+    }
+    await openDataset(activeDataset.id);
+  }
+
+  useEffect(() => {
+    if (
+      !datasetLibraryMode ||
+      !completedParquetImportId ||
+      !activeDataset?.id ||
+      dirty ||
+      handledParquetImportJobsRef.current.has(completedParquetImportId)
+    ) {
+      return undefined;
+    }
+    const jobId = completedParquetImportId;
+    const datasetId = activeDataset.id;
+    const handledJobs = handledParquetImportJobsRef.current;
+    handledJobs.add(jobId);
+    let canceled = false;
+    let settled = false;
+    void (async () => {
+      try {
+        await refreshTrainingDatasets(activeProject?.id);
+        const dataset = await openDatasetRef.current?.(datasetId);
+        if (canceled || !dataset) return;
+        const imported = completedParquetImportCount;
+        setDatasetMessage(
+          Number.isFinite(imported)
+            ? `Parquet import completed with ${imported} image${imported === 1 ? "" : "s"}.`
+            : "Parquet import completed.",
+        );
+        setDatasetError("");
+        settled = true;
+      } catch (err) {
+        if (!canceled) {
+          handledJobs.delete(jobId);
+          setDatasetError(`Parquet import completed, but the dataset could not be reloaded: ${err.message}`);
+        }
+      }
+    })();
+    return () => {
+      canceled = true;
+      if (!settled) {
+        handledJobs.delete(jobId);
+      }
+    };
+  }, [
+    activeDataset?.id,
+    activeProject?.id,
+    completedParquetImportCount,
+    completedParquetImportId,
+    datasetLibraryMode,
+    dirty,
+    refreshTrainingDatasets,
+  ]);
 
   // Drops a member (or an unavailable/orphaned id) from the dataset selection.
   function removeUnavailableAsset(assetId) {


### PR DESCRIPTION
## Summary

- reload the selected dataset detail when its Parquet import job completes
- make the Data Sets Refresh action reload the open dataset as well as the summary list
- preserve unsaved edits by skipping automatic or manual detail replacement while the dataset draft is dirty
- add an end-to-end regression covering an empty open dataset becoming populated after job completion

## Root cause

Parquet finalization updated the persisted dataset, but the Data Sets editor retained the empty dataset object loaded before the job started. Job completion did not refresh training datasets, and the existing Refresh button only updated dataset summaries rather than the selected dataset detail.

## User impact

Completed imports now appear in the open dataset automatically. On the previous build, closing and reopening the dataset or restarting SceneWorks reveals the already-imported items.

## Validation

- `npm.cmd --prefix apps/web run lint`
- `npm.cmd --prefix apps/web test -- src/App.training.test.jsx` — 30 tests passed
- `npm.cmd --prefix apps/web test` — 185 files, 2,586 tests passed
- `git diff --check`
