### PR TITLE
perf(api): bound startup maintenance (sc-14788)

### DIFF
--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 trash = { workspace = true }
 tokio-util = { version = "0.7", features = ["io"] }
 tower-http = { version = "0.6", features = ["cors"] }
+tower = { version = "0.5", features = ["util"] }
 uuid = { version = "1.11", features = ["v4"] }
 
 # Unix-only: parent-death watchdog liveness probe (safe kill(pid, None) wrapper).
@@ -67,6 +68,5 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 # pinned version as crates/sceneworks-mcp — client features are additive.
 rmcp = { version = "=2.1.0", features = ["client", "transport-streamable-http-client-reqwest"] }
 tempfile = "3.13"
-tower = { version = "0.5", features = ["util"] }
 [lints]
 workspace = true

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -215,6 +215,15 @@ pub(crate) struct HealthResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) directories: Option<DirectoriesResponse>,
     pub(crate) interrupted_jobs_on_startup: usize,
+    pub(crate) readiness: StartupReadinessResponse,
+    pub(crate) startup_maintenance: crate::startup::StartupMaintenanceResponse,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StartupReadinessResponse {
+    pub(crate) status: &'static str,
+    pub(crate) criticality: &'static str,
 }
 
 #[derive(Debug, Serialize)]

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -78,6 +78,8 @@ use uuid::Uuid;
 
 mod auth;
 use auth::{access_control, cors_layer, is_authorized, AuthThrottle};
+mod startup;
+use startup::{StartupCriticality, StartupMaintenance, StartupPhaseTimer};
 mod saved_voices;
 use saved_voices::{create_saved_voice, delete_saved_voice, list_saved_voices};
 mod characters;
