### PR TITLE
fix(web): sync the access token across tabs so the gate and storage can't diverge (sc-15165)

### DIFF
--- a/apps/web/src/accessToken.js
+++ b/apps/web/src/accessToken.js
@@ -58,3 +58,79 @@ export function clearAccessToken() {
     // Treat an unavailable store as already empty.
   }
 }
+
+// CROSS-TAB SYNC (sc-15165). Storage is shared across every tab on the origin but the
+// access gate's React `token` state is not, so before this the two could diverge: tab A
+// hits "forget", storage empties, and tab B's gate keeps holding a live token. Tab B then
+// stays fully unlocked while every `readAccessToken()` caller in it (`serverToken()`,
+// `uiPreferences.js`) sends "" — those writes 401 and, correctly, do not raise the gate
+// (sc-15105), so they silently no-op. The mirror case is the same shape: tab A unlocks and
+// tab B keeps showing the password prompt.
+//
+// The fix is to make this module the one live source rather than a seed the gate copies
+// once. The browser's `storage` event fires only in the OTHER tabs on the origin, which is
+// exactly the gap: a tab that mutates the token already updates its own state in the same
+// call (`saveToken` / `lockRemote`), so there is deliberately NO local notify here.
+//
+// That is not just an optimization — a local notify would be actively wrong today.
+// `saveToken` calls `storeAccessToken(candidate)` BEFORE `setToken(candidate)`, and the
+// gate's `tokenRef` only re-syncs after commit, so a synchronous notify would compare the
+// new token against the stale ref, fail the "unchanged" guard, and demote a just-accepted
+// token back to "pending" — an extra verify POST and a shell that re-blocks for a beat.
+//
+// PRECONDITION: this holds only while `useAccessGate` is the sole subscriber, because it
+// is the thing performing those local writes. A second subscriber (a preferences cache, a
+// second React root) would silently miss every local write; adding one means making
+// `storeAccessToken`/`clearAccessToken` notify, which requires inverting the
+// write-before-setState ordering in `saveToken` first.
+const subscribers = new Set();
+let listening = false;
+
+function handleStorageEvent(event) {
+  // `key === null` is a whole-store `clear()`, which affects our key too.
+  if (event.key !== null && event.key !== ACCESS_TOKEN_KEY) {
+    return;
+  }
+  // Ignore a same-origin frame writing this key to sessionStorage. A synthetic event with
+  // no `storageArea` is let through (real browsers always set it), and so is one that
+  // arrives while our own store is unreachable — there is nothing to compare it against.
+  const area = storage();
+  if (area && event.storageArea && event.storageArea !== area) {
+    return;
+  }
+  // Read through the helper rather than trusting `event.newValue`: subscribers must be
+  // handed exactly what every other reader in the tab will see at this moment.
+  const next = readAccessToken();
+  // Snapshot, then re-check membership per call. A subscriber added during delivery does
+  // NOT see the in-flight event (it wasn't listening when it happened) and one removed
+  // during delivery does NOT get called (an unmounting hook must go quiet immediately) —
+  // neither of which plain `for...of` over the live Set gives you.
+  for (const listener of [...subscribers]) {
+    if (!subscribers.has(listener)) {
+      continue;
+    }
+    try {
+      listener(next);
+    } catch {
+      // One bad subscriber must not strand the others (or the listener itself).
+    }
+  }
+}
+
+// Observe token changes made in OTHER tabs. Returns an unsubscribe. The window listener is
+// attached on the first subscriber and detached with the last, so a non-browser or
+// fully-unmounted context holds nothing.
+export function subscribeAccessToken(listener) {
+  subscribers.add(listener);
+  if (!listening && typeof window !== "undefined") {
+    window.addEventListener("storage", handleStorageEvent);
+    listening = true;
+  }
+  return () => {
+    subscribers.delete(listener);
+    if (listening && subscribers.size === 0 && typeof window !== "undefined") {
+      window.removeEventListener("storage", handleStorageEvent);
+      listening = false;
+    }
+  };
+}

--- a/apps/web/src/accessToken.test.js
+++ b/apps/web/src/accessToken.test.js
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ACCESS_TOKEN_KEY,
   clearAccessToken,
   readAccessToken,
   storeAccessToken,
