### PR TITLE
Fix Z-Image quant tier routing and quiet claim polling logs

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -954,6 +954,16 @@ fn normalized_api_route(path: &str, matched_path: Option<&str>) -> Option<String
     None
 }
 
+/// Worker claim is a one-second idle poll, so logging every successful sub-millisecond response
+/// floods the session ring buffer and pushes actionable events out of the Logs screen. Keep the
+/// Server-Timing header on every response, but emit the duration event for this route only when the
+/// request fails or is unexpectedly slow. All other API/MCP routes retain per-request timing logs.
+const SLOW_CLAIM_REQUEST_MS: f64 = 1_000.0;
+
+fn should_log_api_request_duration(route: &str, status: StatusCode, elapsed_ms: f64) -> bool {
+    route != "/api/v1/jobs/claim" || !status.is_success() || elapsed_ms >= SLOW_CLAIM_REQUEST_MS
+}
+
 async fn api_request_timing(request: AxumRequest, next: Next) -> Response {
     let method = request.method().clone();
     // `Uri::path()` excludes the query by contract. Retain it only long enough
@@ -974,14 +984,16 @@ async fn api_request_timing(request: AxumRequest, next: Next) -> Response {
                 .headers_mut()
                 .insert(HeaderName::from_static("server-timing"), value);
         }
-        tracing::info!(
-            event = "api_request_duration",
-            method = %method,
-            route,
-            status = response.status().as_u16(),
-            duration_ms = elapsed_ms,
-            "SceneWorks API response completed"
-        );
+        if should_log_api_request_duration(&route, response.status(), elapsed_ms) {
+            tracing::info!(
+                event = "api_request_duration",
+                method = %method,
+                route,
+                status = response.status().as_u16(),
+                duration_ms = elapsed_ms,
+                "SceneWorks API response completed"
+            );
+        }
     }
 
     response

--- a/apps/rust-api/src/tests/server.rs
+++ b/apps/rust-api/src/tests/server.rs
@@ -36,6 +36,30 @@ fn api_timing_route_labels_exclude_ids_queries_and_unknown_path_tails() {
     assert_eq!(normalized_api_route("/assets/index.js", None), None);
 }
 
+#[test]
+fn successful_idle_claim_poll_does_not_emit_request_duration_noise() {
+    assert!(
+        !should_log_api_request_duration("/api/v1/jobs/claim", StatusCode::OK, 0.91),
+        "the worker's one-second successful claim poll must not flood session logs"
+    );
+    assert!(
+        should_log_api_request_duration(
+            "/api/v1/jobs/claim",
+            StatusCode::INTERNAL_SERVER_ERROR,
+            0.91
+        ),
+        "failed claims remain observable"
+    );
+    assert!(
+        should_log_api_request_duration("/api/v1/jobs/claim", StatusCode::OK, 1_000.0),
+        "unexpectedly slow claims remain observable"
+    );
+    assert!(
+        should_log_api_request_duration("/api/v1/jobs", StatusCode::OK, 0.91),
+        "ordinary API request timing remains unchanged"
+    );
+}
+
 #[tokio::test]
 async fn api_timing_adds_numeric_server_timing_to_success_and_error_responses() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -20,11 +20,11 @@ pub(crate) use crate::{
     inprocess_utility_worker_id, inprocess_worker_gpu_id, lora_artifact_paths,
     merge_model_manifest_entry, mlx_catalog_status, normalized_api_route,
     open_bind_override_enabled, parse_inprocess_utility_worker_count, safe_download_dir,
-    seed_mode_for_config_dir, serialize_job_lora, should_warn_open_bind, strip_jsonc_comments,
-    sweep_stale_asset_uploads_before, sweep_stale_lora_uploads_before, sweep_stale_uploads,
-    validate_model_id, Settings, WorkerCapability, WorkerSnapshot, WorkerStatus,
-    API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST, EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA,
-    HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    seed_mode_for_config_dir, serialize_job_lora, should_log_api_request_duration,
+    should_warn_open_bind, strip_jsonc_comments, sweep_stale_asset_uploads_before,
+    sweep_stale_lora_uploads_before, sweep_stale_uploads, validate_model_id, Settings,
+    WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST,
+    EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
 };
 
 pub(crate) use axum::body::{to_bytes, Body};

