### PR TITLE
chore(cargo): hoist `image` to [workspace.dependencies] so declared features match the build (sc-15052)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,27 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"]
 # the operating system's trash instead of an irreversible unlink. Pinned once here so
 # the api (sync helper) and core (project store purge) resolve the same version.
 trash = "5"
+# Image decode/encode, declared once for the whole workspace (sc-15052). Cargo unifies
+# features for a shared dependency across members, so a member's own feature list never
+# describes what it compiles with — every member builds against the union below. Unlike
+# a version skew this is SILENT: `image` features decide which formats decode, so a crate
+# quietly gains a capability it never declared and `cargo test -p <member>` exercises a
+# configuration that never ships. sc-15028 was that gap — two transcode tests asserted BMP
+# could not decode, green under `-p`, red in the workspace. Declaring it here makes the
+# declaration and the union the same object, so the two cannot drift apart.
+#
+# Keep `default-features = false`: the list below is meant to be exhaustive, and the
+# defaults would pull in codecs (and rayon) nobody asked for. Adding a format here adds it
+# for every member — that is the point. crates/sceneworks-worker/tests/image_workspace_dep_guard.rs
+# fails the build if a member goes back to declaring `image` on its own.
+image = { version = "0.25", default-features = false, features = [
+    "bmp",
+    "gif",
+    "jpeg",
+    "png",
+    "tiff",
+    "webp",
+] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/apps/rust-api/Cargo.toml
+++ b/apps/rust-api/Cargo.toml
@@ -11,7 +11,7 @@ fs2 = "0.4"
 futures-util = "0.3"
 glob = "0.3"
 httpdate = "1"
-image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "tiff", "webp"] }
+image = { workspace = true }
 parking_lot = "0.12"
 mime_guess = { version = "2", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -21,8 +21,8 @@ imagesize = "0.13"
 # bounded payload instead of trusting the sibling `.poster.jpg` filename. Only the
 # pure-Rust JPEG codec is used here; the feature set is the workspace union (sc-15052)
 # because Cargo unifies it anyway — this crate never got a jpeg-only `image` in a real
-# build. `default-features = false` there still keeps the native AVIF chain
-# (libdav1d/nasm/meson) out, which would break the Windows candle lane.
+# build. The union's `default-features = false` also keeps `avif` off, and with it the
+# nasm-dependent encoder chain that would break the Windows candle lane.
 image = { workspace = true }
 # sc-6531: SHA-256 of stored bytes = exact-duplicate key + the cache key for Tier-1
 # embeddings (epic 6529 §6.3). Pinned to the workspace's existing 0.10 line (worker + desktop)

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -15,13 +15,15 @@ serde_json = "1.0"
 mime_guess = "2.0"
 url = "2.5"
 # sc-6531 (Dataset Doctor): read image dimensions from the header without a full decode.
-# `imagesize` reads dataset dimensions without decoding. The poster verifier
-# below enables only the pure-Rust JPEG codec, avoiding native AVIF dependencies
-# (libdav1d/nasm/meson) that would break the Windows candle lane.
+# `imagesize` reads dataset dimensions without decoding.
 imagesize = "0.13"
 # Indexed video posters are served as image/jpeg, so indexing fully decodes the
-# bounded payload instead of trusting the sibling `.poster.jpg` filename.
-image = { version = "0.25", default-features = false, features = ["jpeg"] }
+# bounded payload instead of trusting the sibling `.poster.jpg` filename. Only the
+# pure-Rust JPEG codec is used here; the feature set is the workspace union (sc-15052)
+# because Cargo unifies it anyway — this crate never got a jpeg-only `image` in a real
+# build. `default-features = false` there still keeps the native AVIF chain
+# (libdav1d/nasm/meson) out, which would break the Windows candle lane.
+image = { workspace = true }
 # sc-6531: SHA-256 of stored bytes = exact-duplicate key + the cache key for Tier-1
 # embeddings (epic 6529 §6.3). Pinned to the workspace's existing 0.10 line (worker + desktop)
 # so no new locked version appears.

--- a/crates/sceneworks-core/src/media_convert.rs
+++ b/crates/sceneworks-core/src/media_convert.rs
@@ -40,8 +40,12 @@ pub enum ImageKind {
 }
 
 impl ImageKind {
-    /// True when the worker's `png`/`jpeg`/`webp` `image` build can decode this directly; everything
-    /// else must be transcoded to PNG first.
+    /// True for the png/jpeg/webp set SceneWorks stores assets in; everything else is transcoded to
+    /// PNG on import.
+    ///
+    /// This is a storage policy, not a read of the compiled `image` features. The workspace build
+    /// also decodes bmp/gif/tiff (sc-15052), and those are still transcoded on purpose so stored
+    /// assets stay in three formats. Do not "fix" this list to match the feature union.
     pub fn is_natively_supported(self) -> bool {
         matches!(self, ImageKind::Png | ImageKind::Jpeg | ImageKind::WebP)
     }

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -9602,7 +9602,10 @@ mod tests {
         let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
         let project = store.create_project("Convert").expect("project creates");
 
-        // A valid 1×1 24-bit BMP — not in the worker's png/jpeg/webp `image` build.
+        // A valid 1×1 24-bit BMP. The transcode decision here comes from
+        // `ImageKind::is_natively_supported` (a fixed png/jpeg/webp list), NOT from what the
+        // compiled `image` build can decode — so this fixture is unaffected by the workspace
+        // feature union, which does include `bmp` (sc-15052).
         let mut bmp = Vec::new();
         bmp.extend_from_slice(b"BM");
         bmp.extend_from_slice(&58u32.to_le_bytes());

--- a/crates/sceneworks-image-quality/Cargo.toml
+++ b/crates/sceneworks-image-quality/Cargo.toml
@@ -8,9 +8,13 @@ publish = false
 [dependencies]
 # Tier-0 result types + the pure decision logic this crate feeds (sc-6532, epic 6529).
 sceneworks-core = { path = "../sceneworks-core" }
-# Pure-Rust decode (png/jpeg/webp) — no native codec build, matching the rest of the tree. Dataset
-# uploads are normalized to these formats at import (sc-6143), so this feature set is sufficient.
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
+# Pure-Rust decode — no native codec build, matching the rest of the tree. Dataset uploads are
+# normalized to png/jpeg/webp at import (sc-6143), so that subset is what this crate relies on;
+# the rest of the workspace union (bmp/gif/tiff) comes along because Cargo unifies features and
+# always did. Do NOT narrow it back to a per-crate list: `decode_transcoding`'s tests are written
+# against what ships, and a `-p` build that decodes less than the workspace is how sc-15028
+# produced two green-under-`-p`, red-in-workspace tests (sc-15052).
+image = { workspace = true }
 # Convolution for the Laplacian-variance blur metric.
 imageproc = { version = "0.25", default-features = false }
 # Perceptual hashing for exact/near-duplicate detection (the epic's one sanctioned new dependency).

--- a/crates/sceneworks-image-quality/src/transform.rs
+++ b/crates/sceneworks-image-quality/src/transform.rs
@@ -150,11 +150,14 @@ mod tests {
     ///  2. The compiled `image` build genuinely cannot decode it.
     ///
     /// This used to hand-build a BMP, which made the test pass under
-    /// `cargo test -p sceneworks-image-quality` but FAIL under a workspace `cargo test`. Cargo
-    /// unifies features for the shared `image` 0.25 across workspace members, and `apps/rust-api`
-    /// enables `bmp` — so a workspace build (i.e. every shipped build) decodes BMP natively and gate
-    /// 2 stopped holding. This crate's own `default-features = false, features = [png, jpeg, webp]`
-    /// is NOT what it gets in a real build; the union today is bmp/gif/jpeg/png/tiff/webp.
+    /// `cargo test -p sceneworks-image-quality` but FAIL under a workspace `cargo test` (sc-15028):
+    /// Cargo unified features for the shared `image` 0.25 across members, another member enabled
+    /// `bmp`, and so every shipped build decoded BMP natively and gate 2 stopped holding.
+    /// sc-15052 removed that particular trapdoor — `image` is declared once in the root
+    /// `[workspace.dependencies]` (bmp/gif/jpeg/png/tiff/webp), so this crate's declared features
+    /// and its compiled features are now the same thing in either scope. Gate 2 must still not
+    /// lean on a format merely being absent from that list: the list is workspace-wide and one
+    /// line away from growing.
     ///
     /// HEIC is immune to that drift: `image` 0.25 ships no HEIC decoder under any feature, so gate 2
     /// cannot be silently invalidated by another crate's Cargo.toml. Generated at test time with the

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -13,12 +13,11 @@ publish = false
 fs2 = "0.4"
 futures-util = "0.3"
 glob = "0.3"
-# PNG encoding for generated image assets (epic 3018, sc-3020). png-only keeps the
-# dependency small and cross-platform (the image-job pipeline + its tests run on every
-# platform; only real MLX inference is macOS-gated).
-# png to encode generated assets (sc-3020); jpeg/webp to decode reference/source
-# images for the FLUX.2 edit path (sc-3029) — uploads aren't only PNG.
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
+# png to encode generated assets (epic 3018, sc-3020); jpeg/webp to decode reference/source
+# images for the FLUX.2 edit path (sc-3029) — uploads aren't only PNG. Pure-Rust and
+# cross-platform (the image-job pipeline + its tests run everywhere; only real MLX inference
+# is macOS-gated). Feature set is the workspace union (sc-15052) — it always effectively was.
+image = { workspace = true }
 # CPU raster for DWPose skeleton rendering (epic 3018, sc-3028): filled polygons
 # (rotated-ellipse limbs), circles (joints/points), for the Z-Image strict-pose
 # ControlNet. Pure-Rust + cross-platform (the renderer + its tests run everywhere;

--- a/crates/sceneworks-worker/tests/image_workspace_dep_guard.rs
+++ b/crates/sceneworks-worker/tests/image_workspace_dep_guard.rs
@@ -1,0 +1,462 @@
+//! Structural guard for the workspace-wide `image` dependency (sc-15052).
+//!
+//! Cargo unifies features for a shared dependency across workspace members, so a member's own
+//! feature list never describes what it compiles with — every member builds against the union.
+//! For `image` that divergence is SILENT and behavioural: its features decide which formats
+//! decode, so a crate quietly gains a capability it never declared, and `cargo test -p <member>`
+//! exercises a configuration that never ships. sc-15028 was exactly that: two transcode tests
+//! asserted BMP could not decode, passed under `-p`, and failed in the workspace.
+//!
+//! sc-15052 closed it by hoisting `image` into `[workspace.dependencies]` with the union feature
+//! set, so the declaration and the union are the same object. This guard keeps them that way, in
+//! the spirit of the sibling `candle_kernels_patch_guard.rs` (also a root-`Cargo.toml` structural
+//! guard living here). Two independent halves:
+//!
+//! 1. **Declaration** — parse the manifests: the root declares `image` with the expected features,
+//!    and no member re-declares it with a version/feature list of its own.
+//! 2. **Compilation** — probe `ImageFormat::reading_enabled()`, which is a `cfg!(feature = ..)` in
+//!    `image` itself, so it reports what this build ACTUALLY compiled. It asserts the enabled and
+//!    the disabled formats, so it fails whether the set narrows or silently widens — and because
+//!    it runs under `-p sceneworks-worker` and `--workspace` alike, a scope divergence like
+//!    sc-15028's cannot come back without one of the two scopes going red.
+//!
+//! Parse-only + a `cfg!` read: no GPU, no I/O beyond the manifests, so every CI lane runs it.
+
+use std::path::Path;
+
+/// The feature union declared in `[workspace.dependencies]`. Adding a format is a deliberate
+/// workspace-wide act: update the root `Cargo.toml` and this list together.
+const EXPECTED_FEATURES: &[&str] = &["bmp", "gif", "jpeg", "png", "tiff", "webp"];
+
+// ---------------------------------------------------------------------------------------------
+// Minimal TOML reading. Deliberately dependency-free (same reasoning as candle_kernels_patch_guard:
+// a build guard should not need a parser in the graph). It handles what these manifests use —
+// section headers, `key = value`, and inline tables/arrays spanning lines. It does not handle
+// escaped quotes inside strings, which none of the workspace manifests contain.
+// ---------------------------------------------------------------------------------------------
+
+/// Drop a trailing `#` comment that is outside a string literal.
+fn strip_comment(line: &str) -> &str {
+    let mut in_str = false;
+    for (i, b) in line.bytes().enumerate() {
+        match b {
+            b'"' => in_str = !in_str,
+            b'#' if !in_str => return &line[..i],
+            _ => {}
+        }
+    }
+    line
+}
+
+/// Net bracket/brace nesting introduced by a fragment, ignoring string contents.
+fn depth_delta(s: &str) -> i32 {
+    let mut in_str = false;
+    let mut depth = 0;
+    for b in s.bytes() {
+        match b {
+            b'"' => in_str = !in_str,
+            b'{' | b'[' if !in_str => depth += 1,
+            b'}' | b']' if !in_str => depth -= 1,
+            _ => {}
+        }
+    }
+    depth
+}
+
+/// `(section, key, value)` for every assignment in a manifest, with inline tables and arrays
+/// re-joined onto one logical line so a multi-line `features = [ .. ]` reads as a single value.
+fn manifest_entries(manifest: &str) -> Vec<(String, String, String)> {
+    let mut entries = Vec::new();
+    let mut section = String::new();
+    let mut lines = manifest.lines();
+    while let Some(raw) = lines.next() {
+        let line = strip_comment(raw).trim();
+        if line.is_empty() {
+            continue;
+        }
+        // A logical line starting with `[` and ending with `]` is a section header — a bare array
+        // never starts one, because array values always follow a `key =`. Checking both ends is
+        // what keeps `[target.'cfg(target_os = "macos")'.dependencies]` from parsing as an
+        // assignment on its embedded `=`.
+        if line.starts_with('[') && line.ends_with(']') {
+            section = line
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .trim()
+                .to_string();
+            continue;
+        }
+        let Some((key, first)) = line.split_once('=') else {
+            continue;
+        };
+        let mut value = first.trim().to_string();
+        let mut depth = depth_delta(&value);
+        while depth > 0 {
+            let Some(next) = lines.next() else { break };
+            let next = strip_comment(next).trim();
+            depth += depth_delta(next);
+            value.push(' ');
+            value.push_str(next);
+        }
+        entries.push((section.clone(), key.trim().to_string(), value));
+    }
+    entries
+}
+
+/// Every double-quoted literal in a fragment, in order.
+fn quoted_strings(s: &str) -> Vec<String> {
+    s.split('"')
+        .skip(1)
+        .step_by(2)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Split an inline table's body on its top-level commas.
+fn split_top_level(inner: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_str = false;
+    let mut depth = 0;
+    for c in inner.chars() {
+        match c {
+            '"' => in_str = !in_str,
+            '{' | '[' if !in_str => depth += 1,
+            '}' | ']' if !in_str => depth -= 1,
+            ',' if !in_str && depth == 0 => {
+                parts.push(std::mem::take(&mut current));
+                continue;
+            }
+            _ => {}
+        }
+        current.push(c);
+    }
+    parts.push(current);
+    parts
+        .into_iter()
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+        .collect()
+}
+
+/// Look up one key inside an inline table value such as `{ version = "0.25", .. }`.
+fn inline_field(value: &str, field: &str) -> Option<String> {
+    let inner = value.trim().trim_start_matches('{').trim_end_matches('}');
+    split_top_level(inner).into_iter().find_map(|part| {
+        let (k, v) = part.split_once('=')?;
+        (k.trim() == field).then(|| v.trim().to_string())
+    })
+}
+
+// ---------------------------------------------------------------------------------------------
+// The checks. Separated from file I/O so the red paths below are testable and this cannot rot
+// into a guard that passes because its scan found nothing.
+// ---------------------------------------------------------------------------------------------
+
+/// The root must declare `image` once, with default features off and exactly the union.
+fn check_root(root: &str) -> Result<(), String> {
+    let value = manifest_entries(root)
+        .into_iter()
+        .find(|(section, key, _)| section == "workspace.dependencies" && key == "image")
+        .map(|(_, _, value)| value)
+        .ok_or(
+            "root Cargo.toml has no `image` in [workspace.dependencies]: the hoist from sc-15052 \
+             was undone, so each member's feature list is a mirror that will drift from the union \
+             Cargo actually builds",
+        )?;
+    match inline_field(&value, "default-features").as_deref() {
+        Some("false") => {}
+        other => {
+            return Err(format!(
+                "workspace `image` must set `default-features = false` (found {other:?}): the \
+                 feature list is meant to be exhaustive, and the defaults enable codecs no member \
+                 asked for"
+            ))
+        }
+    }
+    let features = value
+        .find("features")
+        .map(|_| ())
+        .and_then(|()| inline_field(&value, "features"))
+        .map(|list| quoted_strings(&list))
+        .ok_or("workspace `image` declares no `features` list")?;
+    if features != EXPECTED_FEATURES {
+        return Err(format!(
+            "workspace `image` features {features:?} != the union this guard pins \
+             {EXPECTED_FEATURES:?}. Every member compiles against this list — if the change is \
+             intended, update EXPECTED_FEATURES and the compiled-format test together."
+        ));
+    }
+    Ok(())
+}
+
+/// Whether `member` declares `image`, erroring if it declares it as anything but workspace-inherited.
+fn check_member(member: &str, manifest: &str) -> Result<bool, String> {
+    let entries = manifest_entries(manifest);
+    let mut declares = false;
+
+    // `image = { workspace = true }` form, in any dependency table (including target-gated ones).
+    for (section, _key, value) in entries
+        .iter()
+        .filter(|(section, key, _)| key == "image" && section.ends_with("dependencies"))
+    {
+        declares = true;
+        for forbidden in ["default-features", "features", "version"] {
+            if inline_field(value, forbidden).is_some() {
+                return Err(format!(
+                    "{member}/Cargo.toml declares `image` in [{section}] with its own \
+                     `{forbidden}`. That is a mirror of the workspace union, not the union itself \
+                     — Cargo will still build this crate against the union, so a per-crate \
+                     `cargo test -p` would stop being representative of what ships (sc-15028 / \
+                     sc-15052). Use `image = {{ workspace = true }}`."
+                ));
+            }
+        }
+        if inline_field(value, "workspace").as_deref() != Some("true") {
+            return Err(format!(
+                "{member}/Cargo.toml declares `image` in [{section}] as `{value}` rather than \
+                 `{{ workspace = true }}` (sc-15052)."
+            ));
+        }
+    }
+
+    // `[dependencies.image]` sub-table form — same rule, different spelling.
+    for (section, key, _) in entries
+        .iter()
+        .filter(|(section, _, _)| section.ends_with("dependencies.image"))
+    {
+        declares = true;
+        if key != "workspace" {
+            return Err(format!(
+                "{member}/Cargo.toml declares `image` as a [{section}] sub-table with `{key}`: \
+                 only `workspace = true` may appear there (sc-15052)."
+            ));
+        }
+    }
+
+    Ok(declares)
+}
+
+/// Members listed in the root `[workspace]`.
+fn workspace_members(root: &str) -> Vec<String> {
+    manifest_entries(root)
+        .into_iter()
+        .find(|(section, key, _)| section == "workspace" && key == "members")
+        .map(|(_, _, value)| quoted_strings(&value))
+        .unwrap_or_default()
+}
+
+#[test]
+fn image_is_declared_once_for_the_whole_workspace() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let read = |path: std::path::PathBuf| {
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    };
+
+    let root = read(workspace.join("Cargo.toml"));
+    if let Err(msg) = check_root(&root) {
+        panic!("{msg}");
+    }
+
+    let members = workspace_members(&root);
+    assert!(
+        !members.is_empty(),
+        "parsed no members out of the root [workspace]: the scan is broken, not the manifests"
+    );
+
+    let mut declaring = Vec::new();
+    for member in &members {
+        let manifest = read(workspace.join(member).join("Cargo.toml"));
+        match check_member(member, &manifest) {
+            Ok(true) => declaring.push(member.clone()),
+            Ok(false) => {}
+            Err(msg) => panic!("{msg}"),
+        }
+    }
+    // Without this the guard would go green if `image` vanished from every member — a pass that
+    // proves nothing. sc-15052 hoisted it for four of them.
+    assert!(
+        declaring.len() >= 4,
+        "only {declaring:?} inherit the workspace `image`; sc-15052 hoisted it for four members \
+         (rust-api, core, image-quality, worker). If a member genuinely dropped the dependency, \
+         lower this floor deliberately."
+    );
+}
+
+/// The compiled half: what `image` was ACTUALLY built with in this scope.
+///
+/// `reading_enabled()` is a `cfg!(feature = ..)` inside `image`, so this reads the real feature
+/// set rather than the manifest's claim about it. Dds and Pcx are excluded: they return a hardcoded
+/// `false`, so asserting them would pass with the dependency ripped out entirely.
+#[test]
+fn compiled_image_formats_match_the_workspace_declaration() {
+    use image::ImageFormat;
+
+    let enabled = [
+        (ImageFormat::Bmp, "bmp"),
+        (ImageFormat::Gif, "gif"),
+        (ImageFormat::Jpeg, "jpeg"),
+        (ImageFormat::Png, "png"),
+        (ImageFormat::Tiff, "tiff"),
+        (ImageFormat::WebP, "webp"),
+    ];
+    assert_eq!(
+        enabled.len(),
+        EXPECTED_FEATURES.len(),
+        "this probe and EXPECTED_FEATURES have drifted apart"
+    );
+    for (format, feature) in enabled {
+        assert!(
+            format.reading_enabled(),
+            "`image` was compiled WITHOUT `{feature}`, but [workspace.dependencies] declares it. \
+             This scope decodes fewer formats than the shipped build — the sc-15028 trap."
+        );
+    }
+
+    for (format, feature) in [
+        (ImageFormat::Avif, "avif"),
+        (ImageFormat::Farbfeld, "ff"),
+        (ImageFormat::Hdr, "hdr"),
+        (ImageFormat::Ico, "ico"),
+        (ImageFormat::OpenExr, "exr"),
+        (ImageFormat::Pnm, "pnm"),
+        (ImageFormat::Qoi, "qoi"),
+        (ImageFormat::Tga, "tga"),
+    ] {
+        assert!(
+            !format.reading_enabled(),
+            "`image` was compiled WITH `{feature}`, which [workspace.dependencies] does not \
+             declare — `default-features = false` was dropped, or a dependency turned it on. \
+             Code and tests can come to depend on a format nobody declared."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Red-path coverage: each canned manifest is a failure this guard exists to catch, so a
+// regression in the parser cannot quietly turn the real tests above into false greens.
+// ---------------------------------------------------------------------------------------------
+
+const GOOD_ROOT: &str = r#"
+[workspace]
+members = [
+    "apps/rust-api",
+    "crates/sceneworks-core",
+]
+
+[workspace.dependencies]
+trash = "5"
+# A comment mentioning image = { version = "9" } must not be parsed.
+image = { version = "0.25", default-features = false, features = [
+    "bmp",
+    "gif",
+    "jpeg",
+    "png",
+    "tiff",
+    "webp",
+] }
+"#;
+
+const GOOD_MEMBER: &str = r#"
+[package]
+name = "demo"
+
+[dependencies]
+imageproc = { version = "0.25", default-features = false }
+image = { workspace = true }
+image_hasher = "3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mlx-rs = { git = "https://example.invalid" }
+"#;
+
+#[test]
+fn guard_accepts_the_hoisted_shape() {
+    assert_eq!(check_root(GOOD_ROOT), Ok(()));
+    assert_eq!(check_member("demo", GOOD_MEMBER), Ok(true));
+}
+
+#[test]
+fn guard_parses_members_and_ignores_lookalike_keys() {
+    assert_eq!(
+        workspace_members(GOOD_ROOT),
+        vec!["apps/rust-api", "crates/sceneworks-core"]
+    );
+    // `imageproc` / `image_hasher` must not be mistaken for `image` — that would make the member
+    // check fire on crates that never declare it.
+    let no_image = GOOD_MEMBER.replace("image = { workspace = true }\n", "");
+    assert_eq!(check_member("demo", &no_image), Ok(false));
+}
+
+#[test]
+fn guard_rejects_a_dropped_hoist() {
+    // Renames the real declaration only — GOOD_ROOT's decoy comment still spells
+    // `image = { version = "9" }`, so this also proves commented-out text cannot satisfy the
+    // lookup. (Targeting `image = {` instead would rewrite the comment and leave the real
+    // declaration standing, which is how this test first failed.)
+    let root = GOOD_ROOT.replacen(
+        "image = { version = \"0.25\"",
+        "unrelated = { version = \"0.25\"",
+        1,
+    );
+    assert!(root.contains("image = { version = \"9\" }"), "decoy lost");
+    let err = check_root(&root).unwrap_err();
+    assert!(
+        err.contains("no `image` in [workspace.dependencies]"),
+        "{err}"
+    );
+}
+
+#[test]
+fn guard_rejects_default_features_creeping_back_on() {
+    let root = GOOD_ROOT.replacen("default-features = false", "default-features = true", 1);
+    let err = check_root(&root).unwrap_err();
+    assert!(err.contains("default-features = false"), "{err}");
+}
+
+#[test]
+fn guard_rejects_a_narrowed_union() {
+    let root = GOOD_ROOT.replacen("    \"bmp\",\n", "", 1);
+    let err = check_root(&root).unwrap_err();
+    assert!(err.contains("!= the union"), "{err}");
+}
+
+#[test]
+fn guard_rejects_a_member_re_declaring_its_own_features() {
+    // The sc-15028 shape verbatim: a member pinning a narrower list than the workspace union.
+    let member = GOOD_MEMBER.replacen(
+        "image = { workspace = true }",
+        r#"image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }"#,
+        1,
+    );
+    let err = check_member("demo", &member).unwrap_err();
+    assert!(err.contains("its own `default-features`"), "{err}");
+}
+
+#[test]
+fn guard_rejects_a_member_re_declaring_a_bare_version() {
+    let member = GOOD_MEMBER.replacen("image = { workspace = true }", r#"image = "0.25""#, 1);
+    let err = check_member("demo", &member).unwrap_err();
+    assert!(err.contains("rather than"), "{err}");
+}
+
+#[test]
+fn guard_rejects_a_target_gated_re_declaration() {
+    // A dependency table other than plain [dependencies] must not be a way around the rule.
+    let member = GOOD_MEMBER.replacen(
+        r#"mlx-rs = { git = "https://example.invalid" }"#,
+        r#"image = { version = "0.25", features = ["tga"] }"#,
+        1,
+    );
+    let err = check_member("demo", &member).unwrap_err();
+    assert!(err.contains("its own `features`"), "{err}");
+    assert!(err.contains("cfg(target_os = \"macos\")"), "{err}");
+}
+
+#[test]
+fn guard_rejects_the_sub_table_form() {
+    let member = GOOD_MEMBER.replacen("image = { workspace = true }", "", 1)
+        + "\n[dependencies.image]\nversion = \"0.25\"\n";
+    let err = check_member("demo", &member).unwrap_err();
+    assert!(err.contains("sub-table"), "{err}");
+}

--- a/crates/sceneworks-worker/tests/image_workspace_dep_guard.rs
+++ b/crates/sceneworks-worker/tests/image_workspace_dep_guard.rs
@@ -28,6 +28,14 @@ use std::path::Path;
 /// workspace-wide act: update the root `Cargo.toml` and this list together.
 const EXPECTED_FEATURES: &[&str] = &["bmp", "gif", "jpeg", "png", "tiff", "webp"];
 
+/// The members sc-15052 hoisted `image` for, as paths in the root `[workspace] members`.
+const EXPECTED_IMAGE_MEMBERS: &[&str] = &[
+    "apps/rust-api",
+    "crates/sceneworks-core",
+    "crates/sceneworks-image-quality",
+    "crates/sceneworks-worker",
+];
+
 // ---------------------------------------------------------------------------------------------
 // Minimal TOML reading. Deliberately dependency-free (same reasoning as candle_kernels_patch_guard:
 // a build guard should not need a parser in the graph). It handles what these manifests use —
@@ -174,23 +182,41 @@ fn check_root(root: &str) -> Result<(), String> {
             ))
         }
     }
-    let features = value
-        .find("features")
-        .map(|_| ())
-        .and_then(|()| inline_field(&value, "features"))
+    let mut features = inline_field(&value, "features")
         .map(|list| quoted_strings(&list))
         .ok_or("workspace `image` declares no `features` list")?;
-    if features != EXPECTED_FEATURES {
+    // Compared as sets: reordering the root list is cosmetic and must not read as a union change.
+    features.sort();
+    let mut expected: Vec<String> = EXPECTED_FEATURES.iter().map(|f| f.to_string()).collect();
+    expected.sort();
+    if features != expected {
         return Err(format!(
-            "workspace `image` features {features:?} != the union this guard pins \
-             {EXPECTED_FEATURES:?}. Every member compiles against this list — if the change is \
-             intended, update EXPECTED_FEATURES and the compiled-format test together."
+            "workspace `image` features {features:?} != the union this guard pins {expected:?}. \
+             Every member compiles against this list — if the change is intended, update \
+             EXPECTED_FEATURES and the compiled-format test together."
         ));
     }
     Ok(())
 }
 
+/// Fields that re-specify the dependency instead of inheriting it. Any of these on a member's
+/// `image` is the drift this guard exists to stop.
+const FORBIDDEN_FIELDS: &[&str] = &["default-features", "features", "version"];
+
+fn mirror_error(member: &str, section: &str, field: &str) -> String {
+    format!(
+        "{member}/Cargo.toml declares `image` in [{section}] with its own `{field}`. That is a \
+         mirror of the workspace union, not the union itself — Cargo will still build this crate \
+         against the union, so a per-crate `cargo test -p` would stop being representative of what \
+         ships (sc-15028 / sc-15052). Use `image = {{ workspace = true }}`."
+    )
+}
+
 /// Whether `member` declares `image`, erroring if it declares it as anything but workspace-inherited.
+///
+/// Cargo accepts three spellings and this checks all of them, because a guard that only knows the
+/// one currently in the tree just redirects the next regression through the other two:
+/// `image = { .. }`, the dotted `image.features = [..]`, and the `[dependencies.image]` sub-table.
 fn check_member(member: &str, manifest: &str) -> Result<bool, String> {
     let entries = manifest_entries(manifest);
     let mut declares = false;
@@ -201,15 +227,9 @@ fn check_member(member: &str, manifest: &str) -> Result<bool, String> {
         .filter(|(section, key, _)| key == "image" && section.ends_with("dependencies"))
     {
         declares = true;
-        for forbidden in ["default-features", "features", "version"] {
-            if inline_field(value, forbidden).is_some() {
-                return Err(format!(
-                    "{member}/Cargo.toml declares `image` in [{section}] with its own \
-                     `{forbidden}`. That is a mirror of the workspace union, not the union itself \
-                     — Cargo will still build this crate against the union, so a per-crate \
-                     `cargo test -p` would stop being representative of what ships (sc-15028 / \
-                     sc-15052). Use `image = {{ workspace = true }}`."
-                ));
+        for field in FORBIDDEN_FIELDS {
+            if inline_field(value, field).is_some() {
+                return Err(mirror_error(member, section, field));
             }
         }
         if inline_field(value, "workspace").as_deref() != Some("true") {
@@ -220,16 +240,54 @@ fn check_member(member: &str, manifest: &str) -> Result<bool, String> {
         }
     }
 
+    // Dotted-key form: `image.workspace = true`, `image.features = [..]`. This is the likeliest
+    // way the hoist gets undone by hand — it is already this repo's house style for
+    // `version.workspace` / `edition.workspace` / `rust-version.workspace` in every member.
+    let dotted: Vec<(&str, &str, &str)> = entries
+        .iter()
+        .filter(|(section, key, _)| section.ends_with("dependencies") && key.starts_with("image."))
+        .map(|(section, key, value)| {
+            (
+                section.as_str(),
+                key.trim_start_matches("image."),
+                value.as_str(),
+            )
+        })
+        .collect();
+    for (section, field, value) in &dotted {
+        declares = true;
+        if FORBIDDEN_FIELDS.contains(field) {
+            return Err(mirror_error(member, section, field));
+        }
+        if *field == "workspace" && value.trim() != "true" {
+            return Err(format!(
+                "{member}/Cargo.toml sets `image.workspace = {value}` in [{section}]; it must be \
+                 `true` (sc-15052)."
+            ));
+        }
+    }
+    if let Some((section, ..)) = dotted.first() {
+        if !dotted.iter().any(|(_, field, _)| *field == "workspace") {
+            return Err(format!(
+                "{member}/Cargo.toml declares `image.*` keys in [{section}] without \
+                 `image.workspace = true`, so it does not inherit the workspace union (sc-15052)."
+            ));
+        }
+    }
+
     // `[dependencies.image]` sub-table form — same rule, different spelling.
-    for (section, key, _) in entries
+    for (section, key, value) in entries
         .iter()
         .filter(|(section, _, _)| section.ends_with("dependencies.image"))
     {
         declares = true;
-        if key != "workspace" {
+        if FORBIDDEN_FIELDS.contains(&key.as_str()) {
+            return Err(mirror_error(member, section, key));
+        }
+        if key != "workspace" || value.trim() != "true" {
             return Err(format!(
-                "{member}/Cargo.toml declares `image` as a [{section}] sub-table with `{key}`: \
-                 only `workspace = true` may appear there (sc-15052)."
+                "{member}/Cargo.toml declares `image` as a [{section}] sub-table with \
+                 `{key} = {value}`: only `workspace = true` may appear there (sc-15052)."
             ));
         }
     }
@@ -273,13 +331,16 @@ fn image_is_declared_once_for_the_whole_workspace() {
             Err(msg) => panic!("{msg}"),
         }
     }
-    // Without this the guard would go green if `image` vanished from every member — a pass that
-    // proves nothing. sc-15052 hoisted it for four of them.
-    assert!(
-        declaring.len() >= 4,
-        "only {declaring:?} inherit the workspace `image`; sc-15052 hoisted it for four members \
-         (rust-api, core, image-quality, worker). If a member genuinely dropped the dependency, \
-         lower this floor deliberately."
+    declaring.sort();
+    // Pin the identity, not a count: without this the guard would go green if `image` vanished from
+    // every member — a pass that proves nothing — and a count alone would also accept four
+    // DIFFERENT members inheriting it.
+    assert_eq!(
+        declaring, EXPECTED_IMAGE_MEMBERS,
+        "the set of members inheriting the workspace `image` changed. If a member is missing here \
+         but still uses `image`, the likely cause is a hand-written re-declaration this scan did \
+         not recognise as inheritance — check its Cargo.toml before touching this list. Only edit \
+         EXPECTED_IMAGE_MEMBERS when a member genuinely gained or dropped the dependency."
     );
 }
 
@@ -454,9 +515,49 @@ fn guard_rejects_a_target_gated_re_declaration() {
 }
 
 #[test]
+fn guard_rejects_the_dotted_key_form() {
+    // The spelling a developer reaches for by muscle memory, since every member already writes
+    // `version.workspace = true`. Reviewed as the live hole in the first cut of this guard: it
+    // reproduced the sc-15028 divergence (`-p sceneworks-core` back to jpeg alone) while the
+    // declaration check saw nothing.
+    let member = GOOD_MEMBER.replacen(
+        "image = { workspace = true }",
+        "image.version = \"0.25\"\nimage.default-features = false\nimage.features = [\"jpeg\"]",
+        1,
+    );
+    let err = check_member("demo", &member).unwrap_err();
+    assert!(err.contains("its own `version`"), "{err}");
+    assert!(err.contains("[dependencies]"), "{err}");
+}
+
+#[test]
+fn guard_accepts_the_dotted_inheritance_form() {
+    // `image.workspace = true` is legal and equivalent — it must pass, or the guard would be
+    // pushing people away from a correct spelling.
+    let member = GOOD_MEMBER.replacen("image = { workspace = true }", "image.workspace = true", 1);
+    assert_eq!(check_member("demo", &member), Ok(true));
+}
+
+#[test]
+fn guard_rejects_dotted_keys_without_inheritance() {
+    // No forbidden field, but no `workspace = true` either — still not inheriting the union.
+    let member = GOOD_MEMBER.replacen("image = { workspace = true }", "image.optional = true", 1);
+    let err = check_member("demo", &member).unwrap_err();
+    assert!(err.contains("without `image.workspace = true`"), "{err}");
+}
+
+#[test]
+fn guard_accepts_the_sub_table_inheritance_form() {
+    let member = GOOD_MEMBER.replacen("image = { workspace = true }", "", 1)
+        + "\n[dependencies.image]\nworkspace = true\n";
+    assert_eq!(check_member("demo", &member), Ok(true));
+}
+
+#[test]
 fn guard_rejects_the_sub_table_form() {
     let member = GOOD_MEMBER.replacen("image = { workspace = true }", "", 1)
         + "\n[dependencies.image]\nversion = \"0.25\"\n";
     let err = check_member("demo", &member).unwrap_err();
-    assert!(err.contains("sub-table"), "{err}");
+    assert!(err.contains("[dependencies.image]"), "{err}");
+    assert!(err.contains("its own `version`"), "{err}");
 }


### PR DESCRIPTION
Closes [sc-15052](https://app.shortcut.com/trefry/story/15052). Follow-on from sc-15028 — that story fixed the two tests that broke; this fixes the condition that let them break.

## Problem

Cargo unifies features for a shared dependency across workspace members, so a member's own declaration never describes what it compiles with. Four members declared `image` independently:

| member | features declared | features actually compiled |
| --- | --- | --- |
| `apps/rust-api` | bmp, gif, jpeg, png, tiff, webp | all six |
| `crates/sceneworks-core` | jpeg | all six |
| `crates/sceneworks-image-quality` | jpeg, png, webp | all six |
| `crates/sceneworks-worker` | jpeg, png, webp | all six |

For `image` this divergence is **silent and behavioural** — its features decide which formats decode — so `cargo test -p <member>` exercised a configuration that never ships. sc-15028 was exactly that: two transcode tests asserted BMP could not decode, passed under `-p`, and failed in the workspace.

## Change

Declare `image` once in `[workspace.dependencies]` with the union feature set and switch all four members to `image = { workspace = true }`. Aligning the four by hand would also work, but it is a mirror that drifts the next time someone adds a format to one member; hoisting makes the declaration and the union the same object.

## Guard

Adds `crates/sceneworks-worker/tests/image_workspace_dep_guard.rs`, alongside the existing `candle_kernels_patch_guard.rs`, with two independent halves:

- **Declaration** — parses the manifests: the root declares the union, and no member re-declares its own `version`/`features`/`default-features`. All three Cargo spellings are checked (inline table, dotted `image.features = [..]`, and the `[dependencies.image]` sub-table), because a guard that only knows the spelling currently in the tree just redirects the next regression through the other two.
- **Compilation** — probes `ImageFormat::reading_enabled()`, which is a `cfg!(feature = ..)` inside `image`, so it reports what the build *actually* contains rather than what the manifest claims. It asserts the enabled **and** the disabled formats, so it fails whether the union narrows or silently widens, and it runs under `-p` and `--workspace` alike.

Both halves were mutation-checked against the real tree, not just canned strings. `Dds`/`Pcx` are excluded from the disabled list because `image` returns a hardcoded `false` for them — asserting those would pass with the dependency ripped out.

## Verification

- **Union does not move.** Enabled features are identical before and after: `bmp, gif, jpeg, png, tiff, webp`. (The `cargo tree` *text* does change — `sceneworks-core` now appears under the `bmp`/`gif`/`png`/`tiff`/`webp` nodes — but the union is what matters, and it is unchanged.)
- **`Cargo.lock` unchanged.**
- **Each member's `-p` view now equals the workspace view** instead of a subset.
- `cargo build -p <member>` succeeds standalone for all four.
- The sc-15028 tests (`transform_path_transcodes_an_unsupported_source`, `decodes_unsupported_heic_via_transcode`) pass under both `-p` and `--workspace`.
- `npm run rust:check` green — fmt, clippy `-D warnings`, full workspace test suite, build.

## Not in scope

`axum` / `reqwest` / `tokio` are **untouched**, per the story: each correctly describes that member's role, and those features are additive API surface, so under-declaring fails to *compile* under `-p` — loud, not silent. Auditing async handlers for blocking work is likewise out of scope.

## Review-driven follow-ups included

An adversarial review found the guard was blind to dotted keys — already this repo's house style for `version.workspace = true` — which reproduced the sc-15028 divergence while the declaration check saw nothing. Fixed, with red- and green-path tests. It also caught three stale comments that this change falsified (`transform.rs`, `ImageKind::is_natively_supported`, and its `project_store` fixture), all of which described per-crate feature lists that no longer exist; `is_natively_supported` is now documented as the storage policy it actually is, deliberately narrower than the union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)