### PR TITLE
Register Mage-Flow foundation training targets (sc-14054)

### DIFF
--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -3299,6 +3299,48 @@ fn flat_diffusers_snapshot_is_not_treated_as_a_tiered_turnkey() {
 }
 
 #[test]
+fn mage_flow_foundation_targets_resolve_the_installed_flat_mirrors() {
+    // sc-14054: Mage's q4/q8/bf16 catalog variants all materialize the same flat dense snapshot on
+    // every platform. The training targets must therefore resolve their live SceneWorks mirrors
+    // directly and report them ready without inventing a physical `bf16/` subdirectory.
+    for (base_model, expected_repo) in [
+        ("mage_flow_base", "SceneWorks/Mage-Flow-Base"),
+        ("mage_flow_edit_base", "SceneWorks/Mage-Flow-Edit-Base"),
+    ] {
+        let _env = isolate_hf_cache();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp.path().join("data");
+        let target = crate::builtin_training_targets()
+            .targets
+            .into_iter()
+            .find(|target| target.base_model == base_model)
+            .unwrap_or_else(|| panic!("{base_model} target present"));
+        assert_eq!(target.base_model_repo.as_deref(), Some(expected_repo));
+
+        let repo_root =
+            huggingface_repo_cache_path(&data_dir, expected_repo).expect("repo cache path");
+        let revision = "rev14054";
+        let snapshot = repo_root.join("snapshots").join(revision);
+        std::fs::create_dir_all(&snapshot).expect("snapshot dir");
+        std::fs::create_dir_all(repo_root.join("refs")).expect("refs dir");
+        std::fs::write(repo_root.join("refs").join("main"), revision).expect("refs/main");
+        // A readable config/payload certifies a materialized flat snapshot for the resolver path.
+        std::fs::write(snapshot.join("config.json"), "{}").expect("flat snapshot config");
+
+        assert_eq!(
+            resolve_base_model_path(&target, &data_dir),
+            snapshot.display().to_string(),
+            "{base_model}: training resolves the installed flat mirror root"
+        );
+        assert_eq!(
+            training_base_model_status(&data_dir, &target),
+            TrainingBaseStatus::Ready,
+            "{base_model}: the installed flat mirror is training-ready"
+        );
+    }
+}
+
+#[test]
 fn stock_sdxl_target_points_at_installed_turnkey() {
     // Regression guard for issue #1694: the stock `sdxl` training target must name the same
     // `SceneWorks/sdxl-base-mlx` turnkey the catalog + engine install — pointing at the flat

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -1195,13 +1195,16 @@ pub(crate) const CANDLE_ROUTED_TRAINING_KERNELS: &[&str] = &[
 /// exempts a candle worker for a `krea_lora` job it is candle-eligible for (it is also in
 /// [`CANDLE_ROUTED_TRAINING_KERNELS`]), while a generic worker is refused. `sd3_lora` (epic 7841 T3
 /// sc-7884) is MLX-native with no candle trainer yet (the off-Mac/candle SD3.5 trainer is epic
-/// 7982), so — like LTX — only an mlx worker runs it today.
+/// 7982), so — like LTX — only an mlx worker runs it today. `mage_flow_lora` is registered as a
+/// training-target contract in sc-14054 ahead of its native trainer (sc-14055); keeping it here makes
+/// every worker refuse it until that worker explicitly adds the kernel to its routed set.
 pub(crate) const MLX_ONLY_TRAINING_KERNELS: &[&str] = &[
     "ltx_mlx_lora",
     "krea_lora",
     "sd3_lora",
     "anima_lora",
     "krea_control",
+    "mage_flow_lora",
 ];
 
 #[cfg(test)]
@@ -1488,6 +1491,7 @@ mod tests {
         "sd3_lora",
         "anima_lora",
         "krea_control",
+        "mage_flow_lora",
     ];
 
     #[test]

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -437,20 +437,6 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
     TrainingTargetRegistry {
         schema_version: TRAINING_CONTRACT_SCHEMA_VERSION,
         targets: vec![
-            mage_flow_lora_target(
-                "mage_flow_base_lora",
-                "Mage-Flow Base LoRA",
-                "mage_flow_base",
-                "SceneWorks/Mage-Flow-Base",
-                "Train an image LoRA against the undistilled Mage-Flow Base model.",
-            ),
-            mage_flow_lora_target(
-                "mage_flow_edit_base_lora",
-                "Mage-Flow Edit-Base LoRA",
-                "mage_flow_edit_base",
-                "SceneWorks/Mage-Flow-Edit-Base",
-                "Train an image-editing LoRA against the undistilled Mage-Flow Edit-Base model.",
-            ),
             z_image_turbo_lora_target(),
             sdxl_lora_target(),
             illustrious_xl_v1_lora_target(),
@@ -466,6 +452,22 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
             wan_lora_target(),
             wan_t2v_14b_lora_target(),
             wan_i2v_14b_lora_target(),
+            // Keep not-yet-routed foundation contracts after the executable targets so the stable
+            // first-target default remains Z-Image until sc-14055 advertises the Mage kernel.
+            mage_flow_lora_target(
+                "mage_flow_base_lora",
+                "Mage-Flow Base LoRA",
+                "mage_flow_base",
+                "SceneWorks/Mage-Flow-Base",
+                "Train an image LoRA against the undistilled Mage-Flow Base model.",
+            ),
+            mage_flow_lora_target(
+                "mage_flow_edit_base_lora",
+                "Mage-Flow Edit-Base LoRA",
+                "mage_flow_edit_base",
+                "SceneWorks/Mage-Flow-Edit-Base",
+                "Train an image-editing LoRA against the undistilled Mage-Flow Edit-Base model.",
+            ),
         ],
         extra: ExtraFields::new(),
     }

--- a/crates/sceneworks-core/src/training.rs
+++ b/crates/sceneworks-core/src/training.rs
@@ -437,6 +437,20 @@ pub fn builtin_training_targets() -> TrainingTargetRegistry {
     TrainingTargetRegistry {
         schema_version: TRAINING_CONTRACT_SCHEMA_VERSION,
         targets: vec![
+            mage_flow_lora_target(
+                "mage_flow_base_lora",
+                "Mage-Flow Base LoRA",
+                "mage_flow_base",
+                "SceneWorks/Mage-Flow-Base",
+                "Train an image LoRA against the undistilled Mage-Flow Base model.",
+            ),
+            mage_flow_lora_target(
+                "mage_flow_edit_base_lora",
+                "Mage-Flow Edit-Base LoRA",
+                "mage_flow_edit_base",
+                "SceneWorks/Mage-Flow-Edit-Base",
+                "Train an image-editing LoRA against the undistilled Mage-Flow Edit-Base model.",
+            ),
             z_image_turbo_lora_target(),
             sdxl_lora_target(),
             illustrious_xl_v1_lora_target(),
@@ -1241,6 +1255,85 @@ where
         quality_preset: quality_preset.to_owned(),
         config,
         ui,
+        extra: ExtraFields::new(),
+    }
+}
+
+/// Mage-Flow LoRA training targets.
+///
+/// Both foundation variants are flat, dense diffusers snapshots. Their catalog `q4`/`q8`/`bf16`
+/// variants are logical load-time choices over the same installed files, rather than separate
+/// on-disk tier directories. Pointing at the live SceneWorks mirrors keeps the training pre-flight
+/// resolver aligned with what Model Manager installs on macOS and Windows/Linux (sc-14054).
+///
+/// The execution kernel is registered here as the stable contract consumed by the Mage trainer
+/// slice (sc-14055). Until a worker advertises that kernel, the existing worker-capability gate
+/// leaves jobs queued rather than treating registration itself as runtime support.
+fn mage_flow_lora_target(
+    id: &str,
+    name: &str,
+    base_model: &str,
+    base_model_repo: &str,
+    description: &str,
+) -> TrainingTarget {
+    TrainingTarget {
+        id: id.to_owned(),
+        name: name.to_owned(),
+        modality: TrainingModality::Image,
+        output_kind: TrainingOutputKind::Lora,
+        family: "mage-flow".to_owned(),
+        base_model: base_model.to_owned(),
+        base_model_repo: Some(base_model_repo.to_owned()),
+        kernel: "mage_flow_lora".to_owned(),
+        defaults: TrainingConfig {
+            rank: 16,
+            alpha: 16,
+            learning_rate: ContractNumber::from_f64(0.0001).expect("0.0001 is finite"),
+            steps: 3000,
+            batch_size: 1,
+            gradient_accumulation: 1,
+            resolution: 1024,
+            save_every: 250,
+            seed: 42,
+            optimizer: "adamw8bit".to_owned(),
+            trigger_word: None,
+            advanced: object(json!({
+                "mixedPrecision": "bf16",
+                "cacheLatents": true,
+                "cacheTextEmbeddings": true,
+                "gradientCheckpointing": true,
+                "networkType": "lora",
+                "timestepType": "sigmoid",
+                "timestepBias": "high_noise",
+                "lossType": "mse",
+                "weightDecay": 0.0001,
+                "lrScheduler": "constant",
+                "sampleEvery": 500,
+                "sampleSteps": 30,
+                "sampleGuidanceScale": 5.0,
+                "qualityPreset": "balanced",
+                "outputScope": "project",
+                "requestedGpu": "auto"
+            })),
+            extra: ExtraFields::new(),
+        },
+        limits: object(json!({
+            "rank": [4, 128],
+            "alpha": [1, 128],
+            "steps": [200, 6000],
+            "resolutions": [512, 768, 1024],
+            "batchSize": [1, 4],
+            "optimizers": ["adamw8bit", "adamw", "adam", "prodigyopt", "rose"],
+            "networkTypes": ["lora"],
+            "lrSchedulers": ["constant", "linear", "cosine"],
+            "outputScopes": ["project", "global"]
+        })),
+        ui: object(json!({
+            "label": name,
+            "description": description,
+            "recommendedFor": ["character", "style"],
+            "datasetModality": "image"
+        })),
         extra: ExtraFields::new(),
     }
 }

--- a/crates/sceneworks-core/tests/training_contracts.rs
+++ b/crates/sceneworks-core/tests/training_contracts.rs
@@ -256,6 +256,40 @@ fn builtin_registry_exposes_z_image_turbo_target() {
 }
 
 #[test]
+fn builtin_registry_exposes_both_mage_flow_foundation_targets() {
+    let registry = builtin_training_targets();
+    for (id, base_model, repo) in [
+        (
+            "mage_flow_base_lora",
+            "mage_flow_base",
+            "SceneWorks/Mage-Flow-Base",
+        ),
+        (
+            "mage_flow_edit_base_lora",
+            "mage_flow_edit_base",
+            "SceneWorks/Mage-Flow-Edit-Base",
+        ),
+    ] {
+        let target = registry
+            .targets
+            .iter()
+            .find(|target| target.id == id)
+            .unwrap_or_else(|| panic!("{id} target present"));
+        assert_eq!(target.modality, TrainingModality::Image);
+        assert_eq!(target.output_kind, TrainingOutputKind::Lora);
+        assert_eq!(target.family, "mage-flow");
+        assert_eq!(target.base_model, base_model);
+        assert_eq!(target.base_model_repo.as_deref(), Some(repo));
+        assert_eq!(target.kernel, "mage_flow_lora");
+        assert_eq!(target.defaults.resolution, 1024);
+        assert_eq!(
+            target.limits.get("networkTypes"),
+            Some(&serde_json::json!(["lora"]))
+        );
+    }
+}
+
+#[test]
 fn builtin_registry_exposes_sdxl_target() {
     let registry = builtin_training_targets();
     let target = registry
@@ -370,6 +404,49 @@ fn every_training_base_repo_is_installed_by_its_catalog_entry() {
             target.base_model,
             catalog_repos
         );
+    }
+}
+
+/// sc-14054 — Mage's three logical quality variants all install the same flat dense snapshot.
+/// They must remain available on every desktop platform and point at the target's live mirror;
+/// otherwise Training Studio can offer a target whose platform-specific catalog view cannot install
+/// the repo used by the API pre-flight resolver.
+#[test]
+fn mage_flow_training_repos_are_available_on_macos_windows_and_linux() {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc embedded in BUILTIN_MANIFESTS");
+    let catalog: Value = serde_json::from_str(&strip_jsonc_comments(raw))
+        .expect("builtin.models.jsonc parses as JSON");
+    let models = catalog["models"].as_array().expect("catalog models array");
+
+    for (base_model, repo) in [
+        ("mage_flow_base", "SceneWorks/Mage-Flow-Base"),
+        ("mage_flow_edit_base", "SceneWorks/Mage-Flow-Edit-Base"),
+    ] {
+        let model = models
+            .iter()
+            .find(|model| model["id"] == base_model)
+            .unwrap_or_else(|| panic!("{base_model} catalog entry present"));
+        let downloads = model["downloads"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{base_model} downloads array"));
+        for tier in ["q4", "q8", "bf16"] {
+            let download = downloads
+                .iter()
+                .find(|download| download["variant"] == tier)
+                .unwrap_or_else(|| panic!("{base_model} has {tier} training tier"));
+            assert_eq!(download["repo"], repo);
+            assert!(
+                download.get("platforms").is_none(),
+                "{base_model}/{tier} must be installable on macOS, Windows, and Linux"
+            );
+        }
     }
 }
 

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -2,6 +2,188 @@
   "schemaVersion": 1,
   "targets": [
     {
+      "id": "mage_flow_base_lora",
+      "name": "Mage-Flow Base LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "mage-flow",
+      "baseModel": "mage_flow_base",
+      "baseModelRepo": "SceneWorks/Mage-Flow-Base",
+      "kernel": "mage_flow_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 5.0,
+          "sampleSteps": 30,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "datasetModality": "image",
+        "description": "Train an image LoRA against the undistilled Mage-Flow Base model.",
+        "label": "Mage-Flow Base LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
+      "id": "mage_flow_edit_base_lora",
+      "name": "Mage-Flow Edit-Base LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "mage-flow",
+      "baseModel": "mage_flow_edit_base",
+      "baseModelRepo": "SceneWorks/Mage-Flow-Edit-Base",
+      "kernel": "mage_flow_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 5.0,
+          "sampleSteps": 30,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "datasetModality": "image",
+        "description": "Train an image-editing LoRA against the undistilled Mage-Flow Edit-Base model.",
+        "label": "Mage-Flow Edit-Base LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
       "id": "z_image_turbo_lora",
       "name": "Z-Image-Turbo LoRA",
       "modality": "image",

--- a/tests/fixtures/rust_migration_contracts/training/target-registry.json
+++ b/tests/fixtures/rust_migration_contracts/training/target-registry.json
@@ -2,188 +2,6 @@
   "schemaVersion": 1,
   "targets": [
     {
-      "id": "mage_flow_base_lora",
-      "name": "Mage-Flow Base LoRA",
-      "modality": "image",
-      "outputKind": "lora",
-      "family": "mage-flow",
-      "baseModel": "mage_flow_base",
-      "baseModelRepo": "SceneWorks/Mage-Flow-Base",
-      "kernel": "mage_flow_lora",
-      "defaults": {
-        "rank": 16,
-        "alpha": 16,
-        "learningRate": 0.0001,
-        "steps": 3000,
-        "batchSize": 1,
-        "gradientAccumulation": 1,
-        "resolution": 1024,
-        "saveEvery": 250,
-        "seed": 42,
-        "optimizer": "adamw8bit",
-        "advanced": {
-          "cacheLatents": true,
-          "cacheTextEmbeddings": true,
-          "gradientCheckpointing": true,
-          "lossType": "mse",
-          "lrScheduler": "constant",
-          "mixedPrecision": "bf16",
-          "networkType": "lora",
-          "outputScope": "project",
-          "qualityPreset": "balanced",
-          "requestedGpu": "auto",
-          "sampleEvery": 500,
-          "sampleGuidanceScale": 5.0,
-          "sampleSteps": 30,
-          "timestepBias": "high_noise",
-          "timestepType": "sigmoid",
-          "weightDecay": 0.0001
-        }
-      },
-      "limits": {
-        "alpha": [
-          1,
-          128
-        ],
-        "batchSize": [
-          1,
-          4
-        ],
-        "lrSchedulers": [
-          "constant",
-          "linear",
-          "cosine"
-        ],
-        "networkTypes": [
-          "lora"
-        ],
-        "optimizers": [
-          "adamw8bit",
-          "adamw",
-          "adam",
-          "prodigyopt",
-          "rose"
-        ],
-        "outputScopes": [
-          "project",
-          "global"
-        ],
-        "rank": [
-          4,
-          128
-        ],
-        "resolutions": [
-          512,
-          768,
-          1024
-        ],
-        "steps": [
-          200,
-          6000
-        ]
-      },
-      "ui": {
-        "datasetModality": "image",
-        "description": "Train an image LoRA against the undistilled Mage-Flow Base model.",
-        "label": "Mage-Flow Base LoRA",
-        "recommendedFor": [
-          "character",
-          "style"
-        ]
-      }
-    },
-    {
-      "id": "mage_flow_edit_base_lora",
-      "name": "Mage-Flow Edit-Base LoRA",
-      "modality": "image",
-      "outputKind": "lora",
-      "family": "mage-flow",
-      "baseModel": "mage_flow_edit_base",
-      "baseModelRepo": "SceneWorks/Mage-Flow-Edit-Base",
-      "kernel": "mage_flow_lora",
-      "defaults": {
-        "rank": 16,
-        "alpha": 16,
-        "learningRate": 0.0001,
-        "steps": 3000,
-        "batchSize": 1,
-        "gradientAccumulation": 1,
-        "resolution": 1024,
-        "saveEvery": 250,
-        "seed": 42,
-        "optimizer": "adamw8bit",
-        "advanced": {
-          "cacheLatents": true,
-          "cacheTextEmbeddings": true,
-          "gradientCheckpointing": true,
-          "lossType": "mse",
-          "lrScheduler": "constant",
-          "mixedPrecision": "bf16",
-          "networkType": "lora",
-          "outputScope": "project",
-          "qualityPreset": "balanced",
-          "requestedGpu": "auto",
-          "sampleEvery": 500,
-          "sampleGuidanceScale": 5.0,
-          "sampleSteps": 30,
-          "timestepBias": "high_noise",
-          "timestepType": "sigmoid",
-          "weightDecay": 0.0001
-        }
-      },
-      "limits": {
-        "alpha": [
-          1,
-          128
-        ],
-        "batchSize": [
-          1,
-          4
-        ],
-        "lrSchedulers": [
-          "constant",
-          "linear",
-          "cosine"
-        ],
-        "networkTypes": [
-          "lora"
-        ],
-        "optimizers": [
-          "adamw8bit",
-          "adamw",
-          "adam",
-          "prodigyopt",
-          "rose"
-        ],
-        "outputScopes": [
-          "project",
-          "global"
-        ],
-        "rank": [
-          4,
-          128
-        ],
-        "resolutions": [
-          512,
-          768,
-          1024
-        ],
-        "steps": [
-          200,
-          6000
-        ]
-      },
-      "ui": {
-        "datasetModality": "image",
-        "description": "Train an image-editing LoRA against the undistilled Mage-Flow Edit-Base model.",
-        "label": "Mage-Flow Edit-Base LoRA",
-        "recommendedFor": [
-          "character",
-          "style"
-        ]
-      }
-    },
-    {
       "id": "z_image_turbo_lora",
       "name": "Z-Image-Turbo LoRA",
       "modality": "image",
@@ -1605,6 +1423,188 @@
         "datasetModality": "image",
         "description": "Train a Wan2.2 14B (A14B MoE, image-to-video) LoRA from still images. Trains both noise experts against the full-size bf16 base (large; on Windows/Linux a Q8_0 GGUF base fits smaller hosts).",
         "label": "Wan2.2 14B I2V Video LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
+      "id": "mage_flow_base_lora",
+      "name": "Mage-Flow Base LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "mage-flow",
+      "baseModel": "mage_flow_base",
+      "baseModelRepo": "SceneWorks/Mage-Flow-Base",
+      "kernel": "mage_flow_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 5.0,
+          "sampleSteps": 30,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "datasetModality": "image",
+        "description": "Train an image LoRA against the undistilled Mage-Flow Base model.",
+        "label": "Mage-Flow Base LoRA",
+        "recommendedFor": [
+          "character",
+          "style"
+        ]
+      }
+    },
+    {
+      "id": "mage_flow_edit_base_lora",
+      "name": "Mage-Flow Edit-Base LoRA",
+      "modality": "image",
+      "outputKind": "lora",
+      "family": "mage-flow",
+      "baseModel": "mage_flow_edit_base",
+      "baseModelRepo": "SceneWorks/Mage-Flow-Edit-Base",
+      "kernel": "mage_flow_lora",
+      "defaults": {
+        "rank": 16,
+        "alpha": 16,
+        "learningRate": 0.0001,
+        "steps": 3000,
+        "batchSize": 1,
+        "gradientAccumulation": 1,
+        "resolution": 1024,
+        "saveEvery": 250,
+        "seed": 42,
+        "optimizer": "adamw8bit",
+        "advanced": {
+          "cacheLatents": true,
+          "cacheTextEmbeddings": true,
+          "gradientCheckpointing": true,
+          "lossType": "mse",
+          "lrScheduler": "constant",
+          "mixedPrecision": "bf16",
+          "networkType": "lora",
+          "outputScope": "project",
+          "qualityPreset": "balanced",
+          "requestedGpu": "auto",
+          "sampleEvery": 500,
+          "sampleGuidanceScale": 5.0,
+          "sampleSteps": 30,
+          "timestepBias": "high_noise",
+          "timestepType": "sigmoid",
+          "weightDecay": 0.0001
+        }
+      },
+      "limits": {
+        "alpha": [
+          1,
+          128
+        ],
+        "batchSize": [
+          1,
+          4
+        ],
+        "lrSchedulers": [
+          "constant",
+          "linear",
+          "cosine"
+        ],
+        "networkTypes": [
+          "lora"
+        ],
+        "optimizers": [
+          "adamw8bit",
+          "adamw",
+          "adam",
+          "prodigyopt",
+          "rose"
+        ],
+        "outputScopes": [
+          "project",
+          "global"
+        ],
+        "rank": [
+          4,
+          128
+        ],
+        "resolutions": [
+          512,
+          768,
+          1024
+        ],
+        "steps": [
+          200,
+          6000
+        ]
+      },
+      "ui": {
+        "datasetModality": "image",
+        "description": "Train an image-editing LoRA against the undistilled Mage-Flow Edit-Base model.",
+        "label": "Mage-Flow Edit-Base LoRA",
         "recommendedFor": [
           "character",
           "style"


### PR DESCRIPTION
## Summary
- register Mage-Flow Base and Edit-Base as LoRA training targets
- pin both targets to the live SceneWorks mirror repos and retain all-platform q4/q8/bf16 catalog parity
- resolve installed flat Mage snapshots as training-ready and keep the not-yet-routed kernel off generic workers

## Validation
- `cargo test -p sceneworks-core` (619 passed; 1 ignored)
- `cargo test -p sceneworks-rust-api mage_flow_foundation_targets_resolve_the_installed_flat_mirrors`
- `cargo fmt --all -- --check`

Shortcut: https://app.shortcut.com/trefry/story/14054