### PR TITLE
feat(catalog): add resumable Parquet scanner (sc-14955)

### DIFF
--- a/crates/sceneworks-core/src/catalog_store.rs
+++ b/crates/sceneworks-core/src/catalog_store.rs
@@ -38,6 +38,16 @@ const SOURCE_CONFIG_METADATA_KEY: &str = "source_config";
 const ANALYZER_VERSIONS_METADATA_KEY: &str = "analyzer_versions";
 const CHECKPOINTS_METADATA_KEY: &str = "checkpoints";
 const PROGRESS_METADATA_KEY: &str = "processing_progress";
+const CATALOG_ID_METADATA_KEY: &str = "catalog_id";
+const CATALOG_NAME_METADATA_KEY: &str = "name";
+const CATALOG_CREATED_AT_METADATA_KEY: &str = "created_at";
+const CATALOG_SCHEMA_VERSION_METADATA_KEY: &str = "schema_version";
+const RESERVED_CATALOG_METADATA_KEYS: &[&str] = &[
+    CATALOG_ID_METADATA_KEY,
+    CATALOG_NAME_METADATA_KEY,
+    CATALOG_CREATED_AT_METADATA_KEY,
+    CATALOG_SCHEMA_VERSION_METADATA_KEY,
+];
 
 pub type CatalogResult<T> = Result<T, CatalogError>;
 
