### PR TITLE
fix(web): send the access token on the gated ui-preferences PUT (sc-15136)

### DIFF
--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -4,8 +4,15 @@
 //! `http://127.0.0.1:<port>` origin, where both Tauri IPC and origin-keyed
 //! `localStorage` are unreliable across launches (the port — and so the origin —
 //! changes every launch). Routing through the API, the same channel the rest of
-//! the app already uses, makes the choice durable. Non-sensitive, so the routes
-//! are public like `/health`.
+//! the app already uses, makes the choice durable.
+//!
+//! AUTH IS METHOD-ASYMMETRIC here — the routes are NOT simply public (sc-8869, F-067; see
+//! `auth::requires_token`). The GET is public because the theme has to paint before the
+//! access gate to avoid a flash, and the value is non-sensitive. The PUT writes this file to
+//! DISK, so it is gated like every other write (epic 4484): an unauthenticated LAN caller
+//! must not be able to overwrite it. A client that sends the PUT without the access token
+//! gets a 401 on every remote-auth deployment — exactly the bug sc-15136 fixed, after this
+//! doc's older "the routes are public" wording had been echoed into six web call sites.
 
 use super::*;
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -35,6 +35,7 @@ import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
 import { generationModelsForType } from "./modelEligibility.js";
 import { isAccentId } from "./accents.js";
 import { writeDefaultGenerationQuality } from "./generationQuality.js";