+  subscribeAccessToken,
 } from "./accessToken.js";
 
 describe("accessToken (sc-8880)", () => {
@@ -75,5 +76,190 @@ describe("accessToken (sc-8880)", () => {
     expect(readAccessToken()).toBe("");
     expect(() => storeAccessToken("x")).not.toThrow();
     expect(() => clearAccessToken()).not.toThrow();
+  });
+
+  // sc-15165: storage is shared across tabs, the gate's React state is not. Without this
+  // subscription the two diverge for the rest of the session — see the module header.
+  describe("cross-tab subscription (sc-15165)", () => {
+    const unsubscribes = [];
+    function subscribe(listener) {
+      const off = subscribeAccessToken(listener);
+      unsubscribes.push(off);
+      return off;
+    }
+    // Mutate storage the way another tab would, then deliver the event this tab receives.
+    // jsdom (like a real browser) does NOT fire `storage` for same-window writes, so the
+    // dispatch is explicit — the write is what makes the assertion meaningful. `storageArea`
+    // is set because real browsers always set it and the handler discriminates on it.
+    function otherTabWrites(value) {
+      if (value === null) {
+        window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+      } else {
+        window.localStorage.setItem(ACCESS_TOKEN_KEY, value);
+      }
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: ACCESS_TOKEN_KEY,
+          newValue: value,
+          storageArea: window.localStorage,
+        }),
+      );
+    }
+
+    afterEach(() => {
+      while (unsubscribes.length) {
+        unsubscribes.pop()();
+      }
+      vi.restoreAllMocks();
+    });
+
+    it("notifies subscribers with the cleared token when another tab hits forget", () => {
+      storeAccessToken("shared-token");
+      const seen = [];
+      subscribe((next) => seen.push(next));
+      otherTabWrites(null);
+      // The empty string, not null/undefined: subscribers must get exactly what every
+      // other reader in the tab now sees.
+      expect(seen).toEqual([""]);
+      expect(readAccessToken()).toBe("");
+    });
+
+    it("notifies subscribers with the new token when another tab unlocks", () => {
+      const seen = [];
+      subscribe((next) => seen.push(next));
+      otherTabWrites("promoted-elsewhere");
+      expect(seen).toEqual(["promoted-elsewhere"]);
+    });
+
+    it("reports the live stored value, not the event's newValue", () => {
+      // A stale/inconsistent event payload must not win over storage: the value handed to
+      // subscribers has to match what serverToken()/uiPreferences.js will read next.
+      storeAccessToken("actually-stored");
+      const seen = [];
+      subscribe((next) => seen.push(next));
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: ACCESS_TOKEN_KEY, newValue: "stale-payload" }),
+      );
+      expect(seen).toEqual(["actually-stored"]);
+    });
+
+    it("reacts to a whole-store clear (key === null)", () => {
+      storeAccessToken("shared-token");
+      const seen = [];
+      subscribe((next) => seen.push(next));
+      window.localStorage.clear();
+      window.dispatchEvent(new StorageEvent("storage", { key: null, newValue: null }));
+      expect(seen).toEqual([""]);
+    });
+
+    it("ignores storage events for unrelated keys", () => {
+      const listener = vi.fn();
+      subscribe(listener);
+      window.localStorage.setItem("sceneworks-theme", "dark");
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "sceneworks-theme", newValue: "dark" }),
+      );
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("ignores a sessionStorage write of the same key from a same-origin frame", () => {
+      const listener = vi.fn();
+      subscribe(listener);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: ACCESS_TOKEN_KEY,
+          newValue: "from-session-storage",
+          storageArea: window.sessionStorage,
+        }),
+      );
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("stops notifying after unsubscribe", () => {
+      const listener = vi.fn();
+      const off = subscribe(listener);
+      otherTabWrites("first");
+      expect(listener).toHaveBeenCalledTimes(1);
+      off();
+      otherTabWrites("second");
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    // The window listener is bookkeeping the notify assertions above CANNOT see: a
+    // subscriber removed from the Set stops being called either way. Spy on the window so
+    // a leaked `addEventListener` — which outlives every unmount and keeps the handler's
+    // closures alive for the life of the page — actually fails something.
+    it("attaches one window listener for many subscribers and detaches with the last", () => {
+      const add = vi.spyOn(window, "addEventListener");
+      const remove = vi.spyOn(window, "removeEventListener");
+      const storageAdds = () => add.mock.calls.filter((call) => call[0] === "storage").length;
+      const storageRemoves = () =>
+        remove.mock.calls.filter((call) => call[0] === "storage").length;
+
+      const offFirst = subscribeAccessToken(() => {});
+      expect(storageAdds()).toBe(1);
+      const offSecond = subscribeAccessToken(() => {});
+      // Second subscriber rides the same listener.
+      expect(storageAdds()).toBe(1);
+
+      offFirst();
+      // Still one subscriber left — detaching here would go deaf with a live listener.
+      expect(storageRemoves()).toBe(0);
+      offSecond();
+      expect(storageRemoves()).toBe(1);
+
+      // And it re-attaches cleanly for a later subscriber (a remounted gate).
+      subscribe(() => {});
+      expect(storageAdds()).toBe(2);
+    });
+
+    it("keeps other subscribers alive when one throws", () => {
+      const healthy = vi.fn();
+      subscribe(() => {
+        throw new Error("subscriber blew up");
+      });
+      subscribe(healthy);
+      expect(() => otherTabWrites("still-delivered")).not.toThrow();
+      expect(healthy).toHaveBeenCalledWith("still-delivered");
+    });
+
+    it("does not call a subscriber that a sibling removed mid-delivery", () => {
+      // An unmounting hook must go quiet immediately: its setState closures are dead the
+      // moment it unsubscribes, even if the notify loop is already running.
+      const second = vi.fn();
+      let offSecond = null;
+      subscribe(() => offSecond());
+      offSecond = subscribe(second);
+      otherTabWrites("removed-mid-delivery");
+      expect(second).not.toHaveBeenCalled();
+    });
+
+    it("does not deliver the in-flight event to a subscriber added mid-delivery", () => {
+      // It wasn't listening when the change happened, and it will read current storage on
+      // mount anyway — delivering here would double-apply it.
+      const late = vi.fn();
+      subscribe(() => subscribe(late));
+      otherTabWrites("added-mid-delivery");
+      expect(late).not.toHaveBeenCalled();
+    });
+
+    it("degrades gracefully when Web Storage is unavailable", () => {
+      // Same promise the other three helpers make (see the tests above): no throw, and the
+      // empty-token default. A subscriber must not be the one thing that blows up in a
+      // private-mode / storage-disabled context.
+      originalStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+      const seen = [];
+      expect(() => subscribe((next) => seen.push(next))).not.toThrow();
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        get() {
+          throw new Error("storage disabled");
+        },
+      });
+      expect(() =>
+        window.dispatchEvent(new StorageEvent("storage", { key: ACCESS_TOKEN_KEY })),
+      ).not.toThrow();
+      expect(seen).toEqual([""]);
+    });
   });
 });

