### PR TITLE
fix(models): FLUX.2 True V2 convert base → installed re-host tier (sc-14978)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -679,6 +679,19 @@ pub(crate) async fn create_model_convert_job(
     {
         job_payload.insert("baseRepo".to_owned(), Value::String(base_repo.to_owned()));
     }
+    // The quant-tier subdir under `convertBaseRepo` to borrow the base components from (sc-14978): the
+    // FLUX.2-klein re-host keeps each tier in its own subdir, so the borrowed VAE/text-encoder/tokenizer
+    // live under `<tier>/`, not the snapshot root. Absent for root-layout diffusers bases.
+    if let Some(base_subdir) = mlx
+        .get("convertBaseSubdir")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        job_payload.insert(
+            "baseSubdir".to_owned(),
+            Value::String(base_subdir.to_owned()),
+        );
+    }
     if quantize_only {
         job_payload.insert("quantizeOnly".to_owned(), Value::Bool(true));
     }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4273,13 +4273,22 @@
         // Install-time conversion: pull the bf16 single-file from convertSourceRepo,
         // run the FLUX.2-klein diffusers converter (sc-2235), and assemble a local
         // diffusers dir under <data>/models/mlx/flux2_klein_9b_true_v2 by borrowing
-        // components from the installed base klein-9B (convertBaseRepo). The base
+        // the VAE/text-encoder/tokenizer from the installed base klein-9B. The base
         // model must be installed first; the convert job fails clearly if it isn't.
+        // sc-14978: the base is the ungated SceneWorks re-host the base klein card
+        // actually installs (`SceneWorks/flux2-klein-9b-mlx`), NOT the gated upstream
+        // `black-forest-labs/FLUX.2-klein-9B` — no catalog card installs the latter, so
+        // pointing here made the convert base UNSATISFIABLE. The re-host keeps each quant
+        // tier in its own subdir, so convertBaseSubdir names the tier to borrow from; the
+        // borrowed VAE/TE/tokenizer are dense and identical across tiers (only the
+        // transformer is packed), so any installed tier serves — bf16 is the preference and
+        // the worker falls back to whichever tier is present.
         "requiresConversion": true,
         "converter": "flux2_klein_diffusers",
         "convertSourceRepo": "wikeeyang/Flux2-Klein-9B-True-V2",
         "convertSourceFile": "Flux2-Klein-9B-True-v2-bf16.safetensors",
-        "convertBaseRepo": "black-forest-labs/FLUX.2-klein-9B"
+        "convertBaseRepo": "SceneWorks/flux2-klein-9b-mlx",
+        "convertBaseSubdir": "bf16"
       },
       "licenseUrl": "https://huggingface.co/black-forest-labs/FLUX.2-klein-9B/blob/main/LICENSE.md",
       "ui": {

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -649,6 +649,35 @@ fn convert_flux2_klein_diffusers(
     )
 }
 
+/// The base directory a FLUX.2-klein convert borrows its VAE / text-encoder / tokenizer from (sc-14978).
+/// The SceneWorks re-host the base klein card installs (`SceneWorks/flux2-klein-9b-mlx`) keeps each quant
+/// tier in its own subdir, so the borrowed components live under `<tier>/`, not the snapshot root. The
+/// borrowed components are dense and identical across tiers (only the transformer is packed), so any
+/// installed tier serves: prefer `subdir` (the manifest's `convertBaseSubdir`), then fall back to the
+/// standard tiers. When `subdir` is `None` the base is a plain root-layout diffusers snapshot and the
+/// snapshot root itself is used. `None` when no candidate holds the borrowed subdirs — a torn base whose
+/// convert would fail deep with `No such file or directory`.
+fn resolve_flux2_klein_base_dir(snapshot: &Path, subdir: Option<&str>) -> Option<PathBuf> {
+    let holds_borrowed = |dir: &Path| {
+        dir.join("tokenizer").is_dir()
+            && dir.join("text_encoder").is_dir()
+            && dir.join("vae").is_dir()
+    };
+    let Some(subdir) = subdir else {
+        return holds_borrowed(snapshot).then(|| snapshot.to_path_buf());
+    };
+    let mut tiers = vec![subdir];
+    for fallback in ["bf16", "q8", "q4"] {
+        if !tiers.contains(&fallback) {
+            tiers.push(fallback);
+        }
+    }
+    tiers
+        .into_iter()
+        .map(|tier| snapshot.join(tier))
+        .find(|dir| holds_borrowed(dir))
+}
+
 /// Native Rust/MLX LTX-2.3 weight converter (mlx-gen-ltx, sc-3224 engine + sc-3240 cutover). The LTX
 /// path was never actually routed through the Rust job before — only `convert_wan` was ever shelled.
 /// Splits the single-file checkpoint (`source_file`, e.g. eros `10Eros_v1_bf16.safetensors`),
