### PR TITLE
perf(web): lazy-load route families (sc-14786)

### DIFF
--- a/apps/web/bundle-budgets.json
+++ b/apps/web/bundle-budgets.json
@@ -1,0 +1,17 @@
+{
+  "initial": {
+    "rawBytes": 500000,
+    "gzipBytes": 150000,
+    "brotliBytes": 125000
+  },
+  "total": {
+    "rawBytes": 3200000,
+    "gzipBytes": 850000,
+    "brotliBytes": 700000
+  },
+  "largestRoute": {
+    "rawBytes": 1100000,
+    "gzipBytes": 260000,
+    "brotliBytes": 200000
+  }
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -9,28 +9,12 @@ import { CREATE_JOB_DEFINITIONS, makeCreateJob } from "./createJob.js";
 import { pollJobToCompletion } from "./pollJob.js";
 import { AccentPicker } from "./components/AccentPicker.jsx";
 import { Icon } from "./components/Icons.jsx";
+import { lazyScreen } from "./components/LazyScreen.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
 import { FullscreenPreview, assetSeed } from "./components/assetPanels.jsx";
 import { fallbackModels, isLibraryAsset, terminalStatuses } from "./constants.js";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
-import { PoseLibraryScreen } from "./screens/PoseLibraryScreen.jsx";
-import { KeyPointLibraryScreen } from "./screens/KeyPointLibraryScreen.jsx";
-import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
-import { ImageStudio } from "./screens/ImageStudio.jsx";
-import { DocumentStudio } from "./screens/DocumentStudio.jsx";
-import { VideoStudio } from "./screens/VideoStudio.jsx";
-import { AudioStudio } from "./screens/AudioStudio.jsx";
-import { TrainingDataSetsLibrary, TrainingStudio } from "./screens/TrainingStudio.jsx";
-import { CharacterStudio } from "./screens/CharacterStudio.jsx";
-import { EditorScreen } from "./screens/EditorScreen.jsx";
-import { QueueScreen } from "./screens/QueueScreen.jsx";
-import { PresetManagerScreen } from "./screens/PresetManagerScreen.jsx";
-import { SettingsScreen } from "./screens/SettingsScreen.jsx";
-import { LogsScreen } from "./screens/LogsScreen.jsx";
-import { StatsScreen } from "./screens/StatsScreen.jsx";
-import { LicensesScreen } from "./screens/LicensesScreen.jsx";
-import { SetupWizard } from "./screens/SetupWizard.jsx";
 import { editModelForAsset, workflowModelType } from "./presetUtils.js";
 import { sortNewest, sortWorkers, upsertJobNewest } from "./sorters.js";
 import { useCharacters } from "./hooks/useCharacters.js";
@@ -64,7 +48,6 @@ import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 // Simple UI (design handoff "Simple UI for creative studios") — an ALTERNATIVE shell that
 // renders instead of this workspace when the sidebar switch is on Simple. The workspace
 // below is unchanged apart from that switch in its footer.
-import { SimpleShell } from "./simple/SimpleShell.jsx";
 import { SimpleModeSwitch } from "./simple/SimpleModeSwitch.jsx";
 import { useViewportWidth } from "./simple/useContainerWidth.js";
 import {
@@ -110,8 +93,102 @@ import { refreshFailure, refreshSuccess } from "./refreshResult.js";
 
 // Lazy-load the canvas editor so Konva (canvas-based, heavy) stays out of the
 // initial bundle and the jsdom test path — it only loads when the view is opened.
-const ImageEditor = React.lazy(() =>
-  import("./screens/ImageEditor.jsx").then((module) => ({ default: module.ImageEditor })),
+const ImageStudio = lazyScreen(
+  () => import("./screens/ImageStudio.jsx"),
+  "ImageStudio",
+  "Image Studio",
+);
+const VideoStudio = lazyScreen(
+  () => import("./screens/VideoStudio.jsx"),
+  "VideoStudio",
+  "Video Studio",
+);
+const AudioStudio = lazyScreen(
+  () => import("./screens/AudioStudio.jsx"),
+  "AudioStudio",
+  "Audio Studio",
+);
+const CharacterStudio = lazyScreen(
+  () => import("./screens/CharacterStudio.jsx"),
+  "CharacterStudio",
+  "Characters",
+);
+const DocumentStudio = lazyScreen(
+  () => import("./screens/DocumentStudio.jsx"),
+  "DocumentStudio",
+  "Document Studio",
+);
+const loadTrainingScreens = () => import("./screens/TrainingStudio.jsx");
+const TrainingStudio = lazyScreen(loadTrainingScreens, "TrainingStudio", "Training Studio");
+const TrainingDataSetsLibrary = lazyScreen(
+  loadTrainingScreens,
+  "TrainingDataSetsLibrary",
+  "Data Sets",
+);
+const PresetManagerScreen = lazyScreen(
+  () => import("./screens/PresetManagerScreen.jsx"),
+  "PresetManagerScreen",
+  "Presets",
+);
+const PoseLibraryScreen = lazyScreen(
+  () => import("./screens/PoseLibraryScreen.jsx"),
+  "PoseLibraryScreen",
+  "Pose Library",
+);
+const KeyPointLibraryScreen = lazyScreen(
+  () => import("./screens/KeyPointLibraryScreen.jsx"),
+  "KeyPointLibraryScreen",
+  "Key Point Library",
+);
+const EditorScreen = lazyScreen(
+  () => import("./screens/EditorScreen.jsx"),
+  "EditorScreen",
+  "Video Editor",
+);
+const ImageEditor = lazyScreen(
+  () => import("./screens/ImageEditor.jsx"),
+  "ImageEditor",
+  "Image Editor",
+);
+const QueueScreen = lazyScreen(
+  () => import("./screens/QueueScreen.jsx"),
+  "QueueScreen",
+  "Queue",
+);
+const ModelManagerScreen = lazyScreen(
+  () => import("./screens/ModelManagerScreen.jsx"),
+  "ModelManagerScreen",
+  "Models",
+);
+const SettingsScreen = lazyScreen(
+  () => import("./screens/SettingsScreen.jsx"),
+  "SettingsScreen",
+  "Settings",
+);
+const StatsScreen = lazyScreen(
+  () => import("./screens/StatsScreen.jsx"),
+  "StatsScreen",
+  "Generation Stats",
+);
+const LogsScreen = lazyScreen(
+  () => import("./screens/LogsScreen.jsx"),
+  "LogsScreen",
+  "Logs",
+);
+const LicensesScreen = lazyScreen(
+  () => import("./screens/LicensesScreen.jsx"),
+  "LicensesScreen",
+  "Licenses",
+);
+const SetupWizard = lazyScreen(
+  () => import("./screens/SetupWizard.jsx"),
+  "SetupWizard",
+  "Setup Wizard",
+);
+const SimpleShell = lazyScreen(
+  () => import("./simple/SimpleShell.jsx"),
+  "SimpleShell",
+  "Simple UI",
 );
 
 // Selective lazy keep-alive (sc-11959, backbone for epic 11949's edit persistence).
@@ -3273,9 +3350,7 @@ export function App() {
 
         {keepAliveMounted("ImageEditor") ? (
           <KeepAlivePane active={activeView === "ImageEditor"}>
-            <React.Suspense fallback={<section className="page-frame">Loading editor…</section>}>
-              <ImageEditor key={activeProject?.id ?? "default"} />
-            </React.Suspense>
+            <ImageEditor key={activeProject?.id ?? "default"} />
           </KeepAlivePane>
         ) : null}
           </>

--- a/apps/web/src/components/LazyScreen.jsx
+++ b/apps/web/src/components/LazyScreen.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+
+const pendingScreenImports = new Set();
+
+export async function waitForLazyScreenImports() {
+  while (pendingScreenImports.size) {
+    await Promise.allSettled([...pendingScreenImports]);
+    await Promise.resolve();
+  }
+}
+
+class ScreenLoadErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    return (
+      <section className="page-frame lazy-screen-boundary" role="alert">
+        <h2>{this.props.label} could not be loaded</h2>
+        <p>The screen bundle did not finish loading. Check the connection and try again.</p>
+        <button onClick={this.props.onRetry} type="button">
+          Retry
+        </button>
+      </section>
+    );
+  }
+}
+
+function ScreenLoading({ label }) {
+  return (
+    <section
+      aria-busy="true"
+      aria-live="polite"
+      className="page-frame lazy-screen-boundary"
+      role="status"
+    >
+      Loading {label}…
+    </section>
+  );
+}
+
+/**
+ * Build a retryable React.lazy boundary around a named screen export.
+ *
+ * Keeping lazy component creation inside this wrapper lets Retry invoke the
+ * import function again after a transient chunk-load failure. The wrapper
+ * remains mounted inside App's keep-alive panes, so successful screens retain
+ * their existing local state across navigation.
+ */
+export function lazyScreen(importScreen, exportName, label) {
+  const createLazyComponent = () =>
+    React.lazy(async () => {
+      const request = importScreen();
+      pendingScreenImports.add(request);
+      try {
+        const module = await request;
+        const component = module[exportName];
+        if (!component) {
+          throw new Error(`Screen module does not export ${exportName}`);
+        }
+        return { default: component };
+      } finally {
+        pendingScreenImports.delete(request);
+      }
+    });
+
+  function LazyScreen(props) {
+    const [{ attempt, Screen }, setLoadState] = useState(() => ({
+      attempt: 0,
+      Screen: createLazyComponent(),
+    }));
+    const retry = () =>
+      setLoadState((current) => ({
+        attempt: current.attempt + 1,
+        Screen: createLazyComponent(),
+      }));
+
+    return (
+      <ScreenLoadErrorBoundary
+        key={attempt}
+        label={label}
+        onRetry={retry}
+      >
+        <React.Suspense fallback={<ScreenLoading label={label} />}>
+          <Screen {...props} />
+        </React.Suspense>
+      </ScreenLoadErrorBoundary>
+    );
+  }
+
+  LazyScreen.displayName = `Lazy${exportName}`;
+  return LazyScreen;
+}

--- a/apps/web/src/components/LazyScreen.test.jsx
+++ b/apps/web/src/components/LazyScreen.test.jsx
@@ -1,0 +1,80 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lazyScreen } from "./LazyScreen.jsx";
+
+const mountedRoots = [];
+let consoleError;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  while (mountedRoots.length) {
+    const root = mountedRoots.pop();
+    await act(async () => root.unmount());
+  }
+  document.body.innerHTML = "";
+  consoleError.mockRestore();
+});
+
+async function render(ui) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  await act(async () => root.render(ui));
+  return container;
+}
+
+describe("lazyScreen", () => {
+  it("announces loading and then mounts the requested named export", async () => {
+    let resolveImport;
+    const importScreen = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveImport = resolve;
+        }),
+    );
+    const Screen = lazyScreen(importScreen, "ExampleScreen", "Example");
+    const container = await render(<Screen value="ready" />);
+
+    expect(container.querySelector('[role="status"]')?.textContent).toContain("Loading Example");
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
+
+    await act(async () => {
+      resolveImport({ ExampleScreen: ({ value }) => <p>{value}</p> });
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.textContent).toContain("ready");
+  });
+
+  it("surfaces an accessible error and retries a failed import", async () => {
+    const importScreen = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("chunk unavailable"))
+      .mockResolvedValueOnce({ ExampleScreen: () => <p>loaded after retry</p> });
+    const Screen = lazyScreen(importScreen, "ExampleScreen", "Example");
+    const container = await render(<Screen />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain("Example could not be loaded");
+
+    await act(async () => {
+      alert.querySelector("button").click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(importScreen).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("loaded after retry");
+  });
+});