--- a/crates/sceneworks-core/src/jobs_store/routing/candle.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/candle.rs
@@ -319,9 +319,10 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     }
     // Lens / Lens-Turbo and Krea 2 Turbo advertise Q4/Q8 + LoRA/LoKr, so a quant request OR a LoRA stays
     // on the candle lane for them (Krea gained Q4/Q8 in sc-9607, joining Lens in the both-set — sc-9983).
-    // SD3.5 (sc-7880), the Ideogram/Boogu packed families (sc-9607), and Qwen-Image (sc-11020, its
-    // turnkey q4/q8/bf16 tiers) advertise Q4/Q8 but NOT inference LoRA (quant stays, LoRA defers). Every
-    // other candle family advertises neither and defers both. The
+    // Z-Image (Turbo/base), SD3.5 (sc-7880), the Ideogram/Boogu packed families (sc-9607), and Qwen-Image
+    // (sc-11020) accept Q4/Q8 but NOT inference LoRA (quant stays, LoRA defers). Z-Image's value is a
+    // pre-packed tier SELECT, not an on-the-fly quantization request; the shared gate intentionally
+    // covers both forms. Every other candle family advertises neither and defers both. The
     // two capabilities are decoupled: `supports_lora` and `supports_quant` each consult the both-set plus
     // their own list.
     let supports_lora =