@@ -1106,12 +1135,29 @@ async fn resolve_convert_plan(
                     detail: format!("Expected {source_file_name} in {source_repo}."),
                 }));
             }
-            let Some(base_dir) = huggingface_snapshot_dir(&settings.data_dir, &base_repo) else {
+            let Some(base_snapshot) = huggingface_snapshot_dir(&settings.data_dir, &base_repo)
+            else {
                 return Ok(Err(ConvertPlanError {
                     message: "Base FLUX.2-klein model is not installed.",
                     detail: format!(
                         "Install {base_repo} before converting {model_id} — its VAE, text encoder, \
                          and tokenizer are reused."
+                    ),
+                }));
+            };
+            // The re-host keeps each quant tier in its own subdir (bf16/, q8/, q4/); the borrowed
+            // VAE/text-encoder/tokenizer are dense and identical across tiers, so the manifest's
+            // `convertBaseSubdir` names the preferred tier and any installed tier serves. A base with a
+            // plain root diffusers layout (no `baseSubdir`) borrows from the snapshot root (sc-14978).
+            let base_subdir = optional_payload_string(&job.payload, "baseSubdir")
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            let Some(base_dir) = resolve_flux2_klein_base_dir(&base_snapshot, base_subdir) else {
+                return Ok(Err(ConvertPlanError {
+                    message: "Base FLUX.2-klein model is installed but incomplete.",
+                    detail: format!(
+                        "No base tier with a VAE, text encoder, and tokenizer was found under \
+                         {base_repo} for converting {model_id}; re-download the base model."
                     ),
                 }));
             };
@@ -3708,6 +3754,65 @@ mod hardlink_tests {
             b"tokenizer-bytes",
             "the blob itself must be untouched"
         );
+    }
+}
+
+#[cfg(test)]
+mod flux2_convert_tests {
+    use super::*;
+
+    fn seed_tier(root: &Path, tier: &str) {
+        for comp in ["tokenizer", "text_encoder", "vae"] {
+            std::fs::create_dir_all(root.join(tier).join(comp)).unwrap();
+        }
+    }
+
+    /// sc-14978: the FLUX.2-klein convert borrows VAE/text-encoder/tokenizer from a quant-tier subdir of
+    /// the installed re-host (they are dense and identical across tiers). The resolver prefers the
+    /// manifest tier, falls back to any present tier, and rejects a torn base — so pointing
+    /// `convertBaseRepo` at the ungated re-host (whose components live under `<tier>/`, not the snapshot
+    /// root) resolves instead of failing deep with `tokenizer: No such file or directory`.
+    #[test]
+    fn base_dir_prefers_named_tier_then_falls_back_then_rejects_torn() {
+        // Preferred tier present → used.
+        let tmp = tempfile::tempdir().unwrap();
+        seed_tier(tmp.path(), "bf16");
+        assert_eq!(
+            resolve_flux2_klein_base_dir(tmp.path(), Some("bf16")),
+            Some(tmp.path().join("bf16")),
+        );
+
+        // Preferred tier absent but another tier present → fall back to it (borrow is tier-invariant).
+        let tmp2 = tempfile::tempdir().unwrap();
+        seed_tier(tmp2.path(), "q4");
+        assert_eq!(
+            resolve_flux2_klein_base_dir(tmp2.path(), Some("bf16")),
+            Some(tmp2.path().join("q4")),
+        );
+
+        // No tier holds the borrowed components → None (a torn base; the caller surfaces a re-download).
+        let tmp3 = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp3.path().join("bf16").join("transformer")).unwrap();
+        assert_eq!(
+            resolve_flux2_klein_base_dir(tmp3.path(), Some("bf16")),
+            None
+        );
+    }
+
+    /// No `convertBaseSubdir` → a plain root-layout diffusers base borrows from the snapshot root itself.
+    #[test]
+    fn base_dir_without_subdir_uses_root_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        for comp in ["tokenizer", "text_encoder", "vae"] {
+            std::fs::create_dir_all(tmp.path().join(comp)).unwrap();
+        }
+        assert_eq!(
+            resolve_flux2_klein_base_dir(tmp.path(), None),
+            Some(tmp.path().to_path_buf()),
+        );
+        // Root missing the borrowed components → None.
+        let empty = tempfile::tempdir().unwrap();
+        assert_eq!(resolve_flux2_klein_base_dir(empty.path(), None), None);
     }
 }
 

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -370,6 +370,10 @@
               "converter": { "type": "string" },
               "convertSourceFile": { "type": "string" },
               "convertBaseRepo": { "type": "string" },
