### PR TITLE
fix(models): repin the Mage q4 tiers after the precision-floor rebuild (sc-15071)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -40,20 +40,30 @@
       // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
       // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
       // It costs 0.345 GB per tier and is quantized at load exactly as before.
+      //
+      // sc-15071 — why the q4 text encoder (4.331 GB) is nearly the size of the q8 one (4.731 GB):
+      // packed uniformly at 4 bits the q4 tier did not render the prompt at all, it produced a
+      // repeating tiled texture. Two projections have an 8-bit floor — the DiT's `norm_out.linear`
+      // and the Qwen3-VL LM's 36 decoder layers — so q4 now shares q8's decoder layers and differs
+      // only in the token embedding and the vision tower. The q4 DiT grew 2.317 -> 2.326 GB for the
+      // same reason. `mlx.quantize: 4` stays the default because q4 is now correct; the full q4
+      // install is 7.00 GB against q8's 9.45 GB, and peaks at 7.87 GB of unified memory against
+      // 10.11 GB. All six q4 artifacts were regenerated and re-uploaded, which is what moved every
+      // `revision` below — the q8 and bf16 payloads in those commits are byte-identical to before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Base",
-          "revision": "199b4cae841403e8a1cca3c585a09f10fc70d3f1",
+          "revision": "6c119cdac7ce7cf8c1ab4990d9c8ca18641f2c5d",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 2316856860,
-          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 2326294167,
+          "footprint": { "diskSizeBytes": 2326294167, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Base",
-          "revision": "199b4cae841403e8a1cca3c585a09f10fc70d3f1",
+          "revision": "6c119cdac7ce7cf8c1ab4990d9c8ca18641f2c5d",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 4374163324,
@@ -62,7 +72,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Base",
-          "revision": "199b4cae841403e8a1cca3c585a09f10fc70d3f1",
+          "revision": "6c119cdac7ce7cf8c1ab4990d9c8ca18641f2c5d",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 8231571754,
@@ -72,18 +82,18 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q4",
           "subdir": "q4/text_encoder",
           "files": ["q4/text_encoder/*"],
-          "estimatedSizeBytes": 2514418914
+          "estimatedSizeBytes": 4331077508
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q8",
@@ -94,7 +104,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "bf16",
@@ -106,7 +116,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q4",
@@ -117,7 +127,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q8",
@@ -128,7 +138,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "bf16",
@@ -244,20 +254,30 @@
       // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
       // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
       // It costs 0.345 GB per tier and is quantized at load exactly as before.
+      //
+      // sc-15071 — why the q4 text encoder (4.331 GB) is nearly the size of the q8 one (4.731 GB):
+      // packed uniformly at 4 bits the q4 tier did not render the prompt at all, it produced a
+      // repeating tiled texture. Two projections have an 8-bit floor — the DiT's `norm_out.linear`
+      // and the Qwen3-VL LM's 36 decoder layers — so q4 now shares q8's decoder layers and differs
+      // only in the token embedding and the vision tower. The q4 DiT grew 2.317 -> 2.326 GB for the
+      // same reason. `mlx.quantize: 4` stays the default because q4 is now correct; the full q4
+      // install is 7.00 GB against q8's 9.45 GB, and peaks at 7.87 GB of unified memory against
+      // 10.11 GB. All six q4 artifacts were regenerated and re-uploaded, which is what moved every
+      // `revision` below — the q8 and bf16 payloads in those commits are byte-identical to before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit",
-          "revision": "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503",
+          "revision": "dbd4a9c07faca94491ad88ab21225d62e054d9cc",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 2316856860,
-          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 2326294167,
+          "footprint": { "diskSizeBytes": 2326294167, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit",
-          "revision": "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503",
+          "revision": "dbd4a9c07faca94491ad88ab21225d62e054d9cc",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 4374163324,
@@ -266,7 +286,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit",
-          "revision": "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503",
+          "revision": "dbd4a9c07faca94491ad88ab21225d62e054d9cc",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 8231571754,
@@ -276,18 +296,18 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q4",
           "subdir": "q4/text_encoder",
           "files": ["q4/text_encoder/*"],
-          "estimatedSizeBytes": 2514418914
+          "estimatedSizeBytes": 4331077508
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q8",
@@ -298,7 +318,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "bf16",
@@ -310,7 +330,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q4",
@@ -321,7 +341,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q8",
@@ -332,7 +352,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "bf16",
@@ -445,20 +465,30 @@
       // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
       // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
       // It costs 0.345 GB per tier and is quantized at load exactly as before.
+      //
+      // sc-15071 — why the q4 text encoder (4.331 GB) is nearly the size of the q8 one (4.731 GB):
+      // packed uniformly at 4 bits the q4 tier did not render the prompt at all, it produced a
+      // repeating tiled texture. Two projections have an 8-bit floor — the DiT's `norm_out.linear`
+      // and the Qwen3-VL LM's 36 decoder layers — so q4 now shares q8's decoder layers and differs
+      // only in the token embedding and the vision tower. The q4 DiT grew 2.317 -> 2.326 GB for the
+      // same reason. `mlx.quantize: 4` stays the default because q4 is now correct; the full q4
+      // install is 7.00 GB against q8's 9.45 GB, and peaks at 7.87 GB of unified memory against
+      // 10.11 GB. All six q4 artifacts were regenerated and re-uploaded, which is what moved every
+      // `revision` below — the q8 and bf16 payloads in those commits are byte-identical to before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Turbo",
-          "revision": "c3437cbb91e565ab6373e3c7b8e9b8048d29831b",
+          "revision": "75c11a2957aca2c78272984375502105b2b235ab",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 2316856860,
-          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 2326294167,
+          "footprint": { "diskSizeBytes": 2326294167, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Turbo",
-          "revision": "c3437cbb91e565ab6373e3c7b8e9b8048d29831b",
+          "revision": "75c11a2957aca2c78272984375502105b2b235ab",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 4374163324,
@@ -467,7 +497,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Edit-Turbo",
-          "revision": "c3437cbb91e565ab6373e3c7b8e9b8048d29831b",
+          "revision": "75c11a2957aca2c78272984375502105b2b235ab",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 8231571754,
@@ -477,18 +507,18 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q4",
           "subdir": "q4/text_encoder",
           "files": ["q4/text_encoder/*"],
-          "estimatedSizeBytes": 2514418914
+          "estimatedSizeBytes": 4331077508
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q8",
@@ -499,7 +529,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "bf16",
@@ -511,7 +541,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q4",
@@ -522,7 +552,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q8",
@@ -533,7 +563,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "bf16",
@@ -648,20 +678,30 @@
       // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
       // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
       // It costs 0.345 GB per tier and is quantized at load exactly as before.
+      //
+      // sc-15071 — why the q4 text encoder (4.331 GB) is nearly the size of the q8 one (4.731 GB):
+      // packed uniformly at 4 bits the q4 tier did not render the prompt at all, it produced a
+      // repeating tiled texture. Two projections have an 8-bit floor — the DiT's `norm_out.linear`
+      // and the Qwen3-VL LM's 36 decoder layers — so q4 now shares q8's decoder layers and differs
+      // only in the token embedding and the vision tower. The q4 DiT grew 2.317 -> 2.326 GB for the
+      // same reason. `mlx.quantize: 4` stays the default because q4 is now correct; the full q4
+      // install is 7.00 GB against q8's 9.45 GB, and peaks at 7.87 GB of unified memory against
+      // 10.11 GB. All six q4 artifacts were regenerated and re-uploaded, which is what moved every
+      // `revision` below — the q8 and bf16 payloads in those commits are byte-identical to before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Base",
-          "revision": "2c0b473896ef87af5a0873a26ed62c319213ae36",
+          "revision": "d642341926fcdb450c17c8fbda03759e8f731c9b",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 2316856860,
-          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 2326294167,
+          "footprint": { "diskSizeBytes": 2326294167, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Base",
-          "revision": "2c0b473896ef87af5a0873a26ed62c319213ae36",
+          "revision": "d642341926fcdb450c17c8fbda03759e8f731c9b",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 4374163324,
@@ -670,7 +710,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Base",
-          "revision": "2c0b473896ef87af5a0873a26ed62c319213ae36",
+          "revision": "d642341926fcdb450c17c8fbda03759e8f731c9b",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 8231571754,
@@ -680,18 +720,18 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q4",
           "subdir": "q4/text_encoder",
           "files": ["q4/text_encoder/*"],
-          "estimatedSizeBytes": 2514418914
+          "estimatedSizeBytes": 4331077508
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q8",
@@ -702,7 +742,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "bf16",
@@ -714,7 +754,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q4",
@@ -725,7 +765,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q8",
@@ -736,7 +776,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "bf16",
@@ -826,20 +866,30 @@
       // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
       // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
       // It costs 0.345 GB per tier and is quantized at load exactly as before.
+      //
+      // sc-15071 — why the q4 text encoder (4.331 GB) is nearly the size of the q8 one (4.731 GB):
+      // packed uniformly at 4 bits the q4 tier did not render the prompt at all, it produced a
+      // repeating tiled texture. Two projections have an 8-bit floor — the DiT's `norm_out.linear`
+      // and the Qwen3-VL LM's 36 decoder layers — so q4 now shares q8's decoder layers and differs
+      // only in the token embedding and the vision tower. The q4 DiT grew 2.317 -> 2.326 GB for the
+      // same reason. `mlx.quantize: 4` stays the default because q4 is now correct; the full q4
+      // install is 7.00 GB against q8's 9.45 GB, and peaks at 7.87 GB of unified memory against
+      // 10.11 GB. All six q4 artifacts were regenerated and re-uploaded, which is what moved every
+      // `revision` below — the q8 and bf16 payloads in those commits are byte-identical to before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow",
-          "revision": "b9204c289b235bce9ade608f76a009f80a135bfd",
+          "revision": "5f6455818d8ca80ce780e9c01b9e0de1d8c5f9db",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 2316856860,
-          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 2326294167,
+          "footprint": { "diskSizeBytes": 2326294167, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow",
-          "revision": "b9204c289b235bce9ade608f76a009f80a135bfd",
+          "revision": "5f6455818d8ca80ce780e9c01b9e0de1d8c5f9db",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 4374163324,
@@ -848,7 +898,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow",
-          "revision": "b9204c289b235bce9ade608f76a009f80a135bfd",
+          "revision": "5f6455818d8ca80ce780e9c01b9e0de1d8c5f9db",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 8231571754,
@@ -858,18 +908,18 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q4",
           "subdir": "q4/text_encoder",
           "files": ["q4/text_encoder/*"],
-          "estimatedSizeBytes": 2514418914
+          "estimatedSizeBytes": 4331077508
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q8",
@@ -880,7 +930,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "bf16",
@@ -892,7 +942,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q4",
@@ -903,7 +953,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q8",
@@ -914,7 +964,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "bf16",
@@ -1004,20 +1054,30 @@
       // The VAE is DENSE in every tier by design: its quantizable weights are the adaLN projections
       // the one-step decoder folds away at load, so packing them on disk would corrupt the decode.
       // It costs 0.345 GB per tier and is quantized at load exactly as before.
+      //
+      // sc-15071 — why the q4 text encoder (4.331 GB) is nearly the size of the q8 one (4.731 GB):
+      // packed uniformly at 4 bits the q4 tier did not render the prompt at all, it produced a
+      // repeating tiled texture. Two projections have an 8-bit floor — the DiT's `norm_out.linear`
+      // and the Qwen3-VL LM's 36 decoder layers — so q4 now shares q8's decoder layers and differs
+      // only in the token embedding and the vision tower. The q4 DiT grew 2.317 -> 2.326 GB for the
+      // same reason. `mlx.quantize: 4` stays the default because q4 is now correct; the full q4
+      // install is 7.00 GB against q8's 9.45 GB, and peaks at 7.87 GB of unified memory against
+      // 10.11 GB. All six q4 artifacts were regenerated and re-uploaded, which is what moved every
+      // `revision` below — the q8 and bf16 payloads in those commits are byte-identical to before.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Turbo",
-          "revision": "dca431fa8dfb4b3411cf3986435540ed31a7e8b7",
+          "revision": "79016f10f96b441bebb6e6f461838adb8fb3ff5c",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
-          "estimatedSizeBytes": 2316856860,
-          "footprint": { "diskSizeBytes": 2316856860, "residentMemoryBytes": null, "peakMemoryBytes": null }
+          "estimatedSizeBytes": 2326294167,
+          "footprint": { "diskSizeBytes": 2326294167, "residentMemoryBytes": null, "peakMemoryBytes": null }
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Turbo",
-          "revision": "dca431fa8dfb4b3411cf3986435540ed31a7e8b7",
+          "revision": "79016f10f96b441bebb6e6f461838adb8fb3ff5c",
           "variant": "q8",
           "files": ["q8/*"],
           "estimatedSizeBytes": 4374163324,
@@ -1026,7 +1086,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Turbo",
-          "revision": "dca431fa8dfb4b3411cf3986435540ed31a7e8b7",
+          "revision": "79016f10f96b441bebb6e6f461838adb8fb3ff5c",
           "variant": "bf16",
           "files": ["bf16/*"],
           "estimatedSizeBytes": 8231571754,
@@ -1036,18 +1096,18 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q4",
           "subdir": "q4/text_encoder",
           "files": ["q4/text_encoder/*"],
-          "estimatedSizeBytes": 2514418914
+          "estimatedSizeBytes": 4331077508
         },
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "q8",
@@ -1058,7 +1118,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "text_encoder",
           "variant": "bf16",
@@ -1070,7 +1130,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q4",
@@ -1081,7 +1141,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "q8",
@@ -1092,7 +1152,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/Mage-Flow-Components-mlx",
-          "revision": "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62",
+          "revision": "c936de2a107ee8d0869137e73943f6414f23adaa",
           "coRequisite": true,
           "componentId": "vae",
           "variant": "bf16",

--- a/crates/sceneworks-worker/src/mage_flow_q8_mlx_smoke.rs
+++ b/crates/sceneworks-worker/src/mage_flow_q8_mlx_smoke.rs
@@ -17,12 +17,21 @@
 //!   4. `inference_runtime::load("mage_flow_base", &spec)` — the real engine load,
 //!   5. a render, checked non-degenerate.
 //!
-//! **Why q8 and not the default q4 tier.** Mage's q4 tier does not render correctly — at 512x512/30
-//! steps it produces a repeating tiled texture where bf16 and q8 both produce the prompt. That is a
-//! PRE-EXISTING defect in the q4 quantization from sc-14046, not the re-host: load-time q4 over the
-//! ORIGINAL dense `microsoft/Mage-Flow-Base` snapshot produces the identical image, and the packed q4
-//! artifact is bit-identical to it (`max_abs 0.0`). Filed separately. This smoke therefore exercises
-//! the split layout on q8, where a correct render actually proves the right weights were wired.
+//! **Why q8 and not the default q4 tier.** Historical, and no longer a statement about q4's health.
+//! When this smoke was written, Mage's q4 tier did not render correctly — at 512x512/30 steps it
+//! produced a repeating tiled texture where bf16 and q8 both produced the prompt — so q8 was the
+//! only tier on which "a correct render" could prove the split layout had wired the right weights.
+//! **That defect is fixed (sc-15071):** two projections needed an 8-bit floor (the DiT's
+//! `norm_out.linear` and the Qwen3-VL LM's decoder layers), the q4 artifacts on all seven mirrors
+//! were regenerated, and q4 now renders the prompt.
+//!
+//! The smoke stays on q8 because the thing it gates is the **split layout** — DiT-only tier subdir
+//! plus co-requisite TE/VAE dirs — which is identical across tiers, and q8 is what the cache is
+//! already primed with. Tier *correctness* is not this test's job and is no longer left to a
+//! non-degenerate-render check: it belongs to
+//! `mlx-gen-mage/tests/quant_real_weights.rs::every_tier_renders_the_reference_scene_and_a_uniform_q4_head_fails_the_gate`,
+//! which compares each tier against the bf16 render at a fixed seed and is proven by mutation to
+//! fail on exactly the tiled output this file's original note describes.
 //!
 //! Setup — with the q8 tier of BOTH repos in the HF cache, no env is needed:
 //! ```text

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -187,10 +187,10 @@ def test_cached_manifest_and_schema_loaders_return_isolated_copies():
 
 
 COMPONENTS_REPO = "SceneWorks/Mage-Flow-Components-mlx"
-COMPONENTS_REVISION = "5b6ab823ad92cbf5b5033c3ac5de936fa71a6d62"
+COMPONENTS_REVISION = "c936de2a107ee8d0869137e73943f6414f23adaa"
 # Measured on the uploaded artifacts (sc-14980). Per-tier DiT, and the shared per-tier components.
-DIT_BYTES = {"q4": 2316856860, "q8": 4374163324, "bf16": 8231571754}
-TE_BYTES = {"q4": 2514418914, "q8": 4731076490, "bf16": 8887219239}
+DIT_BYTES = {"q4": 2326294167, "q8": 4374163324, "bf16": 8231571754}
+TE_BYTES = {"q4": 4331077508, "q8": 4731076490, "bf16": 8887219239}
 VAE_BYTES = 345053168
 TIERS = ("q4", "q8", "bf16")
 
@@ -242,9 +242,9 @@ def test_mage_flow_generation_family_is_pinned_and_complete():
     """sc-14047 + sc-14980: the generation variants ship physical per-tier artifacts."""
     models = {model["id"]: model for model in _load_builtin_models_manifest()["models"]}
     expected = {
-        "mage_flow_base": ("SceneWorks/Mage-Flow-Base", "2c0b473896ef87af5a0873a26ed62c319213ae36", 30, 5),
-        "mage_flow": ("SceneWorks/Mage-Flow", "b9204c289b235bce9ade608f76a009f80a135bfd", 20, 5),
-        "mage_flow_turbo": ("SceneWorks/Mage-Flow-Turbo", "dca431fa8dfb4b3411cf3986435540ed31a7e8b7", 4, 1),
+        "mage_flow_base": ("SceneWorks/Mage-Flow-Base", "d642341926fcdb450c17c8fbda03759e8f731c9b", 30, 5),
+        "mage_flow": ("SceneWorks/Mage-Flow", "5f6455818d8ca80ce780e9c01b9e0de1d8c5f9db", 20, 5),
+        "mage_flow_turbo": ("SceneWorks/Mage-Flow-Turbo", "79016f10f96b441bebb6e6f461838adb8fb3ff5c", 4, 1),
     }
     for model_id, (repo, revision, steps, guidance) in expected.items():
         model = models[model_id]
@@ -264,9 +264,9 @@ def test_mage_flow_edit_family_is_pinned_complete_and_source_gated():
     """sc-14050 + sc-14980: every edit variant ships physical per-tier artifacts."""
     models = {model["id"]: model for model in _load_builtin_models_manifest()["models"]}
     expected = {
-        "mage_flow_edit_base": ("SceneWorks/Mage-Flow-Edit-Base", "199b4cae841403e8a1cca3c585a09f10fc70d3f1", 30, 5),
-        "mage_flow_edit": ("SceneWorks/Mage-Flow-Edit", "eb22e9ddbdea4a447e63ecd3ad46c62d3d5f3503", 30, 5),
-        "mage_flow_edit_turbo": ("SceneWorks/Mage-Flow-Edit-Turbo", "c3437cbb91e565ab6373e3c7b8e9b8048d29831b", 4, 1),
+        "mage_flow_edit_base": ("SceneWorks/Mage-Flow-Edit-Base", "6c119cdac7ce7cf8c1ab4990d9c8ca18641f2c5d", 30, 5),
+        "mage_flow_edit": ("SceneWorks/Mage-Flow-Edit", "dbd4a9c07faca94491ad88ab21225d62e054d9cc", 30, 5),
+        "mage_flow_edit_turbo": ("SceneWorks/Mage-Flow-Edit-Turbo", "75c11a2957aca2c78272984375502105b2b235ab", 4, 1),
     }
     for model_id, (repo, revision, steps, guidance) in expected.items():
         model = models[model_id]


### PR DESCRIPTION
App-side half of [sc-15071](https://app.shortcut.com/trefry/story/15071). Epic 14034. Pairs with **SceneWorks/inference#270**.

## Why

Mage-Flow's **q4** tier — `mlx.quantize: 4`, the shipped default on all six rows — rendered a repeating blue tiled texture instead of the prompt, so a user installing Mage out of the box got the broken tier. Root cause and fix are in inference#270: an 8-bit precision floor on the DiT's `norm_out.linear` (the output head's adaLN modulation) and on the Qwen3-VL LM's 36 decoder layers. q4 luma correlation against the bf16 render goes 0.329 → 0.877.

A **packed artifact skips load-time quantization**, so that fix does not reach anyone until the published q4 artifacts are rebuilt. This PR is the repin after that rebuild.

## What happened to the artifacts

All six variant mirrors and `SceneWorks/Mage-Flow-Components-mlx` had their `q4/` subdir regenerated with the fixed converter and re-uploaded. `q8/` and `bf16/` were not touched and are byte-identical inside the new commits.

Verified end to end, not just uploaded: the published q4 bytes were downloaded fresh into a clean dir and run through `a_packed_tier_renders_identically_to_load_time_quantization`, which reports **max_abs 0** against the fixed load-time path — and that path is the one measured rendering the cube correctly.

## The change

Revisions repinned on all six variant repos plus the shared components repo, and the two sizes that actually moved:

| row | before | after | why |
|---|---|---|---|
| variant q4 DiT | 2,316,856,860 | 2,326,294,167 | `norm_out.linear` at 8 bits (+9.4 MB) |
| shared q4 text encoder | 2,514,418,914 | 4,331,077,508 | q4 now shares q8's LM decoder layers |

`estimatedSizeBytes` for the variant DiT uses the largest of the six mirrors so the estimate never under-reports; that matches the existing convention of one representative number across the six rows. q4 VAE is unchanged (dense in every tier by design).

**`mlx.quantize: 4` stays the default on all six rows.** q4 is correct now, and it is still a genuine low-memory tier — 7.00 GB installed against q8's 9.45 GB, peaking at 7.87 GB of unified memory against q8's 10.11 GB. Changing the default away from q4 was the fallback the story allowed only if q4 could not be made correct; it can, so it wasn't taken.

The manifest comment block now records why the q4 text encoder is nearly the size of the q8 one, so the next reader does not "fix" the apparent anomaly.

## Tests

`pytest tests/ -m "not e2e and not parity"` (66 passed) — including `test_builtin_manifest_audit.py`, whose pinned `COMPONENTS_REVISION` / `DIT_BYTES` / `TE_BYTES` are updated here. `cargo test -p sceneworks-core --lib builtin_manifests` (18 passed), which covers `mage_flow_family_ships_six_variants_as_prequantized_per_tier_artifacts` and `corequisite_downloads_pin_a_full_sha_revision`. `cargo fmt --check`. No Rust source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