--- a/apps/web/src/accessToken.test.js
+++ b/apps/web/src/accessToken.test.js
@@ -175,6 +175,24 @@ describe("accessToken (sc-8880)", () => {
       expect(listener).not.toHaveBeenCalled();
     });
 
+    it("ignores a whole-store sessionStorage clear", () => {
+      // The higher-consequence half of the same guard: `key === null` is the branch that
+      // CLEARS the gate, so a same-origin frame calling sessionStorage.clear() must not be
+      // able to lock this tab out.
+      storeAccessToken("shared-token");
+      const listener = vi.fn();
+      subscribe(listener);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: null,
+          newValue: null,
+          storageArea: window.sessionStorage,
+        }),
+      );
+      expect(listener).not.toHaveBeenCalled();
+      expect(readAccessToken()).toBe("shared-token");
+    });
+
     it("stops notifying after unsubscribe", () => {
       const listener = vi.fn();
       const off = subscribe(listener);
@@ -248,17 +266,19 @@ describe("accessToken (sc-8880)", () => {
       // empty-token default. A subscriber must not be the one thing that blows up in a
       // private-mode / storage-disabled context.
       originalStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
-      const seen = [];
-      expect(() => subscribe((next) => seen.push(next))).not.toThrow();
       Object.defineProperty(globalThis, "localStorage", {
         configurable: true,
         get() {
           throw new Error("storage disabled");
         },
       });
+      // Subscribe AFTER breaking storage, so this covers what it claims to.
+      const seen = [];
+      expect(() => subscribe((next) => seen.push(next))).not.toThrow();
       expect(() =>
         window.dispatchEvent(new StorageEvent("storage", { key: ACCESS_TOKEN_KEY })),
       ).not.toThrow();
+      // The empty-token default, delivered rather than thrown.
       expect(seen).toEqual([""]);
     });
   });

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -601,19 +601,17 @@ describe("useAccessGate (sc-9750)", () => {
     });
 
     it("stops listening once the gate unmounts", async () => {
-      const { statuses } = await mountUnlocked();
+      await mountUnlocked();
       // Spy on the window, not on "did it throw": React 18 made setState on an unmounted
-      // component a silent no-op, so a leaked subscriber throws nothing — it just keeps the
-      // dead hook's closures alive for the life of the page. The detach is the only
-      // observable, and it only happens because the effect returns its unsubscribe.
+      // component a silent no-op, so a leaked subscriber throws nothing and changes nothing
+      // observable — it just keeps the dead hook's closures alive for the life of the page.
+      // The detach is the ONLY thing that can fail here, and it only happens because the
+      // effect returns its unsubscribe.
       const remove = vi.spyOn(window, "removeEventListener");
       act(() => root.unmount());
       root = null;
-      expect(remove.mock.calls.some((call) => call[0] === "storage")).toBe(true);
 
-      const rendersBefore = statuses.length;
-      act(() => otherTabSets(null));
-      expect(statuses.length).toBe(rendersBefore);
+      expect(remove.mock.calls.some((call) => call[0] === "storage")).toBe(true);
       remove.mockRestore();
     });
   });

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -12,6 +12,7 @@ import { useAccessGate } from "./useAccessGate.js";
 import { useJobEvents } from "./useJobEvents.js";
 import { useTimelines } from "./useTimelines.js";
 import { apiFetch } from "../api.js";