+import { putUiPreferences } from "./uiPreferences.js";
 import { seedLastTiersFromServer } from "./lastTierStore.js";
 import {
   dropUpscaledVariants,
@@ -672,15 +673,15 @@ export function App() {
   // initial paint, but on the desktop shell the UI runs at the API's per-launch
   // http://127.0.0.1:<port> origin, where both localStorage and Tauri IPC are
   // unreliable across launches — so the durable copy lives server-side.
+  // `putUiPreferences` carries the access token (sc-15136): the PUT is gated even
+  // though the launch-time GET below is public, so a credential-less write 401s on
+  // every remote-auth deployment and the theme would never reach disk.
   // Stable across renders (sc-10244): it flows through the static app context to the
   // Image Editor top-bar theme toggle, so a fresh identity each render would bust the
   // static-context memo every tick.
   const changeTheme = useCallback((next) => {
     setTheme(next);
-    apiFetch("/api/v1/ui-preferences", "", {
-      method: "PUT",
-      body: JSON.stringify({ theme: next }),
-    }).catch(() => {});
+    putUiPreferences({ theme: next }).catch(() => {});
   }, []);
   const [accent, setAccent] = useState(readStoredAccent);
   // Same persistence contract as theme: instant localStorage cache + durable
@@ -688,10 +689,7 @@ export function App() {
   // MERGE partial updates (theme writes already rely on this).
   const changeAccent = useCallback((next) => {
     setAccent(next);
-    apiFetch("/api/v1/ui-preferences", "", {
-      method: "PUT",
-      body: JSON.stringify({ accent: next }),
-    }).catch(() => {});
+    putUiPreferences({ accent: next }).catch(() => {});
   }, []);
   // Simple UI (design handoff). `simpleUiDefault` is the persisted "Use Simple UI by
   // default" preference — same durable contract as theme/accent (server copy in
@@ -711,10 +709,7 @@ export function App() {
   const changeSimpleUiDefault = useCallback((next) => {
     setSimpleUiDefault(next);
     writeStoredSimpleDefault(next);
-    apiFetch("/api/v1/ui-preferences", "", {
-      method: "PUT",
-      body: JSON.stringify({ simpleUi: next }),
-    }).catch(() => {});
+    putUiPreferences({ simpleUi: next }).catch(() => {});
   }, []);
   const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
@@ -1303,6 +1298,11 @@ export function App() {
   // Seed the theme from the server on launch (the durable copy; localStorage is
   // only an instant-paint cache). Each toggle persists itself via changeTheme,
   // so there's no save effect to race with this read.
+  //
+  // This READ is the one credential-less ui-preferences call, deliberately: it runs before
+  // the access gate has a token, and the server keeps the GET public precisely so the theme
+  // can paint pre-auth without a flash. Only the disk-writing PUT is gated (sc-8869,
+  // F-067), which is why the writes go through `putUiPreferences` instead (sc-15136).
   useEffect(() => {
     let cancelled = false;
     apiFetch("/api/v1/ui-preferences", "")

--- a/apps/web/src/App.uiPreferences.test.jsx
+++ b/apps/web/src/App.uiPreferences.test.jsx
@@ -1,0 +1,170 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+import { click } from "./testUtils/dom.js";
+import { resetStartupTimingForTests } from "./startupTiming.js";
+
+// sc-15136 — the durable UI-preference writes must be AUTHENTICATED on the wire.
+//
+// `/api/v1/ui-preferences` is method-asymmetric on the server (sc-8869, F-067): the GET is public so
+// the theme can paint before the access gate, but the PUT writes `ui-preferences.json` to disk and is
+// gated. App.jsx sent all three of its writes (theme, accent, the Simple-UI default) with an empty
+// token and swallowed the 401 with `.catch(() => {})`, so on any remote-auth deployment those
+// preferences never reached disk — invisibly, because each also writes a localStorage cache. None of
+// the three had any token coverage before sc-15136, which is how all three shipped that way.
+//
+// These run against the REAL transport (only `fetch` is faked) rather than a mocked `apiFetch`, so the
+// assertion is on the header that actually leaves the client. A mocked-transport test could pass while
+// `apiFetch` dropped the token.
+
+const TOKEN = "lan-password-1";
+
+function fakeApi() {
+  return vi.fn((url) => {
+    const path = new URL(url).pathname;
+    if (path.endsWith("/health")) {
+      return Promise.resolve(response({ status: "ok", authRequired: true }));
+    }
+    if (path.endsWith("/access")) {
+      return Promise.resolve(response({ authRequired: true }));
+    }
+    if (path.endsWith("/auth/verify")) {
+      return Promise.resolve(response({ ok: true }));
+    }
+    if (path.endsWith("/jobs/events/ticket")) {
+      return Promise.resolve(response({ ticket: "stream-ticket" }));
+    }
+    if (path.endsWith("/projects")) {
+      return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+    }
+    if (path.endsWith("/ui-preferences")) {
+      return Promise.resolve(response({}));
+    }
+    return Promise.resolve(response([]));
+  });
+}
+
+// Every PUT the client made to the preferences route, as { body, token }.
+function preferenceWrites() {
+  return global.fetch.mock.calls
+    .filter(([url, init]) => new URL(url).pathname.endsWith("/ui-preferences") && init?.method === "PUT")
+    .map(([, init]) => ({
+      body: JSON.parse(init.body),
+      // `headers` is a Headers instance built by apiFetch.
+      token: init.headers.get("X-SceneWorks-Token"),
+    }));
+}
+
+describe("App — durable UI preference writes carry the access token (sc-15136)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    // A remote browser that already unlocked the host: the verified password is the live token.
+    window.localStorage.setItem("sceneworks-token", TOKEN);
+    window.innerWidth = 1440;
+    global.fetch = fakeApi();
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container.remove();
+    resetStartupTimingForTests();
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  const themeToggle = () =>
+    [...document.body.querySelectorAll("button")].find((button) =>
+      (button.getAttribute("title") ?? "").startsWith("Switch to "),
+    );
+
+  it("sends the token on the theme PUT, so a remote theme change reaches ui-preferences.json", async () => {
+    await renderApp();
+    const toggle = themeToggle();
+    expect(toggle, "theme toggle").toBeTruthy();
+
+    await click(toggle);
+    await settle();
+
+    const writes = preferenceWrites();
+    expect(writes.length).toBeGreaterThan(0);
+    // Pinned to the real token, never to "": a "" assertion here would pass with the fix reverted.
+    expect(writes.at(-1)).toEqual({ body: { theme: "dark" }, token: TOKEN });
+  });
+
+  it("sends the token on the accent PUT", async () => {
+    await renderApp();
+    // The topbar accent picker collapses to a trigger; the alternatives live in the dropdown.
+    const trigger = document.body.querySelector(".accent-picker .accent-swatch.active");
+    expect(trigger, "accent picker trigger").toBeTruthy();
+    await click(trigger);
+
+    const swatch = document.body.querySelector('.accent-picker-menu [role="option"]');
+    expect(swatch, "an alternative accent swatch").toBeTruthy();
+
+    await click(swatch);
+    await settle();
+
+    const writes = preferenceWrites();
+    expect(writes.length).toBeGreaterThan(0);
+    expect(writes.at(-1).token).toBe(TOKEN);
+    expect(Object.keys(writes.at(-1).body)).toEqual(["accent"]);
+  });
+
+  it("sends the token on the Simple-UI-default PUT", async () => {
+    // The third App-owned write, and the one with the longest reach: the toggle lives in the Simple
+    // shell's Settings screen, whose handler is App's `changeSimpleUiDefault`.
+    await renderApp();
+    await click([...document.body.querySelectorAll(".sidebar-footer .su-switch button")][0]);
+    await settle();
+
+    const settingsNav = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent.trim() === "Settings",
+    );
+    expect(settingsNav, "Simple shell Settings nav").toBeTruthy();
+    await click(settingsNav);
+    await settle();
+
+    const toggle = document.body.querySelector('[aria-label="Use Simple UI by default"]');
+    expect(toggle, "Use Simple UI by default toggle").toBeTruthy();
+    await click(toggle);
+    await settle();
+
+    const writes = preferenceWrites();
+    expect(writes.length).toBeGreaterThan(0);
+    expect(writes.at(-1)).toEqual({ body: { simpleUi: true }, token: TOKEN });
+  });
+
+  it("never sends the token on the pre-auth GET, which is public by design", async () => {
+    // The launch-time read runs before the gate has a token and the server keeps it public to
+    // avoid a theme flash. Authenticating it would be harmless but is deliberately not done —
+    // this pins the asymmetry so a future "just send it everywhere" change is a conscious one.
+    await renderApp();
+    const gets = global.fetch.mock.calls.filter(
+      ([url, init]) =>
+        new URL(url).pathname.endsWith("/ui-preferences") && (init?.method ?? "GET") === "GET",
+    );
+    expect(gets.length).toBeGreaterThan(0);
+    for (const [, init] of gets) {
+      expect(init.headers.get("X-SceneWorks-Token")).toBe(null);
+    }
+  });
+});

--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -112,10 +112,14 @@ export async function apiFetch(path, token, options = {}) {
       authRequired: payload?.authRequired,
     });
     // `token` matters: a 401 on a request that deliberately presented NO credential says
-    // nothing about the session token, so it must not drag the gate up. Several callers
-    // do exactly that — e.g. the `PUT /api/v1/ui-preferences` writes pass "" — and before
-    // sc-15105 their 401s were simply swallowed by a `.catch(() => {})`. Without this
-    // check a remote browser would slam into the full-page blocker on a theme toggle.
+    // nothing about the session token, so it must not drag the gate up. The case that
+    // motivated this (sc-15105) was the `PUT /api/v1/ui-preferences` writes passing "" on a
+    // gated route and swallowing the 401 with `.catch(() => {})`: without this check a remote
+    // browser would slam into the full-page blocker on a theme toggle. Those call sites now
+    // send the real token (sc-15136), so the guard is no longer load-bearing for THEM — but it
+    // stays, both because the reasoning is method-independent and because the remaining
+    // credential-less callers (`/api/v1/access`, `/api/v1/health`, the pre-auth ui-preferences
+    // GET) are only public by server convention, which a future gating change could revisit.
     if (response.status === 401 && token) {
       // Notify before throwing so the gate reacts even for the callers that swallow
       // their own errors, and record whether it claimed the session. A throwing handler

--- a/apps/web/src/api.test.js
+++ b/apps/web/src/api.test.js
@@ -121,10 +121,11 @@ describe("ApiError (sc-15105)", () => {
   });
 
   // A 401 on a request that deliberately presented no credential says nothing about the
-  // session token. `PUT /api/v1/ui-preferences` (theme, accent, default quality, last
-  // tier) is a gated route the client calls with "" and a swallowed rejection — routing
-  // those to the gate would slam a remote browser into the full-page blocker on a theme
-  // toggle.
+  // session token, so it must not raise the gate. The motivating case was the
+  // `PUT /api/v1/ui-preferences` writes (theme, accent, default quality, last tier) hitting
+  // that gated route with "" and a swallowed rejection — routing those to the gate would
+  // slam a remote browser into the full-page blocker on a theme toggle. Those writes now
+  // send the real token (sc-15136); the rule itself is about the credential, not the route.
   it("ignores a 401 from a request that presented no token", async () => {
     const handler = vi.fn();
     setUnauthorizedHandler(handler);

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -433,9 +433,11 @@ describe("useAccessGate (sc-9750)", () => {
     });
 
     it("ignores a 401 from a request that presented no token", async () => {
-      // Several callers hit gated routes with an empty token on purpose (the
-      // `PUT /api/v1/ui-preferences` writes) and swallow the rejection. Those 401s say
-      // nothing about the session, and must not drag the blocker over a live app.
+      // A 401 on a request that presented no credential says nothing about the session and
+      // must not drag the blocker over a live app. The motivating case was the
+      // `PUT /api/v1/ui-preferences` writes hitting that gated route with "" and swallowing
+      // the rejection; they now send the real token (sc-15136), so this guards the rule
+      // itself — the credential decides, not the route.
       const { get, statuses } = await mountUnlocked({ verify: { ok: true } });
       const before = verifyCount();
       statuses.length = 0;

--- a/apps/web/src/lastTierStore.js
+++ b/apps/web/src/lastTierStore.js
@@ -21,7 +21,7 @@
 // `defaultTierSelection`, which honors it whenever the sticky tier is still installed and otherwise
 // falls through to the base default — so a stale/uninstalled sticky is safely ignored (clamped).
 
-import { apiFetch } from "./api.js";
+import { putUiPreferences } from "./uiPreferences.js";
 
 const STORAGE_KEY = "sceneworks-last-tier";
 
@@ -29,12 +29,11 @@ const STORAGE_KEY = "sceneworks-last-tier";
 // localStorage alone does NOT survive a desktop relaunch — the shell's `127.0.0.1:<port>` origin changes
 // every launch, wiping origin-keyed storage — so a pick would be forgotten each session without this.
 // Best-effort + fire-and-forget: the localStorage write already succeeded, so a failed PUT only means the
-// pick isn't durable this once. Public route, empty token — mirrors the global default-quality PUT.
+// pick isn't durable this once. The PUT is a GATED write, so it goes through `putUiPreferences`, which
+// attaches the access token (sc-15136) — sending it credential-less 401'd on every remote-auth
+// deployment, silently costing the sticky on the one shell whose localStorage cannot carry it.
 function persistToServer(map) {
-  apiFetch("/api/v1/ui-preferences", "", {
-    method: "PUT",
-    body: JSON.stringify({ perModelTier: map }),
-  }).catch(() => {});
+  putUiPreferences({ perModelTier: map }).catch(() => {});
 }
 
 // Seed the localStorage instant-paint cache from the durable server copy on launch (App.jsx, after

--- a/apps/web/src/lastTierStore.test.js
+++ b/apps/web/src/lastTierStore.test.js
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("./api.js", () => ({ apiFetch: vi.fn(() => Promise.resolve({})) }));
 
 import { apiFetch } from "./api.js";
+import { ACCESS_TOKEN_KEY } from "./accessToken.js";
 import { readLastTier, seedLastTiersFromServer, writeLastTier } from "./lastTierStore.js";
 import { defaultTierSelection } from "./quantTier.js";
 
@@ -149,9 +150,8 @@ describe("lastTierStore — durable server persistence (epic 10721 R1)", () => {
 
     // Every write PUTs the FULL map (so the server can replace wholesale — no deep-merge needed).
     expect(apiFetch).toHaveBeenCalledTimes(3);
-    const [path, token, opts] = apiFetch.mock.calls.at(-1);
+    const [path, , opts] = apiFetch.mock.calls.at(-1);
     expect(path).toBe("/api/v1/ui-preferences");
-    expect(token).toBe(""); // public route
     expect(opts.method).toBe("PUT");
     expect(JSON.parse(opts.body)).toEqual({
       perModelTier: {
@@ -175,5 +175,25 @@ describe("lastTierStore — durable server persistence (epic 10721 R1)", () => {
     expect(readLastTier("image", "sana_sprint_1600m")).toBe("bf16");
     // Seeding is a read-only cache prime — it must not echo a redundant PUT back to the server.
     expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  // sc-15136: the ui-preferences PUT is GATED (only its GET is public), so a credential-less
+  // write 401s on every remote-auth deployment — and this store's `.catch(() => {})` swallowed
+  // it, so the tier sticky silently never reached disk for LAN browsers. The token is pinned to
+  // a NON-EMPTY value on purpose: asserting the "" default would pass with the fix reverted.
+  it("carries the stored access token on the durable PUT (remote-auth deployments)", () => {
+    window.localStorage.setItem(ACCESS_TOKEN_KEY, "lan-password-1");
+    writeLastTier("image", "model_x", "q4");
+    const [, token] = apiFetch.mock.calls.at(-1);
+    expect(token).toBe("lan-password-1");
+  });
+
+  // Desktop/loopback: nothing stored, so the write stays credential-less and
+  // `SCENEWORKS_TRUST_LOOPBACK` carries it. Guards against a fix that hard-fails without a token.
+  it("still PUTs with an empty token when no access token is stored (desktop/loopback)", () => {
+    writeLastTier("image", "model_x", "q4");
+    const [path, token] = apiFetch.mock.calls.at(-1);
+    expect(path).toBe("/api/v1/ui-preferences");
+    expect(token).toBe("");
   });
 });

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -7,6 +7,7 @@ import {
   serverToken,
 } from "../credentials.js";
 import { apiFetch } from "../api.js";
+import { putUiPreferences } from "../uiPreferences.js";
 import { isDesktop, tauriInvoke as invoke } from "../runtime.js";
 import {
   GENERATION_QUALITY_OPTIONS,
@@ -218,7 +219,8 @@ export function SettingsScreen({
   // an instant read for the studio, and the PUT makes it durable across desktop relaunches (the shell's
   // 127.0.0.1:<port> origin changes each launch, wiping origin-keyed localStorage). Same contract as
   // theme/accent in App.jsx — the endpoint MERGES, so sending only this field can't disturb theme/accent.
-  // Token is "" because ui-preferences is a public route (like /health); mirrors App.jsx's PUT.
+  // `putUiPreferences` attaches the access token: only the ui-preferences GET is public, the disk-writing
+  // PUT is gated (sc-8869, F-067), so a credential-less write 401s on any remote-auth deployment (sc-15136).
   async function changeDefaultQuality(value) {
     const request = defaultQualityRequest.current + 1;
     defaultQualityRequest.current = request;
@@ -226,10 +228,7 @@ export function SettingsScreen({
     const next = writeDefaultGenerationQuality(value);
     setDefaultQuality(next);
     try {
-      await apiFetch("/api/v1/ui-preferences", "", {
-        method: "PUT",
-        body: JSON.stringify({ defaultGenerationQuality: next }),
-      });
+      await putUiPreferences({ defaultGenerationQuality: next });
       if (defaultQualityRequest.current === request) {
         setStatus(`Default generation quality set to ${generationQualityLabel(next)}.`);
       }

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -534,11 +534,17 @@ describe("SettingsScreen default generation quality (sc-10728)", () => {
     // cache alone does NOT survive a relaunch (the origin changes), so the change must also PUT to the
     // durable ui-preferences store — same contract as theme/accent in App.jsx. Sending only this field
     // relies on the endpoint MERGING, so theme/accent can't be clobbered.
+    //
+    // The PUT must carry the access token (sc-15136): it is a GATED route — only the pre-auth GET is
+    // public — so the credential-less write this used to send 401'd on every remote-auth deployment and
+    // the preference never reached disk. A non-empty token is pinned on purpose: this assertion
+    // used to read `""`, which is what let the defect sit green here — it passes either way.
+    window.localStorage.setItem("sceneworks-token", "lan-password-1");
     await render();
     await chooseQuality("Q4");
     expect(apiFetch).toHaveBeenCalledWith(
       "/api/v1/ui-preferences",
-      "",
+      "lan-password-1",
       expect.objectContaining({
         method: "PUT",
         body: JSON.stringify({ defaultGenerationQuality: "q4" }),

--- a/apps/web/src/simple/SimpleSettings.jsx
+++ b/apps/web/src/simple/SimpleSettings.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
-import { apiFetch } from "../api.js";
+import { putUiPreferences } from "../uiPreferences.js";
 import { useAppContext } from "../context/AppContext.js";
 import { ACCENTS } from "../accents.js";
 import {
@@ -49,12 +49,11 @@ export function SimpleSettings({ accent, onAccentChange, simpleDefault, onSimple
   function changeQuality(next) {
     const value = writeDefaultGenerationQuality(next);
     setQuality(value);
-    // ui-preferences is a public route (like /health) and MERGES partial updates, so
-    // sending only this field can't disturb theme/accent — same contract as App.jsx.
-    apiFetch("/api/v1/ui-preferences", "", {
-      method: "PUT",
-      body: JSON.stringify({ defaultGenerationQuality: value }),
-    }).catch(() => {});
+    // The endpoint MERGES partial updates, so sending only this field can't disturb
+    // theme/accent — same contract as App.jsx. `putUiPreferences` attaches the access token:
+    // the ui-preferences GET is public but the disk-writing PUT is gated (sc-8869, F-067),
+    // so a credential-less write 401s on any remote-auth deployment (sc-15136).
+    putUiPreferences({ defaultGenerationQuality: value }).catch(() => {});
     toast(`Default quality set to ${generationQualityLabel(value)}`);
   }
 

--- a/apps/web/src/simple/SimpleSettings.test.jsx
+++ b/apps/web/src/simple/SimpleSettings.test.jsx
@@ -1,0 +1,113 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../context/AppContext.js";
+import { SimpleUiContext } from "./SimpleUiContext.js";
+import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+// sc-15136 — the Simple shell's own durable preference write must be authenticated.
+//
+// `PUT /api/v1/ui-preferences` is GATED (only the pre-auth GET is public; sc-8869, F-067). This screen
+// sent the default-quality write with an empty token and swallowed the 401, so on a remote-auth
+// deployment the Simple shell's quality preference never reached `ui-preferences.json` — hidden by the
+// localStorage instant-paint cache that the same handler writes.
+//
+// `apiFetch` is mocked at the transport seam that `uiPreferences.js` uses. The App-level suite
+// (`App.uiPreferences.test.jsx`) covers the real header on the wire; this pins the Simple shell's own
+// call site, which is a second, independent handler from the advanced Settings screen.
+
+const apiFetch = vi.fn(async () => ({}));
+vi.mock("../api.js", () => ({
+  apiFetch,
+  isAbortError: () => false,
+  API_BASE_URL: "",
+  eventUrl: () => "",
+}));
+// `credentials.js` is left real: it routes through the same mocked `apiFetch`, so the
+// credentials card loads empty without a second mock to keep in sync with its exports.
+
+const { SimpleSettings } = await import("./SimpleSettings.jsx");
+
+const APP_CONTEXT = {
+  theme: "light",
+  changeTheme: vi.fn(),
+  visibleWorkers: [],
+  macCapabilities: null,
+};
+
+const SIMPLE_UI = { toast: vi.fn(), breakpoint: "desktop" };
+
+describe("SimpleSettings — durable default-quality write (sc-15136)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    apiFetch.mockClear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    window.localStorage.clear();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={APP_CONTEXT}>
+          <SimpleUiContext.Provider value={SIMPLE_UI}>
+            <SimpleSettings
+              accent="violet"
+              lockedToSimple={false}
+              onAccentChange={vi.fn()}
+              onSimpleDefaultChange={vi.fn()}
+              simpleDefault={false}
+            />
+          </SimpleUiContext.Provider>
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const chooseQuality = async (label) => {
+    const chip = [
+      ...container.querySelectorAll('[aria-label="Default quality"] button'),
+    ].find((button) => button.textContent.trim() === label);
+    expect(chip, `quality chip "${label}"`).toBeTruthy();
+    await click(chip);
+  };
+
+  it("carries the access token on the gated PUT (remote auth)", async () => {
+    // A non-empty token is pinned deliberately: asserting the "" default passes with the fix
+    // reverted. This call site had no token coverage at all before sc-15136.
+    window.localStorage.setItem("sceneworks-token", "lan-password-1");
+    await render();
+
+    await chooseQuality("Q4");
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/v1/ui-preferences",
+      "lan-password-1",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ defaultGenerationQuality: "q4" }),
+      }),
+    );
+  });
+
+  it("still writes with no token on desktop/loopback, where none is stored", async () => {
+    // `SCENEWORKS_TRUST_LOOPBACK` exempts loopback peers before any token comparison, so the
+    // desktop shell must keep persisting with nothing to send.
+    await render();
+
+    await chooseQuality("Q4");
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/v1/ui-preferences",
+      "",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+});

--- a/apps/web/src/uiPreferences.js
+++ b/apps/web/src/uiPreferences.js
@@ -1,0 +1,54 @@
+// The single client seam for writing the durable UI-preferences blob (sc-15136).
+//
+// `/api/v1/ui-preferences` is METHOD-ASYMMETRIC on the server (sc-8869, F-067 —
+// `auth::requires_token`): the GET is public so the pre-auth theme read can load before
+// the access gate and avoid a flash, but the PUT writes `ui-preferences.json` to disk and
+// is GATED like every other write (epic 4484: every write is authenticated). Sending the
+// PUT without the access token therefore 401s on any remote-auth deployment.
+//
+// That is exactly what shipped before sc-15136: six independent call sites (theme, accent,
+// the Simple-UI default, the default generation quality in both shells, and the per-model
+// tier sticky) each hand-rolled the same `apiFetch(path, "", { method: "PUT" })`, three of
+// them under a stale "it's a public route" comment — so on a LAN browser none of those
+// preferences ever reached disk. Five of the six swallowed the 401 with `.catch(() => {})`,
+// and every one of them also writes a localStorage instant-paint cache, so the UI looked
+// correct until localStorage was cleared or another device read the file. (The exception is
+// the advanced Settings screen, which awaits the PUT and DOES surface the failure while
+// rolling its chip back — the one site where the bug was visible rather than silent.)
+//
+// Routing every write through this one function is the fix AND the guard: the token seam
+// exists once, so a seventh preference can't silently reintroduce the same 401. The GET is
+// deliberately NOT routed here — it stays credential-less in `App.jsx` because it runs
+// before the gate has a token to send, and the server exempts it.
+
+import { apiFetch } from "./api.js";
+import { readAccessToken } from "./accessToken.js";
+
+// PUT a partial preferences patch. The endpoint MERGES, so a caller sends only the field it
+// owns and cannot clobber the others.
+//
+// The token comes from `readAccessToken()` rather than a prop/context so the non-component
+// callers (`lastTierStore.js`) reach it without prop-drilling. It is read at CALL time, not at
+// import time: the token is promoted mid-session when the user answers the access gate, so a
+// cached one would leave every write in that session unauthenticated. (`credentials.js`'s
+// `serverToken()` is the same value under a different name — one source, in `accessToken.js`.)
+//
+// Caveat, pre-existing and shared with `serverToken()` (sc-15165): stored-token and the access
+// gate's in-memory `token` state can diverge in the CLEAR direction. If a second tab hits
+// "forget", this tab's gate still holds a live token while storage is empty, so a write here
+// goes out credential-less and its 401 is (correctly) not routed to the gate. Reading storage
+// is still the right call — it is strictly fresher on promotion, which is the case that decides
+// whether a session's writes are authenticated at all.
+//
+// On the desktop shell it is "" and the request still succeeds: `SCENEWORKS_TRUST_LOOPBACK`
+// bypasses the token check for loopback peers before any comparison, so local use stays
+// password-free — which is also why the fix is invisible on the desktop.
+//
+// Returns the `apiFetch` promise so a caller that reports failure (SettingsScreen) can await
+// it; the fire-and-forget callers attach their own `.catch`.
+export function putUiPreferences(patch) {
+  return apiFetch("/api/v1/ui-preferences", readAccessToken(), {
+    method: "PUT",
+    body: JSON.stringify(patch),
+  });
+}

--- a/apps/web/src/uiPreferences.test.js
+++ b/apps/web/src/uiPreferences.test.js
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The seam under test only decides WHAT goes on the wire, so the transport is mocked.
+vi.mock("./api.js", () => ({ apiFetch: vi.fn(() => Promise.resolve({})) }));
+
+import { apiFetch } from "./api.js";
+import { ACCESS_TOKEN_KEY } from "./accessToken.js";
+import { putUiPreferences } from "./uiPreferences.js";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  apiFetch.mockClear();
+  apiFetch.mockImplementation(() => Promise.resolve({}));
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+// sc-15136. `/api/v1/ui-preferences` is method-asymmetric on the server: the GET is public (the
+// pre-auth theme read) but the PUT writes to disk and is GATED (sc-8869, F-067). Six call sites
+// each sent the PUT with "" — so on remote-auth deployments theme, accent, the Simple-UI default,
+// the default quality, and the tier sticky never reached `ui-preferences.json`, invisibly, because
+// every one of them also writes a localStorage cache.
+//
+// How that survived: four of the six had NO test on the token at all, and the two that did
+// (`lastTierStore.test.js`, `SettingsScreen.test.jsx`) asserted the `""` default — a green that
+// says nothing, since it passes with the fix reverted. Every token assertion here pins a
+// NON-EMPTY value for that reason.
+describe("putUiPreferences", () => {
+  it("sends the stored access token so the GATED PUT is authenticated (remote auth)", () => {
+    window.localStorage.setItem(ACCESS_TOKEN_KEY, "lan-password-1");
+
+    putUiPreferences({ theme: "dark" });
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/v1/ui-preferences",
+      "lan-password-1",
+      expect.objectContaining({ method: "PUT", body: JSON.stringify({ theme: "dark" }) }),
+    );
+  });
+
+  it("reads the token at CALL time, not at import time", () => {
+    // The token is promoted mid-session when the user answers the access gate, and the module is
+    // imported long before that. Caching it at import would silently un-authenticate every write
+    // made in the session that mattered.
+    putUiPreferences({ theme: "dark" });
+    expect(apiFetch.mock.calls[0][1]).toBe("");
+
+    window.localStorage.setItem(ACCESS_TOKEN_KEY, "promoted-later");
+    putUiPreferences({ theme: "light" });
+    expect(apiFetch.mock.calls[1][1]).toBe("promoted-later");
+  });
+
+  it("sends an empty token on desktop/loopback, where no token is stored", () => {
+    // `SCENEWORKS_TRUST_LOOPBACK` bypasses the token check for loopback peers before any
+    // comparison, so the desktop shell must keep working with no credential to send.
+    putUiPreferences({ accent: "violet" });
+    expect(apiFetch.mock.calls[0][1]).toBe("");
+  });
+
+  it("sends only the caller's field, so a partial write cannot clobber the others", () => {
+    // The endpoint MERGES; every call site relies on that to own one field.
+    putUiPreferences({ defaultGenerationQuality: "q4" });
+    expect(JSON.parse(apiFetch.mock.calls[0][2].body)).toEqual({ defaultGenerationQuality: "q4" });
+  });
+
+  it("returns the request promise so a caller can await it and observe failure", async () => {
+    // SettingsScreen awaits this to roll back its optimistic cache and surface an error.
+    apiFetch.mockImplementation(() => Promise.reject(new Error("401 Unauthorized")));
+    await expect(putUiPreferences({ theme: "dark" })).rejects.toThrow("401 Unauthorized");
+  });
+});


### PR DESCRIPTION
Fixes [sc-15136](https://app.shortcut.com/trefry/story/15136).

## The defect

`GET /api/v1/ui-preferences` is public, but the **PUT is gated** — `auth::requires_token` special-cases the path and returns `method != Method::GET`, because the PUT writes `ui-preferences.json` to disk and every write must be authenticated (sc-8869, F-067).

The web client sent **all six** of its PUTs with an empty token:

| call site | preference |
|---|---|
| `App.jsx` ×3 | theme, accent, Simple-UI default |
| `screens/SettingsScreen.jsx` | default generation quality |
| `simple/SimpleSettings.jsx` | default generation quality (Simple shell) |
| `lastTierStore.js` | per-model quant tier, on **every** tier pick |

On any remote-auth deployment (`SCENEWORKS_ACCESS_TOKEN` set, LAN browser) every one of those 401'd, so none of those preferences ever reached `ui-preferences.json`. Five of the six swallowed the rejection with `.catch(() => {})`, and all six also write a localStorage instant-paint cache — so the loss was invisible until localStorage was cleared, the browser changed, or another device read the file. Desktop/loopback was unaffected: `SCENEWORKS_TRUST_LOOPBACK` bypasses the token check before any comparison, which is why this never showed up locally.

**Reproduced first**, before any fix: a test pinning a stored token asserted the tier PUT carried it and got `''`.

## Root cause

A duplicated seam. Six hand-rolled `apiFetch(path, "", { method: "PUT" })` calls, three of them under a stale `ui-preferences is a public route (like /health)` comment — inherited from `preferences.rs`'s module doc, which was never updated when sc-8869 made the exemption method-aware.

## The fix

- **New `apps/web/src/uiPreferences.js`** owns the write: one `putUiPreferences(patch)` that attaches `readAccessToken()`. All six call sites route through it, so the token seam exists **once** and a seventh preference can't silently reintroduce the 401.
- The token is read at **call time**, not at import/mount — it is promoted mid-session when the user answers the access gate, so a cached one would leave that whole session's writes unauthenticated. Pinned by a test.
- The **launch-time GET stays credential-less** on purpose (it runs before the gate has a token, and the server keeps it public to avoid a theme flash). A test pins that asymmetry so a future "just send it everywhere" change is a conscious one.
- Corrected the stale comments, **including the origin** at `apps/rust-api/src/preferences.rs` (doc-only — that line is what the six web comments echoed).

### Interaction with sc-15105 / #1890

sc-15105 made `apiFetch` route a 401 to the access gate only when the request actually presented a credential, precisely so these credential-less 401s couldn't drag a remote browser into the full-page blocker on a theme toggle. Now that these PUTs carry the token, a 401 from them **will** reach the gate — which is correct and completes the rotated-password detection from #1890. Verified this can't misfire: `access_control` only 401s on a missing/invalid token (throttling is 429), and all six writes are user-gesture-driven, so there is no background write that could raise the gate at a bad time. The guard itself stays — the rule is about the credential, not the route — and the comments citing these PUTs as live credential-less callers were updated rather than the code.

## Tests

- `uiPreferences.test.js` — the seam (token, call-time read, partial-merge body, awaitable promise).
- `App.uiPreferences.test.jsx` — theme, accent and the Simple-UI default driven **end-to-end** through the real transport (faked `fetch`, not a mocked `apiFetch`), asserting the `X-SceneWorks-Token` header that actually leaves the client — so it would also catch `apiFetch` itself dropping the token.
- `simple/SimpleSettings.test.jsx` — the Simple shell's independent handler.
- Existing `SettingsScreen` / `lastTierStore` suites updated.

Every token assertion pins a **non-empty** token. The two pre-existing `""` assertions were false greens that passed with the fix absent; the other four sites had no token coverage at all. **Mutation-verified**: reverting `readAccessToken()` to `""` turns **8 tests RED** across all six call sites.

## Verification

- `apps/web`: **201 files / 2755 tests pass**, `npm run lint` clean.
- `cargo fmt --all -- --check` clean; `cargo test -p sceneworks-rust-api --lib -- auth` → 33 passed. The server side already pinned the GET-public/PUT-gated contract and needed no change.
- Adversarial review by a fresh subagent: no code defects; its four comment-accuracy findings and the missed `preferences.rs` doc are all addressed in this branch.

## Follow-up filed

[sc-15165](https://app.shortcut.com/trefry/story/15165) — pre-existing, surfaced by the review: the stored token and the access gate's in-memory `token` can diverge in the *clear* direction (multi-tab "forget"), because nothing listens for `storage` events. Shared with the long-standing `serverToken()` idiom; the real fix is a change to the epic-4484 auth seam, so it is tracked separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)