### PR TITLE
perf(web): hydrate active route domains on demand (sc-14783)

### DIFF
--- a/apps/web/src/App.catalogBootstrap.test.jsx
+++ b/apps/web/src/App.catalogBootstrap.test.jsx
@@ -116,7 +116,7 @@ describe("independent project and asset bootstrap (sc-14754)", () => {
     await settle();
   }
 
-  it("renders the active project and populated Assets view while models and presets remain unresolved", async () => {
+  it("renders Assets without requesting inactive model or preset catalogs", async () => {
     const models = deferred();
     const presets = deferred();
     installFetch({
@@ -151,6 +151,8 @@ describe("independent project and asset bootstrap (sc-14754)", () => {
 
     const paths = global.fetch.mock.calls.map(([url]) => new URL(url).pathname);
     expect(paths).toContain("/api/v1/projects/project-a/assets");
+    expect(paths).not.toContain("/api/v1/models");
+    expect(paths).not.toContain("/api/v1/recipe-presets");
     expect(paths.indexOf("/api/v1/projects")).toBeLessThan(
       paths.indexOf("/api/v1/projects/project-a/assets"),
     );
@@ -171,26 +173,20 @@ describe("independent project and asset bootstrap (sc-14754)", () => {
     expect(container.textContent).not.toContain("Global Preset");
   });
 
-  it("keeps an empty Assets view usable when models and presets fail", async () => {
-    const models = deferred();
-    const presets = deferred();
-    installFetch({ models: models.promise, presets: presets.promise });
+  it("keeps an empty Assets view isolated from inactive catalog failures", async () => {
+    installFetch();
 
     await renderApp();
     expect(container.textContent).toContain("No assets in this view");
 
-    await act(async () => {
-      models.reject(new Error("model catalog failed"));
-      presets.reject(new Error("preset catalog failed"));
-    });
-    await settle();
-
     expect(container.querySelector(".project-pill")?.textContent).toContain("Project A");
     expect(container.textContent).toContain("No assets in this view");
-    // Models preserve their non-optional aggregate startup error. Recipe
-    // presets remain optional, matching the prior refreshData contract.
-    expect(container.textContent).toContain("Models: model catalog failed");
-    expect(container.textContent).not.toContain("Presets: preset catalog failed");
+    const paths = global.fetch.mock.calls.map(([url]) => new URL(url).pathname);
+    expect(paths).not.toContain("/api/v1/models");
+    expect(paths).not.toContain("/api/v1/recipe-presets");
+    expect(paths).not.toContain("/api/v1/training/targets");
+    expect(paths).not.toContain("/api/v1/training/presets");
+    expect(paths).not.toContain("/api/v1/prompt-batches");
   });
 
   it("shows loading and error states before unrelated catalogs settle", async () => {

--- a/apps/web/src/App.catalogBootstrap.test.jsx
+++ b/apps/web/src/App.catalogBootstrap.test.jsx
@@ -116,7 +116,7 @@ describe("independent project and asset bootstrap (sc-14754)", () => {
     await settle();
   }
 
-  it("renders Assets without requesting inactive model or preset catalogs", async () => {
+  it("renders Library assets before its deferred detail catalogs settle", async () => {
     const models = deferred();
     const presets = deferred();
     installFetch({
@@ -151,7 +151,7 @@ describe("independent project and asset bootstrap (sc-14754)", () => {
 
     const paths = global.fetch.mock.calls.map(([url]) => new URL(url).pathname);
     expect(paths).toContain("/api/v1/projects/project-a/assets");
-    expect(paths).not.toContain("/api/v1/models");
+    expect(paths).toContain("/api/v1/models");
     expect(paths).not.toContain("/api/v1/recipe-presets");
     expect(paths.indexOf("/api/v1/projects")).toBeLessThan(
       paths.indexOf("/api/v1/projects/project-a/assets"),
@@ -173,7 +173,7 @@ describe("independent project and asset bootstrap (sc-14754)", () => {
     expect(container.textContent).not.toContain("Global Preset");
   });
 
-  it("keeps an empty Assets view isolated from inactive catalog failures", async () => {
+  it("keeps an empty Library isolated from unrelated inactive catalogs", async () => {
     installFetch();
 
     await renderApp();

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -95,6 +95,11 @@ import {
   isCurrentProjectRequest,
   reconcileSelectedAssetId,
 } from "./appStateHelpers.js";
+import {
+  hydrationDomainsForRoute,
+  hydrationLedgerKey,
+  isProjectHydrationDomain,
+} from "./appHydration.js";
 
 // Desktop (Tauri) shell detection (unified helper, epic 4484 story 6). The first-run
 // setup wizard is desktop-only; web/Docker (and a remote LAN browser) keep the
@@ -425,6 +430,7 @@ export function App() {
   const [setupCompleted, setSetupCompleted] = useState(isDesktopShell ? null : true);
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
+  const [simpleActiveScreen, setSimpleActiveScreen] = useState("image");
   // Selective lazy keep-alive (sc-11959): the set of keep-alive views the user has
   // visited at least once. A view mounts on first visit (activeView === view) and,
   // once here, stays mounted (hidden) across navigation so its state survives.
@@ -536,6 +542,29 @@ export function App() {
   // Back-compat: the existing setError(msg)/setError("") call sites map onto the
   // "general" notice kind — a truthy message replaces it, "" dismisses only it.
   const setError = useCallback((message) => pushNotice("general", message), [pushNotice]);
+  // Domain loaders and mutations own separate notice slots. A successful Models
+  // request must never erase a Training or Characters failure (sc-14783).
+  const setDomainError = useCallback(
+    (domain, message) => pushNotice(`domain:${domain}`, message),
+    [pushNotice],
+  );
+  const domainErrors = useMemo(
+    () => ({
+      assets: (message) => setDomainError("assets", message),
+      characters: (message) => setDomainError("characters", message),
+      loras: (message) => setDomainError("loras", message),
+      models: (message) => setDomainError("models", message),
+      personTracks: (message) => setDomainError("person-tracks", message),
+      presets: (message) => setDomainError("presets", message),
+      promptBatches: (message) => setDomainError("prompt-batches", message),
+      savedVoices: (message) => setDomainError("saved-voices", message),
+      timelines: (message) => setDomainError("timelines", message),
+      trainingDatasets: (message) => setDomainError("training-datasets", message),
+      trainingPresets: (message) => setDomainError("training-presets", message),
+      trainingTargets: (message) => setDomainError("training-targets", message),
+    }),
+    [setDomainError],
+  );
   // Remote-access gate (epic 4484), extracted to a hook (sc-9750): owns access probe,
   // host password/token, login-gate draft + error, and the media-ticket mint that must
   // settle before protected data loads. `authenticated`/`ready` gate the data + SSE
@@ -607,9 +636,16 @@ export function App() {
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
   const generatedAssetRefreshesRef = useRef(new Map());
-  const refreshDataRef = useRef(null);
+  const refreshShellDataRef = useRef(null);
+  const refreshModelsRef = useRef(null);
+  const refreshModelAndLorasRef = useRef(null);
+  const refreshTrainingTargetsRef = useRef(null);
+  const refreshTrainingPresetsRef = useRef(null);
+  const hydrateLaunchDomainsRef = useRef(null);
   const refreshAssetsRef = useRef(null);
   const healthRequestRef = useRef(null);
+  const hydrationLedgerRef = useRef(new Map());
+  const previousHydrationProjectIdRef = useRef(null);
   // Latest purgeAsset, held in a ref so the App-level scratch-op survivor (sc-8850) can
   // purge orphaned scratch/result assets from the SSE handler without re-subscribing.
   const purgeAssetRef = useRef(null);
@@ -621,7 +657,6 @@ export function App() {
   const refreshTrainingDatasetsRef = useRef(null);
   const refreshPersonTracksRef = useRef(null);
   const refreshTimelinesRef = useRef(null);
-  const refreshDataWithLoraOverlayRef = useRef(null);
   // A screen (the Image Editor, sc-2434) can register a guard that runs before a
   // user-initiated navigation leaves it — e.g. to confirm discarding unsaved edits.
   // Programmatic setActiveView calls (post-generation hops) deliberately bypass it.
@@ -778,7 +813,14 @@ export function App() {
     updateCharacterLora,
     detachCharacterLora,
     createCharacterTestJob,
-  } = useCharacters({ token, activeProject, activeProjectRef, setError, requestedGpu, setActiveView });
+  } = useCharacters({
+    token,
+    activeProject,
+    activeProjectRef,
+    setError: domainErrors.characters,
+    requestedGpu,
+    setActiveView,
+  });
 
   const {
     presets,
@@ -788,7 +830,7 @@ export function App() {
     updatePreset,
     duplicatePreset,
     deletePreset,
-  } = usePresets({ token, activeProject, activeProjectRef, setError });
+  } = usePresets({ token, activeProject, activeProjectRef, setError: domainErrors.presets });
 
   const {
     savedVoices,
@@ -796,7 +838,12 @@ export function App() {
     refreshSavedVoices,
     createSavedVoice,
     deleteSavedVoice,
-  } = useSavedVoices({ token, activeProject, activeProjectRef, setError });
+  } = useSavedVoices({
+    token,
+    activeProject,
+    activeProjectRef,
+    setError: domainErrors.savedVoices,
+  });
 
   const {
     promptBatches,
@@ -806,7 +853,12 @@ export function App() {
     updatePromptBatch,
     duplicatePromptBatch,
     deletePromptBatch,
-  } = usePromptBatches({ token, activeProject, activeProjectRef, setError });
+  } = usePromptBatches({
+    token,
+    activeProject,
+    activeProjectRef,
+    setError: domainErrors.promptBatches,
+  });
 
   const {
     trainingDatasets,
@@ -833,20 +885,29 @@ export function App() {
     smartCropTrainingDataset,
     stripExifTrainingDataset,
     createTrainingJob,
-  } = useTraining({ token, activeProject, activeProjectRef, setError, setJobs });
+  } = useTraining({
+    token,
+    activeProject,
+    activeProjectRef,
+    setError: domainErrors.trainingDatasets,
+    setJobs,
+  });
 
-  // sc-8811: useModelsAndLoras lists these two cross-cutting refresh orchestrators as
+  // sc-8811: useModelsAndLoras lists these two model-domain refresh orchestrators as
   // useCallback deps of deleteModel/deleteLora, which sit in appContextValue's
-  // dependency array. The orchestrator bodies (refreshData / refreshDataWithLoraOverlay,
-  // defined below) are plain per-render function declarations published into the
+  // dependency array. The orchestrator bodies are published into the
   // refs above, so passing them in directly would give deleteModel/deleteLora — and
   // therefore the whole ~130-key context value — a fresh identity on every App render,
   // silently defeating the sc-4194 memoization. These identity-stable wrappers delegate
   // through the refs instead: callers always invoke the latest body (fresh token /
   // activeProject), while the hook's actions stay referentially stable.
-  const stableRefreshData = useCallback((...args) => refreshDataRef.current?.(...args), []);
+  const stableRefreshData = useCallback((...args) => refreshModelsRef.current?.(...args), []);
   const stableRefreshDataWithLoraOverlay = useCallback(
-    (...args) => refreshDataWithLoraOverlayRef.current?.(...args),
+    (...args) => refreshModelAndLorasRef.current?.(...args),
+    [],
+  );
+  const stableHydrateLaunchDomains = useCallback(
+    (...args) => hydrateLaunchDomainsRef.current?.(...args),
     [],
   );
 
@@ -870,7 +931,8 @@ export function App() {
     token,
     activeProject,
     activeProjectRef,
-    setError,
+    setError: domainErrors.models,
+    setLoraError: domainErrors.loras,
     setJobs,
     setActiveView,
     refreshData: stableRefreshData,
@@ -884,7 +946,14 @@ export function App() {
     createPersonDetectionJob,
     createPersonTrackJob,
     saveTrackCorrections,
-  } = usePersonTracks({ token, activeProject, activeProjectRef, setError, requestedGpu, setActiveView });
+  } = usePersonTracks({
+    token,
+    activeProject,
+    activeProjectRef,
+    setError: domainErrors.personTracks,
+    requestedGpu,
+    setActiveView,
+  });
 
   const {
     timelines,
@@ -906,7 +975,7 @@ export function App() {
     token,
     activeProject,
     activeProjectRef,
-    setError,
+    setError: domainErrors.timelines,
     pushNotice,
     requestedGpu,
     setActiveView,
@@ -1333,45 +1402,60 @@ export function App() {
     if (!ready) {
       return;
     }
-    refreshDataRef.current?.();
+    hydrationLedgerRef.current.clear();
+    const controller = new AbortController();
+    refreshShellDataRef.current?.({ signal: controller.signal });
+    return () => controller.abort();
   }, [ready, token]);
 
-  useEffect(() => {
-    if (!activeProject || !ready) {
+  // Project changes reset only project-owned catalogs. Global models/training
+  // metadata and shared shell state survive. useLayoutEffect prevents the next
+  // project from painting the previous project's unscoped hook state.
+  useLayoutEffect(() => {
+    const nextProjectId = activeProject?.id ?? null;
+    const previousProjectId = previousHydrationProjectIdRef.current;
+    if (previousProjectId === nextProjectId) {
+      return;
+    }
+    previousHydrationProjectIdRef.current = nextProjectId;
+    if (previousProjectId !== null) {
       setAssets([]);
       setLoadedAssetsProjectId(null);
-      setAssetLoadState({ projectId: null, status: "idle", error: "" });
+      setAssetLoadState({
+        projectId: nextProjectId,
+        status: nextProjectId ? "loading" : "idle",
+        error: "",
+      });
       setCharacters([]);
       setSavedVoices([]);
       setPersonTracks([]);
       setTimelines([]);
       setTimelinesProjectId(null);
       setPresets([]);
-      setTrainingTargetsError("");
+      setPromptBatches([]);
+      setLoras([]);
       setTrainingDatasets([]);
       setTrainingDatasetsProjectId(null);
       setTrainingDatasetsError("");
       setSelectedTimelineId(null);
       setActiveTimeline(null);
-      return;
     }
-    // Switching projects (or unmounting) aborts the previous project's in-flight
-    // loads so a slow response can't overwrite the newly-selected project's data.
-    const controller = new AbortController();
-    const { signal } = controller;
-    refreshAssetsRef.current?.(activeProject.id, { signal });
-    refreshCharactersRef.current?.(activeProject.id, { signal });
-    refreshSavedVoicesRef.current?.(activeProject.id, { signal });
-    refreshLorasRef.current?.(activeProject.id, { signal });
-    refreshPresetsRef.current?.(activeProject.id, { signal });
-    refreshPromptBatchesRef.current?.(activeProject.id, { signal });
-    refreshTrainingDatasetsRef.current?.(activeProject.id, { signal });
-    refreshPersonTracksRef.current?.(activeProject.id, { signal });
-    refreshTimelinesRef.current?.(activeProject.id, { signal });
-    return () => controller.abort();
-    // Project identity owns this refresh; project-object churn must not restart every catalog request.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeProject?.id, ready, token]);
+  }, [
+    activeProject?.id,
+    setActiveTimeline,
+    setCharacters,
+    setLoras,
+    setPersonTracks,
+    setPresets,
+    setPromptBatches,
+    setSavedVoices,
+    setSelectedTimelineId,
+    setTimelines,
+    setTimelinesProjectId,
+    setTrainingDatasets,
+    setTrainingDatasetsError,
+    setTrainingDatasetsProjectId,
+  ]);
 
   // sc-11231 (F-037): useJobEvents captures whichever callback existed at subscribe time
   // (its SSE effect deps are only [access.authRequired, ready, token]), so this MUST have a
@@ -1404,8 +1488,8 @@ export function App() {
     dismissNoticeKind,
     generatedAssetRefreshesRef,
     refreshAssetsRef,
-    refreshDataRef,
-    refreshDataWithLoraOverlayRef,
+    refreshModelsRef,
+    refreshModelAndLorasRef,
     refreshPersonTracksRef,
     activeProjectRef,
     enqueueTimelineGenerationApply,
@@ -1423,90 +1507,98 @@ export function App() {
     editorScratchRegistry.sweep(jobs);
   }, [jobs, editorScratchRegistry]);
 
-  async function refreshData() {
-    const fetchInitial = async (label, path, fallback, optional = false) => {
+  async function refreshShellData({ signal } = {}) {
+    const fetchInitial = async (domain, label, path, fallback, optional = false) => {
       try {
-        return { label, value: await apiFetch(path, token), error: "" };
+        const value = await apiFetch(path, token, { signal });
+        setDomainError(domain, "");
+        return { label, value, error: "" };
       } catch (err) {
-        return { label, value: fallback, error: optional ? "" : `${label}: ${err.message}` };
+        if (isAbortError(err)) {
+          return { label, value: fallback, error: "", aborted: true };
+        }
+        const error = optional ? "" : `${label}: ${err.message}`;
+        setDomainError(domain, error);
+        return { label, value: fallback, error };
       }
     };
-    const projectsPromise = fetchInitial("Projects", "/api/v1/projects", []).then((result) => {
+    const projectsPromise = fetchInitial(
+      "projects",
+      "Projects",
+      "/api/v1/projects",
+      [],
+    ).then((result) => {
+      if (result.aborted) return result;
       applySuccessfulProjectRefresh(result, setProjects, setActiveProject);
       setProjectsLoaded(true);
       return result;
     });
-    // Mac UI gating (sc-3486): optional + non-fatal — a fetch failure leaves gating inert.
-    fetchInitial("Mac capabilities", "/api/v1/capabilities/mac", DEFAULT_MAC_CAPABILITIES, true)
+    fetchInitial(
+      "mac-capabilities",
+      "Mac capabilities",
+      "/api/v1/capabilities/mac",
+      DEFAULT_MAC_CAPABILITIES,
+      true,
+    )
       .then((result) => setMacCapabilities(result.value ?? DEFAULT_MAC_CAPABILITIES))
       .catch(() => {});
-    // Projects are the critical path to Assets. The remaining domains commit
-    // independently so no slow catalog gates another domain's usable state.
-    const globalPromises = [
-      fetchInitial("Jobs", "/api/v1/jobs", []).then((result) => {
+    const shellPromises = [
+      fetchInitial("jobs", "Jobs", "/api/v1/jobs", []).then((result) => {
+        if (result.aborted) return result;
         setJobs((current) => mergeFreshJobs(current, result.value));
         setQueueSummary(null);
         return result;
       }),
-      fetchInitial("Workers", "/api/v1/workers", []).then((result) => {
+      fetchInitial("workers", "Workers", "/api/v1/workers", []).then((result) => {
+        if (result.aborted) return result;
         setWorkers(result.value.sort(sortWorkers));
         return result;
       }),
-      fetchInitial("Models", "/api/v1/models", []).then((result) => {
-        setModels(result.value);
-        return result;
-      }),
-      fetchInitial("LoRAs", "/api/v1/loras", []).then((result) => {
-        // Once a project is active, its scoped refresh is authoritative. A
-        // slower global response must not overwrite project entries.
-        if (!activeProjectRef.current) {
-          setLoras(result.value);
-        }
-        return result;
-      }),
-      fetchInitial("Presets", "/api/v1/recipe-presets", [], true).then((result) => {
-        if (!activeProjectRef.current) {
-          setPresets(result.value);
-        }
-        return result;
-      }),
-      fetchInitial(
-        "Training targets",
-        "/api/v1/training/targets",
-        { schemaVersion: 1, targets: [] },
-      ).then((result) => {
-        setTrainingTargets(result.value);
-        setTrainingTargetsError(result.error);
-        return result;
-      }),
-      fetchInitial(
-        "Training presets",
-        "/api/v1/training/presets",
-        { schemaVersion: 1, presets: [] },
-      ).then((result) => {
-        setTrainingPresets(result.value);
-        setTrainingPresetsError(result.error);
-        return result;
-      }),
-      fetchInitial("Prompt batches", "/api/v1/prompt-batches", [], true).then((result) => {
-        if (!activeProjectRef.current) {
-          setPromptBatches(result.value);
-        }
-        return result;
-      }),
     ];
-    // Awaiting all requests preserves refreshData's completion contract and its
-    // aggregate startup error while no longer gating any individual commit.
-    const [projectsResult, ...globalResults] = await Promise.all([
-      projectsPromise,
-      ...globalPromises,
-    ]);
-    setError(
-      [projectsResult, ...globalResults]
-        .map((result) => result.error)
-        .filter(Boolean)
-        .join("; "),
-    );
+    await Promise.all([projectsPromise, ...shellPromises]);
+  }
+
+  async function refreshModels({ signal } = {}) {
+    try {
+      const items = await apiFetch("/api/v1/models", token, { signal });
+      setModels(items);
+      domainErrors.models("");
+      return items;
+    } catch (err) {
+      if (isAbortError(err)) return [];
+      domainErrors.models(err.message);
+      return [];
+    }
+  }
+
+  async function refreshTrainingTargets({ signal } = {}) {
+    try {
+      const catalog = await apiFetch("/api/v1/training/targets", token, { signal });
+      setTrainingTargets(catalog);
+      setTrainingTargetsError("");
+      domainErrors.trainingTargets("");
+      return catalog;
+    } catch (err) {
+      if (isAbortError(err)) return null;
+      setTrainingTargetsError(err.message);
+      domainErrors.trainingTargets(err.message);
+      return null;
+    }
+  }
+
+  async function refreshTrainingPresets({ signal } = {}) {
+    try {
+      const catalog = await apiFetch("/api/v1/training/presets", token, { signal });
+      setTrainingPresets(catalog);
+      setTrainingPresetsError("");
+      domainErrors.trainingPresets("");
+      return catalog;
+    } catch (err) {
+      if (isAbortError(err)) return null;
+      setTrainingPresetsError(err.message);
+      domainErrors.trainingPresets(err.message);
+      return null;
+    }
   }
 
   async function refreshAssets(projectId = activeProject?.id, { signal } = {}) {
@@ -1541,27 +1633,24 @@ export function App() {
       setLoadedAssetsProjectId(projectId);
       setSelectedAssetId((current) => reconcileSelectedAssetId(items, current));
       setAssetLoadState({ projectId, status: "ready", error: "" });
-      setError("");
+      domainErrors.assets("");
     } catch (err) {
       if (isAbortError(err)) return;
       if (!isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId)) {
         return;
       }
       setAssetLoadState({ projectId, status: "error", error: err.message });
-      setError(err.message);
+      domainErrors.assets(err.message);
     } finally {
       settleAssetRequest(timingStartedAt);
     }
   }
 
-  function refreshDataWithLoraOverlay(projectId = activeProjectRef.current?.id) {
-    refreshData()
-      .then(() => {
-        if (projectId) {
-          refreshLoras(projectId);
-        }
-      })
-      .catch(() => {});
+  async function refreshModelAndLoras(projectId = activeProjectRef.current?.id) {
+    await Promise.all([
+      refreshModels(),
+      refreshLoras(projectId || undefined),
+    ]);
   }
 
   // sc-8940: Publish the latest refresh closures into their refs from a post-commit
@@ -1575,7 +1664,12 @@ export function App() {
   // handlers, and React runs all layout effects before any passive effect — preserving
   // the original ordering where consumers saw the fresh closure.
   useLayoutEffect(() => {
-    refreshDataRef.current = refreshData;
+    refreshShellDataRef.current = refreshShellData;
+    refreshModelsRef.current = refreshModels;
+    refreshModelAndLorasRef.current = refreshModelAndLoras;
+    refreshTrainingTargetsRef.current = refreshTrainingTargets;
+    refreshTrainingPresetsRef.current = refreshTrainingPresets;
+    hydrateLaunchDomainsRef.current = hydrateLaunchDomains;
     refreshAssetsRef.current = refreshAssets;
     refreshCharactersRef.current = refreshCharacters;
     refreshSavedVoicesRef.current = refreshSavedVoices;
@@ -1585,8 +1679,121 @@ export function App() {
     refreshTrainingDatasetsRef.current = refreshTrainingDatasets;
     refreshPersonTracksRef.current = refreshPersonTracks;
     refreshTimelinesRef.current = refreshTimelines;
-    refreshDataWithLoraOverlayRef.current = refreshDataWithLoraOverlay;
   });
+
+  // Hydrate only the active screen's domains. Each ledger entry is global or
+  // project-keyed, so keep-alive navigation reuses settled catalogs while a
+  // project switch loads fresh overlays without discarding global state.
+  useEffect(() => {
+    if (!ready || !projectsLoaded) {
+      return;
+    }
+    const setupRoute =
+      isDesktopShell && setupCompleted === false && authenticated;
+    const simpleRoute = !setupRoute && uiMode === SIMPLE_MODE;
+    const route = setupRoute
+      ? "Setup"
+      : simpleRoute
+        ? simpleActiveScreen
+        : activeView;
+    const domains = hydrationDomainsForRoute(route, { simple: simpleRoute });
+    const projectId = activeProject?.id ?? null;
+    const controller = new AbortController();
+    const startedKeys = [];
+    const hydrationLedger = hydrationLedgerRef.current;
+    const refreshers = {
+      assets: (id, options) => refreshAssetsRef.current?.(id, options),
+      characters: (id, options) => refreshCharactersRef.current?.(id, options),
+      savedVoices: (id, options) => refreshSavedVoicesRef.current?.(id, options),
+      loras: (id, options) => refreshLorasRef.current?.(id, options),
+      presets: (id, options) => refreshPresetsRef.current?.(id, options),
+      promptBatches: (id, options) => refreshPromptBatchesRef.current?.(id, options),
+      trainingDatasets: (id, options) =>
+        refreshTrainingDatasetsRef.current?.(id, options),
+      personTracks: (id, options) => refreshPersonTracksRef.current?.(id, options),
+      timelines: (id, options) => refreshTimelinesRef.current?.(id, options),
+      models: (_id, options) => refreshModelsRef.current?.(options),
+      trainingTargets: (_id, options) =>
+        refreshTrainingTargetsRef.current?.(options),
+      trainingPresets: (_id, options) =>
+        refreshTrainingPresetsRef.current?.(options),
+    };
+
+    domains.forEach((domain) => {
+      if (isProjectHydrationDomain(domain) && !projectId) {
+        return;
+      }
+      const key = hydrationLedgerKey(domain, projectId);
+      const current = hydrationLedger.get(key);
+      if (current === "loading" || current === "ready") {
+        return;
+      }
+      const refresh = refreshers[domain];
+      if (!refresh) {
+        return;
+      }
+      hydrationLedger.set(key, "loading");
+      startedKeys.push(key);
+      Promise.resolve(
+        refresh(projectId, { signal: controller.signal }),
+      ).finally(() => {
+        if (controller.signal.aborted) {
+          hydrationLedger.delete(key);
+        } else {
+          hydrationLedger.set(key, "ready");
+        }
+      });
+    });
+
+    return () => {
+      controller.abort();
+      startedKeys.forEach((key) => {
+        if (hydrationLedger.get(key) === "loading") {
+          hydrationLedger.delete(key);
+        }
+      });
+    };
+  }, [
+    activeProject?.id,
+    activeView,
+    authenticated,
+    projectsLoaded,
+    ready,
+    setupCompleted,
+    simpleActiveScreen,
+    token,
+    uiMode,
+  ]);
+
+  async function hydrateLaunchDomains(view, projectId = activeProjectRef.current?.id) {
+    const domains = hydrationDomainsForRoute(view);
+    const refreshers = {
+      assets: (id) => refreshAssetsRef.current?.(id),
+      characters: (id) => refreshCharactersRef.current?.(id),
+      savedVoices: (id) => refreshSavedVoicesRef.current?.(id),
+      loras: (id) => refreshLorasRef.current?.(id),
+      presets: (id) => refreshPresetsRef.current?.(id),
+      promptBatches: (id) => refreshPromptBatchesRef.current?.(id),
+      trainingDatasets: (id) => refreshTrainingDatasetsRef.current?.(id),
+      personTracks: (id) => refreshPersonTracksRef.current?.(id),
+      timelines: (id) => refreshTimelinesRef.current?.(id),
+      models: () => refreshModelsRef.current?.(),
+      trainingTargets: () => refreshTrainingTargetsRef.current?.(),
+      trainingPresets: () => refreshTrainingPresetsRef.current?.(),
+    };
+    await Promise.all(
+      domains.map(async (domain) => {
+        if (isProjectHydrationDomain(domain) && !projectId) return;
+        const key = hydrationLedgerKey(domain, projectId);
+        if (hydrationLedgerRef.current.get(key) === "ready") return;
+        const refresh = refreshers[domain];
+        if (!refresh) return;
+        hydrationLedgerRef.current.set(key, "loading");
+        await refresh(projectId);
+        hydrationLedgerRef.current.set(key, "ready");
+      }),
+    );
+  }
 
   // saveToken / lockRemote (the remote-browser login + lock affordances, epic 4484
   // story 7) live in useAccessGate now (sc-9750) and are destructured above.
@@ -1915,7 +2122,7 @@ export function App() {
     return asset?.generationSet?.recipe ?? asset?.recipe ?? null;
   }
 
-  function sendAssetRecipeToImage(asset, options = {}) {
+  async function sendAssetRecipeToImage(asset, options = {}) {
     const recipe = recipeForAsset(asset);
     if (!asset || !recipe) {
       return;
@@ -1926,8 +2133,14 @@ export function App() {
     // Null → Image Studio leaves the seed random (a close variation), the default.
     const seed = assetSeed(asset);
     const replaySeed = options.keepSeed && seed != null && seed !== "" ? seed : null;
+    const projectId = activeProjectRef.current?.id;
     setSelectedAssetId(asset.id);
     closePreview();
+    setActiveView("Image");
+    await stableHydrateLaunchDomains("Image", projectId);
+    if (projectId && activeProjectRef.current?.id !== projectId) {
+      return;
+    }
     setStudioLaunch({
       id: crypto.randomUUID(),
       view: "Image",
@@ -1936,21 +2149,26 @@ export function App() {
       recipe,
       replaySeed,
     });
-    setActiveView("Image");
   }
 
   // sc-12324: the video twin of sendAssetRecipeToImage — re-run a generated clip from its own
   // recorded recipe, with or without its seed. Distinct from `sendAssetToVideo` below, which
   // sends an asset as a source clip/frame and replays no settings.
-  function sendAssetRecipeToVideo(asset, options = {}) {
+  async function sendAssetRecipeToVideo(asset, options = {}) {
     const recipe = recipeForAsset(asset);
     if (!asset || !recipe) {
       return;
     }
     const seed = assetSeed(asset);
     const replaySeed = options.keepSeed && seed != null && seed !== "" ? seed : null;
+    const projectId = activeProjectRef.current?.id;
     setSelectedAssetId(asset.id);
     closePreview();
+    setActiveView("Video");
+    await stableHydrateLaunchDomains("Video", projectId);
+    if (projectId && activeProjectRef.current?.id !== projectId) {
+      return;
+    }
     setStudioLaunch({
       id: crypto.randomUUID(),
       view: "Video",
@@ -1958,7 +2176,6 @@ export function App() {
       recipe,
       replaySeed,
     });
-    setActiveView("Video");
   }
 
   // Route the viewer's "Use this recipe" to the studio that can actually run the asset's recipe.
@@ -1978,7 +2195,7 @@ export function App() {
   // (generationStudio.jsx). So the launch carries the preset's model and sub-mode too,
   // and the studio sets all three together. `presetId` and `recipe` are mutually
   // exclusive — a recipe launch keeps clearing the preset.
-  const sendPresetToStudio = useCallback((preset) => {
+  const sendPresetToStudio = useCallback(async (preset) => {
     if (!preset?.id) {
       return;
     }
@@ -1987,11 +2204,18 @@ export function App() {
     // to Image Studio, and it stays active if the user switches to Video. Model presets keep
     // carrying model + sub-mode so they resolve in the target studio (sc-10516).
     if (preset.kind === "general") {
-      setStudioLaunch({ id: crypto.randomUUID(), view: "Image", presetGeneralId: preset.id });
+      const projectId = activeProjectRef.current?.id;
       setActiveView("Image");
+      await stableHydrateLaunchDomains("Image", projectId);
+      if (projectId && activeProjectRef.current?.id !== projectId) return;
+      setStudioLaunch({ id: crypto.randomUUID(), view: "Image", presetGeneralId: preset.id });
       return;
     }
     const view = workflowModelType(preset.workflow) === "video" ? "Video" : "Image";
+    const projectId = activeProjectRef.current?.id;
+    setActiveView(view);
+    await stableHydrateLaunchDomains(view, projectId);
+    if (projectId && activeProjectRef.current?.id !== projectId) return;
     setStudioLaunch({
       id: crypto.randomUUID(),
       view,
@@ -1999,8 +2223,7 @@ export function App() {
       presetModel: preset.model ?? null,
       presetMode: preset.defaults?.mode ?? preset.workflow,
     });
-    setActiveView(view);
-  }, []);
+  }, [stableHydrateLaunchDomains]);
 
   const sendAssetToVideo = useCallback((asset, mode = null) => {
     if (!asset) {
@@ -2636,6 +2859,7 @@ export function App() {
             lockedToSimple={uiModeLocked}
             onAccentChange={changeAccent}
             onModeChange={setUiModeOverride}
+            onScreenChange={setSimpleActiveScreen}
             onSimpleDefaultChange={changeSimpleUiDefault}
             simpleDefault={simpleUiDefault}
           />

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -12,7 +12,7 @@ import { Icon } from "./components/Icons.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
 import { FullscreenPreview, assetSeed } from "./components/assetPanels.jsx";
-import { fallbackModels, terminalStatuses } from "./constants.js";
+import { fallbackModels, isLibraryAsset, terminalStatuses } from "./constants.js";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
 import { PoseLibraryScreen } from "./screens/PoseLibraryScreen.jsx";
 import { KeyPointLibraryScreen } from "./screens/KeyPointLibraryScreen.jsx";
@@ -461,6 +461,10 @@ export function App() {
     () => (loadedAssetsProjectId === activeProject?.id ? loadedAssets : []),
     [activeProject?.id, loadedAssets, loadedAssetsProjectId],
   );
+  const hasLibraryConsumerAsset = useMemo(
+    () => assets.some(isLibraryAsset),
+    [assets],
+  );
   const selectedAssetId =
     loadedAssetsProjectId === activeProject?.id ? storedSelectedAssetId : null;
   // A project switch renders before its passive refresh effect runs. Treat that
@@ -646,6 +650,7 @@ export function App() {
   const refreshAssetsRef = useRef(null);
   const healthRequestRef = useRef(null);
   const hydrationLedgerRef = useRef(new Map());
+  const committedHydrationRouteRef = useRef(null);
   const previousHydrationProjectIdRef = useRef(null);
   // Latest purgeAsset, held in a ref so the App-level scratch-op survivor (sc-8850) can
   // purge orphaned scratch/result assets from the SSE handler without re-subscribing.
@@ -1667,6 +1672,20 @@ export function App() {
   // handlers, and React runs all layout effects before any passive effect — preserving
   // the original ordering where consumers saw the fresh closure.
   useLayoutEffect(() => {
+    const setupRoute =
+      isDesktopShell && setupCompleted === false && authenticated;
+    const simpleRoute = !setupRoute && uiMode === SIMPLE_MODE;
+    const route = setupRoute
+      ? "Setup"
+      : simpleRoute
+        ? simpleActiveScreen
+        : activeView;
+    const committedRoute = {
+      route,
+      simple: simpleRoute,
+      projectId: activeProject?.id ?? null,
+    };
+    committedHydrationRouteRef.current = committedRoute;
     refreshShellDataRef.current = refreshShellData;
     refreshModelsRef.current = refreshModels;
     refreshModelAndLorasRef.current = refreshModelAndLoras;
@@ -1682,6 +1701,11 @@ export function App() {
     refreshTrainingDatasetsRef.current = refreshTrainingDatasets;
     refreshPersonTracksRef.current = refreshPersonTracks;
     refreshTimelinesRef.current = refreshTimelines;
+    return () => {
+      if (committedHydrationRouteRef.current === committedRoute) {
+        committedHydrationRouteRef.current = null;
+      }
+    };
   });
 
   const hydrationRefresher = useCallback((domain) => {
@@ -1722,9 +1746,10 @@ export function App() {
     if (!refresh) {
       return Promise.resolve(refreshFailure("missing-refresher"));
     }
-    const entry = { status: "loading", promise: null };
+    const { abort: abortRequest = null, ...refreshOptions } = options;
+    const entry = { status: "loading", promise: null, abort: abortRequest };
     entry.promise = Promise.resolve()
-      .then(() => refresh(projectId, options))
+      .then(() => refresh(projectId, refreshOptions))
       .then((result) => {
         const normalized = result?.ok === true
           ? result
@@ -1770,7 +1795,7 @@ export function App() {
     const domains = hydrationDomainsForRoute(route, { simple: simpleRoute });
     const projectId = activeProject?.id ?? null;
     const controller = new AbortController();
-    const startedKeys = [];
+    const started = [];
     const hydrationLedger = hydrationLedgerRef.current;
 
     domains.forEach((domain) => {
@@ -1779,18 +1804,42 @@ export function App() {
       }
       const key = hydrationLedgerKey(domain, projectId);
       const current = hydrationLedger.get(key);
-      if (current?.status === "loading" || current?.status === "ready") {
+      if (current?.status === "loading") {
+        started.push({ domain, key });
         return;
       }
-      startedKeys.push(key);
-      ensureHydrationDomain(domain, projectId, { signal: controller.signal });
+      if (current?.status === "ready") {
+        return;
+      }
+      started.push({ domain, key });
+      ensureHydrationDomain(domain, projectId, {
+        signal: controller.signal,
+        abort: () => controller.abort(),
+      });
     });
 
     return () => {
+      const next = committedHydrationRouteRef.current;
+      const nextDomains = next
+        ? new Set([
+            ...hydrationDomainsForRoute(next.route, { simple: next.simple }),
+            ...hydrationDomainsForRoute(next.route, {
+              simple: next.simple,
+              deferred: true,
+            }),
+          ])
+        : new Set();
+      if (
+        next?.projectId === projectId &&
+        started.every(({ domain }) => nextDomains.has(domain))
+      ) {
+        return;
+      }
       controller.abort();
-      startedKeys.forEach((key) => {
+      started.forEach(({ key }) => {
         const entry = hydrationLedger.get(key);
         if (entry?.status === "loading") {
+          entry.abort?.();
           hydrationLedger.delete(key);
         }
       });
@@ -1805,6 +1854,75 @@ export function App() {
     setupCompleted,
     simpleActiveScreen,
     token,
+    uiMode,
+  ]);
+
+  // The default Library route paints from its project asset request first. Only
+  // after that catalog settles do we hydrate the secondary detail-panel domains:
+  // characters power "Move to Character", while models power image VQA and audio
+  // model metadata. This keeps startup assets-first without leaving direct Library
+  // entry with permanently incomplete controls.
+  useEffect(() => {
+    if (
+      !ready ||
+      !projectsLoaded ||
+      uiMode === SIMPLE_MODE ||
+      activeView !== "Library" ||
+      !activeProject?.id ||
+      activeAssetLoadState.status !== "ready" ||
+      !hasLibraryConsumerAsset
+    ) {
+      return;
+    }
+    const controller = new AbortController();
+    const domains = hydrationDomainsForRoute("Library", { deferred: true });
+    const startedKeys = [];
+    const hydrationLedger = hydrationLedgerRef.current;
+    domains.forEach((domain) => {
+      const key = hydrationLedgerKey(domain, activeProject.id);
+      const current = hydrationLedger.get(key);
+      if (current?.status !== "ready") {
+        startedKeys.push(key);
+      }
+      ensureHydrationDomain(domain, activeProject.id, {
+        signal: controller.signal,
+        abort: () => controller.abort(),
+      });
+    });
+    return () => {
+      const next = committedHydrationRouteRef.current;
+      const nextDomains = next
+        ? new Set([
+            ...hydrationDomainsForRoute(next.route, { simple: next.simple }),
+            ...hydrationDomainsForRoute(next.route, {
+              simple: next.simple,
+              deferred: true,
+            }),
+          ])
+        : new Set();
+      if (
+        next?.projectId === activeProject.id &&
+        domains.every((domain) => nextDomains.has(domain))
+      ) {
+        return;
+      }
+      controller.abort();
+      startedKeys.forEach((key) => {
+        const entry = hydrationLedger.get(key);
+        if (entry?.status === "loading") {
+          entry.abort?.();
+          hydrationLedger.delete(key);
+        }
+      });
+    };
+  }, [
+    activeAssetLoadState.status,
+    activeProject?.id,
+    activeView,
+    ensureHydrationDomain,
+    hasLibraryConsumerAsset,
+    projectsLoaded,
+    ready,
     uiMode,
   ]);
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -100,6 +100,7 @@ import {
   hydrationLedgerKey,
   isProjectHydrationDomain,
 } from "./appHydration.js";
+import { refreshFailure, refreshSuccess } from "./refreshResult.js";
 
 // Desktop (Tauri) shell detection (unified helper, epic 4484 story 6). The first-run
 // setup wizard is desktop-only; web/Docker (and a remote LAN browser) keep the
@@ -1563,11 +1564,11 @@ export function App() {
       const items = await apiFetch("/api/v1/models", token, { signal });
       setModels(items);
       domainErrors.models("");
-      return items;
+      return refreshSuccess(items);
     } catch (err) {
-      if (isAbortError(err)) return [];
+      if (isAbortError(err)) return refreshFailure("aborted", err);
       domainErrors.models(err.message);
-      return [];
+      return refreshFailure("error", err);
     }
   }
 
@@ -1577,12 +1578,12 @@ export function App() {
       setTrainingTargets(catalog);
       setTrainingTargetsError("");
       domainErrors.trainingTargets("");
-      return catalog;
+      return refreshSuccess(catalog);
     } catch (err) {
-      if (isAbortError(err)) return null;
+      if (isAbortError(err)) return refreshFailure("aborted", err);
       setTrainingTargetsError(err.message);
       domainErrors.trainingTargets(err.message);
-      return null;
+      return refreshFailure("error", err);
     }
   }
 
@@ -1592,25 +1593,25 @@ export function App() {
       setTrainingPresets(catalog);
       setTrainingPresetsError("");
       domainErrors.trainingPresets("");
-      return catalog;
+      return refreshSuccess(catalog);
     } catch (err) {
-      if (isAbortError(err)) return null;
+      if (isAbortError(err)) return refreshFailure("aborted", err);
       setTrainingPresetsError(err.message);
       domainErrors.trainingPresets(err.message);
-      return null;
+      return refreshFailure("error", err);
     }
   }
 
   async function refreshAssets(projectId = activeProject?.id, { signal } = {}) {
     if (!projectId) {
-      return;
+      return refreshFailure("missing-project");
     }
     // SSE job events may describe a background project. Use this render's
     // project, not activeProjectRef: that ref advances in a passive effect while
     // this closure is published from a layout effect. During A→B, the published
     // B closure must reject an A refresh before the passive ref catches up.
     if (!isCurrentProjectRequest(activeProject?.id ?? null, projectId)) {
-      return;
+      return refreshFailure("stale");
     }
     // Keep an already-settled grid usable during background/SSE refreshes.
     // Initial loads, retries, and project switches still expose "loading".
@@ -1627,20 +1628,22 @@ export function App() {
       // project's assets with the old one's. Drop the stale response — mirrors
       // refreshTimelines' guard (useTimelines.js).
       if (!isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId)) {
-        return;
+        return refreshFailure("stale");
       }
       setAssets(items);
       setLoadedAssetsProjectId(projectId);
       setSelectedAssetId((current) => reconcileSelectedAssetId(items, current));
       setAssetLoadState({ projectId, status: "ready", error: "" });
       domainErrors.assets("");
+      return refreshSuccess(items);
     } catch (err) {
-      if (isAbortError(err)) return;
       if (!isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId)) {
-        return;
+        return refreshFailure("stale", err);
       }
+      if (isAbortError(err)) return refreshFailure("aborted", err);
       setAssetLoadState({ projectId, status: "error", error: err.message });
       domainErrors.assets(err.message);
+      return refreshFailure("error", err);
     } finally {
       settleAssetRequest(timingStartedAt);
     }
@@ -1681,6 +1684,74 @@ export function App() {
     refreshTimelinesRef.current = refreshTimelines;
   });
 
+  const hydrationRefresher = useCallback((domain) => {
+    const refreshers = {
+      assets: (id, options) => refreshAssetsRef.current?.(id, options),
+      characters: (id, options) => refreshCharactersRef.current?.(id, options),
+      savedVoices: (id, options) => refreshSavedVoicesRef.current?.(id, options),
+      loras: (id, options) => refreshLorasRef.current?.(id, options),
+      presets: (id, options) => refreshPresetsRef.current?.(id, options),
+      promptBatches: (id, options) => refreshPromptBatchesRef.current?.(id, options),
+      trainingDatasets: (id, options) =>
+        refreshTrainingDatasetsRef.current?.(id, options),
+      personTracks: (id, options) => refreshPersonTracksRef.current?.(id, options),
+      timelines: (id, options) => refreshTimelinesRef.current?.(id, options),
+      models: (_id, options) => refreshModelsRef.current?.(options),
+      trainingTargets: (_id, options) =>
+        refreshTrainingTargetsRef.current?.(options),
+      trainingPresets: (_id, options) =>
+        refreshTrainingPresetsRef.current?.(options),
+    };
+    return refreshers[domain];
+  }, []);
+
+  const ensureHydrationDomain = useCallback((domain, projectId, options = {}) => {
+    if (isProjectHydrationDomain(domain) && !projectId) {
+      return Promise.resolve(refreshFailure("missing-project"));
+    }
+    const ledger = hydrationLedgerRef.current;
+    const key = hydrationLedgerKey(domain, projectId);
+    const current = ledger.get(key);
+    if (current?.status === "ready") {
+      return Promise.resolve(refreshSuccess());
+    }
+    if (current?.status === "loading") {
+      return current.promise;
+    }
+    const refresh = hydrationRefresher(domain);
+    if (!refresh) {
+      return Promise.resolve(refreshFailure("missing-refresher"));
+    }
+    const entry = { status: "loading", promise: null };
+    entry.promise = Promise.resolve()
+      .then(() => refresh(projectId, options))
+      .then((result) => {
+        const normalized = result?.ok === true
+          ? result
+          : result?.ok === false
+            ? result
+            : refreshFailure("error", new Error(`${domain} refresh did not report success`));
+        if (ledger.get(key) === entry) {
+          ledger.set(
+            key,
+            normalized.ok
+              ? { status: "ready" }
+              : { status: "error", reason: normalized.reason, error: normalized.error },
+          );
+        }
+        return normalized;
+      })
+      .catch((error) => {
+        const result = refreshFailure("error", error);
+        if (ledger.get(key) === entry) {
+          ledger.set(key, { status: "error", reason: result.reason, error });
+        }
+        return result;
+      });
+    ledger.set(key, entry);
+    return entry.promise;
+  }, [hydrationRefresher]);
+
   // Hydrate only the active screen's domains. Each ledger entry is global or
   // project-keyed, so keep-alive navigation reuses settled catalogs while a
   // project switch loads fresh overlays without discarding global state.
@@ -1701,23 +1772,6 @@ export function App() {
     const controller = new AbortController();
     const startedKeys = [];
     const hydrationLedger = hydrationLedgerRef.current;
-    const refreshers = {
-      assets: (id, options) => refreshAssetsRef.current?.(id, options),
-      characters: (id, options) => refreshCharactersRef.current?.(id, options),
-      savedVoices: (id, options) => refreshSavedVoicesRef.current?.(id, options),
-      loras: (id, options) => refreshLorasRef.current?.(id, options),
-      presets: (id, options) => refreshPresetsRef.current?.(id, options),
-      promptBatches: (id, options) => refreshPromptBatchesRef.current?.(id, options),
-      trainingDatasets: (id, options) =>
-        refreshTrainingDatasetsRef.current?.(id, options),
-      personTracks: (id, options) => refreshPersonTracksRef.current?.(id, options),
-      timelines: (id, options) => refreshTimelinesRef.current?.(id, options),
-      models: (_id, options) => refreshModelsRef.current?.(options),
-      trainingTargets: (_id, options) =>
-        refreshTrainingTargetsRef.current?.(options),
-      trainingPresets: (_id, options) =>
-        refreshTrainingPresetsRef.current?.(options),
-    };
 
     domains.forEach((domain) => {
       if (isProjectHydrationDomain(domain) && !projectId) {
@@ -1725,30 +1779,18 @@ export function App() {
       }
       const key = hydrationLedgerKey(domain, projectId);
       const current = hydrationLedger.get(key);
-      if (current === "loading" || current === "ready") {
+      if (current?.status === "loading" || current?.status === "ready") {
         return;
       }
-      const refresh = refreshers[domain];
-      if (!refresh) {
-        return;
-      }
-      hydrationLedger.set(key, "loading");
       startedKeys.push(key);
-      Promise.resolve(
-        refresh(projectId, { signal: controller.signal }),
-      ).finally(() => {
-        if (controller.signal.aborted) {
-          hydrationLedger.delete(key);
-        } else {
-          hydrationLedger.set(key, "ready");
-        }
-      });
+      ensureHydrationDomain(domain, projectId, { signal: controller.signal });
     });
 
     return () => {
       controller.abort();
       startedKeys.forEach((key) => {
-        if (hydrationLedger.get(key) === "loading") {
+        const entry = hydrationLedger.get(key);
+        if (entry?.status === "loading") {
           hydrationLedger.delete(key);
         }
       });
@@ -1757,6 +1799,7 @@ export function App() {
     activeProject?.id,
     activeView,
     authenticated,
+    ensureHydrationDomain,
     projectsLoaded,
     ready,
     setupCompleted,
@@ -1767,32 +1810,13 @@ export function App() {
 
   async function hydrateLaunchDomains(view, projectId = activeProjectRef.current?.id) {
     const domains = hydrationDomainsForRoute(view);
-    const refreshers = {
-      assets: (id) => refreshAssetsRef.current?.(id),
-      characters: (id) => refreshCharactersRef.current?.(id),
-      savedVoices: (id) => refreshSavedVoicesRef.current?.(id),
-      loras: (id) => refreshLorasRef.current?.(id),
-      presets: (id) => refreshPresetsRef.current?.(id),
-      promptBatches: (id) => refreshPromptBatchesRef.current?.(id),
-      trainingDatasets: (id) => refreshTrainingDatasetsRef.current?.(id),
-      personTracks: (id) => refreshPersonTracksRef.current?.(id),
-      timelines: (id) => refreshTimelinesRef.current?.(id),
-      models: () => refreshModelsRef.current?.(),
-      trainingTargets: () => refreshTrainingTargetsRef.current?.(),
-      trainingPresets: () => refreshTrainingPresetsRef.current?.(),
-    };
-    await Promise.all(
-      domains.map(async (domain) => {
-        if (isProjectHydrationDomain(domain) && !projectId) return;
-        const key = hydrationLedgerKey(domain, projectId);
-        if (hydrationLedgerRef.current.get(key) === "ready") return;
-        const refresh = refreshers[domain];
-        if (!refresh) return;
-        hydrationLedgerRef.current.set(key, "loading");
-        await refresh(projectId);
-        hydrationLedgerRef.current.set(key, "ready");
-      }),
+    const results = await Promise.all(
+      domains.map((domain) => ensureHydrationDomain(domain, projectId)),
     );
+    const failed = results.filter((result) => result?.ok !== true);
+    return failed.length
+      ? { ok: false, failures: failed }
+      : refreshSuccess();
   }
 
   // saveToken / lockRemote (the remote-browser login + lock affordances, epic 4484
@@ -2137,8 +2161,8 @@ export function App() {
     setSelectedAssetId(asset.id);
     closePreview();
     setActiveView("Image");
-    await stableHydrateLaunchDomains("Image", projectId);
-    if (projectId && activeProjectRef.current?.id !== projectId) {
+    const hydration = await stableHydrateLaunchDomains("Image", projectId);
+    if (hydration?.ok !== true || activeProjectRef.current?.id !== projectId) {
       return;
     }
     setStudioLaunch({
@@ -2165,8 +2189,8 @@ export function App() {
     setSelectedAssetId(asset.id);
     closePreview();
     setActiveView("Video");
-    await stableHydrateLaunchDomains("Video", projectId);
-    if (projectId && activeProjectRef.current?.id !== projectId) {
+    const hydration = await stableHydrateLaunchDomains("Video", projectId);
+    if (hydration?.ok !== true || activeProjectRef.current?.id !== projectId) {
       return;
     }
     setStudioLaunch({
@@ -2206,16 +2230,16 @@ export function App() {
     if (preset.kind === "general") {
       const projectId = activeProjectRef.current?.id;
       setActiveView("Image");
-      await stableHydrateLaunchDomains("Image", projectId);
-      if (projectId && activeProjectRef.current?.id !== projectId) return;
+      const hydration = await stableHydrateLaunchDomains("Image", projectId);
+      if (hydration?.ok !== true || activeProjectRef.current?.id !== projectId) return;
       setStudioLaunch({ id: crypto.randomUUID(), view: "Image", presetGeneralId: preset.id });
       return;
     }
     const view = workflowModelType(preset.workflow) === "video" ? "Video" : "Image";
     const projectId = activeProjectRef.current?.id;
     setActiveView(view);
-    await stableHydrateLaunchDomains(view, projectId);
-    if (projectId && activeProjectRef.current?.id !== projectId) return;
+    const hydration = await stableHydrateLaunchDomains(view, projectId);
+    if (hydration?.ok !== true || activeProjectRef.current?.id !== projectId) return;
     setStudioLaunch({
       id: crypto.randomUUID(),
       view,

--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -429,7 +429,7 @@ describe("SceneWorks app shell", () => {
     const loraRequests = global.fetch.mock.calls
       .map(([url]) => new URL(url))
       .filter((url) => url.pathname.endsWith("/loras"));
-    expect(loraRequests.some((url) => url.search === "")).toBe(true);
+    expect(loraRequests.some((url) => url.search === "")).toBe(false);
     expect(loraRequests.some((url) => url.search === "?projectId=project-1")).toBe(true);
   });
 
@@ -474,7 +474,7 @@ describe("SceneWorks app shell", () => {
     const loraRequests = global.fetch.mock.calls
       .map(([url]) => new URL(url))
       .filter((url) => url.pathname.endsWith("/loras"));
-    expect(loraRequests.some((url) => url.search === "")).toBe(true);
+    expect(loraRequests.some((url) => url.search === "")).toBe(false);
     expect(loraRequests.some((url) => url.search === "?projectId=project-1")).toBe(true);
   });
 

--- a/apps/web/src/App.routeHydration.test.jsx
+++ b/apps/web/src/App.routeHydration.test.jsx
@@ -175,9 +175,102 @@ describe("route-owned App hydration (sc-14783)", () => {
     expect(container.textContent).toContain("Mara portrait set");
   });
 
+  it("hydrates Library detail catalogs after assets settle so direct-entry controls are complete", async () => {
+    const assetRequest = deferred();
+    installFetch({
+      "/api/v1/projects/project-a/assets": () => assetRequest.promise,
+      "/api/v1/projects/project-a/characters": () =>
+        Promise.resolve(response([{ id: "character-a", name: "Mara", projectId: "project-a" }])),
+      "/api/v1/models": () =>
+        Promise.resolve(response([{
+          id: "vqa-model",
+          name: "Vision QA",
+          type: "image",
+          capabilities: ["vqa"],
+        }])),
+    });
+    await renderApp();
+
+    let counts = requestCounts();
+    expect(counts["/api/v1/projects/project-a/characters"]).toBeUndefined();
+    expect(counts["/api/v1/models"]).toBeUndefined();
+
+    await act(async () => {
+      assetRequest.resolve(response([{
+        id: "library-image",
+        projectId: "project-a",
+        type: "image",
+        displayName: "Library portrait",
+        file: { path: "portrait.png", mimeType: "image/png" },
+        status: { favorite: false, rating: 0, rejected: false, trashed: false },
+      }]));
+    });
+    await settle();
+
+    counts = requestCounts();
+    expect(counts["/api/v1/projects/project-a/characters"]).toBe(1);
+    expect(counts["/api/v1/models"]).toBe(1);
+    expect(container.querySelector('select[aria-label="Target character"]')?.textContent).toContain("Mara");
+    expect(container.querySelector('textarea[aria-label="Ask about this image"]')).toBeTruthy();
+  });
+
+  it("retains Library's pending asset hydration when Queue becomes the active consumer", async () => {
+    const assetsRequest = deferred();
+    let assetSignal;
+    installFetch({
+      "/api/v1/projects/project-a/assets": (_url, options) => {
+        assetSignal = options.signal;
+        return assetsRequest.promise;
+      },
+      "/api/v1/jobs": () =>
+        Promise.resolve(response([{
+          id: "historical-job",
+          projectId: "project-a",
+          projectName: "Project A",
+          type: "image_generate",
+          status: "completed",
+          createdAt: "2026-07-26T01:00:00Z",
+          updatedAt: "2026-07-26T01:01:00Z",
+          payload: { prompt: "historical" },
+          result: { assetIds: ["historical-asset"] },
+        }])),
+    });
+    await renderApp();
+    expect(requestCounts()["/api/v1/projects/project-a/assets"]).toBe(1);
+    expect(assetSignal?.aborted).toBe(false);
+
+    await navigate("Queue");
+    expect(assetSignal?.aborted).toBe(false);
+    expect(requestCounts()["/api/v1/projects/project-a/assets"]).toBe(1);
+
+    await act(async () => {
+      assetsRequest.resolve(response([{
+        id: "historical-asset",
+        projectId: "project-a",
+        type: "image",
+        displayName: "Historical thumbnail",
+        file: { path: "historical.png", mimeType: "image/png" },
+        status: { favorite: false, rating: 0, rejected: false, trashed: false },
+      }]));
+    });
+    await settle();
+
+    expect(
+      container.querySelector('button[aria-label="Historical thumbnail"]'),
+    ).toBeTruthy();
+  });
+
   it("retries a failed hydration domain when its route is revisited", async () => {
     let modelAttempts = 0;
     installFetch({
+      "/api/v1/projects/project-a/assets": () =>
+        Promise.resolve(response([{
+          id: "library-image",
+          projectId: "project-a",
+          type: "image",
+          displayName: "Library image",
+          status: {},
+        }])),
       "/api/v1/models": () => {
         modelAttempts += 1;
         return modelAttempts === 1
@@ -187,11 +280,8 @@ describe("route-owned App hydration (sc-14783)", () => {
     });
     await renderApp();
 
-    await navigate("Models");
     expect(container.textContent).toContain("model catalog unavailable");
     expect(modelAttempts).toBe(1);
-
-    await navigate("Assets");
     await navigate("Models");
     expect(modelAttempts).toBe(2);
     expect(container.textContent).not.toContain("model catalog unavailable");

--- a/apps/web/src/App.routeHydration.test.jsx
+++ b/apps/web/src/App.routeHydration.test.jsx
@@ -1,0 +1,263 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function requestPath(url) {
+  return new URL(url, window.location.origin).pathname;
+}
+
+function requestCounts() {
+  return global.fetch.mock.calls.reduce((counts, [url]) => {
+    const path = requestPath(url);
+    counts[path] = (counts[path] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+describe("route-owned App hydration (sc-14783)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function installFetch(overrides = {}) {
+    global.fetch = vi.fn((url, options = {}) => {
+      const requestUrl = new URL(url);
+      const path = requestUrl.pathname;
+      if (overrides[path]) return overrides[path](requestUrl, options);
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-a", name: "Project A" }]));
+      }
+      if (path.endsWith("/training/targets")) {
+        return Promise.resolve(response({ schemaVersion: 1, targets: [] }));
+      }
+      if (path.endsWith("/training/presets")) {
+        return Promise.resolve(response({ schemaVersion: 1, presets: [] }));
+      }
+      if (path.endsWith("/jobs") || path.endsWith("/workers")) {
+        return Promise.resolve(response([]));
+      }
+      return Promise.resolve(response([]));
+    });
+  }
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  async function navigate(label) {
+    const button = [...container.querySelectorAll(".nav-item")].find(
+      (candidate) => candidate.textContent.trim() === label,
+    );
+    expect(button, `navigation button ${label}`).toBeTruthy();
+    await act(async () => {
+      button.click();
+    });
+    await settle();
+  }
+
+  it("hydrates late global/project domains once, on first consumer navigation", async () => {
+    installFetch();
+    await renderApp();
+
+    let counts = requestCounts();
+    expect(counts["/api/v1/projects/project-a/assets"]).toBe(1);
+    [
+      "/api/v1/models",
+      "/api/v1/loras",
+      "/api/v1/recipe-presets",
+      "/api/v1/prompt-batches",
+      "/api/v1/training/targets",
+      "/api/v1/training/presets",
+      "/api/v1/projects/project-a/training/datasets",
+      "/api/v1/projects/project-a/timelines",
+      "/api/v1/projects/project-a/voices",
+      "/api/v1/projects/project-a/characters",
+      "/api/v1/projects/project-a/person-tracks",
+    ].forEach((path) => expect(counts[path]).toBeUndefined());
+
+    await navigate("Train");
+    counts = requestCounts();
+    expect(counts["/api/v1/models"]).toBe(1);
+    expect(counts["/api/v1/loras"]).toBeUndefined();
+    expect(counts["/api/v1/training/targets"]).toBe(1);
+    expect(counts["/api/v1/training/presets"]).toBe(1);
+    expect(counts["/api/v1/projects/project-a/training/datasets"]).toBe(1);
+
+    await navigate("Video Editor");
+    await navigate("Audio");
+    await navigate("Characters");
+    await navigate("Image");
+    await navigate("Video");
+    counts = requestCounts();
+    expect(counts["/api/v1/loras"]).toBe(1);
+    expect(counts["/api/v1/projects/project-a/timelines"]).toBe(1);
+    expect(counts["/api/v1/recipe-presets"]).toBe(1);
+    expect(counts["/api/v1/projects/project-a/voices"]).toBe(1);
+    expect(counts["/api/v1/projects/project-a/characters"]).toBe(1);
+    expect(counts["/api/v1/prompt-batches"]).toBe(1);
+    expect(counts["/api/v1/projects/project-a/person-tracks"]).toBe(1);
+
+    await navigate("Assets");
+    await navigate("Train");
+    counts = requestCounts();
+    expect(counts["/api/v1/projects/project-a/assets"]).toBe(1);
+    expect(counts["/api/v1/models"]).toBe(1);
+    expect(counts["/api/v1/training/targets"]).toBe(1);
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it("refreshes only model-dependent domains for completed model and LoRA jobs", async () => {
+    installFetch();
+    await renderApp();
+    expect(FakeEventSource.instances).toHaveLength(1);
+    const source = FakeEventSource.instances[0];
+    const before = requestCounts();
+
+    await act(async () => {
+      source.listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "model-job",
+          projectId: "project-a",
+          status: "completed",
+          type: "model_import",
+          createdAt: "2026-07-26T01:00:00Z",
+          updatedAt: "2026-07-26T01:00:00Z",
+        }),
+        lastEventId: "10",
+      });
+    });
+    await settle();
+    let counts = requestCounts();
+    expect(counts["/api/v1/models"]).toBe((before["/api/v1/models"] ?? 0) + 1);
+
+    await act(async () => {
+      source.listeners["job.updated"]({
+        data: JSON.stringify({
+          id: "lora-job",
+          projectId: "project-a",
+          status: "completed",
+          type: "lora_import",
+          createdAt: "2026-07-26T01:01:00Z",
+          updatedAt: "2026-07-26T01:01:00Z",
+        }),
+        lastEventId: "11",
+      });
+    });
+    await settle();
+    counts = requestCounts();
+    expect(counts["/api/v1/models"]).toBe((before["/api/v1/models"] ?? 0) + 2);
+    expect(counts["/api/v1/loras"]).toBe((before["/api/v1/loras"] ?? 0) + 1);
+
+    [
+      "/api/v1/projects",
+      "/api/v1/jobs",
+      "/api/v1/workers",
+      "/api/v1/projects/project-a/assets",
+      "/api/v1/training/targets",
+      "/api/v1/training/presets",
+      "/api/v1/projects/project-a/training/datasets",
+      "/api/v1/prompt-batches",
+    ].forEach((path) => expect(counts[path] ?? 0).toBe(before[path] ?? 0));
+  });
+
+  it("does not let a successful sibling domain erase an unrelated error", async () => {
+    installFetch({
+      "/api/v1/models": () => Promise.reject(new Error("model catalog unavailable")),
+      "/api/v1/loras": () => Promise.resolve(response([{ id: "lora-a" }])),
+    });
+    await renderApp();
+    await navigate("Models");
+
+    expect(container.textContent).toContain("model catalog unavailable");
+    expect(requestCounts()["/api/v1/loras"]).toBe(1);
+
+    await navigate("Assets");
+    expect(container.textContent).toContain("model catalog unavailable");
+  });
+
+  it("aborts and suppresses stale route-domain work on a project switch", async () => {
+    const projectACharacters = deferred();
+    let projectASignal;
+    installFetch({
+      "/api/v1/projects": () =>
+        Promise.resolve(
+          response([
+            { id: "project-a", name: "Project A" },
+            { id: "project-b", name: "Project B" },
+          ]),
+        ),
+      "/api/v1/projects/project-a/characters": (_url, options) => {
+        projectASignal = options.signal;
+        return projectACharacters.promise;
+      },
+      "/api/v1/projects/project-b/characters": () =>
+        Promise.resolve(
+          response([{ id: "character-b", name: "Character B", projectId: "project-b" }]),
+        ),
+    });
+    await renderApp();
+    await navigate("Characters");
+    expect(projectASignal?.aborted).toBe(false);
+
+    await act(async () => {
+      container.querySelector(".project-pill").click();
+    });
+    const projectB = [...container.querySelectorAll('[role="option"]')].find(
+      (option) => option.textContent.includes("Project B"),
+    );
+    expect(projectB).toBeTruthy();
+    await act(async () => {
+      projectB.click();
+    });
+    await settle();
+
+    expect(projectASignal.aborted).toBe(true);
+    expect(container.textContent).toContain("Character B");
+    await act(async () => {
+      projectACharacters.resolve(
+        response([{ id: "character-a", name: "Character A", projectId: "project-a" }]),
+      );
+    });
+    await settle();
+    expect(container.textContent).not.toContain("Character A");
+    expect(container.textContent).toContain("Character B");
+  });
+});

--- a/apps/web/src/App.routeHydration.test.jsx
+++ b/apps/web/src/App.routeHydration.test.jsx
@@ -144,6 +144,103 @@ describe("route-owned App hydration (sc-14783)", () => {
     expect(FakeEventSource.instances).toHaveLength(1);
   });
 
+  it("hydrates and renders character training datasets on first Characters navigation", async () => {
+    installFetch({
+      "/api/v1/projects/project-a/characters": () =>
+        Promise.resolve(response([{ id: "character-a", name: "Mara", projectId: "project-a" }])),
+      "/api/v1/projects/project-a/training/datasets": () =>
+        Promise.resolve(response([{
+          id: "dataset-a",
+          name: "Mara portrait set",
+          characterId: "character-a",
+          itemCount: 4,
+          status: "draft",
+        }])),
+    });
+    await renderApp();
+
+    expect(requestCounts()["/api/v1/projects/project-a/training/datasets"]).toBeUndefined();
+    await navigate("Characters");
+    expect(requestCounts()["/api/v1/projects/project-a/training/datasets"]).toBe(1);
+
+    const assetsTab = [...container.querySelectorAll('[role="tab"]')].find(
+      (candidate) => candidate.textContent.trim() === "Assets",
+    );
+    expect(assetsTab).toBeTruthy();
+    await act(async () => {
+      assetsTab.click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("Mara portrait set");
+  });
+
+  it("retries a failed hydration domain when its route is revisited", async () => {
+    let modelAttempts = 0;
+    installFetch({
+      "/api/v1/models": () => {
+        modelAttempts += 1;
+        return modelAttempts === 1
+          ? Promise.reject(new Error("model catalog unavailable"))
+          : Promise.resolve(response([{ id: "model-a", name: "Recovered Model", type: "image" }]));
+      },
+    });
+    await renderApp();
+
+    await navigate("Models");
+    expect(container.textContent).toContain("model catalog unavailable");
+    expect(modelAttempts).toBe(1);
+
+    await navigate("Assets");
+    await navigate("Models");
+    expect(modelAttempts).toBe(2);
+    expect(container.textContent).not.toContain("model catalog unavailable");
+    expect(container.textContent).toContain("Recovered Model");
+  });
+
+  it("does not apply a late recipe launch when required catalog hydration fails", async () => {
+    const asset = {
+      id: "asset-recipe",
+      projectId: "project-a",
+      type: "image",
+      displayName: "Recipe source",
+      file: { path: "source.png", mimeType: "image/png" },
+      status: { favorite: false, rating: 0, rejected: false, trashed: false },
+      generationSet: {
+        recipe: {
+          mode: "text_to_image",
+          model: "missing-model",
+          prompt: "must not be applied after failure",
+        },
+      },
+    };
+    installFetch({
+      "/api/v1/projects/project-a/assets": () => Promise.resolve(response([asset])),
+      "/api/v1/models": () => Promise.reject(new Error("model catalog unavailable")),
+    });
+    await renderApp();
+
+    const tile = container.querySelector(".asset-tile");
+    expect(tile).toBeTruthy();
+    await act(async () => {
+      tile.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    await settle();
+    const useRecipe = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Use this recipe",
+    );
+    expect(useRecipe).toBeTruthy();
+    await act(async () => {
+      useRecipe.click();
+    });
+    await settle();
+
+    expect(container.textContent).toContain("model catalog unavailable");
+    expect(container.querySelector('.image-studio textarea')?.value ?? "").not.toContain(
+      "must not be applied after failure",
+    );
+  });
+
   it("refreshes only model-dependent domains for completed model and LoRA jobs", async () => {
     installFetch();
     await renderApp();

--- a/apps/web/src/appHydration.js
+++ b/apps/web/src/appHydration.js
@@ -24,7 +24,7 @@ export const PROJECT_HYDRATION_DOMAINS = Object.freeze(
 
 const ADVANCED_ROUTE_DOMAINS = Object.freeze({
   Library: ["assets"],
-  Queue: [],
+  Queue: ["assets"],
   Models: ["models", "loras"],
   Settings: [],
   Stats: [],
@@ -59,6 +59,13 @@ const ADVANCED_ROUTE_DOMAINS = Object.freeze({
   Setup: ["models"],
 });
 
+// Default Library startup remains assets-first so its first useful paint is not
+// blocked by secondary catalogs. Once assets settle, the selected detail panel
+// needs these domains for character linking, image VQA, and audio model labels.
+const DEFERRED_ROUTE_DOMAINS = Object.freeze({
+  Library: ["characters", "models"],
+});
+
 const SIMPLE_ROUTE_DOMAINS = Object.freeze({
   image: ["assets", "models", "loras"],
   video: ["assets", "models"],
@@ -70,7 +77,10 @@ const SIMPLE_ROUTE_DOMAINS = Object.freeze({
   licenses: [],
 });
 
-export function hydrationDomainsForRoute(route, { simple = false } = {}) {
+export function hydrationDomainsForRoute(route, { simple = false, deferred = false } = {}) {
+  if (deferred) {
+    return simple ? [] : DEFERRED_ROUTE_DOMAINS[route] ?? [];
+  }
   const source = simple ? SIMPLE_ROUTE_DOMAINS : ADVANCED_ROUTE_DOMAINS;
   return source[route] ?? [];
 }

--- a/apps/web/src/appHydration.js
+++ b/apps/web/src/appHydration.js
@@ -1,0 +1,86 @@
+// Route-owned catalog hydration (sc-14783).
+//
+// Domains are deliberately explicit instead of inferred from component imports. That
+// keeps startup/network behavior reviewable and gives tests a deterministic request
+// contract. Global domains survive project switches; project domains are keyed by the
+// active project and are reset/reloaded only when a consumer route needs them.
+export const GLOBAL_HYDRATION_DOMAINS = Object.freeze(
+  new Set(["models", "trainingTargets", "trainingPresets"]),
+);
+
+export const PROJECT_HYDRATION_DOMAINS = Object.freeze(
+  new Set([
+    "assets",
+    "characters",
+    "savedVoices",
+    "loras",
+    "presets",
+    "promptBatches",
+    "trainingDatasets",
+    "personTracks",
+    "timelines",
+  ]),
+);
+
+const ADVANCED_ROUTE_DOMAINS = Object.freeze({
+  Library: ["assets"],
+  Queue: [],
+  Models: ["models", "loras"],
+  Settings: [],
+  Stats: [],
+  Logs: [],
+  Licenses: [],
+  Image: ["assets", "models", "loras", "presets", "promptBatches", "characters"],
+  Video: ["assets", "models", "loras", "presets", "characters", "personTracks"],
+  Audio: ["assets", "models", "savedVoices"],
+  Characters: ["assets", "characters", "models", "loras", "presets"],
+  Document: ["assets", "models"],
+  Train: [
+    "assets",
+    "characters",
+    "models",
+    "trainingTargets",
+    "trainingPresets",
+    "trainingDatasets",
+  ],
+  LibraryDataSets: [
+    "assets",
+    "characters",
+    "models",
+    "trainingTargets",
+    "trainingPresets",
+    "trainingDatasets",
+  ],
+  Poses: ["assets", "characters"],
+  Keypoints: ["assets", "characters"],
+  Presets: ["models", "loras", "presets"],
+  Editor: ["assets", "characters", "models", "loras", "presets", "timelines"],
+  ImageEditor: ["assets", "characters", "models", "loras"],
+  Setup: ["models"],
+});
+
+const SIMPLE_ROUTE_DOMAINS = Object.freeze({
+  image: ["assets", "models", "loras"],
+  video: ["assets", "models"],
+  audio: ["assets", "models"],
+  assets: ["assets"],
+  models: ["models", "loras"],
+  queue: [],
+  settings: [],
+  licenses: [],
+});
+
+export function hydrationDomainsForRoute(route, { simple = false } = {}) {
+  const source = simple ? SIMPLE_ROUTE_DOMAINS : ADVANCED_ROUTE_DOMAINS;
+  return source[route] ?? [];
+}
+
+export function hydrationLedgerKey(domain, projectId = null) {
+  return PROJECT_HYDRATION_DOMAINS.has(domain)
+    ? `${domain}:project:${projectId ?? "none"}`
+    : `${domain}:global`;
+}
+
+export function isProjectHydrationDomain(domain) {
+  return PROJECT_HYDRATION_DOMAINS.has(domain);
+}

--- a/apps/web/src/appHydration.js
+++ b/apps/web/src/appHydration.js
@@ -33,7 +33,7 @@ const ADVANCED_ROUTE_DOMAINS = Object.freeze({
   Image: ["assets", "models", "loras", "presets", "promptBatches", "characters"],
   Video: ["assets", "models", "loras", "presets", "characters", "personTracks"],
   Audio: ["assets", "models", "savedVoices"],
-  Characters: ["assets", "characters", "models", "loras", "presets"],
+  Characters: ["assets", "characters", "models", "loras", "presets", "trainingDatasets"],
   Document: ["assets", "models"],
   Train: [
     "assets",

--- a/apps/web/src/appHydration.test.js
+++ b/apps/web/src/appHydration.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hydrationDomainsForRoute,
+  hydrationLedgerKey,
+  isProjectHydrationDomain,
+} from "./appHydration.js";
+
+describe("route-owned hydration contract (sc-14783)", () => {
+  it("keeps default Assets isolated from every inactive catalog", () => {
+    expect(hydrationDomainsForRoute("Library")).toEqual(["assets"]);
+  });
+
+  it.each([
+    ["Image", ["assets", "models", "loras", "presets", "promptBatches", "characters"]],
+    ["Video", ["assets", "models", "loras", "presets", "characters", "personTracks"]],
+    ["Audio", ["assets", "models", "savedVoices"]],
+    ["Characters", ["assets", "characters", "models", "loras", "presets"]],
+    ["Document", ["assets", "models"]],
+    [
+      "Train",
+      ["assets", "characters", "models", "trainingTargets", "trainingPresets", "trainingDatasets"],
+    ],
+    [
+      "LibraryDataSets",
+      ["assets", "characters", "models", "trainingTargets", "trainingPresets", "trainingDatasets"],
+    ],
+    ["Poses", ["assets", "characters"]],
+    ["Keypoints", ["assets", "characters"]],
+    ["Presets", ["models", "loras", "presets"]],
+    ["Models", ["models", "loras"]],
+    ["Editor", ["assets", "characters", "models", "loras", "presets", "timelines"]],
+    ["ImageEditor", ["assets", "characters", "models", "loras"]],
+    ["Queue", []],
+    ["Stats", []],
+    ["Logs", []],
+    ["Settings", []],
+    ["Licenses", []],
+  ])("declares every required domain for %s", (route, domains) => {
+    expect(hydrationDomainsForRoute(route)).toEqual(domains);
+  });
+
+  it.each([
+    ["image", ["assets", "models", "loras"]],
+    ["video", ["assets", "models"]],
+    ["audio", ["assets", "models"]],
+    ["assets", ["assets"]],
+    ["models", ["models", "loras"]],
+    ["queue", []],
+    ["settings", []],
+    ["licenses", []],
+  ])("keeps Simple %s demand-driven", (route, domains) => {
+    expect(hydrationDomainsForRoute(route, { simple: true })).toEqual(domains);
+  });
+
+  it("keys global data once and project overlays by project", () => {
+    expect(isProjectHydrationDomain("models")).toBe(false);
+    expect(isProjectHydrationDomain("loras")).toBe(true);
+    expect(hydrationLedgerKey("models", "project-a")).toBe("models:global");
+    expect(hydrationLedgerKey("loras", "project-a")).toBe("loras:project:project-a");
+    expect(hydrationLedgerKey("loras", "project-b")).toBe("loras:project:project-b");
+  });
+});

--- a/apps/web/src/appHydration.test.js
+++ b/apps/web/src/appHydration.test.js
@@ -15,7 +15,7 @@ describe("route-owned hydration contract (sc-14783)", () => {
     ["Image", ["assets", "models", "loras", "presets", "promptBatches", "characters"]],
     ["Video", ["assets", "models", "loras", "presets", "characters", "personTracks"]],
     ["Audio", ["assets", "models", "savedVoices"]],
-    ["Characters", ["assets", "characters", "models", "loras", "presets"]],
+    ["Characters", ["assets", "characters", "models", "loras", "presets", "trainingDatasets"]],
     ["Document", ["assets", "models"]],
     [
       "Train",

--- a/apps/web/src/appHydration.test.js
+++ b/apps/web/src/appHydration.test.js
@@ -31,13 +31,21 @@ describe("route-owned hydration contract (sc-14783)", () => {
     ["Models", ["models", "loras"]],
     ["Editor", ["assets", "characters", "models", "loras", "presets", "timelines"]],
     ["ImageEditor", ["assets", "characters", "models", "loras"]],
-    ["Queue", []],
+    ["Queue", ["assets"]],
     ["Stats", []],
     ["Logs", []],
     ["Settings", []],
     ["Licenses", []],
   ])("declares every required domain for %s", (route, domains) => {
     expect(hydrationDomainsForRoute(route)).toEqual(domains);
+  });
+
+  it("defers Library detail catalogs until its asset catalog settles", () => {
+    expect(hydrationDomainsForRoute("Library")).toEqual(["assets"]);
+    expect(hydrationDomainsForRoute("Library", { deferred: true })).toEqual([
+      "characters",
+      "models",
+    ]);
   });
 
   it.each([

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -250,8 +250,8 @@ describe("useJobEvents (sc-9750)", () => {
       dismissNoticeKind: () => {},
       generatedAssetRefreshesRef: { current: new Map() },
       refreshAssetsRef: { current: () => {} },
-      refreshDataRef: { current: () => {} },
-      refreshDataWithLoraOverlayRef: { current: () => {} },
+      refreshModelsRef: { current: () => {} },
+      refreshModelAndLorasRef: { current: () => {} },
       refreshPersonTracksRef: { current: () => {} },
       activeProjectRef: { current: null },
       enqueueTimelineGenerationApply: () => {},
@@ -575,7 +575,8 @@ describe("useJobEvents (sc-9750)", () => {
         jobs = updater(jobs);
         jobsRef.current = jobs;
       },
-      refreshDataRef: { current: refreshData },
+      refreshModelsRef: { current: refreshData },
+      refreshModelAndLorasRef: { current: () => {} },
       refreshAssetsRef: { current: refreshAssets },
       enqueueTimelineGenerationApply: applyTimeline,
       pushNotice,

--- a/apps/web/src/hooks/projectScopedRefreshStaleGuard.test.jsx
+++ b/apps/web/src/hooks/projectScopedRefreshStaleGuard.test.jsx
@@ -15,18 +15,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCharacters } from "./useCharacters.js";
 import { useModelsAndLoras } from "./useModelsAndLoras.js";
 import { usePersonTracks } from "./usePersonTracks.js";
+import { useTimelines } from "./useTimelines.js";
 
 // Controllable fetch: each apiFetch call parks its resolver so a test can resolve
 // project A's response AFTER the active project has switched to B.
-const pendingResolvers = [];
+const pendingRequests = [];
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
     apiFetch: vi.fn(
       () =>
-        new Promise((resolve) => {
-          pendingResolvers.push(resolve);
+        new Promise((resolve, reject) => {
+          pendingRequests.push({ resolve, reject });
         }),
     ),
   };
@@ -47,6 +48,7 @@ const CASES = [
   { name: "useCharacters.refreshCharacters", hook: useCharacters, refreshKey: "refreshCharacters", stateKey: "characters" },
   { name: "useModelsAndLoras.refreshLoras", hook: useModelsAndLoras, refreshKey: "refreshLoras", stateKey: "loras" },
   { name: "usePersonTracks.refreshPersonTracks", hook: usePersonTracks, refreshKey: "refreshPersonTracks", stateKey: "personTracks" },
+  { name: "useTimelines.refreshTimelines", hook: useTimelines, refreshKey: "refreshTimelines", stateKey: "timelines" },
 ];
 
 describe.each(CASES)("$name stale-project guard (sc-8858)", ({ hook, refreshKey, stateKey }) => {
@@ -55,7 +57,7 @@ describe.each(CASES)("$name stale-project guard (sc-8858)", ({ hook, refreshKey,
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
-    pendingResolvers.length = 0;
+    pendingRequests.length = 0;
     container = document.createElement("div");
     document.body.appendChild(container);
   });
@@ -67,7 +69,7 @@ describe.each(CASES)("$name stale-project guard (sc-8858)", ({ hook, refreshKey,
 
   // Renders the hook, exposing its live api and a way to force a re-render so committed
   // state re-reads. activeProjectRef is a plain mutable ref the test flips mid-flight.
-  function mount(activeProjectRef) {
+  function mount(activeProjectRef, setError = () => {}) {
     let latest = null;
     function Harness() {
       const [, setN] = useState(0);
@@ -76,7 +78,7 @@ describe.each(CASES)("$name stale-project guard (sc-8858)", ({ hook, refreshKey,
           token: "tok",
           activeProject: activeProjectRef.current,
           activeProjectRef,
-          setError: () => {},
+          setError,
           setJobs: () => {},
           requestedGpu: "auto",
           setActiveView: () => {},
@@ -107,12 +109,45 @@ describe.each(CASES)("$name stale-project guard (sc-8858)", ({ hook, refreshKey,
 
     // A's response resolves — it must be dropped, not committed.
     await act(async () => {
-      pendingResolvers[0]([{ id: "from-A" }]);
+      pendingRequests[0].resolve([{ id: "from-A" }]);
       await pending;
     });
     await settle();
 
     expect(get().api[stateKey]).toEqual([]);
+  });
+
+  it("does NOT commit or surface an error after project A is closed", async () => {
+    const activeProjectRef = { current: { id: "A", name: "A" } };
+    const setError = vi.fn();
+    const get = mount(activeProjectRef, setError);
+
+    let pending;
+    act(() => {
+      pending = get().api[refreshKey]("A");
+    });
+    activeProjectRef.current = null;
+
+    await act(async () => {
+      pendingRequests[0].reject(new Error("late A failure"));
+      await pending;
+    });
+    await settle();
+
+    expect(get().api[stateKey]).toEqual([]);
+    expect(setError).not.toHaveBeenCalledWith("late A failure");
+  });
+
+  it("rejects an already-stale explicit refresh before making a request", async () => {
+    const activeProjectRef = { current: { id: "B", name: "B" } };
+    const get = mount(activeProjectRef);
+
+    await act(async () => {
+      const result = await get().api[refreshKey]("A");
+      expect(result).toMatchObject({ ok: false, reason: "stale" });
+    });
+
+    expect(pendingRequests).toHaveLength(0);
   });
 
   it("DOES commit a response for the still-active project", async () => {
@@ -126,7 +161,7 @@ describe.each(CASES)("$name stale-project guard (sc-8858)", ({ hook, refreshKey,
 
     // Active project unchanged — the response is current and must land.
     await act(async () => {
-      pendingResolvers[0]([{ id: "from-A" }]);
+      pendingRequests[0].resolve([{ id: "from-A" }]);
       await pending;
     });
     await settle();
@@ -144,7 +179,7 @@ describe("useModelsAndLoras.refreshLoras global (no project) still commits (sc-8
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
-    pendingResolvers.length = 0;
+    pendingRequests.length = 0;
     container = document.createElement("div");
     document.body.appendChild(container);
   });
@@ -190,7 +225,7 @@ describe("useModelsAndLoras.refreshLoras global (no project) still commits (sc-8
     activeProjectRef.current = { id: "B", name: "B" };
 
     await act(async () => {
-      pendingResolvers[0]([{ id: "global-lora" }]);
+      pendingRequests[0].resolve([{ id: "global-lora" }]);
       await pending;
     });
     await settle();

--- a/apps/web/src/hooks/useCharacters.js
+++ b/apps/web/src/hooks/useCharacters.js
@@ -1,5 +1,7 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 
 // Owns the project's character roster plus every character CRUD/reference/look/LoRA
 // mutation. Extracted from App.jsx (sc-1651) to shrink the god module; behavior is
@@ -16,7 +18,10 @@ export function useCharacters({ token, activeProject, activeProjectRef, setError
   const refreshCharacters = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
       if (!projectId) {
-        return;
+        return refreshFailure("missing-project");
+      }
+      if (!isCurrentProjectRequest(activeProject?.id ?? null, projectId)) {
+        return refreshFailure("stale");
       }
       try {
         const items = await apiFetch(`/api/v1/projects/${projectId}/characters`, token, { signal });
@@ -24,14 +29,19 @@ export function useCharacters({ token, activeProject, activeProjectRef, setError
         // after the user switches away; committing then would clobber the new
         // project's roster with the old one's. Drop the stale response — mirrors
         // refreshTimelines' guard (useTimelines.js).
-        if (activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
-          return;
+        if (!isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId)) {
+          return refreshFailure("stale");
         }
         setCharacters(items);
         setError("");
+        return refreshSuccess(items);
       } catch (err) {
-        if (isAbortError(err)) return;
+        if (!isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId)) {
+          return refreshFailure("stale", err);
+        }
+        if (isAbortError(err)) return refreshFailure("aborted", err);
         setError(err.message);
+        return refreshFailure("error", err);
       }
     },
     [token, activeProject, activeProjectRef, setError],

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -48,8 +48,8 @@ export function useJobEvents({
   dismissNoticeKind,
   generatedAssetRefreshesRef,
   refreshAssetsRef,
-  refreshDataRef,
-  refreshDataWithLoraOverlayRef,
+  refreshModelsRef,
+  refreshModelAndLorasRef,
   refreshPersonTracksRef,
   activeProjectRef,
   enqueueTimelineGenerationApply,
@@ -201,23 +201,23 @@ export function useJobEvents({
         job.status === "completed" &&
         (job.type === "model_download" || job.type === "model_convert" || job.type === "model_import")
       ) {
-        refreshDataRef.current?.();
+        refreshModelsRef.current?.();
       }
       // A completed built-in LoRA download (sc-5944) flips the catalog entry to
       // installed; refresh models+loras so the Models row and any Studio gate update.
       if (job.status === "completed" && job.type === "lora_download") {
-        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
+        refreshModelAndLorasRef.current?.(job.projectId ?? activeProjectRef.current?.id);
       }
       if (job.status === "completed" && job.type === "lora_import") {
         dismissNoticeKind("lora-import");
-        refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
+        refreshModelAndLorasRef.current?.(job.projectId ?? activeProjectRef.current?.id);
       }
       if (job.status === "completed" && job.type === "lora_train" && job.payload?.dryRun === false) {
         if (job.result?.loraRegistered === false) {
           pushNotice("lora-train", `lora training: ${job.result?.loraRegistrationError ?? "Completed training but could not register the LoRA."}`);
         } else {
           dismissNoticeKind("lora-train");
-          refreshDataWithLoraOverlayRef.current?.(job.projectId ?? activeProjectRef.current?.id);
+          refreshModelAndLorasRef.current?.(job.projectId ?? activeProjectRef.current?.id);
         }
       }
       if (job.status === "failed" && !hasVisibleLocalFailure(job)) {

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -42,6 +42,7 @@ export function useModelsAndLoras({
   activeProject,
   activeProjectRef,
   setError,
+  setLoraError = setError,
   setJobs,
   setActiveView,
   refreshData,
@@ -66,13 +67,13 @@ export function useModelsAndLoras({
           return;
         }
         setLoras(items);
-        setError("");
+        setLoraError("");
       } catch (err) {
         if (isAbortError(err)) return;
-        setError(err.message);
+        setLoraError(err.message);
       }
     },
-    [token, activeProject, activeProjectRef, setError],
+    [token, activeProject, activeProjectRef, setLoraError],
   );
 
   const deleteModel = useCallback(
@@ -148,11 +149,11 @@ export function useModelsAndLoras({
     if (result.removedManifestEntry) {
       setLoras((items) => items.filter((item) => item.id !== lora.id || item.scope !== lora.scope));
     }
-    setError("");
+    setLoraError("");
     await refreshDataWithLoraOverlay(activeProject?.id);
     return result;
     },
-    [token, activeProject, setError, refreshDataWithLoraOverlay],
+    [token, activeProject, setLoraError, refreshDataWithLoraOverlay],
   );
 
   // Edit a catalog LoRA's trigger keywords / notes after import (epic 10328). Only
@@ -171,11 +172,11 @@ export function useModelsAndLoras({
         method: "PATCH",
         body: JSON.stringify(updates),
       });
-      setError("");
+      setLoraError("");
       await refreshDataWithLoraOverlay(activeProject?.id);
       return updated;
     },
-    [token, activeProject, setError, refreshDataWithLoraOverlay],
+    [token, activeProject, setLoraError, refreshDataWithLoraOverlay],
   );
 
   // Best-effort trigger-keyword suggestions read from the installed LoRA's embedded
@@ -281,10 +282,10 @@ export function useModelsAndLoras({
     if (options.navigateToQueue ?? false) {
       setActiveView("Queue");
     }
-    setError("");
+    setLoraError("");
     return job;
     },
-    [token, activeProject, setJobs, setActiveView, setError],
+    [token, activeProject, setJobs, setActiveView, setLoraError],
   );
 
   const createModelDownloadJob = useCallback(
@@ -341,14 +342,14 @@ export function useModelsAndLoras({
           body: JSON.stringify({ requestedGpu: "auto" }),
         });
         setJobs((items) => upsertJobNewest(items, job));
-        setError("");
+        setLoraError("");
         return job;
       } catch (err) {
-        setError(err.message);
+        setLoraError(err.message);
         return null;
       }
     },
-    [token, setJobs, setError],
+    [token, setJobs, setLoraError],
   );
 
   return {

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -1,5 +1,7 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 import { appConfirm } from "../appConfirm.jsx";
 import { upsertJobNewest } from "../sorters.js";
 
@@ -55,6 +57,12 @@ export function useModelsAndLoras({
   // SSE-driven re-renders, letting appContextValue memoize.
   const refreshLoras = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
+      if (
+        projectId &&
+        !isCurrentProjectRequest(activeProject?.id ?? null, projectId)
+      ) {
+        return refreshFailure("stale");
+      }
       try {
         const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
         const items = await apiFetch(`/api/v1/loras${query}`, token, { signal });
@@ -63,14 +71,25 @@ export function useModelsAndLoras({
         // LoRA overlay with the old one's. Drop the stale response — mirrors
         // refreshTimelines' guard (useTimelines.js). Only project-scoped refreshes
         // are guarded; a global refresh (projectId undefined) still commits.
-        if (projectId && activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
-          return;
+        if (
+          projectId &&
+          !isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId)
+        ) {
+          return refreshFailure("stale");
         }
         setLoras(items);
         setLoraError("");
+        return refreshSuccess(items);
       } catch (err) {
-        if (isAbortError(err)) return;
+        if (
+          projectId &&
+          !isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId)
+        ) {
+          return refreshFailure("stale", err);
+        }
+        if (isAbortError(err)) return refreshFailure("aborted", err);
         setLoraError(err.message);
+        return refreshFailure("error", err);
       }
     },
     [token, activeProject, activeProjectRef, setLoraError],

--- a/apps/web/src/hooks/usePersonTracks.js
+++ b/apps/web/src/hooks/usePersonTracks.js
@@ -1,5 +1,7 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 
 // Owns the project's person-track state plus detection/track job creation and manual
 // track corrections. Extracted from App.jsx (sc-1651). personTracks is project-scoped
@@ -14,7 +16,10 @@ export function usePersonTracks({ token, activeProject, activeProjectRef, setErr
   const refreshPersonTracks = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
       if (!projectId) {
-        return;
+        return refreshFailure("missing-project");
+      }
+      if (!isCurrentProjectRequest(activeProject?.id ?? null, projectId)) {
+        return refreshFailure("stale");
       }
       try {
         const items = await apiFetch(`/api/v1/projects/${projectId}/person-tracks`, token, { signal });
@@ -22,14 +27,19 @@ export function usePersonTracks({ token, activeProject, activeProjectRef, setErr
         // after the user switches away; committing then would clobber the new
         // project's tracks with the old one's. Drop the stale response — mirrors
         // refreshTimelines' guard (useTimelines.js).
-        if (activeProjectRef?.current?.id && activeProjectRef.current.id !== projectId) {
-          return;
+        if (!isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId)) {
+          return refreshFailure("stale");
         }
         setPersonTracks(items);
         setError("");
+        return refreshSuccess(items);
       } catch (err) {
-        if (isAbortError(err)) return;
+        if (!isCurrentProjectRequest(activeProjectRef?.current?.id ?? null, projectId)) {
+          return refreshFailure("stale", err);
+        }
+        if (isAbortError(err)) return refreshFailure("aborted", err);
         setError(err.message);
+        return refreshFailure("error", err);
       }
     },
     [token, activeProject, activeProjectRef, setError],

--- a/apps/web/src/hooks/useSavedVoices.js
+++ b/apps/web/src/hooks/useSavedVoices.js
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 
 // Owns the project's Voice Clone "saved voices" roster + its create/delete mutations (sc-13517).
 // A saved voice is a named pointer to a library audio reference clip (plus its Chatterbox-VE speaker
@@ -21,7 +22,10 @@ export function useSavedVoices({ token, activeProject, activeProjectRef, setErro
   const refreshSavedVoices = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
       if (!projectId) {
-        return;
+        return refreshFailure("missing-project");
+      }
+      if (!isCurrentProjectRequest(activeProject?.id ?? null, projectId)) {
+        return refreshFailure("stale");
       }
       try {
         const items = await apiFetch(
@@ -32,13 +36,16 @@ export function useSavedVoices({ token, activeProject, activeProjectRef, setErro
         // Drop a stale response for a project the user already switched away from
         // (mirrors refreshCharacters' guard).
         if (!isCurrentVoiceRequest(projectId)) {
-          return;
+          return refreshFailure("stale");
         }
         setSavedVoices(Array.isArray(items) ? items : []);
         setError("");
+        return refreshSuccess(items);
       } catch (err) {
-        if (isAbortError(err) || !isCurrentVoiceRequest(projectId)) return;
+        if (!isCurrentVoiceRequest(projectId)) return refreshFailure("stale", err);
+        if (isAbortError(err)) return refreshFailure("aborted", err);
         setError(err.message);
+        return refreshFailure("error", err);
       }
     },
     [token, activeProject, isCurrentVoiceRequest, setError],

--- a/apps/web/src/hooks/useScopedCrudList.js
+++ b/apps/web/src/hooks/useScopedCrudList.js
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 
 // Shared global/project-scoped catalog mutations. Recipe presets and prompt
 // batches intentionally expose different domain names, but their request,
@@ -24,17 +25,22 @@ export function useScopedCrudList({
 
   const refresh = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
+      if (
+        projectId &&
+        !isCurrentProjectRequest(activeProject?.id ?? null, projectId)
+      ) return refreshFailure("stale");
       try {
         const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
         const next = await apiFetch(`${resourcePath}${query}`, token, { signal });
-        if (!isCurrentRequest(projectId)) return [];
+        if (!isCurrentRequest(projectId)) return refreshFailure("stale");
         setItems(next);
         setError("");
-        return next;
+        return refreshSuccess(next);
       } catch (error) {
-        if (isAbortError(error) || !isCurrentRequest(projectId)) return [];
+        if (!isCurrentRequest(projectId)) return refreshFailure("stale", error);
+        if (isAbortError(error)) return refreshFailure("aborted", error);
         setError(error.message);
-        return [];
+        return refreshFailure("error", error);
       }
     },
     [activeProject, isCurrentRequest, resourcePath, setError, token],

--- a/apps/web/src/hooks/useTimelines.js
+++ b/apps/web/src/hooks/useTimelines.js
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
+import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 import { ensureItemVersionFields } from "../timeline.js";
 
 // Canonical serialization of a persisted-timeline snapshot for dirty comparison (sc-11967).
@@ -112,12 +114,15 @@ export function useTimelines({
   const refreshTimelines = useCallback(
     async (projectId = activeProject?.id, { signal } = {}) => {
       if (!projectId) {
-        return;
+        return refreshFailure("missing-project");
+      }
+      if (!isCurrentProjectRequest(activeProject?.id ?? null, projectId)) {
+        return refreshFailure("stale");
       }
       try {
         const items = await apiFetch(`/api/v1/projects/${projectId}/timelines`, token, { signal });
-        if (activeProjectRef.current?.id && activeProjectRef.current.id !== projectId) {
-          return;
+        if (!isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId)) {
+          return refreshFailure("stale");
         }
         setTimelines(items);
         setTimelinesProjectId(projectId);
@@ -127,15 +132,26 @@ export function useTimelines({
           savedTimelineSnapshotRef.current = null;
         }
         setError("");
+        return refreshSuccess(items);
       } catch (err) {
-        if (isAbortError(err)) return;
+        if (!isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId)) {
+          return refreshFailure("stale", err);
+        }
+        if (isAbortError(err)) return refreshFailure("aborted", err);
         setError(err.message);
+        return refreshFailure("error", err);
       }
     },
     [token, activeProject, activeProjectRef, setError],
   );
 
   async function loadTimeline(projectId, timelineId) {
+    if (
+      !isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId) ||
+      selectedTimelineIdRef.current !== timelineId
+    ) {
+      return;
+    }
     try {
       const timeline = await apiFetch(`/api/v1/projects/${projectId}/timelines/${timelineId}`, token);
       if (activeProjectRef.current?.id !== projectId || selectedTimelineIdRef.current !== timelineId) {
@@ -149,6 +165,12 @@ export function useTimelines({
       pushNotice?.(TIMELINE_GENERATION_CONFLICT_NOTICE, "");
       setError("");
     } catch (err) {
+      if (
+        !isCurrentProjectRequest(activeProjectRef.current?.id ?? null, projectId) ||
+        selectedTimelineIdRef.current !== timelineId
+      ) {
+        return;
+      }
       setError(err.message);
     }
   }

--- a/apps/web/src/hooks/useTraining.js
+++ b/apps/web/src/hooks/useTraining.js
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 import { upsertJobNewest } from "../sorters.js";
 
 // Owns the project's training-dataset state plus dataset CRUD, caption sidecar/job,
@@ -30,7 +31,7 @@ export function useTraining({ token, activeProject, activeProjectRef, setError, 
       // current project's in-flight refresh. Accepted calls receive monotonically
       // increasing ownership so an older request for the *same* project cannot
       // overwrite a newer request or clear its loading state.
-      if (!isCurrentTrainingRequest(projectId)) return [];
+      if (!isCurrentTrainingRequest(projectId)) return refreshFailure("stale");
       const refreshId = ++trainingRefreshIdRef.current;
       const ownsCurrentRefresh = () =>
         refreshId === trainingRefreshIdRef.current &&
@@ -41,23 +42,23 @@ export function useTraining({ token, activeProject, activeProjectRef, setError, 
         setTrainingDatasetsProjectId(null);
         setTrainingDatasetsError("");
         setLoadingTrainingDatasets(false);
-        return [];
+        return refreshFailure("missing-project");
       }
       setLoadingTrainingDatasets(true);
       try {
         const items = await apiFetch(`/api/v1/projects/${projectId}/training/datasets`, token, { signal });
-        if (!ownsCurrentRefresh()) return [];
+        if (!ownsCurrentRefresh()) return refreshFailure("stale");
         setTrainingDatasets(items);
         setTrainingDatasetsProjectId(projectId);
         setTrainingDatasetsError("");
-        return items;
+        return refreshSuccess(items);
       } catch (err) {
-        if (isAbortError(err)) return [];
-        if (!ownsCurrentRefresh()) return [];
+        if (!ownsCurrentRefresh()) return refreshFailure("stale", err);
+        if (isAbortError(err)) return refreshFailure("aborted", err);
         setTrainingDatasets([]);
         setTrainingDatasetsProjectId(projectId);
         setTrainingDatasetsError(err.message);
-        return [];
+        return refreshFailure("error", err);
       } finally {
         if (!signal?.aborted && ownsCurrentRefresh()) {
           setLoadingTrainingDatasets(false);

--- a/apps/web/src/refreshResult.js
+++ b/apps/web/src/refreshResult.js
@@ -1,0 +1,7 @@
+export function refreshSuccess(value) {
+  return { ok: true, value };
+}
+
+export function refreshFailure(reason, error = null) {
+  return error ? { ok: false, reason, error } : { ok: false, reason };
+}

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -65,6 +65,7 @@ export function SimpleShell({
   simpleDefault,
   onSimpleDefaultChange,
   onModeChange,
+  onScreenChange,
   lockedToSimple,
 }) {
   const {
@@ -107,6 +108,9 @@ export function SimpleShell({
   const toastTimer = useRef(null);
 
   useEffect(() => () => clearTimeout(toastTimer.current), []);
+  useEffect(() => {
+    onScreenChange?.(screen);
+  }, [onScreenChange, screen]);
 
   // Opening an asset. An audio asset also becomes the loaded take, so the grid rings it and
   // the viewer opens on its deck; `play` (the tile's play button) starts it immediately.


### PR DESCRIPTION
## Summary
- replace the bulk protected-data bootstrap with explicit route/domain-owned hydration
- keep the default Assets route to projects, shared shell state, SSE, and the active project asset catalog
- key project overlays independently, abort/suppress stale requests on switches, and preserve global catalogs
- scope model/LoRA completion refreshes and domain notices so unrelated endpoints/errors are untouched
- preserve keep-alive, Simple UI, setup/auth, and recipe/preset launch behavior with late catalogs

## Validation
- `npm.cmd test -- --run` (190 files, 2,629 tests)
- `npm.cmd run lint -- --no-cache`
- `npm.cmd run build`
- `git diff --check`

## Evidence
The deterministic request ledger verifies inactive catalogs are absent from default Assets startup, every declared advanced/Simple route demand, one SSE subscription, first-navigation/keep-alive reuse, project-switch abort and stale suppression, model-only versus model+LoRA completion refreshes, and independent domain errors.

Closes sc-14783