### PR TITLE
[sc-14785] Compress and cache embedded web assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ For a public-image deployment with a reusable RunPod template, network volume,
 HTTPS proxy, and token login, follow the
 [turnkey RunPod deployment guide](docs/deploy-runpod.md).
 
+The embedded bundle's build-time Brotli/gzip negotiation, immutable hashed-asset
+cache policy, mutable-entrypoint revalidation, and dynamic-compression extension
+point are documented in
+[Embedded production web delivery](docs/embedded-web-delivery.md).
+
 ```powershell
 docker build --secret id=inference_token,env=SCENEWORKS_INFERENCE_READ_TOKEN `
   --file docker/rust.Dockerfile `

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1972,6 +1972,9 @@ fn parse_single_byte_range(value: &str, total: u64) -> Option<(u64, u64)> {
 /// `embed-web` feature so default/server/test builds need no web build.
 #[cfg(feature = "embed-web")]
 mod web_assets {
+    use std::collections::HashSet;
+    use std::sync::OnceLock;
+
     use axum::body::Body;
     use axum::http::{header, HeaderMap, HeaderValue, StatusCode, Uri};
     use axum::response::{IntoResponse, Response};
@@ -2005,6 +2008,20 @@ mod web_assets {
             .into_owned()
     }
 
+    #[cfg(test)]
+    pub(super) fn first_uncompressed_static_asset_path() -> String {
+        WebAssets::iter()
+            .find(|path| {
+                !path.ends_with(".br")
+                    && !path.ends_with(".gz")
+                    && path.as_ref() != IMMUTABLE_ASSET_MANIFEST
+                    && WebAssets::get(&format!("{path}.br")).is_none()
+                    && WebAssets::get(&format!("{path}.gz")).is_none()
+            })
+            .expect("production web bundle contains an uncompressed static asset")
+            .into_owned()
+    }
+
     // The desktop shell navigates its privileged webview to this server, so the embedded
     // UI runs from this origin and its CSP must come from here (tauri.conf.json only
     // governs the bundled setup screen). Kept narrow: scripts only from this origin (the
@@ -2026,6 +2043,7 @@ form-action 'self'";
 
     const IMMUTABLE_CACHE: &str = "public, max-age=31536000, immutable";
     const REVALIDATE_CACHE: &str = "no-cache";
+    const IMMUTABLE_ASSET_MANIFEST: &str = ".sceneworks-immutable-assets";
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     enum Encoding {
@@ -2052,72 +2070,164 @@ form-action 'self'";
         }
     }
 
-    fn accepted_quality(headers: &HeaderMap, encoding: &str) -> f32 {
-        let mut explicit = None;
-        let mut wildcard = None;
-        for value in headers.get_all(header::ACCEPT_ENCODING) {
-            let Ok(value) = value.to_str() else {
-                continue;
-            };
-            for item in value.split(',') {
-                let mut parts = item.trim().split(';');
-                let name = parts.next().unwrap_or_default().trim();
-                let mut quality = 1.0;
-                for parameter in parts {
-                    let Some((key, value)) = parameter.trim().split_once('=') else {
+    #[derive(Default)]
+    struct EncodingPreferences {
+        header_present: bool,
+        brotli: Option<f32>,
+        gzip: Option<f32>,
+        identity: Option<f32>,
+        wildcard: Option<f32>,
+    }
+
+    impl EncodingPreferences {
+        fn parse(headers: &HeaderMap) -> Self {
+            let mut preferences = Self::default();
+            for value in headers.get_all(header::ACCEPT_ENCODING) {
+                preferences.header_present = true;
+                let Ok(value) = value.to_str() else {
+                    continue;
+                };
+                for item in value.split(',') {
+                    let mut parts = item.trim().split(';');
+                    let name = parts.next().unwrap_or_default().trim();
+                    if name.is_empty() {
                         continue;
-                    };
-                    if key.trim().eq_ignore_ascii_case("q") {
-                        quality = value
-                            .trim()
-                            .parse::<f32>()
-                            .ok()
-                            .filter(|quality| (0.0..=1.0).contains(quality))
-                            .unwrap_or(0.0);
+                    }
+                    let mut quality = 1.0;
+                    for parameter in parts {
+                        let Some((key, value)) = parameter.trim().split_once('=') else {
+                            continue;
+                        };
+                        if key.trim().eq_ignore_ascii_case("q") {
+                            quality = value
+                                .trim()
+                                .parse::<f32>()
+                                .ok()
+                                .filter(|quality| (0.0..=1.0).contains(quality))
+                                .unwrap_or(0.0);
+                        }
+                    }
+                    if name.eq_ignore_ascii_case("br") {
+                        preferences.brotli = Some(quality);
+                    } else if name.eq_ignore_ascii_case("gzip") {
+                        preferences.gzip = Some(quality);
+                    } else if name.eq_ignore_ascii_case("identity") {
+                        preferences.identity = Some(quality);
+                    } else if name == "*" {
+                        preferences.wildcard = Some(quality);
                     }
                 }
-                if name.eq_ignore_ascii_case(encoding) {
-                    explicit = Some(quality);
-                } else if name == "*" {
-                    wildcard = Some(quality);
-                }
+            }
+            preferences
+        }
+
+        fn quality(&self, encoding: Encoding) -> f32 {
+            if !self.header_present {
+                return if encoding == Encoding::Identity {
+                    1.0
+                } else {
+                    0.0
+                };
+            }
+            match encoding {
+                Encoding::Brotli => self.brotli.or(self.wildcard).unwrap_or(0.0),
+                Encoding::Gzip => self.gzip.or(self.wildcard).unwrap_or(0.0),
+                // RFC 9110: identity is acceptable by default unless it is
+                // explicitly excluded, or a wildcard q=0 excludes every
+                // unlisted coding.
+                Encoding::Identity => match self.identity {
+                    Some(quality) => quality,
+                    None if self.wildcard == Some(0.0) => 0.0,
+                    None => 1.0,
+                },
             }
         }
-        explicit.or(wildcard).unwrap_or(0.0)
     }
 
-    fn select_encoding(headers: &HeaderMap, requested: &str) -> Encoding {
-        let br_quality = accepted_quality(headers, "br");
-        let gzip_quality = accepted_quality(headers, "gzip");
-        let has_br = br_quality > 0.0 && WebAssets::get(&format!("{requested}.br")).is_some();
-        let has_gzip = gzip_quality > 0.0 && WebAssets::get(&format!("{requested}.gz")).is_some();
-        if has_br && (!has_gzip || br_quality >= gzip_quality) {
-            Encoding::Brotli
-        } else if has_gzip {
-            Encoding::Gzip
-        } else {
-            Encoding::Identity
+    fn select_encoding(headers: &HeaderMap, requested: &str) -> Option<Encoding> {
+        let preferences = EncodingPreferences::parse(headers);
+        // Deterministic tie-break: Brotli, then gzip, then identity. A client
+        // advertising a coding at q=1 therefore receives compression rather
+        // than an equally acceptable identity response.
+        let candidates = [
+            (
+                Encoding::Brotli,
+                WebAssets::get(&format!("{requested}.br")).is_some(),
+            ),
+            (
+                Encoding::Gzip,
+                WebAssets::get(&format!("{requested}.gz")).is_some(),
+            ),
+            (Encoding::Identity, WebAssets::get(requested).is_some()),
+        ];
+        let mut selected = None;
+        for (encoding, available) in candidates {
+            let quality = preferences.quality(encoding);
+            let is_better = match selected {
+                Some((_, best_quality)) => quality > best_quality,
+                None => true,
+            };
+            if available && quality > 0.0 && is_better {
+                selected = Some((encoding, quality));
+            }
         }
+        selected.map(|(encoding, _)| encoding)
     }
 
-    fn is_hashed_asset(path: &str) -> bool {
-        if !path.starts_with("assets/") {
-            return false;
-        }
-        let Some(file_name) = path.rsplit('/').next() else {
-            return false;
-        };
-        let stem = file_name
-            .rsplit_once('.')
-            .map_or(file_name, |(stem, _)| stem);
-        let Some((_, hash)) = stem.rsplit_once('-') else {
-            return false;
-        };
-        hash.len() >= 8
-            && hash.len() <= 32
-            && hash
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    fn immutable_assets() -> &'static HashSet<String> {
+        static ASSETS: OnceLock<HashSet<String>> = OnceLock::new();
+        ASSETS.get_or_init(|| {
+            WebAssets::get(IMMUTABLE_ASSET_MANIFEST)
+                .map(|manifest| {
+                    String::from_utf8_lossy(&manifest.data)
+                        .lines()
+                        .map(str::trim)
+                        .filter(|path| !path.is_empty())
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default()
+        })
+    }
+
+    fn is_immutable_asset(path: &str) -> bool {
+        immutable_assets().contains(path)
+    }
+
+    #[cfg(test)]
+    pub(super) fn immutable_asset_manifest_path() -> &'static str {
+        IMMUTABLE_ASSET_MANIFEST
+    }
+
+    fn apply_common_headers(
+        response: &mut axum::http::response::Builder,
+        mime: &str,
+        cache_control: &'static str,
+    ) {
+        let headers = response
+            .headers_mut()
+            .expect("embedded response headers are available");
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_str(mime).expect("embedded MIME type is a valid header"),
+        );
+        headers.insert(
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static(CONTENT_SECURITY_POLICY),
+        );
+        headers.insert(header::VARY, HeaderValue::from_static("Accept-Encoding"));
+        headers.insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(cache_control),
+        );
+    }
+
+    fn not_acceptable_response(mime: &str, cache_control: &'static str) -> Response {
+        let mut response = Response::builder().status(StatusCode::NOT_ACCEPTABLE);
+        apply_common_headers(&mut response, mime, cache_control);
+        response
+            .body(Body::empty())
+            .expect("not-acceptable embedded response constructs")
     }
 
     fn etag(hash: [u8; 32]) -> String {
@@ -2154,37 +2264,27 @@ form-action 'self'";
         fallback: bool,
         request_headers: &HeaderMap,
     ) -> Option<Response> {
-        let encoding = select_encoding(request_headers, requested);
-        let representation_path = format!("{requested}{}", encoding.suffix());
-        let file = WebAssets::get(&representation_path)?;
-        let etag = etag(file.metadata.sha256_hash());
-        let cache_control = if !fallback && is_hashed_asset(requested) {
+        let cache_control = if !fallback && is_immutable_asset(requested) {
             IMMUTABLE_CACHE
         } else {
             REVALIDATE_CACHE
         };
+        let Some(encoding) = select_encoding(request_headers, requested) else {
+            return Some(not_acceptable_response(mime, cache_control));
+        };
+        let representation_path = format!("{requested}{}", encoding.suffix());
+        let file = WebAssets::get(&representation_path)?;
+        let etag = etag(file.metadata.sha256_hash());
         let status = if if_none_match(request_headers, &etag) {
             StatusCode::NOT_MODIFIED
         } else {
             StatusCode::OK
         };
         let mut response = Response::builder().status(status);
+        apply_common_headers(&mut response, mime, cache_control);
         let headers = response
             .headers_mut()
             .expect("embedded response headers are available");
-        headers.insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_str(mime).expect("embedded MIME type is a valid header"),
-        );
-        headers.insert(
-            header::CONTENT_SECURITY_POLICY,
-            HeaderValue::from_static(CONTENT_SECURITY_POLICY),
-        );
-        headers.insert(header::VARY, HeaderValue::from_static("Accept-Encoding"));
-        headers.insert(
-            header::CACHE_CONTROL,
-            HeaderValue::from_static(cache_control),
-        );
         headers.insert(
             header::ETAG,
             HeaderValue::from_str(&etag).expect("SHA-256 ETag is a valid header"),
@@ -2214,9 +2314,11 @@ form-action 'self'";
         } else {
             requested
         };
-        // .br/.gz siblings are internal representations, never public paths.
+        // Encoded siblings and the cache allowlist are internal build
+        // metadata, never public paths.
         if !requested.ends_with(".br")
             && !requested.ends_with(".gz")
+            && requested != IMMUTABLE_ASSET_MANIFEST
             && WebAssets::get(requested).is_some()
         {
             let mime = mime_guess::from_path(requested).first_or_octet_stream();

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1972,7 +1972,8 @@ fn parse_single_byte_range(value: &str, total: u64) -> Option<(u64, u64)> {
 /// `embed-web` feature so default/server/test builds need no web build.
 #[cfg(feature = "embed-web")]
 mod web_assets {
-    use axum::http::{header, StatusCode, Uri};
+    use axum::body::Body;
+    use axum::http::{header, HeaderMap, HeaderValue, StatusCode, Uri};
     use axum::response::{IntoResponse, Response};
     use rust_embed::RustEmbed;
 
@@ -1983,8 +1984,24 @@ mod web_assets {
     #[cfg(test)]
     pub(super) fn first_static_asset_path() -> String {
         WebAssets::iter()
-            .find(|path| path.starts_with("assets/"))
+            .find(|path| {
+                path.starts_with("assets/") && !path.ends_with(".br") && !path.ends_with(".gz")
+            })
             .expect("production web bundle contains a static asset")
+            .into_owned()
+    }
+
+    #[cfg(test)]
+    pub(super) fn first_compressible_static_asset_path() -> String {
+        WebAssets::iter()
+            .find(|path| {
+                path.starts_with("assets/")
+                    && !path.ends_with(".br")
+                    && !path.ends_with(".gz")
+                    && WebAssets::get(&format!("{path}.br")).is_some()
+                    && WebAssets::get(&format!("{path}.gz")).is_some()
+            })
+            .expect("production web bundle contains a precompressed static asset")
             .into_owned()
     }
 
@@ -2007,37 +2024,217 @@ base-uri 'self'; \
 frame-ancestors 'none'; \
 form-action 'self'";
 
-    pub(super) async fn serve(uri: Uri) -> Response {
+    const IMMUTABLE_CACHE: &str = "public, max-age=31536000, immutable";
+    const REVALIDATE_CACHE: &str = "no-cache";
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum Encoding {
+        Brotli,
+        Gzip,
+        Identity,
+    }
+
+    impl Encoding {
+        fn suffix(self) -> &'static str {
+            match self {
+                Self::Brotli => ".br",
+                Self::Gzip => ".gz",
+                Self::Identity => "",
+            }
+        }
+
+        fn header_value(self) -> Option<&'static str> {
+            match self {
+                Self::Brotli => Some("br"),
+                Self::Gzip => Some("gzip"),
+                Self::Identity => None,
+            }
+        }
+    }
+
+    fn accepted_quality(headers: &HeaderMap, encoding: &str) -> f32 {
+        let mut explicit = None;
+        let mut wildcard = None;
+        for value in headers.get_all(header::ACCEPT_ENCODING) {
+            let Ok(value) = value.to_str() else {
+                continue;
+            };
+            for item in value.split(',') {
+                let mut parts = item.trim().split(';');
+                let name = parts.next().unwrap_or_default().trim();
+                let mut quality = 1.0;
+                for parameter in parts {
+                    let Some((key, value)) = parameter.trim().split_once('=') else {
+                        continue;
+                    };
+                    if key.trim().eq_ignore_ascii_case("q") {
+                        quality = value
+                            .trim()
+                            .parse::<f32>()
+                            .ok()
+                            .filter(|quality| (0.0..=1.0).contains(quality))
+                            .unwrap_or(0.0);
+                    }
+                }
+                if name.eq_ignore_ascii_case(encoding) {
+                    explicit = Some(quality);
+                } else if name == "*" {
+                    wildcard = Some(quality);
+                }
+            }
+        }
+        explicit.or(wildcard).unwrap_or(0.0)
+    }
+
+    fn select_encoding(headers: &HeaderMap, requested: &str) -> Encoding {
+        let br_quality = accepted_quality(headers, "br");
+        let gzip_quality = accepted_quality(headers, "gzip");
+        let has_br = br_quality > 0.0 && WebAssets::get(&format!("{requested}.br")).is_some();
+        let has_gzip = gzip_quality > 0.0 && WebAssets::get(&format!("{requested}.gz")).is_some();
+        if has_br && (!has_gzip || br_quality >= gzip_quality) {
+            Encoding::Brotli
+        } else if has_gzip {
+            Encoding::Gzip
+        } else {
+            Encoding::Identity
+        }
+    }
+
+    fn is_hashed_asset(path: &str) -> bool {
+        if !path.starts_with("assets/") {
+            return false;
+        }
+        let Some(file_name) = path.rsplit('/').next() else {
+            return false;
+        };
+        let stem = file_name
+            .rsplit_once('.')
+            .map_or(file_name, |(stem, _)| stem);
+        let Some((_, hash)) = stem.rsplit_once('-') else {
+            return false;
+        };
+        hash.len() >= 8
+            && hash.len() <= 32
+            && hash
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    }
+
+    fn etag(hash: [u8; 32]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut value = String::with_capacity(66);
+        value.push('"');
+        for byte in hash {
+            value.push(HEX[(byte >> 4) as usize] as char);
+            value.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        value.push('"');
+        value
+    }
+
+    fn if_none_match(headers: &HeaderMap, current: &str) -> bool {
+        headers
+            .get_all(header::IF_NONE_MATCH)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .map(str::trim)
+            .any(|candidate| {
+                candidate == "*"
+                    || candidate == current
+                    || candidate
+                        .strip_prefix("W/")
+                        .is_some_and(|candidate| candidate == current)
+            })
+    }
+
+    fn embedded_response(
+        requested: &str,
+        mime: &str,
+        fallback: bool,
+        request_headers: &HeaderMap,
+    ) -> Option<Response> {
+        let encoding = select_encoding(request_headers, requested);
+        let representation_path = format!("{requested}{}", encoding.suffix());
+        let file = WebAssets::get(&representation_path)?;
+        let etag = etag(file.metadata.sha256_hash());
+        let cache_control = if !fallback && is_hashed_asset(requested) {
+            IMMUTABLE_CACHE
+        } else {
+            REVALIDATE_CACHE
+        };
+        let status = if if_none_match(request_headers, &etag) {
+            StatusCode::NOT_MODIFIED
+        } else {
+            StatusCode::OK
+        };
+        let mut response = Response::builder().status(status);
+        let headers = response
+            .headers_mut()
+            .expect("embedded response headers are available");
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_str(mime).expect("embedded MIME type is a valid header"),
+        );
+        headers.insert(
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static(CONTENT_SECURITY_POLICY),
+        );
+        headers.insert(header::VARY, HeaderValue::from_static("Accept-Encoding"));
+        headers.insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(cache_control),
+        );
+        headers.insert(
+            header::ETAG,
+            HeaderValue::from_str(&etag).expect("SHA-256 ETag is a valid header"),
+        );
+        if let Some(content_encoding) = encoding.header_value() {
+            headers.insert(
+                header::CONTENT_ENCODING,
+                HeaderValue::from_static(content_encoding),
+            );
+        }
+        let body = if status == StatusCode::NOT_MODIFIED {
+            Body::empty()
+        } else {
+            Body::from(file.data.into_owned())
+        };
+        Some(
+            response
+                .body(body)
+                .expect("embedded response body constructs"),
+        )
+    }
+
+    pub(super) async fn serve(uri: &Uri, request_headers: &HeaderMap) -> Response {
         let requested = uri.path().trim_start_matches('/');
         let requested = if requested.is_empty() {
             "index.html"
         } else {
             requested
         };
-        if let Some(file) = WebAssets::get(requested) {
+        // .br/.gz siblings are internal representations, never public paths.
+        if !requested.ends_with(".br")
+            && !requested.ends_with(".gz")
+            && WebAssets::get(requested).is_some()
+        {
             let mime = mime_guess::from_path(requested).first_or_octet_stream();
-            return (
-                [
-                    (header::CONTENT_TYPE, mime.as_ref()),
-                    (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
-                ],
-                file.data.into_owned(),
-            )
-                .into_response();
+            if let Some(response) =
+                embedded_response(requested, mime.as_ref(), false, request_headers)
+            {
+                return response;
+            }
         }
         // Single-page app: unknown non-API paths resolve to index.html so
         // client-side deep links (e.g. project routes) load correctly.
-        match WebAssets::get("index.html") {
-            Some(index) => (
-                [
-                    (header::CONTENT_TYPE, "text/html; charset=utf-8"),
-                    (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
-                ],
-                index.data.into_owned(),
-            )
-                .into_response(),
-            None => StatusCode::NOT_FOUND.into_response(),
-        }
+        embedded_response(
+            "index.html",
+            "text/html; charset=utf-8",
+            true,
+            request_headers,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response())
     }
 }
 
@@ -2048,7 +2245,7 @@ async fn app_fallback(request: Request<axum::body::Body>) -> Response {
     #[cfg(feature = "embed-web")]
     {
         if !request.uri().path().starts_with("/api/") {
-            return web_assets::serve(request.uri().clone()).await;
+            return web_assets::serve(request.uri(), request.headers()).await;
         }
     }
     route_not_found(request).await

--- a/apps/rust-api/src/tests/embedded_web.rs
+++ b/apps/rust-api/src/tests/embedded_web.rs
@@ -140,7 +140,7 @@ async fn embedded_assets_negotiate_precompressed_representations() {
     assert_eq!(disabled_body, identity_body);
 
     let (unsupported_status, unsupported_headers, unsupported_body) = request_raw(
-        app,
+        app.clone(),
         "GET",
         &asset_path,
         Body::empty(),
@@ -150,6 +150,95 @@ async fn embedded_assets_negotiate_precompressed_representations() {
     assert_eq!(unsupported_status, StatusCode::OK);
     assert!(!unsupported_headers.contains_key(CONTENT_ENCODING));
     assert_eq!(unsupported_body, identity_body);
+
+    let (identity_preferred_status, identity_preferred_headers, identity_preferred_body) =
+        request_raw(
+            app.clone(),
+            "GET",
+            &asset_path,
+            Body::empty(),
+            &[("accept-encoding", "gzip;q=0.4")],
+        )
+        .await;
+    assert_eq!(identity_preferred_status, StatusCode::OK);
+    assert!(!identity_preferred_headers.contains_key(CONTENT_ENCODING));
+    assert_eq!(identity_preferred_body, identity_body);
+
+    let (identity_rejected_status, identity_rejected_headers, _) = request_raw(
+        app.clone(),
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("accept-encoding", "gzip;q=0.4, identity;q=0")],
+    )
+    .await;
+    assert_eq!(identity_rejected_status, StatusCode::OK);
+    assert_eq!(
+        identity_rejected_headers
+            .get(CONTENT_ENCODING)
+            .and_then(|value| value.to_str().ok()),
+        Some("gzip")
+    );
+
+    let (wildcard_status, wildcard_headers, _) = request_raw(
+        app.clone(),
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("accept-encoding", "br;q=0, *;q=0.7, identity;q=0.1")],
+    )
+    .await;
+    assert_eq!(wildcard_status, StatusCode::OK);
+    assert_eq!(
+        wildcard_headers
+            .get(CONTENT_ENCODING)
+            .and_then(|value| value.to_str().ok()),
+        Some("gzip")
+    );
+
+    for rejected in [
+        "br;q=0, gzip;q=0, identity;q=0",
+        "*;q=0",
+        "zstd, identity;q=0",
+    ] {
+        let (status, headers, body) = request_raw(
+            app.clone(),
+            "GET",
+            &asset_path,
+            Body::empty(),
+            &[("accept-encoding", rejected)],
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_ACCEPTABLE,
+            "{rejected} rejects every available representation"
+        );
+        assert!(body.is_empty());
+        assert_eq!(
+            headers.get(VARY).and_then(|value| value.to_str().ok()),
+            Some("Accept-Encoding")
+        );
+    }
+
+    let uncompressed_path = format!(
+        "/{}",
+        crate::web_assets::first_uncompressed_static_asset_path()
+    );
+    let (unavailable_status, _, unavailable_body) = request_raw(
+        app,
+        "GET",
+        &uncompressed_path,
+        Body::empty(),
+        &[("accept-encoding", "gzip, identity;q=0")],
+    )
+    .await;
+    assert_eq!(
+        unavailable_status,
+        StatusCode::NOT_ACCEPTABLE,
+        "an advertised coding is not acceptable when that representation is unavailable"
+    );
+    assert!(unavailable_body.is_empty());
 }
 
 #[tokio::test]
@@ -273,4 +362,39 @@ async fn validators_are_representation_specific_and_spa_fallback_revalidates() {
             .and_then(|value| value.to_str().ok()),
         Some("no-cache")
     );
+}
+
+#[tokio::test]
+async fn internal_precompressed_siblings_and_cache_manifest_are_not_public_assets() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let asset_path = crate::web_assets::first_compressible_static_asset_path();
+    let (_, _, root_body) = request_raw(app.clone(), "GET", "/", Body::empty(), &[]).await;
+
+    for internal_path in [
+        format!("/{asset_path}.br"),
+        format!("/{asset_path}.gz"),
+        format!("/{}", crate::web_assets::immutable_asset_manifest_path()),
+    ] {
+        let (status, headers, body) =
+            request_raw(app.clone(), "GET", &internal_path, Body::empty(), &[]).await;
+        assert_eq!(status, StatusCode::OK, "{internal_path} uses SPA fallback");
+        assert_eq!(
+            headers
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/html; charset=utf-8")
+        );
+        assert!(!headers.contains_key(CONTENT_ENCODING));
+        assert_eq!(
+            headers
+                .get(CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-cache")
+        );
+        assert_eq!(
+            body, root_body,
+            "{internal_path} must not expose build representation bytes"
+        );
+    }
 }

--- a/apps/rust-api/src/tests/embedded_web.rs
+++ b/apps/rust-api/src/tests/embedded_web.rs
@@ -1,5 +1,7 @@
 use super::support::*;
-use axum::http::header::{CONTENT_SECURITY_POLICY, CONTENT_TYPE};
+use axum::http::header::{
+    CACHE_CONTROL, CONTENT_ENCODING, CONTENT_SECURITY_POLICY, CONTENT_TYPE, ETAG, VARY,
+};
 
 #[tokio::test]
 async fn embedded_spa_and_api_share_the_router() {
@@ -59,4 +61,216 @@ async fn embedded_spa_and_api_share_the_router() {
         request(app, "GET", "/api/v1/not-a-route", Value::Null).await;
     assert_eq!(missing_api_status, StatusCode::NOT_FOUND);
     assert_eq!(missing_api["detail"], "Not Found");
+}
+
+#[tokio::test]
+async fn embedded_assets_negotiate_precompressed_representations() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let asset_path = format!(
+        "/{}",
+        crate::web_assets::first_compressible_static_asset_path()
+    );
+
+    let (identity_status, identity_headers, identity_body) =
+        request_raw(app.clone(), "GET", &asset_path, Body::empty(), &[]).await;
+    assert_eq!(identity_status, StatusCode::OK);
+    assert!(!identity_headers.contains_key(CONTENT_ENCODING));
+    assert_eq!(
+        identity_headers
+            .get(VARY)
+            .and_then(|value| value.to_str().ok()),
+        Some("Accept-Encoding")
+    );
+
+    let (brotli_status, brotli_headers, brotli_body) = request_raw(
+        app.clone(),
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("accept-encoding", "gzip, br")],
+    )
+    .await;
+    assert_eq!(brotli_status, StatusCode::OK);
+    assert_eq!(
+        brotli_headers
+            .get(CONTENT_ENCODING)
+            .and_then(|value| value.to_str().ok()),
+        Some("br")
+    );
+    assert_eq!(
+        brotli_headers.get(CONTENT_TYPE),
+        identity_headers.get(CONTENT_TYPE)
+    );
+    assert!(
+        brotli_body.len() < identity_body.len(),
+        "Brotli transfer is smaller than the identity representation"
+    );
+
+    let (gzip_status, gzip_headers, gzip_body) = request_raw(
+        app.clone(),
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("accept-encoding", "br;q=0.4, gzip;q=1")],
+    )
+    .await;
+    assert_eq!(gzip_status, StatusCode::OK);
+    assert_eq!(
+        gzip_headers
+            .get(CONTENT_ENCODING)
+            .and_then(|value| value.to_str().ok()),
+        Some("gzip")
+    );
+    assert!(
+        gzip_body.len() < identity_body.len(),
+        "gzip transfer is smaller than the identity representation"
+    );
+
+    let (disabled_status, disabled_headers, disabled_body) = request_raw(
+        app.clone(),
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("accept-encoding", "br;q=0, gzip;q=0")],
+    )
+    .await;
+    assert_eq!(disabled_status, StatusCode::OK);
+    assert!(!disabled_headers.contains_key(CONTENT_ENCODING));
+    assert_eq!(disabled_body, identity_body);
+
+    let (unsupported_status, unsupported_headers, unsupported_body) = request_raw(
+        app,
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("accept-encoding", "zstd")],
+    )
+    .await;
+    assert_eq!(unsupported_status, StatusCode::OK);
+    assert!(!unsupported_headers.contains_key(CONTENT_ENCODING));
+    assert_eq!(unsupported_body, identity_body);
+}
+
+#[tokio::test]
+async fn embedded_cache_contract_separates_hashed_and_mutable_assets() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let asset_path = format!(
+        "/{}",
+        crate::web_assets::first_compressible_static_asset_path()
+    );
+
+    let (asset_status, asset_headers, asset_body) =
+        request_raw(app.clone(), "GET", &asset_path, Body::empty(), &[]).await;
+    assert_eq!(asset_status, StatusCode::OK);
+    assert!(!asset_body.is_empty());
+    assert_eq!(
+        asset_headers
+            .get(CACHE_CONTROL)
+            .and_then(|value| value.to_str().ok()),
+        Some("public, max-age=31536000, immutable")
+    );
+    let asset_etag = asset_headers
+        .get(ETAG)
+        .and_then(|value| value.to_str().ok())
+        .expect("hashed asset has an ETag")
+        .to_owned();
+    let (reused_status, reused_headers, reused_body) = request_raw(
+        app.clone(),
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("if-none-match", &asset_etag)],
+    )
+    .await;
+    assert_eq!(reused_status, StatusCode::NOT_MODIFIED);
+    assert!(reused_body.is_empty());
+    assert_eq!(reused_headers.get(ETAG), asset_headers.get(ETAG));
+
+    for path in ["/", "/index.html", "/theme-init.js", "/projects/deep-link"] {
+        let (status, headers, body) =
+            request_raw(app.clone(), "GET", path, Body::empty(), &[]).await;
+        assert_eq!(status, StatusCode::OK, "{path} serves");
+        assert!(!body.is_empty(), "{path} has a body");
+        assert_eq!(
+            headers
+                .get(CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-cache"),
+            "{path} must revalidate"
+        );
+        assert!(headers.contains_key(ETAG), "{path} has a validator");
+        assert_eq!(
+            headers.get(VARY).and_then(|value| value.to_str().ok()),
+            Some("Accept-Encoding")
+        );
+    }
+}
+
+#[tokio::test]
+async fn validators_are_representation_specific_and_spa_fallback_revalidates() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let asset_path = format!(
+        "/{}",
+        crate::web_assets::first_compressible_static_asset_path()
+    );
+
+    let (_, identity_headers, _) =
+        request_raw(app.clone(), "GET", &asset_path, Body::empty(), &[]).await;
+    let identity_etag = identity_headers
+        .get(ETAG)
+        .and_then(|value| value.to_str().ok())
+        .expect("identity representation has an ETag");
+    let (encoded_status, encoded_headers, encoded_body) = request_raw(
+        app.clone(),
+        "GET",
+        &asset_path,
+        Body::empty(),
+        &[("accept-encoding", "br"), ("if-none-match", identity_etag)],
+    )
+    .await;
+    assert_eq!(encoded_status, StatusCode::OK);
+    assert!(!encoded_body.is_empty());
+    assert_ne!(encoded_headers.get(ETAG), identity_headers.get(ETAG));
+
+    let (_, fallback_headers, fallback_body) = request_raw(
+        app.clone(),
+        "GET",
+        "/projects/client-route",
+        Body::empty(),
+        &[("accept-encoding", "gzip")],
+    )
+    .await;
+    let fallback_etag = fallback_headers
+        .get(ETAG)
+        .and_then(|value| value.to_str().ok())
+        .expect("SPA fallback has an ETag");
+    assert_eq!(
+        fallback_headers
+            .get(CONTENT_ENCODING)
+            .and_then(|value| value.to_str().ok()),
+        Some("gzip")
+    );
+    assert!(!fallback_body.is_empty());
+    let (revalidated_status, revalidated_headers, revalidated_body) = request_raw(
+        app,
+        "GET",
+        "/projects/client-route",
+        Body::empty(),
+        &[
+            ("accept-encoding", "gzip"),
+            ("if-none-match", fallback_etag),
+        ],
+    )
+    .await;
+    assert_eq!(revalidated_status, StatusCode::NOT_MODIFIED);
+    assert!(revalidated_body.is_empty());
+    assert_eq!(
+        revalidated_headers
+            .get(CACHE_CONTROL)
+            .and_then(|value| value.to_str().ok()),
+        Some("no-cache")
+    );
 }

--- a/apps/web/vite-plugin-precompress.js
+++ b/apps/web/vite-plugin-precompress.js
@@ -1,0 +1,109 @@
+import {
+  brotliCompressSync,
+  constants as zlibConstants,
+  gzipSync,
+} from "node:zlib";
+import { Buffer } from "node:buffer";
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+
+const COMPRESSIBLE_EXTENSIONS = new Set([
+  ".css",
+  ".html",
+  ".js",
+  ".json",
+  ".map",
+  ".md",
+  ".svg",
+  ".txt",
+  ".wasm",
+  ".xml",
+]);
+
+// Tiny responses cost more in headers and decompression setup than they save.
+export const MINIMUM_PRECOMPRESS_BYTES = 256;
+
+export function shouldPrecompress(filePath, byteLength) {
+  return (
+    byteLength >= MINIMUM_PRECOMPRESS_BYTES
+    && COMPRESSIBLE_EXTENSIONS.has(extname(filePath).toLowerCase())
+  );
+}
+
+export function compressRepresentations(source) {
+  const input = Buffer.isBuffer(source) ? source : Buffer.from(source);
+  return {
+    br: brotliCompressSync(input, {
+      params: {
+        [zlibConstants.BROTLI_PARAM_QUALITY]: 9,
+      },
+    }),
+    gzip: gzipSync(input, { level: 9, mtime: 0 }),
+  };
+}
+
+function filesUnder(directory) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...filesUnder(path));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+export function precompressDirectory(directory) {
+  const root = resolve(directory);
+  const results = [];
+  for (const filePath of filesUnder(root)) {
+    if (filePath.endsWith(".br") || filePath.endsWith(".gz")) {
+      continue;
+    }
+    const size = statSync(filePath).size;
+    if (!shouldPrecompress(filePath, size)) {
+      continue;
+    }
+    const source = readFileSync(filePath);
+    const encoded = compressRepresentations(source);
+    writeFileSync(`${filePath}.br`, encoded.br);
+    writeFileSync(`${filePath}.gz`, encoded.gzip);
+    results.push({
+      path: relative(root, filePath).replaceAll("\\", "/"),
+      identityBytes: source.length,
+      brBytes: encoded.br.length,
+      gzipBytes: encoded.gzip.length,
+    });
+  }
+  return results;
+}
+
+/**
+ * Generate Brotli and gzip siblings after Vite has written the complete bundle,
+ * including assets emitted by other plugins such as /theme-init.js.
+ *
+ * Compression is paid once at build time. The Rust embedded-web handler only
+ * selects a representation, so requests never spend CPU recompressing bytes.
+ *
+ * @returns {import("vite").Plugin}
+ */
+export default function precompressPlugin() {
+  let outputDirectory = "dist";
+  return {
+    name: "sceneworks-precompress",
+    apply: "build",
+    configResolved(config) {
+      outputDirectory = resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      precompressDirectory(outputDirectory);
+    },
+  };
+}

--- a/apps/web/vite-plugin-precompress.js
+++ b/apps/web/vite-plugin-precompress.js
@@ -12,6 +12,8 @@ import {
 } from "node:fs";
 import { extname, join, relative, resolve } from "node:path";
 
+export const IMMUTABLE_ASSET_MANIFEST = ".sceneworks-immutable-assets";
+
 const COMPRESSIBLE_EXTENSIONS = new Set([
   ".css",
   ".html",
@@ -45,6 +47,32 @@ export function compressRepresentations(source) {
     }),
     gzip: gzipSync(input, { level: 9, mtime: 0 }),
   };
+}
+
+export function isViteHashedAssetPath(filePath) {
+  const fileName = filePath.replaceAll("\\", "/").split("/").at(-1) ?? "";
+  const extensionIndex = fileName.lastIndexOf(".");
+  const stem = extensionIndex > 0 ? fileName.slice(0, extensionIndex) : fileName;
+  if (stem.length < 10 || stem.at(-9) !== "-") {
+    return false;
+  }
+  const hash = stem.slice(-8);
+  return (
+    /^[A-Za-z0-9_-]{8}$/.test(hash)
+    // A digits-only suffix can be a mutable date/version such as 20260725.
+    // Treat that safe false-negative as mutable rather than granting immutable caching.
+    && /[A-Za-z_-]/.test(hash)
+  );
+}
+
+export function immutableAssetPaths(bundle) {
+  return Object.values(bundle)
+    .map((output) => output.fileName.replaceAll("\\", "/"))
+    .filter((fileName) => (
+      fileName.startsWith("assets/")
+      && isViteHashedAssetPath(fileName)
+    ))
+    .sort();
 }
 
 function filesUnder(directory) {
@@ -96,14 +124,25 @@ export function precompressDirectory(directory) {
  */
 export default function precompressPlugin() {
   let outputDirectory = "dist";
+  let immutableAssets = [];
   return {
     name: "sceneworks-precompress",
     apply: "build",
     configResolved(config) {
       outputDirectory = resolve(config.root, config.build.outDir);
     },
+    generateBundle(_options, bundle) {
+      immutableAssets = immutableAssetPaths(bundle);
+    },
     closeBundle() {
       precompressDirectory(outputDirectory);
+      // This build-owned allowlist is embedded beside the bundle but is not a
+      // public route. Rust consumes it once and never guesses cacheability from
+      // a request path.
+      writeFileSync(
+        join(outputDirectory, IMMUTABLE_ASSET_MANIFEST),
+        `${immutableAssets.join("\n")}\n`,
+      );
     },
   };
 }

--- a/apps/web/vite-plugin-precompress.test.js
+++ b/apps/web/vite-plugin-precompress.test.js
@@ -1,0 +1,63 @@
+import { gunzipSync, brotliDecompressSync } from "node:zlib";
+import { Buffer } from "node:buffer";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  MINIMUM_PRECOMPRESS_BYTES,
+  compressRepresentations,
+  precompressDirectory,
+  shouldPrecompress,
+} from "./vite-plugin-precompress.js";
+
+describe("production precompression", () => {
+  it("round-trips Brotli and gzip representations", () => {
+    const source = Buffer.from("SceneWorks production JavaScript\n".repeat(200));
+    const encoded = compressRepresentations(source);
+
+    expect(brotliDecompressSync(encoded.br)).toEqual(source);
+    expect(gunzipSync(encoded.gzip)).toEqual(source);
+    expect(encoded.br.length).toBeLessThan(source.length);
+    expect(encoded.gzip.length).toBeLessThan(source.length);
+  });
+
+  it("limits work to compressible, non-trivial response types", () => {
+    expect(shouldPrecompress("assets/index-ABC12345.js", MINIMUM_PRECOMPRESS_BYTES)).toBe(true);
+    expect(shouldPrecompress("index.html", MINIMUM_PRECOMPRESS_BYTES)).toBe(true);
+    expect(shouldPrecompress("assets/poster-ABC12345.jpg", 50_000)).toBe(false);
+    expect(shouldPrecompress("assets/font-ABC12345.woff2", 50_000)).toBe(false);
+    expect(shouldPrecompress("assets/tiny-ABC12345.js", 20)).toBe(false);
+  });
+
+  it("writes variants without recompressing media or generated variants", () => {
+    const directory = mkdtempSync(join(tmpdir(), "sceneworks-precompress-"));
+    try {
+      mkdirSync(join(directory, "assets"), { recursive: true });
+      const javascript = Buffer.from("export const scene = true;\n".repeat(200));
+      const media = Buffer.alloc(2048, 7);
+      writeFileSync(join(directory, "assets", "index-ABC12345.js"), javascript);
+      writeFileSync(join(directory, "assets", "poster-ABC12345.jpg"), media);
+
+      const results = precompressDirectory(directory);
+
+      expect(results.map((result) => result.path)).toEqual(["assets/index-ABC12345.js"]);
+      expect(brotliDecompressSync(
+        readFileSync(join(directory, "assets", "index-ABC12345.js.br")),
+      )).toEqual(javascript);
+      expect(gunzipSync(
+        readFileSync(join(directory, "assets", "index-ABC12345.js.gz")),
+      )).toEqual(javascript);
+      expect(() => readFileSync(join(directory, "assets", "poster-ABC12345.jpg.br"))).toThrow();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/web/vite-plugin-precompress.test.js
+++ b/apps/web/vite-plugin-precompress.test.js
@@ -12,8 +12,11 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  IMMUTABLE_ASSET_MANIFEST,
   MINIMUM_PRECOMPRESS_BYTES,
   compressRepresentations,
+  immutableAssetPaths,
+  isViteHashedAssetPath,
   precompressDirectory,
   shouldPrecompress,
 } from "./vite-plugin-precompress.js";
@@ -35,6 +38,30 @@ describe("production precompression", () => {
     expect(shouldPrecompress("assets/poster-ABC12345.jpg", 50_000)).toBe(false);
     expect(shouldPrecompress("assets/font-ABC12345.woff2", 50_000)).toBe(false);
     expect(shouldPrecompress("assets/tiny-ABC12345.js", 20)).toBe(false);
+  });
+
+  it("recognizes Vite hashes without blessing date-like mutable filenames", () => {
+    expect(isViteHashedAssetPath("assets/index-ABC12345.js")).toBe(true);
+    expect(isViteHashedAssetPath("assets/index-aB-cD_12.js")).toBe(true);
+    expect(isViteHashedAssetPath("assets/index-20260725.js")).toBe(false);
+    expect(isViteHashedAssetPath("assets/bootstrap.js")).toBe(false);
+    expect(isViteHashedAssetPath("assets/index-ABC1234.js")).toBe(false);
+    expect(isViteHashedAssetPath("assets/index-ABC123456.js")).toBe(false);
+  });
+
+  it("builds an authoritative immutable allowlist from Vite outputs", () => {
+    const bundle = {
+      entry: { type: "chunk", fileName: "assets/index-aB-cD_12.js" },
+      css: { type: "asset", fileName: "assets/index-ABC12345.css" },
+      dated: { type: "asset", fileName: "assets/bootstrap-20260725.js" },
+      root: { type: "asset", fileName: "theme-init.js" },
+      manifest: { type: "asset", fileName: IMMUTABLE_ASSET_MANIFEST },
+    };
+
+    expect(immutableAssetPaths(bundle)).toEqual([
+      "assets/index-ABC12345.css",
+      "assets/index-aB-cD_12.js",
+    ]);
   });
 
   it("writes variants without recompressing media or generated variants", () => {

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig, searchForWorkspaceRoot } from "vite";
 
+import precompressPlugin from "./vite-plugin-precompress.js";
 import themeInitPlugin from "./vite-plugin-theme-init.js";
 
 // Expose the product version (kept in lockstep across the repo's package.json /
@@ -35,7 +36,7 @@ const configDir = fileURLToPath(new URL("../../config", import.meta.url));
 export default defineConfig({
   // Generate the pre-paint /theme-init.js from src/accents.js at dev/build time
   // (single source of truth for the accent-id list). See vite-plugin-theme-init.js.
-  plugins: [themeInitPlugin()],
+  plugins: [themeInitPlugin(), precompressPlugin()],
   // Matches the existing import.meta.env.VITE_* convention (see api.js). Defining
   // the specific key keeps it lint-safe (no bare global) under no-undef.
   define: {

--- a/docs/embedded-web-delivery.md
+++ b/docs/embedded-web-delivery.md
@@ -1,0 +1,50 @@
+# Embedded production web delivery
+
+SceneWorks serves the production Vite bundle from the Rust API when the
+`embed-web` feature is enabled. The bundle has one explicit response contract
+across desktop, Docker/server, and RunPod.
+
+## Compression
+
+`apps/web/vite-plugin-precompress.js` writes Brotli (`.br`) and gzip (`.gz`)
+siblings for compressible files of at least 256 bytes. The source, Brotli, and
+gzip representations are embedded into the API binary. The handler selects
+`br`, `gzip`, or identity from `Accept-Encoding`, adds
+`Vary: Accept-Encoding`, and uses a representation-specific ETag.
+
+This is deliberately build-time precompression rather than response middleware:
+
+- compression CPU is paid once during the production web build, never on a
+  request;
+- already-compressed images, audio, video, archives, and web fonts are not
+  recompressed;
+- response latency and CPU use are bounded to an embedded lookup and header
+  selection; and
+- the production artifact is identical for desktop, server, and RunPod.
+
+The `.br` and `.gz` siblings are internal representations. They are not public
+routes and retain the original asset's content type when selected.
+
+## Caching
+
+- Content-hashed files under `/assets/` use
+  `Cache-Control: public, max-age=31536000, immutable`.
+- `index.html`, `/theme-init.js`, every other mutable root asset, and SPA
+  fallback responses use `Cache-Control: no-cache`.
+- Every representation has a strong SHA-256 ETag. Conditional reloads can
+  answer `304 Not Modified`, while a changed deployment cannot pin an old
+  entrypoint to new hashed chunks.
+
+The existing content type, content-security-policy, API access-control boundary,
+SPA fallback, and project media/range routes remain owned by their original
+handlers.
+
+## Extension point for SC-14798
+
+SC-14798 can add response compression for dynamic API JSON at the router
+middleware boundary. It must predicate that middleware to dynamic,
+compressible responses and skip any response that already has
+`Content-Encoding`. Embedded web responses already carry their final
+representation and must not pass through a second compression stage. Static
+asset policy and dynamic API policy therefore remain one layered design without
+double compression.

--- a/docs/embedded-web-delivery.md
+++ b/docs/embedded-web-delivery.md
@@ -11,6 +11,9 @@ siblings for compressible files of at least 256 bytes. The source, Brotli, and
 gzip representations are embedded into the API binary. The handler selects
 `br`, `gzip`, or identity from `Accept-Encoding`, adds
 `Vary: Accept-Encoding`, and uses a representation-specific ETag.
+Quality values, wildcard exclusions, and identity are honored; if a client
+rejects every available representation, the handler returns
+`406 Not Acceptable`.
 
 This is deliberately build-time precompression rather than response middleware:
 
@@ -34,6 +37,13 @@ routes and retain the original asset's content type when selected.
 - Every representation has a strong SHA-256 ETag. Conditional reloads can
   answer `304 Not Modified`, while a changed deployment cannot pin an old
   entrypoint to new hashed chunks.
+
+Vite writes an internal `.sceneworks-immutable-assets` allowlist from the
+current Rollup output. Only generated `/assets/` names matching Vite's exact
+eight-character base64url hash shape are listed; digits-only date/version
+suffixes are deliberately treated as mutable. Rust consumes that allowlist
+once and never grants immutable caching by guessing from the request filename.
+The allowlist and `.br`/`.gz` siblings are internal metadata, not public routes.
 
 The existing content type, content-security-policy, API access-control boundary,
 SPA fallback, and project media/range routes remain owned by their original


### PR DESCRIPTION
## Summary
- precompress production web assets with Brotli and gzip during the Vite build, excluding media, fonts, and tiny files
- negotiate embedded representations with Vary: Accept-Encoding and representation-specific SHA-256 ETags
- cache content-hashed /assets files immutably while forcing index, theme bootstrap, mutable assets, and SPA fallback to revalidate
- document the static precompression boundary that SC-14798 can extend for dynamic API JSON without double compression

## Validation
- npm web full suite: 188 files, 2596 tests passed
- focused precompression suite: 3 tests passed; explicit ESLint passed
- production npm build passed and emitted .br/.gz variants
- cargo fmt --all -- --check passed
- cargo clippy -p sceneworks-rust-api --features embed-web --all-targets -- -D warnings passed
- focused embedded/auth Rust tests: 11 passed
- full embed-web API suite: 388 passed, 2 ignored; known unrelated Windows parent_death_resolves_when_watched_parent_exits_windows liveness flake failed
- cargo build -p sceneworks-rust-api --release --features embed-web passed

## Production-equivalent HTTP evidence
The exact Windows release embed-web binary was served on loopback and then stopped. Main JS transfer sizes were 1,732,277 bytes identity, 336,091 Brotli (19.4%), and 422,895 gzip (24.4%); unsupported zstd correctly used identity. The hashed asset returned immutable cache headers, Vary, and a zero-byte 304 for its ETag. Root, theme-init.js, and SPA fallback returned no-cache; the fallback body matched index.html; every hashed JS/CSS path referenced by index.html returned 200.

Actual RunPod was intentionally unavailable for this lane after prior epic evidence, so this is a local production-release-equivalent harness rather than a remote GPU pod. Final integrated RunPod validation remains SC-14789.

Shortcut: https://app.shortcut.com/trefry/story/14785