### PR TITLE
feat(worker): route krea_realtime_14b video jobs to the krea provider (sc-8443)

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs/krea_realtime.rs
+++ b/crates/sceneworks-worker/src/video_jobs/krea_realtime.rs
@@ -1,0 +1,312 @@
+#[cfg(target_os = "macos")]
+use super::ltx::extract_clip_frames;
+#[allow(unused_imports)]
+use super::prelude::*;
+#[cfg(target_os = "macos")]
+use super::wan::{generate_video_using, local_mlx_dir, VideoGenInput};
+
+// ---------------------------------------------------------------------------
+// Real MLX Krea Realtime 14B generation (macOS, via mlx-gen-krea-realtime, epic 8431 / sc-8443 S10):
+// an autoregressive, self-forcing, real-time video denoiser whose SHIPPED checkpoint is Wan 2.1 T2V
+// 14B weight-for-weight (the S1 audit fact the engine crate is built on). What makes it distinct is
+// its inference REGIME — a short per-frame-block few-step Self-Forcing schedule + a rolling causal KV
+// cache — not its weights, so the DiT / z16 VAE / UMT5 text encoder / RoPE / schedulers are all reused
+// from stock Wan inside the engine.
+//
+// Surface (descriptor `pipeline::descriptor`, sc-8440 S7): CFG-OFF video (no negative-prompt / guidance
+// / true-cfg axis — the AR few-step denoise runs a single batch-1 forward per step), sampler
+// `self_forcing`, `supported_quants = []` (dense bf16 load — no load-time quant tier wired yet),
+// `supports_lora = false`, `mac_only = true`. It advertises two conditioning shapes the worker maps its
+// own reference inputs onto here:
+//   * i2v — a `Reference` still VAE-encoded to WARM the AR KV cache from clean context. The engine's
+//     `run` reads only the reference IMAGE (`Conditioning::Reference { image, .. }`), never its
+//     `strength` — the cache-warm has no strength analog — so **i2v `strength` is a NO-OP**, faithful
+//     to the sibling `bernini`/reference paths which also emit `strength: None`. Documented + pinned
+//     below so a future edit can't silently start honoring it.
+//   * v2v — a `VideoClip` source that drives a strength-CONTROLLED AR init (`FewStepSchedule::for_
+//     strength`): a lower strength preserves more of the source. So **v2v DOES honor `strength`**
+//     (`videoConditioningStrength`, default 1.0 — the same knob + default the Wan/LTX v2v paths use).
+//
+// This is the non-gated worker DISPATCH wiring (routing + VideoRequest→GenerationRequest mapping +
+// heartbeat-funnel routing). The real-weight watchable-clip e2e needs the real ~28 GB DiT and is the
+// GATED S13 validation; the MLX rehost of the turnkey snapshot is the gated S2 remainder (sc-8435).
+// LoRA passthrough is the S15 seam (see `generate_krea_realtime`). Mac-only: the off-Mac (candle) lane
+// has NO Krea Realtime engine, so a non-mac job fails loud in `run_video_generate_job` (mirroring the
+// `wan_2_2_vace_fun_14b` mac-only guard) rather than silently routing to a different backend / the stub.
+// ---------------------------------------------------------------------------
+
+/// The SceneWorks/model catalog id for Krea Realtime 14B — identical to the engine registry id
+/// (`mlx_gen_krea_realtime::MODEL_ID`), so the SceneWorks id maps to the engine 1:1 (no `_distilled`-
+/// style split). Named once here so the route, the raw-settings, and the mac-only guard agree.
+#[cfg(target_os = "macos")]
+pub(super) const KREA_REALTIME_MODEL_ID: &str = "krea_realtime_14b";
+
+/// Adapter id recorded on a real MLX Krea Realtime asset (mirrors the `mlx_*` convention).
+#[cfg(target_os = "macos")]
+pub(super) const KREA_REALTIME_ADAPTER: &str = "mlx_krea_realtime";
+
+/// SceneWorks Krea Realtime model id → mlx-gen registry id, or `None` if `model` is not Krea Realtime.
+/// The id IS the engine id (`KREA_REALTIME_MODEL_ID`); no earlier predicate in `resolve_video_route`
+/// can match it (it is not a Wan/LTX/SVD/Bernini/SCAIL-2/Mochi id), so appending the krea arm leaves
+/// every pre-existing route byte-identical.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_engine_id(model: &str) -> Option<&'static str> {
+    (model == KREA_REALTIME_MODEL_ID).then_some(KREA_REALTIME_MODEL_ID)
+}
+
+/// Whether the linked Krea Realtime engine can serve this request now (resolvable weights). `mac_only`
+/// is implicit — this fn is macOS-only, and a non-mac job never reaches the route (it is rejected
+/// loudly in `run_video_generate_job`). Routed by weight availability like the other MLX engines: an
+/// unresolved snapshot falls to `VideoRoute::Stub`, whose fail-loud gate (`ensure_video_engine_
+/// weights`) then surfaces the resolver's precise error instead of a procedural fake clip.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_available(_request: &VideoRequest, settings: &Settings) -> bool {
+    resolve_krea_realtime_model_dir(settings).is_ok()
+}
+
+/// The turnkey SceneWorks Krea Realtime MLX repo (the converted transformer-only DiT snapshot +
+/// the stock Wan `t5_encoder`/`vae`/`tokenizer`). **Provisional**: the MLX rehost to the SceneWorks HF
+/// org is the gated S2 remainder (sc-8435), so the repo may not be published yet — `resolve_krea_
+/// realtime_model_dir` only ever LOOKS UP an already-downloaded snapshot in the local cache (no
+/// network fetch here; there is no on-demand quant-tier fetch because the engine advertises
+/// `supported_quants = []` and loads dense bf16), so an absent repo simply means the env override /
+/// app-managed dir are the resolvable sources until the rehost + download lands.
+#[cfg(target_os = "macos")]
+pub(super) const KREA_REALTIME_REPO: &str = "SceneWorks/krea-realtime-14b-mlx";
+
+/// Resolve the Krea Realtime MLX snapshot dir: env override (`SCENEWORKS_MLX_KREA_REALTIME_DIR`) →
+/// app-managed `<data>/models/mlx/krea_realtime` → the turnkey `SceneWorks/krea-realtime-14b-mlx`
+/// snapshot if already downloaded (mirrors `resolve_bernini_model_dir`). Errors clearly if none is
+/// present (no stub fallback).
+#[cfg(target_os = "macos")]
+pub(super) fn resolve_krea_realtime_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
+    if let Some(dir) = local_mlx_dir(
+        settings,
+        "SCENEWORKS_MLX_KREA_REALTIME_DIR",
+        "krea_realtime",
+    ) {
+        return Ok(dir);
+    }
+    if let Some(dir) = huggingface_snapshot_dir(&settings.data_dir, KREA_REALTIME_REPO) {
+        return Ok(dir);
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "krea_realtime_14b: no MLX weights found. Download the turnkey {KREA_REALTIME_REPO} snapshot \
+         via the Model Manager, set $SCENEWORKS_MLX_KREA_REALTIME_DIR, or place a converted snapshot \
+         at {}.",
+        settings
+            .data_dir
+            .join("models")
+            .join("mlx")
+            .join("krea_realtime")
+            .display(),
+    )))
+}
+
+/// The Krea Realtime video task a request resolves to, from its supplied media: a source clip → `v2v`,
+/// else a reference still → `i2v`, else `t2v`. Routed on the MEDIA (matching how the engine's own `run`
+/// routes on the conditioning it is handed), not the SceneWorks `mode` string, so the mapping is faithful
+/// regardless of which mode label the caller used. Recorded on the asset for observability.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_video_task(request: &VideoRequest) -> &'static str {
+    if request.source_clip_asset_id.is_some() {
+        "v2v"
+    } else if request.source_asset_id.is_some() {
+        "i2v"
+    } else {
+        "t2v"
+    }
+}
+
+/// Raw-settings recorded on a real MLX Krea Realtime asset (mirrors `bernini_raw_settings`).
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_raw_settings(request: &VideoRequest) -> Value {
+    let mut raw = request.advanced.clone();
+    raw.insert("realModelInference".to_owned(), Value::Bool(true));
+    raw.insert("model".to_owned(), Value::String(request.model.clone()));
+    raw.insert("fps".to_owned(), json!(request.fps));
+    // The engine task the supplied media resolved to (lineage / observability).
+    raw.insert(
+        "kreaRealtimeTask".to_owned(),
+        Value::String(krea_realtime_video_task(request).to_owned()),
+    );
+    Value::Object(raw)
+}
+
+/// Build the Krea Realtime conditioning from the (already loaded) reference media — the PURE i2v/v2v
+/// shape decision the engine's `run` mirrors. A source `clip` → one `VideoClip` whose `strength` is
+/// HONORED (v2v drives a strength-controlled AR init). Else a reference `still` → one `Reference` with
+/// `strength: None` — i2v warms the AR KV cache from the still and the engine reads only the image, so
+/// **the i2v strength is a NO-OP** (faithful to the sibling `bernini`/reference paths). Else empty
+/// (t2v). Clip takes precedence over a still, exactly as the engine's `run` prefers `VideoClip`.
+///
+/// Kept pure (loaded media in, conditioning out) so the invariant this story exists to wire — i2v drops
+/// strength, v2v carries it — is unit-testable without a GPU, weights, or on-disk assets.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_conditioning(
+    still: Option<Image>,
+    clip: Option<Vec<Image>>,
+    v2v_strength: f32,
+) -> Vec<Conditioning> {
+    if let Some(frames) = clip {
+        // v2v: the source clip drives the strength-controlled AR init. `frame_idx` is inert for Krea
+        // (its `run` reads only `frames` + `strength`); carried at 0 for the shared `VideoClip` contract.
+        return vec![Conditioning::VideoClip {
+            frames,
+            frame_idx: 0,
+            strength: v2v_strength,
+        }];
+    }
+    if let Some(image) = still {
+        // i2v: the still warms the AR KV cache. `strength` is a NO-OP for the cache-warm (the engine
+        // reads only the image), so it is dropped to `None` — do NOT wire a strength here.
+        return vec![Conditioning::Reference {
+            image,
+            strength: None,
+        }];
+    }
+    Vec::new()
+}
+
+/// Resolve a Krea Realtime request's supplied media into the engine conditioning: a source clip
+/// (`sourceClipAssetId`) → v2v `VideoClip`, else a reference still (`sourceAssetId`) → i2v `Reference`,
+/// else t2v (empty). The clip decodes to the output frame count via the shared `extract_clip_frames`;
+/// the still loads via the shared `load_reference_image`. The shape + strength decision itself lives in
+/// the pure [`krea_realtime_conditioning`].
+#[cfg(target_os = "macos")]
+pub(super) async fn resolve_krea_realtime_conditioning(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<Conditioning>> {
+    // v2v takes precedence over i2v (matches the engine's `run`): a source clip → v2v.
+    if let Some(clip_id) = request.source_clip_asset_id.as_deref() {
+        let frames = extract_clip_frames(
+            api,
+            settings,
+            job,
+            &request.project_id,
+            project_path,
+            clip_id,
+            request.width,
+            request.height,
+            wan_frame_count(request.raw_frame_count()),
+        )
+        .await?;
+        // v2v HONORS strength (`videoConditioningStrength`, default 1.0 — the Wan/LTX v2v convention).
+        let strength = advanced::f32(&request.advanced, "videoConditioningStrength", 1.0);
+        return Ok(krea_realtime_conditioning(None, Some(frames), strength));
+    }
+    // i2v: a reference still (the I2V conditioning source, like SVD's `sourceAssetId`).
+    if let Some(ref_id) = request.source_asset_id.as_deref() {
+        let still = load_reference_image(
+            &settings.data_dir,
+            &request.project_id,
+            ref_id,
+            project_path,
+        )?;
+        // i2v strength is a NO-OP (the pure helper drops it); the `1.0` here is never read.
+        return Ok(krea_realtime_conditioning(Some(still), None, 1.0));
+    }
+    // t2v: no conditioning.
+    Ok(Vec::new())
+}
+
+/// Real MLX Krea Realtime generation (epic 8431 / sc-8443 S10): build the `VideoGenInput` and run the
+/// shared `generate_video` heartbeat funnel. The supplied media resolves to the engine conditioning
+/// ([`resolve_krea_realtime_conditioning`]) — empty for t2v, a `Reference` still for i2v (strength
+/// no-op), a `VideoClip` source for v2v (strength honored). CFG off: no negative prompt / guidance
+/// (the engine advertises none), `steps` from the advanced `steps` knob (else the engine default),
+/// dense bf16 load (`supported_quants = []`, so `quant = None`). Frame count uses the Wan 1-mod-4
+/// stride coercion — the DiT + z16 VAE ARE stock Wan 2.1, so the Wan stride is exactly right.
+///
+/// Runs through the `generate_video` → `generate_video_using` funnel so a long/multi-minute AR job
+/// drives `heartbeat(...)` and is NOT marked `interrupted` by the ~90 s API stale-sweep, and so the
+/// funnel's per-step cancel poll trips the engine's `CancelFlag` promptly (the S8 half of this story's
+/// DoD).
+///
+/// **LoRA passthrough is the S15 seam.** The engine advertises `supports_lora = false`, so no adapter
+/// is wired (`adapters` left empty): forwarding a LoRA to an engine whose load path ignores it would
+/// violate capability honesty. A LoRA-bearing request is NOT rejected — it runs the base DiT — so the
+/// worker never breaks on one; the full dense-LoRA integration (via the shared `resolve_dense_adapters`)
+/// lands in sc-8443's S15.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn generate_krea_realtime(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+) -> WorkerResult<DecodedVideo> {
+    generate_krea_realtime_using(
+        api,
+        settings,
+        job,
+        request,
+        project_path,
+        engine_id,
+        backend,
+        crate::inference_runtime::load,
+    )
+    .await
+}
+
+/// [`generate_krea_realtime`] with the engine loader supplied by the caller (mirrors
+/// `generate_mochi_using`, sc-12318). With the loader threaded in, a test can drive this arm against a
+/// stub `Generator` and assert on the `GenerationRequest` that actually reached the engine (prompt /
+/// steps / seed / frame count / fps and the resolved conditioning) without weights or a GPU.
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn generate_krea_realtime_using(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    project_path: &Path,
+    engine_id: &'static str,
+    backend: &str,
+    load_generator: impl FnOnce(&str, &LoadSpec) -> gen_core::Result<Box<dyn Generator>>
+        + Send
+        + 'static,
+) -> WorkerResult<DecodedVideo> {
+    let conditioning =
+        resolve_krea_realtime_conditioning(api, settings, job, request, project_path).await?;
+    let model_dir = resolve_krea_realtime_model_dir(settings)?;
+    let input = VideoGenInput {
+        sampler: None,
+        scheduler: None,
+        engine_id,
+        model_dir,
+        // Dense bf16 load: the engine advertises `supported_quants = []`, so never request a load-time
+        // quant (a Q4/Q8 request would be capability-dishonest until a tier is wired).
+        quant: None,
+        conditioning,
+        prompt: request.prompt.clone(),
+        // CFG off: the engine advertises no negative-prompt / guidance axis, so leave both unset.
+        negative_prompt: None,
+        width: request.width,
+        height: request.height,
+        frames: wan_frame_count(request.raw_frame_count()),
+        fps: request.fps,
+        steps: super::wan::advanced_opt_u32(request, "steps"),
+        seed: resolve_video_seed(request) as u64,
+        // No `video_mode`: the engine routes purely on the supplied conditioning, not a task string.
+        // No adapters: `supports_lora = false` (LoRA is the S15 seam — see the doc comment).
+        ..VideoGenInput::default()
+    };
+    generate_video_using(
+        api,
+        settings,
+        job,
+        backend,
+        &request.advanced,
+        input,
+        load_generator,
+    )
+    .await
+}

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -201,6 +201,9 @@ enum VideoRoute {
     Bernini(&'static str),
     /// SCAIL-2 standalone character animation (epic 5439). Carries the resolved engine id.
     Scail2(&'static str),
+    /// Krea Realtime 14B autoregressive video (epic 8431 / sc-8443). t2v + i2v (`Reference`) + v2v
+    /// (`VideoClip`); mac-only. Carries the resolved engine id.
+    KreaRealtime(&'static str),
     /// Mochi 1 text-to-video (epic 1788 / sc-11992). Carries the resolved engine id. t2v ONLY —
     /// [`mochi_available`] gates the mode, since `conditioning: []` means there is no other shape.
     Mochi(&'static str),
@@ -249,6 +252,14 @@ fn resolve_video_route(request: &VideoRequest, settings: &Settings) -> VideoRout
         scail2_engine_id(&request.model).filter(|_| scail2_available(request, settings))
     {
         VideoRoute::Scail2(engine_id)
+    } else if let Some(engine_id) = krea_realtime_engine_id(&request.model)
+        .filter(|_| krea_realtime_available(request, settings))
+    {
+        // Krea Realtime 14B (epic 8431 / sc-8443 S10). `krea_realtime_engine_id` matches only
+        // `krea_realtime_14b`, and no earlier predicate can match that id, so routing for every
+        // pre-existing model stays byte-identical. Weights unresolved ⇒ falls to Stub, whose fail-loud
+        // gate refuses rather than handing back a procedural fake clip.
+        VideoRoute::KreaRealtime(engine_id)
     } else if let Some(engine_id) =
         mochi_engine_id(&request.model).filter(|_| mochi_available(request, settings))
     {
@@ -453,6 +464,19 @@ pub(crate) async fn run_video_generate_job(
                 .to_owned(),
         ));
     }
+    // Krea Realtime 14B (epic 8431 / sc-8443) is `mac_only` (descriptor) and has NO candle engine, so
+    // an off-Mac job must fail honestly here rather than fall through to the candle stub / a different
+    // backend — the same silent-degradation trap the VACE-Fun guard above closes. The full candle port
+    // is out of this story's scope.
+    #[cfg(not(target_os = "macos"))]
+    if request.model == "krea_realtime_14b" {
+        return Err(WorkerError::InvalidPayload(
+            "krea_realtime_14b: the native Krea Realtime engine is macOS-only (there is no candle \
+             backend). The job will not be routed to a different backend. Choose another model on \
+             this platform."
+                .to_owned(),
+        ));
+    }
     // Generate: real MLX on macOS for Wan (sc-3034) / LTX+audio (sc-3035) models with
     // resolvable weights, else the procedural stub (non-macOS or missing weights = stub).
     // replace_person (sc-3521) always routes to the native Wan-VACE provider regardless of the
@@ -645,6 +669,28 @@ pub(crate) async fn run_video_generate_job(
                     decoded,
                     SCAIL2_ADAPTER,
                     scail2_raw_settings(&request, lightning),
+                    None,
+                )
+            }
+            VideoRoute::KreaRealtime(engine_id) => {
+                // Krea Realtime 14B (epic 8431 / sc-8443 S10): autoregressive self-forcing video whose
+                // shipped checkpoint is Wan 2.1 T2V 14B weight-for-weight. `generate_krea_realtime` maps
+                // the supplied media to the engine conditioning (a reference still → i2v `Reference`,
+                // strength no-op; a source clip → v2v `VideoClip`, strength honored; else t2v) and drives
+                // the shared `generate_video` heartbeat funnel. CFG off; dense bf16; no LoRA yet (S15).
+                (
+                    generate_krea_realtime(
+                        api,
+                        settings,
+                        job,
+                        &request,
+                        &project_path,
+                        engine_id,
+                        backend,
+                    )
+                    .await?,
+                    KREA_REALTIME_ADAPTER,
+                    krea_realtime_raw_settings(&request),
                     None,
                 )
             }
@@ -1517,6 +1563,12 @@ use scail2::{
 };
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use scail2::{scail2_engine_id, scail2_raw_settings};
+mod krea_realtime;
+#[cfg(target_os = "macos")]
+use krea_realtime::{
+    generate_krea_realtime, krea_realtime_available, krea_realtime_engine_id,
+    krea_realtime_raw_settings, KREA_REALTIME_ADAPTER,
+};
 pub(crate) mod ltx;
 #[cfg(target_os = "macos")]
 use ltx::{generate_ltx, ltx_available, ltx_engine_id, ltx_raw_settings, LTX_ADAPTER};

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -3,7 +3,7 @@ use super::candle::*;
 use super::seedvr2::*;
 use super::*;
 #[cfg(target_os = "macos")]
-use super::{bernini::*, ltx::*, mochi::*, scail2::*, svd::*, vace::*, wan::*};
+use super::{bernini::*, krea_realtime::*, ltx::*, mochi::*, scail2::*, svd::*, vace::*, wan::*};
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use super::{bernini::*, mochi::*, svd::*, wan::*};
 
@@ -37,6 +37,11 @@ fn video_jobs_remains_split_into_real_engine_modules() {
             "pub(super) async fn generate_scail2(",
         ),
         (
+            "krea_realtime",
+            include_str!("krea_realtime.rs"),
+            "pub(super) async fn generate_krea_realtime(",
+        ),
+        (
             "ltx",
             include_str!("ltx.rs"),
             "pub(super) async fn generate_ltx(",
@@ -63,7 +68,16 @@ fn video_jobs_remains_split_into_real_engine_modules() {
         "engine families must be real Rust modules, not textual include! composition"
     );
     for family in [
-        "seedvr2", "wan", "candle", "bernini", "scail2", "ltx", "mochi", "svd", "vace",
+        "seedvr2",
+        "wan",
+        "candle",
+        "bernini",
+        "scail2",
+        "krea_realtime",
+        "ltx",
+        "mochi",
+        "svd",
+        "vace",
     ] {
         assert!(
             !PARENT.contains(&format!("{family}::*")),
@@ -2720,6 +2734,279 @@ fn mochi_routes_to_the_mochi_engine_and_never_degrades_to_a_fake_video() {
     });
     std::fs::remove_dir_all(&root).ok();
     std::fs::remove_dir_all(&empty).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Krea Realtime 14B (epic 8431 / sc-8443 S10) — routing + VideoRequest→GenerationRequest mapping.
+// ---------------------------------------------------------------------------
+
+/// A temp dir holding just a `config.json`, so `local_mlx_dir` accepts it as a resolvable Krea
+/// Realtime snapshot (the loader is stubbed in the mapping test, so the contents are never read).
+#[cfg(target_os = "macos")]
+fn krea_fake_model_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("krea_{tag}_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("config.json"), "{}").unwrap();
+    dir
+}
+
+/// A `JobSnapshot` for a Krea Realtime video job.
+#[cfg(target_os = "macos")]
+fn krea_job_snapshot() -> JobSnapshot {
+    serde_json::from_value(json!({
+        "id": "job-krea-1",
+        "type": "video_generate",
+        "status": "running",
+        "projectId": null,
+        "projectName": null,
+        "payload": { "model": "krea_realtime_14b" },
+        "result": {},
+        "requestedGpu": "auto",
+        "assignedGpu": null,
+        "workerId": "test-worker",
+        "progress": 0.0,
+        "stage": "queued",
+        "message": "queued",
+        "error": null,
+        "etaSeconds": null,
+        "elapsedSeconds": null,
+        "attempts": 1,
+        "sourceJobId": null,
+        "duplicateOfJobId": null,
+        "cancelRequested": false,
+        "createdAt": "2026-07-26T00:00:00Z",
+        "updatedAt": "2026-07-26T00:00:00Z",
+        "startedAt": null,
+        "completedAt": null,
+        "canceledAt": null,
+        "lastHeartbeatAt": null
+    }))
+    .expect("the krea job snapshot deserializes")
+}
+
+/// The SceneWorks id maps to the engine id 1:1 and matches nothing else — so appending the krea arm to
+/// the route ladder can't shadow (or be shadowed by) any pre-existing engine.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_engine_id_maps_only_krea() {
+    assert_eq!(
+        krea_realtime_engine_id("krea_realtime_14b"),
+        Some("krea_realtime_14b")
+    );
+    for other in [
+        "wan_2_2",
+        "wan_2_2_t2v_14b",
+        "scail2_14b",
+        "bernini",
+        "mochi_1",
+        "svd",
+        "ltx_2_3",
+        "krea_2_turbo", // the unrelated IMAGE crate — must NOT collide with the video engine
+    ] {
+        assert_eq!(
+            krea_realtime_engine_id(other),
+            None,
+            "{other} must not resolve to the Krea Realtime engine"
+        );
+    }
+}
+
+/// The invariant this story exists to wire, tested on the pure shape helper without a GPU or assets:
+/// a reference still → i2v `Reference` with `strength` DROPPED (`None`); a source clip → v2v
+/// `VideoClip` with `strength` HONORED; a clip WINS over a still (v2v precedence, matching the engine's
+/// `run`); no media → t2v (empty). Discriminating: the `VideoClip` strength must equal the value passed
+/// (not a hardcoded default), and the `Reference` strength must be `None` — a future edit that started
+/// honoring i2v strength would turn this red.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_conditioning_i2v_drops_strength_v2v_honors_it() {
+    let still = || gen_core::Image {
+        width: 2,
+        height: 2,
+        pixels: vec![0u8; 12],
+    };
+    let clip = || {
+        vec![gen_core::Image {
+            width: 2,
+            height: 2,
+            pixels: vec![0u8; 12],
+        }]
+    };
+
+    // i2v: a still, strength argument is a no-op → Reference { strength: None }.
+    let i2v = krea_realtime_conditioning(Some(still()), None, 0.9);
+    assert_eq!(i2v.len(), 1);
+    match &i2v[0] {
+        Conditioning::Reference { strength, .. } => assert_eq!(
+            *strength, None,
+            "i2v strength is a NO-OP — the reference must carry no strength"
+        ),
+        other => panic!("i2v must be a Reference, got {other:?}"),
+    }
+
+    // v2v: a clip → VideoClip whose strength equals the honored value (0.35, not a default).
+    let v2v = krea_realtime_conditioning(None, Some(clip()), 0.35);
+    assert_eq!(v2v.len(), 1);
+    match &v2v[0] {
+        Conditioning::VideoClip {
+            frames, strength, ..
+        } => {
+            assert_eq!(frames.len(), 1);
+            assert_eq!(*strength, 0.35, "v2v must HONOR the resolved strength");
+        }
+        other => panic!("v2v must be a VideoClip, got {other:?}"),
+    }
+
+    // A clip and a still together → v2v wins (the engine prefers VideoClip).
+    let both = krea_realtime_conditioning(Some(still()), Some(clip()), 0.5);
+    assert_eq!(both.len(), 1);
+    assert!(
+        matches!(both[0], Conditioning::VideoClip { .. }),
+        "a clip must take precedence over a still (v2v)"
+    );
+
+    // No media → t2v (no conditioning).
+    assert!(krea_realtime_conditioning(None, None, 1.0).is_empty());
+}
+
+/// A Krea Realtime job with resolvable weights routes to `VideoRoute::KreaRealtime` — and, critically,
+/// one whose weights DON'T resolve must NOT silently become `VideoRoute::Stub` output: the Stub arm's
+/// fail-loud gate (`ensure_video_engine_weights`) must error. Also pins that adding the krea arm does
+/// not pull any other model onto it.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_routes_to_the_krea_engine_and_never_degrades_to_a_fake_video() {
+    let model_dir = krea_fake_model_dir("route");
+    let settings = Settings {
+        data_dir: std::env::temp_dir().join(format!("krea_route_data_{}", std::process::id())),
+        ..Settings::from_env()
+    };
+    let req = request(json!({
+        "projectId": "p", "model": "krea_realtime_14b", "mode": "text_to_video", "prompt": "p"
+    }));
+    temp_env_var(
+        "SCENEWORKS_MLX_KREA_REALTIME_DIR",
+        model_dir.to_str().unwrap(),
+        || {
+            assert_eq!(
+                resolve_video_route(&req, &settings),
+                VideoRoute::KreaRealtime("krea_realtime_14b")
+            );
+            // A non-krea model never lands on the krea route (even though krea weights ARE available):
+            // routing is keyed on the model id, not merely availability.
+            for other in ["wan_2_2", "scail2_14b", "bernini", "mochi_1"] {
+                let r = request(json!({
+                    "projectId": "p", "model": other, "mode": "text_to_video", "prompt": "p"
+                }));
+                assert!(
+                    !matches!(
+                        resolve_video_route(&r, &settings),
+                        VideoRoute::KreaRealtime(_)
+                    ),
+                    "{other} must not route to KreaRealtime"
+                );
+            }
+        },
+    );
+
+    // Weights absent (empty env override, empty data dir) ⇒ the route falls to Stub, BUT the Stub
+    // arm's fail-loud gate must refuse rather than hand back a procedural fake video.
+    let empty = std::env::temp_dir().join(format!("krea_empty_{}", std::process::id()));
+    std::fs::create_dir_all(&empty).unwrap();
+    let bare = Settings {
+        data_dir: empty.clone(),
+        ..Settings::from_env()
+    };
+    temp_env_var("SCENEWORKS_MLX_KREA_REALTIME_DIR", "", || {
+        assert_eq!(resolve_video_route(&req, &bare), VideoRoute::Stub);
+        let err = ensure_video_engine_weights(&req, &bare)
+            .expect_err("an unprovisioned krea MUST fail loudly, never render a fake video");
+        let WorkerError::InvalidPayload(message) = err else {
+            panic!("expected an actionable InvalidPayload");
+        };
+        assert!(
+            message.contains("krea_realtime_14b") && message.contains("Model Manager"),
+            "the error must name the model and tell the user what to do: {message}"
+        );
+    });
+    std::fs::remove_dir_all(&model_dir).ok();
+    std::fs::remove_dir_all(&empty).ok();
+}
+
+/// The caller-side mapping pin: drives `generate_krea_realtime_using` end to end (through the
+/// `generate_video` heartbeat funnel) against a stub generator and asserts on the `GenerationRequest`
+/// that REACHED the engine — prompt, `steps` (from advanced), seed, fps, and the Wan-lattice frame
+/// count — for a t2v job (no conditioning). CFG off: no negative prompt reaches the engine. This is
+/// what proves the VideoRequest→GenerationRequest scalar mapping AND that the generate path
+/// structurally runs through the funnel (a clip comes back).
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_using_hands_the_engine_the_mapped_t2v_request() {
+    let model_dir = krea_fake_model_dir("map");
+    let settings = Settings {
+        data_dir: model_dir.join("unused-data-dir"),
+        ..offline_settings()
+    };
+    let req = request(json!({
+        "projectId": "p",
+        "model": "krea_realtime_14b",
+        "mode": "text_to_video",
+        "prompt": "aurora over a fjord",
+        "seed": 4242,
+        "fps": 16,
+        "duration": 2.0,
+        "advanced": { "steps": 6 }
+    }));
+    // raw = round(2.0 * 16) = 32; the Wan 1-mod-4 stride floors 32 → 29 (the DiT + z16 VAE ARE stock Wan).
+    assert_eq!(wan_frame_count(req.raw_frame_count()), 29);
+
+    let job = krea_job_snapshot();
+    let probe = ArmProbe::default();
+    let loader = probe.loader();
+    let decoded = temp_env_var(
+        "SCENEWORKS_MLX_KREA_REALTIME_DIR",
+        model_dir.to_str().unwrap(),
+        || {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime builds")
+                .block_on(generate_krea_realtime_using(
+                    &ApiClient::new(&settings),
+                    &settings,
+                    &job,
+                    &req,
+                    // project_path — never touched by a t2v request (no media loaded).
+                    &model_dir,
+                    "krea_realtime_14b",
+                    "mlx",
+                    loader,
+                ))
+        },
+    )
+    .expect("krea t2v generation runs through the funnel against the probe");
+
+    // The clip came back through the funnel — the generate path structurally ran the heartbeat loop.
+    assert!(!decoded.frames.is_empty());
+
+    let seen = probe.request.lock().unwrap();
+    let gen = seen.as_ref().expect("the arm reached the engine");
+    assert_eq!(gen.prompt, "aurora over a fjord");
+    assert_eq!(gen.steps, Some(6), "advanced steps map to the engine steps");
+    assert_eq!(gen.seed, Some(4242), "the explicit seed maps through");
+    assert_eq!(gen.fps, Some(16));
+    assert_eq!(gen.frames, Some(29), "frame count uses the Wan lattice");
+    assert_eq!(
+        gen.negative_prompt, None,
+        "CFG off — no negative prompt reaches the engine"
+    );
+    assert!(
+        gen.conditioning.is_empty(),
+        "a t2v request carries no conditioning"
+    );
+
+    drop(seen);
+    std::fs::remove_dir_all(&model_dir).ok();
 }
 
 /// The on-demand tier fetches are gated on the request's tier toggle — the "fetched on demand if

--- a/crates/sceneworks-worker/src/video_jobs/wan.rs
+++ b/crates/sceneworks-worker/src/video_jobs/wan.rs
@@ -5,6 +5,7 @@ use super::prelude::*;
 #[cfg(target_os = "macos")]
 use super::{
     bernini::{bernini_engine_id, resolve_bernini_model_dir},
+    krea_realtime::{krea_realtime_engine_id, resolve_krea_realtime_model_dir},
     ltx::{ltx_engine_id, resolve_keyframe_conditioning, resolve_ltx_model_dir},
     mochi::{mochi_engine_id, resolve_mochi_model_dir},
     scail2::{resolve_scail2_model_dir, scail2_engine_id},
@@ -148,6 +149,13 @@ pub(crate) fn ensure_video_engine_weights(
     // degradation sc-4176 added this gate to prevent.
     if mochi_engine_id(&request.model).is_some() {
         resolve_mochi_model_dir(settings, request)?;
+    }
+    // Krea Realtime 14B (epic 8431 / sc-8443). Without this arm a Krea job whose weights don't resolve
+    // falls to `VideoRoute::Stub` and the user is handed a PROCEDURAL FAKE VIDEO instead of the
+    // resolver's precise "download the snapshot" error — the silent degradation sc-4176 added this gate
+    // to prevent.
+    if krea_realtime_engine_id(&request.model).is_some() {
+        resolve_krea_realtime_model_dir(settings)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## S10 — Worker dispatch: `krea_realtime_14b` → the Krea Realtime provider

Wires the non-gated worker dispatch (sc-8443, epic 8431) so a `VideoRequest` with model `krea_realtime_14b` routes to the native MLX **Krea Realtime 14B** provider (pinned inference `981c8050`). The engine's shipped checkpoint is Wan 2.1 T2V 14B weight-for-weight; what's distinct is its autoregressive self-forcing regime.

### Routing
- **New module `crates/sceneworks-worker/src/video_jobs/krea_realtime.rs`** — `krea_realtime_engine_id` (→ `krea_realtime_14b`), `krea_realtime_available` (resolvable-weights gate; mac-only), `resolve_krea_realtime_model_dir`, `generate_krea_realtime` (+ the loader-injected `generate_krea_realtime_using` seam), mirroring the `scail2`/`bernini` siblings.
- **`resolve_video_route` ladder** in `mod.rs` gains `VideoRoute::KreaRealtime` (appended after Scail2; the id matches no earlier predicate, so every pre-existing route stays byte-identical). The Stub arm's fail-loud gate (`ensure_video_engine_weights`) gains a krea arm so an unprovisioned job errors with the resolver's precise message instead of rendering a procedural fake clip.
- **Parallel candle/non-mac lane:** krea is `mac_only` (descriptor) with **no candle engine**, so `run_video_generate_job` fails loud off-Mac — mirroring the existing `wan_2_2_vace_fun_14b` mac-only guard — rather than silently falling through to the candle stub / a different backend. (`is_candle_video_engine` already returns `None` for krea.)
- Tests prove the krea route **is** selected for `krea_realtime_14b` (weights present) and is **not** selected for `wan_2_2`/`scail2_14b`/`bernini`/`mochi_1`, and that an unprovisioned job falls to `Stub` **and** `ensure_video_engine_weights` errors (naming the model + "Model Manager").

### Mapping (VideoRequest → gen-core GenerationRequest)
- prompt / `steps` (advanced) / seed / fps / **frame count via the Wan 1-mod-4 lattice** (the DiT + z16 VAE ARE stock Wan 2.1). CFG off → no negative prompt / guidance. Dense bf16 load (`supported_quants = []` → `quant = None`).
- **i2v** — a reference still (`sourceAssetId`) → `Conditioning::Reference`; **`strength` is a NO-OP** (`strength: None`). The AR cache-warm has no strength analog and the engine's `run` reads only the image — faithful to the sibling `bernini`/reference paths. Documented + pinned by a test.
- **v2v** — a source clip (`sourceClipAssetId`) → `Conditioning::VideoClip`; **`strength` IS honored** (`videoConditioningStrength`, default 1.0). A clip wins over a still (matches the engine's own `run`).
- **Heartbeat funnel (S8's DoD half):** generation runs through `generate_video` → `generate_video_using` so a long/multi-minute AR job drives `heartbeat(...)` (not `interrupted` by the ~90 s API stale-sweep) and the funnel's per-step cancel trips the engine's `CancelFlag`.
- A t2v mapping test drives `generate_krea_realtime_using` through the funnel against a stub `Generator` and asserts on the exact `GenerationRequest` the engine received (prompt/steps/seed/fps/frames, empty conditioning); a pure conditioning test pins the i2v-drops-strength / v2v-honors-strength invariant.

### `is_krea_realtime_model` decision — kept OUT of core
The shared dimension/duration/fps/area-cap gates in `sceneworks-core/src/video_request.rs` are **manifest-driven** (`limits.requiresDimensionsMultipleOf` / `maxPixels` / `hardMaxDuration` / `fps`) — not keyed on an `is_*_model` predicate — so krea's constraints (H/W multiple of 16, max 1280, fps, duration) join them via the **S11 manifest `limits`** with no core change. `video_frame_count` already falls through to `wan_frame_count` for krea (correct — stock Wan VAE), so no predicate is needed there either; adding one would be a no-op that only widens surface. The exhaustive `shipped_manifest_matches_each_engines_real_geometry` test asserts `models.len() == ENGINE_GEOMETRY.len()` against the shipped manifest, so **when S11 adds the manifest entry it must also add krea to `ENGINE_GEOMETRY`** — flagged for S11.

### LoRA passthrough — clean seam, deferred to S15
The engine advertises `supports_lora = false`, so no adapter is wired (forwarding a LoRA to an engine whose load path ignores it would violate capability honesty). A LoRA-bearing request is **not rejected** — it runs the base DiT — so the worker never breaks on one. The full dense-LoRA integration (via the shared `resolve_dense_adapters`) is sc-8443's **S15**.

### Verification
- `CARGO_BUILD_JOBS=2 cargo check -p sceneworks-worker` — clean (4m55s cold, no warnings).
- New tests green: `krea_realtime_engine_id_maps_only_krea`, `krea_realtime_conditioning_i2v_drops_strength_v2v_honors_it`, `krea_realtime_routes_to_the_krea_engine_and_never_degrades_to_a_fake_video`, `krea_realtime_using_hands_the_engine_the_mapped_t2v_request`, plus the updated `video_jobs_remains_split_into_real_engine_modules` meta-test.
- Full `video_jobs` module: **147 passed, 0 failed, 16 ignored** (real-weight). `cargo fmt -p sceneworks-worker --check` clean.

### Gated remainder
The **real-asset watchable-clip e2e** needs the real ~28 GB DiT and is the gated **S13** validation. The MLX rehost of the turnkey `SceneWorks/krea-realtime-14b-mlx` snapshot is the gated **S2** remainder (sc-8435); `resolve_krea_realtime_model_dir` references it as a local-cache lookup target (no network fetch here).

Story: [sc-8443](https://app.shortcut.com/trefry/story/8443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)