### PR TITLE
fix(web): re-prompt a remote tab when the host password rotates mid-session (sc-15105)

### DIFF
--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -17,6 +17,72 @@ export function isAbortError(err) {
   return err?.name === "AbortError";
 }
 
+// ---- Failure shape (sc-15105) ---------------------------------------------------
+// `apiFetch` used to throw a bare `new Error(message)`, discarding `response.status`.
+// Nothing downstream could tell a 401 from any other failure, so a token that went
+// stale WHILE a remote tab was open had no seam to re-prompt on: every request 401'd,
+// the message piled up in the notice bands, and the media-ticket / SSE-ticket loops
+// retried forever behind an app that looked broken rather than locked.
+//
+// `message` is deliberately byte-identical to what the bare Error carried, so the ~85
+// existing `setError(err.message)` call sites are untouched; the status just rides
+// along for the few places that want it.
+export class ApiError extends Error {
+  constructor(message, { status, detail, authRequired } = {}) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = detail;
+    // The API tags its auth rejection (`apps/rust-api/src/auth.rs`); other 4xx bodies
+    // don't carry the key, so this is a plain boolean rather than a tri-state.
+    this.authRequired = authRequired === true;
+    // Set on a 401 when the registered handler claims the session (the access gate is
+    // re-verifying and will either re-prompt or resume). The retry loops read this to
+    // decide between "surrender, the gate has it" and "treat it as an ordinary failure".
+    this.reauthenticating = false;
+  }
+}
+
+// True for the API's "you are not authenticated" rejection. Sibling of `isAbortError`.
+export function isUnauthorized(err) {
+  return err?.status === 401;
+}
+
+// True for the API's per-IP attempt throttle (`apps/rust-api/src/auth.rs`), which answers
+// 429 once a peer exceeds its failed-token budget — including on the otherwise public
+// /api/v1/auth/verify. A throttled host is refusing, not unreachable, and the two need
+// different copy: the lockout clears itself in about a minute.
+export function isThrottled(err) {
+  return err?.status === 429;
+}
+
+// True for a 401 the access gate has claimed: it is re-verifying the token and will
+// either re-prompt or resume the session. The retry loops (the media-ticket mint, the
+// SSE-ticket connect) check this and surrender rather than backing off forever against
+// a token that can only 401. A 401 that arrives with no gate registered — or one the
+// gate declined — is false, and stays each caller's ordinary error to handle.
+export function isReauthenticating(err) {
+  return isUnauthorized(err) && err.reauthenticating === true;
+}
+
+// The one place that reacts to a 401, registered by `useAccessGate`. Module-level
+// (not React state, same pattern as `setMediaTicket` below) so EVERY `apiFetch` caller
+// participates without touching a single call site. Unset outside the gate's lifetime
+// and on the desktop/loopback shell, where a 401 is not a thing that happens.
+let unauthorizedHandler = null;
+
+// Returns its own unregister function, which clears the slot only if this handler is
+// still the registered one — so a late cleanup can never evict a newer registration.
+export function setUnauthorizedHandler(handler) {
+  const next = typeof handler === "function" ? handler : null;
+  unauthorizedHandler = next;
+  return () => {
+    if (unauthorizedHandler === next) {
+      unauthorizedHandler = null;
+    }
+  };
+}
+
 // `options` is forwarded to fetch, so callers can pass an AbortController
 // `signal` to cancel a request (e.g. a stale project-scoped load).
 export async function apiFetch(path, token, options = {}) {
@@ -40,7 +106,27 @@ export async function apiFetch(path, token, options = {}) {
         : detail === undefined || detail === null
           ? `Request failed with ${response.status}`
           : JSON.stringify(detail);
-    throw new Error(message);
+    const error = new ApiError(message, {
+      status: response.status,
+      detail,
+      authRequired: payload?.authRequired,
+    });
+    // `token` matters: a 401 on a request that deliberately presented NO credential says
+    // nothing about the session token, so it must not drag the gate up. Several callers
+    // do exactly that — e.g. the `PUT /api/v1/ui-preferences` writes pass "" — and before
+    // sc-15105 their 401s were simply swallowed by a `.catch(() => {})`. Without this
+    // check a remote browser would slam into the full-page blocker on a theme toggle.
+    if (response.status === 401 && token) {
+      // Notify before throwing so the gate reacts even for the callers that swallow
+      // their own errors, and record whether it claimed the session. A throwing handler
+      // must not mask the real API failure, nor be able to swallow the throw.
+      try {
+        error.reauthenticating = unauthorizedHandler?.(error) === true;
+      } catch {
+        // Deliberately ignored: the handler is UI bookkeeping, the ApiError is the truth.
+      }
+    }
+    throw error;
   }
   return payload;
 }