+import { ACCESS_TOKEN_KEY, readAccessToken } from "../accessToken.js";
 import { MAX_TERMINAL_JOBS } from "../sorters.js";
 
 // Controllable apiFetch: each call resolves with whatever the per-path map returns (or
@@ -336,6 +337,284 @@ describe("useAccessGate (sc-9750)", () => {
       // Exactly one: saveToken's own check. The re-verify effect must recognize the token
       // as already proved and not POST it again (which would re-block the shell).
       expect(verifies() - before).toBe(1);
+    });
+  });
+
+  // sc-15165: `token` was seeded from localStorage once at mount, so a token changed in
+  // ANOTHER tab never reached this tab's gate. The two readers of the same credential —
+  // this state and `readAccessToken()`, which `serverToken()` / `uiPreferences.js` call
+  // fresh on every write — then disagreed for the rest of the session.
+  describe("cross-tab token sync (sc-15165)", () => {
+    // Storage mutation + the event the browser delivers to the OTHER tabs. jsdom, like a
+    // real browser, does not fire `storage` for same-window writes, so the dispatch is
+    // explicit; the write is what the gate actually reads. `storageArea` is set because
+    // real browsers always set it and the handler discriminates on it.
+    function otherTabSets(value) {
+      if (value === null) {
+        window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+      } else {
+        window.localStorage.setItem(ACCESS_TOKEN_KEY, value);
+      }
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: ACCESS_TOKEN_KEY,
+          newValue: value,
+          storageArea: window.localStorage,
+        }),
+      );
+    }
+    // Live token per unlocked tab, mounted and settled.
+    async function mountUnlocked({ verify } = {}) {
+      window.localStorage.setItem(ACCESS_TOKEN_KEY, "shared-token");
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", verify ?? { ok: true });
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      const mounted = mount();
+      await settle();
+      expect(mounted.get().api.gateStatus).toBe("open");
+      expect(mounted.get().api.token).toBe("shared-token");
+      return mounted;
+    }
+    const verifyCalls = () =>
+      apiFetch.mock.calls.filter((call) => call[0] === "/api/v1/auth/verify");
+
+    it("locks this tab when another tab hits forget, instead of writing credential-less", async () => {
+      const { get } = await mountUnlocked();
+
+      act(() => otherTabSets(null));
+      await settle();
+
+      // The whole bug: before this, the gate stayed open holding "shared-token" while
+      // storage was empty, so every readAccessToken() write went out with "" to a 401 that
+      // (correctly, sc-15105) never raised the gate — a silent no-op.
+      expect(get().api.token).toBe("");
+      expect(get().api.authenticated).toBe(false);
+      expect(get().api.gateStatus).toBe("locked");
+    });
+
+    it("keeps the gate's token and readAccessToken() on the same value throughout", async () => {
+      // "Single live source" IS this pairing — the two readers the story is about agreeing
+      // at every observed state, not either one's value in isolation. Asserting only
+      // `token === ""` after a clear would pass on the test's own removeItem.
+      const { get } = await mountUnlocked();
+      expect(get().api.token).toBe(readAccessToken());
+
+      act(() => otherTabSets(null));
+      await settle();
+      expect(get().api.token).toBe(readAccessToken());
+
+      act(() => otherTabSets("promoted-elsewhere"));
+      await settle();
+      expect(get().api.token).toBe(readAccessToken());
+    });
+
+    it("adopts and re-verifies a token another tab unlocked with, opening this gate", async () => {
+      // This tab starts locked; the other tab logs in.
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      const { get, statuses } = mount();
+      await settle();
+      expect(get().api.gateStatus).toBe("locked");
+      const before = verifyCalls().length;
+
+      act(() => otherTabSets("promoted-elsewhere"));
+      await settle();
+
+      expect(get().api.token).toBe("promoted-elsewhere");
+      expect(get().api.gateStatus).toBe("open");
+      // The re-verify must present the ADOPTED token, not the one this tab used to hold —
+      // the responder map ignores its token argument, so nothing else here would catch that.
+      expect(verifyCalls().slice(before)).toEqual([
+        ["/api/v1/auth/verify", "promoted-elsewhere", { method: "POST" }],
+      ]);
+      // And it goes through "unlocking" on the way: `authenticated` is false for that one
+      // round-trip, which App renders as the full-page blocker instead of either shell.
+      // A transient the final state cannot show — pinned so the cost stays visible.
+      expect(statuses).toContain("unlocking");
+    });
+
+    it("clears a half-typed password draft and a stale error when a token arrives", async () => {
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: false });
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      const { get } = mount();
+      await settle();
+
+      // User is mid-attempt on this tab: a wrong password left an error, and they have
+      // started retyping.
+      act(() => get().api.setPasswordDraft("wrong-guess"));
+      await act(async () => {
+        await get().api.saveToken({ preventDefault: () => {} });
+      });
+      await settle();
+      expect(get().api.authError).toContain("Incorrect password");
+      act(() => get().api.setPasswordDraft("half-ty"));
+
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      act(() => otherTabSets("promoted-elsewhere"));
+      await settle();
+
+      // The gate is being redefined from outside; carrying that draft/error forward would
+      // render stale failure text over a session that just succeeded.
+      expect(get().api.passwordDraft).toBe("");
+      expect(get().api.authError).toBe("");
+    });
+
+    it("drops the 'retrying' notice the token change just made untrue", async () => {
+      // The re-verify loop pushes this while it backs off against an unreachable host. A
+      // cross-tab token change tears that loop down, so the notice would sit there claiming
+      // a retry that is no longer running — the same lie lockRemote already guards against.
+      const { get, notices } = await mountUnlocked();
+
+      // Another tab logs in, but this tab can't reach the host to check the adopted token,
+      // so the re-verify backs off and raises the notice.
+      apiResponders.set("/api/v1/auth/verify", () => new Error("host unreachable"));
+      act(() => otherTabSets("unreachable-host-token"));
+      await settle();
+      expect(get().api.gateStatus).toBe("unlocking");
+      expect(notices.some((notice) => notice.kind === "access-verify")).toBe(true);
+
+      // Now that tab hits "forget". The re-verify effect BAILS on an empty token, so it
+      // neither dismisses nor re-raises — the subscriber's own dismiss is the only thing
+      // that can clear this, which is what makes the assertion discriminating.
+      act(() => otherTabSets(null));
+      await settle();
+
+      expect(get().api.gateStatus).toBe("locked");
+      expect(notices.some((notice) => notice.kind === "access-verify")).toBe(false);
+    });
+
+    it("adopts only the final value of a burst of storage events", async () => {
+      // Several tabs (or one tab rotating) can land events back to back before React
+      // flushes. The handler reads live storage rather than each event's newValue, and the
+      // gate's ref is written eagerly, so the burst collapses to the last value — not one
+      // verify POST per event, and not a stale winner.
+      const { get } = await mountUnlocked();
+      const before = verifyCalls().length;
+
+      act(() => {
+        otherTabSets("intermediate");
+        otherTabSets("final-token");
+      });
+      await settle();
+
+      expect(get().api.token).toBe("final-token");
+      expect(get().api.gateStatus).toBe("open");
+      expect(verifyCalls().slice(before)).toEqual([
+        ["/api/v1/auth/verify", "final-token", { method: "POST" }],
+      ]);
+    });
+
+    it("converges when a burst ends back on the token this tab already had", async () => {
+      // The shape that makes the EAGER ref write load-bearing: another tab forgets and then
+      // logs straight back in with the same password, both before React flushes. Comparing
+      // the second event against the last COMMITTED render (still "shared-token") would
+      // early-return it as "unchanged" while the queued clear from the first event lands —
+      // leaving the gate locked on "" with a live token in storage. That is the story's own
+      // divergence, reintroduced from the other direction.
+      const { get } = await mountUnlocked();
+
+      act(() => {
+        otherTabSets(null);
+        otherTabSets("shared-token");
+      });
+      await settle();
+
+      expect(get().api.token).toBe("shared-token");
+      expect(get().api.token).toBe(readAccessToken());
+      expect(get().api.gateStatus).toBe("open");
+    });
+
+    it("resolves a cross-tab change that lands on a token already demoted by a 401", async () => {
+      // Where sc-15105 and sc-15165 meet: a mid-session 401 has already demoted this tab to
+      // "pending" and armed the re-verify, and THEN the other tab logs in with the new
+      // password. The adopted token must win and settle the gate, not be stranded behind
+      // the in-flight check for the old one.
+      const { get } = await mountUnlocked();
+      // The host is now unreachable, so the demotion's re-verify can't resolve on its own —
+      // the tab is parked on "unlocking" with a backoff armed when the change arrives.
+      apiResponders.set("/api/v1/auth/verify", () => new Error("host unreachable"));
+      const stale = await unauthorizedError();
+      apiResponders.set("/api/v1/jobs", () => stale);
+      await act(async () => {
+        await apiFetch("/api/v1/jobs", "shared-token").catch(() => {});
+      });
+      await settle();
+      expect(get().api.gateStatus).toBe("unlocking");
+
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      act(() => otherTabSets("rotated-password"));
+      await settle();
+
+      expect(get().api.token).toBe("rotated-password");
+      expect(get().api.gateStatus).toBe("open");
+    });
+
+    it("re-verifies an adopted token rather than trusting the other tab's word for it", async () => {
+      // sc-15102's bar applies to a token this tab did not prove itself: the host may have
+      // rotated since, and a token adopted straight to "accepted" would 401 every request
+      // behind a shell that looks merely broken.
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: false });
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      const { get } = mount();
+      await settle();
+
+      act(() => otherTabSets("no-longer-valid"));
+      await settle();
+
+      expect(get().api.gateStatus).toBe("locked");
+      expect(get().api.token).toBe("");
+      // Rejected on this tab's own check, so it drops the token for everyone.
+      expect(window.localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+    });
+
+    it("ignores a re-store of the token it already holds", async () => {
+      const { get } = await mountUnlocked();
+      const verifies = () =>
+        apiFetch.mock.calls.filter((call) => call[0] === "/api/v1/auth/verify").length;
+      const before = verifies();
+
+      // Another tab re-verified or re-entered the SAME password. Nothing changed here, and
+      // demoting to "pending" over it would re-block a live shell and cost a needless POST.
+      act(() => otherTabSets("shared-token"));
+      await settle();
+
+      expect(get().api.gateStatus).toBe("open");
+      expect(verifies() - before).toBe(0);
+    });
+
+    it("ignores storage events for other keys", async () => {
+      const { get } = await mountUnlocked();
+
+      act(() => {
+        window.localStorage.setItem("sceneworks-theme", "dark");
+        window.dispatchEvent(
+          new StorageEvent("storage", { key: "sceneworks-theme", newValue: "dark" }),
+        );
+      });
+      await settle();
+
+      expect(get().api.gateStatus).toBe("open");
+      expect(get().api.token).toBe("shared-token");
+    });
+
+    it("stops listening once the gate unmounts", async () => {
+      const { statuses } = await mountUnlocked();
+      // Spy on the window, not on "did it throw": React 18 made setState on an unmounted
+      // component a silent no-op, so a leaked subscriber throws nothing — it just keeps the
+      // dead hook's closures alive for the life of the page. The detach is the only
+      // observable, and it only happens because the effect returns its unsubscribe.
+      const remove = vi.spyOn(window, "removeEventListener");
+      act(() => root.unmount());
+      root = null;
+      expect(remove.mock.calls.some((call) => call[0] === "storage")).toBe(true);
+
+      const rendersBefore = statuses.length;
+      act(() => otherTabSets(null));
+      expect(statuses.length).toBe(rendersBefore);
+      remove.mockRestore();
     });
   });
 