@@ -347,12 +348,12 @@ pub(crate) fn image_request_candle_eligible(model: &str, payload: &Map<String, V
     if has_poses {
         return false;
     }
-    // On-the-fly quantization (`advanced.mlxQuantize` > 0) is refused UNLESS the family advertises quant.
+    // A quant/tier request (`advanced.mlxQuantize` > 0) is refused UNLESS the family advertises quant.
     // The sc-3675/sc-5096 candle providers advertise `supported_quants: &[]` (dense bf16/fp16 only), so
     // an explicit quant request can't be honored — refuse it rather than silently running dense
     // (sc-5099). Lens (sc-5126), SD3.5 (sc-7880), Krea (sc-9607/sc-9983), the Ideogram/Boogu packed
-    // families (sc-9607), and Qwen-Image (sc-11020) advertise Q4/Q8, so their quant requests stay on
-    // candle. For the packed families
+    // families (sc-9607), Qwen-Image (sc-11020), and Z-Image advertise Q4/Q8, so their quant requests
+    // stay on candle. For the packed families
     // the `mlxQuantize` value is a turnkey tier-SELECT (which pre-quantized q4/q8 subdir to load), a no-op
     // on the loader rather than a runtime quantize — but the gate is the same: quant-capable → stay.
     if !supports_quant && candle_request_wants_quant(payload) {

--- a/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/catalog.rs
@@ -471,8 +471,8 @@ pub fn mac_capabilities(platform: &str, mac_gating_active: bool) -> MacCapabilit
 /// unchanged — this struct is purely the single source those constants are generated from.
 ///
 /// **Superset invariant (enforced):** `candle_quant`, `candle_lora`, and `candle_quant_lora` all
-/// imply `candle_routed` — a model can only advertise on-the-fly quant / inference LoRA on the candle
-/// lane if it is candle-routed at all. Encoded structurally by [`ModelCaps::new`] (a `debug_assert`
+/// imply `candle_routed` — a model can only advertise a quant tier/select or inference LoRA on the
+/// candle lane if it is candle-routed at all. Encoded structurally by [`ModelCaps::new`] (a `debug_assert`
 /// on every constructed row) and asserted exhaustively over the table by the
 /// `quant_and_lora_columns_are_candle_routed_supersets` test.
 #[derive(Clone, Copy)]
@@ -483,11 +483,13 @@ pub(crate) struct ModelCaps {
     pub(crate) mlx_routed: bool,
     /// The candle (Windows/CUDA) lane serves this model's base txt2img (was `CANDLE_ROUTED_MODELS`).
     pub(crate) candle_routed: bool,
-    /// Candle advertises on-the-fly Q4/Q8 quant but NOT inference LoRA (was `CANDLE_QUANT_MODELS`).
+    /// Candle accepts Q4/Q8 generation requests (either a packed-tier select or load-time quant) but
+    /// NOT inference LoRA (was `CANDLE_QUANT_MODELS`).
     pub(crate) candle_quant: bool,
     /// Candle advertises inference LoRA/LoKr but NOT on-the-fly quant (was `CANDLE_LORA_MODELS`).
     pub(crate) candle_lora: bool,
-    /// Candle advertises BOTH on-the-fly quant AND inference LoRA (was `CANDLE_QUANT_LORA_MODELS`).
+    /// Candle accepts BOTH Q4/Q8 generation requests AND inference LoRA
+    /// (was `CANDLE_QUANT_LORA_MODELS`).
     pub(crate) candle_quant_lora: bool,
 }
 
@@ -580,7 +582,14 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // sc-3022 Z-Image / sc-3023 FLUX.1 / sc-3024 Qwen / sc-3025 FLUX.2 / sc-3026 SDXL — the founding
     // MLX-routed families (grows one family story at a time as each lands real generation in
     // `sceneworks-worker::image_jobs`). CANDLE: SDXL sc-3678, the four families sc-5096.
-    ModelCaps::new("z_image_turbo", true, true, false, false, false),
+    //
+    // Z-Image's candle descriptor deliberately keeps `supported_quants: []`: it does not quantize a
+    // dense checkpoint on the fly. That is NOT the capability this routing bit represents for its
+    // turnkey. `advanced.mlxQuantize` selects an already-packed q4/q8/bf16 directory, and
+    // candle-gen-z-image packed-detects those components from their config. The manifests advertise
+    // `standardTierLayout` and measured candle Q4/BF16 VRAM. Keeping `candle_quant = false` therefore
+    // rejected a valid Q4 tier select as `candle_unsupported` before the worker could load it.
+    ModelCaps::new("z_image_turbo", true, true, true, false, false),
     // Base (non-distilled, full-CFG) Z-Image (epic 8236, sc-8379 control + sc-8679 txt2img). MLX-routed
     // on macOS AND candle-routed off-Mac. The worker registers a real `z_image` MLX engine (MODEL_TABLE:
     // shift-6.0 / ~50-step / real CFG, `mlx_z_image` adapter) plus base strict-control on Mac
@@ -589,7 +598,7 @@ pub(crate) const IMAGE_MODEL_CAPS: &[ModelCaps] = &[
     // here was a wiring gap left by sc-8320/sc-8251 (the base MLX engine + control landed, but this row
     // and `image_request_mlx_eligible` were never updated), so `model_mac_support` hid the model behind
     // "Not available on Mac (MLX only)" even though the Mac worker fully supports it.
-    ModelCaps::new("z_image", true, true, false, false, false),
+    ModelCaps::new("z_image", true, true, true, false, false),
     // `z_image_edit` (epic 3529 / sc-3923): MLX-only edit id on Turbo weights.
     ModelCaps::new("z_image_edit", true, false, false, false, false),
     ModelCaps::new("flux_schnell", true, true, false, false, false),
@@ -1088,11 +1097,10 @@ derive_model_list! {
 }
 
 derive_model_list! {
-    /// The candle image families that advertise on-the-fly Q4/Q8 quant but NOT inference LoRA — Stable
-    /// Diffusion 3.5, Ideogram 4 (+Turbo), and Boogu (Base/Turbo/Edit) (derived from
-    /// [`IMAGE_MODEL_CAPS`]`.candle_quant`, sc-9495; the ideogram/boogu packed families added sc-9983 once
-    /// sc-9607 flipped their `supported_quants`). Quant stays on candle; a LoRA is refused and remains
-    /// queued.
+    /// The candle image families that accept Q4/Q8 generation requests but NOT inference LoRA —
+    /// either by selecting a pre-packed tier (including Z-Image) or by honoring load-time quant.
+    /// Derived from [`IMAGE_MODEL_CAPS`]`.candle_quant` (sc-9495). Quant stays on candle; a LoRA is
+    /// refused and remains queued.
     /// Disjoint from [`CANDLE_QUANT_LORA_MODELS`]; both are consulted by the gate. Subset of
     /// [`CANDLE_ROUTED_MODELS`].
     pub(crate) CANDLE_QUANT_MODELS, IMAGE_MODEL_CAPS, candle_quant
@@ -1396,11 +1404,15 @@ mod tests {
         "krea_2_raw",
     ];
 
+    // Z-Image Turbo/base select already-packed q4/q8/bf16 directories; this is not on-the-fly quant,
+    // but it is still a valid `mlxQuantize` request and therefore belongs in the quant routing set.
     // sc-9983: ideogram/boogu join SD3.5 as quant-only candle families (sc-9607 flipped their
     // `supported_quants` to [Q4, Q8]; no inference LoRA on candle). sc-10819: kolors joins the quant-only
     // set — the candle `candle-gen-kolors` lane now serves the packed q4/q8 `SceneWorks/kolors-mlx` tiers
     // (packed ChatGLM3 + vendored SDXL UNet) and advertises [Q4, Q8], but NO candle inference LoRA.
     const EXPECTED_CANDLE_QUANT_MODELS: &[&str] = &[
+        "z_image_turbo",
+        "z_image",
         "mage_flow_base",
         "mage_flow",
         "mage_flow_turbo",

--- a/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
@@ -891,6 +891,30 @@ fn qwen_image_quant_tier_select_stays_on_candle() {
 }
 
 #[test]
+fn z_image_quant_tier_select_stays_on_candle() {
+    // Z-Image's q4/q8/bf16 turnkeys are already packed. `mlxQuantize` selects the directory; it does
+    // not ask candle-gen-z-image to quantize dense weights at load time. The engine intentionally
+    // keeps `supported_quants: []` for that unsupported on-the-fly operation while packed-detecting
+    // the chosen tier from its component configs. Routing must therefore admit the tier-select for
+    // both Turbo and the base model instead of enforce-failing it as a conditioned shape.
+    for model in ["z_image_turbo", "z_image"] {
+        for bits in [4, 8] {
+            assert!(
+                image_request_candle_eligible(
+                    model,
+                    &object(json!({ "prompt": "a red fox", "advanced": { "mlxQuantize": bits } }))
+                ),
+                "{model} Q{bits} packed-tier select should stay on candle"
+            );
+        }
+        assert!(image_request_candle_eligible(
+            model,
+            &object(json!({ "prompt": "a red fox", "advanced": { "mlxQuantize": 0 } }))
+        ));
+    }
+}
+
+#[test]
 fn flux2_turnkey_quant_tier_select_stays_on_candle() {
     // sc-10222 (epic 9083): the LAST families carrying the "engine wired, router half missed" skew
     // (sc-9983 krea/ideogram/boogu, sc-11020 qwen). `flux2_klein_9b`/`_kv`/`flux2_dev` are worker


### PR DESCRIPTION
## Summary

- route Z-Image Turbo and base Q4/Q8 requests through the Candle lane as packed tier selections
- suppress routine successful `/api/v1/jobs/claim` duration events while retaining failed and slow claim logs
- preserve `Server-Timing` headers for every API response
- add regression coverage for Z-Image packed-tier routing and claim-poll log filtering

## Root cause

Z-Image's Candle engine intentionally does not advertise dense, on-the-fly quantization. Its Q4/Q8 turnkeys are already packed, and `advanced.mlxQuantize` selects the appropriate model directory. The routing catalog treated that selector as an unsupported runtime quantization request and rejected the job before the worker could load the packed tier.

Separately, the worker claim endpoint is polled once per second while idle. The general API timing middleware logged every fast successful poll, flooding session logs with non-actionable events.

## Impact

RunPod/CUDA workers can claim Z-Image Turbo and base Q4/Q8 text-to-image jobs instead of returning `candle_unsupported`. Routine idle claim polls no longer fill the logs, while claim failures and requests taking at least one second remain observable.

## Validation

- `cargo test -p sceneworks-core candle_routing_tests -- --nocapture`
- `cargo test -p sceneworks-rust-api successful_idle_claim_poll_does_not_emit_request_duration_noise -- --nocapture`
- `cargo test -p sceneworks-rust-api api_timing -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
