### PR TITLE
Assets: decouple project media from global catalog bootstrap (sc-14754)

### DIFF
--- a/apps/web/src/App.catalogBootstrap.test.jsx
+++ b/apps/web/src/App.catalogBootstrap.test.jsx
@@ -1,0 +1,224 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("independent project and asset bootstrap (sc-14754)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function installFetch({
+    assets = Promise.resolve(response([])),
+    models = Promise.resolve(response([])),
+    presets = Promise.resolve(response([])),
+    scopedPresets = presets,
+  } = {}) {
+    global.fetch = vi.fn((url) => {
+      const requestUrl = new URL(url);
+      const path = requestUrl.pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-a", name: "Project A" }]));
+      }
+      if (path.endsWith("/projects/project-a/assets")) {
+        return assets;
+      }
+      if (path.endsWith("/models")) {
+        return models;
+      }
+      if (path.endsWith("/recipe-presets")) {
+        return requestUrl.searchParams.has("projectId") ? scopedPresets : presets;
+      }
+      if (path.endsWith("/jobs")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "job-running",
+              projectId: "project-a",
+              status: "running",
+              type: "image",
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/workers")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "worker-a",
+              status: "idle",
+              gpuId: "gpu-a",
+              capabilities: ["image_generate"],
+            },
+          ]),
+        );
+      }
+      if (path.endsWith("/loras")) {
+        return Promise.resolve(response([{ id: "lora-a", name: "LoRA A" }]));
+      }
+      if (path.endsWith("/training/targets")) {
+        return Promise.resolve(
+          response({ schemaVersion: 1, targets: [{ id: "target-a" }] }),
+        );
+      }
+      if (path.endsWith("/training/presets")) {
+        return Promise.resolve(
+          response({ schemaVersion: 1, presets: [{ id: "training-preset-a" }] }),
+        );
+      }
+      if (path.endsWith("/prompt-batches")) {
+        return Promise.resolve(response([{ id: "batch-a", name: "Batch A" }]));
+      }
+      return Promise.resolve(response([]));
+    });
+  }
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  it("renders the active project and populated Assets view while models and presets remain unresolved", async () => {
+    const models = deferred();
+    const presets = deferred();
+    installFetch({
+      assets: Promise.resolve(
+        response([
+          {
+            id: "asset-a",
+            projectId: "project-a",
+            type: "image",
+            origin: "image_studio",
+            displayName: "Hero Asset",
+            status: {},
+          },
+        ]),
+      ),
+      models: models.promise,
+      presets: presets.promise,
+      scopedPresets: Promise.resolve(
+        response([{ id: "project-preset", name: "Project Preset" }]),
+      ),
+    });
+
+    await renderApp();
+
+    expect(container.querySelector(".project-pill")?.textContent).toContain("Project A");
+    expect(container.textContent).toContain("Hero Asset");
+    expect(container.textContent).not.toContain("Loading assets");
+    // Other independently settling domains commit even though the two slow
+    // catalogs are still held open.
+    expect(container.textContent).toContain("1 worker");
+    expect(container.textContent).toContain("Queue 1");
+
+    const paths = global.fetch.mock.calls.map(([url]) => new URL(url).pathname);
+    expect(paths).toContain("/api/v1/projects/project-a/assets");
+    expect(paths.indexOf("/api/v1/projects")).toBeLessThan(
+      paths.indexOf("/api/v1/projects/project-a/assets"),
+    );
+
+    await act(async () => {
+      models.resolve(response([{ id: "model-a", name: "Model A", type: "image" }]));
+      presets.resolve(response([{ id: "global-preset", name: "Global Preset" }]));
+    });
+    await settle();
+
+    await act(async () => {
+      [...container.querySelectorAll(".nav-item")]
+        .find((button) => button.textContent.includes("Presets"))
+        ?.click();
+    });
+    await settle();
+    expect(container.textContent).toContain("Project Preset");
+    expect(container.textContent).not.toContain("Global Preset");
+  });
+
+  it("keeps an empty Assets view usable when models and presets fail", async () => {
+    const models = deferred();
+    const presets = deferred();
+    installFetch({ models: models.promise, presets: presets.promise });
+
+    await renderApp();
+    expect(container.textContent).toContain("No assets in this view");
+
+    await act(async () => {
+      models.reject(new Error("model catalog failed"));
+      presets.reject(new Error("preset catalog failed"));
+    });
+    await settle();
+
+    expect(container.querySelector(".project-pill")?.textContent).toContain("Project A");
+    expect(container.textContent).toContain("No assets in this view");
+    // Models preserve their non-optional aggregate startup error. Recipe
+    // presets remain optional, matching the prior refreshData contract.
+    expect(container.textContent).toContain("Models: model catalog failed");
+    expect(container.textContent).not.toContain("Presets: preset catalog failed");
+  });
+
+  it("shows loading and error states before unrelated catalogs settle", async () => {
+    const assets = deferred();
+    const models = deferred();
+    const presets = deferred();
+    installFetch({
+      assets: assets.promise,
+      models: models.promise,
+      presets: presets.promise,
+    });
+
+    await renderApp();
+    expect(container.textContent).toContain("Loading assets");
+
+    await act(async () => {
+      assets.reject(new Error("asset catalog unavailable"));
+    });
+    await settle();
+
+    expect(container.textContent).toContain(
+      "Couldn't load assets: asset catalog unavailable",
+    );
+
+    await act(async () => {
+      models.resolve(response([]));
+      presets.resolve(response([]));
+    });
+    await settle();
+  });
+});

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -441,6 +441,11 @@ export function App() {
   const [trainingPresetsError, setTrainingPresetsError] = useState("");
   const [loadedAssets, setAssets] = useState([]);
   const [loadedAssetsProjectId, setLoadedAssetsProjectId] = useState(null);
+  const [assetLoadState, setAssetLoadState] = useState({
+    projectId: null,
+    status: "idle",
+    error: "",
+  });
   const [storedSelectedAssetId, setSelectedAssetId] = useState(null);
   // Scope project data during render, not in a passive effect. On A → B (or A
   // → no project), B's first render therefore cannot observe A's assets or raw
@@ -451,6 +456,20 @@ export function App() {
   );
   const selectedAssetId =
     loadedAssetsProjectId === activeProject?.id ? storedSelectedAssetId : null;
+  // A project switch renders before its passive refresh effect runs. Treat that
+  // first render as loading instead of briefly presenting the previous
+  // project's settled state (or a misleading empty catalog).
+  const activeAssetLoadState = useMemo(
+    () =>
+      activeProject && assetLoadState.projectId === activeProject.id
+        ? assetLoadState
+        : {
+            projectId: activeProject?.id ?? null,
+            status: activeProject ? "loading" : "idle",
+            error: "",
+          },
+    [activeProject, assetLoadState],
+  );
   const [projectFilter, setProjectFilter] = useState("all");
   const [requestedGpu, setRequestedGpu] = useState("auto");
   const [latestGenerationSetId, setLatestGenerationSetId] = useState(null);
@@ -1321,6 +1340,7 @@ export function App() {
     if (!activeProject || !ready) {
       setAssets([]);
       setLoadedAssetsProjectId(null);
+      setAssetLoadState({ projectId: null, status: "idle", error: "" });
       setCharacters([]);
       setSavedVoices([]);
       setPersonTracks([]);
@@ -1411,56 +1431,78 @@ export function App() {
         return { label, value: fallback, error: optional ? "" : `${label}: ${err.message}` };
       }
     };
-    const [
-      projectsResult,
-      jobsResult,
-      workersResult,
-      modelsResult,
-      lorasResult,
-      presetsResult,
-      trainingTargetsResult,
-      trainingPresetsResult,
-      promptBatchesResult,
-    ] =
-      await Promise.all([
-        fetchInitial("Projects", "/api/v1/projects", []),
-        fetchInitial("Jobs", "/api/v1/jobs", []),
-        fetchInitial("Workers", "/api/v1/workers", []),
-        fetchInitial("Models", "/api/v1/models", []),
-        fetchInitial("LoRAs", "/api/v1/loras", []),
-        fetchInitial("Presets", "/api/v1/recipe-presets", [], true),
-        fetchInitial("Training targets", "/api/v1/training/targets", { schemaVersion: 1, targets: [] }),
-        fetchInitial("Training presets", "/api/v1/training/presets", { schemaVersion: 1, presets: [] }),
-        fetchInitial("Prompt batches", "/api/v1/prompt-batches", [], true),
-      ]);
+    const projectsPromise = fetchInitial("Projects", "/api/v1/projects", []).then((result) => {
+      applySuccessfulProjectRefresh(result, setProjects, setActiveProject);
+      setProjectsLoaded(true);
+      return result;
+    });
     // Mac UI gating (sc-3486): optional + non-fatal — a fetch failure leaves gating inert.
     fetchInitial("Mac capabilities", "/api/v1/capabilities/mac", DEFAULT_MAC_CAPABILITIES, true)
       .then((result) => setMacCapabilities(result.value ?? DEFAULT_MAC_CAPABILITIES))
       .catch(() => {});
-    applySuccessfulProjectRefresh(projectsResult, setProjects, setActiveProject);
-    setProjectsLoaded(true);
-    setJobs((current) => mergeFreshJobs(current, jobsResult.value));
-    setWorkers(workersResult.value.sort(sortWorkers));
-    setQueueSummary(null);
-    setModels(modelsResult.value);
-    setLoras(lorasResult.value);
-    setPresets(presetsResult.value);
-    setPromptBatches(promptBatchesResult.value);
-    setTrainingTargets(trainingTargetsResult.value);
-    setTrainingTargetsError(trainingTargetsResult.error);
-    setTrainingPresets(trainingPresetsResult.value);
-    setTrainingPresetsError(trainingPresetsResult.error);
+    // Projects are the critical path to Assets. The remaining domains commit
+    // independently so no slow catalog gates another domain's usable state.
+    const globalPromises = [
+      fetchInitial("Jobs", "/api/v1/jobs", []).then((result) => {
+        setJobs((current) => mergeFreshJobs(current, result.value));
+        setQueueSummary(null);
+        return result;
+      }),
+      fetchInitial("Workers", "/api/v1/workers", []).then((result) => {
+        setWorkers(result.value.sort(sortWorkers));
+        return result;
+      }),
+      fetchInitial("Models", "/api/v1/models", []).then((result) => {
+        setModels(result.value);
+        return result;
+      }),
+      fetchInitial("LoRAs", "/api/v1/loras", []).then((result) => {
+        // Once a project is active, its scoped refresh is authoritative. A
+        // slower global response must not overwrite project entries.
+        if (!activeProjectRef.current) {
+          setLoras(result.value);
+        }
+        return result;
+      }),
+      fetchInitial("Presets", "/api/v1/recipe-presets", [], true).then((result) => {
+        if (!activeProjectRef.current) {
+          setPresets(result.value);
+        }
+        return result;
+      }),
+      fetchInitial(
+        "Training targets",
+        "/api/v1/training/targets",
+        { schemaVersion: 1, targets: [] },
+      ).then((result) => {
+        setTrainingTargets(result.value);
+        setTrainingTargetsError(result.error);
+        return result;
+      }),
+      fetchInitial(
+        "Training presets",
+        "/api/v1/training/presets",
+        { schemaVersion: 1, presets: [] },
+      ).then((result) => {
+        setTrainingPresets(result.value);
+        setTrainingPresetsError(result.error);
+        return result;
+      }),
+      fetchInitial("Prompt batches", "/api/v1/prompt-batches", [], true).then((result) => {
+        if (!activeProjectRef.current) {
+          setPromptBatches(result.value);
+        }
+        return result;
+      }),
+    ];
+    // Awaiting all requests preserves refreshData's completion contract and its
+    // aggregate startup error while no longer gating any individual commit.
+    const [projectsResult, ...globalResults] = await Promise.all([
+      projectsPromise,
+      ...globalPromises,
+    ]);
     setError(
-      [
-        projectsResult,
-        jobsResult,
-        workersResult,
-        modelsResult,
-        lorasResult,
-        presetsResult,
-        trainingTargetsResult,
-        trainingPresetsResult,
-      ]
+      [projectsResult, ...globalResults]
         .map((result) => result.error)
         .filter(Boolean)
         .join("; "),
@@ -1478,6 +1520,13 @@ export function App() {
     if (!isCurrentProjectRequest(activeProject?.id ?? null, projectId)) {
       return;
     }
+    // Keep an already-settled grid usable during background/SSE refreshes.
+    // Initial loads, retries, and project switches still expose "loading".
+    setAssetLoadState((current) =>
+      loadedAssetsProjectId === projectId
+        ? { ...current, projectId, error: "" }
+        : { projectId, status: "loading", error: "" },
+    );
     const timingStartedAt = beginAssetRequest();
     try {
       const items = await apiFetch(`/api/v1/projects/${projectId}/assets?includeRejected=true&includeTrashed=true`, token, { signal });
@@ -1491,9 +1540,14 @@ export function App() {
       setAssets(items);
       setLoadedAssetsProjectId(projectId);
       setSelectedAssetId((current) => reconcileSelectedAssetId(items, current));
+      setAssetLoadState({ projectId, status: "ready", error: "" });
       setError("");
     } catch (err) {
       if (isAbortError(err)) return;
+      if (!isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId)) {
+        return;
+      }
+      setAssetLoadState({ projectId, status: "error", error: err.message });
       setError(err.message);
     } finally {
       settleAssetRequest(timingStartedAt);
@@ -2376,8 +2430,12 @@ export function App() {
     // Assets / library (sc-1651 Phase B batch 1)
     assets,
     assetsReady: Boolean(
-      activeProject && loadedAssetsProjectId === activeProject.id
+      activeProject &&
+      loadedAssetsProjectId === activeProject.id &&
+      activeAssetLoadState.status === "ready"
     ),
+    assetsLoading: activeAssetLoadState.status === "loading",
+    assetsError: activeAssetLoadState.error,
     selectedAsset,
     // The RAW selection id (null when nothing is explicitly selected). Studios need it
     // to tell an explicit user selection apart from `selectedAsset`'s assets[0] fallback
@@ -2538,7 +2596,7 @@ export function App() {
     activeProject, mediaAssets, openPreview, sendAssetToImage, sendAssetToVideo,
     activeTimeline, timelines, selectedTimelineId, setSelectedTimelineId, setActiveTimeline, isActiveTimelineDirty,
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
-    assets, loadedAssetsProjectId, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
+    assets, loadedAssetsProjectId, activeAssetLoadState, selectedAsset, selectedAssetId, setSelectedAssetId, deleteAsset, purgeAsset, moveAssetToLibrary, moveAssetToCharacter, importAsset,
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobAction, clearCompletedJobs, cancelPendingJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
     projectFilter, setProjectFilter, projects,

--- a/apps/web/src/App.projectAssetBoundary.test.jsx
+++ b/apps/web/src/App.projectAssetBoundary.test.jsx
@@ -30,6 +30,16 @@ vi.mock("./screens/VideoStudio.jsx", () => ({
 
 import { App } from "./main.jsx";
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
 describe("project asset render boundary", () => {
   let container;
   let root;
@@ -152,5 +162,63 @@ describe("project asset render boundary", () => {
         new URL(url).pathname.endsWith("/projects/project-b/assets"),
       ),
     ).toBe(false);
+  });
+
+  it("aborts project A and ignores its non-abort-aware failure after switching to B", async () => {
+    const projectAAssets = deferred();
+    const baseFetch = global.fetch;
+    let projectASignal;
+    global.fetch = vi.fn((url, options) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/projects/project-a/assets")) {
+        projectASignal = options?.signal;
+        return projectAAssets.promise;
+      }
+      if (path.endsWith("/projects/project-b/assets")) {
+        return Promise.resolve(
+          response([
+            {
+              id: "asset-b",
+              projectId: "project-b",
+              type: "image",
+              origin: "image_studio",
+              displayName: "Asset B",
+              status: {},
+            },
+          ]),
+        );
+      }
+      return baseFetch(url, options);
+    });
+
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    expect(projectASignal?.aborted).toBe(false);
+
+    await act(async () => {
+      document.body.querySelector(".project-pill")?.click();
+    });
+    await act(async () => {
+      [...document.body.querySelectorAll(".project-menu-item")]
+        .find((item) => item.textContent.includes("Project B"))
+        ?.click();
+    });
+    await settle();
+
+    expect(projectASignal?.aborted).toBe(true);
+    expect(container.textContent).toContain("Asset B");
+
+    // Simulate a transport that ignores AbortSignal and reports a late ordinary
+    // failure. The old request must not replace B's settled state or error UI.
+    await act(async () => {
+      projectAAssets.reject(new Error("stale A failure"));
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Asset B");
+    expect(container.textContent).not.toContain("stale A failure");
   });
 });

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -26,6 +26,8 @@ export function LibraryScreen() {
     activeProject,
     assets,
     assetsReady = false,
+    assetsLoading = false,
+    assetsError = "",
     jobs = [],
     imageModels = [],
     createVqaJob,
@@ -243,37 +245,45 @@ export function LibraryScreen() {
 
       <AssetSelectionBar batch={batch} showDiscard={assetMode === "assets"} />
 
-      <div className="library-layout">
-        <AssetGrid
-          audioPlayer={audioPlayer}
-          assets={visibleAssets}
-          onPreview={onPreview}
-          selectedAsset={librarySelectedAsset}
-          setSelectedAssetId={setSelectedAssetId}
-          selectedIds={batch.selectedAssetIds}
-          onToggleSelect={batch.toggleSelect}
-        />
-        <AssetDetail
-          audioPlayer={audioPlayer}
-          asset={librarySelectedAsset}
-          deleteAsset={deleteAsset}
-          purgeAsset={purgeAsset}
-          onPreview={onPreview}
-          onSendImage={onSendImage}
-          onSendVideo={onSendVideo}
-          onSendEditor={onSendEditor}
-          characters={characters}
-          onMoveToCharacter={moveAssetToCharacter ?? null}
-          updateAssetStatus={updateAssetStatus}
-          updateAssetTags={updateAssetTags}
-          availableTags={availableTags}
-          vqaEnabled={vqaEnabled}
-          vqaEntries={vqaEntries}
-          vqaPending={vqaPending}
-          audioModels={audioModels}
-          createVqaJob={createVqaJob}
-        />
-      </div>
+      {assetsLoading ? (
+        <div className="empty-panel" role="status">Loading assets…</div>
+      ) : assetsError ? (
+        <div className="empty-panel error-text" role="alert">
+          Couldn&apos;t load assets: {assetsError}
+        </div>
+      ) : (
+        <div className="library-layout">
+          <AssetGrid
+            audioPlayer={audioPlayer}
+            assets={visibleAssets}
+            onPreview={onPreview}
+            selectedAsset={librarySelectedAsset}
+            setSelectedAssetId={setSelectedAssetId}
+            selectedIds={batch.selectedAssetIds}
+            onToggleSelect={batch.toggleSelect}
+          />
+          <AssetDetail
+            audioPlayer={audioPlayer}
+            asset={librarySelectedAsset}
+            deleteAsset={deleteAsset}
+            purgeAsset={purgeAsset}
+            onPreview={onPreview}
+            onSendImage={onSendImage}
+            onSendVideo={onSendVideo}
+            onSendEditor={onSendEditor}
+            characters={characters}
+            onMoveToCharacter={moveAssetToCharacter ?? null}
+            updateAssetStatus={updateAssetStatus}
+            updateAssetTags={updateAssetTags}
+            availableTags={availableTags}
+            vqaEnabled={vqaEnabled}
+            vqaEntries={vqaEntries}
+            vqaPending={vqaPending}
+            audioModels={audioModels}
+            createVqaJob={createVqaJob}
+          />
+        </div>
+      )}
 
       <AssetBatchModal batch={batch} />
     </section>

--- a/apps/web/src/simple/SimpleAssets.jsx
+++ b/apps/web/src/simple/SimpleAssets.jsx
@@ -23,7 +23,12 @@ const FILTERS = [
 ];
 
 export function SimpleAssets() {
-  const { assets = [], assetsReady = false } = useAppContext();
+  const {
+    assets = [],
+    assetsReady = false,
+    assetsLoading = false,
+    assetsError = "",
+  } = useAppContext();
   const { breakpoint, openPreview, loadedTakeId } = useSimpleUi();
   const [filter, setFilter] = useState("all");
   const [query, setQuery] = useState("");
@@ -78,7 +83,11 @@ export function SimpleAssets() {
         ))}
       </div>
 
-      {visible.length ? (
+      {assetsLoading ? (
+        <p className="su-empty" role="status">Loading assets…</p>
+      ) : assetsError ? (
+        <p className="su-empty" role="alert">Couldn&apos;t load assets: {assetsError}</p>
+      ) : visible.length ? (
         <div
           className="su-asset-grid"
           style={{ "--su-asset-cols": assetGridColumns(breakpoint) }}


### PR DESCRIPTION
## Summary
- commit projects immediately and start project-scoped assets without waiting for models, presets, training metadata, or prompt batches
- settle global domains independently while keeping project-scoped LoRAs, presets, and prompt batches authoritative
- expose truthful Assets loading, empty, populated, and error states in Advanced and Simple UI, preserving background-refresh usability and stale-project suppression

## Validation
- npm.cmd test -- App.catalogBootstrap.test.jsx App.projectAssetBoundary.test.jsx App.simpleUi.test.jsx simple/SimpleShell.test.jsx startupTiming.test.js (55 passed)
- npm.cmd test (188 files, 2597 tests passed)
- npm.cmd run lint
- npm.cmd run build

Shortcut: https://app.shortcut.com/trefry/story/14754