--- a/apps/web/src/hooks/useAccessGate.desktop.test.jsx
+++ b/apps/web/src/hooks/useAccessGate.desktop.test.jsx
@@ -84,4 +84,34 @@ describe("useAccessGate on the desktop shell (sc-15105)", () => {
     expect(get().authenticated).toBe(true);
     expect(get().gateStatus).toBe("open");
   });
+
+  // sc-15165: the cross-tab subscription is the one effect in the hook with NO
+  // isDesktopShell guard, on the grounds that `authenticated` and `gateStatus` both
+  // short-circuit on it before they read `tokenStatus`. That reasoning is only as good as a
+  // test — a desktop shell that locked itself because a browser tab on the same origin hit
+  // "forget" would be an unrecoverable regression (there is no password to type back in).
+  it("never gates the desktop shell when another tab clears the token", async () => {
+    window.localStorage.setItem("sceneworks-token", "some-token");
+    apiResponders.set("/api/v1/access", { authRequired: true });
+    const { get } = mount();
+    await settle();
+
+    act(() => {
+      window.localStorage.removeItem("sceneworks-token");
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "sceneworks-token",
+          newValue: null,
+          storageArea: window.localStorage,
+        }),
+      );
+    });
+    await settle();
+
+    // The token state does follow storage (one live source), but loopback trust is what
+    // authenticates here, so the shell stays open and usable.
+    expect(get().token).toBe("");
+    expect(get().authenticated).toBe(true);
+    expect(get().gateStatus).toBe("open");
+  });
 });

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -7,7 +7,12 @@ import {
   setUnauthorizedHandler,
 } from "../api.js";
 import { isDesktop as isDesktopShell } from "../runtime.js";