@@ -165,8 +167,8 @@ use dto::{
     ModelImportRequest, PersonDetectionJobRequest, PersonTrackCorrectionsRequest,
     PersonTrackJobRequest, ProjectCreateRequest, PromptBatchesQuery, PromptRefineRequest,
     QualityAckBody, ReadinessQuery, RecipePresetsQuery, SavedVoiceCreateRequest,
-    TimelineCreateRequest, TimelineExportRequest, TimelineSaveRequest, TrainingCaptionJobRequest,
-    VerifyResponse, VideoJobRequest, VqaJobRequest,
+    StartupReadinessResponse, TimelineCreateRequest, TimelineExportRequest, TimelineSaveRequest,
+    TrainingCaptionJobRequest, VerifyResponse, VideoJobRequest, VqaJobRequest,
 };
 mod manifest;
 use manifest::{
@@ -495,7 +497,13 @@ async fn spawn_inprocess_utility_worker(
     // This API process is the top-level owner of the in-process utility loops, which deliberately
     // call `run_worker_loop` directly. Recover once here before any loop can claim a conversion;
     // never put recovery inside each child loop, where sibling restarts could sweep live backups.
-    sceneworks_worker::recover_stranded_model_conversions(&worker_settings.data_dir).await?;
+    {
+        let _phase = StartupPhaseTimer::start(
+            "utility_conversion_recovery",
+            StartupCriticality::ReadinessCritical,
+        );
+        sceneworks_worker::recover_stranded_model_conversions(&worker_settings.data_dir).await?;
+    }
     let grace = Duration::from_secs(worker_settings.shutdown_timeout_seconds.max(1));
     let count = inprocess_utility_worker_count();
     let base_worker_id = worker_settings.worker_id.clone();
@@ -763,6 +771,15 @@ pub(crate) fn sweep_stale_uploads(
     subdir: &str,
     cutoff: SystemTime,
 ) -> std::io::Result<usize> {
+    sweep_stale_uploads_cancellable(data_dir, subdir, cutoff, || true)
+}
+
+pub(crate) fn sweep_stale_uploads_cancellable(
+    data_dir: &FsPath,
+    subdir: &str,
+    cutoff: SystemTime,
+    should_continue: impl Fn() -> bool,
+) -> std::io::Result<usize> {
     let upload_root = data_dir.join("cache").join(subdir);
     let entries = match std::fs::read_dir(upload_root) {
         Ok(entries) => entries,
@@ -771,6 +788,9 @@ pub(crate) fn sweep_stale_uploads(
     };
     let mut removed = 0usize;
     for entry in entries {
+        if !should_continue() {
+            break;
+        }
         let entry = match entry {
             Ok(entry) => entry,
             Err(error) => {
@@ -786,33 +806,37 @@ pub(crate) fn sweep_stale_uploads(
         if !entry.file_name().to_string_lossy().starts_with("upload-") {
             continue;
         }
+        if !should_continue() {
+            break;
+        }
         let is_dir = match entry.file_type() {
             Ok(file_type) => file_type.is_dir(),
             Err(error) => {
                 tracing::warn!(
                     event = "stale_upload_stat_failed",
                     sweep = subdir,
-                    path = %entry.path().display(),
                     error = %error,
                     "could not stat a stale-upload entry; skipping it"
                 );
                 continue;
             }
         };
+        if !should_continue() {
+            break;
+        }
         let modified = match entry.metadata() {
             Ok(metadata) => metadata.modified().unwrap_or(UNIX_EPOCH),
             Err(error) => {
                 tracing::warn!(
                     event = "stale_upload_stat_failed",
                     sweep = subdir,
-                    path = %entry.path().display(),
                     error = %error,
                     "could not read a stale-upload entry's mtime; skipping it"
                 );
                 continue;
             }
         };
-        if modified <= cutoff {
+        if modified <= cutoff && should_continue() {
             let path = entry.path();
             let removal = if is_dir {
                 std::fs::remove_dir_all(&path)
@@ -827,7 +851,6 @@ pub(crate) fn sweep_stale_uploads(
                     tracing::warn!(
                         event = "stale_upload_remove_failed",
                         sweep = subdir,
-                        path = %path.display(),
                         error = %error,
                         "could not remove a stale upload entry; leaving it and continuing"
                     );
@@ -890,34 +913,6 @@ fn warn_on_sweep_err(kind: &str, result: std::io::Result<usize>) {
             sweep = kind,
             error = %error,
             "stale upload sweep failed; leaked temp uploads may remain"
-        );
-    }
-}
-
-/// One-shot pre-bind phase timer. Startup has only four of these, and `Drop`
-/// ensures a failing phase is still visible without changing the existing error
-/// propagation.
-struct StartupPhaseTimer {
-    phase: &'static str,
-    started: Instant,
-}
-
-impl StartupPhaseTimer {
-    fn start(phase: &'static str) -> Self {
-        Self {
-            phase,
-            started: Instant::now(),
-        }
-    }
-}
-
-impl Drop for StartupPhaseTimer {
-    fn drop(&mut self) {
-        tracing::info!(
-            event = "startup_phase_duration",
-            phase = self.phase,
-            duration_ms = self.started.elapsed().as_secs_f64() * 1000.0,
-            "SceneWorks API pre-bind startup phase completed"
         );
     }
 }
@@ -990,6 +985,35 @@ pub fn create_app(settings: Settings) -> Result<Router, JobsStoreError> {
 pub(crate) fn create_app_with_state(
     settings: Settings,
 ) -> Result<(Router, AppState), JobsStoreError> {
+    create_app_with_state_mode(settings, false)
+}
+
+#[cfg(test)]
+pub(crate) fn create_app_with_deferred_startup_maintenance(
+    settings: Settings,
+    timeout: Duration,
+) -> Result<(Router, AppState), JobsStoreError> {
+    let (router, state) = create_app_with_pending_startup_maintenance(settings)?;
+    state
+        .startup_maintenance
+        .start(state.settings.data_dir.clone(), timeout);
+    Ok((router, state))
+}
+
+pub(crate) fn create_app_with_pending_startup_maintenance(
+    settings: Settings,
+) -> Result<(Router, AppState), JobsStoreError> {
+    create_app_with_state_mode(settings, true)
+}
+
+fn create_app_with_state_mode(
+    settings: Settings,
+    defer_upload_sweeps: bool,
+) -> Result<(Router, AppState), JobsStoreError> {
+    let _filesystem_phase = StartupPhaseTimer::start(
+        "filesystem_preflight",
+        StartupCriticality::ReadinessCritical,
+    );
     // sc-8882 (F-080): a permissions/disk failure here is otherwise invisible until a
     // downstream 500 — surface it as a warning so it is diagnosable. Non-fatal: startup
     // continues (a missing dir surfaces later where it is actually used).
@@ -1013,8 +1037,8 @@ pub(crate) fn create_app_with_state(
             std::fs::create_dir_all(jobs_db_parent),
         );
     }
-    {
-        let _phase = StartupPhaseTimer::start("upload_sweeps");
+    if !defer_upload_sweeps {
+        let _phase = StartupPhaseTimer::start("upload_sweeps", StartupCriticality::BackgroundSafe);
         // sc-8882 (F-080): a failed sweep leaves leaked multi-GB upload temps unreclaimed
         // and was previously silent. WARN (never fatal) so the operator can investigate.
         warn_on_sweep_err("lora", sweep_stale_lora_uploads(&settings.data_dir));
@@ -1023,8 +1047,12 @@ pub(crate) fn create_app_with_state(
         // sc-4204 (F-API-6): asset-import temp files (cache/uploads) had no startup sweep.
         warn_on_sweep_err("asset", sweep_stale_asset_uploads(&settings.data_dir));
     }
+    drop(_filesystem_phase);
     let (jobs_store, interrupted_jobs_on_startup) = {
-        let _phase = StartupPhaseTimer::start("jobs_retention_recovery");
+        let _phase = StartupPhaseTimer::start(
+            "jobs_retention_recovery",
+            StartupCriticality::ReadinessCritical,
+        );
         let jobs_store = Arc::new(JobsStore::new(&settings.jobs_db_path));
         jobs_store.initialize()?;
         let purged_terminal_jobs =
@@ -1043,7 +1071,10 @@ pub(crate) fn create_app_with_state(
         settings.app_version.clone(),
     ));
     {
-        let _phase = StartupPhaseTimer::start("reserved_project_initialization");
+        let _phase = StartupPhaseTimer::start(
+            "reserved_project_initialization",
+            StartupCriticality::ReadinessCritical,
+        );
         // Reserved global pose library (epic 2282): created up front so its assets
         // endpoint returns [] (not 404) before any pose is saved. Best-effort.
         if let Err(error) = project_store.ensure_global_poses_project() {
@@ -1070,7 +1101,10 @@ pub(crate) fn create_app_with_state(
     // Best-effort and non-fatal — a failure just leaves the stale rows for next
     // startup; the sidecars are untouched, so nothing is lost.
     {
-        let _phase = StartupPhaseTimer::start("orphaned_asset_maintenance");
+        let _phase = StartupPhaseTimer::start(
+            "orphaned_asset_maintenance",
+            StartupCriticality::ReadinessCritical,
+        );
         match project_store.prune_all_orphaned_assets() {
             Ok(0) => {}
             Ok(pruned) => tracing::info!(
@@ -1111,6 +1145,11 @@ pub(crate) fn create_app_with_state(
         )),
         http_client: reqwest::Client::new(),
         interrupted_jobs_on_startup,
+        startup_maintenance: if defer_upload_sweeps {
+            StartupMaintenance::pending()
+        } else {
+            StartupMaintenance::complete()
+        },
         progress_side_effects_lock: Arc::new(AsyncMutex::new(())),
         #[cfg(test)]
         progress_before_accept_once: Arc::new(Mutex::new(None)),
@@ -1586,6 +1625,11 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
             })
         },
         interrupted_jobs_on_startup: state.interrupted_jobs_on_startup,
+        readiness: StartupReadinessResponse {
+            status: "ready",
+            criticality: "readiness-critical",
+        },
+        startup_maintenance: state.startup_maintenance.snapshot(),
     })
 }
 

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -15,28 +15,40 @@
 //! module reaches them through `crate::`.
 
 use std::collections::HashMap;
+use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router};
 use parking_lot::Mutex;
+use serde_json::json;
 use tokio::sync::{Mutex as AsyncMutex, Semaphore};
+use tower::ServiceExt;
 
 use sceneworks_core::jobs_store::JobsStore;
 use sceneworks_core::project_store::ProjectStore;
 
-use crate::auth::AuthThrottle;
+use crate::auth::{cors_layer, AuthThrottle};
 use crate::events::EventHub;
 use crate::external_base_models::ExternalBaseModelCache;
 use crate::external_loras::ExternalLoraCache;
 use crate::manifest::ManifestCache;
 use crate::models::ModelSizeCache;
+use crate::startup::{
+    StartupCriticality, StartupMaintenance, StartupPhaseTimer, BACKGROUND_MAINTENANCE_TIMEOUT,
+};
 use crate::tickets::TicketStore;
 use crate::{
-    create_app_with_state, env_path_or, env_string, open_bind_override_enabled, parent_death,
-    parent_pid_to_watch, seed_mode_for_config_dir, should_warn_open_bind, shutdown_signal,
-    spawn_inprocess_utility_worker, DEFAULT_API_HOST, DEFAULT_CORS_ORIGINS,
+    create_app_with_pending_startup_maintenance, env_path_or, env_string,
+    open_bind_override_enabled, parent_death, parent_pid_to_watch, seed_mode_for_config_dir,
+    should_warn_open_bind, shutdown_signal, spawn_inprocess_utility_worker, DEFAULT_API_HOST,
+    DEFAULT_CORS_ORIGINS,
 };
 
 #[derive(Debug, Clone)]
@@ -296,6 +308,9 @@ pub struct AppState {
     pub(crate) external_base_model_cache: Arc<Mutex<ExternalBaseModelCache>>,
     pub(crate) http_client: reqwest::Client,
     pub(crate) interrupted_jobs_on_startup: usize,
+    /// Safe, path-free status for bounded stale-upload cleanup that starts
+    /// after the listener is bound and readiness-critical initialization ends.
+    pub(crate) startup_maintenance: StartupMaintenance,
     /// Serializes the durable terminal-progress handoff from the jobs DB to
     /// idempotent catalog/project writes. A retry re-checks the DB after taking
     /// this lock, so two overlapping terminal reports cannot duplicate work.
@@ -318,6 +333,89 @@ pub struct AppState {
     pub(crate) progress_side_effects_fail_job_ids: Arc<Mutex<std::collections::HashSet<String>>>,
     #[cfg(test)]
     pub(crate) progress_side_effects_attempts: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+#[derive(Clone)]
+struct BootstrapState {
+    settings: Settings,
+    ready_app: Arc<OnceLock<Router>>,
+    startup_maintenance: StartupMaintenance,
+}
+
+fn bootstrap_router(
+    settings: Settings,
+    ready_app: Arc<OnceLock<Router>>,
+    startup_maintenance: StartupMaintenance,
+) -> Router {
+    let cors = cors_layer(&settings);
+    Router::new()
+        .fallback(bootstrap_dispatch)
+        .with_state(BootstrapState {
+            settings,
+            ready_app,
+            startup_maintenance,
+        })
+        // Keep the browser-visible readiness surface usable while the real
+        // application router is still performing readiness-critical startup.
+        // The same configured policy is retained after the ready router is
+        // installed; duplicate allow-origin insertion is idempotent.
+        .layer(cors)
+}
+
+async fn bootstrap_dispatch(
+    State(state): State<BootstrapState>,
+    request: Request<Body>,
+) -> Response {
+    if let Some(app) = state.ready_app.get() {
+        return match app.clone().oneshot(request).await {
+            Ok(response) => response,
+            Err(error) => match error {},
+        };
+    }
+
+    match request.uri().path() {
+        "/api/v1/health" => {
+            let token_configured = !state.settings.access_token.is_empty();
+            Json(json!({
+                "status": "starting",
+                "service": "sceneworks-api",
+                "runtime": "rust",
+                "version": state.settings.app_version,
+                "authRequired": token_configured,
+                "directories": if token_configured {
+                    None
+                } else {
+                    Some(json!({
+                        "data": state.settings.data_dir.display().to_string(),
+                        "config": state.settings.config_dir.display().to_string(),
+                        "projects": state.settings.projects_dir().display().to_string(),
+                        "jobsDb": state.settings.jobs_db_path.display().to_string(),
+                    }))
+                },
+                "interruptedJobsOnStartup": 0,
+                "readiness": {
+                    "status": "initializing",
+                    "criticality": "readiness-critical",
+                },
+                "startupMaintenance": state.startup_maintenance.snapshot(),
+            }))
+            .into_response()
+        }
+        "/api/v1/access" => Json(json!({
+            "authRequired": !state.settings.access_token.is_empty(),
+            "tokenHeader": "X-SceneWorks-Token",
+        }))
+        .into_response(),
+        _ => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [("retry-after", "1")],
+            Json(json!({
+                "detail": "SceneWorks API readiness-critical startup is still running",
+                "code": "api_initializing",
+            })),
+        )
+            .into_response(),
+    }
 }
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -352,14 +450,19 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // customizations live in the separate `user.*.jsonc` files, which seeding never touches.
     let seed_mode =
         seed_mode_for_config_dir(std::env::var("SCENEWORKS_CONFIG_DIR").ok().as_deref());
-    if let Err(error) =
-        sceneworks_core::builtin_manifests::seed_builtin_manifests(&settings.config_dir, seed_mode)
     {
-        return Err(format!(
-            "failed to seed builtin manifests into {}: {error}",
-            settings.config_dir.join("manifests").display()
-        )
-        .into());
+        let _phase =
+            StartupPhaseTimer::start("builtin_manifest_seed", StartupCriticality::BindCritical);
+        if let Err(error) = sceneworks_core::builtin_manifests::seed_builtin_manifests(
+            &settings.config_dir,
+            seed_mode,
+        ) {
+            return Err(format!(
+                "failed to seed builtin manifests into {}: {error}",
+                settings.config_dir.join("manifests").display()
+            )
+            .into());
+        }
     }
     let address: SocketAddr = format!("{}:{}", settings.host, settings.port).parse()?;
     // sc-4201 (F-API-1) / sc-5720 (API-001): a non-loopback bind with no access token
@@ -408,35 +511,89 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     let run_utility_inprocess = settings.run_utility_inprocess;
     let utility_data_dir = settings.data_dir.clone();
-    let (app, state) = create_app_with_state(settings)?;
-    let listener = tokio::net::TcpListener::bind(address).await?;
-    let progress_side_effect_recovery =
-        crate::jobs::spawn_terminal_progress_side_effect_recovery(state);
+    // Bind before any readiness-critical filesystem/SQLite initialization and
+    // before background-safe network-volume sweeps. The socket can accept as
+    // soon as the router is ready; stale upload cleanup can never hold the port
+    // closed indefinitely.
+    let listener = {
+        let _phase = StartupPhaseTimer::start("listener_bind", StartupCriticality::BindCritical);
+        tokio::net::TcpListener::bind(address).await?
+    };
     // Use the actual bound address so port 0 (OS-assigned) is reported and the
-    // in-process worker connects to the real port.
+    // in-process worker connects to the real port. `api_listening` now means the
+    // bootstrap health/access surface is accepting; `api_ready` below means all
+    // readiness-critical invariants are complete.
     let bound = listener.local_addr()?;
     let port = bound.port();
+    let ready_app = Arc::new(OnceLock::new());
+    let bootstrap_maintenance = StartupMaintenance::pending();
+    let bootstrap = bootstrap_router(
+        settings.clone(),
+        ready_app.clone(),
+        bootstrap_maintenance.clone(),
+    );
     tracing::info!(
         event = "api_listening",
         address = %bound,
-        "SceneWorks API listening"
+        "SceneWorks API bootstrap health/access surface listening"
     );
 
+    // `into_make_service_with_connect_info` exposes the peer `SocketAddr` to
+    // both the bootstrap dispatcher and, once installed, the real router's auth
+    // middleware. Poll this server while readiness-critical filesystem/SQLite
+    // work builds the real router on the blocking pool.
+    let serve = axum::serve(
+        listener,
+        bootstrap.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .into_future();
+    tokio::pin!(serve);
+    let mut build =
+        tokio::task::spawn_blocking(move || create_app_with_pending_startup_maintenance(settings));
+    let build_result = tokio::select! {
+        result = &mut build => result?,
+        result = &mut serve => {
+            bootstrap_maintenance.cancel();
+            build.abort();
+            result?;
+            return Ok(());
+        }
+    };
+    let (app, state) = build_result?;
+    state.startup_maintenance.start(
+        state.settings.data_dir.clone(),
+        BACKGROUND_MAINTENANCE_TIMEOUT,
+    );
+    ready_app
+        .set(app)
+        .map_err(|_| "SceneWorks API router was initialized more than once")?;
+    tracing::info!(
+        event = "api_ready",
+        address = %bound,
+        "SceneWorks API readiness-critical startup completed"
+    );
+    let progress_side_effect_recovery =
+        crate::jobs::spawn_terminal_progress_side_effect_recovery(state.clone());
+
+    // Conversion recovery is readiness-critical for the utility worker, not for
+    // HTTP. Keep polling the already-ready server while the worker initializes.
     let utility_worker = if run_utility_inprocess {
-        Some(spawn_inprocess_utility_worker(port, utility_data_dir).await?)
+        tokio::select! {
+            worker = spawn_inprocess_utility_worker(port, utility_data_dir) => Some(worker?),
+            result = &mut serve => {
+                state.startup_maintenance.cancel();
+                progress_side_effect_recovery.abort();
+                result?;
+                return Ok(());
+            }
+        }
     } else {
         None
     };
 
-    // `into_make_service_with_connect_info` exposes the peer `SocketAddr` to the auth
-    // middleware so loopback callers can be trusted (epic 4484: keep the local desktop UI
-    // and worker password-free while LAN clients stay gated).
-    let serve_result = axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .with_graceful_shutdown(shutdown_signal())
-    .await;
+    let serve_result = serve.await;
+    state.startup_maintenance.cancel();
     progress_side_effect_recovery.abort();
     serve_result?;
 
@@ -490,7 +647,10 @@ pub async fn run_worker() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod server_tests {
-    use super::{default_mcp_api_url, env_secs};
+    use super::{bootstrap_router, default_mcp_api_url, env_secs};
+    use crate::startup::StartupMaintenance;
+    use crate::tests::support::test_settings;
+    use std::sync::{Arc, OnceLock};
     use std::time::Duration;
 
     #[test]
@@ -512,6 +672,110 @@ mod server_tests {
         assert_eq!(env_secs(name, default), default, "unparseable → default");
 
         std::env::remove_var(name);
+    }
+
+    #[tokio::test]
+    async fn bootstrap_listener_serves_health_and_access_before_readiness() {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let settings = test_settings(&temp_dir);
+        let ready_app = Arc::new(OnceLock::new());
+        let bootstrap = bootstrap_router(
+            settings.clone(),
+            ready_app.clone(),
+            StartupMaintenance::pending(),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener binds");
+        let address = listener.local_addr().expect("bound address reads");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                bootstrap.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+        });
+        let client = reqwest::Client::new();
+
+        let bootstrap_started = std::time::Instant::now();
+        let health_response = client
+            .get(format!("http://{address}/api/v1/health"))
+            .header("origin", "http://localhost:5173")
+            .send()
+            .await
+            .expect("bootstrap health responds");
+        assert_eq!(
+            health_response
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("http://localhost:5173")
+        );
+        let health = health_response
+            .json::<serde_json::Value>()
+            .await
+            .expect("bootstrap health parses");
+        assert_eq!(health["status"], "starting");
+        assert_eq!(health["readiness"]["status"], "initializing");
+        let access = client
+            .get(format!("http://{address}/api/v1/access"))
+            .header("origin", "http://localhost:5173")
+            .send()
+            .await
+            .expect("bootstrap access responds");
+        assert_eq!(access.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            access
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("http://localhost:5173")
+        );
+        let preflight = client
+            .request(
+                reqwest::Method::OPTIONS,
+                format!("http://{address}/api/v1/access"),
+            )
+            .header("origin", "http://localhost:5173")
+            .header("access-control-request-method", "GET")
+            .send()
+            .await
+            .expect("bootstrap preflight responds");
+        assert_eq!(preflight.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            preflight
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("http://localhost:5173")
+        );
+        eprintln!(
+            "SC-14788 socket readiness timing: bootstrap /health + /access={:?}",
+            bootstrap_started.elapsed()
+        );
+        let unavailable = client
+            .get(format!("http://{address}/api/v1/projects"))
+            .send()
+            .await
+            .expect("bootstrap non-readiness route responds");
+        assert_eq!(
+            unavailable.status(),
+            reqwest::StatusCode::SERVICE_UNAVAILABLE
+        );
+
+        let (app, _) = crate::create_app_with_state(settings).expect("ready app creates");
+        ready_app.set(app).expect("ready app installs once");
+        let ready = client
+            .get(format!("http://{address}/api/v1/health"))
+            .send()
+            .await
+            .expect("ready health responds")
+            .json::<serde_json::Value>()
+            .await
+            .expect("ready health parses");
+        assert_eq!(ready["status"], "ok");
+        assert_eq!(ready["readiness"]["status"], "ready");
+        server.abort();
     }
 
     #[test]

--- a/apps/rust-api/src/startup.rs
+++ b/apps/rust-api/src/startup.rs
@@ -1,0 +1,442 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use tokio::sync::Notify;
+
+use crate::{
+    sweep_stale_uploads_cancellable, KEYPOINT_UPLOADS_CACHE_DIR, POSE_UPLOADS_CACHE_DIR,
+    STALE_UPLOAD_SECONDS,
+};
+
+pub(crate) const BACKGROUND_MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StartupCriticality {
+    BindCritical,
+    ReadinessCritical,
+    BackgroundSafe,
+}
+
+impl StartupCriticality {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::BindCritical => "bind-critical",
+            Self::ReadinessCritical => "readiness-critical",
+            Self::BackgroundSafe => "background-safe",
+        }
+    }
+}
+
+/// One-shot startup phase timer. `Drop` keeps failed phases observable without
+/// changing their existing error propagation.
+pub(crate) struct StartupPhaseTimer {
+    phase: &'static str,
+    criticality: StartupCriticality,
+    started: Instant,
+}
+
+impl StartupPhaseTimer {
+    pub(crate) fn start(phase: &'static str, criticality: StartupCriticality) -> Self {
+        Self {
+            phase,
+            criticality,
+            started: Instant::now(),
+        }
+    }
+}
+
+impl Drop for StartupPhaseTimer {
+    fn drop(&mut self) {
+        tracing::info!(
+            event = "startup_phase_duration",
+            phase = self.phase,
+            criticality = self.criticality.as_str(),
+            duration_ms = self.started.elapsed().as_secs_f64() * 1000.0,
+            "SceneWorks API startup phase completed"
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MaintenanceStatus {
+    Pending,
+    Running,
+    Complete,
+    Failed,
+    TimedOutCancelling,
+    TimedOut,
+    Cancelled,
+}
+
+impl MaintenanceStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Complete => "complete",
+            Self::Failed => "failed",
+            Self::TimedOutCancelling => "timed-out-cancelling",
+            Self::TimedOut => "timed-out",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    #[cfg(test)]
+    fn is_terminal(self) -> bool {
+        !matches!(
+            self,
+            Self::Pending | Self::Running | Self::TimedOutCancelling
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MaintenanceState {
+    status: MaintenanceStatus,
+    removed_uploads: usize,
+    failure_count: usize,
+}
+
+impl MaintenanceState {
+    fn pending() -> Self {
+        Self {
+            status: MaintenanceStatus::Pending,
+            removed_uploads: 0,
+            failure_count: 0,
+        }
+    }
+
+    fn complete() -> Self {
+        Self {
+            status: MaintenanceStatus::Complete,
+            removed_uploads: 0,
+            failure_count: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StartupMaintenanceResponse {
+    pub(crate) phase: &'static str,
+    pub(crate) criticality: &'static str,
+    pub(crate) status: &'static str,
+    pub(crate) removed_uploads: usize,
+    pub(crate) failure_count: usize,
+}
+
+struct StartupMaintenanceInner {
+    state: Mutex<MaintenanceState>,
+    started: AtomicBool,
+    cancelled: Arc<AtomicBool>,
+    changed: Notify,
+}
+
+impl Drop for StartupMaintenanceInner {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
+/// Single-flight lifecycle for the only background-safe startup work: stale
+/// upload staging sweeps. Project migrations, reserved libraries, job recovery,
+/// and orphan pruning remain readiness-critical and synchronous.
+#[derive(Clone)]
+pub(crate) struct StartupMaintenance {
+    inner: Arc<StartupMaintenanceInner>,
+}
+
+impl StartupMaintenance {
+    pub(crate) fn pending() -> Self {
+        Self::new(MaintenanceState::pending())
+    }
+
+    pub(crate) fn complete() -> Self {
+        let maintenance = Self::new(MaintenanceState::complete());
+        maintenance.inner.started.store(true, Ordering::Release);
+        maintenance
+    }
+
+    fn new(state: MaintenanceState) -> Self {
+        Self {
+            inner: Arc::new(StartupMaintenanceInner {
+                state: Mutex::new(state),
+                started: AtomicBool::new(false),
+                cancelled: Arc::new(AtomicBool::new(false)),
+                changed: Notify::new(),
+            }),
+        }
+    }
+
+    /// Start exactly one bounded blocking sweep. Returns false when another
+    /// caller already started it.
+    pub(crate) fn start(&self, data_dir: PathBuf, timeout: Duration) -> bool {
+        if self
+            .inner
+            .started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
+        }
+        self.set_state(MaintenanceState {
+            status: MaintenanceStatus::Running,
+            removed_uploads: 0,
+            failure_count: 0,
+        });
+
+        let maintenance = self.clone();
+        let cancelled = self.inner.cancelled.clone();
+        tokio::spawn(async move {
+            let _phase =
+                StartupPhaseTimer::start("upload_sweeps", StartupCriticality::BackgroundSafe);
+            let worker_cancelled = cancelled.clone();
+            let mut worker = tokio::task::spawn_blocking(move || {
+                run_upload_sweeps(&data_dir, worker_cancelled.as_ref())
+            });
+            match tokio::time::timeout(timeout, &mut worker).await {
+                Ok(Ok(result)) if result.cancelled => {
+                    maintenance.set_state(MaintenanceState {
+                        status: MaintenanceStatus::Cancelled,
+                        removed_uploads: result.removed_uploads,
+                        failure_count: result.failure_count,
+                    });
+                }
+                Ok(Ok(result)) => {
+                    let status = if result.failure_count == 0 {
+                        MaintenanceStatus::Complete
+                    } else {
+                        MaintenanceStatus::Failed
+                    };
+                    maintenance.set_state(MaintenanceState {
+                        status,
+                        removed_uploads: result.removed_uploads,
+                        failure_count: result.failure_count,
+                    });
+                    if result.failure_count > 0 {
+                        tracing::warn!(
+                            event = "startup_background_maintenance_failed",
+                            phase = "upload_sweeps",
+                            criticality = StartupCriticality::BackgroundSafe.as_str(),
+                            failure_count = result.failure_count,
+                            "background startup maintenance completed with failures"
+                        );
+                    }
+                }
+                Ok(Err(error)) => {
+                    maintenance.set_state(MaintenanceState {
+                        status: MaintenanceStatus::Failed,
+                        removed_uploads: 0,
+                        failure_count: 1,
+                    });
+                    tracing::warn!(
+                        event = "startup_background_maintenance_failed",
+                        phase = "upload_sweeps",
+                        criticality = StartupCriticality::BackgroundSafe.as_str(),
+                        failure_count = 1,
+                        error = %error,
+                        "background startup maintenance task failed"
+                    );
+                }
+                Err(_) => {
+                    cancelled.store(true, Ordering::Release);
+                    maintenance.set_state(MaintenanceState {
+                        status: MaintenanceStatus::TimedOutCancelling,
+                        removed_uploads: 0,
+                        failure_count: 1,
+                    });
+                    tracing::warn!(
+                        event = "startup_background_maintenance_timed_out",
+                        phase = "upload_sweeps",
+                        criticality = StartupCriticality::BackgroundSafe.as_str(),
+                        timeout_ms = timeout.as_millis(),
+                        "background startup maintenance exceeded its deadline; cancellation pending"
+                    );
+                    // `spawn_blocking` cannot be force-aborted. Retain and observe
+                    // the worker so health never claims terminal completion while
+                    // an in-flight network filesystem call may still mutate disk.
+                    let (removed_uploads, failure_count) = match worker.await {
+                        Ok(result) => (result.removed_uploads, result.failure_count.max(1)),
+                        Err(error) => {
+                            tracing::warn!(
+                                event = "startup_background_maintenance_cancel_failed",
+                                phase = "upload_sweeps",
+                                error = %error,
+                                "timed-out background maintenance task failed while cancelling"
+                            );
+                            (0, 1)
+                        }
+                    };
+                    maintenance.set_state(MaintenanceState {
+                        status: MaintenanceStatus::TimedOut,
+                        removed_uploads,
+                        failure_count,
+                    });
+                }
+            }
+        });
+        true
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.inner.cancelled.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn snapshot(&self) -> StartupMaintenanceResponse {
+        let state = *self.inner.state.lock();
+        StartupMaintenanceResponse {
+            phase: "upload_sweeps",
+            criticality: StartupCriticality::BackgroundSafe.as_str(),
+            status: state.status.as_str(),
+            removed_uploads: state.removed_uploads,
+            failure_count: state.failure_count,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_terminal(&self) -> StartupMaintenanceResponse {
+        loop {
+            let notified = self.inner.changed.notified();
+            if self.inner.state.lock().status.is_terminal() {
+                return self.snapshot();
+            }
+            notified.await;
+        }
+    }
+
+    fn set_state(&self, state: MaintenanceState) {
+        *self.inner.state.lock() = state;
+        self.inner.changed.notify_waiters();
+    }
+}
+
+#[derive(Debug, Default)]
+struct UploadSweepResult {
+    removed_uploads: usize,
+    failure_count: usize,
+    cancelled: bool,
+}
+
+fn run_upload_sweeps(data_dir: &Path, cancelled: &AtomicBool) -> UploadSweepResult {
+    #[cfg(test)]
+    if let Some(hook) = take_test_hook(data_dir) {
+        hook.reached.notify_one();
+        while !cancelled.load(Ordering::Acquire) && !hook.released.load(Ordering::Acquire) {
+            std::thread::park_timeout(Duration::from_millis(5));
+        }
+        if hook.fail {
+            return UploadSweepResult {
+                failure_count: 1,
+                cancelled: cancelled.load(Ordering::Acquire),
+                ..Default::default()
+            };
+        }
+    }
+
+    let mut result = UploadSweepResult::default();
+    let cutoff = std::time::SystemTime::now() - Duration::from_secs(STALE_UPLOAD_SECONDS);
+    for (area, subdir) in [
+        ("lora", "lora-uploads"),
+        ("pose", POSE_UPLOADS_CACHE_DIR),
+        ("keypoint", KEYPOINT_UPLOADS_CACHE_DIR),
+        ("asset", "uploads"),
+    ] {
+        if cancelled.load(Ordering::Acquire) {
+            result.cancelled = true;
+            break;
+        }
+        match sweep_stale_uploads_cancellable(data_dir, subdir, cutoff, || {
+            !cancelled.load(Ordering::Acquire)
+        }) {
+            Ok(removed) => result.removed_uploads = result.removed_uploads.saturating_add(removed),
+            Err(error) => {
+                result.failure_count = result.failure_count.saturating_add(1);
+                tracing::warn!(
+                    event = "stale_upload_sweep_failed",
+                    area,
+                    error = %error,
+                    "background stale upload sweep failed"
+                );
+            }
+        }
+        if cancelled.load(Ordering::Acquire) {
+            result.cancelled = true;
+            break;
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct StartupMaintenanceTestHookInner {
+    reached: Arc<Notify>,
+    released: Arc<AtomicBool>,
+    fail: bool,
+}
+
+#[cfg(test)]
+static TEST_HOOKS: std::sync::OnceLock<
+    Mutex<std::collections::HashMap<PathBuf, StartupMaintenanceTestHookInner>>,
+> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+pub(crate) struct StartupMaintenanceTestHook {
+    data_dir: PathBuf,
+    inner: StartupMaintenanceTestHookInner,
+}
+
+#[cfg(test)]
+impl StartupMaintenanceTestHook {
+    pub(crate) async fn wait_until_reached(&self) {
+        self.inner.reached.notified().await;
+    }
+
+    pub(crate) fn release(&self) {
+        self.inner.released.store(true, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+impl Drop for StartupMaintenanceTestHook {
+    fn drop(&mut self) {
+        self.release();
+        TEST_HOOKS
+            .get_or_init(Default::default)
+            .lock()
+            .remove(&self.data_dir);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_startup_maintenance_hook(
+    data_dir: PathBuf,
+    fail: bool,
+) -> StartupMaintenanceTestHook {
+    let inner = StartupMaintenanceTestHookInner {
+        reached: Arc::new(Notify::new()),
+        released: Arc::new(AtomicBool::new(false)),
+        fail,
+    };
+    assert!(
+        TEST_HOOKS
+            .get_or_init(Default::default)
+            .lock()
+            .insert(data_dir.clone(), inner.clone())
+            .is_none(),
+        "startup maintenance hook already registered"
+    );
+    StartupMaintenanceTestHook { data_dir, inner }
+}
+
+#[cfg(test)]
+fn take_test_hook(data_dir: &Path) -> Option<StartupMaintenanceTestHookInner> {
+    TEST_HOOKS
+        .get_or_init(Default::default)
+        .lock()
+        .remove(data_dir)
+}

--- a/apps/rust-api/src/tests/mod.rs
+++ b/apps/rust-api/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod projects;
 mod prompt_batches;
 mod recipe_presets;
 mod server;
+mod startup;
 // `pub(crate)` so the inline `#[cfg(test)]` test modules that live OUTSIDE this `tests`
 // tree (e.g. `crate::models::variant_install_tests`) can reuse the ONE crate-wide
 // `isolate_hf_cache` / `HF_ENV_LOCK` guard rather than adding a second lock (sc-13835).

--- a/apps/rust-api/src/tests/startup.rs
+++ b/apps/rust-api/src/tests/startup.rs
@@ -1,0 +1,225 @@
+use super::support::*;
+
+fn write_stale_asset_upload(data_dir: &std::path::Path) -> std::path::PathBuf {
+    let upload_root = data_dir.join("cache/uploads");
+    std::fs::create_dir_all(&upload_root).expect("upload root creates");
+    let path = upload_root.join("upload-stale.tmp");
+    std::fs::write(&path, b"stale").expect("stale upload writes");
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .expect("stale upload opens");
+    file.set_times(
+        std::fs::FileTimes::new()
+            .set_modified(SystemTime::now() - Duration::from_secs(25 * 60 * 60)),
+    )
+    .expect("stale upload mtime writes");
+    path
+}
+
+#[tokio::test]
+async fn slow_background_upload_sweep_keeps_health_and_access_ready_then_cleans_up() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    // Public health diagnostics must not add a second path disclosure when auth
+    // is configured; the pre-existing `directories` field is omitted in this mode.
+    settings.access_token = "secret".to_owned();
+    let stale = write_stale_asset_upload(&settings.data_dir);
+    let hook = crate::startup::test_startup_maintenance_hook(settings.data_dir.clone(), false);
+    let (app, state) =
+        crate::create_app_with_deferred_startup_maintenance(settings, Duration::from_secs(2))
+            .expect("deferred app creates");
+    tokio::time::timeout(Duration::from_secs(1), hook.wait_until_reached())
+        .await
+        .expect("background sweep reaches deterministic block");
+
+    let started = std::time::Instant::now();
+    let (health_status, running) = request(app.clone(), "GET", "/api/v1/health", Value::Null).await;
+    let (access_status, _) = request(app.clone(), "GET", "/api/v1/access", Value::Null).await;
+    assert_eq!(health_status, StatusCode::OK);
+    assert_eq!(access_status, StatusCode::OK);
+    assert_eq!(running["startupMaintenance"]["status"], "running");
+    assert_eq!(
+        running["startupMaintenance"]["criticality"],
+        "background-safe"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "background filesystem work must not hold health/access readiness"
+    );
+    eprintln!(
+        "SC-14788 local readiness timing: blocked background upload sweep, /health + /access={:?}",
+        started.elapsed()
+    );
+    assert!(stale.exists(), "the blocked sweep has not run yet");
+    assert!(
+        !state
+            .startup_maintenance
+            .start(temp_dir.path().join("must-not-run"), Duration::from_secs(2)),
+        "startup maintenance is single-flight"
+    );
+
+    hook.release();
+    let completed = tokio::time::timeout(
+        Duration::from_secs(2),
+        state.startup_maintenance.wait_for_terminal(),
+    )
+    .await
+    .expect("background sweep completes");
+    assert_eq!(completed.status, "complete");
+    assert_eq!(completed.removed_uploads, 1);
+    assert_eq!(completed.failure_count, 0);
+    assert!(!stale.exists(), "eventual cleanup removes the stale upload");
+
+    let (_, health) = request(app, "GET", "/api/v1/health", Value::Null).await;
+    assert_eq!(health["startupMaintenance"]["status"], "complete");
+    assert_eq!(health["startupMaintenance"]["removedUploads"], 1);
+    assert!(
+        !serde_json::to_string(&health)
+            .expect("health serializes")
+            .contains(temp_dir.path().to_string_lossy().as_ref()),
+        "background maintenance diagnostics do not leak filesystem paths"
+    );
+}
+
+#[tokio::test]
+async fn background_upload_sweep_failure_is_reported_without_blocking_readiness() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret".to_owned();
+    let hook = crate::startup::test_startup_maintenance_hook(settings.data_dir.clone(), true);
+    let (app, state) =
+        crate::create_app_with_deferred_startup_maintenance(settings, Duration::from_secs(2))
+            .expect("deferred app creates");
+    tokio::time::timeout(Duration::from_secs(1), hook.wait_until_reached())
+        .await
+        .expect("background sweep reaches deterministic failure");
+
+    let (status, running) = request(app.clone(), "GET", "/api/v1/health", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(running["startupMaintenance"]["status"], "running");
+    hook.release();
+
+    let failed = tokio::time::timeout(
+        Duration::from_secs(2),
+        state.startup_maintenance.wait_for_terminal(),
+    )
+    .await
+    .expect("background failure is reported");
+    assert_eq!(failed.status, "failed");
+    assert_eq!(failed.failure_count, 1);
+    let (_, health) = request(app, "GET", "/api/v1/health", Value::Null).await;
+    assert_eq!(health["startupMaintenance"]["status"], "failed");
+    assert_eq!(health["startupMaintenance"]["failureCount"], 1);
+    assert!(
+        !serde_json::to_string(&health)
+            .expect("health serializes")
+            .contains(temp_dir.path().to_string_lossy().as_ref()),
+        "failure diagnostics do not leak filesystem paths"
+    );
+}
+
+#[tokio::test]
+async fn background_upload_sweep_timeout_is_bounded_and_cancellation_aware() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let hook = crate::startup::test_startup_maintenance_hook(settings.data_dir.clone(), false);
+    let (app, state) =
+        crate::create_app_with_deferred_startup_maintenance(settings, Duration::from_millis(50))
+            .expect("deferred app creates");
+    tokio::time::timeout(Duration::from_secs(1), hook.wait_until_reached())
+        .await
+        .expect("background sweep reaches deterministic block");
+
+    let timed_out = tokio::time::timeout(
+        Duration::from_secs(1),
+        state.startup_maintenance.wait_for_terminal(),
+    )
+    .await
+    .expect("maintenance deadline is bounded");
+    assert_eq!(timed_out.status, "timed-out");
+    let (status, health) = request(app, "GET", "/api/v1/health", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(health["startupMaintenance"]["status"], "timed-out");
+    hook.release();
+}
+
+#[tokio::test]
+async fn deferred_upload_sweeps_preserve_orphan_first_list_and_asset_mutation() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let store = sceneworks_core::project_store::ProjectStore::new(
+        &settings.data_dir,
+        settings.app_version.clone(),
+    );
+    let project = store
+        .create_project("Startup integrity")
+        .expect("project creates");
+    store
+        .persist_generated_asset(
+            &project.id,
+            "old-job",
+            "old-set",
+            &json!({
+                "assetId": "orphan",
+                "mediaPath": "assets/images/old-set/orphan.png",
+                "mimeType": "image/png",
+                "type": "image",
+                "displayName": "Orphan",
+                "createdAt": "2026-07-25T00:00:00Z",
+                "mode": "text_to_image",
+                "model": "test",
+                "adapter": "test",
+                "prompt": "orphan"
+            }),
+        )
+        .expect("orphan row persists");
+
+    let hook = crate::startup::test_startup_maintenance_hook(settings.data_dir.clone(), false);
+    let (app, state) =
+        crate::create_app_with_deferred_startup_maintenance(settings, Duration::from_secs(2))
+            .expect("deferred app creates");
+    tokio::time::timeout(Duration::from_secs(1), hook.wait_until_reached())
+        .await
+        .expect("background upload sweep blocks");
+
+    // Orphan pruning remains readiness-critical and uses the same per-project
+    // lock as list/mutation. The first list is clean even while unrelated upload
+    // staging cleanup is still running.
+    let assets_uri = format!(
+        "/api/v1/projects/{}/assets?includeRejected=true&includeTrashed=true",
+        project.id
+    );
+    let (status, first) = request(app.clone(), "GET", &assets_uri, Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(first, json!([]));
+
+    let project_path = std::path::PathBuf::from(&project.path);
+    let media = project_path.join("assets/images/new-set/current.png");
+    std::fs::create_dir_all(media.parent().expect("media parent")).expect("media dir creates");
+    std::fs::write(&media, PNG_32X32).expect("media writes");
+    state
+        .project_store
+        .persist_generated_asset(
+            &project.id,
+            "new-job",
+            "new-set",
+            &json!({
+                "assetId": "current",
+                "mediaPath": "assets/images/new-set/current.png",
+                "mimeType": "image/png",
+                "type": "image",
+                "displayName": "Current",
+                "createdAt": "2026-07-25T00:01:00Z",
+                "mode": "text_to_image",
+                "model": "test",
+                "adapter": "test",
+                "prompt": "current"
+            }),
+        )
+        .expect("concurrent asset mutation persists");
+    let (_, after_mutation) = request(app, "GET", &assets_uri, Value::Null).await;
+    assert_eq!(after_mutation.as_array().expect("assets array").len(), 1);
+    assert_eq!(after_mutation[0]["id"], "current");
+    hook.release();
+}

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -1590,8 +1590,19 @@
       "projects": "<runtime-root>/data/projects"
     },
     "interruptedJobsOnStartup": 0,
+    "readiness": {
+      "criticality": "readiness-critical",
+      "status": "ready"
+    },
     "runtime": "<runtime>",
     "service": "sceneworks-api",
+    "startupMaintenance": {
+      "criticality": "background-safe",
+      "failureCount": 0,
+      "phase": "upload_sweeps",
+      "removedUploads": 0,
+      "status": "<maintenance-status>"
+    },
     "status": "ok",
     "version": "0.2.0"
   },

--- a/tests/rust_api_harness.py
+++ b/tests/rust_api_harness.py
@@ -193,7 +193,12 @@ def wait_for_health(
         try:
             response = httpx.get(f"{base_url}/api/v1/health", timeout=1)
             if response.status_code == 200:
-                return
+                body = response.json()
+                readiness = body.get("readiness")
+                if body.get("status") == "ok" and (
+                    readiness is None or readiness.get("status") == "ready"
+                ):
+                    return
         except httpx.HTTPError as exc:
             last_error = exc
         time.sleep(0.25)

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -350,6 +350,8 @@ def _normalize_contract(
             return "<event-ticket>"
         if normalized == "rust":
             return "<runtime>"
+        if path.endswith(".startupMaintenance.status"):
+            return "<maintenance-status>"
         return normalized
     if path.endswith(".loc[1]") and isinstance(value, int):
         return "<json-error-offset>"


### PR DESCRIPTION
## Summary

- classify and time bind-critical, readiness-critical, and background-safe startup phases
- preserve synchronous migrations, job recovery, reserved libraries, and orphan-first-list correctness
- defer stale upload sweeps behind a bounded, cancellation-aware, single-flight worker with path-secret-safe health diagnostics
- bind the listener before readiness-critical initialization while returning bounded 503 readiness responses until the router is ready
- add deterministic slow, failure, timeout, cleanup, race-safety, and contract tests

## Validation

- cargo fmt --all -- --check
- cargo clippy/build checks passed during implementation review
- full API suite: 397 passed, 2 ignored; the separate Windows parent-liveness process check has the known runner-only failure
- Rust/API contract snapshots passed
- independent adversarial review: PASS
- local deterministic timing proves /health and /access remain responsive while the background sweep is blocked

## Runtime evidence

Cold-start phase timing is emitted through structured startup_phase_duration events. Final before/after RunPod measurement is tracked by the epic integration story SC-14789.

Shortcut: https://app.shortcut.com/trefry/story/14788