### PR TITLE
feat(video): add selectable LTX text encoders (sc-13800)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1753,8 +1753,139 @@ pub(crate) async fn model_catalog_sized(state: &AppState) -> Result<Vec<Value>, 
                 .flatten()
         });
         apply_model_catalog_size_fields(model, context.as_ref(), live_estimate)?;
+        apply_runtime_text_encoder_options(model, &state.settings.data_dir)?;
     }
     Ok(models)
+}
+
+/// Add runtime-only text-encoder choices to the public model catalog. The worker owns enumeration so
+/// the API and generation resolver share one completeness predicate. This runs on the response clone,
+/// outside the cached catalog snapshot: an operator who stages a complete alternate and refreshes
+/// Models sees it without a server restart, while no repo/revision/download metadata is persisted.
+fn apply_runtime_text_encoder_options(
+    model: &mut Value,
+    data_dir: &FsPath,
+) -> Result<(), ApiError> {
+    let adapter = model
+        .get("adapter")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let options = sceneworks_worker::text_encoder_options_for_adapter(adapter, data_dir);
+    set_runtime_text_encoder_options(model, options)
+}
+
+fn set_runtime_text_encoder_options(
+    model: &mut Value,
+    options: Vec<sceneworks_worker::TextEncoderOption>,
+) -> Result<(), ApiError> {
+    let object = model
+        .as_object_mut()
+        .ok_or_else(|| ApiError::internal("Model manifest entry must be an object"))?;
+    if options.is_empty() {
+        object.remove("textEncoderOptions");
+    } else {
+        object.insert("textEncoderOptions".to_owned(), json!(options));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod runtime_text_encoder_option_tests {
+    use super::*;
+    #[cfg(target_os = "macos")]
+    use crate::tests::support::isolate_hf_cache;
+
+    #[test]
+    fn catalog_field_is_generic_and_contains_no_distribution_metadata() {
+        let mut model = json!({ "id": "future_video", "adapter": "future_adapter" });
+        set_runtime_text_encoder_options(
+            &mut model,
+            vec![
+                sceneworks_worker::TextEncoderOption {
+                    id: "default",
+                    label: "Bundled encoder (default)",
+                    description: "Uses the installed encoder.",
+                    is_default: true,
+                },
+                sceneworks_worker::TextEncoderOption {
+                    id: "future_staged_encoder",
+                    label: "Staged alternate",
+                    description: "Uses a complete operator-staged alternate.",
+                    is_default: false,
+                },
+            ],
+        )
+        .unwrap();
+
+        let options = model["textEncoderOptions"].as_array().unwrap();
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[1]["id"], "future_staged_encoder");
+        assert_eq!(options[1]["isDefault"], false);
+        for forbidden in ["repo", "revision", "files", "download"] {
+            assert!(
+                options.iter().all(|option| option.get(forbidden).is_none()),
+                "runtime options must not become distribution metadata: {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn models_without_a_runtime_surface_emit_no_selector_field() {
+        let mut model = json!({
+            "id": "fixed_encoder_model",
+            "textEncoderOptions": [{ "id": "stale" }]
+        });
+        set_runtime_text_encoder_options(&mut model, Vec::new()).unwrap();
+        assert!(model.get("textEncoderOptions").is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    fn write_tiny_safetensors(path: &FsPath) {
+        let header = br#"{"weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}"#;
+        let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(header);
+        bytes.push(0);
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn live_options_refresh_when_alternate_becomes_valid_or_corrupt() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().unwrap();
+        let repo = sceneworks_core::hf_home::huggingface_repo_cache_path(
+            data_dir.path(),
+            "TheCluster/amoral-gemma-3-12B-v2-mlx-4bit",
+        )
+        .unwrap();
+        let snapshot = repo.join("snapshots").join("test-revision");
+        std::fs::create_dir_all(&snapshot).unwrap();
+        std::fs::write(
+            snapshot.join("config.json"),
+            br#"{"model_type":"gemma3_text"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            snapshot.join("tokenizer.json"),
+            br#"{"model":{"type":"BPE"}}"#,
+        )
+        .unwrap();
+        write_tiny_safetensors(&snapshot.join("model.safetensors"));
+
+        let mut model = json!({ "id": "ltx_2_3", "adapter": "ltx_video" });
+        apply_runtime_text_encoder_options(&mut model, data_dir.path()).unwrap();
+        assert_eq!(model["textEncoderOptions"].as_array().unwrap().len(), 2);
+
+        std::fs::write(snapshot.join("model.safetensors"), b"truncated").unwrap();
+        apply_runtime_text_encoder_options(&mut model, data_dir.path()).unwrap();
+        let options = model["textEncoderOptions"].as_array().unwrap();
+        assert_eq!(options.len(), 1);
+        assert_eq!(options[0]["id"], "default");
+
+        std::fs::remove_dir_all(&repo).unwrap();
+        apply_runtime_text_encoder_options(&mut model, data_dir.path()).unwrap();
+        assert_eq!(model["textEncoderOptions"].as_array().unwrap().len(), 1);
+    }
 }
 
 async fn model_catalog_snapshot(state: &AppState) -> Result<Arc<Vec<Value>>, ApiError> {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -98,6 +98,8 @@ import {
 } from "../samplerOptions.js";
 
 const ltxVideoModelId = "ltx_2_3";
+const legacyDefaultTextEncoderId = "default";
+const amoralTextEncoderId = "ltx_amoral_gemma_3_12b";
 const ltxIcLoraRequiredModes = new Set(["extend_clip", "video_bridge"]);
 // Keep Video Studio's MLX lane q4-first (sc-10859). Unlike Image Studio, it deliberately does not
 // inherit the app-wide generation-quality setting: video activation peaks need a larger safety margin.
@@ -190,6 +192,11 @@ export function VideoStudio() {
   const [ltxPipeline, setLtxPipeline] = useState(saved.ltxPipeline ?? "auto");
   const [distilledVariant, setDistilledVariant] = useState(saved.distilledVariant ?? "1.1");
   const [precision, setPrecision] = useState(saved.precision ?? "fp8");
+  const [enhancePrompt, setEnhancePrompt] = useState(saved.enhancePrompt ?? false);
+  const [textEncoderSelection, setTextEncoderSelection] = useState({
+    modelId: saved.model ?? null,
+    id: saved.textEncoderModel ?? null,
+  });
   const [quantization, setQuantization] = useState(saved.quantization ?? "auto");
   // MLX generation tier (sc-12165), separate from the torch/GGUF `quantization` state above.
   // The explicit pick is persisted per (video, model), outside the workspace settings snapshot.
@@ -199,6 +206,16 @@ export function VideoStudio() {
   const [recipeModelNotice, setRecipeModelNotice] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   const [model, setModel] = useState(saved.model ?? videoModels[0]?.id ?? ltxVideoModelId);
+  const textEncoderModel =
+    textEncoderSelection.modelId === model ? textEncoderSelection.id : null;
+  const setTextEncoderModel = (next, modelId = model) =>
+    setTextEncoderSelection((current) => {
+      const currentId = current.modelId === modelId ? current.id : null;
+      return {
+        modelId,
+        id: typeof next === "function" ? next(currentId) : next,
+      };
+    });
   const [guideOpen, setGuideOpen] = useState(false);
   // Mac UI gating (sc-3486): hide torch-only video models (e.g. SVD) and snap off one if selected.
   const macVideoModels = useMemo(
@@ -211,6 +228,23 @@ export function VideoStudio() {
     }
   }, [macVideoModels, model]);
   const selectedModel = videoModels.find((item) => item.id === model) ?? videoModels[0];
+  // Runtime-curated selector surface (sc-13800). The API emits only complete encoders the worker can
+  // resolve; Video Studio stays adapter-agnostic and future models can expose the same shape.
+  const textEncoderOptions = selectedModel?.textEncoderOptions ?? [];
+  const supportsTextEncoderSelection = textEncoderOptions.length > 0;
+  const defaultTextEncoderId =
+    textEncoderOptions.find((option) => option.isDefault)?.id ??
+    textEncoderOptions[0]?.id ??
+    legacyDefaultTextEncoderId;
+  const selectedTextEncoderModel =
+    textEncoderModel == null ||
+    (textEncoderModel === legacyDefaultTextEncoderId &&
+      !textEncoderOptions.some((option) => option.id === legacyDefaultTextEncoderId))
+      ? defaultTextEncoderId
+      : textEncoderModel;
+  const selectedTextEncoderAvailable = textEncoderOptions.some(
+    (option) => option.id === selectedTextEncoderModel,
+  );
   // Models gated on the selected tab, not tabs on the selected model (sc-5716). A model "serves" a
   // mode when it declares the capability AND, under active Mac gating, that mode is MLX-routed for
   // it (`macVideoModeBlock` is a no-op off-Mac, so there this is pure capability). The mode tabs,
@@ -743,6 +777,12 @@ export function VideoStudio() {
     setLtxPipeline(rawSettings.ltxPipeline ?? "auto");
     setDistilledVariant(rawSettings.distilledVariant ?? "1.1");
     setPrecision(rawSettings.precision ?? "fp8");
+    setEnhancePrompt(rawSettings.enhancePrompt === true);
+    setTextEncoderModel(
+      rawSettings.textEncoderModel ??
+        (rawSettings.useUncensoredEnhancer === true ? amoralTextEncoderId : null),
+      recipe.model && recipeModelAvailable ? recipe.model : model,
+    );
     setQuantization(rawSettings.quantization ?? "auto");
     setLightning(rawSettings.lightning ?? true);
     setLtxVideoCfg(rawSettings.videoCfgGuidanceScale ?? "");
@@ -845,6 +885,8 @@ export function VideoStudio() {
       ["quantization", setQuantization],
       ["ltxPipeline", setLtxPipeline],
       ["distilledVariant", setDistilledVariant],
+      ["enhancePrompt", setEnhancePrompt],
+      ["textEncoderModel", setTextEncoderModel],
       ["motion", setMotion],
       ["videoCfgGuidanceScale", setLtxVideoCfg],
       ["videoStgGuidanceScale", setLtxVideoStg],
@@ -874,6 +916,9 @@ export function VideoStudio() {
       quantization,
       ltxPipeline,
       distilledVariant,
+      ...(supportsTextEncoderSelection
+        ? { enhancePrompt, textEncoderModel: selectedTextEncoderModel }
+        : {}),
       motion,
       videoCfgGuidanceScale: finiteNumberOrUndefined(ltxVideoCfg),
       videoStgGuidanceScale: finiteNumberOrUndefined(ltxVideoStg),
@@ -890,6 +935,8 @@ export function VideoStudio() {
     ltxPipeline,
     distilledVariant,
     precision,
+    enhancePrompt,
+    textEncoderModel,
     quantization,
     advancedOpen,
     selectedLoraIds,
@@ -1218,6 +1265,14 @@ export function VideoStudio() {
           // stay byte-identical.
           ...(styleApplied ? { styleId, stylePrompt: stylePromptBase } : {}),
           ...(model === ltxVideoModelId ? { ltxPipeline, distilledVariant, precision } : {}),
+          ...(supportsTextEncoderSelection && enhancePrompt
+            ? { enhancePrompt: true }
+            : {}),
+          ...(supportsTextEncoderSelection &&
+          enhancePrompt &&
+          selectedTextEncoderModel !== defaultTextEncoderId
+            ? { textEncoderModel: selectedTextEncoderModel }
+            : {}),
           ...(showTorchQuantization && quantization !== "auto" ? { quantization } : {}),
           ...(selectedMlxQuantize !== null ? { mlxQuantize: selectedMlxQuantize } : {}),
           // Configurable sampler / scheduler (epic 1753). Sealed adapters
@@ -1699,6 +1754,52 @@ export function VideoStudio() {
                       <option value="bf16">BF16 (higher quality, CPU offload)</option>
                     </select>
                   </label>
+                </>
+              ) : null}
+              {supportsTextEncoderSelection ? (
+                <>
+                  <div className="lightning-toggle">
+                    <label className="checkline">
+                      <input
+                        checked={enhancePrompt}
+                        onChange={(event) => setEnhancePrompt(event.target.checked)}
+                        type="checkbox"
+                      />
+                      Enhance prompt before generation
+                    </label>
+                    <p className="helper-copy">
+                      Rewrites the prompt with the selected text encoder before the model encodes it.
+                    </p>
+                  </div>
+                  <label>
+                    Text encoder model
+                    <select
+                      aria-label="Text encoder model"
+                      disabled={!enhancePrompt}
+                      onChange={(event) => setTextEncoderModel(event.target.value)}
+                      value={selectedTextEncoderModel}
+                    >
+                      {textEncoderOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.label}
+                        </option>
+                      ))}
+                      {!selectedTextEncoderAvailable &&
+                      selectedTextEncoderModel !== defaultTextEncoderId ? (
+                        <option disabled value={selectedTextEncoderModel}>
+                          Previously selected encoder (not staged)
+                        </option>
+                      ) : null}
+                    </select>
+                  </label>
+                  <p className="helper-copy">
+                    {!selectedTextEncoderAvailable &&
+                    selectedTextEncoderModel !== defaultTextEncoderId
+                      ? "The recorded encoder is not staged on this worker. Choose the shipped default or stage the alternate before rendering."
+                      : textEncoderOptions.length > 1
+                        ? "Only complete encoders already staged for this worker are listed."
+                        : "The shipped encoder is the default. Complete operator-staged alternates appear here after Models is refreshed."}
+                  </p>
                 </>
               ) : null}
               {selectedModel?.adapter === "ltx_video" ? (

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1201,3 +1201,269 @@ describe("VideoStudio Lightning toggle (sc-10048)", () => {
     expect(payload.advanced.lightning).toBeUndefined();
   });
 });
+
+describe("VideoStudio runtime text-encoder selector (sc-13800)", () => {
+  let container;
+  let root;
+
+  const DEFAULT_ENCODER = {
+    id: "default",
+    label: "Shipped Gemma 3 12B (default)",
+    description: "Uses the Gemma text encoder installed with LTX.",
+    isDefault: true,
+  };
+  const AMORAL_ENCODER = {
+    id: "ltx_amoral_gemma_3_12b",
+    label: "Amoral Gemma 3 12B (operator staged)",
+    description: "Uses the complete alternate Gemma snapshot already staged by the operator.",
+    isDefault: false,
+  };
+  const LTX_WITH_ENCODERS = {
+    ...LTX,
+    adapter: "ltx_video",
+    textEncoderOptions: [DEFAULT_ENCODER, AMORAL_ENCODER],
+  };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const encoderSelect = () => container.querySelector('select[aria-label="Text encoder model"]');
+  const enhanceCheckbox = () =>
+    [...container.querySelectorAll("label")]
+      .find((label) => label.textContent.includes("Enhance prompt before generation"))
+      ?.querySelector('input[type="checkbox"]');
+
+  it("is model-driven and hides an alternate the runtime did not enumerate", async () => {
+    await render(
+      baseContext({
+        videoModels: [
+          {
+            ...LTX_WITH_ENCODERS,
+            textEncoderOptions: [DEFAULT_ENCODER],
+          },
+        ],
+      }),
+    );
+    await openAdvanced(container);
+
+    expect(enhanceCheckbox()).toBeTruthy();
+    expect(encoderSelect()).toBeTruthy();
+    expect([...encoderSelect().options].map((option) => option.value)).toEqual(["default"]);
+    expect(container.textContent).toContain(
+      "Complete operator-staged alternates appear here after Models is refreshed.",
+    );
+
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    await render(baseContext({ videoModels: [{ ...LTX, adapter: "ltx_video" }] }));
+    await openAdvanced(container);
+    expect(encoderSelect()).toBeNull();
+  });
+
+  it("derives a future model's default from capability metadata instead of a hard-coded id", async () => {
+    const futureModel = {
+      ...LTX,
+      id: "future_video",
+      adapter: "future_video",
+      textEncoderOptions: [
+        {
+          id: "future_alternate",
+          label: "Future alternate",
+          description: "A staged future alternate.",
+          isDefault: false,
+        },
+        {
+          id: "future_bundled",
+          label: "Future bundled encoder",
+          description: "The future model's bundled encoder.",
+          isDefault: true,
+        },
+      ],
+    };
+    const context = baseContext({ videoModels: [futureModel] });
+    await render(context);
+    await openAdvanced(container);
+
+    expect(encoderSelect().value).toBe("future_bundled");
+    await click(enhanceCheckbox());
+    await act(async () => setSelect(encoderSelect(), "future_alternate"));
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].advanced.textEncoderModel).toBe(
+      "future_alternate",
+    );
+  });
+
+  it("does not carry one model's encoder id into a model with a disjoint option namespace", async () => {
+    const futureModel = {
+      ...LTX,
+      id: "future_video",
+      name: "Future Video",
+      adapter: "future_video",
+      textEncoderOptions: [
+        {
+          id: "future_bundled",
+          label: "Future bundled encoder",
+          description: "The future model's bundled encoder.",
+          isDefault: true,
+        },
+      ],
+    };
+    await render(baseContext({ videoModels: [LTX_WITH_ENCODERS, futureModel] }));
+    await openAdvanced(container);
+    await click(enhanceCheckbox());
+    await act(async () => setSelect(encoderSelect(), AMORAL_ENCODER.id));
+
+    const modelSelect = container.querySelector(".settings-field-model select");
+    await act(async () => setSelect(modelSelect, futureModel.id));
+    expect(encoderSelect().value).toBe("future_bundled");
+    expect(container.textContent).not.toContain("Previously selected encoder (not staged)");
+  });
+
+  it("applies and clears a preset text-encoder default through functional setter updates", async () => {
+    await render(
+      baseContext({
+        videoModels: [LTX_WITH_ENCODERS],
+        presets: [
+          {
+            id: "amoral_prompt",
+            name: "Amoral prompt",
+            scope: "project",
+            workflow: "text_to_video",
+            model: "ltx_2_3",
+            modes: ["text_to_video"],
+            defaults: {
+              enhancePrompt: true,
+              textEncoderModel: AMORAL_ENCODER.id,
+            },
+          },
+        ],
+      }),
+    );
+
+    await click(buttonWithText(container, "Amoral prompt"));
+    await openAdvanced(container);
+    expect(enhanceCheckbox().checked).toBe(true);
+    expect(encoderSelect().value).toBe(AMORAL_ENCODER.id);
+
+    const presetAxis = container.querySelector(".style-axis-presets");
+    await click(buttonWithText(presetAxis, "None"));
+    expect(enhanceCheckbox().checked).toBe(false);
+    expect(encoderSelect().value).toBe(DEFAULT_ENCODER.id);
+  });
+
+  it("emits the exact non-default selector with prompt enhancement, never the legacy boolean", async () => {
+    const context = baseContext({ videoModels: [LTX_WITH_ENCODERS] });
+    await render(context);
+    await openAdvanced(container);
+
+    expect(encoderSelect().disabled).toBe(true);
+    await click(enhanceCheckbox());
+    expect(encoderSelect().disabled).toBe(false);
+    await act(async () => setSelect(encoderSelect(), AMORAL_ENCODER.id));
+    await act(async () => {});
+    expect(
+      JSON.parse(window.localStorage.getItem("sceneworks-studio-video-project_1")),
+    ).toMatchObject({
+      model: "ltx_2_3",
+      enhancePrompt: true,
+      textEncoderModel: AMORAL_ENCODER.id,
+    });
+    await click(buttonWithText(container, "Render clip"));
+
+    const advanced = context.createVideoJob.mock.calls[0][0].advanced;
+    expect(advanced).toMatchObject({
+      enhancePrompt: true,
+      textEncoderModel: "ltx_amoral_gemma_3_12b",
+    });
+    expect(advanced.useUncensoredEnhancer).toBeUndefined();
+  });
+
+  it("keeps the shipped encoder as the omission-based default", async () => {
+    const context = baseContext({ videoModels: [LTX_WITH_ENCODERS] });
+    await render(context);
+    await openAdvanced(container);
+    await click(enhanceCheckbox());
+    await click(buttonWithText(container, "Render clip"));
+
+    const advanced = context.createVideoJob.mock.calls[0][0].advanced;
+    expect(advanced.enhancePrompt).toBe(true);
+    expect(advanced.textEncoderModel).toBeUndefined();
+  });
+
+  it("round-trips the stable selector through a recorded recipe", async () => {
+    const context = baseContext({
+      videoModels: [LTX_WITH_ENCODERS],
+      studioLaunch: {
+        id: "replay-text-encoder",
+        view: "Video",
+        recipe: {
+          mode: "text_to_video",
+          model: "ltx_2_3",
+          prompt: "A camera glides through a forest",
+          normalizedSettings: {},
+          rawAdapterSettings: {
+            enhancePrompt: true,
+            textEncoderModel: AMORAL_ENCODER.id,
+          },
+        },
+      },
+    });
+    await render(context);
+    await openAdvanced(container);
+
+    expect(enhanceCheckbox().checked).toBe(true);
+    expect(encoderSelect().value).toBe(AMORAL_ENCODER.id);
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].advanced).toMatchObject({
+      enhancePrompt: true,
+      textEncoderModel: AMORAL_ENCODER.id,
+    });
+  });
+
+  it("rehydrates a legacy boolean recipe into the stable selector", async () => {
+    const context = baseContext({
+      videoModels: [LTX_WITH_ENCODERS],
+      studioLaunch: {
+        id: "replay-legacy-text-encoder",
+        view: "Video",
+        recipe: {
+          mode: "text_to_video",
+          model: "ltx_2_3",
+          prompt: "A slow aerial reveal",
+          normalizedSettings: {},
+          rawAdapterSettings: {
+            enhancePrompt: true,
+            useUncensoredEnhancer: true,
+          },
+        },
+      },
+    });
+    await render(context);
+    await openAdvanced(container);
+
+    expect(encoderSelect().value).toBe(AMORAL_ENCODER.id);
+    await click(buttonWithText(container, "Render clip"));
+    const advanced = context.createVideoJob.mock.calls[0][0].advanced;
+    expect(advanced.textEncoderModel).toBe(AMORAL_ENCODER.id);
+    expect(advanced.useUncensoredEnhancer).toBeUndefined();
+  });
+});

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -165,6 +165,7 @@ mod sensenova_jobs;
 use sensenova_jobs::*;
 mod video_jobs;
 use video_jobs::*;
+pub use video_jobs::{text_encoder_options_for_adapter, TextEncoderOption};
 // Pure audio generation — the SceneWorks Audio Studio job path (epic 13400 / sc-13404). Compiled on
 // every platform (the dispatch arm is uniform); the actual candle audio lane is resolved through
 // `inference_runtime::load_audio`, which errors clearly on a build that ships no audio registry (a

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -1617,9 +1617,17 @@ mod tests {
         let (tier, gemma) = (root.join("q4"), root.join("gemma"));
         std::fs::create_dir_all(&tier).unwrap();
         std::fs::create_dir_all(&gemma).unwrap();
-        std::fs::write(gemma.join("config.json"), b"{}").unwrap();
-        std::fs::write(gemma.join("tokenizer.json"), b"{}").unwrap();
-        std::fs::write(gemma.join("model.safetensors"), b"x").unwrap();
+        std::fs::write(
+            gemma.join("config.json"),
+            br#"{"model_type":"gemma3_text"}"#,
+        )
+        .unwrap();
+        std::fs::write(gemma.join("tokenizer.json"), br#"{"model":{"type":"BPE"}}"#).unwrap();
+        let header = br#"{"weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}"#;
+        let mut weights = (header.len() as u64).to_le_bytes().to_vec();
+        weights.extend_from_slice(header);
+        weights.push(0);
+        std::fs::write(gemma.join("model.safetensors"), weights).unwrap();
 
         // Non-LTX engines never resolve an external TE (theirs lives inside the weights dir).
         assert!(training_text_encoder("kolors", &tier).is_none());

--- a/crates/sceneworks-worker/src/video_jobs/ltx.rs
+++ b/crates/sceneworks-worker/src/video_jobs/ltx.rs
@@ -67,19 +67,98 @@ pub(super) fn ltx_dir_is_complete(dir: &Path) -> bool {
     .all(|file| dir.join(file).is_file())
 }
 
-/// Whether `dir` is a complete Gemma-3 text-encoder snapshot the LTX engine can load: its
-/// `config.json`, `tokenizer.json`, the sharded `model.safetensors.index.json`, and every shard that
-/// a non-empty index maps (or a lone `model.safetensors` for a single-file checkpoint). Used so the
-/// eros gemma fetch ([`ensure_ltx_gemma_present`]) no-ops only when gemma is genuinely present and a
-/// half-downloaded dir never shadows a re-fetch ([`resolve_ltx_eros_gemma_dir`]).
+/// Cheap structural validation for one safetensors file. It reads only the bounded JSON header,
+/// verifies at least one tensor entry, and checks every declared byte range against the file length.
+/// This rejects placeholder/truncated files without reading multi-gigabyte tensor bodies.
+#[cfg(target_os = "macos")]
+fn safetensors_file_is_structurally_valid(path: &Path) -> bool {
+    use std::io::Read;
+
+    const MAX_HEADER_BYTES: usize = 100_000_000;
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(file_len) = file.metadata().map(|metadata| metadata.len()) else {
+        return false;
+    };
+    let mut header_len_bytes = [0_u8; 8];
+    if file.read_exact(&mut header_len_bytes).is_err() {
+        return false;
+    }
+    let Ok(header_len) = usize::try_from(u64::from_le_bytes(header_len_bytes)) else {
+        return false;
+    };
+    if header_len == 0 || header_len > MAX_HEADER_BYTES {
+        return false;
+    }
+    let Ok(header_and_prefix) = u64::try_from(header_len).map(|length| length + 8) else {
+        return false;
+    };
+    if header_and_prefix > file_len {
+        return false;
+    }
+    let mut header = vec![0_u8; header_len];
+    if file.read_exact(&mut header).is_err() {
+        return false;
+    }
+    let Ok(Value::Object(entries)) = serde_json::from_slice::<Value>(&header) else {
+        return false;
+    };
+    let data_len = file_len - header_and_prefix;
+    let mut tensor_count = 0_usize;
+    for (name, entry) in entries {
+        if name == "__metadata__" {
+            continue;
+        }
+        let Some(entry) = entry.as_object() else {
+            return false;
+        };
+        if entry.get("dtype").and_then(Value::as_str).is_none()
+            || entry.get("shape").and_then(Value::as_array).is_none()
+        {
+            return false;
+        }
+        let Some(offsets) = entry.get("data_offsets").and_then(Value::as_array) else {
+            return false;
+        };
+        let [start, end] = offsets.as_slice() else {
+            return false;
+        };
+        let (Some(start), Some(end)) = (start.as_u64(), end.as_u64()) else {
+            return false;
+        };
+        if start > end || end > data_len {
+            return false;
+        }
+        tensor_count += 1;
+    }
+    tensor_count > 0
+}
+
+#[cfg(target_os = "macos")]
+fn json_object_file_satisfies(path: &Path, predicate: impl FnOnce(&JsonObject) -> bool) -> bool {
+    std::fs::read(path)
+        .ok()
+        .and_then(|raw| serde_json::from_slice::<Value>(&raw).ok())
+        .and_then(|value| value.as_object().cloned())
+        .is_some_and(|object| predicate(&object))
+}
+
+/// Whether `dir` is a complete Gemma-3 text-encoder snapshot the LTX engine can load: parseable,
+/// non-empty config and tokenizer JSON, plus a structurally valid single safetensors file or every
+/// structurally valid shard mapped by a non-empty index. Used so runtime option discovery and eros
+/// provisioning never accept filename-only placeholders or half-downloaded snapshots.
 #[cfg(target_os = "macos")]
 pub(super) fn ltx_gemma_dir_is_complete(dir: &Path) -> bool {
-    if !dir.join("config.json").is_file() || !dir.join("tokenizer.json").is_file() {
+    if !json_object_file_satisfies(&dir.join("config.json"), |object| !object.is_empty())
+        || !json_object_file_satisfies(&dir.join("tokenizer.json"), |object| {
+            object.get("model").is_some_and(Value::is_object)
+        })
+    {
         return false;
     }
     let Ok(index_raw) = std::fs::read_to_string(dir.join("model.safetensors.index.json")) else {
-        // No shard index ⇒ a single-file checkpoint is complete once its lone weights file exists.
-        return dir.join("model.safetensors").is_file();
+        return safetensors_file_is_structurally_valid(&dir.join("model.safetensors"));
     };
     let Ok(index) = serde_json::from_str::<Value>(&index_raw) else {
         return false;
@@ -97,7 +176,9 @@ pub(super) fn ltx_gemma_dir_is_complete(dir: &Path) -> bool {
     if shards.is_empty() {
         return false;
     }
-    shards.iter().all(|shard| dir.join(shard).is_file())
+    shards
+        .iter()
+        .all(|shard| safetensors_file_is_structurally_valid(&dir.join(shard)))
 }
 
 /// Parse `advanced.mlxQuantize` (int or numeric string) → the requested bit width, if present.
@@ -327,6 +408,63 @@ pub(super) fn resolve_ltx_eros_gemma_dir(settings: &Settings, model_dir: &Path) 
 #[cfg(target_os = "macos")]
 const LTX_UNCENSORED_GEMMA_REPO: &str = "TheCluster/amoral-gemma-3-12B-v2-mlx-4bit";
 
+/// Stable request selector for the shipped Gemma text-encoder backbone. The field is omitted by the
+/// web client for this default, so old jobs and recipes retain identical behavior.
+#[cfg(target_os = "macos")]
+pub const DEFAULT_TEXT_ENCODER_ID: &str = "default";
+/// Stable request selector for LTX's operator-staged, alternate prompt-enhancement Gemma.
+#[cfg(target_os = "macos")]
+pub const AMORAL_TEXT_ENCODER_ID: &str = "ltx_amoral_gemma_3_12b";
+
+/// A selectable prompt text encoder surfaced by the model catalog. This is capability metadata only:
+/// it contains no repo, revision, files, or download action, so operator-staged models remain outside
+/// SceneWorks' distribution catalog.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextEncoderOption {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub description: &'static str,
+    pub is_default: bool,
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn ltx_text_encoder_options(alternate_staged: bool) -> Vec<TextEncoderOption> {
+    let mut options = vec![TextEncoderOption {
+        id: DEFAULT_TEXT_ENCODER_ID,
+        label: "Shipped Gemma 3 12B (default)",
+        description: "Uses the Gemma text encoder installed with LTX.",
+        is_default: true,
+    }];
+    if alternate_staged {
+        options.push(TextEncoderOption {
+            id: AMORAL_TEXT_ENCODER_ID,
+            label: "Amoral Gemma 3 12B (operator staged)",
+            description:
+                "Uses the complete alternate Gemma snapshot already staged by the operator.",
+            is_default: false,
+        });
+    }
+    options
+}
+
+/// Enumerate the complete text encoders this runtime can offer for a model adapter. The UI consumes
+/// this generic list instead of hard-coding LTX ids. LTX is currently the only provider with a
+/// swappable encoder, and that provider is MLX-only; future adapters can extend this registry without
+/// changing Video Studio.
+pub fn text_encoder_options_for_adapter(adapter: &str, data_dir: &Path) -> Vec<TextEncoderOption> {
+    #[cfg(target_os = "macos")]
+    {
+        if adapter == "ltx_video" {
+            return ltx_text_encoder_options(
+                resolve_ltx_uncensored_enhancer_dir(data_dir).is_some(),
+            );
+        }
+    }
+    let _ = (adapter, data_dir);
+    Vec::new()
+}
+
 /// Resolve the optional amoral 4-bit Gemma **enhancer** snapshot for a `useUncensoredEnhancer` LTX job
 /// (sc-2845), to be staged in `LoadSpec::components["uncensored_enhancer"]`. Mirrors the resolution the
 /// MLX LTX provider deleted at sc-13664 (moved into the worker): an operator `$LTX_UNCENSORED_GEMMA_DIR`
@@ -336,15 +474,94 @@ const LTX_UNCENSORED_GEMMA_REPO: &str = "TheCluster/amoral-gemma-3-12B-v2-mlx-4b
 /// [`ltx_gemma_dir_is_complete`] (an mlx_lm gemma snapshot is `config.json` + shards, same shape as the
 /// TE), so a partial/half-downloaded dir never wins.
 #[cfg(target_os = "macos")]
-fn resolve_ltx_uncensored_enhancer_dir(settings: &Settings) -> Option<PathBuf> {
+fn resolve_ltx_uncensored_enhancer_dir(data_dir: &Path) -> Option<PathBuf> {
     if let Some(raw) = std::env::var_os("LTX_UNCENSORED_GEMMA_DIR") {
         let dir = PathBuf::from(raw);
         if ltx_gemma_dir_is_complete(&dir) {
             return Some(dir);
         }
     }
-    let snapshot = huggingface_snapshot_dir(&settings.data_dir, LTX_UNCENSORED_GEMMA_REPO)?;
+    let snapshot = huggingface_snapshot_dir(data_dir, LTX_UNCENSORED_GEMMA_REPO)?;
     ltx_gemma_dir_is_complete(&snapshot).then_some(snapshot)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum LtxTextEncoderSelection {
+    Default,
+    Amoral,
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn selected_ltx_text_encoder(
+    advanced: &JsonObject,
+) -> WorkerResult<LtxTextEncoderSelection> {
+    let legacy = match advanced.get("useUncensoredEnhancer") {
+        None => None,
+        Some(Value::Bool(value)) => Some(*value),
+        Some(_) => {
+            return Err(WorkerError::InvalidPayload(
+                "advanced.useUncensoredEnhancer must be a boolean when present".to_owned(),
+            ));
+        }
+    };
+    let selected = match advanced.get("textEncoderModel") {
+        None => {
+            return Ok(if legacy == Some(true) {
+                LtxTextEncoderSelection::Amoral
+            } else {
+                LtxTextEncoderSelection::Default
+            });
+        }
+        Some(Value::String(id)) if id == DEFAULT_TEXT_ENCODER_ID => {
+            LtxTextEncoderSelection::Default
+        }
+        Some(Value::String(id)) if id == AMORAL_TEXT_ENCODER_ID => LtxTextEncoderSelection::Amoral,
+        Some(Value::String(id)) => Err(WorkerError::InvalidPayload(format!(
+            "unsupported LTX text encoder {id:?}; choose {DEFAULT_TEXT_ENCODER_ID:?} or an \
+             installed option returned by GET /api/v1/models"
+        )))?,
+        Some(_) => {
+            return Err(WorkerError::InvalidPayload(
+                "advanced.textEncoderModel must be a string option id returned by GET /api/v1/models"
+                    .to_owned(),
+            ));
+        }
+    };
+    if legacy.is_some_and(|legacy| legacy != (selected == LtxTextEncoderSelection::Amoral)) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "advanced.textEncoderModel conflicts with advanced.useUncensoredEnhancer={}",
+            legacy.unwrap_or_default()
+        )));
+    }
+    Ok(selected)
+}
+
+#[cfg(target_os = "macos")]
+pub(super) fn resolve_selected_ltx_text_encoder(
+    advanced: &JsonObject,
+    staged_alternate: Option<PathBuf>,
+) -> WorkerResult<(bool, Option<PathBuf>)> {
+    let selection = selected_ltx_text_encoder(advanced)?;
+    let use_alternate = selection == LtxTextEncoderSelection::Amoral;
+    if use_alternate && !advanced::bool(advanced, "enhancePrompt") {
+        return Err(WorkerError::InvalidPayload(format!(
+            "text encoder {AMORAL_TEXT_ENCODER_ID:?} is selected but prompt enhancement is off; \
+             enable advanced.enhancePrompt or choose the default encoder"
+        )));
+    }
+    let dir = if use_alternate {
+        Some(staged_alternate.ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "text encoder {AMORAL_TEXT_ENCODER_ID:?} is selected but its complete weights are \
+                 not staged; set $LTX_UNCENSORED_GEMMA_DIR to a complete snapshot or pre-stage \
+                 TheCluster/amoral-gemma-3-12B-v2-mlx-4bit in the worker's Hugging Face cache"
+            ))
+        })?)
+    } else {
+        None
+    };
+    Ok((use_alternate, dir))
 }
 
 /// On-demand fetch of the bundle's `q8/` subdir (sc-5679). The macOS default download is lean
@@ -1072,6 +1289,13 @@ pub(super) async fn generate_ltx(
     engine_id: &'static str,
     backend: &str,
 ) -> WorkerResult<DecodedVideo> {
+    // Validate and resolve an explicit encoder choice before any clip decoding, model download, or
+    // engine setup. A bad request must remain a cheap, actionable InvalidPayload.
+    let (use_uncensored_enhancer, uncensored_enhancer_dir) = resolve_selected_ltx_text_encoder(
+        &request.advanced,
+        resolve_ltx_uncensored_enhancer_dir(&settings.data_dir),
+    )?;
+    let enhance_prompt = advanced::bool(&request.advanced, "enhancePrompt");
     let video_mode = advanced::bool(&request.advanced, "noAudio").then(|| "no_audio".to_owned());
     let enhance_max_tokens = request
         .advanced
@@ -1110,13 +1334,6 @@ pub(super) async fn generate_ltx(
     } else {
         resolve_bundled_ltx_gemma_dir(&model_dir)
     };
-    // Optional amoral 4-bit Gemma enhancer (sc-2845): when the request opts in, resolve the staged
-    // amoral snapshot so it rides `LoadSpec::components["uncensored_enhancer"]` (sc-13664 deleted the
-    // provider's own `$LTX_UNCENSORED_GEMMA_DIR` / HF-cache scan). Off ⇒ `None`, no staging, no fetch.
-    let use_uncensored_enhancer = advanced::bool(&request.advanced, "useUncensoredEnhancer");
-    let uncensored_enhancer_dir = use_uncensored_enhancer
-        .then(|| resolve_ltx_uncensored_enhancer_dir(settings))
-        .flatten();
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -1136,7 +1353,7 @@ pub(super) async fn generate_ltx(
         seed: resolve_video_seed(request) as u64,
         control_scale: None,
         video_mode,
-        enhance_prompt: advanced::bool(&request.advanced, "enhancePrompt"),
+        enhance_prompt,
         use_uncensored_enhancer,
         enhance_max_tokens,
         enhance_temperature,

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -1520,6 +1520,7 @@ use scail2::{scail2_engine_id, scail2_raw_settings};
 pub(crate) mod ltx;
 #[cfg(target_os = "macos")]
 use ltx::{generate_ltx, ltx_available, ltx_engine_id, ltx_raw_settings, LTX_ADAPTER};
+pub use ltx::{text_encoder_options_for_adapter, TextEncoderOption};
 mod mochi;
 #[cfg(target_os = "macos")]
 use mochi::{generate_mochi, mochi_available, mochi_engine_id, MOCHI_ADAPTER};

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -6722,17 +6722,171 @@ fn ltx_bundle_subdir_picks_quant_and_finds_gemma() {
 /// index, and the shards it maps. Mirrors the real bundle `gemma/` so the completeness +
 /// eros-resolution tests are hermetic.
 #[cfg(target_os = "macos")]
+fn write_tiny_safetensors(path: &Path) {
+    let header = br#"{"weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}"#;
+    let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+    bytes.extend_from_slice(header);
+    bytes.push(0);
+    std::fs::write(path, bytes).unwrap();
+}
+
+#[cfg(target_os = "macos")]
 fn write_complete_gemma_dir(dir: &Path) {
     std::fs::create_dir_all(dir).unwrap();
-    std::fs::write(dir.join("config.json"), b"{}").unwrap();
-    std::fs::write(dir.join("tokenizer.json"), b"{}").unwrap();
+    std::fs::write(dir.join("config.json"), br#"{"model_type":"gemma3_text"}"#).unwrap();
+    std::fs::write(dir.join("tokenizer.json"), br#"{"model":{"type":"BPE"}}"#).unwrap();
     std::fs::write(
             dir.join("model.safetensors.index.json"),
             br#"{"weight_map":{"a":"model-00001-of-00002.safetensors","b":"model-00002-of-00002.safetensors"}}"#,
         )
         .unwrap();
-    std::fs::write(dir.join("model-00001-of-00002.safetensors"), b"x").unwrap();
-    std::fs::write(dir.join("model-00002-of-00002.safetensors"), b"x").unwrap();
+    write_tiny_safetensors(&dir.join("model-00001-of-00002.safetensors"));
+    write_tiny_safetensors(&dir.join("model-00002-of-00002.safetensors"));
+}
+
+#[cfg(target_os = "macos")]
+fn advanced_object(value: Value) -> JsonObject {
+    value.as_object().expect("advanced object").clone()
+}
+
+/// sc-13800: the public option list is generic/stable, but the operator-staged alternate is only
+/// enumerated after the shared completeness resolver says it is available.
+#[cfg(target_os = "macos")]
+#[test]
+fn ltx_text_encoder_options_hide_unstaged_alternate() {
+    let default_only = ltx_text_encoder_options(false);
+    assert_eq!(
+        default_only
+            .iter()
+            .map(|option| option.id)
+            .collect::<Vec<_>>(),
+        vec![DEFAULT_TEXT_ENCODER_ID]
+    );
+    assert!(default_only[0].is_default);
+
+    let staged = ltx_text_encoder_options(true);
+    assert_eq!(
+        staged.iter().map(|option| option.id).collect::<Vec<_>>(),
+        vec![DEFAULT_TEXT_ENCODER_ID, AMORAL_TEXT_ENCODER_ID]
+    );
+    assert!(!staged[1].is_default);
+}
+
+/// sc-13800: the stable selector generalizes the raw boolean without weakening compatibility.
+/// Unknown/non-string/conflicting choices are validation errors, never silent defaults.
+#[cfg(target_os = "macos")]
+#[test]
+fn ltx_text_encoder_selector_is_strict_and_legacy_compatible() {
+    assert_eq!(
+        selected_ltx_text_encoder(&advanced_object(json!({}))).unwrap(),
+        LtxTextEncoderSelection::Default
+    );
+    assert_eq!(
+        selected_ltx_text_encoder(&advanced_object(json!({
+            "textEncoderModel": AMORAL_TEXT_ENCODER_ID
+        })))
+        .unwrap(),
+        LtxTextEncoderSelection::Amoral
+    );
+    assert_eq!(
+        selected_ltx_text_encoder(&advanced_object(json!({
+            "useUncensoredEnhancer": true
+        })))
+        .unwrap(),
+        LtxTextEncoderSelection::Amoral
+    );
+
+    for bad in [
+        json!({ "textEncoderModel": "unknown_encoder" }),
+        json!({ "textEncoderModel": 7 }),
+        json!({
+            "textEncoderModel": DEFAULT_TEXT_ENCODER_ID,
+            "useUncensoredEnhancer": true
+        }),
+        json!({
+            "textEncoderModel": AMORAL_TEXT_ENCODER_ID,
+            "useUncensoredEnhancer": false
+        }),
+        json!({ "useUncensoredEnhancer": "true" }),
+    ] {
+        assert!(
+            matches!(
+                selected_ltx_text_encoder(&advanced_object(bad)),
+                Err(WorkerError::InvalidPayload(_))
+            ),
+            "invalid selector input must fail as a user-facing payload error"
+        );
+    }
+}
+
+/// A selected alternate must both be active (prompt enhancement on) and fully staged before model
+/// load. The returned directory is the one later placed in LoadSpec.components, so this assertion is
+/// mutation-sensitive to the non-default choice.
+#[cfg(target_os = "macos")]
+#[test]
+fn selected_ltx_text_encoder_fails_early_or_stages_exact_alternate() {
+    let advanced = advanced_object(json!({
+        "enhancePrompt": true,
+        "textEncoderModel": AMORAL_TEXT_ENCODER_ID
+    }));
+    let staged = PathBuf::from("/operator/staged/amoral-gemma");
+    let (use_alternate, resolved) =
+        resolve_selected_ltx_text_encoder(&advanced, Some(staged.clone())).unwrap();
+    assert!(use_alternate);
+    assert_eq!(resolved.as_deref(), Some(staged.as_path()));
+
+    let missing = resolve_selected_ltx_text_encoder(&advanced, None)
+        .expect_err("a selected but unstaged alternate must fail");
+    assert!(matches!(missing, WorkerError::InvalidPayload(_)));
+    assert!(missing.to_string().contains("not staged"));
+
+    let disabled = advanced_object(json!({
+        "enhancePrompt": false,
+        "textEncoderModel": AMORAL_TEXT_ENCODER_ID
+    }));
+    let error = resolve_selected_ltx_text_encoder(&disabled, Some(staged))
+        .expect_err("an alternate that would be ignored must not silently pass");
+    assert!(error.to_string().contains("prompt enhancement is off"));
+
+    let (use_alternate, resolved) =
+        resolve_selected_ltx_text_encoder(&advanced_object(json!({})), None).unwrap();
+    assert!(!use_alternate);
+    assert!(resolved.is_none());
+}
+
+/// Keep selector rejection ahead of every expensive or externally visible phase, and keep the
+/// resolved directory wired into the engine input. This source-order guard complements the pure
+/// resolver tests because the async generation seam otherwise requires real LTX weights.
+#[cfg(target_os = "macos")]
+#[test]
+fn generate_ltx_validates_and_stages_the_selector_before_side_effects() {
+    let source = include_str!("ltx.rs");
+    let generate = source
+        .split_once("pub(super) async fn generate_ltx(")
+        .expect("generate_ltx exists")
+        .1;
+    let selector = generate
+        .find("resolve_selected_ltx_text_encoder(")
+        .expect("selector resolution");
+    for side_effect in [
+        "resolve_video_clip_conditioning(",
+        "ensure_ltx_q8_present(",
+        "ensure_ltx_bf16_present(",
+        "ensure_ltx_gemma_present(",
+    ] {
+        assert!(
+            selector < generate.find(side_effect).expect("side-effect call"),
+            "selector validation must precede {side_effect}"
+        );
+    }
+    let input = generate
+        .split_once("let input = VideoGenInput {")
+        .expect("engine input")
+        .1;
+    assert!(
+        input.contains("uncensored_enhancer_dir,"),
+        "the resolved alternate directory must reach VideoGenInput"
+    );
 }
 
 /// `ltx_gemma_dir_is_complete`: needs config + tokenizer + every shard a non-empty index maps
@@ -6749,17 +6903,17 @@ fn ltx_gemma_completeness_requires_config_and_all_shards() {
     assert!(!ltx_gemma_dir_is_complete(&root));
 
     // Missing config.json → incomplete even with weights present.
-    std::fs::write(root.join("model-00002-of-00002.safetensors"), b"x").unwrap();
+    write_tiny_safetensors(&root.join("model-00002-of-00002.safetensors"));
     std::fs::remove_file(root.join("config.json")).unwrap();
     assert!(!ltx_gemma_dir_is_complete(&root));
 
     // Missing tokenizer.json → incomplete even with config + all weights present.
-    std::fs::write(root.join("config.json"), b"{}").unwrap();
+    std::fs::write(root.join("config.json"), br#"{"model_type":"gemma3_text"}"#).unwrap();
     std::fs::remove_file(root.join("tokenizer.json")).unwrap();
     assert!(!ltx_gemma_dir_is_complete(&root));
 
     // Empty or non-string weight maps must not pass vacuously.
-    std::fs::write(root.join("tokenizer.json"), b"{}").unwrap();
+    std::fs::write(root.join("tokenizer.json"), br#"{"model":{"type":"BPE"}}"#).unwrap();
     std::fs::write(
         root.join("model.safetensors.index.json"),
         br#"{"weight_map":{}}"#,
@@ -6776,10 +6930,23 @@ fn ltx_gemma_completeness_requires_config_and_all_shards() {
     // Single-file checkpoint (no index) is complete once config + tokenizer + weights exist.
     let single = std::env::temp_dir().join(format!("sw_gemma_1f_{}", Uuid::new_v4().simple()));
     std::fs::create_dir_all(&single).unwrap();
-    std::fs::write(single.join("config.json"), b"{}").unwrap();
-    std::fs::write(single.join("tokenizer.json"), b"{}").unwrap();
+    std::fs::write(
+        single.join("config.json"),
+        br#"{"model_type":"gemma3_text"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        single.join("tokenizer.json"),
+        br#"{"model":{"type":"BPE"}}"#,
+    )
+    .unwrap();
     assert!(!ltx_gemma_dir_is_complete(&single));
     std::fs::write(single.join("model.safetensors"), b"x").unwrap();
+    assert!(
+        !ltx_gemma_dir_is_complete(&single),
+        "filename-only placeholder weights must not be advertised as loadable"
+    );
+    write_tiny_safetensors(&single.join("model.safetensors"));
     assert!(ltx_gemma_dir_is_complete(&single));
 
     let _ = std::fs::remove_dir_all(&root);


### PR DESCRIPTION
## Summary
- expose runtime-only text encoder options on the model catalog, advertising the operator-staged LTX alternate only after config, tokenizer, and safetensors structural validation
- add a generic Advanced UI prompt-enhancement and text-encoder selector with model-keyed persistence, preset and recipe round trips, and legacy boolean compatibility
- route `advanced.textEncoderModel` through strict, fail-fast MLX LTX resolution before clip decoding or model provisioning, while keeping the shipped Gemma omission-based default and adding no alternate download metadata

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (full suite; run outside the managed sandbox for the existing macOS `sips` HEIC fixture)
- `cargo build`
- Linux no-backend cross-target clippy: `cargo clippy --target x86_64-unknown-linux-gnu -p sceneworks-worker -p sceneworks-rust-api --all-targets -- -D warnings`
- `npm run rust:check:candle`
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run test` (197 files, 2701 tests)
- `npm --prefix apps/web run build`
- focused API, worker, and Video Studio selector suites
- mutation check confirmed outbound non-default selector assertions fail when the mapping is broken
- independent adversarial review: PASS after findings were fixed and re-reviewed

## Evidence limitation
The operator-staged alternate checkpoint is not present on this host, so no real-weight alternate render was claimed. The live catalog tests cover staged, corrupt, and removed cache states; MLX runtime behavior is traced to the pinned inference contract. Candle is typechecked only; no CUDA runtime is available here.

Shortcut: https://app.shortcut.com/trefry/story/13800