### PR TITLE
SC-14784: reuse model catalog sweep for presets

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -229,14 +229,15 @@ pub(crate) fn validate_interleave_job(payload: &InterleaveJobRequest) -> Result<
 /// `validate_job_lora_compatibility`, each of which formerly re-assembled
 /// `model_catalog`/`lora_catalog` from scratch — re-running the per-model install-state
 /// probes (recursive HF-cache walks, `model_is_installed`, `mlx_catalog_status`) 2–3×
-/// over the whole catalog per submit. Threading one snapshot through those seams makes
-/// each catalog's filesystem probing run exactly once per job-create.
+/// over the whole catalog per submit. Threading one snapshot through those seams limits
+/// each request to one model value and one LoRA value; the model value may require no
+/// new filesystem probing when the process-shared generation is already warm.
 ///
-/// This is deliberately request-scoped rather than a shared TTL cache: the snapshot lives
-/// only for the duration of one job-create, so there is no staleness window and the
-/// catalog contents seen by preset expansion and by LoRA validation are guaranteed
-/// identical. It memoizes per `project_id` (constant within a single job-create), so both
-/// the `project_id`-scoped and the `None` (no-project) catalog reads are covered.
+/// The request-scoped layer still guarantees that preset expansion and LoRA validation
+/// see identical values within one job-create. Its model value is sourced from the
+/// process-shared, generation-keyed install-state cache (SC-14784), which coalesces cold
+/// callers and is invalidated by model lifecycle completion, model deletion, and model
+/// manifest writes. LoRAs remain memoized only per `(request, project_id)`.
 #[derive(Default)]
 pub(crate) struct JobCatalogSnapshot {
     models: tokio::sync::OnceCell<Vec<Value>>,
@@ -244,8 +245,8 @@ pub(crate) struct JobCatalogSnapshot {
 }
 
 impl JobCatalogSnapshot {
-    /// The model catalog, built once per request and reused thereafter. Identical output
-    /// to a direct `model_catalog(state)` call.
+    /// The model catalog, fetched once per request and reused thereafter. The direct
+    /// `model_catalog(state)` call may itself reuse the current process-shared generation.
     pub(crate) async fn models(&self, state: &AppState) -> Result<&[Value], ApiError> {
         let models = self
             .models

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -9,17 +9,19 @@ pub(crate) async fn list_jobs(
             return Err(ApiError::bad_request("Unsupported job status"));
         }
     }
-    Ok(Json(
-        store_call(state, move |store, timeout| {
-            store.mark_stale_workers_interrupted(timeout)?;
-            store.list_jobs(
-                query.project_id.as_deref(),
-                query.status.as_deref(),
-                query.limit.unwrap_or(100),
-            )
-        })
-        .await?,
-    ))
+    let (sweep, jobs) = store_call(state.clone(), move |store, timeout| {
+        let sweep = store.mark_stale_workers_interrupted(timeout)?;
+        let jobs = store.list_jobs(
+            query.project_id.as_deref(),
+            query.status.as_deref(),
+            query.limit.unwrap_or(100),
+        );
+        Ok((sweep, jobs))
+    })
+    .await?;
+    handle_stale_sweep(&state, &sweep);
+    let jobs = jobs?;
+    Ok(Json(jobs))
 }
 
 /// Worker → API write of a job's structured generation metrics (epic 10402).
@@ -118,9 +120,9 @@ pub(crate) async fn claim_job(
     let enforce_unsupported = state.settings.mlx_enforce_unsupported;
     let candle_required = state.settings.candle_required;
     let candle_enforce = state.settings.candle_enforce_unsupported;
-    let (response, decision, stranded, unsupported, candle_stranded, candle_unsupported) =
-        store_call(state.clone(), move |store, timeout| {
-            store.mark_stale_workers_interrupted(timeout)?;
+    let (stale_sweep, claim_result) = store_call(state.clone(), move |store, timeout| {
+        let stale_sweep = store.mark_stale_workers_interrupted(timeout)?;
+        let claim_result = (|| {
             // macOS MLX-required (sc-3483): before claiming, fail any MLX-eligible job left
             // stranded because no live `mlx` worker took it within the grace window — reusing
             // the worker timeout as that window. No-op when the flag is off.
@@ -136,7 +138,7 @@ pub(crate) async fn claim_job(
             let candle_unsupported =
                 store.fail_unsupported_candle_jobs(candle_required, candle_enforce)?;
             let (job, decision) = store.claim_next_job_routed(&payload.worker_id, mlx_required)?;
-            Ok((
+            Ok::<_, JobsStoreError>((
                 job,
                 decision,
                 stranded,
@@ -144,8 +146,13 @@ pub(crate) async fn claim_job(
                 candle_stranded,
                 candle_unsupported,
             ))
-        })
-        .await?;
+        })();
+        Ok((stale_sweep, claim_result))
+    })
+    .await?;
+    handle_stale_sweep(&state, &stale_sweep);
+    let (response, decision, stranded, unsupported, candle_stranded, candle_unsupported) =
+        claim_result?;
     for job in &stranded {
         emit_mlx_unavailable(job);
         publish(&state, "job.updated", job);
@@ -185,6 +192,8 @@ pub(crate) async fn claim_job(
         publish(&state, "job.updated", job);
     }
     if response.is_some()
+        || !stale_sweep.workers.is_empty()
+        || !stale_sweep.jobs.is_empty()
         || !stranded.is_empty()
         || !unsupported.is_empty()
         || !candle_stranded.is_empty()
@@ -707,6 +716,15 @@ pub(crate) fn terminal_model_job_changes_catalog(job_type: &JobType, status: &Jo
         status,
         JobStatus::Completed | JobStatus::Failed | JobStatus::Canceled | JobStatus::Interrupted
     )
+}
+
+pub(crate) fn invalidate_model_catalog_for_terminal_jobs(state: &AppState, jobs: &[JobSnapshot]) {
+    if jobs
+        .iter()
+        .any(|job| terminal_model_job_changes_catalog(&job.job_type, &job.status))
+    {
+        state.model_catalog_cache.invalidate();
+    }
 }
 
 pub(crate) const PROGRESS_SIDE_EFFECT_RECOVERY_BATCH: usize = 128;

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -635,6 +635,15 @@ pub(crate) async fn update_job_progress(
     let mut publish_job_update = accepted.applied;
     let mut job = accepted.job;
 
+    // Model workers mutate install receipts, imported manifests, or converted
+    // output directories before reporting a terminal status. Advance the
+    // shared catalog generation for every accepted terminal outcome (including
+    // failures/cancellation, which may leave an incomplete cache) so the next
+    // `/models`, preset, or job-validation caller observes the new filesystem.
+    if accepted.applied && terminal_model_job_changes_catalog(&job.job_type, &job.status) {
+        state.model_catalog_cache.invalidate();
+    }
+
     if terminal_side_effects_pending {
         // The request that accepted the terminal state gets the first chance to
         // drain its durable handoff. If it errors or the process dies, the
@@ -688,6 +697,16 @@ pub(crate) async fn update_job_progress(
         publish_queue(&state).await?;
     }
     Ok(Json(job))
+}
+
+pub(crate) fn terminal_model_job_changes_catalog(job_type: &JobType, status: &JobStatus) -> bool {
+    matches!(
+        job_type,
+        JobType::ModelDownload | JobType::ModelImport | JobType::ModelConvert
+    ) && matches!(
+        status,
+        JobStatus::Completed | JobStatus::Failed | JobStatus::Canceled | JobStatus::Interrupted
+    )
 }
 
 pub(crate) const PROGRESS_SIDE_EFFECT_RECOVERY_BATCH: usize = 128;

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -137,8 +137,8 @@ mod ideogram;
 mod jobs;
 use jobs::{
     cancel_job, cancel_pending_jobs, claim_job, clear_job, clear_jobs, create_job, duplicate_job,
-    get_job, get_job_metrics, list_jobs, list_metrics, retry_job, update_job_progress,
-    upsert_job_metrics,
+    get_job, get_job_metrics, invalidate_model_catalog_for_terminal_jobs, list_jobs, list_metrics,
+    retry_job, update_job_progress, upsert_job_metrics,
 };
 mod workers;
 use workers::{
@@ -2135,21 +2135,22 @@ async fn queue_summary_snapshot_inner(
     state: AppState,
     skip_sweep: bool,
 ) -> Result<QueueSummary, ApiError> {
-    let (sweep, summary): (StaleSweep, QueueSummary) =
-        store_call(state.clone(), move |store, timeout| {
-            // When the caller already swept this request, don't pay for a second
-            // sweep — just read the summary. The empty StaleSweep means the
-            // job.updated fan-out below is a no-op (the caller emitted those
-            // events off its own sweep result).
-            let sweep = if skip_sweep {
-                StaleSweep::default()
-            } else {
-                store.mark_stale_workers_interrupted(timeout)?
-            };
-            let summary = store.queue_summary()?;
-            Ok((sweep, summary))
-        })
-        .await?;
+    let (sweep, summary) = store_call(state.clone(), move |store, timeout| {
+        // When the caller already swept this request, don't pay for a second
+        // sweep — just read the summary. The empty StaleSweep means the
+        // job.updated fan-out below is a no-op (the caller emitted those
+        // events off its own sweep result).
+        let sweep = if skip_sweep {
+            StaleSweep::default()
+        } else {
+            store.mark_stale_workers_interrupted(timeout)?
+        };
+        let summary = store.queue_summary();
+        Ok((sweep, summary))
+    })
+    .await?;
+    handle_stale_sweep(&state, &sweep);
+    let summary = summary?;
     // The stale-sweep mutates jobs to `interrupted` in the DB but — unlike a worker-reported
     // terminal status (`update_job_progress`) or the supervisor crash path (`worker_terminated`) —
     // emits no per-job event. Broadcast `job.updated` for each swept job so a live client's job card
@@ -2158,10 +2159,18 @@ async fn queue_summary_snapshot_inner(
     // (sc-8186). The sweep returns each job exactly once (it also flips the owning worker offline, so
     // a later sweep can't re-select it), so this neither spams nor double-fires. When skip_sweep is
     // set the sweep is empty, so nothing is broadcast here.
-    for job in &sweep.jobs {
-        publish(&state, "job.updated", job);
-    }
     Ok(summary)
+}
+
+/// Apply the API-visible consequences of a stale-worker sweep exactly once at
+/// every route that can trigger one. The store returns the terminal job
+/// snapshots so callers can invalidate model install state and notify live
+/// clients rather than silently discarding those transitions.
+fn handle_stale_sweep(state: &AppState, sweep: &StaleSweep) {
+    invalidate_model_catalog_for_terminal_jobs(state, &sweep.jobs);
+    for job in &sweep.jobs {
+        publish(state, "job.updated", job);
+    }
 }
 
 async fn create_generation_job(
@@ -2366,11 +2375,14 @@ async fn catalog_delete_warnings(
     }
 
     let item_id = id.to_owned();
-    let jobs = store_call(state.clone(), move |store, timeout| {
-        store.mark_stale_workers_interrupted(timeout)?;
-        store.list_jobs(None, None, 100)
+    let (sweep, jobs) = store_call(state.clone(), move |store, timeout| {
+        let sweep = store.mark_stale_workers_interrupted(timeout)?;
+        let jobs = store.list_jobs(None, None, 100);
+        Ok((sweep, jobs))
     })
     .await?;
+    handle_stale_sweep(state, &sweep);
+    let jobs = jobs?;
     let job_ids = jobs
         .iter()
         .filter(|job| job_references_catalog_item(job, kind, &item_id))

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -180,7 +180,7 @@ mod models;
 use models::{
     create_model_convert_job, create_model_download_job, create_model_import_job, delete_model,
     delete_model_variant, list_models, model_catalog, model_is_installed,
-    resolve_model_manifest_entry, ModelSizeCache,
+    resolve_model_manifest_entry, ModelCatalogCache, ModelSizeCache,
 };
 #[cfg(test)]
 use models::{
@@ -1100,6 +1100,7 @@ pub(crate) fn create_app_with_state(
         auth_throttle: Arc::new(AuthThrottle::default()),
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
+        model_catalog_cache: Arc::new(ModelCatalogCache::default()),
         model_size_cache: Arc::new(Mutex::new(ModelSizeCache::default())),
         #[cfg(test)]
         model_size_estimate_test_hook: Arc::new(Mutex::new(None)),

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2793,10 +2793,76 @@ struct ArtifactRemoval {
     trash_failed_paths: Vec<String>,
 }
 
+#[cfg(test)]
+static TEST_TRASH_OUTCOMES: std::sync::OnceLock<Mutex<HashMap<PathBuf, bool>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(test)]
+pub(crate) struct TestTrashOutcomesGuard {
+    paths: Vec<PathBuf>,
+}
+
+#[cfg(test)]
+impl Drop for TestTrashOutcomesGuard {
+    fn drop(&mut self) {
+        let mut outcomes = TEST_TRASH_OUTCOMES.get_or_init(Default::default).lock();
+        for path in &self.paths {
+            outcomes.remove(path);
+        }
+    }
+}
+
+/// Install one-shot deterministic OS-trash outcomes for route tests. A `true`
+/// outcome removes the path as if the trash move succeeded; `false` leaves it
+/// in place and reports the same recoverable failure as `trash::delete`.
+#[cfg(test)]
+pub(crate) fn test_trash_outcomes(
+    entries: impl IntoIterator<Item = (PathBuf, bool)>,
+) -> TestTrashOutcomesGuard {
+    let mut outcomes = TEST_TRASH_OUTCOMES.get_or_init(Default::default).lock();
+    let mut paths = Vec::new();
+    for (path, succeeds) in entries {
+        assert!(
+            outcomes.insert(path.clone(), succeeds).is_none(),
+            "test trash outcome already registered for {}",
+            path.display()
+        );
+        paths.push(path);
+    }
+    TestTrashOutcomesGuard { paths }
+}
+
 /// Move a single path to the operating-system trash (Windows Recycle Bin / macOS
 /// Trash / Linux XDG trash). `trash::delete` is blocking, so it runs on the blocking
 /// pool to avoid stalling the async runtime.
 async fn move_path_to_os_trash(path: PathBuf) -> Result<(), String> {
+    #[cfg(test)]
+    let test_outcome = {
+        TEST_TRASH_OUTCOMES
+            .get_or_init(Default::default)
+            .lock()
+            .remove(&path)
+    };
+    #[cfg(test)]
+    if let Some(succeeds) = test_outcome {
+        if !succeeds {
+            return Err("injected OS-trash failure".to_owned());
+        }
+        let metadata = tokio::fs::symlink_metadata(&path)
+            .await
+            .map_err(|error| format!("injected trash could not inspect path: {error}"))?;
+        if metadata.is_dir() {
+            tokio::fs::remove_dir_all(&path)
+                .await
+                .map_err(|error| format!("injected trash could not remove directory: {error}"))?;
+        } else {
+            tokio::fs::remove_file(&path)
+                .await
+                .map_err(|error| format!("injected trash could not remove file: {error}"))?;
+        }
+        return Ok(());
+    }
+
     tokio::task::spawn_blocking(move || trash::delete(&path))
         .await
         .map_err(|error| format!("trash task failed: {error}"))?

--- a/apps/rust-api/src/manifest.rs
+++ b/apps/rust-api/src/manifest.rs
@@ -143,6 +143,12 @@ where
     let entries = load_manifest_entries(state, path, field).await?;
     let (entries, result) = operation(entries)?;
     save_manifest_entries(path, field, entries).await?;
+    // A model-manifest mutation changes both catalog membership and the inputs
+    // to install-state resolution. Invalidate only after the atomic write
+    // succeeds so failed CRUD leaves the last known-good snapshot reusable.
+    if field == "models" {
+        state.model_catalog_cache.invalidate();
+    }
     Ok(result)
 }
 

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -23,27 +23,88 @@ const MODEL_SIZE_POSITIVE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 /// Generation-keyed, process-local snapshot of the model catalog after its
 /// filesystem install-state sweep.
 ///
-/// A cold caller holds `snapshot` while building, so concurrent `/models`,
-/// global preset, project preset, and job-validation requests join that one
-/// sweep. `invalidate` is synchronous and advances `generation` before any
-/// model lifecycle/manifest writer returns. If a writer races a cold build,
-/// the builder observes the newer generation and rebuilds instead of publishing
-/// stale state. Errors are never cached.
+/// A separate async serializer makes concurrent cold `/models`, global preset,
+/// project preset, and job-validation requests join one sweep without holding
+/// the short synchronous state lock across filesystem work. `invalidate`
+/// advances the generation and clears the snapshot in that same critical
+/// section. Publication validates its generation under the same lock, so a
+/// writer racing a cold build forces a rebuild instead of publishing or
+/// returning stale state. Errors are never cached.
 #[derive(Default)]
 pub(crate) struct ModelCatalogCache {
-    generation: std::sync::atomic::AtomicU64,
-    snapshot: tokio::sync::Mutex<Option<(u64, Arc<Vec<Value>>)>>,
+    state: Mutex<ModelCatalogCacheState>,
+    build_serializer: tokio::sync::Mutex<()>,
+    #[cfg(test)]
+    before_publish_test_hook: Mutex<Option<ModelCatalogBeforePublishTestHook>>,
+}
+
+#[derive(Default)]
+struct ModelCatalogCacheState {
+    generation: u64,
+    snapshot: Option<(u64, Arc<Vec<Value>>)>,
 }
 
 impl ModelCatalogCache {
     pub(crate) fn invalidate(&self) {
-        self.generation
-            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        let mut state = self.state.lock();
+        state.generation = state.generation.wrapping_add(1);
+        state.snapshot = None;
     }
 
     #[cfg(test)]
     pub(crate) fn generation(&self) -> u64 {
-        self.generation.load(std::sync::atomic::Ordering::Acquire)
+        self.state.lock().generation
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_before_publish_test_hook(&self, hook: ModelCatalogBeforePublishTestHook) {
+        *self.before_publish_test_hook.lock() = Some(hook);
+    }
+
+    #[cfg(test)]
+    async fn pause_before_publish_for_test(&self) {
+        let hook = self.before_publish_test_hook.lock().take();
+        if let Some(hook) = hook {
+            hook.pause().await;
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct ModelCatalogBeforePublishTestHook {
+    reached: Arc<tokio::sync::Semaphore>,
+    release: Arc<tokio::sync::Semaphore>,
+}
+
+#[cfg(test)]
+impl ModelCatalogBeforePublishTestHook {
+    pub(crate) fn blocked() -> Self {
+        Self {
+            reached: Arc::new(tokio::sync::Semaphore::new(0)),
+            release: Arc::new(tokio::sync::Semaphore::new(0)),
+        }
+    }
+
+    pub(crate) async fn wait_until_reached(&self) {
+        self.reached
+            .acquire()
+            .await
+            .expect("model-catalog publish hook remains open")
+            .forget();
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.add_permits(1);
+    }
+
+    async fn pause(&self) {
+        self.reached.add_permits(1);
+        self.release
+            .acquire()
+            .await
+            .expect("model-catalog publish hook remains open")
+            .forget();
     }
 }
 
@@ -1656,30 +1717,48 @@ pub(crate) async fn model_catalog_sized(state: &AppState) -> Result<Vec<Value>, 
 }
 
 async fn model_catalog_snapshot(state: &AppState) -> Result<Arc<Vec<Value>>, ApiError> {
-    let mut cached = state.model_catalog_cache.snapshot.lock().await;
-    loop {
-        let generation = state
-            .model_catalog_cache
-            .generation
-            .load(std::sync::atomic::Ordering::Acquire);
-        if let Some((cached_generation, snapshot)) = cached.as_ref() {
-            if *cached_generation == generation {
+    {
+        let cache_state = state.model_catalog_cache.state.lock();
+        if let Some((snapshot_generation, snapshot)) = cache_state.snapshot.as_ref() {
+            if *snapshot_generation == cache_state.generation {
                 return Ok(snapshot.clone());
             }
         }
+    }
+
+    // Serialize only builders. The synchronous generation/snapshot state lock
+    // is never held across the expensive filesystem sweep.
+    let _build_guard = state.model_catalog_cache.build_serializer.lock().await;
+    loop {
+        let generation = {
+            // Another builder may have populated the cache while this caller
+            // waited for the async serializer.
+            let cache_state = state.model_catalog_cache.state.lock();
+            if let Some((snapshot_generation, snapshot)) = cache_state.snapshot.as_ref() {
+                if *snapshot_generation == cache_state.generation {
+                    return Ok(snapshot.clone());
+                }
+            }
+            cache_state.generation
+        };
 
         let snapshot = Arc::new(build_model_catalog_snapshot(state).await?);
-        let current_generation = state
+
+        #[cfg(test)]
+        state
             .model_catalog_cache
-            .generation
-            .load(std::sync::atomic::Ordering::Acquire);
-        if current_generation == generation {
-            *cached = Some((generation, snapshot.clone()));
+            .pause_before_publish_for_test()
+            .await;
+
+        let mut cache_state = state.model_catalog_cache.state.lock();
+        if cache_state.generation == generation {
+            cache_state.snapshot = Some((generation, snapshot.clone()));
             return Ok(snapshot);
         }
+        drop(cache_state);
         // A model writer completed while the filesystem sweep was running.
-        // Keep the serializer and rebuild at the new generation so no waiter
-        // can observe the stale result.
+        // Keep the async serializer and rebuild at the new generation. The
+        // stale result was never published or returned.
     }
 }
 

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -823,12 +823,30 @@ pub(crate) async fn delete_model(
         state.settings.data_dir.join("models"),
         huggingface_hub_cache_dir(&state.settings.data_dir),
     ];
-    let removal = remove_owned_artifacts(
+    let removal = match remove_owned_artifacts(
         model_artifact_paths(cleanup_source, &state.settings.data_dir),
         &allowed_roots,
         permanent,
     )
-    .await?;
+    .await
+    {
+        Ok(removal) => {
+            if !removal.removed_paths.is_empty() {
+                // Invalidate immediately after the filesystem mutation. Later
+                // trash-failure and manifest/error returns must not leave the
+                // warm install-state snapshot describing paths already moved.
+                state.model_catalog_cache.invalidate();
+            }
+            removal
+        }
+        Err(error) => {
+            // Artifact removal is intentionally incremental. An inspection or
+            // unlink error may follow successful earlier removals whose result
+            // cannot be recovered from the error, so conservatively refresh.
+            state.model_catalog_cache.invalidate();
+            return Err(error);
+        }
+    };
     // Some owned files could not reach the OS trash and nothing was permanently
     // deleted. Leave the registry entry in place and ask the client to confirm.
     if !permanent && !removal.trash_failed_paths.is_empty() {
@@ -901,7 +919,7 @@ pub(crate) async fn delete_model_variant(
     // tier as a `files`-filtered slice of a shared HF cache repo (sc-12024); convert-at-install
     // models (Anima) keep it as a real `<converted>/<tier>/` dir emitted by one convert job
     // (sc-12025). Resolve whichever this model uses; a variant that is neither has nothing to delete.
-    let removal = if let Some(download) = model_download_for_variant(&model, &variant) {
+    let removal_result = if let Some(download) = model_download_for_variant(&model, &variant) {
         let repo = download
             .get("repo")
             .and_then(Value::as_str)
@@ -946,7 +964,7 @@ pub(crate) async fn delete_model_variant(
             &allowed_roots,
             true,
         )
-        .await?
+        .await
     } else if model_has_convert_tier(&model, &variant) {
         // Convert-at-install: the tier is a real dir under the converted MLX tree. Prefer the
         // catalog's resolved `mlxConvertedPath`; fall back to the canonical convert output dir.
@@ -956,12 +974,25 @@ pub(crate) async fn delete_model_variant(
             .map(PathBuf::from)
             .unwrap_or_else(|| data_dir.join("models").join("mlx").join(&model_id));
         // Always permanent (skip the OS trash) — see the fn doc (sc-12088).
-        remove_converted_tier(converted.join(&variant), &allowed_roots, true).await?
+        remove_converted_tier(converted.join(&variant), &allowed_roots, true).await
     } else {
         return Err(ApiError::bad_request(format!(
             "Model does not advertise a '{variant}' quant tier"
         )));
     };
+    let removal = match removal_result {
+        Ok(removal) => removal,
+        Err(error) => {
+            // Tier removal is also incremental (snapshot links, blobs, then
+            // managed paths). Refresh conservatively if any later step errors.
+            state.model_catalog_cache.invalidate();
+            return Err(error);
+        }
+    };
+    // Invalidate before every post-removal early return. A successful removal
+    // may have changed installState/variantStates even when the route later
+    // decides there was no independently reclaimable logical tier.
+    state.model_catalog_cache.invalidate();
     let shared_logical_tier = removal.removed_paths.is_empty()
         && !removal.retained_paths.is_empty()
         && model_download_for_variant(&model, &variant).is_some();
@@ -970,9 +1001,6 @@ pub(crate) async fn delete_model_variant(
             "Tier '{variant}' is not installed"
         )));
     }
-    // Tier deletion changes installState/variantStates without touching a
-    // manifest, so it must explicitly advance the shared snapshot generation.
-    state.model_catalog_cache.invalidate();
     Ok(Json(json!({
         "id": model_id,
         "variant": variant,

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -20,6 +20,33 @@ const MODEL_SIZE_NEGATIVE_TTL: Duration = Duration::from_secs(300);
 // without making ordinary warm catalog loads depend on Hugging Face.
 const MODEL_SIZE_POSITIVE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 
+/// Generation-keyed, process-local snapshot of the model catalog after its
+/// filesystem install-state sweep.
+///
+/// A cold caller holds `snapshot` while building, so concurrent `/models`,
+/// global preset, project preset, and job-validation requests join that one
+/// sweep. `invalidate` is synchronous and advances `generation` before any
+/// model lifecycle/manifest writer returns. If a writer races a cold build,
+/// the builder observes the newer generation and rebuilds instead of publishing
+/// stale state. Errors are never cached.
+#[derive(Default)]
+pub(crate) struct ModelCatalogCache {
+    generation: std::sync::atomic::AtomicU64,
+    snapshot: tokio::sync::Mutex<Option<(u64, Arc<Vec<Value>>)>>,
+}
+
+impl ModelCatalogCache {
+    pub(crate) fn invalidate(&self) {
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
 #[cfg(test)]
 #[derive(Clone)]
 pub(crate) struct ModelSizeEstimateTestHook {
@@ -882,6 +909,9 @@ pub(crate) async fn delete_model_variant(
             "Tier '{variant}' is not installed"
         )));
     }
+    // Tier deletion changes installState/variantStates without touching a
+    // manifest, so it must explicitly advance the shared snapshot generation.
+    state.model_catalog_cache.invalidate();
     Ok(Json(json!({
         "id": model_id,
         "variant": variant,
@@ -1597,14 +1627,60 @@ pub(crate) fn max_model_upload_bytes() -> usize {
 /// byte-accurate download size — so an unreachable huggingface.co can't stall
 /// those paths (sc-4169).
 pub(crate) async fn model_catalog(state: &AppState) -> Result<Vec<Value>, ApiError> {
-    model_catalog_inner(state, false).await
+    Ok(model_catalog_snapshot(state).await?.as_ref().clone())
 }
 
 /// Catalog with live Hugging Face download-size estimates (negative-cached on
 /// failure). Reserved for `GET /models`, the one surface that displays
 /// download sizes.
 pub(crate) async fn model_catalog_sized(state: &AppState) -> Result<Vec<Value>, ApiError> {
-    model_catalog_inner(state, true).await
+    // Preserve SC-14800's cold-path overlap: Hugging Face metadata estimation
+    // begins from the cheap manifest inputs while the shared install-state
+    // snapshot is being built (or joined) independently.
+    let size_estimates = estimate_current_model_catalog_sizes(state);
+    let snapshot = model_catalog_snapshot(state);
+    let (size_estimates, snapshot) = tokio::join!(size_estimates, snapshot);
+    let size_estimates = size_estimates?;
+    let mut models = snapshot?.as_ref().clone();
+    for model in &mut models {
+        let context = model_download_context(model)?;
+        let live_estimate = context.as_ref().and_then(|context| {
+            size_estimates
+                .get(&(context.repo.clone(), context.files.clone()))
+                .copied()
+                .flatten()
+        });
+        apply_model_catalog_size_fields(model, context.as_ref(), live_estimate)?;
+    }
+    Ok(models)
+}
+
+async fn model_catalog_snapshot(state: &AppState) -> Result<Arc<Vec<Value>>, ApiError> {
+    let mut cached = state.model_catalog_cache.snapshot.lock().await;
+    loop {
+        let generation = state
+            .model_catalog_cache
+            .generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        if let Some((cached_generation, snapshot)) = cached.as_ref() {
+            if *cached_generation == generation {
+                return Ok(snapshot.clone());
+            }
+        }
+
+        let snapshot = Arc::new(build_model_catalog_snapshot(state).await?);
+        let current_generation = state
+            .model_catalog_cache
+            .generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        if current_generation == generation {
+            *cached = Some((generation, snapshot.clone()));
+            return Ok(snapshot);
+        }
+        // A model writer completed while the filesystem sweep was running.
+        // Keep the serializer and rebuild at the new generation so no waiter
+        // can observe the stale result.
+    }
 }
 
 // sc-4205 (F-API-12): the per-model install/cache state, formerly threaded through a
@@ -3800,14 +3876,16 @@ async fn estimate_model_catalog_sizes(
     .collect()
 }
 
-async fn model_catalog_inner(
+async fn load_model_catalog_inputs(
     state: &AppState,
-    estimate_sizes: bool,
-) -> Result<Vec<Value>, ApiError> {
-    // sc-8819 (F-017): observe full-catalog assembly (the per-model FS install-state probe
-    // sweep) so a test can assert it runs once per job-create.
-    #[cfg(test)]
-    crate::test_note_model_catalog_build();
+) -> Result<
+    (
+        Vec<Value>,
+        Vec<Option<DownloadContext>>,
+        std::collections::HashSet<String>,
+    ),
+    ApiError,
+> {
     let manifest_dir = state.settings.config_dir.join("manifests");
     let builtin =
         load_manifest_entries(state, &manifest_dir.join("builtin.models.jsonc"), "models").await?;
@@ -3829,7 +3907,22 @@ async fn model_catalog_inner(
         .iter()
         .map(model_download_context)
         .collect::<Result<Vec<_>, _>>()?;
-    let size_estimates = estimate_model_catalog_sizes(state, &download_contexts, estimate_sizes);
+    Ok((models, download_contexts, user_model_ids))
+}
+
+async fn estimate_current_model_catalog_sizes(
+    state: &AppState,
+) -> Result<HashMap<ModelSizeCacheKey, Option<u64>>, ApiError> {
+    let (_, download_contexts, _) = load_model_catalog_inputs(state).await?;
+    Ok(estimate_model_catalog_sizes(state, &download_contexts, true).await)
+}
+
+async fn build_model_catalog_snapshot(state: &AppState) -> Result<Vec<Value>, ApiError> {
+    // sc-8819 (F-017): observe full-catalog assembly (the per-model FS install-state probe
+    // sweep) so tests can assert request-scoped and process-shared reuse.
+    #[cfg(test)]
+    crate::test_note_model_catalog_build();
+    let (models, download_contexts, user_model_ids) = load_model_catalog_inputs(state).await?;
 
     let data_dir = Arc::new(state.settings.data_dir.clone());
     let user_model_ids = Arc::new(user_model_ids);
@@ -3867,18 +3960,14 @@ async fn model_catalog_inner(
         let mut cache = external_base_cache.lock();
         crate::external_base_models::scan_external_base_models(&external_roots, &mut cache)
     });
-    let (size_estimates, models, external) =
-        tokio::join!(size_estimates, catalog_sweep, external_scan);
+    let (models, external) = tokio::join!(catalog_sweep, external_scan);
     let mut models = models?.into_iter().flatten().collect::<Vec<_>>();
     for model in &mut models {
         let context = model_download_context(model)?;
-        let live_estimate = context.as_ref().and_then(|context| {
-            size_estimates
-                .get(&(context.repo.clone(), context.files.clone()))
-                .copied()
-                .flatten()
-        });
-        apply_model_catalog_size_fields(model, context.as_ref(), live_estimate)?;
+        // The shared snapshot carries deterministic manifest fallbacks only.
+        // `/models` overlays live estimates on its response clone; presets and
+        // job validation never wait on unrelated Hugging Face network calls.
+        apply_model_catalog_size_fields(model, context.as_ref(), None)?;
     }
     let external = external.map_err(|err| {
         ApiError::internal(format!("external model catalog scan task failed: {err}"))

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -194,10 +194,11 @@ pub(crate) async fn recipe_preset_catalog(
     recipe_preset_catalog_with(state, project_id, None).await
 }
 
-/// `recipe_preset_catalog` with an optional caller-supplied model catalog snapshot
-/// (sc-8819). When `snapshot` is `Some`, the model catalog it exposes is reused instead
-/// of re-running the per-model filesystem install-state probes; the resulting presets are
-/// byte-for-byte identical to the `None` path.
+/// `recipe_preset_catalog` with an optional request-scoped model catalog snapshot
+/// (sc-8819). When present, it guarantees one consistent value across a job-create.
+/// Without it, `model_catalog` uses SC-14784's process-shared generation cache, whose
+/// cold callers coalesce and whose model lifecycle/manifest invalidations prevent stale
+/// install state from surviving a mutation. Both paths finalize identical presets.
 pub(crate) async fn recipe_preset_catalog_with(
     state: &AppState,
     project_id: Option<&str>,
@@ -216,8 +217,8 @@ pub(crate) async fn recipe_preset_catalog_with(
         .into_iter()
         .map(|preset| normalize_recipe_preset_entry(preset, "global", &user_manifest))
         .collect::<Result<Vec<_>, _>>()?;
-    // Reuse the request-scoped model catalog snapshot when the caller threaded one
-    // (sc-8819), else build a fresh catalog exactly as before.
+    // Reuse the request-scoped value when a job-create threaded one (sc-8819);
+    // ordinary route callers reuse/build the process-shared generation snapshot.
     let owned_models;
     let models: &[Value] = match snapshot {
         Some(snapshot) => snapshot.models(state).await?,

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -31,7 +31,7 @@ use crate::events::EventHub;
 use crate::external_base_models::ExternalBaseModelCache;
 use crate::external_loras::ExternalLoraCache;
 use crate::manifest::ManifestCache;
-use crate::models::ModelSizeCache;
+use crate::models::{ModelCatalogCache, ModelSizeCache};
 use crate::tickets::TicketStore;
 use crate::{
     create_app_with_state, env_path_or, env_string, open_bind_override_enabled, parent_death,
@@ -278,6 +278,11 @@ pub struct AppState {
     pub(crate) auth_throttle: Arc<AuthThrottle>,
     pub(crate) manifest_cache: Arc<Mutex<ManifestCache>>,
     pub(crate) manifest_write_locks: Arc<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>>,
+    /// One generation-keyed install-state snapshot shared by `/models`, recipe
+    /// preset reads, and request-scoped job validation. The cache serializes a
+    /// cold build so concurrent callers join the same filesystem sweep; model
+    /// lifecycle completion and model-manifest writes advance its generation.
+    pub(crate) model_catalog_cache: Arc<ModelCatalogCache>,
     pub(crate) model_size_cache: Arc<Mutex<ModelSizeCache>>,
     #[cfg(test)]
     pub(crate) model_size_estimate_test_hook:

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -699,6 +699,178 @@ async fn models_catalog_starts_install_sweep_before_size_estimation_completes() 
 }
 
 #[tokio::test]
+async fn concurrent_models_and_preset_routes_share_one_install_state_sweep() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({
+            "schemaVersion": 1,
+            "models": [{
+                "id": "shared_model",
+                "name": "Shared Model",
+                "family": "shared-test",
+                "type": "image",
+                "capabilities": ["edit_image"],
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": "shared/model",
+                    "files": ["*.safetensors"]
+                }],
+                "__testCatalogProbeDelayMs": 250
+            }]
+        }))
+        .expect("model manifest serializes"),
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.recipe-presets.jsonc"),
+        r#"{ "schemaVersion": 1, "presets": [] }"#,
+    )
+    .expect("builtin presets writes");
+    std::fs::write(
+        config_dir.join("user.recipe-presets.jsonc"),
+        r#"{
+            "schemaVersion": 1,
+            "presets": [{
+                "id": "legacy_edit",
+                "name": "Legacy Edit",
+                "modes": ["edit_image"],
+                "builtInLoras": []
+            }]
+        }"#,
+    )
+    .expect("user presets writes");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("user loras writes");
+    let marker_dir = temp_dir.path().join("data/models/shared__model");
+    std::fs::create_dir_all(&marker_dir).expect("model marker dir creates");
+    std::fs::write(marker_dir.join(".sceneworks-download-complete.json"), "{}")
+        .expect("model marker writes");
+
+    crate::test_reset_catalog_build_counters();
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(false);
+    let size_hook = crate::models::ModelSizeEstimateTestHook::blocked(Some(1234));
+    *state.model_size_estimate_test_hook.lock() = Some(size_hook.clone());
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Preset Coalescing Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    let models_task = tokio::spawn(request(app.clone(), "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), size_hook.wait_for_call())
+        .await
+        .expect("live size estimation starts");
+    let global_task = tokio::spawn(request(
+        app.clone(),
+        "GET",
+        "/api/v1/recipe-presets",
+        Value::Null,
+    ));
+    let project_uri = format!("/api/v1/recipe-presets?projectId={project_id}");
+    let project_task =
+        tokio::spawn(async move { request(app, "GET", &project_uri, Value::Null).await });
+
+    let preset_started = std::time::Instant::now();
+    let (global, project) = tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::join!(global_task, project_task)
+    })
+    .await
+    .expect("preset routes finish while unrelated live size lookup is blocked");
+    let global = global.expect("global preset task joins");
+    let project = project.expect("project preset task joins");
+    for (status, presets) in [global, project] {
+        assert_eq!(status, StatusCode::OK);
+        let preset = &presets.as_array().expect("preset array")[0];
+        assert_eq!(preset["workflow"], "edit_image");
+        assert_eq!(preset["model"], "shared_model");
+        assert_eq!(preset["modes"], json!(["edit_image"]));
+        assert_eq!(preset["loras"], json!([]));
+        assert_eq!(
+            preset["appliedDefaults"]["notes"],
+            json!([
+                "workflow inferred from legacy modes as edit_image",
+                "model defaulted to shared_model for legacy preset"
+            ])
+        );
+    }
+    assert!(
+        !models_task.is_finished(),
+        "/models remains blocked on its response-only size estimate"
+    );
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        1,
+        "concurrent /models, global preset, and project preset callers must join one install-state sweep"
+    );
+
+    let preset_elapsed = preset_started.elapsed();
+    let models_release_started = std::time::Instant::now();
+    size_hook.release_one();
+    let (status, models) = tokio::time::timeout(Duration::from_secs(2), models_task)
+        .await
+        .expect("models route completes after size release")
+        .expect("models task joins");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["downloadSizeBytes"], json!(1234));
+    eprintln!(
+        "SC-14784 local route timing: global+project presets={preset_elapsed:?}, /models after size release={:?}, install-state sweeps=1",
+        models_release_started.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn model_catalog_invalidation_refreshes_install_state() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    single_model_manifest(&config_dir, "refresh_model", "refresh/model");
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(true);
+    crate::test_reset_catalog_build_counters();
+
+    let (status, cold) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cold[0]["installState"], "missing");
+    let marker_dir = temp_dir.path().join("data/models/refresh__model");
+    std::fs::create_dir_all(&marker_dir).expect("model marker dir creates");
+    std::fs::write(marker_dir.join(".sceneworks-download-complete.json"), "{}")
+        .expect("model marker writes");
+
+    let (_, still_cached) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(still_cached[0]["installState"], "missing");
+    assert_eq!(crate::test_model_catalog_builds(), 1);
+
+    let before = state.model_catalog_cache.generation();
+    state.model_catalog_cache.invalidate();
+    assert_eq!(state.model_catalog_cache.generation(), before + 1);
+    let (status, refreshed) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(refreshed[0]["installState"], "installed");
+    assert_eq!(crate::test_model_catalog_builds(), 2);
+}
+
+#[tokio::test]
 async fn models_catalog_disabled_size_estimation_skips_upstream_requests() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -871,6 +871,57 @@ async fn model_catalog_invalidation_refreshes_install_state() {
 }
 
 #[tokio::test]
+async fn invalidation_before_snapshot_publication_forces_current_generation_rebuild() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    single_model_manifest(&config_dir, "racing_model", "racing/model");
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(true);
+    crate::test_reset_catalog_build_counters();
+    let publish_hook = crate::models::ModelCatalogBeforePublishTestHook::blocked();
+    state
+        .model_catalog_cache
+        .set_before_publish_test_hook(publish_hook.clone());
+
+    let request_task = tokio::spawn(request(app.clone(), "GET", "/api/v1/models", Value::Null));
+    tokio::time::timeout(Duration::from_secs(2), publish_hook.wait_until_reached())
+        .await
+        .expect("first-generation snapshot reaches pre-publication boundary");
+
+    // Change the install-state input and invalidate while generation 0 is
+    // built but not yet published. The request must discard that result,
+    // rebuild generation 1, and return only the installed state.
+    let marker_dir = temp_dir.path().join("data/models/racing__model");
+    std::fs::create_dir_all(&marker_dir).expect("model marker dir creates");
+    std::fs::write(marker_dir.join(".sceneworks-download-complete.json"), "{}")
+        .expect("model marker writes");
+    state.model_catalog_cache.invalidate();
+    publish_hook.release();
+
+    let (status, models) = tokio::time::timeout(Duration::from_secs(2), request_task)
+        .await
+        .expect("racing request completes")
+        .expect("racing request joins");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(models[0]["installState"], "installed");
+    assert_eq!(state.model_catalog_cache.generation(), 1);
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        2,
+        "generation 0 must be discarded and rebuilt after invalidation"
+    );
+
+    let (_, warm) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(warm[0]["installState"], "installed");
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        2,
+        "the generation 1 result is the only published warm snapshot"
+    );
+}
+
+#[tokio::test]
 async fn models_catalog_disabled_size_estimation_skips_upstream_requests() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -3616,6 +3616,109 @@ async fn catalog_delete_routes_remove_manifest_entries_and_owned_artifacts() {
     assert_eq!(loras.as_array().expect("loras array").len(), 0);
 }
 
+#[tokio::test]
+async fn partial_model_trash_failure_invalidates_warm_install_and_variant_state() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{
+            "schemaVersion": 1,
+            "models": [{
+                "id": "partial_model",
+                "name": "Partial Model",
+                "type": "image",
+                "family": "test",
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": "partial/model",
+                    "variant": "q4",
+                    "default": true,
+                    "files": ["q4/*"]
+                }],
+                "source": {
+                    "provider": "local",
+                    "path": "models/partial_trash_failure"
+                }
+            }]
+        }"#,
+    )
+    .expect("user models writes");
+    for (name, field) in [
+        ("builtin.loras.jsonc", "loras"),
+        ("user.loras.jsonc", "loras"),
+        ("builtin.recipe-presets.jsonc", "presets"),
+        ("user.recipe-presets.jsonc", "presets"),
+    ] {
+        std::fs::write(
+            config_dir.join(name),
+            format!(r#"{{ "schemaVersion": 1, "{field}": [] }}"#),
+        )
+        .expect("sibling manifest writes");
+    }
+
+    let managed_dir = temp_dir.path().join("data/models/partial__model");
+    std::fs::create_dir_all(managed_dir.join("q4")).expect("managed q4 creates");
+    std::fs::write(
+        managed_dir.join(".sceneworks-download-complete.json"),
+        r#"{ "repo": "partial/model" }"#,
+    )
+    .expect("managed completion marker writes");
+    std::fs::write(managed_dir.join("q4/model.safetensors"), "weights")
+        .expect("managed tier writes");
+    let failing_dir = temp_dir.path().join("data/models/partial_trash_failure");
+    std::fs::create_dir_all(&failing_dir).expect("failing source creates");
+    std::fs::write(failing_dir.join("weights.safetensors"), "weights")
+        .expect("failing source writes");
+
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(true);
+    crate::test_reset_catalog_build_counters();
+    let (status, warm) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(warm[0]["installState"], "installed");
+    assert_eq!(warm[0]["variants"][0]["variant"], "q4");
+    assert_eq!(warm[0]["variants"][0]["installState"], "installed");
+    assert_eq!(crate::test_model_catalog_builds(), 1);
+
+    // The owned managed tier moves successfully, then the later source path
+    // fails to move. The route returns the recoverable confirmation response
+    // after a real mutation, rather than reaching manifest deletion.
+    let _trash =
+        crate::test_trash_outcomes([(managed_dir.clone(), true), (failing_dir.clone(), false)]);
+    let (status, partial) = request(
+        app.clone(),
+        "DELETE",
+        "/api/v1/models/partial_model",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(partial["trashUnavailable"], true);
+    assert_eq!(partial["removedManifestEntry"], false);
+    assert_eq!(partial["removedLocalArtifacts"], true);
+    assert!(!managed_dir.exists(), "the first artifact was removed");
+    assert!(failing_dir.exists(), "the failed artifact remains");
+
+    let (status, refreshed) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(refreshed[0]["installState"], "missing");
+    assert_eq!(refreshed[0]["variants"][0]["variant"], "q4");
+    assert_eq!(refreshed[0]["variants"][0]["installState"], "missing");
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        2,
+        "the partial-error early return must invalidate the warm snapshot"
+    );
+}
+
 #[test]
 fn model_download_size_helpers_match_contract_shapes() {
     let siblings = json!([

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -1,6 +1,35 @@
 //! rust-api jobs tests (split from tests.rs, sc-11217 F-030).
 use super::support::*;
 
+#[test]
+fn terminal_model_lifecycle_jobs_invalidate_catalog_snapshots() {
+    for job_type in [
+        crate::JobType::ModelDownload,
+        crate::JobType::ModelImport,
+        crate::JobType::ModelConvert,
+    ] {
+        for status in [
+            crate::JobStatus::Completed,
+            crate::JobStatus::Failed,
+            crate::JobStatus::Canceled,
+            crate::JobStatus::Interrupted,
+        ] {
+            assert!(
+                crate::jobs::terminal_model_job_changes_catalog(&job_type, &status),
+                "{job_type:?} {status:?} may change install state"
+            );
+        }
+        assert!(!crate::jobs::terminal_model_job_changes_catalog(
+            &job_type,
+            &crate::JobStatus::Running
+        ));
+    }
+    assert!(!crate::jobs::terminal_model_job_changes_catalog(
+        &crate::JobType::ImageGenerate,
+        &crate::JobStatus::Completed
+    ));
+}
+
 /// F-003 / sc-11159: a path-traversal `model` id is rejected at the POST boundary for BOTH
 /// the image and video enqueue lanes (before any job is created), closing the remote
 /// arbitrary-write primitive the worker filename builders would otherwise expose.

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -30,6 +30,172 @@ fn terminal_model_lifecycle_jobs_invalidate_catalog_snapshots() {
     ));
 }
 
+#[tokio::test]
+async fn worker_termination_refreshes_warm_model_catalog_after_artifact_mutation() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    single_model_manifest(&config_dir, "crashed_model", "crashed/model");
+    let (app, state) =
+        create_app_with_state(test_settings(&temp_dir)).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(true);
+    crate::test_reset_catalog_build_counters();
+
+    let (status, warm) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(warm[0]["installState"], "missing");
+    assert_eq!(crate::test_model_catalog_builds(), 1);
+
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/register",
+        json!({
+            "workerId": "download-worker",
+            "gpuId": "cpu",
+            "gpuName": null,
+            "capabilities": ["model_download"],
+            "loadedModels": []
+        }),
+    )
+    .await;
+    let (status, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "model_download",
+            "payload": { "modelId": "crashed_model" },
+            "requestedGpu": "auto"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let job_id = created["id"].as_str().expect("job id is string");
+    let (status, claim) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/claim",
+        json!({ "workerId": "download-worker" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(claim["job"]["id"], job_id);
+
+    let marker_dir = temp_dir.path().join("data/models/crashed__model");
+    std::fs::create_dir_all(&marker_dir).expect("model marker dir creates");
+    std::fs::write(marker_dir.join(".sceneworks-download-complete.json"), "{}")
+        .expect("model marker writes");
+
+    let (status, failed) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/download-worker/terminated",
+        json!({ "signal": 9, "exitCode": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(failed["status"], "failed");
+
+    let (status, refreshed) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(refreshed[0]["installState"], "installed");
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        2,
+        "worker termination must invalidate a warm install-state snapshot"
+    );
+}
+
+#[tokio::test]
+async fn stale_worker_sweep_refreshes_warm_model_catalog_after_artifact_mutation() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    single_model_manifest(&config_dir, "stale_model", "stale/model");
+    let mut settings = test_settings(&temp_dir);
+    settings.worker_timeout_seconds = 1;
+    let jobs_db_path = settings.jobs_db_path.clone();
+    let (app, state) = create_app_with_state(settings).expect("app and state create");
+    *state.model_size_estimate_disabled_override.lock() = Some(true);
+    crate::test_reset_catalog_build_counters();
+
+    let (status, warm) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(warm[0]["installState"], "missing");
+    assert_eq!(crate::test_model_catalog_builds(), 1);
+
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/register",
+        json!({
+            "workerId": "import-worker",
+            "gpuId": "cpu",
+            "gpuName": null,
+            "capabilities": ["model_import"],
+            "loadedModels": []
+        }),
+    )
+    .await;
+    let (status, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs",
+        json!({
+            "type": "model_import",
+            "payload": { "modelId": "stale_model" },
+            "requestedGpu": "auto"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let job_id = created["id"].as_str().expect("job id is string");
+    let (status, claim) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/jobs/claim",
+        json!({ "workerId": "import-worker" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(claim["job"]["id"], job_id);
+
+    let marker_dir = temp_dir.path().join("data/models/stale__model");
+    std::fs::create_dir_all(&marker_dir).expect("model marker dir creates");
+    std::fs::write(marker_dir.join(".sceneworks-download-complete.json"), "{}")
+        .expect("model marker writes");
+
+    let connection = rusqlite::Connection::open(jobs_db_path).expect("jobs db opens");
+    let updated = connection
+        .execute(
+            "update workers set last_seen_at = '2000-01-01T00:00:00Z' where id = ?1",
+            rusqlite::params!["import-worker"],
+        )
+        .expect("worker timestamp ages");
+    assert_eq!(updated, 1);
+    drop(connection);
+
+    let (status, _) = request(app.clone(), "GET", "/api/v1/queue", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, interrupted) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/{job_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(interrupted["status"], "interrupted");
+
+    let (status, refreshed) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(refreshed[0]["installState"], "installed");
+    assert_eq!(
+        crate::test_model_catalog_builds(),
+        2,
+        "stale-worker interruption must invalidate a warm install-state snapshot"
+    );
+}
+
 /// F-003 / sc-11159: a path-traversal `model` id is rejected at the POST boundary for BOTH
 /// the image and video enqueue lanes (before any job is created), closing the remote
 /// arbitrary-write primitive the worker filename builders would otherwise expose.

--- a/apps/rust-api/src/workers.rs
+++ b/apps/rust-api/src/workers.rs
@@ -9,13 +9,15 @@ pub(crate) async fn queue_summary(
 pub(crate) async fn list_workers(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<WorkerSnapshot>>, ApiError> {
-    Ok(Json(
-        store_call(state, move |store, timeout| {
-            store.mark_stale_workers_interrupted(timeout)?;
-            store.list_workers()
-        })
-        .await?,
-    ))
+    let (sweep, workers) = store_call(state.clone(), move |store, timeout| {
+        let sweep = store.mark_stale_workers_interrupted(timeout)?;
+        let workers = store.list_workers();
+        Ok((sweep, workers))
+    })
+    .await?;
+    handle_stale_sweep(&state, &sweep);
+    let workers = workers?;
+    Ok(Json(workers))
 }
 
 /// Person-workflow readiness derived from the live (non-offline) workers: a
@@ -51,11 +53,14 @@ pub(crate) fn person_readiness_from_workers(workers: &[WorkerSnapshot]) -> Value
 pub(crate) async fn person_capability_readiness(
     State(state): State<AppState>,
 ) -> Result<Json<Value>, ApiError> {
-    let workers = store_call(state, move |store, timeout| {
-        store.mark_stale_workers_interrupted(timeout)?;
-        store.list_workers()
+    let (sweep, workers) = store_call(state.clone(), move |store, timeout| {
+        let sweep = store.mark_stale_workers_interrupted(timeout)?;
+        let workers = store.list_workers();
+        Ok((sweep, workers))
     })
     .await?;
+    handle_stale_sweep(&state, &sweep);
+    let workers = workers?;
     Ok(Json(
         json!({ "person": person_readiness_from_workers(&workers) }),
     ))
@@ -188,6 +193,7 @@ pub(crate) async fn worker_terminated(
     })
     .await?;
     if let Some(job) = &failed {
+        invalidate_model_catalog_for_terminal_jobs(&state, std::slice::from_ref(job));
         publish(&state, "job.updated", job);
         publish_queue(&state).await?;
     }


### PR DESCRIPTION
## Summary

- share one generation-keyed model install-state snapshot across /models, global/project recipe presets, and job validation
- keep live Hugging Face size estimation response-local and concurrent with the cold filesystem sweep
- invalidate after model manifest writes, model/tier deletion, and terminal download/import/convert outcomes
- add production-route concurrency, legacy preset, cache refresh, and lifecycle invalidation regressions

## Validation

- cargo fmt --all -- --check
- cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings
- cargo build -p sceneworks-rust-api
- cargo test -p sceneworks-rust-api: 395 passed, 2 ignored; known unrelated Windows parent-liveness test fails (also fails in isolation: freshly spawned parent reads as dead)
- focused preset/catalog/job tests pass
- local slow-probe route timing: global + project presets 252.1191 ms with one 250 ms install-state sweep; /models completed 0.3045 ms after releasing its independent size lookup

## Runtime scope

Populated RunPod timing remains owned by SC-14789; no paid pod was started for this story.

Shortcut: https://app.shortcut.com/trefry/story/14784