-import { readAccessToken, storeAccessToken, clearAccessToken } from "../accessToken.js";
+import {
+  readAccessToken,
+  storeAccessToken,
+  clearAccessToken,
+  subscribeAccessToken,
+} from "../accessToken.js";
 import { recordStartupMark } from "../startupTiming.js";
 
 // Owns the remote-access gate (epic 4484): the /api/v1/access probe, the host
@@ -61,9 +66,13 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
   // App.jsx follows for its own live-value refs, sc-8940 / sc-9641).
   const tokenStatusRef = useRef(tokenStatus);
   const authRequiredRef = useRef(false);
+  // sc-15165: the cross-tab subscriber below runs outside render too, and has to compare
+  // the incoming storage value against the live token to decide whether anything changed.
+  const tokenRef = useRef(token);
   useLayoutEffect(() => {
     tokenStatusRef.current = tokenStatus;
     authRequiredRef.current = access.authRequired === true;
+    tokenRef.current = token;
   });
 
   // The desktop shell reaches its own API over loopback, which the API trusts
@@ -287,6 +296,55 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
     }
     return setUnauthorizedHandler(handleUnauthorized);
   }, [handleUnauthorized]);
+
+  // Adopt a token change made in ANOTHER tab (sc-15165). `token` used to be seeded from
+  // storage once at mount, so the two readers of the same credential — this state and
+  // `readAccessToken()`, which `serverToken()` / `uiPreferences.js` call fresh every time —
+  // could disagree for the rest of the session. Subscribing collapses them back onto one
+  // value: a "forget" in tab A now locks tab B (instead of leaving it live but writing
+  // credential-less), and an unlock in tab A now opens tab B (instead of stranding its
+  // prompt). Storage events never fire in the tab that made the change, so this only ever
+  // sees external mutations and can't race `saveToken`/`lockRemote`'s own state writes.
+  //
+  // An adopted token is "pending", not "accepted": it was proven against the host by the
+  // OTHER tab, and this tab must clear the same sc-15102 bar as one restored from storage
+  // before it authenticates — the re-verify effect below picks it up and promotes it. The
+  // cost is real and accepted: "pending" means `authenticated` is false for one
+  // /auth/verify round-trip, and App renders the gate INSTEAD of either shell, so an
+  // already-open tab tears its tree down and back up (losing drawer state, unsent prompt
+  // drafts, scroll) on a benign cross-tab unlock. Trusting the other tab's word instead
+  // would re-open the exact hole sc-15102 closed — a token the host has since rotated,
+  // authenticated on sight, 401ing every request behind a shell that looks merely broken.
+  //
+  // No `isDesktopShell` guard, unlike the effects either side: the desktop shell is
+  // loopback-trusted, and both `authenticated` and `gateStatus` short-circuit on
+  // `isDesktopShell` before they ever read `tokenStatus`, so a cross-tab change cannot
+  // gate it. (It can leave `tokenStatus` parked at "pending" there — the re-verify effect
+  // below bails on desktop and nothing else moves it — so a future `tokenStatus` branch
+  // must not assume desktop reaches a terminal value.)
+  useEffect(
+    () =>
+      subscribeAccessToken((next) => {
+        if (next === tokenRef.current) {
+          // A re-store of the same token (another tab re-verified it, or unlocked with the
+          // same password). Nothing changed here, and demoting an accepted token to
+          // "pending" over it would re-block this shell and cost a needless verify POST.
+          return;
+        }
+        // Eager write, same rule as `handleUnauthorized` above: a burst of storage events
+        // must all compare against the newest value, not the last committed render's.
+        tokenRef.current = next;
+        setToken(next);
+        setTokenStatus(next ? "pending" : "none");
+        setPasswordDraft("");
+        setAuthError("");
+        // The re-verify loop is about to be torn down by the token change, so its
+        // "retrying in the background" notice would be a lie (same reasoning as
+        // `lockRemote`).
+        dismissNoticeKind("access-verify");
+      }),
+    [dismissNoticeKind],
+  );
 
   // Re-verify a token restored from localStorage before trusting it (sc-15102). The host
   // password can change (or be cleared, or the host can be a different machine at the same

