### PR TITLE
Mage-Flow Studio UI — native-resolution controls, 4:1 presets, ÷16 stride (sc-14058)

### DIFF
--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -9,6 +9,7 @@
 // of their inputs, so the requirement/error split is unit-testable.
 
 import { presetLoraIssues } from "./generationValidation.js";
+import { MAX_IMAGE_DIMENSION, MIN_IMAGE_DIMENSION } from "./resolutionOverride.js";
 import { promptBudget } from "./styleComposer.js";
 import { issue } from "./validation/issues.js";
 
@@ -117,6 +118,19 @@ export function imageGenerateValidation({
   return issues;
 }
 
+// The user-facing ERROR for an inline [WxH] batch directive that breaks the selected model's geometry
+// (sc-14058). Names the offending size, then the model's own range — and its required stride when the
+// model renders at native resolution (a declared step > 1, e.g. Mage-Flow's ÷16). A non-native model
+// (step <= 1) keeps the exact "out of range — each side must be MIN–MAX" wording it always had, so those
+// models don't regress. This is the batch-path twin of dimensionConstraintMessage for the single path.
+export function batchResolutionMessage({ width, height } = {}, { min, max, step } = {}) {
+  const size = `[${width}×${height}]`;
+  if (Number.isInteger(step) && step > 1) {
+    return `A prompt’s ${size} size isn’t valid for this model — each side must be ${min}–${max} and a multiple of ${step}.`;
+  }
+  return `A prompt’s ${size} size is out of range — each side must be ${min}–${max}.`;
+}
+
 // The prompt-batch Run. The errors are pushed in the same priority order the batch panel
 // has always shown them one at a time, so `summarize().surfaced[0]` is exactly the message
 // that used to win the `? :` chain. An empty batch is a silent requirement; its "add a
@@ -129,8 +143,11 @@ export function imageBatchValidation({
   groupIssues = [],
   resolutionIssues = [],
   promptBudgetOverages = [],
-  minDimension,
-  maxDimension,
+  // Per-model geometry constraints for the inline [WxH] batch directive (sc-14058). Same source the
+  // single-generate gate reads — modelDimensionConstraints(selectedModel) — so a native-resolution model
+  // (Mage-Flow) narrows the batch check to its own range + ÷16 stride, while every other model keeps the
+  // global 256–4096 / no-stride envelope. Defaults to that global envelope for callers with no model.
+  dimensionConstraints = { min: MIN_IMAGE_DIMENSION, max: MAX_IMAGE_DIMENSION, step: 1 },
 } = {}) {
   const issues = [];
   if (!activeProject) {
@@ -156,10 +173,7 @@ export function imageBatchValidation({
     );
   }
   if (resolutionIssues.length) {
-    const res = resolutionIssues[0];
-    issues.push(
-      issue.error(null, `A prompt’s [${res.width}×${res.height}] size is out of range — each side must be ${minDimension}–${maxDimension}.`),
-    );
+    issues.push(issue.error(null, batchResolutionMessage(resolutionIssues[0], dimensionConstraints)));
   }
   if (promptBudgetOverages.length) {
     issues.push(issue.error(null, batchPromptBudgetMessage(promptBudgetOverages)));

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -56,6 +56,11 @@ export function imageGenerateValidation({
   // imageMultiPhase.multiPhaseIssues (an enabled-but-broken phase list blocks Generate with an
   // error). Empty when the editor is off or the model has no multi-phase lane.
   multiPhaseIssues = [],
+  // Free Width/Height override out of the selected model's native range or off its required stride
+  // (sc-14058, native-resolution families like Mage-Flow). A pre-computed, user-facing ERROR string
+  // (or null) — a value the user actively broke that nothing else on the form explains, so it blocks
+  // Generate AND is surfaced. Null/absent leaves the gate unchanged for every other model.
+  dimensionError = null,
 } = {}) {
   const issues = [];
   if (!activeProject) {
@@ -104,6 +109,11 @@ export function imageGenerateValidation({
   issues.push(...presetLoraIssues({ presetMissing, presetIncompatible, loraIncompatible, modelName }));
   // Multi-phase denoise problems (sc-13885) — already kinded (errors) by multiPhaseIssues.
   issues.push(...multiPhaseIssues);
+  // A broken free Width/Height override (sc-14058): an error, not a requirement — the two number boxes
+  // hold a value the user actively broke, and only this message explains the dead Generate button.
+  if (dimensionError) {
+    issues.push(issue.error(null, dimensionError));
+  }
   return issues;
 }
 

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -59,6 +59,18 @@ describe("imageGenerateValidation", () => {
     );
   });
 
+  it("surfaces a broken Width/Height override as an error and stays silent when valid (sc-14058)", () => {
+    // No dimension error (valid or a non-native model) → nothing added, draft still ready.
+    expect(summarize(imageGenerateValidation({ ...whole, dimensionError: null })).ready).toBe(true);
+    // A native-resolution stride/range violation blocks Generate AND surfaces the exact message —
+    // an error, not a silent requirement (the two number boxes hold a value the user actively broke).
+    const msg = "Width and height must be between 512 and 2048 and a multiple of 16.";
+    const withError = imageGenerateValidation({ ...whole, dimensionError: msg });
+    const rolled = summarize(withError);
+    expect(rolled.ready).toBe(false);
+    expect(rolled.surfaced.map((i) => i.message)).toContain(msg);
+  });
+
   it("requires caption content on a structured model, silently", () => {
     const issues = imageGenerateValidation({ ...whole, structuredActive: true, captionHasContent: false, prompt: "" });
     expect(kinds(issues, "caption")).toEqual(["requirement"]);

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { issue, summarize } from "./validation/issues.js";
 import {
   batchPromptBudgetOverages,
+  batchResolutionMessage,
   imageBatchValidation,
   imageGenerateValidation,
 } from "./imageStudioValidation.js";
@@ -225,8 +226,9 @@ describe("imageBatchValidation", () => {
     groupIssues: [],
     resolutionIssues: [],
     promptBudgetOverages: [],
-    minDimension: 256,
-    maxDimension: 4096,
+    // The global backend envelope — a non-native model (no declared stride). A native-resolution model
+    // (Mage-Flow) passes its own narrower { min: 512, max: 2048, step: 16 } here instead (sc-14058).
+    dimensionConstraints: { min: 256, max: 4096, step: 1 },
   };
 
   it("passes a whole batch draft", () => {
@@ -250,6 +252,38 @@ describe("imageBatchValidation", () => {
   it("surfaces an out-of-range resolution with the offending size", () => {
     const summary = summarize(imageBatchValidation({ ...whole, resolutionIssues: [{ width: 5000, height: 300 }] }));
     expect(summary.surfaced[0].message).toBe("A prompt’s [5000×300] size is out of range — each side must be 256–4096.");
+  });
+
+  // sc-14058: a native-resolution model (Mage-Flow) passes its own { min, max, step } — the batch [WxH]
+  // directive must report THAT range + the required stride, never the global 256–4096 / no-stride text.
+  it("reports a native model's own range AND stride for an inline [WxH] batch directive", () => {
+    const summary = summarize(
+      imageBatchValidation({
+        ...whole,
+        resolutionIssues: [{ width: 1000, height: 1000 }],
+        dimensionConstraints: { min: 512, max: 2048, step: 16 },
+      }),
+    );
+    expect(summary.ready).toBe(false);
+    expect(summary.surfaced[0].kind).toBe("error");
+    expect(summary.surfaced[0].message).toBe(
+      "A prompt’s [1000×1000] size isn’t valid for this model — each side must be 512–2048 and a multiple of 16.",
+    );
+    // The tell that the fix is live: it never falls back to the global backend envelope.
+    expect(summary.surfaced[0].message).not.toContain("256");
+    expect(summary.surfaced[0].message).not.toContain("4096");
+  });
+
+  // batchResolutionMessage is the batch twin of dimensionConstraintMessage: a plain (no-stride) model
+  // keeps the historical "out of range — each side must be MIN–MAX" wording, so non-native models don't
+  // regress; a stride model gains the "multiple of N" clause.
+  it("batchResolutionMessage: no-stride keeps the legacy wording, a stride model adds the multiple clause", () => {
+    expect(batchResolutionMessage({ width: 5000, height: 300 }, { min: 256, max: 4096, step: 1 })).toBe(
+      "A prompt’s [5000×300] size is out of range — each side must be 256–4096.",
+    );
+    expect(batchResolutionMessage({ width: 600, height: 600 }, { min: 512, max: 2048, step: 16 })).toBe(
+      "A prompt’s [600×600] size isn’t valid for this model — each side must be 512–2048 and a multiple of 16.",
+    );
   });
 
   it("blocks at 4001 Unicode scalars, allows 4000, and identifies every offending resolved item", () => {

--- a/apps/web/src/resolutionOverride.js
+++ b/apps/web/src/resolutionOverride.js
@@ -26,3 +26,66 @@ export function resolveEffectiveDimensions({ resolution, widthOverride, heightOv
 function inRange(value) {
   return Number.isFinite(value) && value >= MIN_IMAGE_DIMENSION && value <= MAX_IMAGE_DIMENSION;
 }
+
+// Per-model geometry constraints for the free Width/Height override (sc-14058). Most models keep the
+// global backend envelope (256–4096, no stride) so their controls are untouched. A NATIVE-RESOLUTION
+// model — one that declares a required dimension stride via `limits.requiresDimensionsMultipleOf`
+// (Mage-Flow = 16) — is instead bounded by the extremes of its own published resolution ladder (Mage:
+// 512–2048) and stepped by that stride. Deriving the range from the advisory ladder keeps it per-model
+// and declarative: no extra manifest key, and a model that widens its ladder widens its free range in
+// lockstep. Returns { min, max, step }; `step <= 1` means "no stride" (the common case).
+export function modelDimensionConstraints(model) {
+  const step = Number(model?.limits?.requiresDimensionsMultipleOf);
+  if (!Number.isInteger(step) || step <= 1) {
+    return { min: MIN_IMAGE_DIMENSION, max: MAX_IMAGE_DIMENSION, step: 1 };
+  }
+  const sides = Array.isArray(model?.limits?.resolutions)
+    ? model.limits.resolutions
+        .flatMap((entry) => String(entry).split("x").map((value) => Number(value)))
+        .filter((value) => Number.isFinite(value) && value > 0)
+    : [];
+  const min = sides.length ? Math.max(MIN_IMAGE_DIMENSION, Math.min(...sides)) : MIN_IMAGE_DIMENSION;
+  const max = sides.length ? Math.min(MAX_IMAGE_DIMENSION, Math.max(...sides)) : MAX_IMAGE_DIMENSION;
+  return { min, max, step };
+}
+
+function sideInRange(value, { min, max }) {
+  return Number.isFinite(value) && value >= min && value <= max;
+}
+
+function sideOnStride(value, step) {
+  return step <= 1 || (Number.isFinite(value) && value % step === 0);
+}
+
+// Effective dimensions PLUS the selected model's native-resolution constraints (sc-14058). Layers the
+// per-model range + stride on top of the pure `resolveEffectiveDimensions` primitive (left unchanged so
+// its existing callers/tests stay byte-identical). Returns the resolved width/height, the constraints
+// used, and WHY it is invalid split into `outOfRange` / `offStride` so the Studio can surface a precise,
+// user-facing error (never a raw requirement string). `invalid` is the OR of the two — the single flag
+// the Generate gate reads.
+export function evaluateModelDimensions({ model, resolution, widthOverride, heightOverride }) {
+  const constraints = modelDimensionConstraints(model);
+  const { width, height } = resolveEffectiveDimensions({ resolution, widthOverride, heightOverride });
+  const outOfRange = !(sideInRange(width, constraints) && sideInRange(height, constraints));
+  const offStride =
+    constraints.step > 1 && !(sideOnStride(width, constraints.step) && sideOnStride(height, constraints.step));
+  return { width, height, constraints, outOfRange, offStride, invalid: outOfRange || offStride };
+}
+
+// The user-facing error message for a broken free Width/Height override, or null when the dimensions are
+// valid. Kept here (pure) so the message and the gate cannot drift. An ERROR, not a requirement: the two
+// number boxes hold a value the user actively broke, and nothing else on the form explains the dead CTA.
+export function dimensionConstraintMessage(evaluation) {
+  if (!evaluation || !evaluation.invalid) {
+    return null;
+  }
+  const { constraints, outOfRange, offStride } = evaluation;
+  const range = `between ${constraints.min} and ${constraints.max}`;
+  if (outOfRange && offStride) {
+    return `Width and height must be ${range} and a multiple of ${constraints.step}.`;
+  }
+  if (outOfRange) {
+    return `Width and height must be ${range}.`;
+  }
+  return `Width and height must be a multiple of ${constraints.step} — this model renders at native resolution.`;
+}

--- a/apps/web/src/resolutionOverride.test.js
+++ b/apps/web/src/resolutionOverride.test.js
@@ -2,8 +2,22 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_IMAGE_DIMENSION,
   MIN_IMAGE_DIMENSION,
+  dimensionConstraintMessage,
+  evaluateModelDimensions,
+  modelDimensionConstraints,
   resolveEffectiveDimensions,
 } from "./resolutionOverride.js";
+
+// A native-resolution model shaped like Mage-Flow's catalog projection: a ÷16 stride plus a
+// resolution ladder whose extremes (512 and 2048) bound the free override.
+const mageModel = {
+  limits: {
+    requiresDimensionsMultipleOf: 16,
+    resolutions: ["512x512", "1024x1024", "2048x2048", "2048x512", "512x2048"],
+  },
+};
+// A plain model with no stride — must be left on the global 256–4096 envelope, untouched.
+const plainModel = { limits: { resolutions: ["1024x1024", "1280x720"] } };
 
 describe("resolveEffectiveDimensions", () => {
   it("uses the Aspect dropdown when no override is set", () => {
@@ -59,5 +73,110 @@ describe("resolveEffectiveDimensions", () => {
     expect(
       resolveEffectiveDimensions({ resolution: "768x1280", widthOverride: null, heightOverride: null }),
     ).toEqual({ width: 768, height: 1280, invalid: false });
+  });
+});
+
+describe("modelDimensionConstraints", () => {
+  it("keeps a non-native model on the global 256–4096 envelope with no stride", () => {
+    expect(modelDimensionConstraints(plainModel)).toEqual({
+      min: MIN_IMAGE_DIMENSION,
+      max: MAX_IMAGE_DIMENSION,
+      step: 1,
+    });
+    // A missing model is the same untouched default (fallback catalog / loading state).
+    expect(modelDimensionConstraints(undefined)).toEqual({
+      min: MIN_IMAGE_DIMENSION,
+      max: MAX_IMAGE_DIMENSION,
+      step: 1,
+    });
+  });
+
+  it("derives a native model's range from its ladder extremes and carries the stride", () => {
+    expect(modelDimensionConstraints(mageModel)).toEqual({ min: 512, max: 2048, step: 16 });
+  });
+});
+
+describe("evaluateModelDimensions (native-resolution enforcement)", () => {
+  it("accepts a 4:1 native preset (2048x512) on a ÷16 model", () => {
+    const result = evaluateModelDimensions({ model: mageModel, resolution: "2048x512" });
+    expect(result).toMatchObject({ width: 2048, height: 512, invalid: false, offStride: false, outOfRange: false });
+  });
+
+  it("rejects an off-stride override as offStride (not out of range)", () => {
+    const result = evaluateModelDimensions({
+      model: mageModel,
+      resolution: "1024x1024",
+      widthOverride: "1000", // 1000 % 16 !== 0, but within 512–2048
+      heightOverride: "",
+    });
+    expect(result).toMatchObject({ invalid: true, offStride: true, outOfRange: false });
+  });
+
+  it("rejects a below-native override (256) as out of range on a 512–2048 model", () => {
+    const result = evaluateModelDimensions({
+      model: mageModel,
+      resolution: "1024x1024",
+      widthOverride: "256", // ÷16 clean, but below the model's 512 native floor
+      heightOverride: "",
+    });
+    expect(result).toMatchObject({ invalid: true, outOfRange: true, offStride: false });
+  });
+
+  it("rejects an above-native override (4096) as out of range even though the backend cap allows it", () => {
+    const result = evaluateModelDimensions({
+      model: mageModel,
+      resolution: "1024x1024",
+      widthOverride: "",
+      heightOverride: "4096",
+    });
+    expect(result).toMatchObject({ invalid: true, outOfRange: true });
+  });
+
+  it("does NOT impose a stride on a plain model — a ÷16-violating size stays valid", () => {
+    const result = evaluateModelDimensions({
+      model: plainModel,
+      resolution: "1024x1024",
+      widthOverride: "1000",
+      heightOverride: "",
+    });
+    expect(result).toMatchObject({ invalid: false, offStride: false });
+  });
+});
+
+describe("dimensionConstraintMessage", () => {
+  it("returns null when the dimensions are valid", () => {
+    const ok = evaluateModelDimensions({ model: mageModel, resolution: "1024x1024" });
+    expect(dimensionConstraintMessage(ok)).toBeNull();
+  });
+
+  it("names the stride for an off-stride error", () => {
+    const bad = evaluateModelDimensions({
+      model: mageModel,
+      resolution: "1024x1024",
+      widthOverride: "1000",
+    });
+    expect(dimensionConstraintMessage(bad)).toBe(
+      "Width and height must be a multiple of 16 — this model renders at native resolution.",
+    );
+  });
+
+  it("names the native range for an out-of-range error", () => {
+    const bad = evaluateModelDimensions({
+      model: mageModel,
+      resolution: "1024x1024",
+      widthOverride: "256",
+    });
+    expect(dimensionConstraintMessage(bad)).toBe("Width and height must be between 512 and 2048.");
+  });
+
+  it("names both range and stride when both are broken", () => {
+    const bad = evaluateModelDimensions({
+      model: mageModel,
+      resolution: "1024x1024",
+      widthOverride: "5000", // above 2048 AND above the 4096 cap AND (5000 % 16 !== 0)
+    });
+    expect(dimensionConstraintMessage(bad)).toBe(
+      "Width and height must be between 512 and 2048 and a multiple of 16.",
+    );
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -22,8 +22,6 @@ import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
 import BatchPromptPanel from "../components/BatchPromptPanel.jsx";
 import { expandBatch, linkedGroupIssues, missingKeys, parsePromptResolution } from "../promptBatch.js";
 import {
-  MAX_IMAGE_DIMENSION,
-  MIN_IMAGE_DIMENSION,
   dimensionConstraintMessage,
   evaluateModelDimensions,
   modelDimensionConstraints,
@@ -2238,17 +2236,22 @@ export function ImageStudio() {
   }, [batchRun, jobs]);
   const batchMissingKeys = missingKeys(batchPrompts, batchVariables);
   const batchGroupIssues = linkedGroupIssues(batchPrompts);
-  // Prompt lines whose leading [WxH] directive (sc-10063) is out of the backend 256–4096
-  // range — block the run and name the offending size.
+  // Prompt lines whose leading [WxH] directive (sc-10063) breaks the SELECTED model's geometry — the
+  // SAME per-model range + stride the single-generate gate enforces (sc-14058), not the raw backend
+  // envelope. For a native-resolution model (Mage-Flow) an off-range OR off-÷16-stride size blocks the
+  // Run; every other model keeps the global 256–4096 / no-stride check. Reuses evaluateModelDimensions
+  // so the batch and single paths cannot drift.
   const batchResolutionIssues = batchPrompts
     .map((line) => parsePromptResolution(line).resolution)
     .filter(
       (res) =>
         res &&
-        (res.width < MIN_IMAGE_DIMENSION ||
-          res.width > MAX_IMAGE_DIMENSION ||
-          res.height < MIN_IMAGE_DIMENSION ||
-          res.height > MAX_IMAGE_DIMENSION),
+        evaluateModelDimensions({
+          model: selectedModel,
+          resolution: `${res.width}x${res.height}`,
+          widthOverride: "",
+          heightOverride: "",
+        }).invalid,
     );
   // A structured-caption model can batch, but only if the prompt-refiner is available to
   // auto-write a caption per resolved prompt (sc-9980).
@@ -2277,8 +2280,10 @@ export function ImageStudio() {
       missingKeys: batchMissingKeys,
       groupIssues: batchGroupIssues,
       resolutionIssues: batchResolutionIssues,
-      minDimension: MIN_IMAGE_DIMENSION,
-      maxDimension: MAX_IMAGE_DIMENSION,
+      // Per-model range + stride for the inline [WxH] directive — the SAME constraints the free
+      // Width/Height override uses (sc-14058). A native-resolution model narrows the batch check to its
+      // own 512–2048 / ÷16 envelope; every other model gets the global 256–4096 / no-stride default.
+      dimensionConstraints,
     }),
     [
       activeProject,
@@ -2287,6 +2292,7 @@ export function ImageStudio() {
       batchMissingKeys,
       batchGroupIssues,
       batchResolutionIssues,
+      dimensionConstraints,
     ],
   );
   // sc-13131 / sc-13133: the live composed-prompt preview for the selected Style Catalog entry, and

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -24,7 +24,9 @@ import { expandBatch, linkedGroupIssues, missingKeys, parsePromptResolution } fr
 import {
   MAX_IMAGE_DIMENSION,
   MIN_IMAGE_DIMENSION,
-  resolveEffectiveDimensions,
+  dimensionConstraintMessage,
+  evaluateModelDimensions,
+  modelDimensionConstraints,
 } from "../resolutionOverride.js";
 import { pidDecodeHeadsUp } from "../pidDecodeNotice.js";
 import { batchItemStatus, summarizeBatchRun } from "../batchOps.js";
@@ -1571,15 +1573,23 @@ export function ImageStudio() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [launchRequest?.id]);
   const [dropdownWidth, dropdownHeight] = resolution.split("x").map((value) => Number(value));
+  // Per-model geometry constraints for the free Width/Height override (sc-14058). Native-resolution
+  // families (Mage-Flow) declare a ÷16 stride and a 512–2048 native range; every other model keeps the
+  // global 256–4096 envelope with no stride. Drives the override inputs' min/max/step affordance below.
+  const dimensionConstraints = modelDimensionConstraints(selectedModel);
   // A non-empty Width/Height override wins for that axis; empty falls back to the Aspect
   // dropdown. The resulting dims flow through the existing top-level width/height payload,
   // so submit() and the batch builder need no further change. Logic lives in the pure,
-  // unit-tested resolveEffectiveDimensions helper.
-  const { width, height, invalid: dimensionsInvalid } = resolveEffectiveDimensions({
+  // unit-tested evaluateModelDimensions helper, which layers the model's range + stride on top.
+  const dimensionEval = evaluateModelDimensions({
+    model: selectedModel,
     resolution,
     widthOverride,
     heightOverride,
   });
+  const { width, height, invalid: dimensionsInvalid } = dimensionEval;
+  // A precise, user-facing ERROR (never a raw requirement): names this model's actual range/stride.
+  const dimensionError = dimensionConstraintMessage(dimensionEval);
 
   // PiD high-res decode heads-up (sc-10144): PiD super-resolves the base render 4×, so a large base at
   // the default 4K tier is a multi-minute (auto-tiled above 4096², sc-10087) decode that can look hung.
@@ -1867,7 +1877,7 @@ export function ImageStudio() {
       return;
     }
     if (dimensionsInvalid) {
-      setSubmitError("Width and height must each be between 256 and 4096.");
+      setSubmitError(dimensionError ?? "Width and height must each be between 256 and 4096.");
       return;
     }
     setSubmitting(true);
@@ -2131,7 +2141,7 @@ export function ImageStudio() {
       return;
     }
     if (dimensionsInvalid) {
-      setBatchError("Width and height must each be between 256 and 4096.");
+      setBatchError(dimensionError ?? "Width and height must each be between 256 and 4096.");
       return;
     }
     setBatchError("");
@@ -2323,6 +2333,10 @@ export function ImageStudio() {
       modelName: selectedModel?.name,
       // Multi-phase denoise problems (sc-13885): an enabled-but-broken phase list blocks Generate.
       multiPhaseIssues: multiPhaseValidationIssues,
+      // Free Width/Height override out of the model's range or off its ÷16 stride (sc-14058). A precise
+      // ERROR message (not a raw requirement) so the dead Generate button states its reason pre-emptively,
+      // not only on click. null when the dimensions are valid.
+      dimensionError,
     }),
     [
       activeProject,
@@ -2343,6 +2357,7 @@ export function ImageStudio() {
       selectedLoraValidationResult,
       selectedModel,
       multiPhaseValidationIssues,
+      dimensionError,
     ],
   );
   const batchValidity = useValidation(imageBatchValidation, batchDraft, undefined);
@@ -3180,8 +3195,9 @@ export function ImageStudio() {
               <label>
                 Width override
                 <input
-                  min="256"
-                  max="4096"
+                  min={dimensionConstraints.min}
+                  max={dimensionConstraints.max}
+                  step={dimensionConstraints.step}
                   onChange={(event) => setWidthOverride(event.target.value)}
                   placeholder={String(dropdownWidth)}
                   type="number"
@@ -3191,8 +3207,9 @@ export function ImageStudio() {
               <label>
                 Height override
                 <input
-                  min="256"
-                  max="4096"
+                  min={dimensionConstraints.min}
+                  max={dimensionConstraints.max}
+                  step={dimensionConstraints.step}
                   onChange={(event) => setHeightOverride(event.target.value)}
                   placeholder={String(dropdownHeight)}
                   type="number"

--- a/apps/web/src/screens/ImageStudio.mageFlow.test.jsx
+++ b/apps/web/src/screens/ImageStudio.mageFlow.test.jsx
@@ -1,0 +1,306 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, setInput, setSelect, unmountRoot } from "../testUtils/dom.js";
+
+// Studio UI coverage for the Mage-Flow native-resolution image family (sc-14058, epic 14034 P6).
+// Mage rides the generic manifest/tier/catalog machinery, so these tests assert the family-specific
+// behaviors the story owns: it appears in BOTH the generation and edit pickers, its 4:1 aspect presets
+// and ÷16 native-resolution stride are enforced in the Studio (as a surfaced ERROR, not a silent
+// requirement), its per-variant step/CFG defaults flow through, its edit mode exposes source +
+// instruction + multi-reference, and its quant tier is never silently switched.
+
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, apiFetch: vi.fn(async () => ({})) };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { ImageStudio } from "./ImageStudio.jsx";
+
+// The full native-resolution aspect ladder the manifest advertises for Mage-Flow (every entry ÷16,
+// 512–2048 per side, incl. the 4:1 preset 2048x512 and its 1:4 inverse 512x2048).
+const MAGE_RESOLUTIONS = [
+  "512x512", "768x768", "1024x1024", "1536x1536", "2048x2048",
+  "1280x720", "1536x1024", "2048x1024", "2048x512",
+  "720x1280", "1024x1536", "1024x2048", "512x2048",
+];
+
+const MAGE_GUIDE = { title: "Mage-Flow Prompt Guide", path: "/prompt-guides/mage-flow.md" };
+
+// Mage-Flow RL (gen). Deliberately declares NO memory floor so the resolution fit-gate never trims a
+// bucket in the jsdom (unknown-memory) harness — every advertised aspect is offered.
+const MAGE_RL = {
+  id: "mage_flow",
+  name: "Mage-Flow RL",
+  type: "image",
+  family: "mage-flow",
+  capabilities: ["text_to_image"],
+  defaults: { resolution: "1024x1024", steps: 20, guidanceScale: 5 },
+  limits: { resolutions: MAGE_RESOLUTIONS, requiresDimensionsMultipleOf: 16 },
+  loraCompatibility: {},
+  ui: { promptGuide: MAGE_GUIDE },
+};
+
+const MAGE_TURBO = {
+  ...MAGE_RL,
+  id: "mage_flow_turbo",
+  name: "Mage-Flow Turbo",
+  defaults: { resolution: "1024x1024", steps: 4, guidanceScale: 1 },
+};
+
+const MAGE_EDIT = {
+  ...MAGE_RL,
+  id: "mage_flow_edit",
+  name: "Mage-Flow Edit",
+  capabilities: ["edit_image"],
+  defaults: { resolution: "1024x1024", steps: 30, guidanceScale: 5 },
+  ui: { sourceWithMultiReference: true, promptHint: "Describe the edit.", promptGuide: MAGE_GUIDE },
+};
+
+// A plain (non-native-resolution) model: no stride declared, so its free override must stay on the
+// global 256–4096 envelope with NO stride — the discriminating control case.
+const PLAIN = {
+  id: "z_image_turbo",
+  name: "Z Image Turbo",
+  type: "image",
+  family: "z-image",
+  capabilities: ["text_to_image"],
+  defaults: { resolution: "1024x1024" },
+  limits: { resolutions: ["1024x1024", "1536x1024"] },
+  loraCompatibility: {},
+  ui: {},
+};
+
+const MAC_CAPS = {
+  macGatingActive: true,
+  platform: "darwin",
+  notAvailableLabel: "Not available on Mac (MLX only)",
+  features: {},
+  training: { supportedKernels: [], lokrOnWanSupported: false },
+};
+
+function baseContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    characters: [],
+    createImageJob: vi.fn(async () => ({ id: "job-1" })),
+    createPreset: vi.fn(async (payload) => ({ id: payload.id })),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    purgeAsset: vi.fn(),
+    gpuOptions: [],
+    imageModels: [MAGE_RL],
+    importAsset: vi.fn(),
+    latestImageAssets: [],
+    recentImageAssets: [],
+    studioLaunch: null,
+    imageLocalJobs: [],
+    loras: [],
+    jobAction: vi.fn(),
+    rememberLocalGenerationJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    presets: [],
+    requestedGpu: "",
+    selectedAsset: null,
+    setRequestedGpu: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Label-scoped input/select lookup (the label text prefix identifies the field).
+const field = (container, labelText) => {
+  const label = [...container.querySelectorAll("label")].find((node) =>
+    node.textContent.trim().startsWith(labelText),
+  );
+  return label?.querySelector("input, select, textarea");
+};
+// Exact-label lookup (disambiguates "Guidance" from "Guidance method").
+const exactField = (container, labelText) => {
+  const label = [...container.querySelectorAll("label")].find(
+    (node) => node.querySelector("input, select, textarea") && node.firstChild?.textContent?.trim() === labelText,
+  );
+  return label?.querySelector("input, select, textarea");
+};
+const optionValues = (select) => [...select.options].map((option) => option.value);
+const optionLabels = (select) => [...select.options].map((option) => option.textContent);
+const generateButton = () =>
+  [...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate");
+const modeTab = (label) =>
+  [...document.body.querySelectorAll(".mode-tabs button")].find((b) => b.textContent === label);
+const headButtons = () => [...document.body.querySelectorAll(".asset-picker-head button")];
+
+// Set a controlled <textarea> value through the native setter (setInput only handles <input>).
+function setTextarea(element, value) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+  setter.call(element, value);
+  element.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+describe("ImageStudio — Mage-Flow family (sc-14058)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+  const openAdvanced = () => click(document.body.querySelector(".advanced-section-toggle"));
+
+  it("lists the Mage-Flow family in BOTH the generation and the edit model pickers", async () => {
+    await render(baseContext({ imageModels: [MAGE_RL, MAGE_TURBO, MAGE_EDIT] }));
+    // Generation (Text mode): the gen variants are selectable, the edit variant is NOT.
+    let picker = field(container, "Model");
+    expect(picker).toBeTruthy();
+    expect(optionLabels(picker)).toEqual(expect.arrayContaining(["Mage-Flow RL", "Mage-Flow Turbo"]));
+    expect(optionLabels(picker)).not.toContain("Mage-Flow Edit");
+
+    // Edit mode: the edit variant is selectable, the gen variants are NOT.
+    await click(modeTab("Edit"));
+    await act(async () => {});
+    picker = field(container, "Model");
+    expect(optionLabels(picker)).toContain("Mage-Flow Edit");
+    expect(optionLabels(picker)).not.toContain("Mage-Flow RL");
+  });
+
+  it("offers the 4:1 aspect preset and its inverse in the resolution menu", async () => {
+    await render(baseContext({ imageModels: [MAGE_RL] }));
+    const aspect = field(container, "Aspect");
+    expect(aspect).toBeTruthy();
+    expect(optionValues(aspect)).toEqual(expect.arrayContaining(["2048x512", "512x2048", "2048x2048"]));
+    // Default seeds to the native square.
+    expect(aspect.value).toBe("1024x1024");
+  });
+
+  it("stamps the ÷16 native-resolution stride and 512–2048 range on the free Width/Height overrides", async () => {
+    await render(baseContext({ imageModels: [MAGE_RL] }));
+    await openAdvanced();
+    await act(async () => {});
+    const widthInput = field(container, "Width override");
+    const heightInput = field(container, "Height override");
+    expect(widthInput.getAttribute("step")).toBe("16");
+    expect(widthInput.getAttribute("min")).toBe("512");
+    expect(widthInput.getAttribute("max")).toBe("2048");
+    expect(heightInput.getAttribute("step")).toBe("16");
+    expect(heightInput.getAttribute("min")).toBe("512");
+    expect(heightInput.getAttribute("max")).toBe("2048");
+  });
+
+  it("surfaces an off-stride override as an ERROR that blocks Generate, and clears on a ÷16 value", async () => {
+    await render(baseContext({ imageModels: [MAGE_RL] }));
+    // A valid prompt so the dimension override is the ONLY thing that can block Generate.
+    await act(async () => setTextarea(container.querySelector('textarea[aria-label="Prompt"]'), "a red boat"));
+    await openAdvanced();
+    await act(async () => {});
+
+    // 1000 is within 512–2048 but not a multiple of 16 → surfaced error + Generate disabled.
+    await act(async () => setInput(field(container, "Width override"), "1000"));
+    expect(container.textContent).toContain("must be a multiple of 16");
+    expect(generateButton().disabled).toBe(true);
+
+    // 1536 is ÷16 and in range → the error clears and Generate is enabled again.
+    await act(async () => setInput(field(container, "Width override"), "1536"));
+    expect(container.textContent).not.toContain("must be a multiple of 16");
+    expect(generateButton().disabled).toBe(false);
+  });
+
+  it("rejects a below-native override with the model's actual range in the message (not 256–4096)", async () => {
+    await render(baseContext({ imageModels: [MAGE_RL] }));
+    await act(async () => setTextarea(container.querySelector('textarea[aria-label="Prompt"]'), "a red boat"));
+    await openAdvanced();
+    await act(async () => {});
+    await act(async () => setInput(field(container, "Width override"), "256")); // ÷16 clean, below 512
+    expect(container.textContent).toContain("must be between 512 and 2048");
+    expect(container.textContent).not.toContain("between 256 and 4096");
+    expect(generateButton().disabled).toBe(true);
+  });
+
+  it("does NOT impose a stride on a non-native model — its free override stays 256–4096 with no step", async () => {
+    await render(baseContext({ imageModels: [PLAIN] }));
+    await act(async () => setTextarea(container.querySelector('textarea[aria-label="Prompt"]'), "a red boat"));
+    await openAdvanced();
+    await act(async () => {});
+    const widthInput = field(container, "Width override");
+    expect(widthInput.getAttribute("step")).toBe("1");
+    expect(widthInput.getAttribute("min")).toBe("256");
+    expect(widthInput.getAttribute("max")).toBe("4096");
+    // 1000 (not ÷16) is perfectly valid for a plain model — no stride error, Generate stays enabled.
+    await act(async () => setInput(widthInput, "1000"));
+    expect(container.textContent).not.toContain("must be a multiple of 16");
+    expect(generateButton().disabled).toBe(false);
+  });
+
+  it("wires Turbo's 4-step / CFG-off defaults and seeds the native default resolution", async () => {
+    await render(baseContext({ imageModels: [MAGE_TURBO] }));
+    await openAdvanced();
+    await act(async () => {});
+    expect(field(container, "Aspect").value).toBe("1024x1024");
+    expect(field(container, "Steps").getAttribute("placeholder")).toBe("4");
+    expect(exactField(container, "Guidance").getAttribute("placeholder")).toBe("1");
+  });
+
+  it("wires RL's 20-step / CFG-5 defaults", async () => {
+    await render(baseContext({ imageModels: [MAGE_RL] }));
+    await openAdvanced();
+    await act(async () => {});
+    expect(field(container, "Steps").getAttribute("placeholder")).toBe("20");
+    expect(exactField(container, "Guidance").getAttribute("placeholder")).toBe("5");
+  });
+
+  it("exposes edit-mode source + instruction + optional multi-reference for a Mage edit model", async () => {
+    await render(baseContext({ imageModels: [MAGE_EDIT] }));
+    await click(modeTab("Edit"));
+    await act(async () => {});
+    // The instruction field is the shared prompt textarea.
+    expect(container.querySelector('textarea[aria-label="Prompt"]')).toBeTruthy();
+    // A single required Source image picker...
+    expect(headButtons().some((b) => b.textContent === "Select image")).toBe(true);
+    // ...PLUS an optional ordered multi-reference set (ui.sourceWithMultiReference), distinct from the
+    // multiReference models that REPLACE the single source.
+    expect(container.textContent).toContain("Additional references");
+  });
+
+  it("shows every quant tier for a multi-tier Mage model and never silently switches the chosen tier", async () => {
+    const mageMatrix = {
+      ...MAGE_RL,
+      hasVariantMatrix: true,
+      variants: ["q4", "q8", "bf16"].map((tier) => ({
+        variant: tier,
+        default: tier === "q4",
+        installState: "installed",
+      })),
+    };
+    await render(baseContext({ imageModels: [mageMatrix], macCapabilities: MAC_CAPS }));
+    await openAdvanced();
+    await act(async () => {});
+    const picker = [...container.querySelectorAll("label.quant-tier-picker select")][0];
+    expect(picker).toBeTruthy();
+    expect(optionValues(picker)).toEqual(["q4", "q8", "bf16"]);
+
+    // The user picks bf16 — a creative choice that must STICK across re-render/effects (no auto-fallback).
+    await act(async () => setSelect(picker, "bf16"));
+    await act(async () => {});
+    const after = [...container.querySelectorAll("label.quant-tier-picker select")][0];
+    expect(after.value).toBe("bf16");
+  });
+});

--- a/apps/web/src/screens/ImageStudio.mageFlow.test.jsx
+++ b/apps/web/src/screens/ImageStudio.mageFlow.test.jsx
@@ -250,6 +250,48 @@ describe("ImageStudio — Mage-Flow family (sc-14058)", () => {
     expect(generateButton().disabled).toBe(false);
   });
 
+  // sc-14058 (batch path): the inline [WxH] batch directive must be gated by the SAME per-model range +
+  // ÷16 stride as the single-generate free override — not the global 256–4096 envelope. Both offending
+  // sizes below sit INSIDE 256–4096, so a global-envelope check (the pre-fix behavior) would wave them
+  // through and only fail at job time. Also proves the message names the native range/stride, not 256–4096.
+  it("enforces the native range + ÷16 stride on inline [WxH] batch directives and surfaces the native error", async () => {
+    await render(baseContext({ imageModels: [MAGE_RL] }));
+    await click(container.querySelector(".batch-toggle"));
+    await act(async () => {});
+    const batchInput = container.querySelector('textarea[aria-label="Batch prompts"]');
+    expect(batchInput).toBeTruthy();
+    const warning = () => container.querySelector(".batch-warning");
+    const runBtn = () => [...document.body.querySelectorAll("button")].find((b) => b.textContent.includes("Run batch"));
+
+    // [1000x1000] is off the ÷16 stride; [600x600] is below the 512 native floor. Both are within 256–4096.
+    await act(async () => setTextarea(batchInput, "[1000x1000] a red boat\n[600x600] a blue car"));
+    expect(warning()).toBeTruthy();
+    expect(warning().textContent).toContain("multiple of 16");
+    expect(warning().textContent).toContain("512");
+    expect(warning().textContent).toContain("2048");
+    // The discriminator: the batch never falls back to the global backend envelope.
+    expect(warning().textContent).not.toContain("256");
+    expect(warning().textContent).not.toContain("4096");
+    expect(runBtn().disabled).toBe(true);
+
+    // A native, ÷16-clean [1536x1536] clears the block and re-enables the Run.
+    await act(async () => setTextarea(batchInput, "[1536x1536] a red boat"));
+    expect(warning()).toBeFalsy();
+    expect(runBtn().disabled).toBe(false);
+  });
+
+  it("leaves a non-native model's inline [WxH] batch directive on the global 256–4096 / no-stride envelope", async () => {
+    await render(baseContext({ imageModels: [PLAIN] }));
+    await click(container.querySelector(".batch-toggle"));
+    await act(async () => {});
+    const batchInput = container.querySelector('textarea[aria-label="Batch prompts"]');
+    // 1000 is not ÷16 but perfectly valid for a plain model — no batch warning, Run stays enabled.
+    await act(async () => setTextarea(batchInput, "[1000x1000] a red boat"));
+    expect(container.querySelector(".batch-warning")).toBeFalsy();
+    const runBtn = [...document.body.querySelectorAll("button")].find((b) => b.textContent.includes("Run batch"));
+    expect(runBtn.disabled).toBe(false);
+  });
+
   it("wires Turbo's 4-step / CFG-off defaults and seeds the native default resolution", async () => {
     await render(baseContext({ imageModels: [MAGE_TURBO] }));
     await openAdvanced();

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -78,12 +78,24 @@
         "scheduler": "default"
       },
       "limits": {
+        // Mage-Flow is native-resolution (512–2048 per side, any aspect incl. 4:1). This advisory
+        // menu is the curated aspect ladder; the free Width/Height override (bounded by these
+        // extremes and the binding stride below) covers everything in between. Every entry is a
+        // multiple of 16 so a preset can never violate the stride.
         "resolutions": [
           "512x512",
           "768x768",
           "1024x1024",
+          "1536x1536",
+          "2048x2048",
           "1280x720",
-          "720x1280"
+          "1536x1024",
+          "2048x1024",
+          "2048x512",
+          "720x1280",
+          "1024x1536",
+          "1024x2048",
+          "512x2048"
         ],
         "count": [
           1,
@@ -95,7 +107,10 @@
         ],
         "schedulers": [
           "default"
-        ]
+        ],
+        // NR-MMDiT patch=1 over 16x-downsampled Mage-VAE latents ⇒ both sides must be multiples of 16.
+        // The Studio enforces this stride on the free Width/Height override (resolutionOverride.js).
+        "requiresDimensionsMultipleOf": 16
       },
       "mlx": {
         "quantize": 4
@@ -190,12 +205,24 @@
         "scheduler": "default"
       },
       "limits": {
+        // Mage-Flow is native-resolution (512–2048 per side, any aspect incl. 4:1). This advisory
+        // menu is the curated aspect ladder; the free Width/Height override (bounded by these
+        // extremes and the binding stride below) covers everything in between. Every entry is a
+        // multiple of 16 so a preset can never violate the stride.
         "resolutions": [
           "512x512",
           "768x768",
           "1024x1024",
+          "1536x1536",
+          "2048x2048",
           "1280x720",
-          "720x1280"
+          "1536x1024",
+          "2048x1024",
+          "2048x512",
+          "720x1280",
+          "1024x1536",
+          "1024x2048",
+          "512x2048"
         ],
         "count": [
           1,
@@ -207,7 +234,10 @@
         ],
         "schedulers": [
           "default"
-        ]
+        ],
+        // NR-MMDiT patch=1 over 16x-downsampled Mage-VAE latents ⇒ both sides must be multiples of 16.
+        // The Studio enforces this stride on the free Width/Height override (resolutionOverride.js).
+        "requiresDimensionsMultipleOf": 16
       },
       "mlx": {
         "quantize": 4
@@ -299,12 +329,24 @@
         "scheduler": "default"
       },
       "limits": {
+        // Mage-Flow is native-resolution (512–2048 per side, any aspect incl. 4:1). This advisory
+        // menu is the curated aspect ladder; the free Width/Height override (bounded by these
+        // extremes and the binding stride below) covers everything in between. Every entry is a
+        // multiple of 16 so a preset can never violate the stride.
         "resolutions": [
           "512x512",
           "768x768",
           "1024x1024",
+          "1536x1536",
+          "2048x2048",
           "1280x720",
-          "720x1280"
+          "1536x1024",
+          "2048x1024",
+          "2048x512",
+          "720x1280",
+          "1024x1536",
+          "1024x2048",
+          "512x2048"
         ],
         "count": [
           1,
@@ -316,7 +358,10 @@
         ],
         "schedulers": [
           "default"
-        ]
+        ],
+        // NR-MMDiT patch=1 over 16x-downsampled Mage-VAE latents ⇒ both sides must be multiples of 16.
+        // The Studio enforces this stride on the free Width/Height override (resolutionOverride.js).
+        "requiresDimensionsMultipleOf": 16
       },
       "mlx": {
         "quantize": 4
@@ -390,10 +435,21 @@
         "scheduler": "default"
       },
       "limits": {
-        "resolutions": ["512x512", "768x768", "1024x1024", "1280x720", "720x1280"],
+        // Mage-Flow is native-resolution (512–2048 per side, any aspect incl. 4:1). This advisory
+        // menu is the curated aspect ladder; the free Width/Height override (bounded by these
+        // extremes and the binding stride below) covers everything in between. Every entry is a
+        // multiple of 16 so a preset can never violate the stride.
+        "resolutions": [
+          "512x512", "768x768", "1024x1024", "1536x1536", "2048x2048",
+          "1280x720", "1536x1024", "2048x1024", "2048x512",
+          "720x1280", "1024x1536", "1024x2048", "512x2048"
+        ],
         "count": [1, 2, 4],
         "samplers": ["default"],
-        "schedulers": ["default"]
+        "schedulers": ["default"],
+        // NR-MMDiT patch=1 over 16x-downsampled Mage-VAE latents ⇒ both sides must be multiples of 16.
+        // The Studio enforces this stride on the free Width/Height override (resolutionOverride.js).
+        "requiresDimensionsMultipleOf": 16
       },
       "loraCompatibility": { "families": ["mage-flow"], "types": ["style", "enhance", "character"] },
       "mlx": { "quantize": 4 },
@@ -460,10 +516,21 @@
         "scheduler": "default"
       },
       "limits": {
-        "resolutions": ["512x512", "768x768", "1024x1024", "1280x720", "720x1280"],
+        // Mage-Flow is native-resolution (512–2048 per side, any aspect incl. 4:1). This advisory
+        // menu is the curated aspect ladder; the free Width/Height override (bounded by these
+        // extremes and the binding stride below) covers everything in between. Every entry is a
+        // multiple of 16 so a preset can never violate the stride.
+        "resolutions": [
+          "512x512", "768x768", "1024x1024", "1536x1536", "2048x2048",
+          "1280x720", "1536x1024", "2048x1024", "2048x512",
+          "720x1280", "1024x1536", "1024x2048", "512x2048"
+        ],
         "count": [1, 2, 4],
         "samplers": ["default"],
-        "schedulers": ["default"]
+        "schedulers": ["default"],
+        // NR-MMDiT patch=1 over 16x-downsampled Mage-VAE latents ⇒ both sides must be multiples of 16.
+        // The Studio enforces this stride on the free Width/Height override (resolutionOverride.js).
+        "requiresDimensionsMultipleOf": 16
       },
       "loraCompatibility": { "families": ["mage-flow"], "types": ["style", "enhance", "character"] },
       "mlx": { "quantize": 4 },
@@ -530,10 +597,21 @@
         "scheduler": "default"
       },
       "limits": {
-        "resolutions": ["512x512", "768x768", "1024x1024", "1280x720", "720x1280"],
+        // Mage-Flow is native-resolution (512–2048 per side, any aspect incl. 4:1). This advisory
+        // menu is the curated aspect ladder; the free Width/Height override (bounded by these
+        // extremes and the binding stride below) covers everything in between. Every entry is a
+        // multiple of 16 so a preset can never violate the stride.
+        "resolutions": [
+          "512x512", "768x768", "1024x1024", "1536x1536", "2048x2048",
+          "1280x720", "1536x1024", "2048x1024", "2048x512",
+          "720x1280", "1024x1536", "1024x2048", "512x2048"
+        ],
         "count": [1, 2, 4],
         "samplers": ["default"],
-        "schedulers": ["default"]
+        "schedulers": ["default"],
+        // NR-MMDiT patch=1 over 16x-downsampled Mage-VAE latents ⇒ both sides must be multiples of 16.
+        // The Studio enforces this stride on the free Width/Height override (resolutionOverride.js).
+        "requiresDimensionsMultipleOf": 16
       },
       "loraCompatibility": { "families": ["mage-flow"], "types": ["style", "enhance", "character"] },
       "mlx": { "quantize": 4 },

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -240,8 +240,8 @@
               "requiresDimensionsMultipleOf": {
                 "type": "integer", "minimum": 1,
                 "x-sceneworks-contract": "binding",
-                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "fn dimension_multiple_of(" }, { "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "let multiple = dimension_multiple_of(model_manifest_entry)" }],
-                "description": "Required render-dimension stride; core normalizes geometry to this value."
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "fn dimension_multiple_of(" }, { "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "let multiple = dimension_multiple_of(model_manifest_entry)" }, { "path": "apps/web/src/resolutionOverride.js", "anchor": "requiresDimensionsMultipleOf" }],
+                "description": "Required render-dimension stride; core normalizes video geometry to this value, and Image Studio enforces it as the free Width/Height override stride for native-resolution image models (Mage-Flow)."
               },
               "recommendedMaxDuration": {
                 "type": "number", "exclusiveMinimum": 0,


### PR DESCRIPTION
## Summary

Adds the Studio-UI surface for the **Mage-Flow** image family (epic 14034, P6 / sc-14058). Mage rides the generic manifest → catalog → Studio machinery landed by sc-14047/sc-14050, so this PR wires the **family-specific resolution behavior** and lets the rest (pickers, tier selector, edit mode, defaults, guide) flow through the existing catalog projection.

## Scope vs each acceptance criterion

- **Family in BOTH gen + edit pickers (6 variants)** — the 6 Mage rows are already in the manifest with the right `capabilities` (`text_to_image` for gen, `edit_image` for edit); the catalog projects them and the pickers filter by capability. Covered by a test asserting the gen picker lists the gen variants (not edit) and the edit picker lists the edit variant (not gen).
- **Quant-tier selector — Auto default, never silently switch, uninstalled tier surfaced not auto-fallback** — fully generic (`tierPickerOptions`/`defaultTierSelection`/`isBelowFloor`): all possible tiers render, un-downloaded ones disabled with a reason, and an explicit pick sticks. Covered by a test on a multi-tier Mage model.
- **Resolution: free W/H 512–2048 + aspect presets incl. 4:1 + ÷16 stride, default 1024²** —
  - Manifest: expanded `limits.resolutions` on all 6 rows to the native aspect ladder incl. `2048x512` (4:1) and `512x2048` (1:4); declared the binding **÷16** stride via the existing `limits.requiresDimensionsMultipleOf` key. Default stays `1024x1024`.
  - Web: `modelDimensionConstraints`/`evaluateModelDimensions`/`dimensionConstraintMessage` in `resolutionOverride.js`. A native-resolution model is bounded by its ladder extremes (512–2048) and stepped by its stride; the free Width/Height override inputs carry per-model `min`/`max`/`step`. Every other model keeps the global 256–4096 envelope with **no** stride (untouched).
- **Edit mode: source image + instruction + multi-reference** — the manifest edit rows set `ui.sourceWithMultiReference: true`, which the Studio already renders as a required Source picker + optional ordered reference set; the instruction is the shared prompt field. Covered by a test.
- **Per-variant defaults** — Base 30/cfg5, RL 20/cfg5, Turbo 4/cfg1-off, edit likewise, all in the manifest `defaults` and surfaced by the generic seed logic (resolution seeded; steps/CFG as placeholders). Covered by tests (Turbo 4/1, RL 20/5, resolution 1024²).
- **Model guide** — `ui.promptGuide.path: /prompt-guides/mage-flow.md` (file already on main) is wired the same way as other families.
- **Preserve all controls** — additive only; no control removed or hidden.
- **Validation shows `error`, not raw `requirement`** — a broken free override becomes an `issue.error` (`imageGenerateValidation`) that surfaces pre-emptively AND blocks Generate, with the model's actual range/stride in the message (not the old hard-coded "256–4096"). The submit-time guards use the same per-model message.

## Review follow-up — batch `[WxH]` directive now uses the same per-model constraints
Adversarial review found the single-generate resolution gate enforced each native model's 512–2048 range + ÷16 stride, but the **prompt-batch inline `[WxH]` directive** path did not — it validated against the global 256–4096 / no-stride envelope, so a Mage batch like `[1000x1000]` (off ÷16) or `[600x600]`/`[3000x3000]` (out of native range) passed UI validation and only failed at job time.

Fix: the batch directive check in `ImageStudio.jsx` now routes each parsed `[WxH]` through the **same** `evaluateModelDimensions(selectedModel, …)` helper the single-generate free override uses, and `imageBatchValidation` surfaces a native range/stride ERROR (new pure `batchResolutionMessage`, the batch-path twin of `dimensionConstraintMessage`) that blocks the Run — exactly like the single path. Non-native models keep the global 256–4096 / no-stride behavior unchanged (verified by a control test). Also merged current `main` (PR #1870 guide/manifest test, response-compression) into the branch.

## Tests added
- `resolutionOverride.test.js` — +11 discriminating cases (native range/stride derivation, 4:1 accept, off-stride vs out-of-range split, non-native model untouched, message wording).
- `imageStudioValidation.test.js` — +1 (dimension error surfaces as an error, silent when valid); **+2 for the batch path** — a native model reports its own range **and** stride for an inline `[WxH]` directive (never falls back to 256–4096), and `batchResolutionMessage` keeps the legacy no-stride wording for non-native models while adding the "multiple of N" clause for stride models.
- `screens/ImageStudio.mageFlow.test.jsx` — 10 integration tests (both pickers, 4:1 preset, ÷16 input attrs, off-stride surfaced+blocking, below-native range message, non-native control case, Turbo/RL defaults, edit source+instruction+multi-ref, tier picker no silent-switch); **+2 for the batch path** — an off-stride `[1000x1000]` + below-native `[600x600]` Mage batch is blocked with the native range/stride error (message asserts 512/2048/"multiple of 16", never 256/4096) and an on-native `[1536x1536]` clears it; a non-native model's `[1000x1000]` stays valid on the global envelope. Both fail if the fix is reverted (verified).

## How verified
- Full web vitest: **2681 pass** (194 files); `eslint src` clean.
- Manifest conformance audit (`tests/test_builtin_manifest_audit.py`): **59 pass**; full non-e2e/non-parity python suite: **66 pass**.
- Parity contract snapshot does not capture model resolution lists, so the parity lane is unaffected.

Story: https://app.shortcut.com/trefry/story/14058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