@@ -1179,7 +1189,7 @@ fn validate_metadata_key(key: &str) -> CatalogResult<()> {
 
 fn validate_metadata_entry(key: &str, value: &str) -> CatalogResult<()> {
     validate_metadata_key(key)?;
-    if matches!(key, "catalogId" | "schemaVersion") {
+    if RESERVED_CATALOG_METADATA_KEYS.contains(&key) {
         return Err(CatalogError::InvalidCatalog(
             "Catalog identity metadata is read-only".to_owned(),
         ));
@@ -1521,9 +1531,12 @@ fn write_database_metadata(
         .unchecked_transaction()
         .map_err(|error| map_sqlite_error(database_path, error))?;
     for (key, value) in [
-        ("catalog_id", descriptor.id.as_str()),
-        ("name", descriptor.name.as_str()),
-        ("created_at", descriptor.created_at.as_str()),
+        (CATALOG_ID_METADATA_KEY, descriptor.id.as_str()),
+        (CATALOG_NAME_METADATA_KEY, descriptor.name.as_str()),
+        (
+            CATALOG_CREATED_AT_METADATA_KEY,
+            descriptor.created_at.as_str(),
+        ),
     ] {
         transaction
             .execute(
@@ -1543,9 +1556,12 @@ fn validate_database_metadata(
     descriptor: &CatalogDescriptor,
 ) -> CatalogResult<()> {
     for (key, expected) in [
-        ("catalog_id", descriptor.id.as_str()),
-        ("name", descriptor.name.as_str()),
-        ("created_at", descriptor.created_at.as_str()),
+        (CATALOG_ID_METADATA_KEY, descriptor.id.as_str()),
+        (CATALOG_NAME_METADATA_KEY, descriptor.name.as_str()),
+        (
+            CATALOG_CREATED_AT_METADATA_KEY,
+            descriptor.created_at.as_str(),
+        ),
     ] {
         let actual: Option<String> = connection
             .query_row(
@@ -2205,6 +2221,56 @@ mod tests {
             registry.open_attached("00000000000000000000000000000000"),
             Err(CatalogError::NotFound(_))
         ));
+    }
+
+    #[test]
+    fn atomic_scanner_metadata_cannot_overwrite_catalog_identity() {
+        let temporary = tempdir().expect("temp directory");
+        let root = temporary.path().join("catalog");
+        let mut catalog = Catalog::create(&root, "Reserved metadata").expect("catalog creates");
+        let descriptor = catalog.descriptor().clone();
+        let original = RESERVED_CATALOG_METADATA_KEYS
+            .iter()
+            .map(|key| {
+                (
+                    *key,
+                    catalog
+                        .metadata(key)
+                        .expect("reserved metadata reads before attempted write"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        for (index, (key, expected)) in original.iter().enumerate() {
+            let record_id = format!("reserved-{index}");
+            let attempted_record = record(&record_id);
+            assert!(
+                matches!(
+                    catalog.append_records_and_metadata(&[attempted_record], &[(*key, "tampered")]),
+                    Err(CatalogError::InvalidCatalog(_))
+                ),
+                "{key} must be read-only"
+            );
+            assert_eq!(
+                catalog.metadata(key).expect("reserved metadata rereads"),
+                *expected,
+                "{key} must remain unchanged"
+            );
+            assert!(
+                !catalog
+                    .contains_record_id(&record_id)
+                    .expect("record existence checks"),
+                "record and metadata writes must fail atomically for {key}"
+            );
+        }
+        catalog.close();
+
+        let reopened = Catalog::open(&root).expect("catalog remains reopenable");
+        assert_eq!(reopened.descriptor(), &descriptor);
+        assert_eq!(reopened.storage_accounting().unwrap().record_count, 0);
+        for (key, expected) in original {
+            assert_eq!(reopened.metadata(key).unwrap(), expected);
+        }
     }
 
     #[test]

--- a/crates/sceneworks-core/src/catalog_store.rs
+++ b/crates/sceneworks-core/src/catalog_store.rs
@@ -242,8 +242,22 @@ impl Catalog {
     }
 
     pub fn append_records(&mut self, records: &[NewCatalogRecord]) -> CatalogResult<usize> {
+        self.append_records_and_metadata(records, &[])
+    }
+
+    /// Appends a bounded record batch and advances scanner metadata in the same
+    /// SQLite transaction. A process crash can therefore only leave both the
+    /// records and checkpoint committed, or neither committed.
+    pub fn append_records_and_metadata(
+        &mut self,
+        records: &[NewCatalogRecord],
+        metadata: &[(&str, &str)],
+    ) -> CatalogResult<usize> {
         for record in records {
             validate_record(record)?;
+        }
+        for (key, value) in metadata {
+            validate_metadata_entry(key, value)?;
         }
         let database_path = self.database_path();
         let transaction = self
@@ -281,10 +295,50 @@ impl Catalog {
                     .map_err(|error| map_sqlite_error(&database_path, error))?;
             }
         }
+        {
+            let mut statement = transaction
+                .prepare_cached(
+                    "insert into catalog_metadata(key, value) values (?1, ?2)
+                     on conflict(key) do update set value = excluded.value",
+                )
+                .map_err(|error| map_sqlite_error(&database_path, error))?;
+            for (key, value) in metadata {
+                statement
+                    .execute(params![key, value])
+                    .map_err(|error| map_sqlite_error(&database_path, error))?;
+            }
+        }
         transaction
             .commit()
             .map_err(|error| map_sqlite_error(&database_path, error))?;
         Ok(records.len())
+    }
+
+    pub fn metadata(&self, key: &str) -> CatalogResult<Option<String>> {
+        validate_metadata_key(key)?;
+        self.connection
+            .query_row(
+                "select value from catalog_metadata where key = ?1",
+                [key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| map_sqlite_error(&self.database_path(), error))
+    }
+
+    pub fn contains_record_id(&self, record_id: &str) -> CatalogResult<bool> {
+        if record_id.trim().is_empty() || record_id.len() > 512 || record_id.contains('\0') {
+            return Err(CatalogError::InvalidCatalog(
+                "Catalog record id must contain 1 to 512 non-NUL bytes".to_owned(),
+            ));
+        }
+        self.connection
+            .query_row(
+                "select exists(select 1 from catalog_records where id = ?1)",
+                [record_id],
+                |row| row.get(0),
+            )
+            .map_err(|error| map_sqlite_error(&self.database_path(), error))
     }
 
     pub fn page_records(&self, offset: u64, limit: u32) -> CatalogResult<Vec<CatalogRecord>> {
@@ -508,6 +562,27 @@ impl CatalogRegistry {
 
     pub fn open_catalog(&self, root: impl AsRef<Path>) -> CatalogResult<Catalog> {
         Catalog::open(root)
+    }
+
+    /// Resolves an attached catalog by its stable identity. Callers that operate
+    /// on catalog IDs use this instead of accepting a root path from a request.
+    pub fn open_attached(&self, catalog_id: &str) -> CatalogResult<Catalog> {
+        let attached = self
+            .load()?
+            .catalogs
+            .into_iter()
+            .find(|catalog| catalog.id == catalog_id)
+            .ok_or_else(|| {
+                CatalogError::NotFound(format!("Attached catalog not found: {catalog_id}"))
+            })?;
+        let catalog = Catalog::open(&attached.path)?;
+        if catalog.descriptor().id != catalog_id {
+            return Err(CatalogError::InvalidCatalog(format!(
+                "Attached catalog identity changed at {}",
+                attached.path.display()
+            )));
+        }
+        Ok(catalog)
     }
 
     pub fn attach(&self, root: impl AsRef<Path>) -> CatalogResult<AttachedCatalog> {
@@ -739,6 +814,30 @@ fn validate_record(record: &NewCatalogRecord) -> CatalogResult<()> {
                 "Catalog artifact paths cannot be blank or contain NUL".to_owned(),
             ));
         }
+    }
+    Ok(())
+}
+
+fn validate_metadata_key(key: &str) -> CatalogResult<()> {
+    if key.trim().is_empty() || key.len() > 256 || key.contains('\0') {
+        return Err(CatalogError::InvalidCatalog(
+            "Catalog metadata keys must contain 1 to 256 non-NUL bytes".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_metadata_entry(key: &str, value: &str) -> CatalogResult<()> {
+    validate_metadata_key(key)?;
+    if matches!(key, "catalogId" | "schemaVersion") {
+        return Err(CatalogError::InvalidCatalog(
+            "Catalog identity metadata is read-only".to_owned(),
+        ));
+    }
+    if value.len() > 1024 * 1024 || value.contains('\0') {
+        return Err(CatalogError::InvalidCatalog(
+            "Catalog metadata values cannot exceed 1 MiB or contain NUL".to_owned(),
+        ));
     }
     Ok(())
 }

--- a/crates/sceneworks-worker/src/catalog_parquet_scanner.rs
+++ b/crates/sceneworks-worker/src/catalog_parquet_scanner.rs
@@ -1,0 +1,1016 @@
+//! Restart-safe, bounded indexing of LAION-style Parquet metadata into an
+//! isolated [`Catalog`].
+//!
+//! This scanner deliberately stores only metadata and source identities. It
+//! does not download images or create a SceneWorks training dataset.
+
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::record::{Field, Row};
+use sceneworks_core::catalog_store::{Catalog, CatalogError, CatalogRegistry, NewCatalogRecord};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashSet};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+const CHECKPOINT_KEY: &str = "scanner.parquet.checkpoint.v1";
+const DEFAULT_BATCH_SIZE: usize = 1_000;
+const MAX_BATCH_SIZE: usize = 10_000;
+const MAX_CAPTION_CHARS: usize = 2_048;
+const MAX_IMAGE_EDGE: u32 = 16_384;
+
+#[derive(Debug)]
+pub enum CatalogParquetScanError {
+    Io(std::io::Error),
+    Parquet(parquet::errors::ParquetError),
+    Catalog(CatalogError),
+    Json(serde_json::Error),
+    InvalidSource(String),
+    CheckpointMismatch(String),
+}
+
+impl std::fmt::Display for CatalogParquetScanError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "{error}"),
+            Self::Parquet(error) => write!(formatter, "{error}"),
+            Self::Catalog(error) => write!(formatter, "{error}"),
+            Self::Json(error) => write!(formatter, "{error}"),
+            Self::InvalidSource(detail) | Self::CheckpointMismatch(detail) => {
+                formatter.write_str(detail)
+            }
+        }
+    }
+}
+
+impl std::error::Error for CatalogParquetScanError {}
+
+impl From<std::io::Error> for CatalogParquetScanError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<parquet::errors::ParquetError> for CatalogParquetScanError {
+    fn from(error: parquet::errors::ParquetError) -> Self {
+        Self::Parquet(error)
+    }
+}
+
+impl From<CatalogError> for CatalogParquetScanError {
+    fn from(error: CatalogError) -> Self {
+        Self::Catalog(error)
+    }
+}
+
+impl From<serde_json::Error> for CatalogParquetScanError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub type CatalogParquetScanResult<T> = Result<T, CatalogParquetScanError>;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct CatalogParquetScanOptions {
+    pub url_column: Option<String>,
+    pub caption_column: Option<String>,
+    pub min_width: Option<u32>,
+    pub min_height: Option<u32>,
+    pub max_width: Option<u32>,
+    pub max_height: Option<u32>,
+    pub caption_includes: Vec<String>,
+    pub caption_excludes: Vec<String>,
+    pub require_people: bool,
+    pub max_unsafe_score: Option<f64>,
+    pub min_aesthetic_score: Option<f64>,
+    /// Transaction size. This does not change the semantic scan identity.
+    pub batch_size: usize,
+    /// Optional per-invocation row budget, used by schedulers to yield and
+    /// resume long scans. This does not change the semantic scan identity.
+    pub max_rows: Option<u64>,
+}
+
+impl Default for CatalogParquetScanOptions {
+    fn default() -> Self {
+        Self {
+            url_column: None,
+            caption_column: None,
+            min_width: None,
+            min_height: None,
+            max_width: Some(MAX_IMAGE_EDGE),
+            max_height: Some(MAX_IMAGE_EDGE),
+            caption_includes: Vec::new(),
+            caption_excludes: Vec::new(),
+            require_people: false,
+            max_unsafe_score: None,
+            min_aesthetic_score: None,
+            batch_size: DEFAULT_BATCH_SIZE,
+            max_rows: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogParquetScanCounts {
+    pub scanned: u64,
+    pub accepted: u64,
+    pub rejected: u64,
+    pub duplicate: u64,
+    pub malformed: u64,
+    pub reasons: BTreeMap<String, u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogParquetCheckpoint {
+    pub source_signature: String,
+    pub options_signature: String,
+    /// Index of the next shard to read.
+    pub shard: usize,
+    /// Index of the next row group to read within `shard`.
+    pub row_group: usize,
+    /// Index of the next row to read within `row_group`.
+    pub row: u64,
+    pub complete: bool,
+    pub counts: CatalogParquetScanCounts,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogParquetScanReport {
+    pub checkpoint: CatalogParquetCheckpoint,
+    pub source_shards: Vec<PathBuf>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SemanticOptions<'a> {
+    url_column: &'a Option<String>,
+    caption_column: &'a Option<String>,
+    min_width: Option<u32>,
+    min_height: Option<u32>,
+    max_width: Option<u32>,
+    max_height: Option<u32>,
+    caption_includes: Vec<String>,
+    caption_excludes: Vec<String>,
+    require_people: bool,
+    max_unsafe_score: Option<f64>,
+    min_aesthetic_score: Option<f64>,
+}
+
+/// Indexes a bounded pass of Parquet rows into `catalog`.
+///
+/// Calling this again with the same source and semantic options resumes at the
+/// exact next shard/row-group/row. A different source or filter configuration is
+/// rejected rather than silently mixing two scans in one catalog.
+pub fn scan_attached_parquet_catalog(
+    registry: &CatalogRegistry,
+    catalog_id: &str,
+    source: &Path,
+    options: &CatalogParquetScanOptions,
+) -> CatalogParquetScanResult<CatalogParquetScanReport> {
+    let mut catalog = registry.open_attached(catalog_id)?;
+    scan_parquet_catalog(&mut catalog, source, options)
+}
+
+fn scan_parquet_catalog(
+    catalog: &mut Catalog,
+    source: &Path,
+    options: &CatalogParquetScanOptions,
+) -> CatalogParquetScanResult<CatalogParquetScanReport> {
+    validate_options(options)?;
+    let shards = parquet_shards(source)?;
+    let source_signature = source_signature(&shards)?;
+    let options_signature = options_signature(options)?;
+    let mut checkpoint = load_checkpoint(catalog, &source_signature, &options_signature)?;
+    if checkpoint.complete {
+        return Ok(CatalogParquetScanReport {
+            checkpoint,
+            source_shards: shards,
+        });
+    }
+
+    let batch_size = options.batch_size.clamp(1, MAX_BATCH_SIZE);
+    let row_budget = options.max_rows.unwrap_or(u64::MAX);
+    let mut rows_this_pass = 0_u64;
+    let mut pending = Vec::with_capacity(batch_size);
+    let mut pending_ids = HashSet::with_capacity(batch_size);
+
+    for (shard_index, shard) in shards.iter().enumerate().skip(checkpoint.shard) {
+        let reader = SerializedFileReader::new(File::open(shard)?)?;
+        let row_group_start = if shard_index == checkpoint.shard {
+            checkpoint.row_group
+        } else {
+            0
+        };
+        for row_group_index in row_group_start..reader.num_row_groups() {
+            let row_start =
+                if shard_index == checkpoint.shard && row_group_index == checkpoint.row_group {
+                    checkpoint.row
+                } else {
+                    0
+                };
+            let row_group = reader.get_row_group(row_group_index)?;
+            let rows = row_group.get_row_iter(None)?;
+            for (row_index, row) in rows.enumerate().skip(row_start as usize) {
+                if rows_this_pass >= row_budget {
+                    flush_batch(catalog, &mut pending, &checkpoint)?;
+                    return Ok(CatalogParquetScanReport {
+                        checkpoint,
+                        source_shards: shards,
+                    });
+                }
+                rows_this_pass = rows_this_pass.saturating_add(1);
+                checkpoint.counts.scanned = checkpoint.counts.scanned.saturating_add(1);
+                checkpoint.shard = shard_index;
+                checkpoint.row_group = row_group_index;
+                checkpoint.row = row_index as u64 + 1;
+
+                match row {
+                    Ok(row) => match catalog_record_for_row(
+                        &row,
+                        shard,
+                        shard_index,
+                        row_group_index,
+                        row_index as u64,
+                        options,
+                    ) {
+                        RowOutcome::Accept(record) => {
+                            if pending_ids.contains(&record.id)
+                                || catalog.contains_record_id(&record.id)?
+                            {
+                                increment_duplicate(&mut checkpoint.counts);
+                            } else {
+                                pending_ids.insert(record.id.clone());
+                                pending.push(record);
+                                checkpoint.counts.accepted =
+                                    checkpoint.counts.accepted.saturating_add(1);
+                            }
+                        }
+                        RowOutcome::Reject(reason) => {
+                            increment_rejected(&mut checkpoint.counts, reason)
+                        }
+                        RowOutcome::Malformed(reason) => {
+                            increment_malformed(&mut checkpoint.counts, reason)
+                        }
+                    },
+                    Err(_) => increment_malformed(&mut checkpoint.counts, "row_decode"),
+                }
+
+                if pending.len() >= batch_size || checkpoint.counts.scanned % batch_size as u64 == 0
+                {
+                    flush_batch(catalog, &mut pending, &checkpoint)?;
+                    pending_ids.clear();
+                }
+            }
+            checkpoint.row_group = row_group_index + 1;
+            checkpoint.row = 0;
+            flush_batch(catalog, &mut pending, &checkpoint)?;
+            pending_ids.clear();
+        }
+        checkpoint.shard = shard_index + 1;
+        checkpoint.row_group = 0;
+        checkpoint.row = 0;
+        flush_batch(catalog, &mut pending, &checkpoint)?;
+        pending_ids.clear();
+    }
+
+    checkpoint.complete = true;
+    flush_batch(catalog, &mut pending, &checkpoint)?;
+    Ok(CatalogParquetScanReport {
+        checkpoint,
+        source_shards: shards,
+    })
+}
+
+/// Whole-word/phrase matcher shared with the existing materializing importer.
+/// Punctuation and case are ignored, but substrings inside larger words are not.
+pub(crate) fn caption_matches_term(caption: &str, term: &str) -> bool {
+    let caption_tokens = word_tokens(caption);
+    let term_tokens = word_tokens(term);
+    !term_tokens.is_empty()
+        && caption_tokens
+            .windows(term_tokens.len())
+            .any(|window| window == term_tokens)
+}
+
+pub(crate) fn parquet_shards(source: &Path) -> CatalogParquetScanResult<Vec<PathBuf>> {
+    if !source.is_absolute() {
+        return Err(CatalogParquetScanError::InvalidSource(
+            "Parquet source path must be absolute.".to_owned(),
+        ));
+    }
+    let canonical = std::fs::canonicalize(source)?;
+    let metadata = std::fs::metadata(&canonical)?;
+    let mut shards = if metadata.is_file() {
+        if !has_parquet_extension(&canonical) {
+            return Err(CatalogParquetScanError::InvalidSource(
+                "Parquet source file must end in .parquet.".to_owned(),
+            ));
+        }
+        vec![canonical]
+    } else if metadata.is_dir() {
+        let mut discovered = Vec::new();
+        for entry in std::fs::read_dir(&canonical)? {
+            let path = entry?.path();
+            if path.is_file() && has_parquet_extension(&path) {
+                discovered.push(std::fs::canonicalize(path)?);
+            }
+        }
+        discovered
+    } else {
+        Vec::new()
+    };
+    shards.sort();
+    shards.dedup();
+    if shards.is_empty() {
+        return Err(CatalogParquetScanError::InvalidSource(
+            "Parquet source contains no .parquet shards.".to_owned(),
+        ));
+    }
+    Ok(shards)
+}
+
+fn validate_options(options: &CatalogParquetScanOptions) -> CatalogParquetScanResult<()> {
+    if options.batch_size == 0 || options.batch_size > MAX_BATCH_SIZE {
+        return Err(CatalogParquetScanError::InvalidSource(format!(
+            "Parquet catalog batch size must be between 1 and {MAX_BATCH_SIZE}."
+        )));
+    }
+    for (name, value) in [
+        ("maxUnsafeScore", options.max_unsafe_score),
+        ("minAestheticScore", options.min_aesthetic_score),
+    ] {
+        if value.is_some_and(|value| !value.is_finite()) {
+            return Err(CatalogParquetScanError::InvalidSource(format!(
+                "{name} must be finite."
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn load_checkpoint(
+    catalog: &Catalog,
+    source_signature: &str,
+    options_signature: &str,
+) -> CatalogParquetScanResult<CatalogParquetCheckpoint> {
+    let Some(payload) = catalog.metadata(CHECKPOINT_KEY)? else {
+        return Ok(CatalogParquetCheckpoint {
+            source_signature: source_signature.to_owned(),
+            options_signature: options_signature.to_owned(),
+            shard: 0,
+            row_group: 0,
+            row: 0,
+            complete: false,
+            counts: CatalogParquetScanCounts::default(),
+        });
+    };
+    let checkpoint: CatalogParquetCheckpoint = serde_json::from_str(&payload)?;
+    if checkpoint.source_signature != source_signature {
+        return Err(CatalogParquetScanError::CheckpointMismatch(
+            "Parquet source changed after this catalog scan started.".to_owned(),
+        ));
+    }
+    if checkpoint.options_signature != options_signature {
+        return Err(CatalogParquetScanError::CheckpointMismatch(
+            "Parquet scan filters changed after this catalog scan started.".to_owned(),
+        ));
+    }
+    Ok(checkpoint)
+}
+
+fn flush_batch(
+    catalog: &mut Catalog,
+    pending: &mut Vec<NewCatalogRecord>,
+    checkpoint: &CatalogParquetCheckpoint,
+) -> CatalogParquetScanResult<()> {
+    let payload = serde_json::to_string(checkpoint)?;
+    catalog.append_records_and_metadata(pending, &[(CHECKPOINT_KEY, payload.as_str())])?;
+    pending.clear();
+    Ok(())
+}
+
+enum RowOutcome {
+    Accept(NewCatalogRecord),
+    Reject(&'static str),
+    Malformed(&'static str),
+}
+
+#[allow(clippy::too_many_arguments)]
+fn catalog_record_for_row(
+    row: &Row,
+    shard: &Path,
+    shard_index: usize,
+    row_group: usize,
+    row_index: u64,
+    options: &CatalogParquetScanOptions,
+) -> RowOutcome {
+    let url_aliases = requested_aliases(
+        options.url_column.as_deref(),
+        &["url", "sample_url", "image_url"],
+    );
+    let caption_aliases = requested_aliases(
+        options.caption_column.as_deref(),
+        &["text", "caption", "description"],
+    );
+    let Some(url) = row_string_alias(row, &url_aliases) else {
+        return RowOutcome::Malformed("missing_url");
+    };
+    let Some(caption) = row_string_alias(row, &caption_aliases) else {
+        return RowOutcome::Malformed("missing_caption");
+    };
+    let url = url.trim().replace("&amp;", "&");
+    let caption = caption.trim();
+    if url.is_empty() {
+        return RowOutcome::Malformed("blank_url");
+    }
+    if caption.is_empty() {
+        return RowOutcome::Malformed("blank_caption");
+    }
+    if !valid_public_http_url(&url) {
+        return RowOutcome::Reject("invalid_url");
+    }
+
+    let width = row_u32_alias(row, &["width", "image_width", "original_width"]);
+    let height = row_u32_alias(row, &["height", "image_height", "original_height"]);
+    if width.is_some_and(|value| {
+        options.min_width.is_some_and(|minimum| value < minimum)
+            || options.max_width.is_some_and(|maximum| value > maximum)
+    }) || height.is_some_and(|value| {
+        options.min_height.is_some_and(|minimum| value < minimum)
+            || options.max_height.is_some_and(|maximum| value > maximum)
+    }) {
+        return RowOutcome::Reject("dimensions");
+    }
+    if !options.caption_includes.is_empty()
+        && !options
+            .caption_includes
+            .iter()
+            .any(|term| caption_matches_term(caption, term))
+    {
+        return RowOutcome::Reject("caption_include");
+    }
+    if options
+        .caption_excludes
+        .iter()
+        .any(|term| caption_matches_term(caption, term))
+    {
+        return RowOutcome::Reject("caption_exclude");
+    }
+    if options.require_people && !caption_describes_people(caption) {
+        return RowOutcome::Reject("people");
+    }
+
+    let unsafe_score = row_f64_alias(
+        row,
+        &[
+            "punsafe",
+            "unsafe_score",
+            "nsfw_score",
+            "nsfw",
+            "safety_score",
+        ],
+    );
+    if options
+        .max_unsafe_score
+        .zip(unsafe_score)
+        .is_some_and(|(maximum, score)| score > maximum)
+    {
+        return RowOutcome::Reject("safety");
+    }
+    let aesthetic_score = row_f64_alias(
+        row,
+        &["aesthetic", "aesthetic_score", "aesthetic_score_laion_v2"],
+    );
+    if options
+        .min_aesthetic_score
+        .zip(aesthetic_score)
+        .is_some_and(|(minimum, score)| score < minimum)
+    {
+        return RowOutcome::Reject("aesthetic");
+    }
+
+    let digest = Sha256::digest(url.as_bytes());
+    let id = format!("pq_{}", hex_prefix(&digest, 32));
+    RowOutcome::Accept(NewCatalogRecord {
+        id,
+        image_path: url.clone(),
+        thumbnail_path: None,
+        embedding_path: None,
+        artifact_path: None,
+        metadata: json!({
+            "url": url,
+            "caption": caption.chars().take(MAX_CAPTION_CHARS).collect::<String>(),
+            "width": width,
+            "height": height,
+            "unsafeScore": unsafe_score,
+            "aestheticScore": aesthetic_score,
+            "source": {
+                "shard": shard,
+                "shardIndex": shard_index,
+                "rowGroup": row_group,
+                "row": row_index,
+            }
+        }),
+    })
+}
+
+fn increment_reason(counts: &mut CatalogParquetScanCounts, reason: &str) {
+    let count = counts.reasons.entry(reason.to_owned()).or_default();
+    *count = count.saturating_add(1);
+}
+
+fn increment_rejected(counts: &mut CatalogParquetScanCounts, reason: &'static str) {
+    counts.rejected = counts.rejected.saturating_add(1);
+    increment_reason(counts, reason);
+}
+
+fn increment_malformed(counts: &mut CatalogParquetScanCounts, reason: &'static str) {
+    counts.malformed = counts.malformed.saturating_add(1);
+    increment_reason(counts, reason);
+}
+
+fn increment_duplicate(counts: &mut CatalogParquetScanCounts) {
+    counts.duplicate = counts.duplicate.saturating_add(1);
+    increment_reason(counts, "duplicate_url");
+}
+
+fn requested_aliases<'a>(requested: Option<&'a str>, defaults: &'a [&'a str]) -> Vec<&'a str> {
+    requested
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| vec![value])
+        .unwrap_or_else(|| defaults.to_vec())
+}
+
+fn find_field<'a>(row: &'a Row, aliases: &[&str]) -> Option<&'a Field> {
+    row.get_column_iter()
+        .find(|(name, _)| {
+            aliases
+                .iter()
+                .any(|requested| name.eq_ignore_ascii_case(requested))
+        })
+        .map(|(_, field)| field)
+}
+
+fn row_string_alias(row: &Row, aliases: &[&str]) -> Option<String> {
+    match find_field(row, aliases)? {
+        Field::Str(value) => Some(value.clone()),
+        Field::Bytes(value) => std::str::from_utf8(value.data()).ok().map(str::to_owned),
+        _ => None,
+    }
+}
+
+fn row_u32_alias(row: &Row, aliases: &[&str]) -> Option<u32> {
+    match find_field(row, aliases)? {
+        Field::Byte(value) => u32::try_from(*value).ok(),
+        Field::Short(value) => u32::try_from(*value).ok(),
+        Field::Int(value) => u32::try_from(*value).ok(),
+        Field::Long(value) => u32::try_from(*value).ok(),
+        Field::UByte(value) => Some((*value).into()),
+        Field::UShort(value) => Some((*value).into()),
+        Field::UInt(value) => Some(*value),
+        Field::ULong(value) => u32::try_from(*value).ok(),
+        Field::Float(value) if value.is_finite() && *value >= 0.0 => Some(*value as u32),
+        Field::Double(value) if value.is_finite() && *value >= 0.0 => Some(*value as u32),
+        _ => None,
+    }
+}
+
+fn row_f64_alias(row: &Row, aliases: &[&str]) -> Option<f64> {
+    match find_field(row, aliases)? {
+        Field::Byte(value) => Some((*value).into()),
+        Field::Short(value) => Some((*value).into()),
+        Field::Int(value) => Some((*value).into()),
+        Field::Long(value) => Some(*value as f64),
+        Field::UByte(value) => Some((*value).into()),
+        Field::UShort(value) => Some((*value).into()),
+        Field::UInt(value) => Some((*value).into()),
+        Field::ULong(value) => Some(*value as f64),
+        Field::Float(value) if value.is_finite() => Some((*value).into()),
+        Field::Double(value) if value.is_finite() => Some(*value),
+        Field::Str(value) => parse_metadata_score(value),
+        Field::Bytes(value) => std::str::from_utf8(value.data())
+            .ok()
+            .and_then(parse_metadata_score),
+        _ => None,
+    }
+}
+
+fn parse_metadata_score(value: &str) -> Option<f64> {
+    let normalized = value.trim().to_ascii_lowercase();
+    normalized.parse().ok().or(match normalized.as_str() {
+        "safe" | "false" | "unlikely" => Some(0.0),
+        "unsafe" | "nsfw" | "true" | "porn" => Some(1.0),
+        _ => None,
+    })
+}
+
+fn valid_public_http_url(value: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(value) else {
+        return false;
+    };
+    matches!(url.scheme(), "http" | "https")
+        && url.host_str().is_some()
+        && url.username().is_empty()
+        && url.password().is_none()
+}
+
+fn caption_describes_people(caption: &str) -> bool {
+    const PEOPLE_TERMS: &[&str] = &[
+        "person",
+        "people",
+        "human",
+        "man",
+        "men",
+        "woman",
+        "women",
+        "boy",
+        "boys",
+        "girl",
+        "girls",
+        "child",
+        "children",
+        "lady",
+        "gentleman",
+        "portrait",
+        "self portrait",
+    ];
+    PEOPLE_TERMS
+        .iter()
+        .any(|term| caption_matches_term(caption, term))
+}
+
+fn word_tokens(value: &str) -> Vec<String> {
+    value
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_lowercase)
+        .collect()
+}
+
+fn has_parquet_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| value.eq_ignore_ascii_case("parquet"))
+}
+
+fn source_signature(shards: &[PathBuf]) -> CatalogParquetScanResult<String> {
+    let mut digest = Sha256::new();
+    for shard in shards {
+        let metadata = std::fs::metadata(shard)?;
+        let modified = metadata
+            .modified()
+            .ok()
+            .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+            .map(|value| value.as_nanos())
+            .unwrap_or_default();
+        digest.update(shard.to_string_lossy().as_bytes());
+        digest.update([0]);
+        digest.update(metadata.len().to_le_bytes());
+        digest.update(modified.to_le_bytes());
+    }
+    Ok(hex_prefix(&digest.finalize(), 64))
+}
+
+fn options_signature(options: &CatalogParquetScanOptions) -> CatalogParquetScanResult<String> {
+    let semantic = SemanticOptions {
+        url_column: &options.url_column,
+        caption_column: &options.caption_column,
+        min_width: options.min_width,
+        min_height: options.min_height,
+        max_width: options.max_width,
+        max_height: options.max_height,
+        caption_includes: normalized_terms(&options.caption_includes),
+        caption_excludes: normalized_terms(&options.caption_excludes),
+        require_people: options.require_people,
+        max_unsafe_score: options.max_unsafe_score,
+        min_aesthetic_score: options.min_aesthetic_score,
+    };
+    let payload = serde_json::to_vec(&semantic)?;
+    Ok(hex_prefix(&Sha256::digest(payload), 64))
+}
+
+fn normalized_terms(terms: &[String]) -> Vec<String> {
+    let mut terms = terms
+        .iter()
+        .map(|term| word_tokens(term).join(" "))
+        .filter(|term| !term.is_empty())
+        .collect::<Vec<_>>();
+    terms.sort();
+    terms.dedup();
+    terms
+}
+
+fn hex_prefix(bytes: &[u8], chars: usize) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(chars);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        if output.len() == chars {
+            break;
+        }
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+        if output.len() == chars {
+            break;
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parquet::basic::Compression;
+    use parquet::data_type::{ByteArray, ByteArrayType, DoubleType, Int32Type, Int64Type};
+    use parquet::file::properties::WriterProperties;
+    use parquet::file::writer::SerializedFileWriter;
+    use parquet::schema::parser::parse_message_type;
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    struct TestRow<'a> {
+        url: &'a str,
+        caption: &'a str,
+        width: i32,
+        height: i32,
+        unsafe_score: f64,
+        aesthetic: f64,
+        marker: i64,
+    }
+
+    fn write_rows(path: &Path, row_groups: &[Vec<TestRow<'_>>]) {
+        let schema = Arc::new(
+            parse_message_type(
+                "message laion {
+                    REQUIRED BINARY UrL (UTF8);
+                    REQUIRED BINARY TeXt (UTF8);
+                    REQUIRED INT32 WiDtH;
+                    REQUIRED INT32 HeIgHt;
+                    REQUIRED DOUBLE PuNsAfE;
+                    REQUIRED DOUBLE AeStHeTiC_ScOrE;
+                    REQUIRED INT64 marker;
+                }",
+            )
+            .expect("test schema"),
+        );
+        let properties = Arc::new(
+            WriterProperties::builder()
+                .set_compression(Compression::SNAPPY)
+                .build(),
+        );
+        let mut writer = SerializedFileWriter::new(
+            File::create(path).expect("test parquet creates"),
+            schema,
+            properties,
+        )
+        .expect("writer creates");
+        for rows in row_groups {
+            let mut row_group = writer.next_row_group().expect("row group creates");
+            let mut column_index = 0;
+            while let Some(mut column) = row_group.next_column().expect("column advances") {
+                match column_index {
+                    0 | 1 => {
+                        let values = rows
+                            .iter()
+                            .map(|row| {
+                                if column_index == 0 {
+                                    ByteArray::from(row.url)
+                                } else {
+                                    ByteArray::from(row.caption)
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        column
+                            .typed::<ByteArrayType>()
+                            .write_batch(&values, None, None)
+                            .expect("strings write");
+                    }
+                    2 | 3 => {
+                        let values = rows
+                            .iter()
+                            .map(|row| {
+                                if column_index == 2 {
+                                    row.width
+                                } else {
+                                    row.height
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        column
+                            .typed::<Int32Type>()
+                            .write_batch(&values, None, None)
+                            .expect("ints write");
+                    }
+                    4 | 5 => {
+                        let values = rows
+                            .iter()
+                            .map(|row| {
+                                if column_index == 4 {
+                                    row.unsafe_score
+                                } else {
+                                    row.aesthetic
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        column
+                            .typed::<DoubleType>()
+                            .write_batch(&values, None, None)
+                            .expect("doubles write");
+                    }
+                    6 => {
+                        let values = rows.iter().map(|row| row.marker).collect::<Vec<_>>();
+                        column
+                            .typed::<Int64Type>()
+                            .write_batch(&values, None, None)
+                            .expect("longs write");
+                    }
+                    other => panic!("unexpected column index: {other}"),
+                }
+                column.close().expect("column closes");
+                column_index += 1;
+            }
+            row_group.close().expect("row group closes");
+        }
+        writer.close().expect("writer closes");
+    }
+
+    fn row(url: &'static str, caption: &'static str) -> TestRow<'static> {
+        TestRow {
+            url,
+            caption,
+            width: 1024,
+            height: 1024,
+            unsafe_score: 0.01,
+            aesthetic: 7.0,
+            marker: 0,
+        }
+    }
+
+    #[test]
+    fn whole_word_people_matching_excludes_known_false_positives() {
+        assert!(caption_describes_people("portrait of a woman"));
+        assert!(caption_matches_term(
+            "a young woman, outdoors",
+            "young woman"
+        ));
+        assert!(!caption_matches_term("a watchman tower", "man"));
+        assert!(!caption_describes_people("Watchman graphic novel cover"));
+        assert!(!caption_describes_people(
+            "BMW model photographed in a studio"
+        ));
+        assert!(!caption_describes_people("Tasmania wilderness panorama"));
+    }
+
+    #[test]
+    fn resumes_at_exact_row_group_and_row_without_duplicate_records() {
+        let temporary = tempfile::tempdir().expect("temp directory");
+        let source = temporary.path().join("source");
+        std::fs::create_dir(&source).expect("source creates");
+        write_rows(
+            &source.join("part-00000.parquet"),
+            &[
+                vec![
+                    row("https://example.com/1.jpg", "one person"),
+                    row("https://example.com/2.jpg", "two people"),
+                ],
+                vec![
+                    row("https://example.com/3.jpg", "three women"),
+                    row("https://example.com/4.jpg", "four men"),
+                ],
+            ],
+        );
+        let registry = CatalogRegistry::new(temporary.path().join("state"));
+        let catalog = registry
+            .create_catalog(temporary.path().join("catalog"), "Resume")
+            .expect("catalog creates");
+        let catalog_id = catalog.descriptor().id.clone();
+        catalog.close();
+        let first = scan_attached_parquet_catalog(
+            &registry,
+            &catalog_id,
+            &source,
+            &CatalogParquetScanOptions {
+                max_rows: Some(3),
+                batch_size: 2,
+                ..CatalogParquetScanOptions::default()
+            },
+        )
+        .expect("first bounded scan");
+        assert!(!first.checkpoint.complete);
+        assert_eq!(
+            (
+                first.checkpoint.shard,
+                first.checkpoint.row_group,
+                first.checkpoint.row
+            ),
+            (0, 1, 1)
+        );
+        assert_eq!(first.checkpoint.counts.accepted, 3);
+
+        let mismatch = scan_attached_parquet_catalog(
+            &registry,
+            &catalog_id,
+            &source,
+            &CatalogParquetScanOptions {
+                require_people: true,
+                ..CatalogParquetScanOptions::default()
+            },
+        )
+        .expect_err("changed filters cannot silently mix scans");
+        assert!(matches!(
+            mismatch,
+            CatalogParquetScanError::CheckpointMismatch(_)
+        ));
+
+        let resumed = scan_attached_parquet_catalog(
+            &registry,
+            &catalog_id,
+            &source,
+            &CatalogParquetScanOptions {
+                max_rows: None,
+                batch_size: 1,
+                ..CatalogParquetScanOptions::default()
+            },
+        )
+        .expect("scan resumes");
+        assert!(resumed.checkpoint.complete);
+        assert_eq!(resumed.checkpoint.counts.scanned, 4);
+        assert_eq!(resumed.checkpoint.counts.accepted, 4);
+        assert_eq!(resumed.checkpoint.counts.duplicate, 0);
+        let catalog = registry
+            .open_attached(&catalog_id)
+            .expect("attached catalog opens");
+        assert_eq!(catalog.storage_accounting().unwrap().record_count, 4);
+        let page = catalog.page_records_after(None, 10).expect("records page");
+        assert_eq!(page.records[2].metadata["source"]["rowGroup"], 1);
+        assert_eq!(page.records[2].metadata["source"]["row"], 0);
+    }
+
+    #[test]
+    fn case_insensitive_columns_filters_and_reason_counts_are_stable() {
+        let temporary = tempfile::tempdir().expect("temp directory");
+        let source = temporary.path().join("filters.parquet");
+        let mut invalid_dimensions = row("https://example.com/small.jpg", "a person");
+        invalid_dimensions.width = 100;
+        let mut unsafe_row = row("https://example.com/unsafe.jpg", "a person");
+        unsafe_row.unsafe_score = 0.9;
+        let mut ugly = row("https://example.com/ugly.jpg", "a person");
+        ugly.aesthetic = 2.0;
+        write_rows(
+            &source,
+            &[vec![
+                row("https://example.com/ok.jpg", "portrait of a woman"),
+                row("https://example.com/ok.jpg", "duplicate woman"),
+                row("ftp://example.com/no.jpg", "a woman"),
+                invalid_dimensions,
+                unsafe_row,
+                ugly,
+                row("https://example.com/watchman.jpg", "Watchman in Tasmania"),
+                row(
+                    "https://example.com/excluded.jpg",
+                    "a person with watermark",
+                ),
+                row("", "a person"),
+                row("https://example.com/blank.jpg", ""),
+            ]],
+        );
+        let mut catalog =
+            Catalog::create(temporary.path().join("catalog"), "Filters").expect("catalog creates");
+        let report = scan_parquet_catalog(
+            &mut catalog,
+            &source,
+            &CatalogParquetScanOptions {
+                min_width: Some(512),
+                min_height: Some(512),
+                caption_includes: vec!["person".to_owned(), "woman".to_owned()],
+                caption_excludes: vec!["watermark".to_owned()],
+                require_people: true,
+                max_unsafe_score: Some(0.5),
+                min_aesthetic_score: Some(5.0),
+                batch_size: 2,
+                ..CatalogParquetScanOptions::default()
+            },
+        )
+        .expect("scan succeeds");
+        let counts = report.checkpoint.counts;
+        assert_eq!(counts.scanned, 10);
+        assert_eq!(counts.accepted, 1);
+        assert_eq!(counts.duplicate, 1);
+        assert_eq!(counts.rejected, 6);
+        assert_eq!(counts.malformed, 2);
+        assert_eq!(counts.reasons["invalid_url"], 1);
+        assert_eq!(counts.reasons["dimensions"], 1);
+        assert_eq!(counts.reasons["safety"], 1);
+        assert_eq!(counts.reasons["aesthetic"], 1);
+        assert_eq!(counts.reasons["caption_include"], 1);
+        assert_eq!(counts.reasons["caption_exclude"], 1);
+        assert_eq!(counts.reasons["blank_url"], 1);
+        assert_eq!(counts.reasons["blank_caption"], 1);
+    }
+}

--- a/crates/sceneworks-worker/src/catalog_parquet_scanner.rs
+++ b/crates/sceneworks-worker/src/catalog_parquet_scanner.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashSet};
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -20,6 +20,7 @@ const DEFAULT_BATCH_SIZE: usize = 1_000;
 const MAX_BATCH_SIZE: usize = 10_000;
 const MAX_CAPTION_CHARS: usize = 2_048;
 const MAX_IMAGE_EDGE: u32 = 16_384;
+const SCAN_LOCK_FILE: &str = ".parquet-scan.lock";
 
 #[derive(Debug)]
 pub enum CatalogParquetScanError {
@@ -29,6 +30,7 @@ pub enum CatalogParquetScanError {
     Json(serde_json::Error),
     InvalidSource(String),
     CheckpointMismatch(String),
+    Busy(String),
 }
 
 impl std::fmt::Display for CatalogParquetScanError {
@@ -38,7 +40,7 @@ impl std::fmt::Display for CatalogParquetScanError {
             Self::Parquet(error) => write!(formatter, "{error}"),
             Self::Catalog(error) => write!(formatter, "{error}"),
             Self::Json(error) => write!(formatter, "{error}"),
-            Self::InvalidSource(detail) | Self::CheckpointMismatch(detail) => {
+            Self::InvalidSource(detail) | Self::CheckpointMismatch(detail) | Self::Busy(detail) => {
                 formatter.write_str(detail)
             }
         }
@@ -163,6 +165,48 @@ struct SemanticOptions<'a> {
     min_aesthetic_score: Option<f64>,
 }
 
+/// Cross-process lease for the single mutable Parquet checkpoint in a catalog.
+///
+/// Utility workers are separate processes, so an in-process mutex is
+/// insufficient. The advisory OS lock is released automatically when the file
+/// handle drops, including after an unwinding failure or process exit.
+struct CatalogScanLease {
+    _file: File,
+}
+
+impl CatalogScanLease {
+    fn acquire(catalog: &Catalog) -> CatalogParquetScanResult<Self> {
+        use fs2::FileExt as _;
+
+        let lock_path = catalog.root().join(SCAN_LOCK_FILE);
+        if let Ok(metadata) = std::fs::symlink_metadata(&lock_path) {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(CatalogParquetScanError::InvalidSource(format!(
+                    "Catalog scan lock must be a regular file: {}",
+                    lock_path.display()
+                )));
+            }
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        let contended = fs2::lock_contended_error().raw_os_error();
+        match file.try_lock_exclusive() {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(error) if error.raw_os_error() == contended => {
+                Err(CatalogParquetScanError::Busy(format!(
+                    "Catalog {} already has an active Parquet scan.",
+                    catalog.descriptor().id
+                )))
+            }
+            Err(error) => Err(CatalogParquetScanError::Io(error)),
+        }
+    }
+}
+
 /// Indexes a bounded pass of Parquet rows into `catalog`.
 ///
 /// Calling this again with the same source and semantic options resumes at the
@@ -183,6 +227,7 @@ fn scan_parquet_catalog(
     source: &Path,
     options: &CatalogParquetScanOptions,
 ) -> CatalogParquetScanResult<CatalogParquetScanReport> {
+    let _lease = CatalogScanLease::acquire(catalog)?;
     validate_options(options)?;
     let shards = parquet_shards(source)?;
     let source_signature = source_signature(&shards)?;
@@ -352,6 +397,27 @@ fn validate_options(options: &CatalogParquetScanOptions) -> CatalogParquetScanRe
             )));
         }
     }
+    for (name, minimum, maximum) in [
+        ("width", options.min_width, options.max_width),
+        ("height", options.min_height, options.max_height),
+    ] {
+        if minimum
+            .zip(maximum)
+            .is_some_and(|(minimum, maximum)| minimum > maximum)
+        {
+            return Err(CatalogParquetScanError::InvalidSource(format!(
+                "Parquet catalog minimum {name} cannot exceed maximum {name}."
+            )));
+        }
+    }
+    if options
+        .max_unsafe_score
+        .is_some_and(|value| !(0.0..=1.0).contains(&value))
+    {
+        return Err(CatalogParquetScanError::InvalidSource(
+            "maxUnsafeScore must be between 0 and 1.".to_owned(),
+        ));
+    }
     Ok(())
 }
 
@@ -437,8 +503,24 @@ fn catalog_record_for_row(
         return RowOutcome::Reject("invalid_url");
     }
 
-    let width = row_u32_alias(row, &["width", "image_width", "original_width"]);
-    let height = row_u32_alias(row, &["height", "image_height", "original_height"]);
+    let width = match filtered_dimension(
+        row_u32_alias(row, &["width", "image_width", "original_width"]),
+        options.min_width.is_some() || options.max_width.is_some(),
+        "missing_width",
+        "invalid_width",
+    ) {
+        Ok(value) => value,
+        Err(reason) => return RowOutcome::Malformed(reason),
+    };
+    let height = match filtered_dimension(
+        row_u32_alias(row, &["height", "image_height", "original_height"]),
+        options.min_height.is_some() || options.max_height.is_some(),
+        "missing_height",
+        "invalid_height",
+    ) {
+        Ok(value) => value,
+        Err(reason) => return RowOutcome::Malformed(reason),
+    };
     if width.is_some_and(|value| {
         options.min_width.is_some_and(|minimum| value < minimum)
             || options.max_width.is_some_and(|maximum| value > maximum)
@@ -467,16 +549,24 @@ fn catalog_record_for_row(
         return RowOutcome::Reject("people");
     }
 
-    let unsafe_score = row_f64_alias(
-        row,
-        &[
-            "punsafe",
-            "unsafe_score",
-            "nsfw_score",
-            "nsfw",
-            "safety_score",
-        ],
-    );
+    let unsafe_score = match filtered_score(
+        row_probability_alias(
+            row,
+            &[
+                "punsafe",
+                "unsafe_score",
+                "nsfw_score",
+                "nsfw",
+                "safety_score",
+            ],
+        ),
+        options.max_unsafe_score.is_some(),
+        "missing_safety",
+        "invalid_safety",
+    ) {
+        Ok(value) => value,
+        Err(reason) => return RowOutcome::Malformed(reason),
+    };
     if options
         .max_unsafe_score
         .zip(unsafe_score)
@@ -484,10 +574,18 @@ fn catalog_record_for_row(
     {
         return RowOutcome::Reject("safety");
     }
-    let aesthetic_score = row_f64_alias(
-        row,
-        &["aesthetic", "aesthetic_score", "aesthetic_score_laion_v2"],
-    );
+    let aesthetic_score = match filtered_score(
+        row_f64_alias(
+            row,
+            &["aesthetic", "aesthetic_score", "aesthetic_score_laion_v2"],
+        ),
+        options.min_aesthetic_score.is_some(),
+        "missing_aesthetic",
+        "invalid_aesthetic",
+    ) {
+        Ok(value) => value,
+        Err(reason) => return RowOutcome::Malformed(reason),
+    };
     if options
         .min_aesthetic_score
         .zip(aesthetic_score)
@@ -566,8 +664,18 @@ fn row_string_alias(row: &Row, aliases: &[&str]) -> Option<String> {
     }
 }
 
-fn row_u32_alias(row: &Row, aliases: &[&str]) -> Option<u32> {
-    match find_field(row, aliases)? {
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum MetadataField<T> {
+    Missing,
+    Invalid,
+    Value(T),
+}
+
+fn row_u32_alias(row: &Row, aliases: &[&str]) -> MetadataField<u32> {
+    let Some(field) = find_field(row, aliases) else {
+        return MetadataField::Missing;
+    };
+    let value = match field {
         Field::Byte(value) => u32::try_from(*value).ok(),
         Field::Short(value) => u32::try_from(*value).ok(),
         Field::Int(value) => u32::try_from(*value).ok(),
@@ -576,14 +684,25 @@ fn row_u32_alias(row: &Row, aliases: &[&str]) -> Option<u32> {
         Field::UShort(value) => Some((*value).into()),
         Field::UInt(value) => Some(*value),
         Field::ULong(value) => u32::try_from(*value).ok(),
-        Field::Float(value) if value.is_finite() && *value >= 0.0 => Some(*value as u32),
-        Field::Double(value) if value.is_finite() && *value >= 0.0 => Some(*value as u32),
+        Field::Float(value) => exact_u32((*value).into()),
+        Field::Double(value) => exact_u32(*value),
+        Field::Str(value) => value.trim().parse().ok(),
+        Field::Bytes(value) => std::str::from_utf8(value.data())
+            .ok()
+            .and_then(|value| value.trim().parse().ok()),
         _ => None,
+    };
+    match value {
+        Some(value) => MetadataField::Value(value),
+        None => MetadataField::Invalid,
     }
 }
 
-fn row_f64_alias(row: &Row, aliases: &[&str]) -> Option<f64> {
-    match find_field(row, aliases)? {
+fn row_f64_alias(row: &Row, aliases: &[&str]) -> MetadataField<f64> {
+    let Some(field) = find_field(row, aliases) else {
+        return MetadataField::Missing;
+    };
+    let value = match field {
         Field::Byte(value) => Some((*value).into()),
         Field::Short(value) => Some((*value).into()),
         Field::Int(value) => Some((*value).into()),
@@ -599,13 +718,60 @@ fn row_f64_alias(row: &Row, aliases: &[&str]) -> Option<f64> {
             .ok()
             .and_then(parse_metadata_score),
         _ => None,
+    };
+    match value {
+        Some(value) if value.is_finite() => MetadataField::Value(value),
+        _ => MetadataField::Invalid,
+    }
+}
+
+fn row_probability_alias(row: &Row, aliases: &[&str]) -> MetadataField<f64> {
+    match row_f64_alias(row, aliases) {
+        MetadataField::Value(value) if (0.0..=1.0).contains(&value) => MetadataField::Value(value),
+        MetadataField::Value(_) => MetadataField::Invalid,
+        other => other,
+    }
+}
+
+fn exact_u32(value: f64) -> Option<u32> {
+    (value.is_finite() && value >= 0.0 && value <= u32::MAX as f64 && value.fract() == 0.0)
+        .then_some(value as u32)
+}
+
+fn filtered_dimension(
+    field: MetadataField<u32>,
+    required: bool,
+    missing_reason: &'static str,
+    invalid_reason: &'static str,
+) -> Result<Option<u32>, &'static str> {
+    match field {
+        MetadataField::Value(value) => Ok(Some(value)),
+        MetadataField::Missing if required => Err(missing_reason),
+        MetadataField::Invalid if required => Err(invalid_reason),
+        MetadataField::Missing | MetadataField::Invalid => Ok(None),
+    }
+}
+
+fn filtered_score(
+    field: MetadataField<f64>,
+    required: bool,
+    missing_reason: &'static str,
+    invalid_reason: &'static str,
+) -> Result<Option<f64>, &'static str> {
+    match field {
+        MetadataField::Value(value) => Ok(Some(value)),
+        MetadataField::Missing if required => Err(missing_reason),
+        MetadataField::Invalid if required => Err(invalid_reason),
+        MetadataField::Missing | MetadataField::Invalid => Ok(None),
     }
 }
 
 fn parse_metadata_score(value: &str) -> Option<f64> {
     let normalized = value.trim().to_ascii_lowercase();
     normalized.parse().ok().or(match normalized.as_str() {
-        "safe" | "false" | "unlikely" => Some(0.0),
+        "safe" | "sfw" | "false" => Some(0.0),
+        "unlikely" => Some(0.25),
+        "unsure" => Some(0.5),
         "unsafe" | "nsfw" | "true" | "porn" => Some(1.0),
         _ => None,
     })
@@ -840,6 +1006,70 @@ mod tests {
         writer.close().expect("writer closes");
     }
 
+    fn write_rows_without_scores(path: &Path, rows: &[TestRow<'_>], include_dimensions: bool) {
+        let schema = Arc::new(
+            parse_message_type(if include_dimensions {
+                "message laion {
+                    REQUIRED BINARY URL (UTF8);
+                    REQUIRED BINARY TEXT (UTF8);
+                    REQUIRED INT32 WIDTH;
+                    REQUIRED INT32 HEIGHT;
+                }"
+            } else {
+                "message laion {
+                    REQUIRED BINARY URL (UTF8);
+                    REQUIRED BINARY TEXT (UTF8);
+                }"
+            })
+            .expect("test schema"),
+        );
+        let mut writer = SerializedFileWriter::new(
+            File::create(path).expect("test parquet creates"),
+            schema,
+            Arc::new(WriterProperties::builder().build()),
+        )
+        .expect("writer creates");
+        let mut row_group = writer.next_row_group().expect("row group creates");
+        let mut column_index = 0;
+        while let Some(mut column) = row_group.next_column().expect("column advances") {
+            if column_index < 2 {
+                let values = rows
+                    .iter()
+                    .map(|row| {
+                        ByteArray::from(if column_index == 0 {
+                            row.url
+                        } else {
+                            row.caption
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                column
+                    .typed::<ByteArrayType>()
+                    .write_batch(&values, None, None)
+                    .expect("strings write");
+            } else {
+                let values = rows
+                    .iter()
+                    .map(|row| {
+                        if column_index == 2 {
+                            row.width
+                        } else {
+                            row.height
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                column
+                    .typed::<Int32Type>()
+                    .write_batch(&values, None, None)
+                    .expect("dimensions write");
+            }
+            column.close().expect("column closes");
+            column_index += 1;
+        }
+        row_group.close().expect("row group closes");
+        writer.close().expect("writer closes");
+    }
+
     fn row(url: &'static str, caption: &'static str) -> TestRow<'static> {
         TestRow {
             url,
@@ -865,6 +1095,63 @@ mod tests {
             "BMW model photographed in a studio"
         ));
         assert!(!caption_describes_people("Tasmania wilderness panorama"));
+    }
+
+    #[test]
+    fn catalog_scan_lease_is_exclusive_and_releases_for_same_or_changed_options() {
+        let temporary = tempfile::tempdir().expect("temp directory");
+        let source = temporary.path().join("source.parquet");
+        write_rows(
+            &source,
+            &[vec![row("https://example.com/one.jpg", "one person")]],
+        );
+        let registry = CatalogRegistry::new(temporary.path().join("state"));
+        let first_catalog = registry
+            .create_catalog(temporary.path().join("catalog"), "Lease")
+            .expect("catalog creates");
+        let catalog_id = first_catalog.descriptor().id.clone();
+        let lease = CatalogScanLease::acquire(&first_catalog).expect("first lease acquires");
+        first_catalog.close();
+
+        for options in [
+            CatalogParquetScanOptions::default(),
+            CatalogParquetScanOptions {
+                require_people: true,
+                ..CatalogParquetScanOptions::default()
+            },
+        ] {
+            let error = scan_attached_parquet_catalog(&registry, &catalog_id, &source, &options)
+                .expect_err("concurrent scan must not reach checkpoint or writes");
+            assert!(matches!(error, CatalogParquetScanError::Busy(_)));
+        }
+        let untouched = registry
+            .open_attached(&catalog_id)
+            .expect("catalog reopens while lease is held");
+        assert_eq!(
+            untouched.metadata(CHECKPOINT_KEY).expect("metadata reads"),
+            None,
+            "contended scans must not load or publish a checkpoint"
+        );
+        assert_eq!(
+            untouched
+                .storage_accounting()
+                .expect("accounting")
+                .record_count,
+            0,
+            "contended scans must not mix records"
+        );
+        untouched.close();
+
+        drop(lease);
+        let report = scan_attached_parquet_catalog(
+            &registry,
+            &catalog_id,
+            &source,
+            &CatalogParquetScanOptions::default(),
+        )
+        .expect("lease releases on drop");
+        assert!(report.checkpoint.complete);
+        assert_eq!(report.checkpoint.counts.accepted, 1);
     }
 
     #[test]
@@ -962,6 +1249,12 @@ mod tests {
         unsafe_row.unsafe_score = 0.9;
         let mut ugly = row("https://example.com/ugly.jpg", "a person");
         ugly.aesthetic = 2.0;
+        let mut negative_width = row("https://example.com/negative.jpg", "a person");
+        negative_width.width = -1;
+        let mut invalid_safety = row("https://example.com/nan-safety.jpg", "a person");
+        invalid_safety.unsafe_score = f64::NAN;
+        let mut invalid_aesthetic = row("https://example.com/nan-aesthetic.jpg", "a person");
+        invalid_aesthetic.aesthetic = f64::NAN;
         write_rows(
             &source,
             &[vec![
@@ -978,6 +1271,9 @@ mod tests {
                 ),
                 row("", "a person"),
                 row("https://example.com/blank.jpg", ""),
+                negative_width,
+                invalid_safety,
+                invalid_aesthetic,
             ]],
         );
         let mut catalog =
@@ -999,11 +1295,11 @@ mod tests {
         )
         .expect("scan succeeds");
         let counts = report.checkpoint.counts;
-        assert_eq!(counts.scanned, 10);
+        assert_eq!(counts.scanned, 13);
         assert_eq!(counts.accepted, 1);
         assert_eq!(counts.duplicate, 1);
         assert_eq!(counts.rejected, 6);
-        assert_eq!(counts.malformed, 2);
+        assert_eq!(counts.malformed, 5);
         assert_eq!(counts.reasons["invalid_url"], 1);
         assert_eq!(counts.reasons["dimensions"], 1);
         assert_eq!(counts.reasons["safety"], 1);
@@ -1012,5 +1308,156 @@ mod tests {
         assert_eq!(counts.reasons["caption_exclude"], 1);
         assert_eq!(counts.reasons["blank_url"], 1);
         assert_eq!(counts.reasons["blank_caption"], 1);
+        assert_eq!(counts.reasons["invalid_width"], 1);
+        assert_eq!(counts.reasons["invalid_safety"], 1);
+        assert_eq!(counts.reasons["invalid_aesthetic"], 1);
+    }
+
+    #[test]
+    fn configured_filters_reject_missing_metadata_and_invalid_ranges() {
+        let temporary = tempfile::tempdir().expect("temp directory");
+        let no_dimensions = temporary.path().join("no-dimensions.parquet");
+        let no_scores = temporary.path().join("no-scores.parquet");
+        let rows = [row("https://example.com/one.jpg", "one person")];
+        write_rows_without_scores(&no_dimensions, &rows, false);
+        write_rows_without_scores(&no_scores, &rows, true);
+
+        let scan = |name: &str,
+                    source: &Path,
+                    options: CatalogParquetScanOptions|
+         -> CatalogParquetScanCounts {
+            let registry = CatalogRegistry::new(temporary.path().join(format!("{name}-state")));
+            let catalog = registry
+                .create_catalog(temporary.path().join(format!("{name}-catalog")), name)
+                .expect("catalog creates");
+            let catalog_id = catalog.descriptor().id.clone();
+            catalog.close();
+            scan_attached_parquet_catalog(&registry, &catalog_id, source, &options)
+                .expect("scan reports malformed metadata")
+                .checkpoint
+                .counts
+        };
+
+        let missing_dimensions = scan(
+            "missing-dimensions",
+            &no_dimensions,
+            CatalogParquetScanOptions::default(),
+        );
+        assert_eq!(missing_dimensions.malformed, 1);
+        assert_eq!(missing_dimensions.reasons["missing_width"], 1);
+
+        let missing_safety = scan(
+            "missing-safety",
+            &no_scores,
+            CatalogParquetScanOptions {
+                max_unsafe_score: Some(0.5),
+                ..CatalogParquetScanOptions::default()
+            },
+        );
+        assert_eq!(missing_safety.malformed, 1);
+        assert_eq!(missing_safety.reasons["missing_safety"], 1);
+
+        let missing_aesthetic = scan(
+            "missing-aesthetic",
+            &no_scores,
+            CatalogParquetScanOptions {
+                min_aesthetic_score: Some(5.0),
+                ..CatalogParquetScanOptions::default()
+            },
+        );
+        assert_eq!(missing_aesthetic.malformed, 1);
+        assert_eq!(missing_aesthetic.reasons["missing_aesthetic"], 1);
+
+        for options in [
+            CatalogParquetScanOptions {
+                min_width: Some(100),
+                max_width: Some(99),
+                ..CatalogParquetScanOptions::default()
+            },
+            CatalogParquetScanOptions {
+                min_height: Some(100),
+                max_height: Some(99),
+                ..CatalogParquetScanOptions::default()
+            },
+            CatalogParquetScanOptions {
+                max_unsafe_score: Some(1.1),
+                ..CatalogParquetScanOptions::default()
+            },
+        ] {
+            assert!(matches!(
+                validate_options(&options),
+                Err(CatalogParquetScanError::InvalidSource(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn checkpoint_crosses_shards_and_source_mutation_is_rejected() {
+        let temporary = tempfile::tempdir().expect("temp directory");
+        let source = temporary.path().join("source");
+        std::fs::create_dir(&source).expect("source creates");
+        write_rows(
+            &source.join("part-00000.parquet"),
+            &[vec![row("https://example.com/one.jpg", "one person")]],
+        );
+        write_rows(
+            &source.join("part-00001.parquet"),
+            &[vec![row("https://example.com/two.jpg", "two people")]],
+        );
+        let registry = CatalogRegistry::new(temporary.path().join("state"));
+        let catalog = registry
+            .create_catalog(temporary.path().join("catalog"), "Shards")
+            .expect("catalog creates");
+        let catalog_id = catalog.descriptor().id.clone();
+        catalog.close();
+        let first = scan_attached_parquet_catalog(
+            &registry,
+            &catalog_id,
+            &source,
+            &CatalogParquetScanOptions {
+                max_rows: Some(1),
+                ..CatalogParquetScanOptions::default()
+            },
+        )
+        .expect("first shard scans");
+        assert_eq!(
+            (
+                first.checkpoint.shard,
+                first.checkpoint.row_group,
+                first.checkpoint.row
+            ),
+            (1, 0, 0)
+        );
+        let resumed = scan_attached_parquet_catalog(
+            &registry,
+            &catalog_id,
+            &source,
+            &CatalogParquetScanOptions::default(),
+        )
+        .expect("second shard resumes");
+        assert!(resumed.checkpoint.complete);
+        assert_eq!(resumed.checkpoint.counts.accepted, 2);
+        let catalog = registry
+            .open_attached(&catalog_id)
+            .expect("catalog reopens");
+        let page = catalog.page_records_after(None, 10).expect("records page");
+        assert_eq!(page.records[1].metadata["source"]["shardIndex"], 1);
+        catalog.close();
+
+        write_rows(
+            &source.join("part-00002.parquet"),
+            &[vec![row("https://example.com/three.jpg", "three women")]],
+        );
+        let error = scan_attached_parquet_catalog(
+            &registry,
+            &catalog_id,
+            &source,
+            &CatalogParquetScanOptions::default(),
+        )
+        .expect_err("changed shard set cannot resume");
+        assert!(matches!(
+            error,
+            CatalogParquetScanError::CheckpointMismatch(_)
+        ));
     }
 }

--- a/crates/sceneworks-worker/src/dataset_parquet_jobs.rs
+++ b/crates/sceneworks-worker/src/dataset_parquet_jobs.rs
@@ -317,27 +317,8 @@ fn normalized_filter_terms(payload: &JsonObject, field: &str) -> Vec<String> {
 }
 
 fn parquet_files(source: &Path) -> WorkerResult<Vec<PathBuf>> {
-    if source.is_file() {
-        return Ok(vec![source.to_path_buf()]);
-    }
-    let mut files = std::fs::read_dir(source)?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| {
-            path.is_file()
-                && path
-                    .extension()
-                    .and_then(|value| value.to_str())
-                    .is_some_and(|value| value.eq_ignore_ascii_case("parquet"))
-        })
-        .collect::<Vec<_>>();
-    files.sort();
-    if files.is_empty() {
-        return Err(WorkerError::InvalidPayload(
-            "Parquet source directory contains no .parquet files.".to_owned(),
-        ));
-    }
-    Ok(files)
+    crate::catalog_parquet_scanner::parquet_shards(source)
+        .map_err(|error| WorkerError::InvalidPayload(error.to_string()))
 }
 
 fn read_candidates(
@@ -393,12 +374,12 @@ fn read_candidates(
             if url.is_empty()
                 || caption.is_empty()
                 || (!caption_includes.is_empty()
-                    && !caption_includes
-                        .iter()
-                        .any(|term| caption_lower.contains(term)))
-                || caption_excludes
-                    .iter()
-                    .any(|term| caption_lower.contains(term))
+                    && !caption_includes.iter().any(|term| {
+                        crate::catalog_parquet_scanner::caption_matches_term(&caption_lower, term)
+                    }))
+                || caption_excludes.iter().any(|term| {
+                    crate::catalog_parquet_scanner::caption_matches_term(&caption_lower, term)
+                })
                 || width.zip(height).is_some_and(|(width, height)| {
                     width < min_edge
                         || height < min_edge

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -191,6 +191,7 @@ use caption_jobs::*;
 // ordinary SceneWorks dataset.
 mod dataset_parquet_jobs;
 use dataset_parquet_jobs::*;
+pub mod catalog_parquet_scanner;
 // The shared scaffold both dataset-analysis jobs route through (sc-8836, F-034) — the `CancelJoinGuard`
 // select loop, per-item progress ramp, and sidecar POST extracted out of the two near-duplicate modules.
 // Gated to the same lanes as its only callers (the real `run_*_analysis_job` in the two modules below);


### PR DESCRIPTION
## Summary
- add attached-catalog-only resumable LAION-style Parquet scanning with atomic row-group checkpoints and per-reason accounting
- apply case-insensitive discovery, deterministic identity/dedup, whole-word/phrase people filtering, dimensions/URL/caption/safety/aesthetic filters, and cross-process scan serialization
- keep catalog records independent of projects/training datasets while preserving the legacy importer through shared scanner primitives

## Validation
- independent adversarial review: PASS (high confidence) after concurrency, fail-closed metadata, and reserved-key corruption fixes
- focused scanner: 6/6; catalog core: 18/18
- full worker library: 465 passed, 4 ignored
- strict core/worker Clippy with warnings denied
- rust-api check, formatting, and diff validation

Shortcut: https://app.shortcut.com/trefry/story/14955