### PR TITLE
feat(mage): per-tier downloads + shared TE/VAE co-requisites (sc-14980, sc-14979)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "libc",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -489,6 +489,7 @@ dependencies = [
  "candle-audio-moss-tts",
  "candle-audio-moss-tts-realtime",
  "candle-audio-openvoice",
+ "candle-audio-stable-audio-3",
  "candle-audio-whisper",
  "candle-llm",
 ]
@@ -496,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -512,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -521,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -533,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -549,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -562,7 +563,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -577,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -590,7 +591,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -603,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -612,9 +613,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-audio-stable-audio-3"
+version = "0.0.0"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
+dependencies = [
+ "candle-audio",
+ "candle-nn",
+ "core-llm",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokenizers 0.22.2",
+]
+
+[[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -657,7 +674,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -675,7 +692,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -686,7 +703,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -699,7 +716,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -712,7 +729,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -751,7 +768,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -765,7 +782,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -778,7 +795,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -788,7 +805,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -798,7 +815,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -815,7 +832,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -829,7 +846,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -843,7 +860,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -856,7 +873,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -865,7 +882,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -880,7 +897,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -895,7 +912,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -909,7 +926,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -921,7 +938,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mage"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -939,7 +956,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -952,7 +969,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "image",
@@ -962,7 +979,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -979,7 +996,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -992,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1003,7 +1020,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -1013,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -1027,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1043,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1061,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1072,7 +1089,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1084,7 +1101,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1094,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1106,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1123,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "cudaforge",
 ]
@@ -1131,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1495,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -4007,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "memmap2",
  "pmetal-mlx-rs",
@@ -4022,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4034,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4047,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4060,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -4100,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4113,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4123,7 +4140,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4132,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4141,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4154,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4166,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4178,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4190,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4199,7 +4216,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4211,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4225,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4238,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4249,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mage"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4262,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4273,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4284,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4295,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4306,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4315,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4324,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4334,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4345,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4359,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4372,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4382,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4393,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4403,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4416,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4440,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "core-llm",
  "half",
@@ -6034,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -6044,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -6055,7 +6072,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6337,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=6147a596be2739f6c4f76644fe901dc28a7e00c7#6147a596be2739f6c4f76644fe901dc28a7e00c7"
+source = "git+https://github.com/SceneWorks/inference?rev=d1b8668463971ff62f5971400071bdc9914558d3#d1b8668463971ff62f5971400071bdc9914558d3"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "6147a596be2739f6c4f76644fe901dc28a7e00c7" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "d1b8668463971ff62f5971400071bdc9914558d3" }

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -524,7 +524,18 @@ pub(crate) async fn create_model_download_job(
     // is a different artifact than the model's primary checkpoint and must not be reconciled
     // against the model's family.
     let requested_gpu = requested_gpu_or_auto(payload.requested_gpu);
-    for co_requisite in model_co_requisite_downloads(&model) {
+    // Only the SELECTED tier's co-requisites (sc-14980). Mage-Flow's shared text encoder exists as
+    // three per-tier subtrees; fetching all of them would pull 16.1 GB of text encoder for a q4
+    // install that needs 2.51 GB. Tier-agnostic co-requisites (every other family) are unaffected —
+    // they carry no `variant` and always apply. Read the tier off the resolved `download` rather than
+    // the request so the default-tier install (no explicit `variant`) picks up its tier too.
+    let selected_variant = download
+        .get("variant")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    for co_requisite in
+        model_co_requisite_downloads_for_variant(&model, selected_variant.as_deref())
+    {
         let co_payload = build_model_download_job_payload(
             &model,
             &model_id,
@@ -3011,7 +3022,57 @@ fn install_state_for(
         let mut hard_co_requisites_installed = true;
         let mut soft_co_requisite_update = false;
         let mut co_requisite_incomplete = false;
-        for co_requisite in model_co_requisite_downloads(model) {
+        // Tier-scoped co-requisites (sc-14980) are gated like the tiers themselves: this state is a
+        // model-level AGGREGATE that counts a quant-matrix model installed when ANY tier is fully
+        // present, so requiring every tier's shared text encoder would report a complete, working q4
+        // install as incomplete forever. Satisfy them when at least one tier's set is fully cached;
+        // tier-agnostic co-requisites (every other family) keep the strict all-must-be-present rule.
+        let tier_scoped: Vec<Value> = model_co_requisite_downloads(model)
+            .into_iter()
+            .filter(|download| co_requisite_variant(download).is_some())
+            .collect();
+        if !tier_scoped.is_empty() {
+            let tiers: std::collections::BTreeSet<String> = tier_scoped
+                .iter()
+                .filter_map(co_requisite_variant)
+                .collect();
+            let any_tier_complete = tiers.iter().any(|tier| {
+                tier_scoped
+                    .iter()
+                    .filter(|download| co_requisite_variant(download).as_deref() == Some(tier))
+                    .all(|download| {
+                        download
+                            .get("repo")
+                            .and_then(Value::as_str)
+                            .and_then(|repo| huggingface_repo_cache_path(data_dir, repo))
+                            .map(|path| {
+                                huggingface_cache_health(
+                                    &path,
+                                    &string_array_field(download, "files"),
+                                )
+                            })
+                            .is_some_and(|health| health.installed)
+                    })
+            });
+            if !any_tier_complete {
+                hard_co_requisites_installed = false;
+                missing_required_files.extend(
+                    tier_scoped
+                        .iter()
+                        .filter_map(|download| {
+                            download
+                                .get("repo")
+                                .and_then(Value::as_str)
+                                .map(str::to_owned)
+                        })
+                        .collect::<std::collections::BTreeSet<_>>(),
+                );
+            }
+        }
+        for co_requisite in model_co_requisite_downloads(model)
+            .into_iter()
+            .filter(|download| co_requisite_variant(download).is_none())
+        {
             let Some(repo) = co_requisite.get("repo").and_then(Value::as_str) else {
                 continue;
             };
@@ -3713,10 +3774,20 @@ fn apply_model_catalog_size_fields(
     // Co-requisites (sc-9696) install alongside the primary, so the displayed footprint must
     // include them (e.g. PiD's ~2.7 GB checkpoint + ~5.2 GB gemma-2-2b-it). Their sizes come
     // from the manifest (the live HF estimate above only sizes the primary repo).
-    let co_requisite_size_bytes: u64 = model_co_requisite_downloads(model)
-        .iter()
-        .filter_map(|download| manifest_download_size_bytes(model, download))
-        .sum();
+    // Only the co-requisites the SELECTED tier actually pulls (sc-14980) — otherwise a q4 Mage-Flow
+    // install would advertise the sum of all three shared text-encoder tiers.
+    // The displayed footprint is for the DEFAULT download, so size only the co-requisites that
+    // download actually pulls (sc-14980) — otherwise a q4 Mage-Flow install would advertise the sum
+    // of all three shared text-encoder tiers (16.1 GB instead of 2.51 GB).
+    let default_variant = model_download(model)
+        .as_ref()
+        .and_then(|download| download.get("variant").and_then(Value::as_str))
+        .map(str::to_owned);
+    let co_requisite_size_bytes: u64 =
+        model_co_requisite_downloads_for_variant(model, default_variant.as_deref())
+            .iter()
+            .filter_map(|download| manifest_download_size_bytes(model, download))
+            .sum();
     let effective_download_size_bytes = match primary_size_bytes {
         Some(primary) => Some(primary + co_requisite_size_bytes),
         None if co_requisite_size_bytes > 0 => Some(co_requisite_size_bytes),
@@ -4287,6 +4358,45 @@ pub(crate) fn is_co_requisite_download(download: &Value) -> bool {
 /// alongside the primary (e.g. the PiD decoder's shared gemma-2-2b-it caption encoder). The catalog
 /// has already restricted `downloads` to the current OS (`retain_downloads_for_os`), so every entry
 /// returned applies to this platform. Only provider-supported entries are returned.
+/// Whether a co-requisite row is scoped to ONE quant tier (sc-14980).
+///
+/// Every co-requisite before sc-14980 is tier-agnostic — the PiD decoder's gemma caption encoder,
+/// chatterbox's `ve`/`perth`, MMAudio's five components — and carries no `variant`, so it applies to
+/// whatever tier is selected. Mage-Flow's shared Qwen3-VL text encoder and Mage-VAE are the first
+/// that are themselves per-tier: they exist as `q4`/`q8`/`bf16` subtrees of one components mirror,
+/// and only the one matching the selected tier should be fetched, sized, or gated on. Keying that on
+/// the presence of `variant` keeps every existing co-requisite on exactly its current path.
+pub(crate) fn co_requisite_variant(download: &Value) -> Option<String> {
+    download
+        .get("variant")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
+}
+
+/// The co-requisite downloads that apply to `variant` (sc-14980).
+///
+/// Tier-agnostic rows (no `variant`) always apply. A tier-scoped row applies only to its own tier;
+/// when no tier is in scope, every tier-scoped row is returned so callers that genuinely aggregate
+/// across tiers still see them all.
+pub(crate) fn model_co_requisite_downloads_for_variant(
+    model: &Value,
+    variant: Option<&str>,
+) -> Vec<Value> {
+    let wanted = variant.map(|value| value.trim().to_ascii_lowercase());
+    model_co_requisite_downloads(model)
+        .into_iter()
+        .filter(
+            |download| match (co_requisite_variant(download), wanted.as_deref()) {
+                (None, _) => true,
+                (Some(_), None) => true,
+                (Some(row), Some(wanted)) => row == wanted,
+            },
+        )
+        .collect()
+}
+
 pub(crate) fn model_co_requisite_downloads(model: &Value) -> Vec<Value> {
     model
         .get("downloads")
@@ -6686,11 +6796,18 @@ mod variant_delete_tests {
         assert_eq!(removal.reclaimed_bytes, 0);
     }
 
+    /// A model whose logical tiers SHARE one file predicate reclaims nothing and keeps the snapshot.
+    ///
+    /// This is the load-time-quant contract, and it is still the right behavior for any family that
+    /// ships one dense snapshot per variant. Mage-Flow used to be the shipping example; since
+    /// sc-14980 its tiers are physically distinct, so the fixture below is a synthetic overlapping
+    /// model rather than a Mage row — see
+    /// `mage_flow_per_tier_delete_reclaims_only_that_tiers_dit` for Mage's actual shape.
     #[tokio::test]
     async fn overlapping_logical_tiers_retain_the_shared_snapshot_and_reclaim_zero() {
         let tmp = tempfile::tempdir().unwrap();
         let hub = tmp.path().join("hub");
-        let repo = hub.join("models--SceneWorks--Mage-Flow");
+        let repo = hub.join("models--Org--overlapping-tiers");
         seed(
             &repo,
             "transformer/diffusion_pytorch_model.safetensors",
@@ -6724,6 +6841,97 @@ mod variant_delete_tests {
             .exists());
         assert!(repo.join("blobs/te").exists());
         assert!(repo.join("blobs/vae").exists());
+    }
+
+    /// sc-14980 / sc-14979 — Mage-Flow's per-tier delete reclaims REAL bytes, and reclaims only its
+    /// own tier's DiT.
+    ///
+    /// This is the physical-reclaim acceptance sc-14046 delegated. It replaces the honest-but-empty
+    /// zero-byte outcome the load-time-quant layout could offer, and it is the reason the tiers had
+    /// to become physically distinct artifacts. The byte counts are the REAL sizes measured on the
+    /// uploaded mirrors, so a re-host that silently changed the layout would move them.
+    ///
+    /// Three things must hold simultaneously, and each is a distinct way the design could fail:
+    ///   - the deleted tier's DiT bytes are actually reclaimed (not 0);
+    ///   - the OTHER installed tier's DiT survives intact (predicates are disjoint);
+    ///   - the SHARED text encoder + VAE survive — they live in a different repo entirely and are
+    ///     co-requisites, so a variant/tier delete can never strand another installed variant.
+    #[tokio::test]
+    async fn mage_flow_per_tier_delete_reclaims_only_that_tiers_dit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hub = tmp.path().join("hub");
+        // The variant mirror: q4 and q8 DiT tiers installed side by side.
+        let variant = hub.join("models--SceneWorks--Mage-Flow-Base");
+        // Real uploaded sizes, scaled down by 1e6 so the fixture stays a unit test; the RATIO and
+        // the disjointness are what the assertions are about.
+        const Q4_DIT: usize = 2316; // 2.317 GB
+        const Q8_DIT: usize = 4374; // 4.374 GB
+        seed(
+            &variant,
+            "q4/transformer/diffusion_pytorch_model.safetensors",
+            "q4dit",
+            Q4_DIT,
+        );
+        seed(&variant, "q4/model_index.json", "q4idx", 1);
+        seed(
+            &variant,
+            "q8/transformer/diffusion_pytorch_model.safetensors",
+            "q8dit",
+            Q8_DIT,
+        );
+        seed(&variant, "q8/model_index.json", "q8idx", 1);
+        // The SHARED components mirror — a different repo, reached only through co-requisite rows.
+        let components = hub.join("models--SceneWorks--Mage-Flow-Components-mlx");
+        seed(
+            &components,
+            "q4/text_encoder/model.safetensors",
+            "q4te",
+            2514,
+        );
+        seed(
+            &components,
+            "q4/vae/diffusion_pytorch_model.safetensors",
+            "q4vae",
+            345,
+        );
+
+        // Delete the q4 tier. `retained` carries the SURVIVING tiers' predicates, exactly as
+        // `delete_model_variant` builds it (co-requisites are excluded there by construction, which
+        // is why no components predicate appears here).
+        let removal = remove_tier_artifacts(
+            Some(variant.clone()),
+            None,
+            &["q4/*".to_owned()],
+            &["q8/*".to_owned()],
+            std::slice::from_ref(&hub),
+            true,
+        )
+        .await
+        .unwrap();
+
+        // 1. Real bytes, not zero: exactly the q4 DiT + its tier index.
+        assert_eq!(
+            removal.reclaimed_bytes,
+            (Q4_DIT + 1) as u64,
+            "a Mage tier delete must reclaim that tier's own bytes — a 0 here means the tiers went \
+             back to sharing one file predicate"
+        );
+        assert!(!removal.removed_paths.is_empty());
+        assert!(!variant.join("blobs/q4dit").exists());
+        assert!(!variant.join("snapshots/rev/q4").exists());
+
+        // 2. The sibling tier is untouched.
+        assert!(variant.join("blobs/q8dit").exists());
+        assert!(variant
+            .join("snapshots/rev/q8/transformer/diffusion_pytorch_model.safetensors")
+            .exists());
+
+        // 3. The shared components are untouched — different repo, never in the delete's scope.
+        assert!(components.join("blobs/q4te").exists());
+        assert!(components.join("blobs/q4vae").exists());
+        assert!(components
+            .join("snapshots/rev/q4/text_encoder/model.safetensors")
+            .exists());
     }
 
     // Convert-at-install (Anima) tiers are real `<converted>/<tier>/` dirs with a packed DiT plus

--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -1790,7 +1790,32 @@ fn snapshot_is_tiered_turnkey(snapshot: &FsPath) -> bool {
 /// check the actual dirs. Testing the backbone as `transformer/`-only silently reported every
 /// SDXL-family tiered turnkey as un-installed, since those pack `unet/` (sc-10613).
 fn bf16_component_tree_present(bf16: &FsPath) -> bool {
-    has_backbone_dir(bf16) && bf16.join("text_encoder").is_dir() && bf16.join("vae").is_dir()
+    if !has_backbone_dir(bf16) {
+        return false;
+    }
+    if bf16.join("text_encoder").is_dir() && bf16.join("vae").is_dir() {
+        return true;
+    }
+    // sc-14980: a SPLIT tier ships only the components it owns, and declares exactly those in its
+    // own `model_index.json`. Mage-Flow's bf16 tier is the DiT + scheduler; its text encoder and VAE
+    // are bit-identical across all six variants and are hosted once as shared co-requisites, so
+    // requiring them *inside* the tier would report a complete, trainable install as
+    // `TrainingTierMissing` forever.
+    //
+    // This arm is purely ADDITIVE — it is only reached when the classic check already failed, and it
+    // only passes when the tier DECLARES a component set that excludes text_encoder/vae and has
+    // every declared component on disk. A tier that declares `text_encoder` (krea-2-raw-mlx's bf16
+    // declares transformer + text_encoder + tokenizer + vae + scheduler, and every SDXL-family
+    // turnkey the same) still fails here exactly as before, so no existing target is weakened.
+    let Some(declared) = sceneworks_core::mlx_tier_completeness::tier_declared_components(bf16)
+    else {
+        return false;
+    };
+    !declared.is_empty()
+        && !declared.iter().any(|component| component == "text_encoder")
+        && declared
+            .iter()
+            .all(|component| bf16.join(component).is_dir())
 }
 
 /// For a tiered-turnkey re-host (epic 9992 Krea 2 Raw: `SceneWorks/krea-2-raw-mlx` ships `bf16/ q8/ q4/`

--- a/config/inference-third-party-source.json
+++ b/config/inference-third-party-source.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Exact audit of production include_str!/include_bytes! sites and known hand-ports in the pinned inference revision. The digest is checked by check-license-coverage.mjs; any inference pin change forces a new audit. Tests/fixtures are outside this production inventory.",
-  "inferenceRevision": "6147a596be2739f6c4f76644fe901dc28a7e00c7",
-  "auditDigest": "0145820a35db9096056baeec1b49bc2a3972056d63f43d7e5c24ee7218c77181",
+  "inferenceRevision": "d1b8668463971ff62f5971400071bdc9914558d3",
+  "auditDigest": "f431d729983d331b61d0c82625c22a915b41c4f40cfad9eb89c6cf47d60e291b",
   "artifacts": [
     {
       "id": "cmudict",
@@ -17,7 +17,7 @@
   "provenanceScan": {
     "scanner": "scripts/scan-inference-provenance.mjs",
     "candidateList": "config/inference-provenance-candidates.tsv",
-    "revision": "6147a596be2739f6c4f76644fe901dc28a7e00c7",
+    "revision": "d1b8668463971ff62f5971400071bdc9914558d3",
     "pathFilter": "production .rs; exclude tests, testdata, benches, examples, and _vendor path segments",
     "markerRegex": "faithful ... port(s), ported from, port(s) of, vendor(s)/vendored, transcribed, copied ... verbatim, adapted from (case-insensitive)",
     "normalization": "matched marker text lowercased, internal whitespace collapsed, sorted, newline joined",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -22,48 +22,119 @@
       ],
       "macOnly": false,
       "downloads": [
+      // sc-14980 / sc-14979 — PHYSICAL per-tier artifacts with a SHARED text encoder + VAE.
+      //
+      // Each tier fetches only its own `<tier>/` DiT subdir, so a q4 user downloads 2.32 GB of
+      // transformer instead of the whole 17.5 GB dense snapshot, and a per-tier delete reclaims
+      // exactly that tier's bytes (the tiers no longer share one file predicate). The flat dense
+      // root is still HOSTED on the mirror so pre-existing installs keep loading, but no tier
+      // fetches it.
+      //
+      // `text_encoder/` and `vae/` are BIT-IDENTICAL across all six Mage variants (only the 8.232 GB
+      // DiT differs), so they are hosted ONCE in SceneWorks/Mage-Flow-Components-mlx and declared
+      // here as per-tier `coRequisite` rows carrying `componentId` + `subdir`. Being co-requisites
+      // makes them structurally exempt from per-variant/per-tier delete, so removing one variant or
+      // tier can never strand another that still needs them. All six variants at bf16 cost 58.62 GB
+      // instead of 105.04 GB; a second variant is an ~8.2 GB delta.
+      //
+      // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
+      // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
+      // It costs 0.345 GB per tier and is quantized at load exactly as before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Base",
-          "revision": "5345fa8b0d41bdd612351f0933ef4cc9021281ab",
+          "revision": "199b4cae841403e8a1cca3c585a09f10fc70d3f1",
           "variant": "q4",
           "default": true,
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714677
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 2316856860,
+          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Base",
-          "revision": "5345fa8b0d41bdd612351f0933ef4cc9021281ab",
+          "revision": "199b4cae841403e8a1cca3c585a09f10fc70d3f1",
           "variant": "q8",
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714677
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 4374163324,
+          "footprint": { "diskSizeBytes": 4374163324, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Base",
-          "revision": "5345fa8b0d41bdd612351f0933ef4cc9021281ab",
+          "revision": "199b4cae841403e8a1cca3c585a09f10fc70d3f1",
           "variant": "bf16",
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714677
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 8231571754,
+          "footprint": { "diskSizeBytes": 8231571754, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Shared Qwen3-VL-4B text encoder — one per tier, fetched only for the selected tier.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q4",
+          "subdir": "q4/text_encoder",
+          "files": ["q4/text_encoder/*"],
+          "estimatedSizeBytes": 2514418914
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q8",
+          "subdir": "q8/text_encoder",
+          "files": ["q8/text_encoder/*"],
+          "estimatedSizeBytes": 4731076490
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "bf16",
+          "subdir": "bf16/text_encoder",
+          "files": ["bf16/text_encoder/*"],
+          "estimatedSizeBytes": 8887219239
+        },
+        // Shared Mage-VAE — dense in every tier (see the note above).
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q4",
+          "subdir": "q4/vae",
+          "files": ["q4/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q8",
+          "subdir": "q8/vae",
+          "files": ["q8/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "bf16",
+          "subdir": "bf16/vae",
+          "files": ["bf16/vae/*"],
+          "estimatedSizeBytes": 345053168
         }
       ],
       "paths": {
@@ -113,7 +184,13 @@
         "requiresDimensionsMultipleOf": 16
       },
       "mlx": {
-        "quantize": 4
+        // The image-lane default tier. With physical artifacts this now also selects WHICH `<tier>/`
+        // subdir `standard_tier_subdir` descends into, not just a load-time quantize call.
+        "quantize": 4,
+        // sc-14980: the tiers are physically distinct `q4/ q8/ bf16/` subtrees now, so the worker
+        // must resolve the tier subdir rather than the snapshot root. This is what makes a per-tier
+        // delete reclaim real bytes.
+        "standardTierLayout": true
       },
       // Shared across all six Mage rows. Physical CUDA run 30194676028 measured the per-process
       // nvidia-smi high-water at q4 14.67 / q8 16.95 / bf16 20.41 GB for the registered 1024²,
@@ -149,48 +226,119 @@
       ],
       "macOnly": false,
       "downloads": [
+      // sc-14980 / sc-14979 — PHYSICAL per-tier artifacts with a SHARED text encoder + VAE.
+      //
+      // Each tier fetches only its own `<tier>/` DiT subdir, so a q4 user downloads 2.32 GB of
+      // transformer instead of the whole 17.5 GB dense snapshot, and a per-tier delete reclaims
+      // exactly that tier's bytes (the tiers no longer share one file predicate). The flat dense
+      // root is still HOSTED on the mirror so pre-existing installs keep loading, but no tier
+      // fetches it.
+      //
+      // `text_encoder/` and `vae/` are BIT-IDENTICAL across all six Mage variants (only the 8.232 GB
+      // DiT differs), so they are hosted ONCE in SceneWorks/Mage-Flow-Components-mlx and declared
+      // here as per-tier `coRequisite` rows carrying `componentId` + `subdir`. Being co-requisites
+      // makes them structurally exempt from per-variant/per-tier delete, so removing one variant or
+      // tier can never strand another that still needs them. All six variants at bf16 cost 58.62 GB
+      // instead of 105.04 GB; a second variant is an ~8.2 GB delta.
+      //
+      // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
+      // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
+      // It costs 0.345 GB per tier and is quantized at load exactly as before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit",
-          "revision": "d668ecc8ce5addcb3c0bbe268227eb17f832aa9f",
+          "revision": "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503",
           "variant": "q4",
           "default": true,
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714677
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 2316856860,
+          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit",
-          "revision": "d668ecc8ce5addcb3c0bbe268227eb17f832aa9f",
+          "revision": "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503",
           "variant": "q8",
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714677
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 4374163324,
+          "footprint": { "diskSizeBytes": 4374163324, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit",
-          "revision": "d668ecc8ce5addcb3c0bbe268227eb17f832aa9f",
+          "revision": "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503",
           "variant": "bf16",
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714677
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 8231571754,
+          "footprint": { "diskSizeBytes": 8231571754, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Shared Qwen3-VL-4B text encoder — one per tier, fetched only for the selected tier.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q4",
+          "subdir": "q4/text_encoder",
+          "files": ["q4/text_encoder/*"],
+          "estimatedSizeBytes": 2514418914
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q8",
+          "subdir": "q8/text_encoder",
+          "files": ["q8/text_encoder/*"],
+          "estimatedSizeBytes": 4731076490
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "bf16",
+          "subdir": "bf16/text_encoder",
+          "files": ["bf16/text_encoder/*"],
+          "estimatedSizeBytes": 8887219239
+        },
+        // Shared Mage-VAE — dense in every tier (see the note above).
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q4",
+          "subdir": "q4/vae",
+          "files": ["q4/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q8",
+          "subdir": "q8/vae",
+          "files": ["q8/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "bf16",
+          "subdir": "bf16/vae",
+          "files": ["bf16/vae/*"],
+          "estimatedSizeBytes": 345053168
         }
       ],
       "paths": {
@@ -240,7 +388,13 @@
         "requiresDimensionsMultipleOf": 16
       },
       "mlx": {
-        "quantize": 4
+        // The image-lane default tier. With physical artifacts this now also selects WHICH `<tier>/`
+        // subdir `standard_tier_subdir` descends into, not just a load-time quantize call.
+        "quantize": 4,
+        // sc-14980: the tiers are physically distinct `q4/ q8/ bf16/` subtrees now, so the worker
+        // must resolve the tier subdir rather than the snapshot root. This is what makes a per-tier
+        // delete reclaim real bytes.
+        "standardTierLayout": true
       },
       "candle": {
         "minMemoryGb": 17,
@@ -273,48 +427,119 @@
       ],
       "macOnly": false,
       "downloads": [
+      // sc-14980 / sc-14979 — PHYSICAL per-tier artifacts with a SHARED text encoder + VAE.
+      //
+      // Each tier fetches only its own `<tier>/` DiT subdir, so a q4 user downloads 2.32 GB of
+      // transformer instead of the whole 17.5 GB dense snapshot, and a per-tier delete reclaims
+      // exactly that tier's bytes (the tiers no longer share one file predicate). The flat dense
+      // root is still HOSTED on the mirror so pre-existing installs keep loading, but no tier
+      // fetches it.
+      //
+      // `text_encoder/` and `vae/` are BIT-IDENTICAL across all six Mage variants (only the 8.232 GB
+      // DiT differs), so they are hosted ONCE in SceneWorks/Mage-Flow-Components-mlx and declared
+      // here as per-tier `coRequisite` rows carrying `componentId` + `subdir`. Being co-requisites
+      // makes them structurally exempt from per-variant/per-tier delete, so removing one variant or
+      // tier can never strand another that still needs them. All six variants at bf16 cost 58.62 GB
+      // instead of 105.04 GB; a second variant is an ~8.2 GB delta.
+      //
+      // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
+      // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
+      // It costs 0.345 GB per tier and is quantized at load exactly as before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Turbo",
-          "revision": "3e5ae67807083a25f3d344bc2c5ff16276415a14",
+          "revision": "c3437cbb91e565ab6373e3c7b8e9b8048d29831b",
           "variant": "q4",
           "default": true,
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714653
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 2316856860,
+          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Turbo",
-          "revision": "3e5ae67807083a25f3d344bc2c5ff16276415a14",
+          "revision": "c3437cbb91e565ab6373e3c7b8e9b8048d29831b",
           "variant": "q8",
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714653
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 4374163324,
+          "footprint": { "diskSizeBytes": 4374163324, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Turbo",
-          "revision": "3e5ae67807083a25f3d344bc2c5ff16276415a14",
+          "revision": "c3437cbb91e565ab6373e3c7b8e9b8048d29831b",
           "variant": "bf16",
-          "files": [
-            "model_index.json",
-            "scheduler/*",
-            "text_encoder/*",
-            "transformer/*",
-            "vae/*"
-          ],
-          "estimatedSizeBytes": 17495714653
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 8231571754,
+          "footprint": { "diskSizeBytes": 8231571754, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Shared Qwen3-VL-4B text encoder — one per tier, fetched only for the selected tier.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q4",
+          "subdir": "q4/text_encoder",
+          "files": ["q4/text_encoder/*"],
+          "estimatedSizeBytes": 2514418914
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q8",
+          "subdir": "q8/text_encoder",
+          "files": ["q8/text_encoder/*"],
+          "estimatedSizeBytes": 4731076490
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "bf16",
+          "subdir": "bf16/text_encoder",
+          "files": ["bf16/text_encoder/*"],
+          "estimatedSizeBytes": 8887219239
+        },
+        // Shared Mage-VAE — dense in every tier (see the note above).
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q4",
+          "subdir": "q4/vae",
+          "files": ["q4/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q8",
+          "subdir": "q8/vae",
+          "files": ["q8/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "bf16",
+          "subdir": "bf16/vae",
+          "files": ["bf16/vae/*"],
+          "estimatedSizeBytes": 345053168
         }
       ],
       "paths": {
@@ -364,7 +589,13 @@
         "requiresDimensionsMultipleOf": 16
       },
       "mlx": {
-        "quantize": 4
+        // The image-lane default tier. With physical artifacts this now also selects WHICH `<tier>/`
+        // subdir `standard_tier_subdir` descends into, not just a load-time quantize call.
+        "quantize": 4,
+        // sc-14980: the tiers are physically distinct `q4/ q8/ bf16/` subtrees now, so the worker
+        // must resolve the tier subdir rather than the snapshot root. This is what makes a per-tier
+        // delete reclaim real bytes.
+        "standardTierLayout": true
       },
       "candle": {
         "minMemoryGb": 17,
@@ -399,30 +630,119 @@
       "capabilities": ["text_to_image"],
       "macOnly": false,
       "downloads": [
+      // sc-14980 / sc-14979 — PHYSICAL per-tier artifacts with a SHARED text encoder + VAE.
+      //
+      // Each tier fetches only its own `<tier>/` DiT subdir, so a q4 user downloads 2.32 GB of
+      // transformer instead of the whole 17.5 GB dense snapshot, and a per-tier delete reclaims
+      // exactly that tier's bytes (the tiers no longer share one file predicate). The flat dense
+      // root is still HOSTED on the mirror so pre-existing installs keep loading, but no tier
+      // fetches it.
+      //
+      // `text_encoder/` and `vae/` are BIT-IDENTICAL across all six Mage variants (only the 8.232 GB
+      // DiT differs), so they are hosted ONCE in SceneWorks/Mage-Flow-Components-mlx and declared
+      // here as per-tier `coRequisite` rows carrying `componentId` + `subdir`. Being co-requisites
+      // makes them structurally exempt from per-variant/per-tier delete, so removing one variant or
+      // tier can never strand another that still needs them. All six variants at bf16 cost 58.62 GB
+      // instead of 105.04 GB; a second variant is an ~8.2 GB delta.
+      //
+      // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
+      // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
+      // It costs 0.345 GB per tier and is quantized at load exactly as before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Base",
-          "revision": "a160c0a2c9d82106687d969d161c313c7e528550",
+          "revision": "2c0b473896ef87af5a0873a26ed62c319213ae36",
           "variant": "q4",
           "default": true,
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375789
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 2316856860,
+          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Base",
-          "revision": "a160c0a2c9d82106687d969d161c313c7e528550",
+          "revision": "2c0b473896ef87af5a0873a26ed62c319213ae36",
           "variant": "q8",
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375789
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 4374163324,
+          "footprint": { "diskSizeBytes": 4374163324, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Base",
-          "revision": "a160c0a2c9d82106687d969d161c313c7e528550",
+          "revision": "2c0b473896ef87af5a0873a26ed62c319213ae36",
           "variant": "bf16",
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375789
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 8231571754,
+          "footprint": { "diskSizeBytes": 8231571754, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Shared Qwen3-VL-4B text encoder — one per tier, fetched only for the selected tier.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q4",
+          "subdir": "q4/text_encoder",
+          "files": ["q4/text_encoder/*"],
+          "estimatedSizeBytes": 2514418914
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q8",
+          "subdir": "q8/text_encoder",
+          "files": ["q8/text_encoder/*"],
+          "estimatedSizeBytes": 4731076490
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "bf16",
+          "subdir": "bf16/text_encoder",
+          "files": ["bf16/text_encoder/*"],
+          "estimatedSizeBytes": 8887219239
+        },
+        // Shared Mage-VAE — dense in every tier (see the note above).
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q4",
+          "subdir": "q4/vae",
+          "files": ["q4/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q8",
+          "subdir": "q8/vae",
+          "files": ["q8/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "bf16",
+          "subdir": "bf16/vae",
+          "files": ["bf16/vae/*"],
+          "estimatedSizeBytes": 345053168
         }
       ],
       "paths": { "model": "${HF_CACHE}/SceneWorks/Mage-Flow-Base" },
@@ -452,7 +772,15 @@
         "requiresDimensionsMultipleOf": 16
       },
       "loraCompatibility": { "families": ["mage-flow"], "types": ["style", "enhance", "character"] },
-      "mlx": { "quantize": 4 },
+      "mlx": {
+        // The image-lane default tier. With physical artifacts this now also selects WHICH `<tier>/`
+        // subdir `standard_tier_subdir` descends into, not just a load-time quantize call.
+        "quantize": 4,
+        // sc-14980: the tiers are physically distinct `q4/ q8/ bf16/` subtrees now, so the worker
+        // must resolve the tier subdir rather than the snapshot root. This is what makes a per-tier
+        // delete reclaim real bytes.
+        "standardTierLayout": true
+      },
       "candle": {
         "minMemoryGb": 17,
         "vramGbByTier": { "q4": 14.67, "q8": 16.95, "bf16": 20.41 },
@@ -480,30 +808,119 @@
       "capabilities": ["text_to_image"],
       "macOnly": false,
       "downloads": [
+      // sc-14980 / sc-14979 — PHYSICAL per-tier artifacts with a SHARED text encoder + VAE.
+      //
+      // Each tier fetches only its own `<tier>/` DiT subdir, so a q4 user downloads 2.32 GB of
+      // transformer instead of the whole 17.5 GB dense snapshot, and a per-tier delete reclaims
+      // exactly that tier's bytes (the tiers no longer share one file predicate). The flat dense
+      // root is still HOSTED on the mirror so pre-existing installs keep loading, but no tier
+      // fetches it.
+      //
+      // `text_encoder/` and `vae/` are BIT-IDENTICAL across all six Mage variants (only the 8.232 GB
+      // DiT differs), so they are hosted ONCE in SceneWorks/Mage-Flow-Components-mlx and declared
+      // here as per-tier `coRequisite` rows carrying `componentId` + `subdir`. Being co-requisites
+      // makes them structurally exempt from per-variant/per-tier delete, so removing one variant or
+      // tier can never strand another that still needs them. All six variants at bf16 cost 58.62 GB
+      // instead of 105.04 GB; a second variant is an ~8.2 GB delta.
+      //
+      // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
+      // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
+      // It costs 0.345 GB per tier and is quantized at load exactly as before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow",
-          "revision": "e6719fb1abb0d3fa83ecebbf31cbf431eb054ab8",
+          "revision": "b9204c289b235bce9ade608f76a009f80a135bfd",
           "variant": "q4",
           "default": true,
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375766
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 2316856860,
+          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow",
-          "revision": "e6719fb1abb0d3fa83ecebbf31cbf431eb054ab8",
+          "revision": "b9204c289b235bce9ade608f76a009f80a135bfd",
           "variant": "q8",
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375766
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 4374163324,
+          "footprint": { "diskSizeBytes": 4374163324, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow",
-          "revision": "e6719fb1abb0d3fa83ecebbf31cbf431eb054ab8",
+          "revision": "b9204c289b235bce9ade608f76a009f80a135bfd",
           "variant": "bf16",
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375766
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 8231571754,
+          "footprint": { "diskSizeBytes": 8231571754, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Shared Qwen3-VL-4B text encoder — one per tier, fetched only for the selected tier.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q4",
+          "subdir": "q4/text_encoder",
+          "files": ["q4/text_encoder/*"],
+          "estimatedSizeBytes": 2514418914
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q8",
+          "subdir": "q8/text_encoder",
+          "files": ["q8/text_encoder/*"],
+          "estimatedSizeBytes": 4731076490
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "bf16",
+          "subdir": "bf16/text_encoder",
+          "files": ["bf16/text_encoder/*"],
+          "estimatedSizeBytes": 8887219239
+        },
+        // Shared Mage-VAE — dense in every tier (see the note above).
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q4",
+          "subdir": "q4/vae",
+          "files": ["q4/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q8",
+          "subdir": "q8/vae",
+          "files": ["q8/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "bf16",
+          "subdir": "bf16/vae",
+          "files": ["bf16/vae/*"],
+          "estimatedSizeBytes": 345053168
         }
       ],
       "paths": { "model": "${HF_CACHE}/SceneWorks/Mage-Flow" },
@@ -533,7 +950,15 @@
         "requiresDimensionsMultipleOf": 16
       },
       "loraCompatibility": { "families": ["mage-flow"], "types": ["style", "enhance", "character"] },
-      "mlx": { "quantize": 4 },
+      "mlx": {
+        // The image-lane default tier. With physical artifacts this now also selects WHICH `<tier>/`
+        // subdir `standard_tier_subdir` descends into, not just a load-time quantize call.
+        "quantize": 4,
+        // sc-14980: the tiers are physically distinct `q4/ q8/ bf16/` subtrees now, so the worker
+        // must resolve the tier subdir rather than the snapshot root. This is what makes a per-tier
+        // delete reclaim real bytes.
+        "standardTierLayout": true
+      },
       "candle": {
         "minMemoryGb": 17,
         "vramGbByTier": { "q4": 14.67, "q8": 16.95, "bf16": 20.41 },
@@ -561,30 +986,119 @@
       "capabilities": ["text_to_image"],
       "macOnly": false,
       "downloads": [
+      // sc-14980 / sc-14979 — PHYSICAL per-tier artifacts with a SHARED text encoder + VAE.
+      //
+      // Each tier fetches only its own `<tier>/` DiT subdir, so a q4 user downloads 2.32 GB of
+      // transformer instead of the whole 17.5 GB dense snapshot, and a per-tier delete reclaims
+      // exactly that tier's bytes (the tiers no longer share one file predicate). The flat dense
+      // root is still HOSTED on the mirror so pre-existing installs keep loading, but no tier
+      // fetches it.
+      //
+      // `text_encoder/` and `vae/` are BIT-IDENTICAL across all six Mage variants (only the 8.232 GB
+      // DiT differs), so they are hosted ONCE in SceneWorks/Mage-Flow-Components-mlx and declared
+      // here as per-tier `coRequisite` rows carrying `componentId` + `subdir`. Being co-requisites
+      // makes them structurally exempt from per-variant/per-tier delete, so removing one variant or
+      // tier can never strand another that still needs them. All six variants at bf16 cost 58.62 GB
+      // instead of 105.04 GB; a second variant is an ~8.2 GB delta.
+      //
+      // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
+      // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
+      // It costs 0.345 GB per tier and is quantized at load exactly as before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Turbo",
-          "revision": "6fc43b7b586078997047acc9c39dbbd26044a035",
+          "revision": "dca431fa8dfb4b3411cf3986435540ed31a7e8b7",
           "variant": "q4",
           "default": true,
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375767
+          "files": ["q4/*"],
+          "estimatedSizeBytes": 2316856860,
+          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Turbo",
-          "revision": "6fc43b7b586078997047acc9c39dbbd26044a035",
+          "revision": "dca431fa8dfb4b3411cf3986435540ed31a7e8b7",
           "variant": "q8",
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375767
+          "files": ["q8/*"],
+          "estimatedSizeBytes": 4374163324,
+          "footprint": { "diskSizeBytes": 4374163324, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Turbo",
-          "revision": "6fc43b7b586078997047acc9c39dbbd26044a035",
+          "revision": "dca431fa8dfb4b3411cf3986435540ed31a7e8b7",
           "variant": "bf16",
-          "files": ["model_index.json", "scheduler/*", "text_encoder/*", "transformer/*", "vae/*"],
-          "estimatedSizeBytes": 17507375767
+          "files": ["bf16/*"],
+          "estimatedSizeBytes": 8231571754,
+          "footprint": { "diskSizeBytes": 8231571754, "residentMemoryBytes": null, "peakMemoryBytes": null }
+        },
+        // Shared Qwen3-VL-4B text encoder — one per tier, fetched only for the selected tier.
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q4",
+          "subdir": "q4/text_encoder",
+          "files": ["q4/text_encoder/*"],
+          "estimatedSizeBytes": 2514418914
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "q8",
+          "subdir": "q8/text_encoder",
+          "files": ["q8/text_encoder/*"],
+          "estimatedSizeBytes": 4731076490
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "text_encoder",
+          "variant": "bf16",
+          "subdir": "bf16/text_encoder",
+          "files": ["bf16/text_encoder/*"],
+          "estimatedSizeBytes": 8887219239
+        },
+        // Shared Mage-VAE — dense in every tier (see the note above).
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q4",
+          "subdir": "q4/vae",
+          "files": ["q4/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "q8",
+          "subdir": "q8/vae",
+          "files": ["q8/vae/*"],
+          "estimatedSizeBytes": 345053168
+        },
+        {
+          "provider": "huggingface",
+          "repo": "SceneWorks/Mage-Flow-Components-mlx",
+          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "coRequisite": true,
+          "componentId": "vae",
+          "variant": "bf16",
+          "subdir": "bf16/vae",
+          "files": ["bf16/vae/*"],
+          "estimatedSizeBytes": 345053168
         }
       ],
       "paths": { "model": "${HF_CACHE}/SceneWorks/Mage-Flow-Turbo" },
@@ -614,7 +1128,15 @@
         "requiresDimensionsMultipleOf": 16
       },
       "loraCompatibility": { "families": ["mage-flow"], "types": ["style", "enhance", "character"] },
-      "mlx": { "quantize": 4 },
+      "mlx": {
+        // The image-lane default tier. With physical artifacts this now also selects WHICH `<tier>/`
+        // subdir `standard_tier_subdir` descends into, not just a load-time quantize call.
+        "quantize": 4,
+        // sc-14980: the tiers are physically distinct `q4/ q8/ bf16/` subtrees now, so the worker
+        // must resolve the tier subdir rather than the snapshot root. This is what makes a per-tier
+        // delete reclaim real bytes.
+        "standardTierLayout": true
+      },
       "candle": {
         "minMemoryGb": 17,
         "vramGbByTier": { "q4": 14.67, "q8": 16.95, "bf16": 20.41 },

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -1013,27 +1013,29 @@ mod tests {
     }
 
     #[test]
-    fn mage_flow_family_ships_six_variants_as_load_time_quant_tiers() {
-        // sc-14059 (epic 14034, P6): pin the shipped Mage-Flow catalog shape that the desktop
-        // provisioning + per-tier download/delete flows depend on. This is the manifest-contract
-        // guard that keeps two shipped behaviors HONEST, and it discriminates a real regression
-        // from the current state rather than asserting a code default:
+    fn mage_flow_family_ships_six_variants_as_prequantized_per_tier_artifacts() {
+        // sc-14980 / sc-14979 (epic 14034), superseding the sc-14059 load-time-quant invariant.
         //
-        //   1. Per-tier delete honesty (closes sc-14046's delegated acceptance). Mage's three
-        //      q4/q8/bf16 tiers are LOAD-TIME MLX quant choices over ONE dense diffusers snapshot,
-        //      not physically-distinct on-disk artifacts. The overlap-safe tier delete in
-        //      apps/rust-api (delete_model_variant) only reclaims zero bytes and preserves the
-        //      shared snapshot BECAUSE every tier declares the SAME repo+revision+files. If a future
-        //      edit gave the tiers distinct file predicates (e.g. z-image-style `q4/*` subdirs) that
-        //      per-tier delete would begin removing real bytes another logical tier still needs and
-        //      corrupt the snapshot — so the identical-predicate invariant is load-bearing, not
-        //      cosmetic. The absence of `mlx.standardTierLayout` (which z_image_turbo DOES set to
-        //      route to physical `<tier>/` subdirs) is the discriminating marker that Mage is
-        //      on-the-fly quant, not a physical tier matrix.
-        //   2. Resume/retry skip (sc-13614 pattern). Because the three tier download jobs carry
-        //      identical repo+revision+files, downloading a second tier of an already-installed
-        //      variant re-verifies but never re-fetches bytes (downloads.rs size-equals-expected
-        //      skip), and installing one tier marks all three installed.
+        // Mage's q4/q8/bf16 are no longer on-the-fly quantization over ONE dense snapshot; they are
+        // physically distinct `<tier>/` artifacts on our mirrors, with the text encoder and VAE —
+        // bit-identical across all six variants — hosted once as per-tier co-requisites. The old
+        // test pinned the exact opposite (identical repo+revision+files across tiers, and
+        // `standardTierLayout` absent), so it is REPLACED rather than relaxed. What it protected is
+        // preserved and inverted here, plus the two new invariants the split layout depends on:
+        //
+        //   1. Per-tier delete honesty (closes sc-14046's delegated acceptance). Each tier now
+        //      declares its OWN `<tier>/*` predicate, so the overlap-safe delete in apps/rust-api
+        //      reclaims that tier's real bytes while the other tiers' predicates keep theirs. The
+        //      DISTINCT-predicate invariant is now the load-bearing one; identical predicates would
+        //      silently return per-tier delete to reclaiming zero bytes.
+        //   2. Shared components are never stranded. text_encoder/vae are `coRequisite` rows, which
+        //      per-variant and per-tier delete skip structurally, so deleting one variant or tier
+        //      can never remove weights another installed variant still needs.
+        //   3. `mlx.standardTierLayout` MUST be set — it is what routes the worker into
+        //      `standard_tier_subdir` so a tier request loads `<tier>/` instead of the snapshot root.
+        //   4. Every co-requisite carries `componentId` + `subdir` + `variant`: the id matches the
+        //      `mlx_mage` descriptor's `required_components`, the subdir addresses the component dir
+        //      inside the shared mirror, and the variant scopes the fetch to one tier.
         //
         // It also proves the P6 model guide (apps/web/public/prompt-guides/mage-flow.md) is wired to
         // every variant.
@@ -1083,6 +1085,12 @@ mod tests {
             ("mage_flow_edit_turbo", "edit_image", 4, 1.0),
         ];
 
+        // The one shared components mirror, pinned. Every variant must agree on it — a second
+        // components repo would silently double the shared-weight cost the split layout exists to
+        // avoid.
+        const COMPONENTS_REPO: &str = "SceneWorks/Mage-Flow-Components-mlx";
+        const TIERS: [&str; 3] = ["q4", "q8", "bf16"];
+
         for (id, capability, steps, guidance) in expected {
             let model = find(id);
             assert_eq!(
@@ -1117,25 +1125,45 @@ mod tests {
                 "{id} points at the P6 Mage-Flow model guide"
             );
 
-            // Load-time quant marker, and NOT a physical per-tier layout.
+            // The physical-tier markers. `quantize` still names the default tier, but it now selects
+            // WHICH subdir is loaded, and `standardTierLayout` is what makes the worker descend.
             assert_eq!(
                 model["mlx"]["quantize"].as_u64(),
                 Some(4),
-                "{id} declares the image-lane load-time quant default tier"
+                "{id} declares q4 as the default tier"
             );
-            assert!(
-                model["mlx"]["standardTierLayout"].is_null(),
-                "{id} must NOT declare standardTierLayout — its q4/q8/bf16 are on-the-fly quant over \
-                 one dense snapshot, not physical <tier>/ subdirs (that flag is what makes per-tier \
-                 delete reclaim real bytes, which would corrupt Mage's shared snapshot)"
+            assert_eq!(
+                model["mlx"]["standardTierLayout"].as_bool(),
+                Some(true),
+                "{id} MUST declare standardTierLayout — without it the worker loads the snapshot \
+                 ROOT instead of the requested `<tier>/` subdir, silently serving the dense flat \
+                 weights for every tier and making per-tier delete meaningless again"
             );
 
-            // The three tiers must share ONE repo+revision+file predicate (the overlap invariant).
             let downloads = model["downloads"]
                 .as_array()
                 .unwrap_or_else(|| panic!("{id} has a downloads array"));
+            let tier_rows: Vec<&serde_json::Value> = downloads
+                .iter()
+                .filter(|d| d.get("coRequisite").and_then(serde_json::Value::as_bool) != Some(true))
+                .collect();
+            let co_reqs: Vec<&serde_json::Value> = downloads
+                .iter()
+                .filter(|d| d.get("coRequisite").and_then(serde_json::Value::as_bool) == Some(true))
+                .collect();
+            assert_eq!(
+                tier_rows.len(),
+                3,
+                "{id} declares exactly the q4/q8/bf16 tiers"
+            );
+            assert_eq!(
+                co_reqs.len(),
+                6,
+                "{id} declares the shared text_encoder + vae at each of the three tiers"
+            );
+
             let tier_of = |variant: &str| {
-                downloads
+                *tier_rows
                     .iter()
                     .find(|d| {
                         d["variant"]
@@ -1146,11 +1174,6 @@ mod tests {
             };
             let (q4, q8, bf16) = (tier_of("q4"), tier_of("q8"), tier_of("bf16"));
             assert_eq!(
-                downloads.len(),
-                3,
-                "{id} declares exactly the q4/q8/bf16 tiers (no co-requisites today)"
-            );
-            assert_eq!(
                 q4["default"].as_bool(),
                 Some(true),
                 "{id} q4 is the default install tier"
@@ -1159,45 +1182,140 @@ mod tests {
                 q8["default"].as_bool() != Some(true) && bf16["default"].as_bool() != Some(true),
                 "{id} marks only one default tier"
             );
-            for field in ["repo", "revision", "files"] {
+
+            // THE inverted invariant. Under load-time quant the three tiers had to share one file
+            // predicate so a per-tier delete could not corrupt the shared snapshot. Now they must
+            // NOT: each tier owns a disjoint `<tier>/*` subtree, which is exactly what lets a tier
+            // delete reclaim real bytes while the siblings survive. Identical predicates here would
+            // mean the re-host silently regressed to zero-byte tier deletes.
+            for (name, tier) in [("q4", q4), ("q8", q8), ("bf16", bf16)] {
+                let files: Vec<&str> = tier["files"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{id} {name} declares a files predicate"))
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .collect();
                 assert_eq!(
-                    q4[field], q8[field],
-                    "{id} q4 and q8 must share an identical {field} (load-time quant overlap invariant)"
+                    files,
+                    vec![format!("{name}/*")],
+                    "{id} {name} must fetch ONLY its own tier subtree"
                 );
-                assert_eq!(
-                    q4[field], bf16[field],
-                    "{id} q4 and bf16 must share an identical {field} (load-time quant overlap invariant)"
-                );
+                // Fetching the flat dense tree would defeat the whole re-host: the tier download
+                // would pull all 17.5 GB again. The dense root stays HOSTED for existing installs,
+                // but no tier may reference it.
+                for legacy in [
+                    "transformer/*",
+                    "text_encoder/*",
+                    "vae/*",
+                    "model_index.json",
+                ] {
+                    assert!(
+                        !files.contains(&legacy),
+                        "{id} {name} must not fetch the flat dense {legacy}"
+                    );
+                }
             }
-            // The shared predicate is the COMPLETE flat diffusers snapshot the mlx_mage adapter loads
-            // (required_components: &[] — it reads the whole dir, so every component must be fetched).
-            let files: Vec<&str> = q4["files"]
-                .as_array()
-                .unwrap_or_else(|| panic!("{id} q4 declares a files predicate"))
-                .iter()
-                .filter_map(serde_json::Value::as_str)
-                .collect();
-            for required in [
-                "model_index.json",
-                "scheduler/*",
-                "text_encoder/*",
-                "transformer/*",
-                "vae/*",
-            ] {
-                assert!(
-                    files.contains(&required),
-                    "{id} must fetch {required} for a complete loadable snapshot; got {files:?}"
-                );
-            }
-            // The mirror lives under our own HF org (never microsoft/*), pinned to an immutable SHA.
+            assert_ne!(
+                q4["files"], q8["files"],
+                "{id} q4 and q8 must own DISJOINT file predicates (physical per-tier reclaim)"
+            );
+            assert_ne!(
+                q4["files"], bf16["files"],
+                "{id} q4 and bf16 must own DISJOINT file predicates (physical per-tier reclaim)"
+            );
+
+            // The mirror lives under our own HF org (never microsoft/*), pinned to an immutable SHA,
+            // and all three tiers come from the SAME variant repo (only the subdir differs).
             let repo = q4["repo"].as_str().unwrap_or_default();
             assert!(
                 repo.starts_with("SceneWorks/Mage-Flow"),
                 "{id} pulls from the SceneWorks org mirror, not upstream; got {repo:?}"
             );
+            for (name, tier) in [("q8", q8), ("bf16", bf16)] {
+                assert_eq!(
+                    tier["repo"].as_str(),
+                    Some(repo),
+                    "{id} {name} ships in the same variant mirror as q4"
+                );
+            }
+            for (name, tier) in [("q4", q4), ("q8", q8), ("bf16", bf16)] {
+                assert!(
+                    tier["revision"].as_str().is_some_and(is_full_sha_revision),
+                    "{id} {name} pins a full 40-hex mirror revision"
+                );
+                // A tier that reported the dense snapshot's size would mis-quote the download by ~3x
+                // and defeat the point of the split, so require a plausible per-tier size.
+                let bytes = tier["estimatedSizeBytes"].as_u64().unwrap_or_default();
+                assert!(
+                    (1..12_000_000_000).contains(&bytes),
+                    "{id} {name} must declare its OWN tier size, not the 17.5 GB dense snapshot; \
+                     got {bytes}"
+                );
+            }
+            // Physically distinct means physically SMALLER as the tier drops.
+            let size = |tier: &serde_json::Value| tier["estimatedSizeBytes"].as_u64().unwrap_or(0);
             assert!(
-                q4["revision"].as_str().is_some_and(is_full_sha_revision),
-                "{id} pins a full 40-hex mirror revision"
+                size(q4) < size(q8) && size(q8) < size(bf16),
+                "{id} tier sizes must be strictly ordered q4 < q8 < bf16 — equal sizes would mean \
+                 the tiers are not physically distinct artifacts"
+            );
+
+            // ---- shared components (sc-14979) --------------------------------------------------
+            for component in ["text_encoder", "vae"] {
+                for tier in TIERS {
+                    let row = co_reqs
+                        .iter()
+                        .find(|d| {
+                            d["componentId"].as_str() == Some(component)
+                                && d["variant"]
+                                    .as_str()
+                                    .is_some_and(|v| v.eq_ignore_ascii_case(tier))
+                        })
+                        .unwrap_or_else(|| {
+                            panic!("{id} declares the shared {component} co-requisite for {tier}")
+                        });
+                    assert_eq!(
+                        row["repo"].as_str(),
+                        Some(COMPONENTS_REPO),
+                        "{id} {component}/{tier} resolves from the ONE shared components mirror — a \
+                         per-variant copy would restore the 105 GB six-variant install"
+                    );
+                    assert!(
+                        row["revision"].as_str().is_some_and(is_full_sha_revision),
+                        "{id} {component}/{tier} pins a full 40-hex revision"
+                    );
+                    assert_eq!(
+                        row["subdir"].as_str(),
+                        Some(format!("{tier}/{component}").as_str()),
+                        "{id} {component}/{tier} must address its exact component dir — without \
+                         `subdir` the whole components snapshot is staged and the engine is handed \
+                         the wrong directory"
+                    );
+                    let files: Vec<&str> = row["files"]
+                        .as_array()
+                        .unwrap_or_else(|| panic!("{id} {component}/{tier} declares files"))
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .collect();
+                    assert_eq!(
+                        files,
+                        vec![format!("{tier}/{component}/*")],
+                        "{id} {component}/{tier} fetches only its own tier's component subtree"
+                    );
+                }
+            }
+            // The component ids must be exactly what the mlx_mage descriptor advertises as
+            // `required_components`; a typo resolves to no row and fails the job at load.
+            let mut ids: Vec<&str> = co_reqs
+                .iter()
+                .filter_map(|d| d["componentId"].as_str())
+                .collect();
+            ids.sort_unstable();
+            ids.dedup();
+            assert_eq!(
+                ids,
+                vec!["text_encoder", "vae"],
+                "{id} co-requisites provision exactly the two components mlx_mage requires"
             );
         }
     }

--- a/crates/sceneworks-core/src/mlx_tier_completeness.rs
+++ b/crates/sceneworks-core/src/mlx_tier_completeness.rs
@@ -13,6 +13,42 @@
 
 use std::path::Path;
 
+/// The component names a tier's own `model_index.json` declares, or `None` when it ships none.
+///
+/// A diffusers `model_index.json` maps a component name to a `[library, class]` pair; every other
+/// value is configuration. Keys starting with `_` are metadata (`_class_name`, `_diffusers_version`,
+/// and sc-14980's `_sceneworks_tier` / `_sceneworks_shared_components`) and are never components.
+///
+/// Shared (sc-13513 / sc-14980) so the worker's tier resolver, rust-api's catalog completeness, and
+/// the training-base gate all read a tier's declared component set the same way — a split tier that
+/// ships only the components it owns must look identical to all three.
+pub fn tier_declared_components(dir: &Path) -> Option<Vec<String>> {
+    let raw = std::fs::read_to_string(dir.join("model_index.json")).ok()?;
+    let index: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    Some(
+        index
+            .as_object()?
+            .iter()
+            .filter(|(key, value)| !key.starts_with('_') && is_component_entry(value))
+            .map(|(key, _)| key.clone())
+            .collect(),
+    )
+}
+
+/// Whether a `model_index.json` value names a COMPONENT — the diffusers `[library, class]` pair.
+///
+/// Three things in a real index are NOT components, and all three must be rejected here (each is
+/// live in a shipping turnkey, so a laxer test fails a good tier):
+/// - `[null, null]` marks an ABSENT optional component — `SceneWorks/realvisxl-mlx` declares
+///   `feature_extractor` and `image_encoder` this way and ships neither dir.
+/// - config arrays — `SceneWorks/krea-2-raw-mlx` declares `text_encoder_select_layers: [2, 5, 8, …]`.
+/// - config scalars — krea's `patch_size: 2`, realvisxl's `force_zeros_for_empty_prompt: true`.
+fn is_component_entry(value: &serde_json::Value) -> bool {
+    value
+        .as_array()
+        .is_some_and(|pair| pair.len() == 2 && pair.iter().all(serde_json::Value::is_string))
+}
+
 /// Whether `dir` holds at least one non-hidden file whose name ends with `suffix` (e.g. `.safetensors`
 /// / `.index.json`). The building block for the per-family completeness checks: a hidden AppleDouble
 /// `._*` sidecar never counts (SceneWorks#1333).

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -34,7 +34,7 @@ nix = { version = "0.29", default-features = false, features = ["process", "sign
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "6147a596be2739f6c4f76644fe901dc28a7e00c7" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "d1b8668463971ff62f5971400071bdc9914558d3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -84,13 +84,13 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # against 35+ minutes on CPU for a single 3 s clip. The nearest-upsample-vocoder providers (Kokoro,
 # Chatterbox) are auto-routed back to CPU inside the lane, because candle-core's Metal backend lacks
 # upsample_nearest1d (sc-13691) — so enabling this stays correct instead of crashing them.
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "6147a596be2739f6c4f76644fe901dc28a7e00c7", features = ["audio-metal"] }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "d1b8668463971ff62f5971400071bdc9914558d3", features = ["audio-metal"] }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "6147a596be2739f6c4f76644fe901dc28a7e00c7", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "d1b8668463971ff62f5971400071bdc9914558d3", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2673,24 +2673,27 @@ fn attach_required_components(
         &descriptor,
         &manifest_value,
         settings,
-        tier.as_deref(),
+        tier,
     )?;
     Ok(components
         .into_iter()
         .fold(spec, |spec, (id, source)| spec.with_component(id, source)))
 }
 
-/// The tier a [`LoadSpec`]'s weights dir resolved to, when it is a standard `<tier>/` subdir.
+/// The tier a [`LoadSpec`]'s weights dir resolved to, for matching a per-tier `coRequisite`'s
+/// `variant` (sc-14980).
 ///
-/// `None` for a flat snapshot (whose final segment is a commit sha, not a tier), which is what keeps
-/// single-row co-requisites — every audio model, and Mage on a legacy flat install — on the
-/// tier-agnostic path.
-fn resolved_tier_name(spec: &LoadSpec) -> Option<String> {
+/// Delegates to [`tier_key_from_resolved_dir`] — the established "what tier is this dir" answer, so
+/// the co-requisite lookup cannot drift from the tier the backbone actually loads at. `None` for a
+/// flat snapshot (whose final segment is a commit sha), which keeps single-row co-requisites — every
+/// audio model, and Mage on a legacy flat install — on the tier-agnostic path. A `None` here against
+/// a model that DOES declare per-tier rows is refused loudly by `resolve_co_requisites_for_tier`
+/// rather than guessed, so an unrecognized layout can never silently pair mismatched weights.
+fn resolved_tier_name(spec: &LoadSpec) -> Option<&'static str> {
     let WeightsSource::Dir(dir) = &spec.weights else {
         return None;
     };
-    let name = dir.file_name()?.to_str()?;
-    matches!(name, "bf16" | "q8" | "q4" | "nvfp4").then(|| name.to_owned())
+    tier_key_from_resolved_dir(dir)
 }
 
 /// Resolve SDXL's three caller-staged components (`tokenizer_clip_l` / `tokenizer_clip_bigg` /

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -513,23 +513,13 @@ impl CandleImageRoute {
             CandleImageRoute::QwenControl => qwen_control::QWEN_CONTROL_ENGINE,
             CandleImageRoute::KolorsControl => kolors_control::KOLORS_CONTROL_ENGINE,
             CandleImageRoute::ZimageControl => zimage_control::ZIMAGE_CTRL_ENGINE,
-            CandleImageRoute::Flux2Control => {
-                flux2_control_candle::FLUX2_CONTROL_CANDLE_ENGINE
-            }
-            CandleImageRoute::Flux1Control => {
-                flux1_control_candle::FLUX1_CONTROL_CANDLE_ENGINE
-            }
+            CandleImageRoute::Flux2Control => flux2_control_candle::FLUX2_CONTROL_CANDLE_ENGINE,
+            CandleImageRoute::Flux1Control => flux1_control_candle::FLUX1_CONTROL_CANDLE_ENGINE,
             CandleImageRoute::KreaControl => krea_control_candle::KREA_CONTROL_ENGINE,
             CandleImageRoute::PoseReject | CandleImageRoute::PoseControlBaseMissing => STUB_ADAPTER,
-            CandleImageRoute::ZimageComfyui => {
-                zimage_comfyui_candle::ZIMAGE_COMFYUI_CANDLE_ENGINE
-            }
-            CandleImageRoute::QwenImageComfyui => {
-                qwen_comfyui_candle::QWEN_COMFYUI_CANDLE_ENGINE
-            }
-            CandleImageRoute::Flux2Comfyui => {
-                flux2_comfyui_candle::FLUX2_COMFYUI_CANDLE_ENGINE
-            }
+            CandleImageRoute::ZimageComfyui => zimage_comfyui_candle::ZIMAGE_COMFYUI_CANDLE_ENGINE,
+            CandleImageRoute::QwenImageComfyui => qwen_comfyui_candle::QWEN_COMFYUI_CANDLE_ENGINE,
+            CandleImageRoute::Flux2Comfyui => flux2_comfyui_candle::FLUX2_COMFYUI_CANDLE_ENGINE,
             CandleImageRoute::Bernini => CANDLE_BERNINI_IMAGE_ADAPTER,
             CandleImageRoute::MageEdit | CandleImageRoute::CandleTxt2Img => {
                 candle_adapter_label(&request.model)
@@ -788,19 +778,21 @@ fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
 /// intentionally excluded because each repo resolves its own receipt independently.
 #[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn requested_receipt_variant(request: &ImageRequest) -> Option<String> {
-    if let Some(bits) = request
-        .advanced
-        .get("mlxQuantize")
-        .and_then(|value| value.as_i64().or_else(|| value.as_str()?.trim().parse().ok()))
-    {
-        return Some(if bits <= 0 {
-            "bf16"
-        } else if bits > 4 {
-            "q8"
-        } else {
-            "q4"
-        }
-        .to_owned());
+    if let Some(bits) = request.advanced.get("mlxQuantize").and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_str()?.trim().parse().ok())
+    }) {
+        return Some(
+            if bits <= 0 {
+                "bf16"
+            } else if bits > 4 {
+                "q8"
+            } else {
+                "q4"
+            }
+            .to_owned(),
+        );
     }
     let selectable = request
         .model_manifest_entry
@@ -851,11 +843,7 @@ const IDEOGRAM_MLX_TURNKEY_REVISION: &str = "a3095855b8819dc0d6b067cb1354aaa7da1
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn turnkey_tier_revision<'a>(
-    repo: &str,
-    default_repo: &str,
-    default_revision: &'a str,
-) -> &'a str {
+fn turnkey_tier_revision<'a>(repo: &str, default_repo: &str, default_revision: &'a str) -> &'a str {
     if repo == default_repo {
         default_revision
     } else {
@@ -877,8 +865,7 @@ fn pinned_turnkey_snapshot_for_request(
     if repo != default_repo {
         return None;
     }
-    let root =
-        crate::model_jobs::huggingface_pinned_snapshot_dir(data_dir, repo, revision)?;
+    let root = crate::model_jobs::huggingface_pinned_snapshot_dir(data_dir, repo, revision)?;
     let selected = match request.model.as_str() {
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => {
             boogu_model_subdir(&root, request)
@@ -987,9 +974,9 @@ pub(crate) fn resolve_weights_dir(
     // all load inputs on the receipt side of the all-receipt-or-all-current boundary.
     if !has_pinned_turnkey_snapshot
         && receipt_snapshot
-        .as_deref()
-        .and_then(tier_key_from_resolved_dir)
-        .is_some()
+            .as_deref()
+            .and_then(tier_key_from_resolved_dir)
+            .is_some()
     {
         return Ok(receipt_snapshot);
     }
@@ -1254,7 +1241,12 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
                 entries
                     .flatten()
                     .filter(|entry| !sceneworks_core::lora_family::is_hidden_file(&entry.path()))
-                    .any(|entry| entry.file_name().to_string_lossy().ends_with(".safetensors"))
+                    .any(|entry| {
+                        entry
+                            .file_name()
+                            .to_string_lossy()
+                            .ends_with(".safetensors")
+                    })
             })
             .unwrap_or(false);
         has_dit.then_some(dir)
@@ -1282,7 +1274,7 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         &present,
         &sceneworks_core::mlx_tier_completeness::anima_tier_complete,
     )
-        .unwrap_or_else(|| root.to_path_buf())
+    .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// The candle off-Mac Anima weights dir (sc-10676): the `split_files/` subdir of the HF snapshot `root`
@@ -1443,7 +1435,7 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         &present,
         &sceneworks_core::mlx_tier_completeness::boogu_tier_complete,
     )
-        .unwrap_or_else(|| root.to_path_buf())
+    .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// Pick the engine-complete packed subdir of a Krea 2 Turbo turnkey `root`: `q4/` when the request opts
@@ -1508,8 +1500,12 @@ fn krea_model_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: bool
     // whose `model_index.json` component tree is fully on disk, so Raw with a torn `q8/` and a
     // complete `bf16/` training-base tier now generates off bf16 instead of dying on the absent
     // `q8/tokenizer/` (issue #850's symptom).
-    pick_loadable_tier(&[preferred, "q8", "q4", "bf16"], &present, &tier_components_present)
-        .unwrap_or_else(|| root.to_path_buf())
+    pick_loadable_tier(
+        &[preferred, "q8", "q4", "bf16"],
+        &present,
+        &tier_components_present,
+    )
+    .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// The private HF repo hosting the Krea 2 INT8-ConvRot DiT single-file checkpoint (sc-9300, epic
@@ -1548,10 +1544,7 @@ fn wants_krea_convrot(request: &ImageRequest) -> bool {
 /// is enforced ENGINE-side (`ensure_int8_floor` inside `load_components_convrot`) AND surfaced as the
 /// worker's `int8_convrot` capability, so an ineligible card never reaches here (the picker hides it).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn resolve_krea_convrot(
-    request: &ImageRequest,
-    settings: &Settings,
-) -> Option<(PathBuf, PathBuf)> {
+fn resolve_krea_convrot(request: &ImageRequest, settings: &Settings) -> Option<(PathBuf, PathBuf)> {
     if !wants_krea_convrot(request) {
         return None;
     }
@@ -1710,8 +1703,7 @@ async fn ensure_boogu_tier_present(
             || tier_dir
                 .join("transformer/diffusion_pytorch_model.safetensors.index.json")
                 .is_file()
-    })
-    {
+    }) {
         return Ok(());
     }
     // The tier subfolder nests transformer/mllm/vae (leaf-dir globs, like the catalog Q8 entry).
@@ -1720,11 +1712,10 @@ async fn ensure_boogu_tier_present(
         format!("{tier}/mllm/*"),
         format!("{tier}/vae/*"),
     ];
-    let revision =
-        turnkey_tier_revision(&repo, model.default_repo(), BOOGU_MLX_TURNKEY_REVISION);
+    let revision = turnkey_tier_revision(&repo, model.default_repo(), BOOGU_MLX_TURNKEY_REVISION);
     crate::model_jobs::ensure_hf_files_cached(api, settings, job, &repo, revision, &files)
-    .await
-    .map(|_| ())
+        .await
+        .map(|_| ())
 }
 
 /// On-demand fetch of Ideogram 4's non-default `q8/` tier (sc-9607, epic 9083). The catalog download
@@ -1783,16 +1774,15 @@ async fn ensure_ideogram_tier_present(
         root.join(tier)
             .join("transformer/model.safetensors")
             .is_file()
-    })
-    {
+    }) {
         return Ok(());
     }
     let files = vec![format!("{tier}/*")];
     let revision =
         turnkey_tier_revision(&repo, model.default_repo(), IDEOGRAM_MLX_TURNKEY_REVISION);
     crate::model_jobs::ensure_hf_files_cached(api, settings, job, &repo, revision, &files)
-    .await
-    .map(|_| ())
+        .await
+        .map(|_| ())
 }
 
 #[cfg(any(
@@ -2673,10 +2663,34 @@ fn attach_required_components(
         return Ok(spec);
     }
     let manifest_value = Value::Object(manifest_entry.clone());
-    let components = resolve_co_requisites(&descriptor, &manifest_value, settings)?;
+    // Mage-Flow's shared text encoder / VAE are themselves per-tier (sc-14980), so the co-requisite
+    // must match the tier actually resolved for the BACKBONE — not the tier the request asked for,
+    // which `standard_tier_subdir`'s completeness fallback may have stepped away from. Reading it
+    // back off the resolved weights dir keeps the two in lockstep by construction: a q4 request that
+    // fell back to q8 gets the q8 text encoder, never a mixed pair.
+    let tier = resolved_tier_name(&spec);
+    let components = crate::model_jobs::resolve_co_requisites_for_tier(
+        &descriptor,
+        &manifest_value,
+        settings,
+        tier.as_deref(),
+    )?;
     Ok(components
         .into_iter()
         .fold(spec, |spec, (id, source)| spec.with_component(id, source)))
+}
+
+/// The tier a [`LoadSpec`]'s weights dir resolved to, when it is a standard `<tier>/` subdir.
+///
+/// `None` for a flat snapshot (whose final segment is a commit sha, not a tier), which is what keeps
+/// single-row co-requisites — every audio model, and Mage on a legacy flat install — on the
+/// tier-agnostic path.
+fn resolved_tier_name(spec: &LoadSpec) -> Option<String> {
+    let WeightsSource::Dir(dir) = &spec.weights else {
+        return None;
+    };
+    let name = dir.file_name()?.to_str()?;
+    matches!(name, "bf16" | "q8" | "q4" | "nvfp4").then(|| name.to_owned())
 }
 
 /// Resolve SDXL's three caller-staged components (`tokenizer_clip_l` / `tokenizer_clip_bigg` /
@@ -2908,7 +2922,11 @@ pub(crate) fn read_advanced_sampling_knobs(
     let scheduler_shift = advanced
         .get("schedulerShift")
         .or_else(|| advanced.get("timestepShift"))
-        .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
+        .and_then(|value| {
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+        })
         .map(|value| value as f32);
     (name("sampler"), name("scheduler"), scheduler_shift)
 }
@@ -2999,7 +3017,8 @@ mod metrics_settings_tests {
                 "usePid": true, "pidTarget": "2k", "guidanceMethod": "cfgpp"
             }
         }));
-        let metrics = image_settings_metrics(&req, Some(30), None, Some("bf16".to_owned()), None, 1);
+        let metrics =
+            image_settings_metrics(&req, Some(30), None, Some("bf16".to_owned()), None, 1);
         assert_eq!(metrics.sampler.as_deref(), Some("dpmpp_2m"));
         assert_eq!(metrics.scheduler.as_deref(), Some("karras"));
         assert_eq!(
@@ -3104,9 +3123,14 @@ mod sampling_knob_tests {
     // engine default = the guaranteed no-op), exactly like the sampler/scheduler read.
     #[test]
     fn read_guidance_method_strips_default_and_blank() {
-        assert_eq!(read_advanced_guidance_method(&advanced(serde_json::json!({}))), None);
         assert_eq!(
-            read_advanced_guidance_method(&advanced(serde_json::json!({"guidanceMethod": "default"}))),
+            read_advanced_guidance_method(&advanced(serde_json::json!({}))),
+            None
+        );
+        assert_eq!(
+            read_advanced_guidance_method(&advanced(
+                serde_json::json!({"guidanceMethod": "default"})
+            )),
             None
         );
         assert_eq!(
@@ -3114,7 +3138,9 @@ mod sampling_knob_tests {
             None
         );
         assert_eq!(
-            read_advanced_guidance_method(&advanced(serde_json::json!({"guidanceMethod": "cfg_pp"}))),
+            read_advanced_guidance_method(&advanced(
+                serde_json::json!({"guidanceMethod": "cfg_pp"})
+            )),
             Some("cfg_pp".to_owned())
         );
     }
@@ -3143,7 +3169,9 @@ mod sampling_knob_tests {
         );
         // Blank / whitespace-only names are also treated as the default (no name).
         assert_eq!(
-            read_advanced_sampling_knobs(&advanced(serde_json::json!({"sampler": "  ", "scheduler": ""}))),
+            read_advanced_sampling_knobs(&advanced(
+                serde_json::json!({"sampler": "  ", "scheduler": ""})
+            )),
             (None, None, None)
         );
     }
@@ -3564,7 +3592,12 @@ pub(crate) fn resolve_control_identity_source(
         .map(str::trim)
         .filter(|id| !id.is_empty())?
         .to_owned();
-    match load_reference_image(&settings.data_dir, &request.project_id, &asset_id, project_path) {
+    match load_reference_image(
+        &settings.data_dir,
+        &request.project_id,
+        &asset_id,
+        project_path,
+    ) {
         Ok(image) => Some((image, asset_id)),
         Err(error) => {
             tracing::warn!(
@@ -3756,7 +3789,8 @@ fn resolve_boogu_edit(
     let ids = boogu_edit_reference_ids(request);
     let mut references = Vec::with_capacity(ids.len());
     for id in &ids {
-        let source = load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
+        let source =
+            load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
         let source = fit_engine_image(source, request.width, request.height, &request.fit_mode)?;
         references.push(source);
     }
@@ -3775,7 +3809,8 @@ fn resolve_mage_edit(
     let ids = mage_edit_reference_ids(request);
     let mut references = Vec::with_capacity(ids.len());
     for id in &ids {
-        let source = load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
+        let source =
+            load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
         references.push(fit_engine_image(
             source,
             request.width,
@@ -4715,9 +4750,7 @@ fn vram_reject_tail(installed_smaller: &[&str]) -> String {
 fn vram_reject_tail_for_tier(installed: Vec<&'static str>, rejected_tier: &str) -> String {
     let smaller: Vec<&'static str> = installed
         .into_iter()
-        .filter(|candidate| {
-            tier_quality_rank(candidate) < tier_quality_rank(rejected_tier)
-        })
+        .filter(|candidate| tier_quality_rank(candidate) < tier_quality_rank(rejected_tier))
         .collect();
     vram_reject_tail(&smaller)
 }
@@ -4739,14 +4772,13 @@ fn candle_tier_fit(
         crate::vram_gate::fit_decision(needed, budget),
         sequential_capable,
     ) {
-        crate::vram_gate::FitDecision::Fits | crate::vram_gate::FitDecision::Unknown => TierFit::Fits,
-        crate::vram_gate::FitDecision::Offload {
-            available_gb, ..
-        } => {
+        crate::vram_gate::FitDecision::Fits | crate::vram_gate::FitDecision::Unknown => {
+            TierFit::Fits
+        }
+        crate::vram_gate::FitDecision::Offload { available_gb, .. } => {
             // Resident won't fit but the provider stages — fits only if the MEASURED sequential peak
             // fits (unmeasured ⇒ best-effort run, so `sequential_overflow_gb` yields None ⇒ Fits).
-            let seq_needed =
-                crate::vram_gate::predicted_sequential_peak_gb(manifest_entry, tier);
+            let seq_needed = crate::vram_gate::predicted_sequential_peak_gb(manifest_entry, tier);
             match crate::vram_gate::sequential_overflow_gb(seq_needed, budget) {
                 Some(seq_gb) => TierFit::TooBig {
                     needed_gb: seq_gb,
@@ -4991,7 +5023,9 @@ async fn generate_candle_stream(
     let adapter_count = adapters.len();
 
     let count = request.count as usize;
-    let seeds: Vec<i64> = (0..count).map(|index| resolve_seed(request, index)).collect();
+    let seeds: Vec<i64> = (0..count)
+        .map(|index| resolve_seed(request, index))
+        .collect();
     // Ideogram 4 (epic 4725, sc-6501) is JSON-caption-only: a raw plain-text prompt is out-of-
     // distribution and stochastically renders the "Image blocked by safety filter" placeholder. Wrap a
     // non-caption prompt into a minimal valid caption — the same worker-side guarantee the macOS path
@@ -5101,7 +5135,8 @@ async fn generate_candle_stream(
     // sc-9092) — the same `model_repo` the MLX path records.
     let repo = model_repo(request, &model);
     // `mut`: rebuilt with the corrected `quant_bits` if the sc-10733 downtier lands on a lower tier.
-    let mut raw_settings = mlx_raw_settings(request, &repo, steps, quant_bits, guidance.or(true_cfg));
+    let mut raw_settings =
+        mlx_raw_settings(request, &repo, steps, quant_bits, guidance.or(true_cfg));
     // Per-generation PiD decode (epic 7840): resolve the PiD checkpoint + Gemma for this model's latent
     // space when `advanced.usePid` is set and the snapshots are cached; otherwise keep the native VAE.
     // `use_pid` and `spec.pid` stay in lockstep (the engine rejects a mismatch). Every candle image
@@ -5317,13 +5352,10 @@ async fn generate_candle_stream(
                 needed_gb,
                 available_gb,
             } => {
-                let installed_smaller: Vec<&'static str> =
-                    installed_tier_keys(request, settings)
-                        .into_iter()
-                        .filter(|candidate| {
-                            tier_quality_rank(candidate) < tier_quality_rank(tier)
-                        })
-                        .collect();
+                let installed_smaller: Vec<&'static str> = installed_tier_keys(request, settings)
+                    .into_iter()
+                    .filter(|candidate| tier_quality_rank(candidate) < tier_quality_rank(tier))
+                    .collect();
                 return Err(WorkerError::InvalidPayload(format!(
                     "{model} at the {tier} tier needs ~{needed} GB of VRAM (with headroom) but GPU \
                      {gpu} has ~{available} GB available. {tail}",
@@ -5507,7 +5539,11 @@ fn image_settings_metrics(
     };
     let number_field = |key: &str| -> Option<serde_json::Number> {
         adv.get(key)
-            .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
+            .and_then(|value| {
+                value
+                    .as_f64()
+                    .or_else(|| value.as_str()?.trim().parse().ok())
+            })
             .and_then(serde_json::Number::from_f64)
     };
     let loras: Vec<String> = request.loras.iter().filter_map(lora_label).collect();
@@ -5526,7 +5562,10 @@ fn image_settings_metrics(
         true_cfg_scale: number_field("trueCfgScale"),
         guidance_method: string_or("guidanceMethod", "cfg"),
         use_pid: Some(adv.get("usePid").and_then(Value::as_bool).unwrap_or(false)),
-        pid_target: adv.get("pidTarget").and_then(Value::as_str).map(str::to_owned),
+        pid_target: adv
+            .get("pidTarget")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
         width: Some(request.width),
         height: Some(request.height),
         seed: request.seed.or_else(|| request.seeds.first().copied()),
@@ -6077,8 +6116,14 @@ mod candle_label_tests {
     fn vram_reject_tail_names_only_installed_smaller_tiers() {
         // Two smaller tiers installed → both offered, uppercased, highest-fidelity first.
         let tail = vram_reject_tail(&["q8", "q4"]);
-        assert!(tail.contains("Q8 / Q4"), "lists installed smaller tiers: {tail}");
-        assert!(!tail.contains("picker"), "never points at the picker: {tail}");
+        assert!(
+            tail.contains("Q8 / Q4"),
+            "lists installed smaller tiers: {tail}"
+        );
+        assert!(
+            !tail.contains("picker"),
+            "never points at the picker: {tail}"
+        );
         // One smaller tier installed.
         assert!(vram_reject_tail(&["q4"]).contains("(Q4)"));
         // None smaller installed (the single-tier / q4-only case) → says so, no tier list, no picker.
@@ -6098,9 +6143,18 @@ mod boogu_tier_tests {
         // download). 1..=4 → packed q4; <=0 → dense bf16. Consistent with krea/ideogram (sc-8513).
         assert_eq!(boogu_tier_subdir("base", None), None);
         assert_eq!(boogu_tier_subdir("base", Some(8)), None);
-        assert_eq!(boogu_tier_subdir("base", Some(4)), Some("base-q4".to_owned()));
-        assert_eq!(boogu_tier_subdir("turbo", Some(2)), Some("turbo-q4".to_owned()));
-        assert_eq!(boogu_tier_subdir("edit", Some(0)), Some("edit-bf16".to_owned()));
+        assert_eq!(
+            boogu_tier_subdir("base", Some(4)),
+            Some("base-q4".to_owned())
+        );
+        assert_eq!(
+            boogu_tier_subdir("turbo", Some(2)),
+            Some("turbo-q4".to_owned())
+        );
+        assert_eq!(
+            boogu_tier_subdir("edit", Some(0)),
+            Some("edit-bf16".to_owned())
+        );
         assert_eq!(
             boogu_tier_subdir("base", Some(-1)),
             Some("base-bf16".to_owned())
@@ -6249,7 +6303,11 @@ mod standard_tier_tests {
         // Packed q4/q8 single-file + dense sharded bf16 (only the index.json shape).
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+        seed_tier(
+            root,
+            "bf16",
+            "diffusion_pytorch_model.safetensors.index.json",
+        );
 
         // No selection → q8 default (epic 10721 / sc-10726), clamped to installed.
         assert_eq!(
@@ -6679,12 +6737,16 @@ mod standard_tier_tests {
     fn nvfp4_requested_reads_only_the_explicit_quant_tier_label() {
         // The explicit label, tolerant of surrounding whitespace / casing like the sibling parsers.
         assert!(nvfp4_requested(&request(json!({ "quantTier": "nvfp4" }))));
-        assert!(nvfp4_requested(&request(json!({ "quantTier": "  nvfp4 " }))));
+        assert!(nvfp4_requested(&request(
+            json!({ "quantTier": "  nvfp4 " })
+        )));
         assert!(nvfp4_requested(&request(json!({ "quantTier": "NVFP4" }))));
         // Nothing else asks for NVFP4: no label, another tier's label, a non-string, or ANY bits value.
         assert!(!nvfp4_requested(&request(json!({}))));
         assert!(!nvfp4_requested(&request(json!({ "quantTier": "q4" }))));
-        assert!(!nvfp4_requested(&request(json!({ "quantTier": "int8-convrot" }))));
+        assert!(!nvfp4_requested(&request(
+            json!({ "quantTier": "int8-convrot" })
+        )));
         assert!(!nvfp4_requested(&request(json!({ "quantTier": 4 }))));
         assert!(!nvfp4_requested(&request(json!({ "quantTier": true }))));
         for bits in [0, 4, 8] {
@@ -6704,7 +6766,11 @@ mod standard_tier_tests {
         let root = tmp.path();
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+        seed_tier(
+            root,
+            "bf16",
+            "diffusion_pytorch_model.safetensors.index.json",
+        );
         seed_tier(root, NVFP4_TIER, "diffusion_pytorch_model.safetensors");
 
         // The injected `true` says "the HOST is Blackwell-eligible" — the hardware gate is ON, but no
@@ -6745,7 +6811,10 @@ mod standard_tier_tests {
         );
         // NOT Blackwell (pre-sm_120 NVIDIA, macOS/MLX, or the neither build) → the label is ignored and
         // the request lands on an installed tier via the normal chain. A clean fallback, not an error.
-        assert_eq!(standard_tier_subdir_gated(root, &picked, false), root.join("q8"));
+        assert_eq!(
+            standard_tier_subdir_gated(root, &picked, false),
+            root.join("q8")
+        );
 
         // sm_120 but the tier ISN'T converted yet (sc-11043 owns the converter; the shipping case today)
         // → rejoins the same clean chain rather than failing the load.
@@ -6880,7 +6949,11 @@ mod standard_tier_tests {
         // The carve-out is not a general NVFP4 kill-switch: a NON-dense-TE model on the same terms
         // still selects the tier, so the fix can't be masking the arm entirely.
         assert_eq!(
-            resolve_quant_gated(&request(json!({ "quantTier": "nvfp4" })), true, Some(&nvfp4_dir)),
+            resolve_quant_gated(
+                &request(json!({ "quantTier": "nvfp4" })),
+                true,
+                Some(&nvfp4_dir)
+            ),
             (Some(Quant::Nvfp4), None)
         );
     }
@@ -6995,7 +7068,11 @@ mod standard_tier_tests {
         // Same host, same request, but the tier IS installed → the label is nvfp4. This is what proves
         // the fix pins the label to the DISK and isn't just disabling the tier.
         let converted = tempfile::tempdir().unwrap();
-        seed_tier(converted.path(), "q8", "diffusion_pytorch_model.safetensors");
+        seed_tier(
+            converted.path(),
+            "q8",
+            "diffusion_pytorch_model.safetensors",
+        );
         seed_tier(
             converted.path(),
             NVFP4_TIER,
@@ -7053,7 +7130,10 @@ mod standard_tier_tests {
             root.join(NVFP4_TIER)
         );
         // Off Blackwell → clean fallback to the shipped q8 default.
-        assert_eq!(krea_model_subdir_gated(root, &picked, false), root.join("q8"));
+        assert_eq!(
+            krea_model_subdir_gated(root, &picked, false),
+            root.join("q8")
+        );
         // SC#5: krea's existing tiers resolve exactly as before on a Blackwell host with an `nvfp4/`
         // dir present.
         for (advanced, expected) in [
@@ -7083,7 +7163,10 @@ mod standard_tier_tests {
             min_quality_floor(&with_floor(json!({ "minQualityTier": "q8" }))),
             Some("q8")
         );
-        assert_eq!(min_quality_floor(&with_floor(json!({ "quantize": 4 }))), None);
+        assert_eq!(
+            min_quality_floor(&with_floor(json!({ "quantize": 4 }))),
+            None
+        );
         assert_eq!(
             min_quality_floor(&with_floor(json!({ "minQualityTier": "q2" }))),
             None
@@ -7338,7 +7421,11 @@ mod standard_tier_tests {
                 .unwrap(),
         );
         let tier = standard_tier_subdir(&root, &req);
-        assert_eq!(tier, root.join("q4"), "worker must resolve the q4 tier subdir");
+        assert_eq!(
+            tier,
+            root.join("q4"),
+            "worker must resolve the q4 tier subdir"
+        );
         assert!(
             tier.join("model_index.json").is_file() && tier.join("unet").is_dir(),
             "q4 tier subdir missing turnkey layout (model_index.json + unet/): {}",
@@ -7348,7 +7435,8 @@ mod standard_tier_tests {
         // Load the packed q4 tier through the MLX `sdxl` engine (Quant::Q4 = harmless no-op on the
         // already-packed weights) and render a 768x768 image.
         let spec = LoadSpec::new(WeightsSource::Dir(tier.clone())).with_quant(Quant::Q4);
-        let generator = crate::inference_runtime::load("sdxl", &spec).expect("load MLX sdxl provider on q4 tier");
+        let generator = crate::inference_runtime::load("sdxl", &spec)
+            .expect("load MLX sdxl provider on q4 tier");
         let gen_req = GenerationRequest {
             prompt: "a photorealistic portrait of a red fox in a snowy forest, golden hour"
                 .to_owned(),
@@ -7371,9 +7459,21 @@ mod standard_tier_tests {
         let n = image.pixels.len() as f64;
         assert!(n > 0.0, "empty image buffer");
         let mean = image.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
-        let std = (image.pixels.iter().map(|&p| (p as f64 - mean).powi(2)).sum::<f64>() / n).sqrt();
-        println!("[sc-8746 smoke] realvisxl q4 tier render {}x{} std {std:.2}", image.width, image.height);
-        assert!(std > 5.0, "render looks degenerate (std {std:.2}) — possible NaN / all-black decode");
+        let std = (image
+            .pixels
+            .iter()
+            .map(|&p| (p as f64 - mean).powi(2))
+            .sum::<f64>()
+            / n)
+            .sqrt();
+        println!(
+            "[sc-8746 smoke] realvisxl q4 tier render {}x{} std {std:.2}",
+            image.width, image.height
+        );
+        assert!(
+            std > 5.0,
+            "render looks degenerate (std {std:.2}) — possible NaN / all-black decode"
+        );
     }
 
     /// A model built with a manifest entry so `uses_standard_tier_layout` / `is_dense_te_tier`
@@ -7415,7 +7515,10 @@ mod standard_tier_tests {
     #[cfg(any(target_os = "macos", feature = "backend-candle"))]
     #[test]
     fn dense_te_tier_is_manifest_driven_with_registry_backcompat() {
-        assert!(is_dense_te_tier(&manifest_request("flux2_klein_9b", json!({}))));
+        assert!(is_dense_te_tier(&manifest_request(
+            "flux2_klein_9b",
+            json!({})
+        )));
         assert!(is_dense_te_tier(&manifest_request(
             "some_dense_te_model",
             json!({ "denseTextEncoderTier": true })
@@ -7488,7 +7591,11 @@ mod standard_tier_tests {
         // Krea turnkey: packed q4/q8 single-file transformer + dense sharded bf16 (index.json only).
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+        seed_tier(
+            root,
+            "bf16",
+            "diffusion_pytorch_model.safetensors.index.json",
+        );
 
         // q8-default (no selection) / q4 (bits<=4) / bf16 (bits<=0) each resolve to their tier subdir.
         assert_eq!(
@@ -7535,7 +7642,10 @@ mod standard_tier_tests {
         index.insert("patch_size".to_owned(), json!(2));
         index.insert("feature_extractor".to_owned(), json!([null, null]));
         for component in declared {
-            index.insert((*component).to_owned(), json!(["transformers", "SomeClass"]));
+            index.insert(
+                (*component).to_owned(),
+                json!(["transformers", "SomeClass"]),
+            );
         }
         std::fs::write(
             dir.join("model_index.json"),
@@ -7550,7 +7660,13 @@ mod standard_tier_tests {
     }
 
     /// The Krea tier component set, as the real `q8/model_index.json` declares it.
-    const KREA_COMPONENTS: &[&str] = &["transformer", "tokenizer", "text_encoder", "vae", "scheduler"];
+    const KREA_COMPONENTS: &[&str] = &[
+        "transformer",
+        "tokenizer",
+        "text_encoder",
+        "vae",
+        "scheduler",
+    ];
 
     /// sc-12279 (issue #850): a TORN tier — backbone landed, `tokenizer/` did not — must not
     /// short-circuit the fallback chain. Before this, `present()` accepted a tier on its transformer
@@ -7600,7 +7716,9 @@ mod standard_tier_tests {
     #[test]
     fn krea_tier_probe_still_returns_a_torn_tier_when_it_is_all_there_is() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "krea_2_raw", "advanced": {} }).as_object().unwrap(),
+            json!({ "model": "krea_2_raw", "advanced": {} })
+                .as_object()
+                .unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         seed_diffusers_tier(
@@ -7636,7 +7754,12 @@ mod standard_tier_tests {
         assert!(tier_components_present(&root.join("q8")));
 
         // Torn: `tokenizer/` declared but absent.
-        seed_diffusers_tier(root, "q4", KREA_COMPONENTS, &["text_encoder", "vae", "scheduler"]);
+        seed_diffusers_tier(
+            root,
+            "q4",
+            KREA_COMPONENTS,
+            &["text_encoder", "vae", "scheduler"],
+        );
         assert!(!tier_components_present(&root.join("q4")));
 
         // A component dir holding ONLY an AppleDouble sidecar has no tokenizer (SceneWorks#1333).
@@ -7669,7 +7792,11 @@ mod standard_tier_tests {
     fn seed_sana_tier(root: &Path, tier: &str, complete: bool) {
         let dir = root.join(tier);
         std::fs::create_dir_all(dir.join("transformer")).unwrap();
-        std::fs::write(dir.join("transformer/diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        std::fs::write(
+            dir.join("transformer/diffusion_pytorch_model.safetensors"),
+            b"x",
+        )
+        .unwrap();
         if complete {
             std::fs::create_dir_all(dir.join("vae")).unwrap();
             std::fs::write(dir.join("vae/diffusion_pytorch_model.safetensors"), b"x").unwrap();
@@ -7713,7 +7840,9 @@ mod standard_tier_tests {
     #[test]
     fn sana_torn_tier_is_returned_when_it_is_all_there_is() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "sana_1600m", "advanced": {} }).as_object().unwrap(),
+            json!({ "model": "sana_1600m", "advanced": {} })
+                .as_object()
+                .unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         seed_sana_tier(tmp.path(), "q8", false);
@@ -7729,7 +7858,9 @@ mod standard_tier_tests {
     #[test]
     fn non_sana_standard_turnkey_ignores_the_sana_completeness_branch() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "flux_dev", "advanced": {} }).as_object().unwrap(),
+            json!({ "model": "flux_dev", "advanced": {} })
+                .as_object()
+                .unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -7744,7 +7875,11 @@ mod standard_tier_tests {
     fn seed_boogu_tier(root: &Path, folder: &str, complete: bool) {
         let dir = root.join(folder);
         std::fs::create_dir_all(dir.join("transformer")).unwrap();
-        std::fs::write(dir.join("transformer/diffusion_pytorch_model.safetensors"), b"x").unwrap();
+        std::fs::write(
+            dir.join("transformer/diffusion_pytorch_model.safetensors"),
+            b"x",
+        )
+        .unwrap();
         std::fs::write(dir.join("transformer/config.json"), b"{}").unwrap();
         if complete {
             std::fs::create_dir_all(dir.join("mllm")).unwrap();
@@ -7760,7 +7895,9 @@ mod standard_tier_tests {
     #[test]
     fn boogu_torn_tier_falls_through_to_a_complete_sibling() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "boogu_image", "advanced": {} }).as_object().unwrap(),
+            json!({ "model": "boogu_image", "advanced": {} })
+                .as_object()
+                .unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -7780,7 +7917,9 @@ mod standard_tier_tests {
     #[test]
     fn resolved_tier_is_complete_flags_a_torn_sana_tier() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "sana_1600m", "advanced": {} }).as_object().unwrap(),
+            json!({ "model": "sana_1600m", "advanced": {} })
+                .as_object()
+                .unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -7798,7 +7937,9 @@ mod standard_tier_tests {
     fn resolved_tier_is_complete_flags_a_torn_sensenova_tier_and_a_fast_tier_missing_its_marker() {
         let sensenova = |model: &str| {
             ImageRequest::from_payload(
-                json!({ "model": model, "advanced": {} }).as_object().unwrap(),
+                json!({ "model": model, "advanced": {} })
+                    .as_object()
+                    .unwrap(),
             )
         };
         let tmp = tempfile::tempdir().unwrap();
@@ -7833,7 +7974,11 @@ mod standard_tier_tests {
     fn seed_anima_tier(root: &Path, tier: &str, complete: bool) {
         let dir = root.join(tier);
         std::fs::create_dir_all(dir.join("diffusion_models")).unwrap();
-        std::fs::write(dir.join("diffusion_models/anima-base-v1.0.safetensors"), b"x").unwrap();
+        std::fs::write(
+            dir.join("diffusion_models/anima-base-v1.0.safetensors"),
+            b"x",
+        )
+        .unwrap();
         if complete {
             std::fs::create_dir_all(dir.join("text_encoders")).unwrap();
             std::fs::write(dir.join("text_encoders/qwen_3_06b_base.safetensors"), b"x").unwrap();
@@ -7848,7 +7993,9 @@ mod standard_tier_tests {
     #[test]
     fn anima_torn_tier_falls_through_to_a_complete_sibling() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "anima_base", "advanced": {} }).as_object().unwrap(),
+            json!({ "model": "anima_base", "advanced": {} })
+                .as_object()
+                .unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -7891,7 +8038,11 @@ mod standard_tier_tests {
         let root = tmp.path();
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+        seed_tier(
+            root,
+            "bf16",
+            "diffusion_pytorch_model.safetensors.index.json",
+        );
 
         // Floor bf16, no explicit pick → the dense bf16 (raised above the q8 default).
         assert_eq!(
@@ -7940,7 +8091,11 @@ mod standard_tier_tests {
         // A Lens turnkey ships packed per-tier subdirs (transformer + gpt-oss-20b MoE TE + FLUX.2 VAE).
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
+        seed_tier(
+            root,
+            "bf16",
+            "diffusion_pytorch_model.safetensors.index.json",
+        );
 
         // A/B tier toggle: default (q8, sc-10726) / mlxQuantize:8 (q8) / mlxQuantize:0 (bf16) each
         // resolve to their tier subdir — the default now prefers the clean q8 tier (clamped to
@@ -8091,7 +8246,11 @@ mod standard_tier_tests {
         // Boogu floor capped by installed: bf16 floor but only the packed Q8 `base/` on disk → Q8.
         {
             let only_q8 = tempfile::tempdir().unwrap();
-            seed_tier(only_q8.path(), "base", "diffusion_pytorch_model.safetensors");
+            seed_tier(
+                only_q8.path(),
+                "base",
+                "diffusion_pytorch_model.safetensors",
+            );
             assert_eq!(
                 boogu_model_subdir(
                     only_q8.path(),
@@ -8292,9 +8451,8 @@ mod quant_tier_reconcile_tests {
                     .unwrap(),
             )
         };
-        let default = ImageRequest::from_payload(
-            json!({ "model": "flux2_klein_9b" }).as_object().unwrap(),
-        );
+        let default =
+            ImageRequest::from_payload(json!({ "model": "flux2_klein_9b" }).as_object().unwrap());
         // No selection → the q8 default (matches standard_tier_subdir's preferred, sc-10726).
         assert_eq!(dense_te_requested_tier_bits(&default), Some(8));
         assert_eq!(dense_te_requested_tier_bits(&req(json!(0))), None); // bf16 opt-out
@@ -8452,7 +8610,10 @@ mod capability_downtier_tests {
         assert_eq!(tier_key_from_resolved_dir(&root.join("q8")), Some("q8"));
         assert_eq!(tier_key_from_resolved_dir(&root.join("bf16")), Some("bf16"));
         // Boogu `<variant>-<tier>` suffix + the bare `<variant>` packed Q8 default.
-        assert_eq!(tier_key_from_resolved_dir(&root.join("base-q4")), Some("q4"));
+        assert_eq!(
+            tier_key_from_resolved_dir(&root.join("base-q4")),
+            Some("q4")
+        );
         assert_eq!(
             tier_key_from_resolved_dir(&root.join("turbo-bf16")),
             Some("bf16")
@@ -8621,7 +8782,8 @@ mod mlx_downtier_emulation_tests {
             let dir = root.join(tier).join("transformer");
             std::fs::create_dir_all(&dir).expect("mk tier dir");
             let file = std::fs::File::create(dir.join("model.safetensors")).expect("mk weights");
-            file.set_len(gib * 1024 * 1024 * 1024).expect("sparse weights");
+            file.set_len(gib * 1024 * 1024 * 1024)
+                .expect("sparse weights");
             root.join(tier)
         };
         let q8_dir = make_tier("q8", 5);
@@ -8665,8 +8827,9 @@ mod candle_downtier_emulation_tests {
     #[test]
     #[ignore = "sc-10733 AC#6 e2e; run with SCENEWORKS_CUDA_VRAM_CAP_GB=30"]
     fn candle_downtier_via_emulation_knob() {
-        let cap = crate::vram_gate::cuda_vram_cap_gb()
-            .expect("set SCENEWORKS_CUDA_VRAM_CAP_GB (e.g. 30) — between the q4 (~28) and q8 (~38) peaks");
+        let cap = crate::vram_gate::cuda_vram_cap_gb().expect(
+            "set SCENEWORKS_CUDA_VRAM_CAP_GB (e.g. 30) — between the q4 (~28) and q8 (~38) peaks",
+        );
         // The knob-emulated budget: no real reading + the cap ⇒ a synthetic `free = total = cap` budget,
         // so this exercises the whole chain without a CUDA card.
         let budget = crate::vram_gate::apply_vram_cap(None, crate::vram_gate::cuda_vram_cap_gb());

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -513,13 +513,23 @@ impl CandleImageRoute {
             CandleImageRoute::QwenControl => qwen_control::QWEN_CONTROL_ENGINE,
             CandleImageRoute::KolorsControl => kolors_control::KOLORS_CONTROL_ENGINE,
             CandleImageRoute::ZimageControl => zimage_control::ZIMAGE_CTRL_ENGINE,
-            CandleImageRoute::Flux2Control => flux2_control_candle::FLUX2_CONTROL_CANDLE_ENGINE,
-            CandleImageRoute::Flux1Control => flux1_control_candle::FLUX1_CONTROL_CANDLE_ENGINE,
+            CandleImageRoute::Flux2Control => {
+                flux2_control_candle::FLUX2_CONTROL_CANDLE_ENGINE
+            }
+            CandleImageRoute::Flux1Control => {
+                flux1_control_candle::FLUX1_CONTROL_CANDLE_ENGINE
+            }
             CandleImageRoute::KreaControl => krea_control_candle::KREA_CONTROL_ENGINE,
             CandleImageRoute::PoseReject | CandleImageRoute::PoseControlBaseMissing => STUB_ADAPTER,
-            CandleImageRoute::ZimageComfyui => zimage_comfyui_candle::ZIMAGE_COMFYUI_CANDLE_ENGINE,
-            CandleImageRoute::QwenImageComfyui => qwen_comfyui_candle::QWEN_COMFYUI_CANDLE_ENGINE,
-            CandleImageRoute::Flux2Comfyui => flux2_comfyui_candle::FLUX2_COMFYUI_CANDLE_ENGINE,
+            CandleImageRoute::ZimageComfyui => {
+                zimage_comfyui_candle::ZIMAGE_COMFYUI_CANDLE_ENGINE
+            }
+            CandleImageRoute::QwenImageComfyui => {
+                qwen_comfyui_candle::QWEN_COMFYUI_CANDLE_ENGINE
+            }
+            CandleImageRoute::Flux2Comfyui => {
+                flux2_comfyui_candle::FLUX2_COMFYUI_CANDLE_ENGINE
+            }
             CandleImageRoute::Bernini => CANDLE_BERNINI_IMAGE_ADAPTER,
             CandleImageRoute::MageEdit | CandleImageRoute::CandleTxt2Img => {
                 candle_adapter_label(&request.model)
@@ -778,21 +788,19 @@ fn model_repo(request: &ImageRequest, model: &ResolvedModel) -> String {
 /// intentionally excluded because each repo resolves its own receipt independently.
 #[cfg(any(target_os = "macos", feature = "backend-candle"))]
 fn requested_receipt_variant(request: &ImageRequest) -> Option<String> {
-    if let Some(bits) = request.advanced.get("mlxQuantize").and_then(|value| {
-        value
-            .as_i64()
-            .or_else(|| value.as_str()?.trim().parse().ok())
-    }) {
-        return Some(
-            if bits <= 0 {
-                "bf16"
-            } else if bits > 4 {
-                "q8"
-            } else {
-                "q4"
-            }
-            .to_owned(),
-        );
+    if let Some(bits) = request
+        .advanced
+        .get("mlxQuantize")
+        .and_then(|value| value.as_i64().or_else(|| value.as_str()?.trim().parse().ok()))
+    {
+        return Some(if bits <= 0 {
+            "bf16"
+        } else if bits > 4 {
+            "q8"
+        } else {
+            "q4"
+        }
+        .to_owned());
     }
     let selectable = request
         .model_manifest_entry
@@ -843,7 +851,11 @@ const IDEOGRAM_MLX_TURNKEY_REVISION: &str = "a3095855b8819dc0d6b067cb1354aaa7da1
     target_os = "macos",
     all(not(target_os = "macos"), feature = "backend-candle")
 ))]
-fn turnkey_tier_revision<'a>(repo: &str, default_repo: &str, default_revision: &'a str) -> &'a str {
+fn turnkey_tier_revision<'a>(
+    repo: &str,
+    default_repo: &str,
+    default_revision: &'a str,
+) -> &'a str {
     if repo == default_repo {
         default_revision
     } else {
@@ -865,7 +877,8 @@ fn pinned_turnkey_snapshot_for_request(
     if repo != default_repo {
         return None;
     }
-    let root = crate::model_jobs::huggingface_pinned_snapshot_dir(data_dir, repo, revision)?;
+    let root =
+        crate::model_jobs::huggingface_pinned_snapshot_dir(data_dir, repo, revision)?;
     let selected = match request.model.as_str() {
         "boogu_image" | "boogu_image_turbo" | "boogu_image_edit" => {
             boogu_model_subdir(&root, request)
@@ -974,9 +987,9 @@ pub(crate) fn resolve_weights_dir(
     // all load inputs on the receipt side of the all-receipt-or-all-current boundary.
     if !has_pinned_turnkey_snapshot
         && receipt_snapshot
-            .as_deref()
-            .and_then(tier_key_from_resolved_dir)
-            .is_some()
+        .as_deref()
+        .and_then(tier_key_from_resolved_dir)
+        .is_some()
     {
         return Ok(receipt_snapshot);
     }
@@ -1241,12 +1254,7 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
                 entries
                     .flatten()
                     .filter(|entry| !sceneworks_core::lora_family::is_hidden_file(&entry.path()))
-                    .any(|entry| {
-                        entry
-                            .file_name()
-                            .to_string_lossy()
-                            .ends_with(".safetensors")
-                    })
+                    .any(|entry| entry.file_name().to_string_lossy().ends_with(".safetensors"))
             })
             .unwrap_or(false);
         has_dit.then_some(dir)
@@ -1274,7 +1282,7 @@ fn anima_tier_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         &present,
         &sceneworks_core::mlx_tier_completeness::anima_tier_complete,
     )
-    .unwrap_or_else(|| root.to_path_buf())
+        .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// The candle off-Mac Anima weights dir (sc-10676): the `split_files/` subdir of the HF snapshot `root`
@@ -1435,7 +1443,7 @@ fn boogu_model_subdir(root: &Path, request: &ImageRequest) -> PathBuf {
         &present,
         &sceneworks_core::mlx_tier_completeness::boogu_tier_complete,
     )
-    .unwrap_or_else(|| root.to_path_buf())
+        .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// Pick the engine-complete packed subdir of a Krea 2 Turbo turnkey `root`: `q4/` when the request opts
@@ -1500,12 +1508,8 @@ fn krea_model_subdir_gated(root: &Path, request: &ImageRequest, nvfp4_host: bool
     // whose `model_index.json` component tree is fully on disk, so Raw with a torn `q8/` and a
     // complete `bf16/` training-base tier now generates off bf16 instead of dying on the absent
     // `q8/tokenizer/` (issue #850's symptom).
-    pick_loadable_tier(
-        &[preferred, "q8", "q4", "bf16"],
-        &present,
-        &tier_components_present,
-    )
-    .unwrap_or_else(|| root.to_path_buf())
+    pick_loadable_tier(&[preferred, "q8", "q4", "bf16"], &present, &tier_components_present)
+        .unwrap_or_else(|| root.to_path_buf())
 }
 
 /// The private HF repo hosting the Krea 2 INT8-ConvRot DiT single-file checkpoint (sc-9300, epic
@@ -1544,7 +1548,10 @@ fn wants_krea_convrot(request: &ImageRequest) -> bool {
 /// is enforced ENGINE-side (`ensure_int8_floor` inside `load_components_convrot`) AND surfaced as the
 /// worker's `int8_convrot` capability, so an ineligible card never reaches here (the picker hides it).
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
-fn resolve_krea_convrot(request: &ImageRequest, settings: &Settings) -> Option<(PathBuf, PathBuf)> {
+fn resolve_krea_convrot(
+    request: &ImageRequest,
+    settings: &Settings,
+) -> Option<(PathBuf, PathBuf)> {
     if !wants_krea_convrot(request) {
         return None;
     }
@@ -1703,7 +1710,8 @@ async fn ensure_boogu_tier_present(
             || tier_dir
                 .join("transformer/diffusion_pytorch_model.safetensors.index.json")
                 .is_file()
-    }) {
+    })
+    {
         return Ok(());
     }
     // The tier subfolder nests transformer/mllm/vae (leaf-dir globs, like the catalog Q8 entry).
@@ -1712,10 +1720,11 @@ async fn ensure_boogu_tier_present(
         format!("{tier}/mllm/*"),
         format!("{tier}/vae/*"),
     ];
-    let revision = turnkey_tier_revision(&repo, model.default_repo(), BOOGU_MLX_TURNKEY_REVISION);
+    let revision =
+        turnkey_tier_revision(&repo, model.default_repo(), BOOGU_MLX_TURNKEY_REVISION);
     crate::model_jobs::ensure_hf_files_cached(api, settings, job, &repo, revision, &files)
-        .await
-        .map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 /// On-demand fetch of Ideogram 4's non-default `q8/` tier (sc-9607, epic 9083). The catalog download
@@ -1774,15 +1783,16 @@ async fn ensure_ideogram_tier_present(
         root.join(tier)
             .join("transformer/model.safetensors")
             .is_file()
-    }) {
+    })
+    {
         return Ok(());
     }
     let files = vec![format!("{tier}/*")];
     let revision =
         turnkey_tier_revision(&repo, model.default_repo(), IDEOGRAM_MLX_TURNKEY_REVISION);
     crate::model_jobs::ensure_hf_files_cached(api, settings, job, &repo, revision, &files)
-        .await
-        .map(|_| ())
+    .await
+    .map(|_| ())
 }
 
 #[cfg(any(
@@ -2669,12 +2679,8 @@ fn attach_required_components(
     // back off the resolved weights dir keeps the two in lockstep by construction: a q4 request that
     // fell back to q8 gets the q8 text encoder, never a mixed pair.
     let tier = resolved_tier_name(&spec);
-    let components = crate::model_jobs::resolve_co_requisites_for_tier(
-        &descriptor,
-        &manifest_value,
-        settings,
-        tier,
-    )?;
+    let components =
+        crate::model_jobs::resolve_co_requisites_for_tier(&descriptor, &manifest_value, settings, tier)?;
     Ok(components
         .into_iter()
         .fold(spec, |spec, (id, source)| spec.with_component(id, source)))
@@ -2925,11 +2931,7 @@ pub(crate) fn read_advanced_sampling_knobs(
     let scheduler_shift = advanced
         .get("schedulerShift")
         .or_else(|| advanced.get("timestepShift"))
-        .and_then(|value| {
-            value
-                .as_f64()
-                .or_else(|| value.as_str()?.trim().parse().ok())
-        })
+        .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
         .map(|value| value as f32);
     (name("sampler"), name("scheduler"), scheduler_shift)
 }
@@ -3020,8 +3022,7 @@ mod metrics_settings_tests {
                 "usePid": true, "pidTarget": "2k", "guidanceMethod": "cfgpp"
             }
         }));
-        let metrics =
-            image_settings_metrics(&req, Some(30), None, Some("bf16".to_owned()), None, 1);
+        let metrics = image_settings_metrics(&req, Some(30), None, Some("bf16".to_owned()), None, 1);
         assert_eq!(metrics.sampler.as_deref(), Some("dpmpp_2m"));
         assert_eq!(metrics.scheduler.as_deref(), Some("karras"));
         assert_eq!(
@@ -3126,14 +3127,9 @@ mod sampling_knob_tests {
     // engine default = the guaranteed no-op), exactly like the sampler/scheduler read.
     #[test]
     fn read_guidance_method_strips_default_and_blank() {
+        assert_eq!(read_advanced_guidance_method(&advanced(serde_json::json!({}))), None);
         assert_eq!(
-            read_advanced_guidance_method(&advanced(serde_json::json!({}))),
-            None
-        );
-        assert_eq!(
-            read_advanced_guidance_method(&advanced(
-                serde_json::json!({"guidanceMethod": "default"})
-            )),
+            read_advanced_guidance_method(&advanced(serde_json::json!({"guidanceMethod": "default"}))),
             None
         );
         assert_eq!(
@@ -3141,9 +3137,7 @@ mod sampling_knob_tests {
             None
         );
         assert_eq!(
-            read_advanced_guidance_method(&advanced(
-                serde_json::json!({"guidanceMethod": "cfg_pp"})
-            )),
+            read_advanced_guidance_method(&advanced(serde_json::json!({"guidanceMethod": "cfg_pp"}))),
             Some("cfg_pp".to_owned())
         );
     }
@@ -3172,9 +3166,7 @@ mod sampling_knob_tests {
         );
         // Blank / whitespace-only names are also treated as the default (no name).
         assert_eq!(
-            read_advanced_sampling_knobs(&advanced(
-                serde_json::json!({"sampler": "  ", "scheduler": ""})
-            )),
+            read_advanced_sampling_knobs(&advanced(serde_json::json!({"sampler": "  ", "scheduler": ""}))),
             (None, None, None)
         );
     }
@@ -3595,12 +3587,7 @@ pub(crate) fn resolve_control_identity_source(
         .map(str::trim)
         .filter(|id| !id.is_empty())?
         .to_owned();
-    match load_reference_image(
-        &settings.data_dir,
-        &request.project_id,
-        &asset_id,
-        project_path,
-    ) {
+    match load_reference_image(&settings.data_dir, &request.project_id, &asset_id, project_path) {
         Ok(image) => Some((image, asset_id)),
         Err(error) => {
             tracing::warn!(
@@ -3792,8 +3779,7 @@ fn resolve_boogu_edit(
     let ids = boogu_edit_reference_ids(request);
     let mut references = Vec::with_capacity(ids.len());
     for id in &ids {
-        let source =
-            load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
+        let source = load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
         let source = fit_engine_image(source, request.width, request.height, &request.fit_mode)?;
         references.push(source);
     }
@@ -3812,8 +3798,7 @@ fn resolve_mage_edit(
     let ids = mage_edit_reference_ids(request);
     let mut references = Vec::with_capacity(ids.len());
     for id in &ids {
-        let source =
-            load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
+        let source = load_reference_image(&settings.data_dir, &request.project_id, id, project_path)?;
         references.push(fit_engine_image(
             source,
             request.width,
@@ -4753,7 +4738,9 @@ fn vram_reject_tail(installed_smaller: &[&str]) -> String {
 fn vram_reject_tail_for_tier(installed: Vec<&'static str>, rejected_tier: &str) -> String {
     let smaller: Vec<&'static str> = installed
         .into_iter()
-        .filter(|candidate| tier_quality_rank(candidate) < tier_quality_rank(rejected_tier))
+        .filter(|candidate| {
+            tier_quality_rank(candidate) < tier_quality_rank(rejected_tier)
+        })
         .collect();
     vram_reject_tail(&smaller)
 }
@@ -4775,13 +4762,14 @@ fn candle_tier_fit(
         crate::vram_gate::fit_decision(needed, budget),
         sequential_capable,
     ) {
-        crate::vram_gate::FitDecision::Fits | crate::vram_gate::FitDecision::Unknown => {
-            TierFit::Fits
-        }
-        crate::vram_gate::FitDecision::Offload { available_gb, .. } => {
+        crate::vram_gate::FitDecision::Fits | crate::vram_gate::FitDecision::Unknown => TierFit::Fits,
+        crate::vram_gate::FitDecision::Offload {
+            available_gb, ..
+        } => {
             // Resident won't fit but the provider stages — fits only if the MEASURED sequential peak
             // fits (unmeasured ⇒ best-effort run, so `sequential_overflow_gb` yields None ⇒ Fits).
-            let seq_needed = crate::vram_gate::predicted_sequential_peak_gb(manifest_entry, tier);
+            let seq_needed =
+                crate::vram_gate::predicted_sequential_peak_gb(manifest_entry, tier);
             match crate::vram_gate::sequential_overflow_gb(seq_needed, budget) {
                 Some(seq_gb) => TierFit::TooBig {
                     needed_gb: seq_gb,
@@ -5026,9 +5014,7 @@ async fn generate_candle_stream(
     let adapter_count = adapters.len();
 
     let count = request.count as usize;
-    let seeds: Vec<i64> = (0..count)
-        .map(|index| resolve_seed(request, index))
-        .collect();
+    let seeds: Vec<i64> = (0..count).map(|index| resolve_seed(request, index)).collect();
     // Ideogram 4 (epic 4725, sc-6501) is JSON-caption-only: a raw plain-text prompt is out-of-
     // distribution and stochastically renders the "Image blocked by safety filter" placeholder. Wrap a
     // non-caption prompt into a minimal valid caption — the same worker-side guarantee the macOS path
@@ -5138,8 +5124,7 @@ async fn generate_candle_stream(
     // sc-9092) — the same `model_repo` the MLX path records.
     let repo = model_repo(request, &model);
     // `mut`: rebuilt with the corrected `quant_bits` if the sc-10733 downtier lands on a lower tier.
-    let mut raw_settings =
-        mlx_raw_settings(request, &repo, steps, quant_bits, guidance.or(true_cfg));
+    let mut raw_settings = mlx_raw_settings(request, &repo, steps, quant_bits, guidance.or(true_cfg));
     // Per-generation PiD decode (epic 7840): resolve the PiD checkpoint + Gemma for this model's latent
     // space when `advanced.usePid` is set and the snapshots are cached; otherwise keep the native VAE.
     // `use_pid` and `spec.pid` stay in lockstep (the engine rejects a mismatch). Every candle image
@@ -5355,10 +5340,13 @@ async fn generate_candle_stream(
                 needed_gb,
                 available_gb,
             } => {
-                let installed_smaller: Vec<&'static str> = installed_tier_keys(request, settings)
-                    .into_iter()
-                    .filter(|candidate| tier_quality_rank(candidate) < tier_quality_rank(tier))
-                    .collect();
+                let installed_smaller: Vec<&'static str> =
+                    installed_tier_keys(request, settings)
+                        .into_iter()
+                        .filter(|candidate| {
+                            tier_quality_rank(candidate) < tier_quality_rank(tier)
+                        })
+                        .collect();
                 return Err(WorkerError::InvalidPayload(format!(
                     "{model} at the {tier} tier needs ~{needed} GB of VRAM (with headroom) but GPU \
                      {gpu} has ~{available} GB available. {tail}",
@@ -5542,11 +5530,7 @@ fn image_settings_metrics(
     };
     let number_field = |key: &str| -> Option<serde_json::Number> {
         adv.get(key)
-            .and_then(|value| {
-                value
-                    .as_f64()
-                    .or_else(|| value.as_str()?.trim().parse().ok())
-            })
+            .and_then(|value| value.as_f64().or_else(|| value.as_str()?.trim().parse().ok()))
             .and_then(serde_json::Number::from_f64)
     };
     let loras: Vec<String> = request.loras.iter().filter_map(lora_label).collect();
@@ -5565,10 +5549,7 @@ fn image_settings_metrics(
         true_cfg_scale: number_field("trueCfgScale"),
         guidance_method: string_or("guidanceMethod", "cfg"),
         use_pid: Some(adv.get("usePid").and_then(Value::as_bool).unwrap_or(false)),
-        pid_target: adv
-            .get("pidTarget")
-            .and_then(Value::as_str)
-            .map(str::to_owned),
+        pid_target: adv.get("pidTarget").and_then(Value::as_str).map(str::to_owned),
         width: Some(request.width),
         height: Some(request.height),
         seed: request.seed.or_else(|| request.seeds.first().copied()),
@@ -6119,14 +6100,8 @@ mod candle_label_tests {
     fn vram_reject_tail_names_only_installed_smaller_tiers() {
         // Two smaller tiers installed → both offered, uppercased, highest-fidelity first.
         let tail = vram_reject_tail(&["q8", "q4"]);
-        assert!(
-            tail.contains("Q8 / Q4"),
-            "lists installed smaller tiers: {tail}"
-        );
-        assert!(
-            !tail.contains("picker"),
-            "never points at the picker: {tail}"
-        );
+        assert!(tail.contains("Q8 / Q4"), "lists installed smaller tiers: {tail}");
+        assert!(!tail.contains("picker"), "never points at the picker: {tail}");
         // One smaller tier installed.
         assert!(vram_reject_tail(&["q4"]).contains("(Q4)"));
         // None smaller installed (the single-tier / q4-only case) → says so, no tier list, no picker.
@@ -6146,18 +6121,9 @@ mod boogu_tier_tests {
         // download). 1..=4 → packed q4; <=0 → dense bf16. Consistent with krea/ideogram (sc-8513).
         assert_eq!(boogu_tier_subdir("base", None), None);
         assert_eq!(boogu_tier_subdir("base", Some(8)), None);
-        assert_eq!(
-            boogu_tier_subdir("base", Some(4)),
-            Some("base-q4".to_owned())
-        );
-        assert_eq!(
-            boogu_tier_subdir("turbo", Some(2)),
-            Some("turbo-q4".to_owned())
-        );
-        assert_eq!(
-            boogu_tier_subdir("edit", Some(0)),
-            Some("edit-bf16".to_owned())
-        );
+        assert_eq!(boogu_tier_subdir("base", Some(4)), Some("base-q4".to_owned()));
+        assert_eq!(boogu_tier_subdir("turbo", Some(2)), Some("turbo-q4".to_owned()));
+        assert_eq!(boogu_tier_subdir("edit", Some(0)), Some("edit-bf16".to_owned()));
         assert_eq!(
             boogu_tier_subdir("base", Some(-1)),
             Some("base-bf16".to_owned())
@@ -6306,11 +6272,7 @@ mod standard_tier_tests {
         // Packed q4/q8 single-file + dense sharded bf16 (only the index.json shape).
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(
-            root,
-            "bf16",
-            "diffusion_pytorch_model.safetensors.index.json",
-        );
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
         // No selection → q8 default (epic 10721 / sc-10726), clamped to installed.
         assert_eq!(
@@ -6740,16 +6702,12 @@ mod standard_tier_tests {
     fn nvfp4_requested_reads_only_the_explicit_quant_tier_label() {
         // The explicit label, tolerant of surrounding whitespace / casing like the sibling parsers.
         assert!(nvfp4_requested(&request(json!({ "quantTier": "nvfp4" }))));
-        assert!(nvfp4_requested(&request(
-            json!({ "quantTier": "  nvfp4 " })
-        )));
+        assert!(nvfp4_requested(&request(json!({ "quantTier": "  nvfp4 " }))));
         assert!(nvfp4_requested(&request(json!({ "quantTier": "NVFP4" }))));
         // Nothing else asks for NVFP4: no label, another tier's label, a non-string, or ANY bits value.
         assert!(!nvfp4_requested(&request(json!({}))));
         assert!(!nvfp4_requested(&request(json!({ "quantTier": "q4" }))));
-        assert!(!nvfp4_requested(&request(
-            json!({ "quantTier": "int8-convrot" })
-        )));
+        assert!(!nvfp4_requested(&request(json!({ "quantTier": "int8-convrot" }))));
         assert!(!nvfp4_requested(&request(json!({ "quantTier": 4 }))));
         assert!(!nvfp4_requested(&request(json!({ "quantTier": true }))));
         for bits in [0, 4, 8] {
@@ -6769,11 +6727,7 @@ mod standard_tier_tests {
         let root = tmp.path();
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(
-            root,
-            "bf16",
-            "diffusion_pytorch_model.safetensors.index.json",
-        );
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
         seed_tier(root, NVFP4_TIER, "diffusion_pytorch_model.safetensors");
 
         // The injected `true` says "the HOST is Blackwell-eligible" — the hardware gate is ON, but no
@@ -6814,10 +6768,7 @@ mod standard_tier_tests {
         );
         // NOT Blackwell (pre-sm_120 NVIDIA, macOS/MLX, or the neither build) → the label is ignored and
         // the request lands on an installed tier via the normal chain. A clean fallback, not an error.
-        assert_eq!(
-            standard_tier_subdir_gated(root, &picked, false),
-            root.join("q8")
-        );
+        assert_eq!(standard_tier_subdir_gated(root, &picked, false), root.join("q8"));
 
         // sm_120 but the tier ISN'T converted yet (sc-11043 owns the converter; the shipping case today)
         // → rejoins the same clean chain rather than failing the load.
@@ -6952,11 +6903,7 @@ mod standard_tier_tests {
         // The carve-out is not a general NVFP4 kill-switch: a NON-dense-TE model on the same terms
         // still selects the tier, so the fix can't be masking the arm entirely.
         assert_eq!(
-            resolve_quant_gated(
-                &request(json!({ "quantTier": "nvfp4" })),
-                true,
-                Some(&nvfp4_dir)
-            ),
+            resolve_quant_gated(&request(json!({ "quantTier": "nvfp4" })), true, Some(&nvfp4_dir)),
             (Some(Quant::Nvfp4), None)
         );
     }
@@ -7071,11 +7018,7 @@ mod standard_tier_tests {
         // Same host, same request, but the tier IS installed → the label is nvfp4. This is what proves
         // the fix pins the label to the DISK and isn't just disabling the tier.
         let converted = tempfile::tempdir().unwrap();
-        seed_tier(
-            converted.path(),
-            "q8",
-            "diffusion_pytorch_model.safetensors",
-        );
+        seed_tier(converted.path(), "q8", "diffusion_pytorch_model.safetensors");
         seed_tier(
             converted.path(),
             NVFP4_TIER,
@@ -7133,10 +7076,7 @@ mod standard_tier_tests {
             root.join(NVFP4_TIER)
         );
         // Off Blackwell → clean fallback to the shipped q8 default.
-        assert_eq!(
-            krea_model_subdir_gated(root, &picked, false),
-            root.join("q8")
-        );
+        assert_eq!(krea_model_subdir_gated(root, &picked, false), root.join("q8"));
         // SC#5: krea's existing tiers resolve exactly as before on a Blackwell host with an `nvfp4/`
         // dir present.
         for (advanced, expected) in [
@@ -7166,10 +7106,7 @@ mod standard_tier_tests {
             min_quality_floor(&with_floor(json!({ "minQualityTier": "q8" }))),
             Some("q8")
         );
-        assert_eq!(
-            min_quality_floor(&with_floor(json!({ "quantize": 4 }))),
-            None
-        );
+        assert_eq!(min_quality_floor(&with_floor(json!({ "quantize": 4 }))), None);
         assert_eq!(
             min_quality_floor(&with_floor(json!({ "minQualityTier": "q2" }))),
             None
@@ -7424,11 +7361,7 @@ mod standard_tier_tests {
                 .unwrap(),
         );
         let tier = standard_tier_subdir(&root, &req);
-        assert_eq!(
-            tier,
-            root.join("q4"),
-            "worker must resolve the q4 tier subdir"
-        );
+        assert_eq!(tier, root.join("q4"), "worker must resolve the q4 tier subdir");
         assert!(
             tier.join("model_index.json").is_file() && tier.join("unet").is_dir(),
             "q4 tier subdir missing turnkey layout (model_index.json + unet/): {}",
@@ -7438,8 +7371,7 @@ mod standard_tier_tests {
         // Load the packed q4 tier through the MLX `sdxl` engine (Quant::Q4 = harmless no-op on the
         // already-packed weights) and render a 768x768 image.
         let spec = LoadSpec::new(WeightsSource::Dir(tier.clone())).with_quant(Quant::Q4);
-        let generator = crate::inference_runtime::load("sdxl", &spec)
-            .expect("load MLX sdxl provider on q4 tier");
+        let generator = crate::inference_runtime::load("sdxl", &spec).expect("load MLX sdxl provider on q4 tier");
         let gen_req = GenerationRequest {
             prompt: "a photorealistic portrait of a red fox in a snowy forest, golden hour"
                 .to_owned(),
@@ -7462,21 +7394,9 @@ mod standard_tier_tests {
         let n = image.pixels.len() as f64;
         assert!(n > 0.0, "empty image buffer");
         let mean = image.pixels.iter().map(|&p| p as f64).sum::<f64>() / n;
-        let std = (image
-            .pixels
-            .iter()
-            .map(|&p| (p as f64 - mean).powi(2))
-            .sum::<f64>()
-            / n)
-            .sqrt();
-        println!(
-            "[sc-8746 smoke] realvisxl q4 tier render {}x{} std {std:.2}",
-            image.width, image.height
-        );
-        assert!(
-            std > 5.0,
-            "render looks degenerate (std {std:.2}) — possible NaN / all-black decode"
-        );
+        let std = (image.pixels.iter().map(|&p| (p as f64 - mean).powi(2)).sum::<f64>() / n).sqrt();
+        println!("[sc-8746 smoke] realvisxl q4 tier render {}x{} std {std:.2}", image.width, image.height);
+        assert!(std > 5.0, "render looks degenerate (std {std:.2}) — possible NaN / all-black decode");
     }
 
     /// A model built with a manifest entry so `uses_standard_tier_layout` / `is_dense_te_tier`
@@ -7518,10 +7438,7 @@ mod standard_tier_tests {
     #[cfg(any(target_os = "macos", feature = "backend-candle"))]
     #[test]
     fn dense_te_tier_is_manifest_driven_with_registry_backcompat() {
-        assert!(is_dense_te_tier(&manifest_request(
-            "flux2_klein_9b",
-            json!({})
-        )));
+        assert!(is_dense_te_tier(&manifest_request("flux2_klein_9b", json!({}))));
         assert!(is_dense_te_tier(&manifest_request(
             "some_dense_te_model",
             json!({ "denseTextEncoderTier": true })
@@ -7594,11 +7511,7 @@ mod standard_tier_tests {
         // Krea turnkey: packed q4/q8 single-file transformer + dense sharded bf16 (index.json only).
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(
-            root,
-            "bf16",
-            "diffusion_pytorch_model.safetensors.index.json",
-        );
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
         // q8-default (no selection) / q4 (bits<=4) / bf16 (bits<=0) each resolve to their tier subdir.
         assert_eq!(
@@ -7645,10 +7558,7 @@ mod standard_tier_tests {
         index.insert("patch_size".to_owned(), json!(2));
         index.insert("feature_extractor".to_owned(), json!([null, null]));
         for component in declared {
-            index.insert(
-                (*component).to_owned(),
-                json!(["transformers", "SomeClass"]),
-            );
+            index.insert((*component).to_owned(), json!(["transformers", "SomeClass"]));
         }
         std::fs::write(
             dir.join("model_index.json"),
@@ -7663,13 +7573,7 @@ mod standard_tier_tests {
     }
 
     /// The Krea tier component set, as the real `q8/model_index.json` declares it.
-    const KREA_COMPONENTS: &[&str] = &[
-        "transformer",
-        "tokenizer",
-        "text_encoder",
-        "vae",
-        "scheduler",
-    ];
+    const KREA_COMPONENTS: &[&str] = &["transformer", "tokenizer", "text_encoder", "vae", "scheduler"];
 
     /// sc-12279 (issue #850): a TORN tier — backbone landed, `tokenizer/` did not — must not
     /// short-circuit the fallback chain. Before this, `present()` accepted a tier on its transformer
@@ -7719,9 +7623,7 @@ mod standard_tier_tests {
     #[test]
     fn krea_tier_probe_still_returns_a_torn_tier_when_it_is_all_there_is() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "krea_2_raw", "advanced": {} })
-                .as_object()
-                .unwrap(),
+            json!({ "model": "krea_2_raw", "advanced": {} }).as_object().unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         seed_diffusers_tier(
@@ -7757,12 +7659,7 @@ mod standard_tier_tests {
         assert!(tier_components_present(&root.join("q8")));
 
         // Torn: `tokenizer/` declared but absent.
-        seed_diffusers_tier(
-            root,
-            "q4",
-            KREA_COMPONENTS,
-            &["text_encoder", "vae", "scheduler"],
-        );
+        seed_diffusers_tier(root, "q4", KREA_COMPONENTS, &["text_encoder", "vae", "scheduler"]);
         assert!(!tier_components_present(&root.join("q4")));
 
         // A component dir holding ONLY an AppleDouble sidecar has no tokenizer (SceneWorks#1333).
@@ -7795,11 +7692,7 @@ mod standard_tier_tests {
     fn seed_sana_tier(root: &Path, tier: &str, complete: bool) {
         let dir = root.join(tier);
         std::fs::create_dir_all(dir.join("transformer")).unwrap();
-        std::fs::write(
-            dir.join("transformer/diffusion_pytorch_model.safetensors"),
-            b"x",
-        )
-        .unwrap();
+        std::fs::write(dir.join("transformer/diffusion_pytorch_model.safetensors"), b"x").unwrap();
         if complete {
             std::fs::create_dir_all(dir.join("vae")).unwrap();
             std::fs::write(dir.join("vae/diffusion_pytorch_model.safetensors"), b"x").unwrap();
@@ -7843,9 +7736,7 @@ mod standard_tier_tests {
     #[test]
     fn sana_torn_tier_is_returned_when_it_is_all_there_is() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "sana_1600m", "advanced": {} })
-                .as_object()
-                .unwrap(),
+            json!({ "model": "sana_1600m", "advanced": {} }).as_object().unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         seed_sana_tier(tmp.path(), "q8", false);
@@ -7861,9 +7752,7 @@ mod standard_tier_tests {
     #[test]
     fn non_sana_standard_turnkey_ignores_the_sana_completeness_branch() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "flux_dev", "advanced": {} })
-                .as_object()
-                .unwrap(),
+            json!({ "model": "flux_dev", "advanced": {} }).as_object().unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -7878,11 +7767,7 @@ mod standard_tier_tests {
     fn seed_boogu_tier(root: &Path, folder: &str, complete: bool) {
         let dir = root.join(folder);
         std::fs::create_dir_all(dir.join("transformer")).unwrap();
-        std::fs::write(
-            dir.join("transformer/diffusion_pytorch_model.safetensors"),
-            b"x",
-        )
-        .unwrap();
+        std::fs::write(dir.join("transformer/diffusion_pytorch_model.safetensors"), b"x").unwrap();
         std::fs::write(dir.join("transformer/config.json"), b"{}").unwrap();
         if complete {
             std::fs::create_dir_all(dir.join("mllm")).unwrap();
@@ -7898,9 +7783,7 @@ mod standard_tier_tests {
     #[test]
     fn boogu_torn_tier_falls_through_to_a_complete_sibling() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "boogu_image", "advanced": {} })
-                .as_object()
-                .unwrap(),
+            json!({ "model": "boogu_image", "advanced": {} }).as_object().unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -7920,9 +7803,7 @@ mod standard_tier_tests {
     #[test]
     fn resolved_tier_is_complete_flags_a_torn_sana_tier() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "sana_1600m", "advanced": {} })
-                .as_object()
-                .unwrap(),
+            json!({ "model": "sana_1600m", "advanced": {} }).as_object().unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -7940,9 +7821,7 @@ mod standard_tier_tests {
     fn resolved_tier_is_complete_flags_a_torn_sensenova_tier_and_a_fast_tier_missing_its_marker() {
         let sensenova = |model: &str| {
             ImageRequest::from_payload(
-                json!({ "model": model, "advanced": {} })
-                    .as_object()
-                    .unwrap(),
+                json!({ "model": model, "advanced": {} }).as_object().unwrap(),
             )
         };
         let tmp = tempfile::tempdir().unwrap();
@@ -7977,11 +7856,7 @@ mod standard_tier_tests {
     fn seed_anima_tier(root: &Path, tier: &str, complete: bool) {
         let dir = root.join(tier);
         std::fs::create_dir_all(dir.join("diffusion_models")).unwrap();
-        std::fs::write(
-            dir.join("diffusion_models/anima-base-v1.0.safetensors"),
-            b"x",
-        )
-        .unwrap();
+        std::fs::write(dir.join("diffusion_models/anima-base-v1.0.safetensors"), b"x").unwrap();
         if complete {
             std::fs::create_dir_all(dir.join("text_encoders")).unwrap();
             std::fs::write(dir.join("text_encoders/qwen_3_06b_base.safetensors"), b"x").unwrap();
@@ -7996,9 +7871,7 @@ mod standard_tier_tests {
     #[test]
     fn anima_torn_tier_falls_through_to_a_complete_sibling() {
         let request = ImageRequest::from_payload(
-            json!({ "model": "anima_base", "advanced": {} })
-                .as_object()
-                .unwrap(),
+            json!({ "model": "anima_base", "advanced": {} }).as_object().unwrap(),
         );
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
@@ -8041,11 +7914,7 @@ mod standard_tier_tests {
         let root = tmp.path();
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(
-            root,
-            "bf16",
-            "diffusion_pytorch_model.safetensors.index.json",
-        );
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
         // Floor bf16, no explicit pick → the dense bf16 (raised above the q8 default).
         assert_eq!(
@@ -8094,11 +7963,7 @@ mod standard_tier_tests {
         // A Lens turnkey ships packed per-tier subdirs (transformer + gpt-oss-20b MoE TE + FLUX.2 VAE).
         seed_tier(root, "q4", "diffusion_pytorch_model.safetensors");
         seed_tier(root, "q8", "diffusion_pytorch_model.safetensors");
-        seed_tier(
-            root,
-            "bf16",
-            "diffusion_pytorch_model.safetensors.index.json",
-        );
+        seed_tier(root, "bf16", "diffusion_pytorch_model.safetensors.index.json");
 
         // A/B tier toggle: default (q8, sc-10726) / mlxQuantize:8 (q8) / mlxQuantize:0 (bf16) each
         // resolve to their tier subdir — the default now prefers the clean q8 tier (clamped to
@@ -8249,11 +8114,7 @@ mod standard_tier_tests {
         // Boogu floor capped by installed: bf16 floor but only the packed Q8 `base/` on disk → Q8.
         {
             let only_q8 = tempfile::tempdir().unwrap();
-            seed_tier(
-                only_q8.path(),
-                "base",
-                "diffusion_pytorch_model.safetensors",
-            );
+            seed_tier(only_q8.path(), "base", "diffusion_pytorch_model.safetensors");
             assert_eq!(
                 boogu_model_subdir(
                     only_q8.path(),
@@ -8454,8 +8315,9 @@ mod quant_tier_reconcile_tests {
                     .unwrap(),
             )
         };
-        let default =
-            ImageRequest::from_payload(json!({ "model": "flux2_klein_9b" }).as_object().unwrap());
+        let default = ImageRequest::from_payload(
+            json!({ "model": "flux2_klein_9b" }).as_object().unwrap(),
+        );
         // No selection → the q8 default (matches standard_tier_subdir's preferred, sc-10726).
         assert_eq!(dense_te_requested_tier_bits(&default), Some(8));
         assert_eq!(dense_te_requested_tier_bits(&req(json!(0))), None); // bf16 opt-out
@@ -8613,10 +8475,7 @@ mod capability_downtier_tests {
         assert_eq!(tier_key_from_resolved_dir(&root.join("q8")), Some("q8"));
         assert_eq!(tier_key_from_resolved_dir(&root.join("bf16")), Some("bf16"));
         // Boogu `<variant>-<tier>` suffix + the bare `<variant>` packed Q8 default.
-        assert_eq!(
-            tier_key_from_resolved_dir(&root.join("base-q4")),
-            Some("q4")
-        );
+        assert_eq!(tier_key_from_resolved_dir(&root.join("base-q4")), Some("q4"));
         assert_eq!(
             tier_key_from_resolved_dir(&root.join("turbo-bf16")),
             Some("bf16")
@@ -8785,8 +8644,7 @@ mod mlx_downtier_emulation_tests {
             let dir = root.join(tier).join("transformer");
             std::fs::create_dir_all(&dir).expect("mk tier dir");
             let file = std::fs::File::create(dir.join("model.safetensors")).expect("mk weights");
-            file.set_len(gib * 1024 * 1024 * 1024)
-                .expect("sparse weights");
+            file.set_len(gib * 1024 * 1024 * 1024).expect("sparse weights");
             root.join(tier)
         };
         let q8_dir = make_tier("q8", 5);
@@ -8830,9 +8688,8 @@ mod candle_downtier_emulation_tests {
     #[test]
     #[ignore = "sc-10733 AC#6 e2e; run with SCENEWORKS_CUDA_VRAM_CAP_GB=30"]
     fn candle_downtier_via_emulation_knob() {
-        let cap = crate::vram_gate::cuda_vram_cap_gb().expect(
-            "set SCENEWORKS_CUDA_VRAM_CAP_GB (e.g. 30) — between the q4 (~28) and q8 (~38) peaks",
-        );
+        let cap = crate::vram_gate::cuda_vram_cap_gb()
+            .expect("set SCENEWORKS_CUDA_VRAM_CAP_GB (e.g. 30) — between the q4 (~28) and q8 (~38) peaks");
         // The knob-emulated budget: no real reading + the cap ⇒ a synthetic `free = total = cap` budget,
         // so this exercises the whole chain without a CUDA card.
         let budget = crate::vram_gate::apply_vram_cap(None, crate::vram_gate::cuda_vram_cap_gb());

--- a/crates/sceneworks-worker/src/image_jobs/tier_resolver.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tier_resolver.rs
@@ -278,32 +278,12 @@ pub(super) fn min_quality_floor(request: &ImageRequest) -> Option<&str> {
 /// perfectly good tier lose the chain to a sibling that merely ships an index, which is a worse bug
 /// than the one this fixes. We only ever demote a tier on POSITIVE evidence: its own index naming a
 /// component that is not on disk.
-fn tier_declared_components(dir: &Path) -> Option<Vec<String>> {
-    let raw = std::fs::read_to_string(dir.join("model_index.json")).ok()?;
-    let index: Value = serde_json::from_str(&raw).ok()?;
-    Some(
-        index
-            .as_object()?
-            .iter()
-            .filter(|(key, value)| !key.starts_with('_') && is_component_entry(value))
-            .map(|(key, _)| key.clone())
-            .collect(),
-    )
-}
-
-/// Whether a `model_index.json` value names a COMPONENT — the diffusers `[library, class]` pair.
-///
-/// Three things in a real index are NOT components, and all three must be rejected here (each is
-/// live in a shipping turnkey, so a laxer test fails a good tier):
-/// - `[null, null]` marks an ABSENT optional component — `SceneWorks/realvisxl-mlx` declares
-///   `feature_extractor` and `image_encoder` this way and ships neither dir.
-/// - config arrays — `SceneWorks/krea-2-raw-mlx` declares `text_encoder_select_layers: [2, 5, 8, …]`.
-/// - config scalars — krea's `patch_size: 2`, realvisxl's `force_zeros_for_empty_prompt: true`.
-fn is_component_entry(value: &Value) -> bool {
-    value
-        .as_array()
-        .is_some_and(|pair| pair.len() == 2 && pair.iter().all(Value::is_string))
-}
+/// Moved to `sceneworks_core::mlx_tier_completeness` (sc-14980) so this resolver, rust-api's catalog
+/// completeness, and the training-base gate all read a tier's declared component set the SAME way —
+/// a split tier that ships only the components it owns must look identical to all three. Re-exported
+/// here rather than reimplemented, for the same anti-drift reason the per-family predicates are
+/// shared (sc-13513).
+use sceneworks_core::mlx_tier_completeness::tier_declared_components;
 
 /// Whether every component `dir`'s own `model_index.json` declares is actually on disk (sc-12279).
 ///

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -362,6 +362,14 @@ mod illustrious_train_apply_mlx_smoke;
 // non-degenerate (both transformer + gpt-oss MoE TE are packed per-tier; NOT a dense-TE model).
 #[cfg(all(test, target_os = "macos"))]
 mod lens_turbo_q4_mlx_smoke;
+
+// Real-weight MLX smoke for the Mage-Flow q4 worker lane (sc-14980 / sc-14979). Mage is the first
+// family whose tier subdir is NOT engine-complete — `<snapshot>/q4/` is DiT-only, and the shared text
+// encoder + VAE arrive as per-tier co-requisites — so this is the on-device proof that the manifest's
+// per-tier downloads and the pinned engine agree. It fails loudly against an engine pinned before the
+// sc-14979 split, which is exactly the ordering hazard the pin bump closes.
+#[cfg(all(test, target_os = "macos"))]
+mod mage_flow_q8_mlx_smoke;
 // Real-weight MLX smoke for the recovered base Lens Q4 worker lane (sc-8767, epic 8506 Group-B).
 // Test-only + macOS-only; drives `crate::inference_runtime::load("lens")` with a Q4 LoadSpec against the packed `q4/`
 // turnkey subdir. On-device evidence that the SceneWorks/lens-mlx pre-quantized q4 tier loads through the

--- a/crates/sceneworks-worker/src/mage_flow_q8_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/mage_flow_q8_mlx_smoke.rs
@@ -1,0 +1,228 @@
+//! Local real-weight MLX smoke for the Mage-Flow **Q8** worker lane (sc-14980 / sc-14979).
+//! `#[ignore]`d — run by hand on an Apple-Silicon Mac.
+//!
+//! This is the ORDERING-SAFETY proof for the per-tier re-host. Mage is the first family whose tier
+//! subdir is NOT engine-complete: `<snapshot>/q8/` holds the DiT and scheduler only, while the text
+//! encoder and VAE — bit-identical across all six variants — live once in
+//! `SceneWorks/Mage-Flow-Components-mlx` and are staged as per-tier `coRequisite` components. So the
+//! failure this guards against is specific and was real before the pin bump: the worker resolves
+//! `<snapshot>/q8` via `standard_tier_subdir`, and an engine that expects a FLAT diffusers root then
+//! looks for `<snapshot>/q8/text_encoder/` and dies at load. A manifest that ships per-tier downloads
+//! against an engine pinned before the split is exactly that break.
+//!
+//! It drives the real seam `generate_stream` uses, minus the API/job plumbing:
+//!   1. `standard_tier_subdir` → `<snapshot>/q8` (asserted to be DiT-only, so the check is honest),
+//!   2. `resolve_co_requisites_for_tier(.., Some("q8"))` → the shared TE + VAE component dirs,
+//!   3. `LoadSpec::new(Dir(<snapshot>/q8)).with_quant(Q8)` + those components,
+//!   4. `inference_runtime::load("mage_flow_base", &spec)` — the real engine load,
+//!   5. a render, checked non-degenerate.
+//!
+//! **Why q8 and not the default q4 tier.** Mage's q4 tier does not render correctly — at 512x512/30
+//! steps it produces a repeating tiled texture where bf16 and q8 both produce the prompt. That is a
+//! PRE-EXISTING defect in the q4 quantization from sc-14046, not the re-host: load-time q4 over the
+//! ORIGINAL dense `microsoft/Mage-Flow-Base` snapshot produces the identical image, and the packed q4
+//! artifact is bit-identical to it (`max_abs 0.0`). Filed separately. This smoke therefore exercises
+//! the split layout on q8, where a correct render actually proves the right weights were wired.
+//!
+//! Setup — with the q8 tier of BOTH repos in the HF cache, no env is needed:
+//! ```text
+//! # optional: MAGE_Q8_STEPS=4 MAGE_Q8_W=512 MAGE_Q8_H=512 MAGE_Q8_PROMPT="..." MAGE_Q8_OUT_DIR=/tmp/mage_q8_smoke
+//! cargo test -p sceneworks-worker --release mage_flow_q8_mlx_gpu_smoke -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Quant, WeightsSource};
+
+use super::smoke_support::{env_or, image_mean, image_std, is_all_zero, save_png};
+
+const VARIANT_REPO: &str = "SceneWorks/Mage-Flow-Base";
+const COMPONENTS_REPO: &str = "SceneWorks/Mage-Flow-Components-mlx";
+const MODEL_ID: &str = "mage_flow_base";
+
+/// The hub cache root this smoke reads from: whatever the environment already points at, else the
+/// standard `~/.cache/huggingface/hub` that `huggingface_hub` downloads into.
+fn hub_cache_root() -> Option<PathBuf> {
+    for key in ["HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"] {
+        if let Ok(value) = std::env::var(key) {
+            if !value.trim().is_empty() {
+                return Some(PathBuf::from(value));
+            }
+        }
+    }
+    if let Ok(value) = std::env::var("HF_HOME") {
+        if !value.trim().is_empty() {
+            return Some(PathBuf::from(value).join("hub"));
+        }
+    }
+    Some(PathBuf::from(std::env::var("HOME").ok()?).join(".cache/huggingface/hub"))
+}
+
+/// The cached snapshot of `repo` whose `q8/` subdir exists. `None` when that tier is not pulled.
+fn cached_q8_snapshot(hub: &Path, repo: &str) -> Option<PathBuf> {
+    let snapshots = hub
+        .join(format!("models--{}", repo.replace('/', "--")))
+        .join("snapshots");
+    std::fs::read_dir(&snapshots)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .find_map(|entry| {
+            let path = entry.path();
+            path.join("q8").is_dir().then_some(path)
+        })
+}
+
+#[test]
+#[ignore = "real-weight MLX smoke; needs the SceneWorks/Mage-Flow-Base + Mage-Flow-Components-mlx q8 tiers cached + an Apple-Silicon Mac"]
+fn mage_flow_q8_mlx_gpu_smoke() {
+    let hub = hub_cache_root().expect("a resolvable HF hub cache root");
+    // Pin the worker's cache resolution to the SAME hub this smoke discovered in, so the
+    // co-requisite resolver reads the tiers we just verified rather than a different data_dir's
+    // cache. Without this the resolve fails with "not installed" even though the tiers are present.
+    let _env = crate::test_env::EnvVars::set(&[("HF_HUB_CACHE", &hub.display().to_string())]);
+    let Some(variant) = cached_q8_snapshot(&hub, VARIANT_REPO) else {
+        panic!("{VARIANT_REPO} q8 tier is not in the HF cache — pull it before running this smoke");
+    };
+    let Some(components) = cached_q8_snapshot(&hub, COMPONENTS_REPO) else {
+        panic!(
+            "{COMPONENTS_REPO} q8 tier is not in the HF cache — the shared text encoder + VAE are a \
+             co-requisite of every Mage variant, so this smoke cannot prove the split layout without it"
+        );
+    };
+    let tier = variant.join("q8");
+
+    // The premise of the whole test: the tier is DiT-only. If a future re-host put the text encoder
+    // back inside the tier, the load below would pass for the WRONG reason (the flat-root fallback),
+    // and this smoke would silently stop testing the co-requisite path.
+    assert!(
+        tier.join("transformer/diffusion_pytorch_model.safetensors")
+            .is_file(),
+        "the q8 tier must carry the packed DiT"
+    );
+    assert!(
+        !tier.join("text_encoder").exists() && !tier.join("vae").exists(),
+        "the q8 tier must NOT contain text_encoder/ or vae/ — they are shared co-requisites, and \
+         their presence here would make this smoke pass without exercising the component seam"
+    );
+
+    // 2. The component seam, tier-matched — the exact call `attach_required_components` makes.
+    let descriptor = crate::inference_runtime::media_descriptor(MODEL_ID)
+        .unwrap_or_else(|| panic!("{MODEL_ID} is a registered media provider"));
+    assert_eq!(
+        descriptor.required_components,
+        &["text_encoder", "vae"],
+        "the pinned engine must advertise the shared components; an engine pinned BEFORE the \
+         sc-14979 split advertises &[] and would look for {}/text_encoder instead",
+        tier.display()
+    );
+    let manifest = builtin_manifest_entry(MODEL_ID);
+    // The REAL environment's HF cache resolution — the same `Settings` a running worker uses, so
+    // the co-requisite resolves out of the actual hub cache rather than a synthetic fixture.
+    let settings = crate::Settings::from_env();
+    let staged = crate::model_jobs::resolve_co_requisites_for_tier(
+        &descriptor,
+        &manifest,
+        &settings,
+        Some("q8"),
+    )
+    .expect("the q8 shared components resolve from the components mirror");
+
+    // They must resolve into the COMPONENTS repo's q8 subtree — not the variant snapshot.
+    for (id, source) in &staged {
+        let gen_core::WeightsSource::Dir(dir) = source else {
+            panic!("{id} must stage as a directory");
+        };
+        assert!(
+            dir.starts_with(&components) && dir.ends_with(format!("q8/{id}")),
+            "{id} must resolve to {}/q8/{id}, got {}",
+            components.display(),
+            dir.display()
+        );
+        assert!(dir.is_dir(), "{id} component dir must exist on disk");
+    }
+    println!("staged components: {:?}", staged.keys().collect::<Vec<_>>());
+
+    // 3-4. The real load, exactly as generate_stream builds it.
+    let spec = staged.into_iter().fold(
+        LoadSpec::new(WeightsSource::Dir(tier.clone())).with_quant(Quant::Q8),
+        |spec, (id, source)| spec.with_component(id, source),
+    );
+    let model = crate::inference_runtime::load(MODEL_ID, &spec).unwrap_or_else(|error| {
+        panic!(
+            "the q8 tier at {} must load with the shared components staged — this is the exact \
+             failure a stale engine pin produces: {error}",
+            tier.display()
+        )
+    });
+
+    // 5. Render and check it is a real image.
+    let steps: u32 = env_or("MAGE_Q8_STEPS", "8").parse().expect("steps");
+    let width: u32 = env_or("MAGE_Q8_W", "512").parse().expect("width");
+    let height: u32 = env_or("MAGE_Q8_H", "512").parse().expect("height");
+    let prompt = env_or(
+        "MAGE_Q8_PROMPT",
+        "a red cube on a white table, studio lighting",
+    );
+    let request = GenerationRequest {
+        prompt: prompt.clone(),
+        width,
+        height,
+        count: 1,
+        seed: Some(42),
+        steps: Some(steps),
+        guidance: Some(5.0),
+        ..Default::default()
+    };
+    let mut last = String::new();
+    let output = model
+        .generate(&request, &mut |progress| {
+            let line = format!("{progress:?}");
+            if line != last {
+                println!("[progress] {line}");
+                last = line;
+            }
+        })
+        .expect("q8 generation");
+    let GenerationOutput::Images(images) = output else {
+        panic!("mage_flow_base must produce images");
+    };
+    let image = images.first().expect("one image");
+
+    assert!(!is_all_zero(image), "the q8 render must not be all-zero");
+    let (mean, std) = (image_mean(image), image_std(image));
+    println!("q8 render: mean={mean:.2} std={std:.2} ({width}x{height}, {steps} steps)");
+    // A dynamic-range floor alone is NOT a quality gate: Mage's q4 tier renders a repeating tiled
+    // texture that scores std ~64 and would sail past any such check (see the q4 note above). The
+    // meaningful assertions here are the structural ones ABOVE — the tier is DiT-only, the engine
+    // advertises the components, and they resolve out of the shared mirror — plus a sanity floor so
+    // a flat/black frame still fails loudly.
+    assert!(
+        std >= 20.0 && (10.0..245.0).contains(&mean),
+        "the q8 render looks degenerate (mean {mean:.2}, std {std:.2})"
+    );
+
+    let out_dir = PathBuf::from(env_or("MAGE_Q8_OUT_DIR", "/tmp/mage_q8_smoke"));
+    std::fs::create_dir_all(&out_dir).expect("out dir");
+    save_png(image, &out_dir.join("mage_flow_base_q8.png"));
+    println!("wrote {}", out_dir.join("mage_flow_base_q8.png").display());
+}
+
+/// The shipped catalog entry for `model_id`, read straight from the embedded builtin manifest — the
+/// same bytes the worker resolves co-requisites against.
+fn builtin_manifest_entry(model_id: &str) -> serde_json::Value {
+    let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc is embedded");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
+            .expect("builtin.models.jsonc parses");
+    manifest["models"]
+        .as_array()
+        .expect("models array")
+        .iter()
+        .find(|entry| entry.get("id").and_then(serde_json::Value::as_str) == Some(model_id))
+        .cloned()
+        .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
+}

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1739,6 +1739,27 @@ pub(crate) fn resolve_co_requisites(
     manifest_entry: &Value,
     settings: &Settings,
 ) -> WorkerResult<BTreeMap<String, gen_core::WeightsSource>> {
+    resolve_co_requisites_for_tier(descriptor, manifest_entry, settings, None)
+}
+
+/// [`resolve_co_requisites`], for a model whose co-requisites are themselves **per-tier** (sc-14980).
+///
+/// Mage-Flow hosts its shared Qwen3-VL text encoder and Mage-VAE once, as `q4/`+`q8/`+`bf16/`
+/// subtrees of one components mirror, so a component id maps to THREE `coRequisite` rows that differ
+/// only by `variant`. `tier` selects among them, and each row's `subdir` addresses the component dir
+/// inside the shared snapshot (`resolve_co_requisites` otherwise resolves whole-snapshot dirs, which
+/// cannot express "the `q4/text_encoder/` subtree").
+///
+/// Behavior is unchanged wherever a component id maps to exactly ONE row — every audio co-requisite
+/// today — so this is additive. When a component id maps to several rows, a `tier` is REQUIRED: a
+/// first-wins pick would silently serve a bf16 text encoder to a q4 request, which is precisely the
+/// class of silent tier mismatch physical per-tier artifacts exist to eliminate.
+pub(crate) fn resolve_co_requisites_for_tier(
+    descriptor: &gen_core::ModelDescriptor,
+    manifest_entry: &Value,
+    settings: &Settings,
+    tier: Option<&str>,
+) -> WorkerResult<BTreeMap<String, gen_core::WeightsSource>> {
     let mut components = BTreeMap::new();
     if descriptor.required_components.is_empty() {
         return Ok(components);
@@ -1750,21 +1771,51 @@ pub(crate) fn resolve_co_requisites(
         .map(Vec::as_slice)
         .unwrap_or(&[]);
     for &component_id in descriptor.required_components {
-        // The `coRequisite` download that PROVISIONS this component id — matched on the explicit
+        // The `coRequisite` download(s) that PROVISION this component id — matched on the explicit
         // `componentId` field the manifest sets (never inferred from repo names, sc-13679).
-        let download = downloads
+        let candidates: Vec<&Value> = downloads
             .iter()
-            .find(|download| {
+            .filter(|download| {
                 download.get("coRequisite").and_then(Value::as_bool) == Some(true)
                     && download.get("componentId").and_then(Value::as_str) == Some(component_id)
             })
-            .ok_or_else(|| {
-                WorkerError::InvalidPayload(format!(
-                    "{model_id} requires the model component '{component_id}', but its catalog entry \
+            .collect();
+        let download = match candidates.as_slice() {
+            [] => {
+                return Err(WorkerError::InvalidPayload(format!(
+                "{model_id} requires the model component '{component_id}', but its catalog entry \
                      declares no `coRequisite` download tagged `componentId: \"{component_id}\"` — \
                      the model manifest entry is misconfigured"
-                ))
-            })?;
+            )))
+            }
+            [only] => *only,
+            many => {
+                let tier = tier.ok_or_else(|| {
+                    WorkerError::InvalidPayload(format!(
+                        "{model_id}: the '{component_id}' component declares {} per-tier \
+                         `coRequisite` rows but no tier was resolved for this request — refusing to \
+                         guess, because picking the wrong one would silently serve another tier's \
+                         weights",
+                        many.len()
+                    ))
+                })?;
+                many.iter()
+                    .copied()
+                    .find(|download| {
+                        download
+                            .get("variant")
+                            .and_then(Value::as_str)
+                            .is_some_and(|variant| variant.eq_ignore_ascii_case(tier))
+                    })
+                    .ok_or_else(|| {
+                        WorkerError::InvalidPayload(format!(
+                            "{model_id}: the '{component_id}' component declares no `coRequisite` row \
+                             for the resolved {tier} tier — install {model_id}'s {tier} tier, or the \
+                             model manifest entry is misconfigured"
+                        ))
+                    })?
+            }
+        };
         let repo = download
             .get("repo")
             .and_then(Value::as_str)
@@ -1809,11 +1860,13 @@ pub(crate) fn resolve_co_requisites(
                 }
                 gen_core::WeightsSource::File(path)
             }
-            [] => gen_core::WeightsSource::Dir(snapshot),
+            [] => gen_core::WeightsSource::Dir(component_dir(&snapshot, download, model_id)?),
             _ => {
                 // Multi-file components are staged as directories because providers join their own
                 // internal paths, but the pre-load all-or-nothing contract still requires every
-                // manifest-declared file or pattern to be present.
+                // manifest-declared file or pattern to be present. The declared patterns are
+                // SNAPSHOT-relative (they are what the downloader fetched), while `subdir` narrows
+                // what the provider is handed — so check against the snapshot, stage the subdir.
                 for file in &files {
                     if !snapshot_contains_declared_file(&snapshot, file)? {
                         return Err(WorkerError::InvalidPayload(format!(
@@ -1822,12 +1875,40 @@ pub(crate) fn resolve_co_requisites(
                         )));
                     }
                 }
-                gen_core::WeightsSource::Dir(snapshot)
+                gen_core::WeightsSource::Dir(component_dir(&snapshot, download, model_id)?)
             }
         };
         components.insert(component_id.to_owned(), source);
     }
     Ok(components)
+}
+
+/// The directory a co-requisite download stages: the cached snapshot, narrowed by an optional
+/// `subdir` (sc-14980).
+///
+/// A shared components mirror hosts several components AND several tiers in one repo
+/// (`<tier>/text_encoder/`, `<tier>/vae/`), so "the snapshot" is not the thing a provider should be
+/// handed. `subdir` names the exact component dir. It arrives from the payload `modelManifestEntry`
+/// — unvalidated over the LAN jobs API — so it is confined under the snapshot with [`safe_join`] for
+/// the same reason `files` and `revision` are (sc-13583 / sc-13842): a `..`/absolute entry would
+/// otherwise stage an arbitrary host directory as this component's weights.
+fn component_dir(snapshot: &Path, download: &Value, model_id: &str) -> WorkerResult<PathBuf> {
+    let Some(subdir) = download
+        .get("subdir")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(snapshot.to_path_buf());
+    };
+    let dir = safe_join(snapshot, subdir)?;
+    if !dir.is_dir() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "{model_id}: the co-requisite subdirectory `{subdir}` is missing from the cached \
+             snapshot — reinstall {model_id} to repair it"
+        )));
+    }
+    Ok(dir)
 }
 
 fn snapshot_contains_declared_file(snapshot: &Path, declared: &str) -> WorkerResult<bool> {

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1847,7 +1847,12 @@ pub(crate) fn resolve_co_requisites_for_tier(
             .map(|files| files.iter().filter_map(Value::as_str).collect())
             .unwrap_or_default();
         let source = match files.as_slice() {
-            [file] => {
+            // A single LITERAL filename resolves to that file (chatterbox's `ve.safetensors`). A
+            // single GLOB does not: it names a set, so it must take the directory arm below like any
+            // other multi-entry predicate (sc-14980 — Mage's `["q4/text_encoder/*"]`). Without this
+            // guard the pattern is `safe_join`ed verbatim, `is_file()` is false for a path with a
+            // literal `*` in it, and a correctly-installed component reports as missing.
+            [file] if !file.contains(['*', '?', '[']) => {
                 // `file` comes from the payload `modelManifestEntry`; confine it under the snapshot so
                 // a `..`/absolute entry can't stage an arbitrary host file as this component's weights
                 // (on Windows `join` with an absolute path replaces the base entirely) (sc-13583).
@@ -5004,6 +5009,133 @@ mod co_requisite_tests {
             "config.json",
         ),
     ];
+
+    fn mage_descriptor(id: &'static str) -> gen_core::ModelDescriptor {
+        gen_core::ModelDescriptor {
+            id,
+            family: "mage-flow",
+            backend: "mlx",
+            modality: gen_core::Modality::Image,
+            capabilities: gen_core::Capabilities::default(),
+            required_components: &["text_encoder", "vae"],
+        }
+    }
+
+    /// The six SHIPPED Mage rows, whose shared text encoder + VAE are per-tier co-requisites.
+    const MAGE_MODEL_IDS: &[&str] = &[
+        "mage_flow_base",
+        "mage_flow",
+        "mage_flow_turbo",
+        "mage_flow_edit_base",
+        "mage_flow_edit",
+        "mage_flow_edit_turbo",
+    ];
+
+    /// Stage the shared components mirror's `<tier>/text_encoder/` + `<tier>/vae/` for one tier.
+    fn stage_mage_components(data_dir: &Path, manifest: &Value, tier: &str) {
+        for download in manifest["downloads"].as_array().expect("downloads") {
+            if download.get("coRequisite").and_then(Value::as_bool) != Some(true) {
+                continue;
+            }
+            if download.get("variant").and_then(Value::as_str) != Some(tier) {
+                continue;
+            }
+            let repo = download["repo"].as_str().expect("repo");
+            let revision = download["revision"].as_str().expect("revision");
+            let subdir = download["subdir"].as_str().expect("subdir");
+            // One real file inside the component dir, so both the `files` glob check and the
+            // `subdir` is_dir() check see a populated tree.
+            stage_snapshot_file(
+                data_dir,
+                repo,
+                revision,
+                &format!("{subdir}/model.safetensors"),
+            );
+        }
+    }
+
+    /// sc-14980/sc-14979 — a per-tier co-requisite resolves to the tier's own component DIR.
+    ///
+    /// Discriminating in the way that matters: only the q4 tier is staged, and the assertion is that
+    /// each component path ends in `q4/<component>`. A resolver that ignored `subdir` would hand
+    /// back the snapshot ROOT (the engine would then look for `text_encoder/` at the top level and
+    /// fail), and one that ignored `variant` would pick whichever row came first.
+    #[test]
+    fn mage_per_tier_co_requisites_resolve_to_the_matching_tier_component_dir() {
+        for &model_id in MAGE_MODEL_IDS {
+            let _env = isolate_hf_cache();
+            let data_dir = tempfile::tempdir().expect("temp data dir");
+            let manifest = builtin_manifest_entry(model_id);
+            stage_mage_components(data_dir.path(), &manifest, "q4");
+
+            let components = resolve_co_requisites_for_tier(
+                &mage_descriptor(model_id),
+                &manifest,
+                &settings_at(data_dir.path().to_path_buf()),
+                Some("q4"),
+            )
+            .unwrap_or_else(|error| panic!("{model_id}: q4 components are staged: {error:?}"));
+
+            let keys: Vec<&str> = components.keys().map(String::as_str).collect();
+            assert_eq!(keys, vec!["text_encoder", "vae"], "{model_id}");
+            for component in ["text_encoder", "vae"] {
+                let gen_core::WeightsSource::Dir(dir) = &components[component] else {
+                    panic!("{model_id}: {component} must stage as a directory");
+                };
+                assert!(
+                    dir.ends_with(format!("q4/{component}")),
+                    "{model_id}: {component} must resolve to the q4 component dir, got {}",
+                    dir.display()
+                );
+                assert!(dir.is_dir(), "{model_id}: {component} dir must exist");
+            }
+        }
+    }
+
+    /// Asking for a tier whose shared components are NOT installed fails BEFORE the engine load,
+    /// rather than silently handing back another tier's text encoder.
+    #[test]
+    fn mage_co_requisites_refuse_a_tier_that_is_not_installed() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let manifest = builtin_manifest_entry("mage_flow_base");
+        stage_mage_components(data_dir.path(), &manifest, "q4");
+
+        let error = resolve_co_requisites_for_tier(
+            &mage_descriptor("mage_flow_base"),
+            &manifest,
+            &settings_at(data_dir.path().to_path_buf()),
+            Some("bf16"),
+        )
+        .expect_err("bf16 components are not staged, so resolution must fail");
+        let message = format!("{error:?}");
+        assert!(
+            message.contains("not installed") || message.contains("missing"),
+            "the failure must be actionable, got {message}"
+        );
+    }
+
+    /// A per-tier component with NO tier in scope is refused rather than guessed. Picking the first
+    /// matching row would silently serve a bf16 text encoder to a q4 render.
+    #[test]
+    fn mage_co_requisites_refuse_to_guess_a_tier_when_none_is_resolved() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let manifest = builtin_manifest_entry("mage_flow_base");
+        stage_mage_components(data_dir.path(), &manifest, "q4");
+
+        let error = resolve_co_requisites_for_tier(
+            &mage_descriptor("mage_flow_base"),
+            &manifest,
+            &settings_at(data_dir.path().to_path_buf()),
+            None,
+        )
+        .expect_err("three per-tier rows with no tier in scope must not be guessed");
+        assert!(
+            format!("{error:?}").contains("refusing to guess"),
+            "got {error:?}"
+        );
+    }
 
     #[test]
     fn moss_codec_co_requisite_resolves_from_every_live_moss_tts_entry() {

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -586,6 +586,14 @@
                   }
                 },
                 {
+                  "$comment": "sc-14980: a subdir narrows WHICH directory of a coRequisite's snapshot is staged for its componentId, so like componentId it is valid ONLY on coRequisite: true entries.",
+                  "if": { "required": ["subdir"] },
+                  "then": {
+                    "properties": { "coRequisite": { "const": true } },
+                    "required": ["coRequisite"]
+                  }
+                },
+                {
                   "$comment": "sc-13771: a componentId names a component PROVISIONED by a coRequisite download, so it is valid ONLY on coRequisite: true entries — a manifest-local invariant that JSON Schema CAN enforce without inference-descriptor knowledge (contrast the componentId ⟺ some descriptor.required_components match, which the manifest audit cannot see and stays a runtime resolve_co_requisites check).",
                   "if": { "required": ["componentId"] },
                   "then": {
@@ -613,13 +621,19 @@
                   "pattern": "^[a-z][a-z0-9_]*$",
                   "description": "Optional stable component id this coRequisite download PROVISIONS for the model's engine (epic 13657, sc-13679). When set (valid ONLY on `coRequisite: true` entries — schema-enforced by the allOf conditional above, sc-13771), the worker stages the resolved local path under this id in the engine's `LoadSpec::components`, matched against the provider's `ModelDescriptor::required_components` advertisement — the explicit repo→component mapping (never inferred from repo names) that the generic `resolve_co_requisites` seam reads. Lowercase snake_case, same shape as a descriptor id. Examples: chatterbox_tts's ve/perth co-requisites carry `voice_embedding`/`perth`; SDXL's carry `tokenizer_clip_l`/`tokenizer_clip_bigg`/`vae_fp16_fix` (sc-13682). Absent on a co-requisite the engine does not read as a named component (e.g. the PiD-gemma / Wan-Lightning shared weights)."
                 },
+                "subdir": {
+                  "type": "string",
+                  "pattern": "^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$",
+                  "x-sceneworks-contract": "binding",
+                  "description": "Optional path, relative to this coRequisite's cached snapshot, of the directory actually staged for `componentId` (sc-14980). Valid ONLY on `coRequisite: true` entries — schema-enforced by the allOf conditional above. Without it a multi-file co-requisite stages the WHOLE snapshot, which cannot express a shared mirror hosting SEVERAL components at SEVERAL quant tiers: Mage-Flow's `SceneWorks/Mage-Flow-Components-mlx` holds `<tier>/text_encoder/` and `<tier>/vae/`, so each row sets `subdir` to the exact component dir (e.g. `q4/text_encoder`) while `files` keeps listing the snapshot-relative patterns the downloader fetches. Confined under the snapshot with safe_join at resolve time, so a `..`/absolute value is rejected rather than staged."
+                },
                 "default": {
                   "type": "boolean",
                   "description": "Marks the canonical alternate used for displayed size, install path, and download jobs. For a quant matrix this marks the DEFAULT tier (the one that installs when no explicit variant is requested)."
                 },
                 "variant": {
                   "$ref": "#/$defs/quantVariantKey",
-                  "description": "The quantization tier this entry provisions (bf16 / q8 / q4). Present only on quant-matrix entries (sc-8508); a single-variant model omits it. The web/download-job selects a tier by this key, and per-variant install tracking reports which tiers are on disk. Never combined with coRequisite (a co-requisite is not a selectable tier)."
+                  "description": "The quantization tier this entry provisions (bf16 / q8 / q4). Present only on quant-matrix entries (sc-8508); a single-variant model omits it. The web/download-job selects a tier by this key, and per-variant install tracking reports which tiers are on disk. On a NON-coRequisite entry this is the selectable tier. On a `coRequisite: true` entry (sc-14980) it instead SCOPES that co-requisite to one tier: Mage-Flow's shared text encoder and VAE exist as q4/q8/bf16 subtrees of a single components mirror, so only the row matching the selected tier is fetched, sized, and gated on, and `resolve_co_requisites_for_tier` picks among same-`componentId` rows by it. A co-requisite WITHOUT a variant is tier-agnostic and always applies — every pre-sc-14980 co-requisite."
                 },
                 "coRequisite": {
                   "type": "boolean",

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -186,20 +186,65 @@ def test_cached_manifest_and_schema_loaders_return_isolated_copies():
     assert _load_schema(SCHEMA_PATH)["type"] == original_type
 
 
+COMPONENTS_REPO = "SceneWorks/Mage-Flow-Components-mlx"
+COMPONENTS_REVISION = "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62"
+# Measured on the uploaded artifacts (sc-14980). Per-tier DiT, and the shared per-tier components.
+DIT_BYTES = {"q4": 2316856860, "q8": 4374163324, "bf16": 8231571754}
+TE_BYTES = {"q4": 2514418914, "q8": 4731076490, "bf16": 8887219239}
+VAE_BYTES = 345053168
+TIERS = ("q4", "q8", "bf16")
+
+
+def _assert_mage_tier_layout(model, model_id, repo, revision):
+    """sc-14980/sc-14979: the shared per-tier shape every Mage row must have.
+
+    Supersedes the sc-14047/sc-14050 "complete flat snapshot" pin: the tiers are physically
+    distinct `<tier>/` artifacts now, and the text encoder + VAE are hosted once as per-tier
+    co-requisites rather than duplicated into all six variant mirrors.
+    """
+    downloads = model["downloads"]
+    tiers = [d for d in downloads if not d.get("coRequisite")]
+    co_reqs = [d for d in downloads if d.get("coRequisite")]
+
+    assert [d["variant"] for d in tiers] == list(TIERS), model_id
+    assert sum(d.get("default") is True for d in tiers) == 1, model_id
+    for entry in tiers:
+        tier = entry["variant"]
+        assert entry["repo"] == repo, model_id
+        assert entry["revision"] == revision, model_id
+        # Each tier fetches ONLY its own subtree — this is what makes a per-tier delete reclaim
+        # real bytes. A shared full-snapshot predicate here would silently restore 0-byte deletes.
+        assert entry["files"] == [f"{tier}/*"], (model_id, tier)
+        assert entry["estimatedSizeBytes"] == DIT_BYTES[tier], (model_id, tier)
+
+    # The shared components: one mirror, one pinned revision, addressed per tier via `subdir`.
+    assert len(co_reqs) == 6, model_id
+    for component, sizes in (("text_encoder", TE_BYTES), ("vae", None)):
+        for tier in TIERS:
+            row = next(
+                d
+                for d in co_reqs
+                if d["componentId"] == component and d["variant"] == tier
+            )
+            assert row["repo"] == COMPONENTS_REPO, (model_id, component, tier)
+            assert row["revision"] == COMPONENTS_REVISION, (model_id, component, tier)
+            assert row["subdir"] == f"{tier}/{component}", (model_id, component, tier)
+            assert row["files"] == [f"{tier}/{component}/*"], (model_id, component, tier)
+            expected = sizes[tier] if sizes else VAE_BYTES
+            assert row["estimatedSizeBytes"] == expected, (model_id, component, tier)
+
+    assert model["mlx"]["standardTierLayout"] is True, model_id
+    assert model["mlx"]["quantize"] == 4, model_id
+    assert model["paths"]["model"] == f"${{HF_CACHE}}/{repo}"
+
+
 def test_mage_flow_generation_family_is_pinned_and_complete():
-    """sc-14047: all published Mage generation variants remain loadable flat snapshots."""
+    """sc-14047 + sc-14980: the generation variants ship physical per-tier artifacts."""
     models = {model["id"]: model for model in _load_builtin_models_manifest()["models"]}
     expected = {
-        "mage_flow_base": ("SceneWorks/Mage-Flow-Base", "a160c0a2c9d82106687d969d161c313c7e528550", 30, 5),
-        "mage_flow": ("SceneWorks/Mage-Flow", "e6719fb1abb0d3fa83ecebbf31cbf431eb054ab8", 20, 5),
-        "mage_flow_turbo": ("SceneWorks/Mage-Flow-Turbo", "6fc43b7b586078997047acc9c39dbbd26044a035", 4, 1),
-    }
-    complete_snapshot = {
-        "model_index.json",
-        "scheduler/*",
-        "text_encoder/*",
-        "transformer/*",
-        "vae/*",
+        "mage_flow_base": ("SceneWorks/Mage-Flow-Base", "2c0b473896ef87af5a0873a26ed62c319213ae36", 30, 5),
+        "mage_flow": ("SceneWorks/Mage-Flow", "b9204c289b235bce9ade608f76a009f80a135bfd", 20, 5),
+        "mage_flow_turbo": ("SceneWorks/Mage-Flow-Turbo", "dca431fa8dfb4b3411cf3986435540ed31a7e8b7", 4, 1),
     }
     for model_id, (repo, revision, steps, guidance) in expected.items():
         model = models[model_id]
@@ -212,34 +257,18 @@ def test_mage_flow_generation_family_is_pinned_and_complete():
         }
         assert model["defaults"]["steps"] == steps
         assert model["defaults"]["guidanceScale"] == guidance
-        downloads = model["downloads"]
-        assert [entry["variant"] for entry in downloads] == ["q4", "q8", "bf16"]
-        assert sum(entry.get("default") is True for entry in downloads) == 1
-        for entry in downloads:
-            assert entry["repo"] == repo
-            assert entry["revision"] == revision
-            # These are load-time quant choices over one dense mirror, so every logical tier
-            # uses the same full-snapshot predicate. Physical tier provisioning belongs to sc-14059.
-            assert set(entry["files"]) == complete_snapshot
-        assert model["paths"]["model"] == f"${{HF_CACHE}}/{repo}"
+        _assert_mage_tier_layout(model, model_id, repo, revision)
 
 
 def test_mage_flow_edit_family_is_pinned_complete_and_source_gated():
-    """sc-14050: every edit variant is a complete shared-component snapshot."""
+    """sc-14050 + sc-14980: every edit variant ships physical per-tier artifacts."""
     models = {model["id"]: model for model in _load_builtin_models_manifest()["models"]}
     expected = {
-        "mage_flow_edit_base": ("SceneWorks/Mage-Flow-Edit-Base", "5345fa8b0d41bdd612351f0933ef4cc9021281ab", 17495714677, 30, 5),
-        "mage_flow_edit": ("SceneWorks/Mage-Flow-Edit", "d668ecc8ce5addcb3c0bbe268227eb17f832aa9f", 17495714677, 30, 5),
-        "mage_flow_edit_turbo": ("SceneWorks/Mage-Flow-Edit-Turbo", "3e5ae67807083a25f3d344bc2c5ff16276415a14", 17495714653, 4, 1),
+        "mage_flow_edit_base": ("SceneWorks/Mage-Flow-Edit-Base", "199b4cae841403e8a1cca3c585a09f10fc70d3f1", 30, 5),
+        "mage_flow_edit": ("SceneWorks/Mage-Flow-Edit", "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503", 30, 5),
+        "mage_flow_edit_turbo": ("SceneWorks/Mage-Flow-Edit-Turbo", "c3437cbb91e565ab6373e3c7b8e9b8048d29831b", 4, 1),
     }
-    complete_snapshot = {
-        "model_index.json",
-        "scheduler/*",
-        "text_encoder/*",
-        "transformer/*",
-        "vae/*",
-    }
-    for model_id, (repo, revision, size, steps, guidance) in expected.items():
+    for model_id, (repo, revision, steps, guidance) in expected.items():
         model = models[model_id]
         assert model["family"] == "mage-flow"
         assert model["adapter"] == "mlx_mage"
@@ -254,14 +283,7 @@ def test_mage_flow_edit_family_is_pinned_complete_and_source_gated():
         assert model["defaults"]["guidanceScale"] == guidance
         assert model["ui"]["sourceWithMultiReference"] is True
         assert model["ui"]["recommendedFor"] == ["edit_image"]
-        assert [entry["variant"] for entry in model["downloads"]] == ["q4", "q8", "bf16"]
-        assert sum(entry.get("default") is True for entry in model["downloads"]) == 1
-        for entry in model["downloads"]:
-            assert entry["repo"] == repo
-            assert entry["revision"] == revision
-            assert entry["estimatedSizeBytes"] == size
-            assert set(entry["files"]) == complete_snapshot
-        assert model["paths"]["model"] == f"${{HF_CACHE}}/{repo}"
+        _assert_mage_tier_layout(model, model_id, repo, revision)
 
 
 def _model_table_default_repos() -> dict[str, str]:


### PR DESCRIPTION
App half of **sc-14980** (physical per-tier quant artifacts) and **sc-14979** (shared TE/VAE co-requisites). Epic 14034. Pairs with SceneWorks/inference#262.

Michael authorized the re-host and publishing to the SceneWorks HF org.

## The problem

Mage's three tiers carried **identical** `repo`+`revision`+`files`, so a q4 user downloaded the full 17.5 GB dense snapshot and a per-tier delete truthfully reclaimed **0 bytes**. The mirrors now host physically distinct `<tier>/` artifacts plus one shared components repo.

## Measured effect

| | before | after |
|---|---|---|
| one q4 install | 17.50 GB | **5.18 GB** |
| all six at q4 | 105.04 GB | **16.76 GB** |
| all six at bf16 | 105.04 GB | **58.62 GB** |
| second variant | +17.5 GB | **+8.2 GB** |

58.62 GB matches the epic's 58.65 GB target.

## Manifest (all six rows)

- Each tier fetches only `<tier>/*` from its variant mirror, repinned to the commit that added the subdirs. The flat dense root stays **hosted** so existing installs keep loading, but no tier fetches it.
- `text_encoder` + `vae` — bit-identical across all six variants — become per-tier `coRequisite` rows against `SceneWorks/Mage-Flow-Components-mlx`. Co-requisites are structurally exempt from per-variant/per-tier delete, so removing one variant or tier can never strand another.
- `mlx.standardTierLayout: true` routes the worker into `standard_tier_subdir`.

## Per-tier co-requisites — a new, additive capability

Mage is the first model whose *co-requisites are themselves per-tier*, which needed two primitives:

- **`subdir`** on a co-requisite download names the exact component dir inside a shared snapshot. Without it a multi-file co-requisite stages the **whole** snapshot, which cannot express a mirror hosting several components at several tiers. Confined with `safe_join` (same treatment as `files`/`revision`, sc-13583), and **schema-restricted to `coRequisite` rows** mirroring `componentId`. New manifest field ⇒ `model-manifest.schema.json` updated, so the parity lane stays green.
- **`resolve_co_requisites_for_tier`** picks among same-`componentId` rows by tier. The tier is read back off the **resolved** weights dir, not the request, so a q4 request that `standard_tier_subdir`'s completeness fallback stepped down to q8 gets the **q8** text encoder — never a mixed pair. Where a component id maps to one row (every audio co-requisite today) behavior is byte-identical.
- Install queue / size estimate / install-state are all tier-scoped, so a q4 install pulls 2.51 GB of text encoder instead of all three tiers' 16.1 GB. Install-state treats tier-scoped co-reqs as satisfied when **any** tier's set is complete, matching the existing "installed when any tier is present" aggregate — otherwise a working q4 install would report incomplete forever. Co-requisites **without** a `variant` stay tier-agnostic, so no existing family changes.

The image path needed no new plumbing: `attach_required_components` already existed and was documented as dormant pending the first image provider advertising components. Mage is that provider.

## Training gate (re-examined, per review)

`bf16_component_tree_present` required `text_encoder/` and `vae/` *inside* the bf16 tier. Under the split layout a complete, trainable bf16 install would report `TrainingTierMissing` **forever**. It gains a purely **additive** arm for tiers that declare their own component set and exclude `text_encoder` — reached only after the classic check already failed, so it cannot weaken anything. Verified against the live `SceneWorks/krea-2-raw-mlx` mirror, whose bf16 declares `transformer + text_encoder + tokenizer + vae + scheduler` and therefore still takes the original path; every SDXL-family turnkey likewise.

**`TrainingTierMissing` is now genuinely reachable for Mage**, which it was not before: a q4-only install has no bf16 backbone, so the gate returns the typed error rather than a false `Ready`. The engine-side twin lands in inference#262 — the trainer refuses a packed base outright.

> Note on the earlier hand-off: sc-14056's `mage_flow_foundation_targets_are_missing_when_not_installed` asserts `Missing` against an **empty** data dir, an outcome identical under either layout, so it passes unchanged and did **not** catch this. The resolver change above is what actually needed doing.

## Tests

- **The sc-14059 invariant test is replaced, not relaxed.** It pinned the exact opposite (identical predicates across tiers, `standardTierLayout` absent). The replacement pins the physical shape and stays discriminating — three mutations each fail it: dropping `standardTierLayout`, making q8's predicate equal q4's, and dropping a `subdir`.
- **New `mage_flow_per_tier_delete_reclaims_only_that_tiers_dit`** — sc-14046's delegated physical-reclaim DoD. Deleting q4 reclaims its own DiT bytes while the q8 tier **and** the shared components repo survive.
- `overlapping_logical_tiers_...` kept as a mechanism test (still correct for any shared-predicate family) but re-pointed at a synthetic model — it no longer describes Mage.
- The two Python manifest-audit tests that pinned the flat-snapshot shape updated in lockstep.

## Verification

`cargo fmt --check`, `clippy -D warnings`, `sceneworks-core` 643 + `rust-api` 432 + `worker` 1067 passing, manifest audit 59/59 (includes schema validation of `subdir`), web 2693/2693 across 197 files. Re-run after merging `origin/main`.

### Pre-existing failure, deliberately untouched

`crates/sceneworks-worker/src/image_decode.rs:157` (`decodes_unsupported_bmp_via_transcode`) asserts `image::open(&path).is_err()`. That is feature-unification dependent: it passes under `-p sceneworks-worker` alone and **fails** under `-p sceneworks-core -p sceneworks-worker -p sceneworks-rust-api`, because another package enables the `image` crate's BMP feature. **Reproduced twice on a clean `origin/main` tree with all local changes stashed**, so it is not from this PR. Flagged rather than silently fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)