+              "convertBaseSubdir": {
+                "type": "string",
+                "description": "Quant-tier subdir under convertBaseRepo's snapshot whose (dense, tier-invariant) VAE/text-encoder/tokenizer the converter borrows — e.g. \"bf16\" for the FLUX.2-klein turnkey, whose components live under <tier>/ rather than the snapshot root. The worker prefers this tier and falls back to any installed tier. Omit when convertBaseRepo is a plain root-layout diffusers snapshot."
+              },
               "autoDistillLora": {
                 "type": "object",
                 "additionalProperties": false,

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -1239,7 +1239,11 @@ def test_flux2_true_v2_manifest_install_time_conversion():
     assert mlx["requiresConversion"] is True
     assert mlx["converter"] == "flux2_klein_diffusers"
     assert mlx["convertSourceRepo"] == "wikeeyang/Flux2-Klein-9B-True-V2"
-    assert mlx["convertBaseRepo"] == "black-forest-labs/FLUX.2-klein-9B"
+    # sc-14978: the convert borrows the base VAE/text-encoder/tokenizer from the ungated
+    # re-host the base klein card actually installs (NOT the gated upstream, which no card
+    # installs), reading them from its per-tier bf16/ subdir.
+    assert mlx["convertBaseRepo"] == "SceneWorks/flux2-klein-9b-mlx"
+    assert mlx["convertBaseSubdir"] == "bf16"
     assert mlx["quantize"] == 8
 
 


### PR DESCRIPTION
Follow-up to #1869 / GH #1858 (comment). Closes sc-14978.

## Problem
**FLUX.2 [klein] 9B True V2** (`flux2_klein_9b_true_v2`) can never convert. The convert-at-install job borrows the base VAE/text-encoder/tokenizer from `convertBaseRepo`, which pinned the **gated** `black-forest-labs/FLUX.2-klein-9B` — but **no catalog card installs that repo** (the base klein card installs the ungated re-host `SceneWorks/flux2-klein-9b-mlx`). So the base requirement is unsatisfiable through the app. Confirmed on the reporter's machine: the gated upstream is absent; only the re-host + the wikeeyang source are cached; no converted output exists.

Pointing at the re-host root doesn't work either — it keeps each quant tier in its own subdir (`bf16/tokenizer`, …), with no root-level `tokenizer/`, which fails deep with the reported `tokenizer: No such file or directory`.

## Fix
Borrow from the installed re-host's tier subdir. The borrowed VAE/TE/tokenizer are **dense and identical across tiers** (only the transformer is packed), so any installed tier serves.

- **Manifest:** `convertBaseRepo` → `SceneWorks/flux2-klein-9b-mlx` + new `convertBaseSubdir: "bf16"`.
- **Schema:** add `convertBaseSubdir` to the `mlx` object (it's `additionalProperties:false`).
- **API:** forward `convertBaseSubdir` → job payload `baseSubdir`.
- **Worker:** `resolve_flux2_klein_base_dir` resolves the convert base to the preferred tier subdir, falls back to any present tier (`bf16 > q8 > q4`), and rejects a torn base with an actionable *"installed but incomplete — re-download"* error instead of a deep tokenizer failure. A base with no `baseSubdir` (root-layout diffusers snapshot) is unchanged.

## Verification
- Cross-platform unit tests: prefer-named-tier / fallback-to-present-tier / reject-torn, and the root-layout (no-subdir) path — all green.
- Manifest + schema parse; every `mlx` key is schema-allowed; `cargo fmt --check` + clippy clean; branch is off latest `main`.
- Grounded in the reporter's cache: the installed base klein's `bf16/` tier holds `tokenizer/`, `text_encoder/`, `vae/`, so the borrow resolves.

**Not exercised here:** a full end-to-end MLX convert (needs the running worker + GPU); the resolver logic and the external `convert_and_assemble` borrow contract are unit-covered. The exact error text the reporter saw wasn't fully reconciled (may be a slightly different build/path) but doesn't change this root cause or fix — see sc-14978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)