--- a/apps/web/src/api.test.js
+++ b/apps/web/src/api.test.js
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { apiFetch } from "./api.js";
+import {
+  ApiError,
+  apiFetch,
+  isReauthenticating,
+  isThrottled,
+  isUnauthorized,
+  setUnauthorizedHandler,
+} from "./api.js";
 
 describe("apiFetch response handling", () => {
   afterEach(() => {
@@ -27,5 +34,172 @@ describe("apiFetch response handling", () => {
     global.fetch = vi.fn(async () => response);
 
     await expect(apiFetch("/empty", "")).resolves.toBeNull();
+  });
+});
+
+// sc-15105: the thrown failure now carries the HTTP status, which is the seam the
+// mid-session re-prompt hangs on. The message must not move — ~85 call sites do
+// `setError(err.message)` and their notice copy is user-visible.
+describe("ApiError (sc-15105)", () => {
+  afterEach(() => {
+    setUnauthorizedHandler(null);
+    vi.restoreAllMocks();
+  });
+
+  function respondWith(body, status) {
+    global.fetch = vi.fn(async () =>
+      new Response(body === null ? "" : JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }
+
+  it("carries status, detail and authRequired off the API's 401 body", async () => {
+    respondWith({ detail: "SceneWorks access token required", authRequired: true }, 401);
+
+    const err = await apiFetch("/api/v1/jobs", "stale").catch((caught) => caught);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+    expect(err.detail).toBe("SceneWorks access token required");
+    expect(err.authRequired).toBe(true);
+    // The byte-identical message the bare Error used to carry.
+    expect(err.message).toBe("SceneWorks access token required");
+  });
+
+  it("carries the status on non-401 failures without claiming authRequired", async () => {
+    respondWith({ detail: "nope" }, 500);
+
+    const err = await apiFetch("/api/v1/jobs", "").catch((caught) => caught);
+
+    expect(err.status).toBe(500);
+    expect(err.authRequired).toBe(false);
+    expect(isUnauthorized(err)).toBe(false);
+  });
+
+  it("keeps the synthesized message for a failure body with no detail", async () => {
+    respondWith(null, 503);
+
+    const err = await apiFetch("/api/v1/jobs", "").catch((caught) => caught);
+
+    expect(err.message).toBe("Request failed with 503");
+    expect(err.status).toBe(503);
+  });
+
+  it("isUnauthorized ignores errors that are not an API 401", () => {
+    expect(isUnauthorized(new Error("Failed to fetch"))).toBe(false);
+    expect(isUnauthorized(undefined)).toBe(false);
+    expect(isUnauthorized(new ApiError("x", { status: 403 }))).toBe(false);
+    expect(isUnauthorized(new ApiError("x", { status: 401 }))).toBe(true);
+  });
+
+  it("flags the API's per-IP attempt throttle separately from an unreachable host", async () => {
+    respondWith({ detail: "Too many attempts" }, 429);
+
+    const err = await apiFetch("/api/v1/auth/verify", "guess").catch((caught) => caught);
+
+    expect(isThrottled(err)).toBe(true);
+    expect(isThrottled(new Error("Failed to fetch"))).toBe(false);
+    expect(isThrottled(new ApiError("x", { status: 401 }))).toBe(false);
+  });
+
+  it("notifies the registered handler on a 401, and only on a 401", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+
+    respondWith({ detail: "SceneWorks access token required", authRequired: true }, 401);
+    await apiFetch("/api/v1/jobs", "stale").catch(() => {});
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].status).toBe(401);
+
+    respondWith({ detail: "forbidden" }, 403);
+    await apiFetch("/api/v1/jobs", "stale").catch(() => {});
+    respondWith({ ok: true }, 200);
+    await apiFetch("/api/v1/jobs", "stale");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  // A 401 on a request that deliberately presented no credential says nothing about the
+  // session token. `PUT /api/v1/ui-preferences` (theme, accent, default quality, last
+  // tier) is a gated route the client calls with "" and a swallowed rejection — routing
+  // those to the gate would slam a remote browser into the full-page blocker on a theme
+  // toggle.
+  it("ignores a 401 from a request that presented no token", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    respondWith({ detail: "SceneWorks access token required", authRequired: true }, 401);
+
+    const err = await apiFetch("/api/v1/ui-preferences", "").catch((caught) => caught);
+
+    expect(handler).not.toHaveBeenCalled();
+    // Still a fully-formed failure for the caller — just not the gate's business.
+    expect(err.status).toBe(401);
+    expect(err.reauthenticating).toBe(false);
+  });
+
+  it("records on the error whether the handler claimed the session", async () => {
+    respondWith({ detail: "SceneWorks access token required", authRequired: true }, 401);
+
+    setUnauthorizedHandler(() => true);
+    let err = await apiFetch("/api/v1/jobs", "stale").catch((caught) => caught);
+    expect(err.reauthenticating).toBe(true);
+    expect(isReauthenticating(err)).toBe(true);
+
+    setUnauthorizedHandler(() => false);
+    err = await apiFetch("/api/v1/jobs", "stale").catch((caught) => caught);
+    expect(err.reauthenticating).toBe(false);
+    expect(isReauthenticating(err)).toBe(false);
+
+    // A handler returning a truthy non-boolean is not a claim either.
+    setUnauthorizedHandler(() => "yes");
+    err = await apiFetch("/api/v1/jobs", "stale").catch((caught) => caught);
+    expect(err.reauthenticating).toBe(false);
+
+    setUnauthorizedHandler(null);
+    err = await apiFetch("/api/v1/jobs", "stale").catch((caught) => caught);
+    expect(err.reauthenticating).toBe(false);
+  });
+
+  it("stops notifying once the handler is unregistered", async () => {
+    const handler = vi.fn();
+    const unregister = setUnauthorizedHandler(handler);
+    unregister();
+    respondWith({ detail: "SceneWorks access token required" }, 401);
+
+    await apiFetch("/api/v1/jobs", "stale").catch(() => {});
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stale unregister evict a newer handler", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = setUnauthorizedHandler(first);
+    setUnauthorizedHandler(second);
+    // A late cleanup from the previous registration must be a no-op, not a hole in which
+    // 401s go unhandled.
+    unregisterFirst();
+    respondWith({ detail: "SceneWorks access token required" }, 401);
+
+    await apiFetch("/api/v1/jobs", "stale").catch(() => {});
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("still throws the ApiError when the handler itself throws", async () => {
+    setUnauthorizedHandler(() => {
+      throw new Error("handler exploded");
+    });
+    respondWith({ detail: "SceneWorks access token required" }, 401);
+
+    const err = await apiFetch("/api/v1/jobs", "stale").catch((caught) => caught);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+    expect(err.message).toBe("SceneWorks access token required");
+    // A throwing handler cannot be treated as having claimed the session.
+    expect(err.reauthenticating).toBe(false);
   });
 });

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -17,20 +17,51 @@ import { MAX_TERMINAL_JOBS } from "../sorters.js";
 // Controllable apiFetch: each call resolves with whatever the per-path map returns (or
 // rejects when the value is an Error), so a test can drive the /access probe, the
 // media-ticket mint, and /auth/verify independently. setMediaTicket is a spy.
+//
+// sc-15105: the mock reproduces the one behavior of the real `apiFetch` that the hook
+// depends on — a 401 notifies the handler registered via `setUnauthorizedHandler` before
+// the rejection propagates. (That api.js contract is pinned directly in api.test.js;
+// here it is the seam under test.) `unauthorizedHandler` is captured rather than left in
+// the real module so a test can also assert whether one was registered at all.
 const apiResponders = new Map();
 const setMediaTicketSpy = vi.fn();
+let unauthorizedHandler = null;
+// Build the rejection the API produces for a stale token, using the real ApiError.
+async function unauthorizedError() {
+  const { ApiError } = await vi.importActual("../api.js");
+  return new ApiError("SceneWorks access token required", {
+    status: 401,
+    detail: "SceneWorks access token required",
+    authRequired: true,
+  });
+}
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    apiFetch: vi.fn((path) => {
+    apiFetch: vi.fn((path, token) => {
       const responder = apiResponders.get(path);
       const value = typeof responder === "function" ? responder() : responder;
       if (value instanceof Error) {
+        // Mirrors api.js: only a 401 on a request that actually presented the token
+        // reaches the handler, and the handler's boolean lands on the error. A test can
+        // opt a specific error out of the notify to isolate a caller-side seam.
+        if (value.status === 401 && token && value.notifyGate !== false) {
+          value.reauthenticating = unauthorizedHandler?.(value) === true;
+        }
         return Promise.reject(value);
       }
       return Promise.resolve(value ?? {});
     }),
+    setUnauthorizedHandler: (handler) => {
+      const next = typeof handler === "function" ? handler : null;
+      unauthorizedHandler = next;
+      return () => {
+        if (unauthorizedHandler === next) {
+          unauthorizedHandler = null;
+        }
+      };
+    },
     eventUrl: (path, ticket) => {
       const url = new URL(path, "http://localhost");
       if (ticket) {
@@ -83,6 +114,7 @@ describe("useAccessGate (sc-9750)", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     apiResponders.clear();
     setMediaTicketSpy.mockClear();
+    unauthorizedHandler = null;
     window.localStorage.clear();
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -96,25 +128,41 @@ describe("useAccessGate (sc-9750)", () => {
   function mount() {
     let latest = null;
     const notices = [];
+    // Every push, including ones a later dismiss removes from `notices`. Asserting on the
+    // surviving array alone cannot see a notice that is raised and then swept away by the
+    // gate coming up one render later — which is exactly the misleading flash sc-15105's
+    // mint seam exists to prevent.
+    const pushed = [];
+    // Every gateStatus this hook has rendered. A mid-session demotion is a transient the
+    // final state cannot show: the shell blocks, then re-opens if the re-verify passes.
+    const statuses = [];
+    // App feeds these three in identity-stable (useCallback with []), and the hook's
+    // header documents that contract — its effect dependency arrays are built on it.
+    // Declared outside the component so the harness honors it too: fresh closures per
+    // render would re-run the mint / re-verify effects on every unrelated state change,
+    // which is a property of the harness, not of the hook (sc-15105).
+    const deps = {
+      setError: () => {},
+      pushNotice: (kind, message) => {
+        pushed.push({ kind, message });
+        notices.push({ kind, message });
+      },
+      dismissNoticeKind: (kind) => {
+        for (let i = notices.length - 1; i >= 0; i -= 1) {
+          if (notices[i].kind === kind) notices.splice(i, 1);
+        }
+      },
+    };
     function Harness() {
       const [, setN] = useState(0);
-      latest = {
-        api: useAccessGate({
-          setError: () => {},
-          pushNotice: (kind, message) => notices.push({ kind, message }),
-          dismissNoticeKind: (kind) => {
-            for (let i = notices.length - 1; i >= 0; i -= 1) {
-              if (notices[i].kind === kind) notices.splice(i, 1);
-            }
-          },
-        }),
-        rerender: () => setN((n) => n + 1),
-      };
+      const api = useAccessGate(deps);
+      statuses.push(api.gateStatus);
+      latest = { api, rerender: () => setN((n) => n + 1) };
       return null;
     }
     root = createRoot(container);
     act(() => root.render(<Harness />));
-    return { get: () => latest, notices };
+    return { get: () => latest, notices, pushed, statuses };
   }
 
   it("resolves authenticated+ready with no auth required and mints no media ticket", async () => {
@@ -291,6 +339,251 @@ describe("useAccessGate (sc-9750)", () => {
     });
   });
 
+  // sc-15105: the same token can go stale WHILE the tab is open — the host rotates its
+  // password under Settings → Remote access and restarts the API. sc-15102 re-verified
+  // only at startup, so an already-open remote tab kept `authenticated` true, 401'd every
+  // request into the notice bands, and never re-prompted.
+  describe("mid-session 401 (sc-15105)", () => {
+    // Take a stored token all the way to an unlocked session so the 401 below arrives
+    // against tokenStatus "accepted" — the state the bug lived in.
+    async function mountUnlocked({ verify, ticket } = {}) {
+      window.localStorage.setItem("sceneworks-token", "old-password");
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", verify ?? { ok: true });
+      apiResponders.set(
+        "/api/v1/files/ticket",
+        ticket ?? { ticket: "media-1", expiresInSeconds: 300 },
+      );
+      const mounted = mount();
+      await settle();
+      return mounted;
+    }
+
+    // Fire `count` 401s the way a real gated route does — concurrently, as a page full of
+    // screens would when the host restarts under them. The token argument matters: api.js
+    // only routes a 401 to the gate when the request actually presented a credential.
+    async function fire401(count = 1, token = "old-password") {
+      const stale = await unauthorizedError();
+      apiResponders.set("/api/v1/jobs", () => stale);
+      await act(async () => {
+        await Promise.all(
+          Array.from({ length: count }, () =>
+            apiFetch("/api/v1/jobs", token).catch(() => {}),
+          ),
+        );
+      });
+      await settle();
+    }
+
+    const verifyCount = () =>
+      apiFetch.mock.calls.filter((call) => call[0] === "/api/v1/auth/verify").length;
+
+    it("re-prompts an already-open tab when the re-verify rejects the token", async () => {
+      let verify = { ok: true };
+      const { get } = await mountUnlocked({ verify: () => verify });
+      expect(get().api.gateStatus).toBe("open");
+
+      // The host rotated its password and restarted: the live token is now wrong.
+      verify = { ok: false };
+      await fire401();
+
+      // No reload needed — the full-page blocker takes over and asks for the new one.
+      expect(get().api.gateStatus).toBe("locked");
+      expect(get().api.token).toBe("");
+      expect(get().api.authError).toContain("no longer works");
+      expect(window.localStorage.getItem("sceneworks-token")).toBeNull();
+    });
+
+    it("unlocks with the new password after a mid-session rotation", async () => {
+      let verify = { ok: true };
+      const { get } = await mountUnlocked({ verify: () => verify });
+      verify = { ok: false };
+      await fire401();
+      expect(get().api.gateStatus).toBe("locked");
+
+      verify = { ok: true };
+      act(() => get().api.setPasswordDraft("new-password"));
+      await act(async () => {
+        await get().api.saveToken({ preventDefault: () => {} });
+      });
+      await settle();
+
+      expect(get().api.gateStatus).toBe("open");
+      expect(get().api.token).toBe("new-password");
+      expect(window.localStorage.getItem("sceneworks-token")).toBe("new-password");
+    });
+
+    it("does not log the user out when the re-verify still passes", async () => {
+      const { get, statuses } = await mountUnlocked({ verify: { ok: true } });
+      const before = verifyCount();
+      statuses.length = 0;
+
+      await fire401();
+
+      // The 401 really was adjudicated — asserting only the end state would pass just as
+      // well with no handler registered at all, since "nothing happened" looks identical.
+      expect(verifyCount() - before).toBe(1);
+      expect(statuses).toContain("unlocking");
+      // ...and one unlucky endpoint did not evict a session the host still accepts.
+      expect(statuses[statuses.length - 1]).toBe("open");
+      expect(get().api.token).toBe("old-password");
+      expect(window.localStorage.getItem("sceneworks-token")).toBe("old-password");
+      // The session is fully live again, not merely unblocked.
+      expect(get().api.ready).toBe(true);
+    });
+
+    it("ignores a 401 from a request that presented no token", async () => {
+      // Several callers hit gated routes with an empty token on purpose (the
+      // `PUT /api/v1/ui-preferences` writes) and swallow the rejection. Those 401s say
+      // nothing about the session, and must not drag the blocker over a live app.
+      const { get, statuses } = await mountUnlocked({ verify: { ok: true } });
+      const before = verifyCount();
+      statuses.length = 0;
+
+      await fire401(1, "");
+
+      expect(verifyCount()).toBe(before);
+      expect(statuses.every((status) => status === "open")).toBe(true);
+      expect(get().api.token).toBe("old-password");
+    });
+
+    it("leaves an already-locked gate alone instead of stranding it on 'unlocking'", async () => {
+      // tokenStatus "none" means the gate is up with no token to check. Demoting it to
+      // "pending" would render "unlocking" forever: the re-verify effect bails on an empty
+      // token, so nothing would ever move it off that state.
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      const { get } = mount();
+      await settle();
+      expect(get().api.gateStatus).toBe("locked");
+
+      await fire401(1, "whatever-stale-token");
+
+      expect(get().api.gateStatus).toBe("locked");
+    });
+
+    it("issues exactly one /auth/verify for a storm of concurrent 401s", async () => {
+      const { get } = await mountUnlocked({ verify: { ok: true } });
+      const before = verifyCount();
+
+      await fire401(8);
+
+      // The guard is a ref, not state: all eight land before React flushes.
+      expect(verifyCount() - before).toBe(1);
+      expect(get().api.gateStatus).toBe("open");
+
+      // And the storm is not a one-shot fuse — a later rotation is still detected.
+      apiResponders.set("/api/v1/auth/verify", { ok: false });
+      await fire401(3);
+      expect(get().api.gateStatus).toBe("locked");
+    });
+
+    it("reports a throttled host as a lockout, not as an unreachable one", async () => {
+      // A rotation storm can trip the API's per-IP attempt throttle, which answers 429 —
+      // including on the public verify route. "Couldn't reach the host" sends the user
+      // hunting a network fault instead of waiting out a lockout that clears itself.
+      const { ApiError } = await vi.importActual("../api.js");
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set(
+        "/api/v1/auth/verify",
+        () => new ApiError("Too many attempts", { status: 429 }),
+      );
+      const { get } = mount();
+      await settle();
+
+      act(() => get().api.setPasswordDraft("new-password"));
+      await act(async () => {
+        await get().api.saveToken({ preventDefault: () => {} });
+      });
+      await settle();
+
+      expect(get().api.authError).toContain("Too many password attempts");
+    });
+
+    it("surrenders the media-ticket mint to the gate instead of retrying forever", async () => {
+      const stale = await unauthorizedError();
+      // The tab unlocked on the old password (first verify), then the host rotated it —
+      // so the mint's 401 is the first thing that notices, and the re-verify it triggers
+      // finds the token rejected.
+      let verifyCalls = 0;
+      const { get, pushed } = await mountUnlocked({
+        verify: () => (verifyCalls++ === 0 ? { ok: true } : { ok: false }),
+        // The mint is itself a gated route, so it 401s along with everything else.
+        ticket: () => stale,
+      });
+
+      expect(get().api.gateStatus).toBe("locked");
+      // The "retrying in the background" notice is never raised: nothing is retrying, and
+      // the gate is what the user needs to see. NOTE: this assertion holds with and
+      // without the mint's own `isReauthenticating` early return, because `act` flushes
+      // the demotion (and so the effect teardown that sets `closed`) before the rejection
+      // continuation runs, and the pre-existing `closed` check then short-circuits the
+      // catch. A real browser resolves that race the other way — the catch runs first —
+      // which is what the early return is actually for. The outcome below is the
+      // regression guard; the ordering itself is not reproducible under `act`.
+      expect(pushed.some((n) => n.kind === "media-ticket")).toBe(false);
+      expect(get().api.ready).toBe(false);
+    });
+
+    it("raises no media-ticket notice for a 401 the gate has claimed", async () => {
+      // The mint's own seam, isolated from the demotion. `notifyGate:false` keeps the gate
+      // from demoting (so the effect is never torn down and its `closed` short-circuit
+      // cannot mask the result), while `reauthenticating` marks the error as claimed —
+      // exactly the state a real browser is in when the rejection lands before React
+      // commits the teardown.
+      const stale = await unauthorizedError();
+      stale.notifyGate = false;
+      stale.reauthenticating = true;
+      const { get, pushed } = await mountUnlocked({
+        verify: { ok: true },
+        ticket: () => stale,
+      });
+
+      // No "retrying in the background" lie, and no backoff mint armed behind the gate.
+      expect(pushed.some((n) => n.kind === "media-ticket")).toBe(false);
+      expect(get().api.gateStatus).toBe("open");
+    });
+
+    it("still degrades media normally for a 401 the gate did not claim", async () => {
+      const stale = await unauthorizedError();
+      stale.notifyGate = false;
+      const { get, pushed } = await mountUnlocked({
+        verify: { ok: true },
+        ticket: () => stale,
+      });
+
+      // Unclaimed ⇒ the pre-existing sc-9063 behavior: degraded media, a notice, and the
+      // app still usable. Surrendering here would silently break thumbnails instead.
+      expect(pushed.some((n) => n.kind === "media-ticket")).toBe(true);
+      expect(get().api.ready).toBe(true);
+    });
+
+    it("declines a 401 on a deployment that requires no password", async () => {
+      // A host that answers /api/v1/access with authRequired:false cannot produce a 401
+      // a password prompt would fix — it disagrees with itself. Claiming it would silence
+      // the caller's own error handling behind a gate that will never appear.
+      apiResponders.set("/api/v1/access", { authRequired: false });
+      const { get } = mount();
+      await settle();
+      expect(get().api.gateStatus).toBe("open");
+
+      const stale = await unauthorizedError();
+      apiResponders.set("/api/v1/jobs", () => stale);
+      const err = await act(async () =>
+        apiFetch("/api/v1/jobs", "some-token").catch((caught) => caught),
+      );
+
+      expect(err.reauthenticating).toBe(false);
+      expect(get().api.gateStatus).toBe("open");
+    });
+
+    it("registers a 401 handler in remote-browser mode", async () => {
+      await mountUnlocked({ verify: { ok: true } });
+      // The desktop counterpart (no handler at all) is pinned in
+      // useAccessGate.desktop.test.jsx, which mocks isDesktop true.
+      expect(typeof unauthorizedHandler).toBe("function");
+    });
+  });
+
   // sc-15102: `gateStatus` is the single blocking decision App branches on.
   describe("gateStatus", () => {
     it("stays open while the first access probe is in flight, then blocks once it fails", async () => {
@@ -324,6 +617,7 @@ describe("useJobEvents (sc-9750)", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     apiResponders.clear();
     apiFetch.mockClear();
+    unauthorizedHandler = null;
     FakeEventSource.instances = [];
     window.EventSource = FakeEventSource;
     container = document.createElement("div");
@@ -374,6 +668,50 @@ describe("useJobEvents (sc-9750)", () => {
     act(() => root.render(<Harness />));
     return { setProps: (next) => act(() => setProps(next)) };
   }
+
+  // sc-15105: the SSE ticket POST is a gated route, so a mid-session password rotation
+  // 401s it too. It used to push the raw "SceneWorks access token required" into the error
+  // band and arm an exponential-backoff reconnect that could never succeed.
+  it("surrenders the SSE ticket to the access gate on a claimed 401", async () => {
+    const stale = await unauthorizedError();
+    // No gate is mounted in this describe, so mark the error claimed directly and opt it
+    // out of the mock's notify (which would otherwise overwrite the flag with false).
+    stale.notifyGate = false;
+    stale.reauthenticating = true;
+    const errors = [];
+    apiResponders.set("/api/v1/jobs/events/ticket", () => stale);
+    mount(
+      baseProps({
+        access: { authRequired: true },
+        token: "old-password",
+        setError: (message) => errors.push(message),
+      }),
+    );
+    await settle();
+
+    // No error-band copy and no EventSource: the gate is taking over, and `ready` will
+    // drop out from under this effect.
+    expect(errors).toEqual([]);
+    expect(FakeEventSource.instances.length).toBe(0);
+  });
+
+  it("still reports a 401 the gate did not claim as an ordinary ticket failure", async () => {
+    const stale = await unauthorizedError();
+    const errors = [];
+    apiResponders.set("/api/v1/jobs/events/ticket", () => stale);
+    mount(
+      baseProps({
+        access: { authRequired: true },
+        token: "old-password",
+        setError: (message) => errors.push(message),
+      }),
+    );
+    await settle();
+
+    // `reauthenticating` false (no gate registered, or the gate declined) ⇒ the pre-existing
+    // notice + backoff behavior, not silence.
+    expect(errors).toEqual(["SceneWorks access token required"]);
+  });
 
   it("does not open an EventSource until ready is true", async () => {
     const { setProps } = mount(baseProps({ ready: false }));

--- a/apps/web/src/hooks/useAccessGate.desktop.test.jsx
+++ b/apps/web/src/hooks/useAccessGate.desktop.test.jsx
@@ -1,0 +1,87 @@
+// sc-15105: the desktop half of the 401 re-prompt. The desktop shell reaches its own API
+// over trusted loopback and is authenticated unconditionally (epic 4484), so it must never
+// be prompted for a password — it doesn't even register a 401 reaction. That requires
+// `isDesktop: true` at module scope, which the shared appGateHooks.test.jsx pins to false
+// for every test in the file, so this case lives in its own file rather than fighting a
+// mid-suite remock.
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAccessGate } from "./useAccessGate.js";
+
+const apiResponders = new Map();
+let unauthorizedHandler = null;
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiFetch: vi.fn((path) => Promise.resolve(apiResponders.get(path) ?? {})),
+    setMediaTicket: () => {},
+    setUnauthorizedHandler: (handler) => {
+      unauthorizedHandler = typeof handler === "function" ? handler : null;
+    },
+  };
+});
+
+vi.mock("../runtime.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, isDesktop: true };
+});
+
+async function settle() {
+  await act(async () => {
+    for (let i = 0; i < 6; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+describe("useAccessGate on the desktop shell (sc-15105)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    apiResponders.clear();
+    unauthorizedHandler = null;
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  function mount() {
+    let latest = null;
+    function Harness() {
+      latest = useAccessGate({
+        setError: () => {},
+        pushNotice: () => {},
+        dismissNoticeKind: () => {},
+      });
+      return null;
+    }
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+    return { get: () => latest };
+  }
+
+  it("registers no 401 handler, even against a host that requires a password", async () => {
+    // The harshest shape: a stored token AND an auth-requiring host. The remote build
+    // registers a handler here (pinned in appGateHooks.test.jsx); the desktop build must
+    // not, so nothing on this shell can ever be demoted to the password prompt.
+    window.localStorage.setItem("sceneworks-token", "some-token");
+    apiResponders.set("/api/v1/access", { authRequired: true });
+    const { get } = mount();
+    await settle();
+
+    expect(unauthorizedHandler).toBeNull();
+    expect(get().authenticated).toBe(true);
+    expect(get().gateStatus).toBe("open");
+  });
+});

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -1,5 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { apiFetch, setMediaTicket } from "../api.js";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  apiFetch,
+  isReauthenticating,
+  isThrottled,
+  setMediaTicket,
+  setUnauthorizedHandler,
+} from "../api.js";
 import { isDesktop as isDesktopShell } from "../runtime.js";
 import { readAccessToken, storeAccessToken, clearAccessToken } from "../accessToken.js";
 import { recordStartupMark } from "../startupTiming.js";
@@ -46,6 +52,19 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
   const [passwordDraft, setPasswordDraft] = useState("");
   // Wrong-password feedback for the remote-browser login gate (epic 4484 story 7).
   const [authError, setAuthError] = useState("");
+  // sc-15105: mirrors of the two values the 401 handler below reads. It runs outside
+  // React's render cycle (inside `apiFetch`) and must decide before any state has
+  // flushed, so it cannot read `tokenStatus`/`access` directly. Synced in a bare
+  // useLayoutEffect (no dep array) rather than the render body — a discarded concurrent
+  // or StrictMode render must not be able to publish state that never committed, and
+  // must not clobber the eager write `handleUnauthorized` makes below (the same rule
+  // App.jsx follows for its own live-value refs, sc-8940 / sc-9641).
+  const tokenStatusRef = useRef(tokenStatus);
+  const authRequiredRef = useRef(false);
+  useLayoutEffect(() => {
+    tokenStatusRef.current = tokenStatus;
+    authRequiredRef.current = access.authRequired === true;
+  });
 
   // The desktop shell reaches its own API over loopback, which the API trusts
   // (SCENEWORKS_TRUST_LOOPBACK), so it's authenticated without a password — never prompt
@@ -131,8 +150,17 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
         attempt = 0;
         const ttlMs = Math.max(15, Number(response.expiresInSeconds) || 0) * 1000;
         timer = window.setTimeout(acquire, Math.max(5000, Math.floor(ttlMs / 3)));
-      } catch {
+      } catch (err) {
         if (closed) {
+          return;
+        }
+        if (isReauthenticating(err)) {
+          // sc-15105: the token went stale under us and the gate has claimed the session.
+          // Surrender instead of arming a backoff that can only 401 again forever — and
+          // skip the "retrying in the background" notice, which would be a lie (nothing
+          // is retrying) on the blocker that is about to appear. The effect re-runs and
+          // mints afresh if the re-verify keeps the session. A 401 the gate did NOT claim
+          // falls through to the ordinary degraded-media path below.
           return;
         }
         recordStartupMark("media-authorization-settled");
@@ -215,6 +243,51 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // sc-15105: the same staleness can arrive MID-SESSION — the host rotates its password
+  // and restarts the API while the tab sits open — and sc-15102's re-verify only runs at
+  // startup, so nothing re-prompted. `apiFetch` now calls this on every 401.
+  //
+  // Deliberately NOT a logout: one unlucky endpoint must not evict a good session. We
+  // demote the token from "accepted" back to "pending", which drops `authenticated`
+  // (blocking the shell behind the gate's "unlocking" state and stopping the mint/SSE
+  // loops via their effect cleanups) and re-arms the re-verify effect below — the single
+  // place that decides between "the password really did change" (ok:false ⇒ drop it, show
+  // the prompt) and "route-specific 401" (ok:true ⇒ keep the session, resume).
+  //
+  // Only demote from "accepted". "none" means the gate is already locked with no token —
+  // flipping that to "pending" would show "unlocking" forever, because the re-verify
+  // effect below bails on an empty token and nothing would ever move it on. "pending"
+  // means a check is already in flight. Both are still the gate owning the failure, so
+  // they return true. The eager ref write is what makes a storm collapse: a page full of
+  // screens 401ing at once all land here before React flushes.
+  //
+  // Returns whether the gate claimed the session; `apiFetch` records that on the error as
+  // `reauthenticating` so the mint / SSE retry loops can tell "surrender, the gate has
+  // it" from "an ordinary failure I should keep handling myself".
+  const handleUnauthorized = useCallback(() => {
+    // A deployment with no password can't produce a 401 the gate could act on — a 401
+    // here means the host disagrees with its own /api/v1/access answer, which is not
+    // something a password prompt fixes.
+    if (!authRequiredRef.current) {
+      return false;
+    }
+    if (tokenStatusRef.current === "accepted") {
+      tokenStatusRef.current = "pending";
+      setTokenStatus("pending");
+    }
+    return true;
+  }, []);
+
+  useEffect(() => {
+    if (isDesktopShell) {
+      // The desktop shell reaches its own API over trusted loopback and is authenticated
+      // unconditionally (see `authenticated` above) — it must never be prompted, so it
+      // doesn't register a 401 reaction at all (epic 4484).
+      return undefined;
+    }
+    return setUnauthorizedHandler(handleUnauthorized);
+  }, [handleUnauthorized]);
+
   // Re-verify a token restored from localStorage before trusting it (sc-15102). The host
   // password can change (or be cleared, or the host can be a different machine at the same
   // LAN address) between visits, and nothing in the client re-prompts on a 401 — so an
@@ -223,6 +296,10 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
   // the first protected load and never races it. A rejected token is dropped and the gate
   // shows the password prompt; an unreachable host keeps the token and retries with
   // backoff (mirroring the probe/mint loops) so a transient outage self-heals.
+  //
+  // sc-15105 gave this effect a second entry point: `handleUnauthorized` above demotes an
+  // accepted token to "pending" on a 401, so the same check now adjudicates both "restored
+  // from storage, never proven" and "was proven, then the host rotated its password".
   useEffect(() => {
     if (isDesktopShell || !accessResolved || !access.authRequired) {
       return undefined;
@@ -250,13 +327,15 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
         setTokenStatus("none");
         setAuthError("The saved password no longer works on this host. Enter the current one.");
         dismissNoticeKind("access-verify");
-      } catch {
+      } catch (err) {
         if (closed) {
           return;
         }
         pushNotice(
           "access-verify",
-          "access check: couldn't reach the host to confirm the saved password. Retrying in the background.",
+          isThrottled(err)
+            ? "access check: the host is temporarily refusing password attempts from this device after too many failures. Retrying in the background."
+            : "access check: couldn't reach the host to confirm the saved password. Retrying in the background.",
         );
         const delay = Math.min(30000, 1000 * 2 ** attempt);
         attempt += 1;
@@ -294,8 +373,16 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
           setAuthError("Incorrect password. Try again.");
           return;
         }
-      } catch {
-        setAuthError("Couldn't reach the host to verify the password.");
+      } catch (err) {
+        // sc-15105: a rotation storm can trip the host's per-IP attempt throttle
+        // (`apps/rust-api/src/auth.rs`), which answers 429 — including for this public
+        // verify route. Reporting that as "couldn't reach the host" sends the user
+        // hunting a network fault instead of waiting out a lockout that clears itself.
+        setAuthError(
+          isThrottled(err)
+            ? "Too many password attempts from this device. Wait a minute, then try again."
+            : "Couldn't reach the host to verify the password.",
+        );
         return;
       }
       storeAccessToken(candidate);

--- a/apps/web/src/hooks/useJobEvents.js
+++ b/apps/web/src/hooks/useJobEvents.js
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { apiFetch, eventUrl } from "../api.js";
+import { apiFetch, eventUrl, isReauthenticating } from "../api.js";
 import {
   acceptsJobUpdate,
   jobRevision,
@@ -418,6 +418,14 @@ export function useJobEvents({
           ticket = response.ticket;
         }
       } catch (err) {
+        if (isReauthenticating(err)) {
+          // sc-15105: the token went stale mid-session and the access gate has claimed the
+          // session. Don't push the raw "SceneWorks access token required" into the error
+          // band and don't arm a reconnect that can only 401 again — `ready` drops with the
+          // gate, tearing this effect down, and it re-subscribes if the re-verify keeps the
+          // session. A 401 the gate did NOT claim stays an ordinary failure below.
+          return;
+        }
         setError(err.message);
         if (!closed) {
           const delay = Math.min(30000, 1000 * 2 ** reconnectAttempt);


### PR DESCRIPTION
Closes [sc-15105](https://app.shortcut.com/trefry/story/15105).

## The bug

[sc-15102](https://app.shortcut.com/trefry/story/15102) made the remote-access gate a full-page blocker and re-verified a token restored from `localStorage` at startup — which closes the **reload** case only. A token that goes stale **while the tab is open** (host rotates its Remote-access password, SceneWorks restarts) was still unhandled: `authenticated` stayed true, every `apiFetch` 401'd into the per-domain/general notice bands, the media-ticket mint and the SSE-ticket connect backed off **forever**, and nothing re-prompted. The only escapes were a manual reload or noticing the topbar "Lock" button.

The reason nothing *could* re-prompt: `apiFetch` threw a bare `new Error(message)` and discarded `response.status`, so no code downstream could distinguish a 401 from any other failure.

## The fix

- **Carry the status.** `ApiError extends Error` with `status`, `detail`, `authRequired`. `message` is byte-identical to what the bare `Error` carried, so the ~85 existing `setError(err.message)` sites and their user-visible copy are untouched. Adds `isUnauthorized` / `isReauthenticating` / `isThrottled` beside the existing `isAbortError`.
- **One handler, no call-site churn.** The unauthorized handler is module-level state in `api.js` (same pattern as `setMediaTicket`), so every `apiFetch` caller participates. `setUnauthorizedHandler` returns its own unregister, which only clears the slot if that handler is still the registered one.
- **Re-verify, don't log out.** On a 401 `useAccessGate` demotes the token from `"accepted"` to `"pending"` and lets sc-15102's existing re-verify effect adjudicate: `ok:false` ⇒ drop the token and show the prompt; `ok:true` ⇒ route-specific 401, keep the session. One unlucky endpoint cannot evict a good session.
- **Storm guard.** The demotion decision reads an eagerly-written ref, not React state, so a page full of screens 401ing at once collapses to exactly one `POST /api/v1/auth/verify`. Only `"accepted"` demotes: flipping `"none"` would strand the gate on `"unlocking"` forever, because the re-verify effect bails on an empty token.
- **The two runaway loops surrender.** The media-ticket mint and the SSE-ticket connect return early on a 401 the gate has *claimed*, instead of pushing a "retrying in the background" notice that is a lie and arming a backoff that can only 401 again. A 401 the gate **declines** keeps its pre-existing handling, so nothing goes silently broken.

## Two things found in review, beyond the story text

- **`PUT /api/v1/ui-preferences` is a gated route the client calls with an empty token** (six sites: theme, accent, Simple-UI default, default quality, last tier — all `.catch(() => {})`). Routing those 401s to the gate would have slammed a remote browser into the full-page blocker on a *theme toggle*. `apiFetch` now only notifies the handler when the request actually presented a credential — a 401 on a deliberately credential-less request says nothing about the session token. The underlying defect (those preferences never persist on a remote-auth deployment) is filed separately as [sc-15136](https://app.shortcut.com/trefry/story/15136).
- **A 429 from the host's per-IP attempt throttle read as "couldn't reach the host"**, sending the user hunting a network fault instead of waiting out a lockout that clears itself in ~60s. Both the re-verify notice and the unlock error now say what actually happened.

Desktop/loopback registers no 401 handler at all, so it can never be prompted (epic 4484).

## Verification

Ran the real scenario against a live gated API (`SCENEWORKS_ACCESS_TOKEN` set, loopback trust off, isolated data dir):

1. Browser tab unlocked with `old-password` — full shell live, token in `localStorage`.
2. Rotated the host token to `new-password` and restarted the API. **Tab untouched.**
3. First subsequent request 401'd → the tab dropped its stale token and landed on the full-page `AccessGate` reading *"The saved password no longer works on this host. Enter the current one."* — **no reload**.
4. Entered `new-password` in that same tab → shell back, new token stored.

Server logs for the whole episode: **2** `auth_rejected` events before the client surrendered, **0** `auth_throttled` — well inside the 10-failure budget.

`apps/web`: 2742 tests / 198 files, `eslint`, and `npm run build` all clean. Every new guard was mutation-checked (deleted, confirmed a test goes red); the one place that could not be made discriminating — the mint's early return, which `act` masks by flushing the effect teardown before the rejection continuation — is documented as such in the test rather than left as a silent false green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)