--- a/apps/web/src/main.testSupport.jsx
+++ b/apps/web/src/main.testSupport.jsx
@@ -9,6 +9,7 @@
 // what main.test.jsx defined. It is named *.testSupport.jsx (not *.test.jsx) so
 // Vitest's default include glob does not collect it as a test file.
 import React, { act } from "react";
+import { waitForLazyScreenImports } from "./components/LazyScreen.jsx";
 import { AppContext } from "./context/AppContext.js";
 import { ImageStudio } from "./screens/ImageStudio.jsx";
 import { ModelManagerScreen } from "./screens/ModelManagerScreen.jsx";
@@ -200,6 +201,13 @@ export function errorResponse(status, detail) {
 
 export async function settle() {
   await act(async () => {
+    for (let index = 0; index < 6; index += 1) {
+      await Promise.resolve();
+    }
+    // Route screens resolve through Vite's dynamic-import transform. Await the
+    // imports tracked by the shared lazy boundary, then drain the React work
+    // queued when each Suspense boundary resolves.
+    await waitForLazyScreenImports();
     for (let index = 0; index < 6; index += 1) {
       await Promise.resolve();
     }

--- a/apps/web/src/testUtils/dom.js
+++ b/apps/web/src/testUtils/dom.js
@@ -7,6 +7,7 @@
 // that runs inside the caller's own `act`) intentionally keep their own copy.
 import { act } from "react";
 import { createRoot } from "react-dom/client";
+import { waitForLazyScreenImports } from "../components/LazyScreen.jsx";
 
 // Dispatch a bubbling click and flush the resulting React work inside `act`.
 // Matches the `async function click(element)` form the studio suites shared.
@@ -14,6 +15,10 @@ export async function click(element) {
   await act(async () => {
     element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
   });
+  // Navigation can resolve a route-level dynamic import after the click
+  // commit. Flush that tracked import in a second act so callers observe the
+  // mounted screen, not only its Suspense fallback.
+  await act(async () => waitForLazyScreenImports());
 }
 
 // Set a controlled <input> value through the native setter (bypassing React's

--- a/apps/web/vite-plugin-bundle-report.js
+++ b/apps/web/vite-plugin-bundle-report.js
@@ -1,0 +1,264 @@
+import { brotliCompressSync, constants, gzipSync } from "node:zlib";
+
+export const routeFamilies = Object.freeze({
+  "Image Studio": ["/src/screens/ImageStudio.jsx"],
+  "Video Studio": ["/src/screens/VideoStudio.jsx"],
+  "Audio Studio": ["/src/screens/AudioStudio.jsx"],
+  Characters: ["/src/screens/CharacterStudio.jsx"],
+  "Document Studio": ["/src/screens/DocumentStudio.jsx"],
+  Training: ["/src/screens/TrainingStudio.jsx"],
+  Presets: ["/src/screens/PresetManagerScreen.jsx"],
+  "Pose Library": ["/src/screens/PoseLibraryScreen.jsx"],
+  "Key Point Library": ["/src/screens/KeyPointLibraryScreen.jsx"],
+  "Video Editor": ["/src/screens/EditorScreen.jsx"],
+  "Image Editor": ["/src/screens/ImageEditor.jsx"],
+  Queue: ["/src/screens/QueueScreen.jsx"],
+  Models: ["/src/screens/ModelManagerScreen.jsx"],
+  Settings: ["/src/screens/SettingsScreen.jsx"],
+  Stats: ["/src/screens/StatsScreen.jsx"],
+  Logs: ["/src/screens/LogsScreen.jsx"],
+  Licenses: ["/src/screens/LicensesScreen.jsx"],
+  "Setup Wizard": ["/src/screens/SetupWizard.jsx"],
+  "Simple UI": ["/src/simple/SimpleShell.jsx"],
+});
+
+export const initialExclusions = Object.freeze({
+  "Stats/Recharts": [
+    "/src/screens/StatsScreen.jsx",
+    "/node_modules/recharts/",
+    "/node_modules/recharts-scale/",
+    "/node_modules/victory-vendor/",
+    "/node_modules/d3-",
+  ],
+  "Image Editor/Konva": [
+    "/src/screens/ImageEditor.jsx",
+    "/node_modules/konva/",
+    "/node_modules/react-konva/",
+    "/node_modules/react-reconciler/",
+  ],
+  "Licenses/license corpus": [
+    "/src/screens/LicensesScreen.jsx",
+    "/src/data/bundledLicenses.js",
+    "/apps/desktop/licenses/",
+  ],
+  Models: ["/src/screens/ModelManagerScreen.jsx"],
+  "Inactive studio families": [
+    "/src/screens/ImageStudio.jsx",
+    "/src/screens/VideoStudio.jsx",
+    "/src/screens/AudioStudio.jsx",
+    "/src/screens/CharacterStudio.jsx",
+    "/src/screens/DocumentStudio.jsx",
+    "/src/screens/TrainingStudio.jsx",
+    "/src/screens/PresetManagerScreen.jsx",
+    "/src/screens/PoseLibraryScreen.jsx",
+    "/src/screens/KeyPointLibraryScreen.jsx",
+    "/src/screens/EditorScreen.jsx",
+  ],
+  "Simple UI": ["/src/simple/SimpleShell.jsx", "/src/simple/studioParts.jsx"],
+  "Setup Wizard": ["/src/screens/SetupWizard.jsx"],
+});
+
+function normalize(value) {
+  return String(value).replaceAll("\\", "/");
+}
+
+function compressedSizes(code) {
+  const source = Buffer.from(code);
+  return {
+    rawBytes: source.byteLength,
+    gzipBytes: gzipSync(source, { level: 9 }).byteLength,
+    brotliBytes: brotliCompressSync(source, {
+      params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
+    }).byteLength,
+  };
+}
+
+function assetSource(asset) {
+  return typeof asset.source === "string" ? asset.source : Buffer.from(asset.source);
+}
+
+function collectStaticChunks(startNames, chunks) {
+  const collected = new Set();
+  const pending = [...startNames];
+  while (pending.length) {
+    const fileName = pending.pop();
+    if (collected.has(fileName) || !chunks.has(fileName)) {
+      continue;
+    }
+    collected.add(fileName);
+    pending.push(...chunks.get(fileName).imports);
+  }
+  return collected;
+}
+
+function summarize(fileNames, chunkSizes) {
+  const result = { rawBytes: 0, gzipBytes: 0, brotliBytes: 0 };
+  for (const fileName of fileNames) {
+    const size = chunkSizes.get(fileName);
+    if (!size) continue;
+    result.rawBytes += size.rawBytes;
+    result.gzipBytes += size.gzipBytes;
+    result.brotliBytes += size.brotliBytes;
+  }
+  return result;
+}
+
+function budgetViolations(label, actual, budget) {
+  return Object.entries(budget)
+    .filter(([metric, limit]) => actual[metric] > limit)
+    .map(
+      ([metric, limit]) =>
+        `${label} ${metric} is ${actual[metric]} bytes (budget ${limit} bytes)`,
+    );
+}
+
+export function buildBundleReport(bundle, budgets) {
+  const chunks = new Map(
+    Object.values(bundle)
+      .filter((item) => item.type === "chunk")
+      .map((chunk) => [chunk.fileName, chunk]),
+  );
+  // Vite's pre-paint theme bootstrap is emitted as a JavaScript asset rather
+  // than a Rollup chunk. It is nevertheless fetched by index.html on first
+  // paint, so include emitted *.js assets in the initial and total JS budgets.
+  const scriptAssets = new Map(
+    Object.values(bundle)
+      .filter((item) => item.type === "asset" && item.fileName.endsWith(".js"))
+      .map((asset) => [asset.fileName, asset]),
+  );
+  const chunkSizes = new Map(
+    [
+      ...[...chunks].map(([fileName, chunk]) => [
+        fileName,
+        compressedSizes(chunk.code),
+      ]),
+      ...[...scriptAssets].map(([fileName, asset]) => [
+        fileName,
+        compressedSizes(assetSource(asset)),
+      ]),
+    ],
+  );
+  const initialNames = new Set([
+    ...collectStaticChunks(
+      [...chunks.values()].filter((chunk) => chunk.isEntry).map((chunk) => chunk.fileName),
+      chunks,
+    ),
+    ...scriptAssets.keys(),
+  ]);
+
+  const reportNames = new Set([
+    ...chunks.keys(),
+    ...scriptAssets.keys(),
+  ]);
+  const routeMembership = new Map(
+    [...reportNames].map((fileName) => [fileName, []]),
+  );
+
+  const routeChunks = {};
+  const violations = [];
+  const initialModuleIds = [...initialNames].flatMap((fileName) =>
+    Object.keys(chunks.get(fileName)?.modules ?? {}).map(normalize),
+  );
+
+  for (const [domain, excludedFragments] of Object.entries(initialExclusions)) {
+    const leaked = initialModuleIds.find((moduleId) =>
+      excludedFragments.some((fragment) => moduleId.includes(fragment)),
+    );
+    if (leaked) {
+      violations.push(`${domain} leaked into the initial Assets graph via ${leaked}`);
+    }
+  }
+
+  for (const [route, moduleSuffixes] of Object.entries(routeFamilies)) {
+    const starts = [...chunks.values()]
+      .filter((chunk) =>
+        Object.keys(chunk.modules).some((moduleId) =>
+          moduleSuffixes.some((suffix) => normalize(moduleId).endsWith(suffix)),
+        ),
+      )
+      .map((chunk) => chunk.fileName);
+    if (!starts.length) {
+      violations.push(`${route} did not produce a route chunk`);
+      continue;
+    }
+    const loaded = collectStaticChunks(starts, chunks);
+    for (const initialName of initialNames) loaded.delete(initialName);
+    for (const fileName of loaded) routeMembership.get(fileName)?.push(route);
+    routeChunks[route] = {
+      entryChunks: starts.sort(),
+      chunks: [...loaded].sort(),
+      ...summarize(loaded, chunkSizes),
+    };
+  }
+
+  const allNames = reportNames;
+  const initial = {
+    chunks: [...initialNames].sort(),
+    ...summarize(initialNames, chunkSizes),
+  };
+  const total = {
+    chunks: [...allNames].sort(),
+    ...summarize(allNames, chunkSizes),
+  };
+  const largestRoute = Object.entries(routeChunks).reduce(
+    (largest, [route, values]) =>
+      values.gzipBytes > largest.gzipBytes ? { route, ...values } : largest,
+    { route: null, rawBytes: 0, gzipBytes: 0, brotliBytes: 0, chunks: [] },
+  );
+
+  violations.push(...budgetViolations("Initial JavaScript", initial, budgets.initial));
+  violations.push(...budgetViolations("Total JavaScript", total, budgets.total));
+  violations.push(
+    ...budgetViolations(
+      `Largest route (${largestRoute.route ?? "none"})`,
+      largestRoute,
+      budgets.largestRoute,
+    ),
+  );
+
+  return {
+    schemaVersion: 1,
+    initial,
+    routes: routeChunks,
+    total,
+    largestRoute,
+    chunks: [...allNames]
+      .map((fileName) => {
+        const chunk = chunks.get(fileName);
+        return {
+          fileName,
+          name: chunk?.name ?? fileName,
+          type: chunk ? "chunk" : "asset",
+          entry: Boolean(chunk?.isEntry),
+          initial: initialNames.has(fileName),
+          routes: routeMembership.get(fileName).sort(),
+          ...chunkSizes.get(fileName),
+        };
+      })
+      .sort((left, right) => left.fileName.localeCompare(right.fileName)),
+    budgets,
+    violations,
+  };
+}
+
+export default function bundleReportPlugin({ budgets }) {
+  let violations = [];
+
+  return {
+    name: "sceneworks-bundle-report",
+    generateBundle(_options, bundle) {
+      const report = buildBundleReport(bundle, budgets);
+      violations = report.violations;
+      this.emitFile({
+        type: "asset",
+        fileName: "bundle-report.json",
+        source: `${JSON.stringify(report, null, 2)}\n`,
+      });
+    },
+    writeBundle() {
+      if (violations.length) {
+        this.error(`Bundle budget failed:\n- ${violations.join("\n- ")}`);
+      }
+    },
+  };
+}

--- a/apps/web/vite-plugin-bundle-report.test.js
+++ b/apps/web/vite-plugin-bundle-report.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBundleReport, routeFamilies } from "./vite-plugin-bundle-report.js";
+
+const roomyBudgets = {
+  initial: { rawBytes: 10000, gzipBytes: 10000, brotliBytes: 10000 },
+  total: { rawBytes: 10000, gzipBytes: 10000, brotliBytes: 10000 },
+  largestRoute: { rawBytes: 10000, gzipBytes: 10000, brotliBytes: 10000 },
+};
+
+function chunk(fileName, { code = "export default 1;", imports = [], isEntry = false, modules = {} } = {}) {
+  return { type: "chunk", fileName, name: fileName, code, imports, isEntry, modules };
+}
+
+function asset(fileName, source = "window.__THEME__ = true;") {
+  return { type: "asset", fileName, source };
+}
+
+function completeRouteChunks() {
+  return Object.fromEntries(
+    Object.entries(routeFamilies).map(([route, [moduleId]], index) => {
+      const fileName = `assets/route-${index}.js`;
+      return [
+        fileName,
+        chunk(fileName, {
+          code: `export const route = ${JSON.stringify(route)};`,
+          imports: ["assets/shared.js"],
+          modules: { [`C:/repo/apps/web${moduleId}`]: {} },
+        }),
+      ];
+    }),
+  );
+}
+
+describe("bundle report", () => {
+  it("separates the entry graph from route static dependencies and records compression", () => {
+    const report = buildBundleReport(
+      {
+        "assets/index.js": chunk("assets/index.js", {
+          isEntry: true,
+          imports: ["assets/shared.js"],
+          modules: { "C:/repo/apps/web/src/main.jsx": {} },
+        }),
+        "assets/shared.js": chunk("assets/shared.js", {
+          modules: { "C:/repo/apps/web/src/shared.js": {} },
+        }),
+        "theme-init.js": asset("theme-init.js"),
+        ...completeRouteChunks(),
+      },
+      roomyBudgets,
+    );
+
+    expect(report.initial.chunks).toEqual([
+      "assets/index.js",
+      "assets/shared.js",
+      "theme-init.js",
+    ]);
+    expect(report.chunks.find((item) => item.fileName === "theme-init.js")).toMatchObject({
+      type: "asset",
+      initial: true,
+    });
+    expect(report.routes.Stats.chunks).toHaveLength(1);
+    expect(report.routes.Stats.chunks[0]).toMatch(/^assets\/route-/);
+    expect(report.initial.gzipBytes).toBeGreaterThan(0);
+    expect(report.initial.brotliBytes).toBeGreaterThan(0);
+    expect(report.violations).toEqual([]);
+  });
+
+  it("fails when a lazy route leaks into the initial graph or a budget regresses", () => {
+    const routeChunks = completeRouteChunks();
+    const statsFile = Object.keys(routeChunks).find((fileName) =>
+      Object.keys(routeChunks[fileName].modules)[0].endsWith("/src/screens/StatsScreen.jsx"),
+    );
+    const report = buildBundleReport(
+      {
+        "assets/index.js": chunk("assets/index.js", {
+          isEntry: true,
+          imports: [statsFile],
+          modules: { "C:/repo/apps/web/src/main.jsx": {} },
+          code: "x".repeat(2000),
+        }),
+        "assets/shared.js": chunk("assets/shared.js"),
+        ...routeChunks,
+      },
+      {
+        ...roomyBudgets,
+        initial: { rawBytes: 1, gzipBytes: 1, brotliBytes: 1 },
+      },
+    );
+
+    expect(
+      report.violations.some((message) =>
+        message.startsWith("Stats/Recharts leaked into the initial Assets graph"),
+      ),
+    ).toBe(true);
+    expect(report.violations.some((message) => message.includes("Initial JavaScript"))).toBe(true);
+  });
+});

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig, searchForWorkspaceRoot } from "vite";
 
+import bundleReportPlugin from "./vite-plugin-bundle-report.js";
 import themeInitPlugin from "./vite-plugin-theme-init.js";
 
 // Expose the product version (kept in lockstep across the repo's package.json /
@@ -12,6 +13,9 @@ import themeInitPlugin from "./vite-plugin-theme-init.js";
 // unavailable — see the sidebar footer in App.jsx.
 const pkg = JSON.parse(
   readFileSync(fileURLToPath(new URL("./package.json", import.meta.url)), "utf8"),
+);
+const bundleBudgets = JSON.parse(
+  readFileSync(fileURLToPath(new URL("./bundle-budgets.json", import.meta.url)), "utf8"),
 );
 
 // The About → Licenses screen (sc-3778) imports the bundled-license corpus
@@ -35,7 +39,7 @@ const configDir = fileURLToPath(new URL("../../config", import.meta.url));
 export default defineConfig({
   // Generate the pre-paint /theme-init.js from src/accents.js at dev/build time
   // (single source of truth for the accent-id list). See vite-plugin-theme-init.js.
-  plugins: [themeInitPlugin()],
+  plugins: [themeInitPlugin(), bundleReportPlugin({ budgets: bundleBudgets })],
   // Matches the existing import.meta.env.VITE_* convention (see api.js). Defining
   // the specific key keeps it lint-safe (no bare global) under no-undef.
   define: {
@@ -59,20 +63,6 @@ export default defineConfig({
       // Keep the default workspace-root allowance and add the desktop license
       // corpus the Licenses screen imports from.
       allow: [searchForWorkspaceRoot(process.cwd()), licensesDir, documentsDir, configDir],
-    },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        // Peel third-party code (React et al.) into a separate, rarely-changing
-        // chunk so the app bundle stays under Vite's size warning and the vendor
-        // chunk caches across app-only deploys.
-        manualChunks(id) {
-          if (id.includes("node_modules")) {
-            return "vendor";
-          }
-        },
-      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- lazy-load every inactive route family plus Setup Wizard and Simple UI behind an accessible loading/error boundary
- preserve the route demand-hydration behavior merged by SC-14783
- replace catch-all vendor chunking with natural route chunks
- generate raw/gzip/Brotli bundle reports and fail production builds on regressions

Shortcut: https://app.shortcut.com/trefry/story/14786

## Validation
- focused lazy/report + SC-14783 overlap suite: 62/62 passed
- full web suite: 192 files, 2,649/2,649 passed
- ESLint passed
- production Vite build passed with zero budget violations
- initial JS: 395,548 raw / 119,496 gzip / 102,200 Brotli
- total JS: 2,703,014 raw / 728,634 gzip / 588,155 Brotli
- largest route: Simple UI, 184,955 gzip
- embedded release build passed before the final main rebase; the exact-head rerun was interrupted before completion
- production HTTP entry smoke passed 23/23 before the final main rebase
- browser UI smoke unavailable because the connected browser runtime exposed no browser instances