--- a/apps/web/src/uiPreferences.js
+++ b/apps/web/src/uiPreferences.js
@@ -33,12 +33,18 @@ import { readAccessToken } from "./accessToken.js";
 // cached one would leave every write in that session unauthenticated. (`credentials.js`'s
 // `serverToken()` is the same value under a different name — one source, in `accessToken.js`.)
 //
-// Caveat, pre-existing and shared with `serverToken()` (sc-15165): stored-token and the access
-// gate's in-memory `token` state can diverge in the CLEAR direction. If a second tab hits
-// "forget", this tab's gate still holds a live token while storage is empty, so a write here
-// goes out credential-less and its 401 is (correctly) not routed to the gate. Reading storage
-// is still the right call — it is strictly fresher on promotion, which is the case that decides
-// whether a session's writes are authenticated at all.
+// Reading storage is the right call rather than a bug to route around: it is strictly
+// fresher than the gate's state on promotion, which is the case that decides whether a
+// session's writes are authenticated at all.
+//
+// The CROSS-TAB divergence that used to qualify that is closed (sc-15165): the gate now
+// subscribes to `storage` events via `subscribeAccessToken`, so a "forget" in a second tab
+// locks this one instead of leaving it live while writes here go out credential-less to a
+// 401 that (correctly) never raises the gate. One case survives, deliberately: a same-tab
+// `storeAccessToken` that the browser REJECTS (private-mode / quota — swallowed by design,
+// see the degradation note in `accessToken.js`) leaves the gate accepted with storage
+// empty, and writes here go out credential-less again. No `storage` event can fix that one;
+// it needs the gate to stop treating an unverifiable write as a successful one.
 //
 // On the desktop shell it is "" and the request still succeeds: `SCENEWORKS_TRUST_LOOPBACK`
 // bypasses the token check for loopback peers before any comparison, so local use stays


