### PR TITLE
fix(editor): send the resolved quant tier, never an uninstalled one (#1516)

### DIFF
--- a/apps/web/src/components/editor/useEditorGeneration.js
+++ b/apps/web/src/components/editor/useEditorGeneration.js
@@ -137,6 +137,21 @@ export function useEditorGeneration({ context }) {
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
   const showTierPicker = possibleTiers.length > 1 && availableTiers.length > 0;
+  // The tier the request actually carries. State when it is installed, else the same
+  // EDITOR_DEFAULT_TIER-first rule the reconciler below applies. This is a belt at the payload
+  // layer (mirroring the Image Studio's, sc-12090): no state — a catalog that settled after the
+  // model-change clamp ran, a persisted `editor-video` snapshot naming a tier since deleted — can
+  // leak a tier that is not on disk. Empty when nothing is installed, so `tierQuantize` returns
+  // null and the payload omits the field entirely rather than naming a tier the worker can't load.
+  const resolvedTier = useMemo(() => {
+    if (availableTiers.includes(quantTier)) {
+      return quantTier;
+    }
+    if (!availableTiers.length) {
+      return "";
+    }
+    return availableTiers.includes(EDITOR_DEFAULT_TIER) ? EDITOR_DEFAULT_TIER : availableTiers[0];
+  }, [availableTiers, quantTier]);
   const showLightning = WAN_A14B_LIGHTNING_MODEL_IDS.has(model);
   const lightningActive = showLightning && lightning;
 
@@ -162,11 +177,20 @@ export function useEditorGeneration({ context }) {
       setScheduler(schedulerDefaultFromModel(selectedModel));
       setSchedulerShift(schedulerShiftDefaultFromModel(selectedModel));
     }
-    if (availableTiers.length && !availableTiers.includes(quantTier)) {
-      setQuantTier(availableTiers.includes(EDITOR_DEFAULT_TIER) ? EDITOR_DEFAULT_TIER : availableTiers[0]);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedModel?.id]);
+
+  // Tier reconciliation is keyed on the INSTALLED SET, not on `selectedModel?.id` like the clamp
+  // above, because the two do not settle together: the editor mounts with the persisted snapshot's
+  // tier while the model catalog is still loading, so `availableTiers` fills in (or a later refresh
+  // reports a tier deleted/torn) with the model id unchanged — which the id-keyed effect never sees.
+  // Left there, the picker would highlight a tier the user does not have on disk.
+  useEffect(() => {
+    if (!availableTiers.length || availableTiers.includes(quantTier)) {
+      return;
+    }
+    setQuantTier(availableTiers.includes(EDITOR_DEFAULT_TIER) ? EDITOR_DEFAULT_TIER : availableTiers[0]);
+  }, [availableTiers, quantTier]);
 
   const [width, height] = String(resolution).split("x").map(Number);
   const motionPct = Math.round(((MOTIONS.indexOf(motion) + 1) / MOTIONS.length) * 100);
@@ -262,11 +286,17 @@ export function useEditorGeneration({ context }) {
   // per-action mode + source asset + advanced.timelineAction/timelineContext. Blank /
   // default / non-finite values are omitted so the engine re-derives its own defaults.
   function buildBasePayload() {
-    const mlxQuantize = tierQuantize(quantTier);
+    const mlxQuantize = tierQuantize(resolvedTier);
     const advanced = {
       resolution,
       motion,
-      ...(showTierPicker && mlxQuantize !== null ? { mlxQuantize } : {}),
+      // On-disk tier fidelity (sc-12090, #1516): send the RESOLVED tier's mlxQuantize whenever it
+      // maps to a known quant value — NOT only when the picker is shown. A model with a single
+      // possible tier hides the picker, but the tier the state resolved must still ride the payload,
+      // or the worker falls back to its own q8 default (`preferred_tier`, tier_resolver.rs) and
+      // budgets the VRAM gate against a tier the user never downloaded. `resolvedTier` is already
+      // clamped to the installed set, so this can only ever name a tier that is on disk.
+      ...(mlxQuantize !== null ? { mlxQuantize } : {}),
       ...(sampler && sampler !== "default" ? { sampler } : {}),
       ...(scheduler && scheduler !== "default" ? { scheduler } : {}),
       ...(scheduler && scheduler !== "default" && Number.isFinite(Number(schedulerShift))

--- a/apps/web/src/components/editor/useEditorGeneration.tier.test.jsx
+++ b/apps/web/src/components/editor/useEditorGeneration.tier.test.jsx
@@ -1,0 +1,123 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadStudioSettingsMock } = vi.hoisted(() => ({ loadStudioSettingsMock: vi.fn(() => ({})) }));
+vi.mock("../../hooks/useStudioSettings.js", () => ({
+  loadStudioSettings: loadStudioSettingsMock,
+  useStudioSettingsWriter: () => {},
+}));
+// The preset/LoRA machinery is orthogonal to tier selection; stub it so the harness needs no catalog.
+vi.mock("../generationStudio.jsx", () => ({
+  useGenerationStudio: () => ({
+    selectedPreset: null,
+    selectedPresetId: null,
+    selectedLoras: [],
+    selectedLoraIds: [],
+    loraWeights: {},
+    showIncompatibleLoras: false,
+    generalStackIds: [],
+    effectiveLoraWeight: () => 1,
+  }),
+}));
+
+import { useEditorGeneration } from "./useEditorGeneration.js";
+
+// A download-matrix video model: `variants` carries every POSSIBLE tier, `installState` says which
+// are actually on disk. `installed` lists the tiers to mark installed.
+function matrixModel(possible, installed) {
+  return {
+    id: "vid_model",
+    hasVariantMatrix: true,
+    variants: possible.map((tier) => ({
+      variant: tier,
+      installState: installed.includes(tier) ? "installed" : "missing",
+    })),
+  };
+}
+
+// A single-tier model (no variant matrix): one possible tier, so the picker never renders.
+function singleTierModel(tier) {
+  return { id: "vid_model", mlxTiers: [tier] };
+}
+
+describe("useEditorGeneration — quant tier rides the payload (sc-12090, #1516)", () => {
+  let container;
+  let root;
+  let latest;
+
+  function Harness({ model }) {
+    latest = useEditorGeneration({
+      context: { activeProject: { id: "p1" }, videoModels: model ? [model] : [] },
+    });
+    return null;
+  }
+
+  function render(model) {
+    act(() => {
+      root.render(<Harness model={model} />);
+    });
+  }
+
+  beforeEach(() => {
+    loadStudioSettingsMock.mockReturnValue({});
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("sends the installed tier even though a single-tier model hides the picker", () => {
+    render(singleTierModel("bf16"));
+
+    // One possible tier ⇒ no picker. The old payload gated mlxQuantize on `showTierPicker`, so the
+    // request carried no tier at all and the worker fell back to its own q8 default — against a tier
+    // this user never downloaded. bf16 maps to 0, which must survive the falsy-value spread.
+    expect(latest.showTierPicker).toBe(false);
+    expect(latest.buildBasePayload().advanced.mlxQuantize).toBe(0);
+  });
+
+  it("never sends a tier that stopped being installed under the same model", () => {
+    // Both tiers on disk; the user picks q8.
+    render(matrixModel(["q4", "q8"], ["q4", "q8"]));
+    act(() => latest.selectTier("q8"));
+    expect(latest.buildBasePayload().advanced.mlxQuantize).toBe(8);
+
+    // A catalog refresh now reports q8 gone (deleted to reclaim disk, or newly detected torn) with
+    // the MODEL ID UNCHANGED — the transition the model-id-keyed clamp never observes. Continuing to
+    // send 8 is exactly the #1516 symptom: the VRAM gate budgets a tier that is not on disk and
+    // rejects the job. Both the payload and the picker's own state must follow the installed set.
+    render(matrixModel(["q4", "q8"], ["q4"]));
+    expect(latest.buildBasePayload().advanced.mlxQuantize).toBe(4);
+    expect(latest.quantTier).toBe("q4");
+  });
+
+  it("honors an explicit pick of an installed tier", () => {
+    render(matrixModel(["q4", "q8"], ["q4", "q8"]));
+
+    act(() => latest.selectTier("q8"));
+    expect(latest.buildBasePayload().advanced.mlxQuantize).toBe(8);
+  });
+
+  it("refuses to select an un-downloaded tier", () => {
+    loadStudioSettingsMock.mockReturnValue({ quantTier: "q4" });
+    render(matrixModel(["q4", "q8"], ["q4"]));
+
+    act(() => latest.selectTier("q8"));
+    expect(latest.quantTier).toBe("q4");
+    expect(latest.buildBasePayload().advanced.mlxQuantize).toBe(4);
+  });
+
+  it("omits the tier entirely when nothing is installed", () => {
+    render(matrixModel(["q4", "q8"], []));
+
+    // No installed tier to name — the worker resolves one itself rather than being handed a
+    // tier that is guaranteed to be absent.
+    expect(latest.buildBasePayload().advanced.mlxQuantize).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Closes the last surviving instance of the **#1516** quant-tier pattern: a generation request naming a tier the user does not have on disk, which the worker then budgets the VRAM gate against and rejects with *"not enough VRAM/RAM"*.

**Root cause.** `useEditorGeneration.buildBasePayload` gated the tier on picker visibility:

```js
...(showTierPicker && mlxQuantize !== null ? { mlxQuantize } : {}),
```

That is exactly the shape `sc-12090` removed from `imageJobAdvanced.js`, whose replacement comment names this issue. `showTierPicker` is `possibleTiers.length > 1 && availableTiers.length > 0`, so a model with a **single possible tier** hides the picker and the request carried no tier at all — and the worker's `preferred_tier` (`tier_resolver.rs`) maps an absent `mlxQuantize` to **q8**. On a model whose only tier is `bf16` or `q4`, the gate then sizes the job against a q8 the user never downloaded. `bf16 → 0` also meant the value had to survive a falsy-value spread, which the old `showTierPicker &&` chain obscured.

A second, independent hole in the same area: tier reconciliation lived inside the effect keyed on `[selectedModel?.id]`. The installed set and the model id do not settle together — a catalog refresh that reports a tier **deleted** (reclaiming disk) or **newly detected torn** leaves the model id unchanged, so that effect never runs and the stale tier stays both in the picker and in the payload.

**Fix.**
- `resolvedTier` — a payload-layer clamp to the installed set, applying the same `EDITOR_DEFAULT_TIER`-first rule the reconciler uses. This mirrors the Image Studio's belt (`ImageStudio.jsx`, `availableTiers.includes(quantTier) ? quantTier : ""`). When nothing is installed it resolves to `""`, so `tierQuantize` returns `null` and the field is omitted entirely rather than naming a tier the worker cannot load.
- `mlxQuantize` is emitted whenever the resolved tier maps to a known quant value, no longer gated on `showTierPicker`.
- Tier reconciliation moved to its own effect keyed on the **installed set**.

Deliberately **not** sending `mlxQuantizeExplicit`: the editor has no per-(screen, model) sticky store, so there is no deliberate pick to honor. Omitting it leaves the worker's capability downtier (`sc-10733`) free to lower the tier if it does not fit — the safe direction.

Behavior is otherwise unchanged: the fallback rule (`q4` first, else the lowest installed tier) is the existing one, moved rather than rewritten.

## Related issue

Partially addresses #1670 — deliberately **not** auto-closing. That issue has two halves; its LoRA-import half is #1876. This is the other half, the reporter's *"my previous bug report of #1516 still persists"*.

Scoped honestly: the reporter's screenshots show the **Image Studio**, whose instance of this bug `sc-12090` already fixed on `main`. This PR fixes the **editor rail**, the one surface where the pattern survived. If the reporter is still hitting it in the Image Studio on 0.8.0, the cause is something the current `main` code does not explain and the job payload's `advanced` block would be the next thing to look at. The same class of defect was independently reported in #850 (*"you did find a model selection bug, that I thought was already fixed"*), so closing the remaining instance has value regardless of which surface the reporter was on.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

New `useEditorGeneration.tier.test.jsx` (5 tests). The two that pin the fix were **verified to fail on the parent commit and pass with it**:

- *sends the installed tier even though a single-tier model hides the picker* — `bf16`-only model, asserts `mlxQuantize === 0`. Fails without the fix (field absent).
- *never sends a tier that stopped being installed under the same model* — both tiers installed, user picks q8, then a refresh reports q8 gone with the model id unchanged; asserts the payload and the picker state both fall back to q4. Fails without the fix (still sends 8).

The other three are control/guard cases (explicit pick honored, un-downloaded tier refused, field omitted when nothing is installed) and pass either way by design.

- Full web suite: **196 files / 2667 tests pass**, no regression.
- `npm --prefix apps/web run lint` — clean.
- `npm --prefix apps/web run build` — succeeds.

Not verified in the live app: the editor rail needs pairing, an open project, a timeline asset, and a real multi-tier on-disk model, so the payload wiring was verified through the hook-level tests instead.

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) — n/a, no Rust touched
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build`
- [ ] I ran `npm run check` (scaffold checks) — not run; no scaffold, manifest, or workflow files touched
- [ ] I updated documentation where relevant — n/a; the reasoning lives in the comments next to the code
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change

## Reviewer notes

Three adjacent gaps surfaced while tracing this path and are **not** addressed here, to keep the change to one logical fix:

1. `shouldShowTierPicker` (`quantTier.js:334`) is exported and asserted by tests but has **no production call site** — its `installedTiers(...).length > 1` rule is the old semantics, while all three studios use `possibleTiers.length > 1 && availableTiers.length > 0`. Anyone reading the helper to understand render behavior gets the wrong answer.
2. Video Studio never sends `mlxQuantizeExplicit`, so a deliberate sticky video-tier pick can still be silently capability-downtiered.
3. In `gate_tier_key`, when the on-disk probe returns `None` (a `modelPath` override or flat root), the gate falls back to `requested_tier_key`, which consults `manifest.mlx.quantize` (mostly `4`) while `standard_tier_subdir` does not (defaults q8) — an under-prediction on that path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2o3ThtBkE21NsPAAz7cpU)_