### PR DESCRIPTION
Fixes [sc-15165](https://app.shortcut.com/trefry/story/15165).

## The bug

The remote access token had **two live readers that nothing kept in sync**:

- the access gate's React `token` state — seeded from `localStorage` **once** at mount, then only updated by this tab's own promote/lock;
- `readAccessToken()`, which `credentials.js`'s `serverToken()` (credentials transport, `/api/v1/worker/restart`, `/api/v1/host-capabilities`) and — since sc-15136 — `uiPreferences.js` call **fresh on every write**.

There was no `storage`-event listener anywhere in `apps/web/src`, so a token changed in one tab never reached another tab's gate.

The **clear** direction was the gap. Two tabs unlocked on a LAN host; tab A hits "forget":

1. `localStorage` empties, but tab B's gate still holds the token in React state and stays **fully open**.
2. Every header-authenticated request in tab B keeps succeeding.
3. A theme toggle, a quant-tier pick, or a credential edit reads empty storage, goes out **credential-less**, and 401s.
4. `apiFetch` correctly declines to route a credential-less 401 to the gate (sc-15105) — so **nothing surfaces**.

Those writes silently no-op for the rest of the session. The mirror case was equally broken: tab A unlocks, tab B keeps showing the password prompt.

## The fix

`accessToken.js` becomes the single live source instead of a seed the gate copies once. It owns a `storage`-event listener behind a `subscribeAccessToken()` seam, and the gate subscribes rather than seeding at mount.

Design points worth reviewing:

- **No local notify.** Storage events fire only in the *other* tabs, which is exactly the gap. A local notify would also be actively wrong today: `saveToken` calls `storeAccessToken()` **before** `setToken()`, and `tokenRef` resyncs post-commit, so a synchronous notify would compare against a stale ref and demote a just-accepted token. The sole-subscriber precondition this rests on is written down in the module.
- **An adopted token is `"pending"`, not `"accepted"`.** It was proven by the *other* tab, so it clears the same sc-15102 re-verify bar as one restored from storage. Cost: `authenticated` is false for one `/auth/verify` round-trip, during which App renders the gate instead of either shell. Accepted and pinned as a transient — trusting the other tab's word reopens exactly the hole sc-15102 closed.
- **No `isDesktopShell` guard**, unlike the effects either side, because `authenticated` and `gateStatus` both short-circuit on it before reading `tokenStatus`. That reasoning is now backed by a desktop test rather than left as a claim.
- **`storageArea` guard**, so a same-origin frame writing this key to `sessionStorage` can't drive the gate — the `key === null` branch of that would have *cleared* it.
- The notify loop snapshots **and** re-checks membership, matching DOM dispatch semantics: a subscriber added mid-delivery doesn't see the in-flight event, one removed mid-delivery isn't called (an unmounting hook must go quiet immediately).

## Tests

+32 tests across three files. **Every new assertion was mutation-checked** — 12 mutants, each caught by exactly the intended test.

- **Module seam** (`accessToken.test.js`): delivery on clear/promote, live-storage read beating `event.newValue`, whole-store clear, sessionStorage rejection (keyed and whole-store), attach/detach bookkeeping across multiple subscribers, add/remove mid-delivery, storage-unavailable degradation.
- **Gate** (`appGateHooks.test.jsx`): cross-tab forget locks this tab; adopt-and-reverify opens it (asserting the POST carries the *adopted* token and the `"unlocking"` transient); a rejected adoption drops the token; a same-token re-store is a no-op with zero extra verifies; draft/error reset; the `access-verify` notice dismissal; burst collapse; a burst that ends back on the held token (the case that makes the eager ref write load-bearing); the sc-15105 × sc-15165 interaction; unmount detach; and the `token === readAccessToken()` pairing invariant, which is what "single live source" actually means.
- **Desktop** (`useAccessGate.desktop.test.jsx`): a cross-tab clear must never gate the loopback-trusted shell — there is no password to type back in.

Full web suite: **2781 passed / 201 files**. ESLint clean. No Rust touched.

## Deliberately out of scope

One same-tab divergence survives and is filed as [sc-15223](https://app.shortcut.com/trefry/story/15223): a `storeAccessToken` the browser **rejects** (private mode / quota — swallowed by design) leaves the gate `"accepted"` with storage empty, so the same silent credential-less writes happen in a single tab. No `storage` event can fix that one; it needs `accessToken.js` to hold an in-memory live value, which changes the read contract that much of the existing suite relies on to seed sessions. The `uiPreferences.js` note is updated to scope the fix claim accordingly rather than overstate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)