### PR TITLE
fix(web): serve the access token from memory, not storage (sc-15223)

### DIFF
--- a/apps/web/src/App.auth.test.jsx
+++ b/apps/web/src/App.auth.test.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./main.jsx";
 import { getMediaTicket, setMediaTicket } from "./api.js";
+import { resetAccessTokenForTests } from "./accessToken.js";
 import { FakeEventSource, response, errorResponse, settle, buttonInside, changeField } from "./main.testSupport.jsx";
 
 describe("SceneWorks app shell", () => {
@@ -16,6 +17,10 @@ describe("SceneWorks app shell", () => {
     FakeEventSource.instances = [];
     window.EventSource = FakeEventSource;
     window.localStorage.clear();
+    // sc-15223: the live token is module state that outlives a test, and tests here mount
+    // the gate, whose saveToken/lockRemote/re-verify paths move it. Clearing storage alone
+    // would leave that value in place and the raw seeding below would be ignored.
+    resetAccessTokenForTests();
     global.fetch = vi.fn((url) => {
       const path = new URL(url).pathname;
       if (path.endsWith("/health")) {

--- a/apps/web/src/App.uiPreferences.test.jsx
+++ b/apps/web/src/App.uiPreferences.test.jsx
@@ -5,6 +5,7 @@ import { App } from "./main.jsx";
 import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
 import { click } from "./testUtils/dom.js";
 import { resetStartupTimingForTests } from "./startupTiming.js";
+import { resetAccessTokenForTests } from "./accessToken.js";
 
 // sc-15136 — the durable UI-preference writes must be AUTHENTICATED on the wire.
 //
@@ -68,6 +69,10 @@ describe("App — durable UI preference writes carry the access token (sc-15136)
     FakeEventSource.instances = [];
     window.EventSource = FakeEventSource;
     window.localStorage.clear();
+    // sc-15223: the live token is module state that outlives a test, and tests here mount
+    // the gate, whose saveToken/lockRemote/re-verify paths move it. Clearing storage alone
+    // would leave that value in place and the raw seeding below would be ignored.
+    resetAccessTokenForTests();
     // A remote browser that already unlocked the host: the verified password is the live token.
     window.localStorage.setItem("sceneworks-token", TOKEN);
     window.innerWidth = 1440;

--- a/apps/web/src/accessToken.js
+++ b/apps/web/src/accessToken.js
@@ -2,6 +2,10 @@
 // host access password: a correct password verified against /api/v1/auth/verify is
 // promoted to the live token, sent as the Bearer credential on every authed request.
 //
+// The live value is held in module state and `localStorage` is its persistence cache
+// (sc-15223 — see the note above `liveToken` below); the threat model of that cache is
+// unchanged and is what follows.
+//
 // STORAGE / THREAT MODEL (sc-8880, F-078): the token is persisted verbatim in
 // localStorage under a single key so it survives reloads — a hard requirement for a
 // LAN remote-access tool where re-typing the password every session would be a real
@@ -32,17 +36,56 @@ function storage() {
   }
 }
 
-// The persisted access token, or "" when none is stored / storage is unavailable.
-export function readAccessToken() {
+// IN-MEMORY LIVE VALUE (sc-15223). `localStorage` is this module's PERSISTENCE CACHE, not
+// its source of truth: it exists so the token survives a reload, and it is allowed to fail.
+//
+// Every write helper below swallows a storage rejection by design — private mode, disabled
+// site storage, an over-quota origin — because refusing to run in those browsers would be a
+// worse outcome than not persisting. But before this the read helper went straight back to
+// storage, so a swallowed write left the two halves of the app disagreeing about the same
+// credential for the whole session: `useAccessGate` opened the gate on a token the host had
+// just proven, while every `readAccessToken()` caller (`serverToken()`, `uiPreferences.js`)
+// read the empty store and sent "". Those writes 401'd, and `apiFetch` correctly does NOT
+// route a credential-less 401 to the gate (sc-15105), so they silently no-op'd. Unlike the
+// cross-tab case (sc-15165) no `storage` event can ever repair it — storage is never going
+// to hold the value.
+//
+// So the live value lives here and the helpers keep it authoritative unconditionally:
+// `storeAccessToken`/`clearAccessToken` set it BEFORE attempting to persist, and
+// `readAccessToken()` prefers it whenever this session has set one. Persistence becomes a
+// best-effort side effect, which is what it always actually was.
+//
+// `null` means "no helper has run this session" — distinct from `""` ("this session forgot
+// the token"), which must NOT fall back to a stale stored value. A fresh page load starts at
+// `null` and reads through to storage, which is the reload path the cache exists for.
+let liveToken = null;
+
+// Read the persistence cache. `null` (not `""`) when the store is unreachable or the read
+// itself throws, so callers can tell "storage says empty" from "storage says nothing" — the
+// difference between adopting a value and clobbering the live one with a phantom clear.
+function readStoredToken() {
   try {
-    return storage()?.getItem(ACCESS_TOKEN_KEY) ?? "";
+    const area = storage();
+    return area ? (area.getItem(ACCESS_TOKEN_KEY) ?? "") : null;
   } catch {
-    return "";
+    return null;
   }
 }
 
-// Persist the verified access token so it survives reloads (see threat-model note).
+// The live access token, or "" when there is none. Read at CALL time by design — the token
+// is promoted mid-session when the user answers the gate, so a value cached by an importer
+// would leave that session's writes unauthenticated (see `uiPreferences.js`).
+export function readAccessToken() {
+  return liveToken ?? readStoredToken() ?? "";
+}
+
+// Promote the verified access token to the live value, then persist it so it survives
+// reloads (see threat-model note). The order matters: the live value is set unconditionally
+// so a store that refuses the write cannot desync the session (sc-15223).
 export function storeAccessToken(token) {
+  // Coerced because `null`/`undefined` is this module's "no helper has run" sentinel: storing
+  // one would silently mean "read through to storage" instead of "the token is this".
+  liveToken = token ?? "";
   try {
     storage()?.setItem(ACCESS_TOKEN_KEY, token);
   } catch {
@@ -50,13 +93,30 @@ export function storeAccessToken(token) {
   }
 }
 
-// Forget the stored token (the "lock"/forget affordance re-shows the login gate).
+// Forget the token (the "lock"/forget affordance re-shows the login gate). Same ordering
+// rule, and the higher-consequence half of it: a store that refuses `removeItem` must not
+// leave a forgotten password live for `readAccessToken()` to keep sending.
 export function clearAccessToken() {
+  liveToken = "";
   try {
     storage()?.removeItem(ACCESS_TOKEN_KEY);
   } catch {
     // Treat an unavailable store as already empty.
   }
+}
+
+// Test seam: drop the in-memory value so the next `readAccessToken()` reads through to
+// storage again — i.e. simulate the fresh page load that resets it in a real browser.
+//
+// WHO NEEDS IT: a test file that seeds sessions with a raw
+// `localStorage.setItem(ACCESS_TOKEN_KEY, ...)` AND contains any test that moves the live
+// value (mounting the gate is enough — `saveToken`/`lockRemote`/the re-verify rejection all
+// call the helpers above). Module state outlives an individual test, so `localStorage.clear()`
+// alone leaves the earlier value in place and the raw seed is then ignored. A file that only
+// reads the token needs nothing, and one that calls `vi.resetModules()` per test (e.g.
+// `screens/SettingsScreen.test.jsx`) already gets a fresh module instance.
+export function resetAccessTokenForTests() {
+  liveToken = null;
 }
 
 // CROSS-TAB SYNC (sc-15165). Storage is shared across every tab on the origin but the
@@ -82,7 +142,9 @@ export function clearAccessToken() {
 // is the thing performing those local writes. A second subscriber (a preferences cache, a
 // second React root) would silently miss every local write; adding one means making
 // `storeAccessToken`/`clearAccessToken` notify, which requires inverting the
-// write-before-setState ordering in `saveToken` first.
+// write-before-setState ordering in `saveToken` first. (sc-15223 does NOT relax this: a
+// local write moves `liveToken`, so a non-subscribing reader like `serverToken()` sees it
+// immediately — but a SUBSCRIBER still learns nothing without a notify.)
 const subscribers = new Set();
 let listening = false;
 
@@ -97,6 +159,22 @@ function handleStorageEvent(event) {
   const area = storage();
   if (area && event.storageArea && event.storageArea !== area) {
     return;
+  }
+  // Another tab changed the shared store, so storage is the truth again and must overwrite
+  // this tab's live value (sc-15223) — otherwise a session that had set one would pin it and
+  // go deaf to every cross-tab change, undoing sc-15165. That deliberately includes clobbering
+  // a live token the store itself never accepted: a real `storage` event means a peer tab DID
+  // write the shared store, so its value outranks ours, and a whole-store `clear()` locking us
+  // is the fail-closed direction.
+  //
+  // The `null` guard is narrower than that, and covers only an event arriving while OUR store
+  // is unreachable or its reads throw — no browser dispatches one in that state, so it is a
+  // synthetic/misdelivered event with no truth to adopt. Note this is NOT the private-mode
+  // case this story is about: there `getItem` works and returns null-for-absent, which reads
+  // as "" and does overwrite. Only a store we cannot read at all yields `null` here.
+  const stored = readStoredToken();
+  if (stored !== null) {
+    liveToken = stored;
   }
   // Read through the helper rather than trusting `event.newValue`: subscribers must be
   // handed exactly what every other reader in the tab will see at this moment.

--- a/apps/web/src/accessToken.test.js
+++ b/apps/web/src/accessToken.test.js
@@ -1,13 +1,21 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ACCESS_TOKEN_KEY,
   clearAccessToken,
   readAccessToken,
+  resetAccessTokenForTests,
   storeAccessToken,
   subscribeAccessToken,
 } from "./accessToken.js";
+import { installUnavailableStorage, installWriteRejectingStorage } from "./testUtils/storage.js";
 
 describe("accessToken (sc-8880)", () => {
+  beforeEach(() => {
+    // sc-15223: the live token is module state that outlives a test. Reset it so each test
+    // starts from the fresh-page-load state (nothing in memory, read through to storage).
+    resetAccessTokenForTests();
+  });
+
   afterEach(() => {
     // Restore any storage descriptor a test replaced, and clear the key.
     if (originalStorageDescriptor) {
@@ -51,10 +59,15 @@ describe("accessToken (sc-8880)", () => {
         throw new Error("storage disabled");
       },
     });
-    // No throw from any helper; read yields the empty-token default.
-    expect(() => storeAccessToken("x")).not.toThrow();
+    // No throw from any helper, and nothing to read before a write.
     expect(readAccessToken()).toBe("");
+    // sc-15223: the token still goes live even though it cannot be persisted. It used to
+    // read back as "" here — the divergence that left the gate open while every
+    // `readAccessToken()` caller sent an empty credential.
+    expect(() => storeAccessToken("x")).not.toThrow();
+    expect(readAccessToken()).toBe("x");
     expect(() => clearAccessToken()).not.toThrow();
+    expect(readAccessToken()).toBe("");
   });
 
   it("degrades gracefully when individual storage operations throw", () => {
@@ -75,7 +88,126 @@ describe("accessToken (sc-8880)", () => {
     });
     expect(readAccessToken()).toBe("");
     expect(() => storeAccessToken("x")).not.toThrow();
+    // Same sc-15223 contract with the store present but hostile on every operation.
+    expect(readAccessToken()).toBe("x");
     expect(() => clearAccessToken()).not.toThrow();
+    expect(readAccessToken()).toBe("");
+  });
+
+  // sc-15223: `localStorage` is the PERSISTENCE CACHE, not the source. A write the browser
+  // refuses must not be able to desync the session — the same-tab remainder of the sc-15165
+  // divergence, and the one no `storage` event can ever repair.
+  describe("live value vs persistence cache (sc-15223)", () => {
+    // One slot per installed fixture rather than a shared variable: a test that installs
+    // twice would otherwise overwrite the real descriptor with a broken one and leak it into
+    // every later test in the file.
+    const restores = [];
+    function rejectWrites() {
+      restores.push(installWriteRejectingStorage());
+    }
+
+    afterEach(() => {
+      while (restores.length) {
+        restores.pop()();
+      }
+    });
+
+    it("serves the live token when the store refused to persist it", () => {
+      rejectWrites();
+      storeAccessToken("private-mode-password");
+      // The store really is empty — this is what made the old read return "".
+      expect(window.localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+      expect(readAccessToken()).toBe("private-mode-password");
+    });
+
+    it("forgets a live token the store never held", () => {
+      rejectWrites();
+      storeAccessToken("private-mode-password");
+      clearAccessToken();
+      // The higher-consequence direction: `removeItem` on an empty store is a no-op, so the
+      // in-memory reset is the ONLY thing that can stop a forgotten password being sent.
+      expect(readAccessToken()).toBe("");
+    });
+
+    it("distinguishes 'this session forgot it' from 'this session never set one'", () => {
+      // A cleared session must NOT fall back to whatever storage still holds — otherwise a
+      // "lock" that could not reach the store would resurrect the password on the next read.
+      window.localStorage.setItem(ACCESS_TOKEN_KEY, "left-behind");
+      clearAccessToken();
+      window.localStorage.setItem(ACCESS_TOKEN_KEY, "left-behind");
+      expect(readAccessToken()).toBe("");
+
+      // ...while a session that has set nothing DOES read through, which is the reload path
+      // the persistence cache exists for.
+      resetAccessTokenForTests();
+      expect(readAccessToken()).toBe("left-behind");
+    });
+
+    it("lets a cross-tab change overwrite the live value (sc-15165 still wins)", () => {
+      // Pinning the live value would make the tab deaf to every `storage` event, undoing the
+      // fix this one builds on. A test that only asserted the subscriber's argument would
+      // miss it — `readAccessToken()` is what the other callers use.
+      storeAccessToken("mine");
+      const seen = [];
+      const off = subscribeAccessToken((next) => seen.push(next));
+      window.localStorage.setItem(ACCESS_TOKEN_KEY, "theirs");
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: ACCESS_TOKEN_KEY,
+          newValue: "theirs",
+          storageArea: window.localStorage,
+        }),
+      );
+      off();
+
+      expect(seen).toEqual(["theirs"]);
+      expect(readAccessToken()).toBe("theirs");
+    });
+
+    it("adopts a peer tab's value over a live token the store itself never held", () => {
+      // The write-rejecting posture does NOT make this tab's live value untouchable. A real
+      // `storage` event means a peer DID write the shared store, so its value outranks ours —
+      // pinning the live token here would make a private-mode tab deaf to sc-15165 forever.
+      // (This is the case the `stored !== null` guard below does not cover, on purpose:
+      // `getItem` works here and answers null-for-absent, which is a real answer.)
+      rejectWrites();
+      storeAccessToken("never-persisted");
+      const seen = [];
+      const off = subscribeAccessToken((next) => seen.push(next));
+      // No `storageArea`: the installed store is a plain object, which jsdom refuses to
+      // accept as one. The handler lets a `storageArea`-less event through by design (real
+      // browsers always set it), which is the same allowance the sc-15165 tests above rely on.
+      window.dispatchEvent(new StorageEvent("storage", { key: null }));
+      off();
+
+      expect(seen).toEqual([""]);
+      expect(readAccessToken()).toBe("");
+    });
+
+    it("does not let an UNREADABLE store phantom-clear the live token", () => {
+      // The narrow case the guard is actually for: no browser dispatches a `storage` event
+      // while our own store is unreachable, so this is a synthetic/misdelivered one carrying
+      // no truth to adopt. Treating that as "" would lock a tab whose in-memory value is the
+      // only copy of the credential in existence.
+      storeAccessToken("only-copy");
+      const seen = [];
+      const off = subscribeAccessToken((next) => seen.push(next));
+      restores.push(installUnavailableStorage());
+      window.dispatchEvent(new StorageEvent("storage", { key: ACCESS_TOKEN_KEY }));
+      off();
+
+      expect(seen).toEqual(["only-copy"]);
+      expect(readAccessToken()).toBe("only-copy");
+    });
+
+    it("treats a nullish store argument as an empty token, not as 'unset'", () => {
+      // `null`/`undefined` is the module's "no helper has run this session" sentinel, so an
+      // uncoerced nullish store would silently mean "read through to storage" — the opposite
+      // of what storing a value means.
+      window.localStorage.setItem(ACCESS_TOKEN_KEY, "left-behind");
+      storeAccessToken(null);
+      expect(readAccessToken()).toBe("");
+    });
   });
 
   // sc-15165: storage is shared across tabs, the gate's React state is not. Without this

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -12,7 +12,12 @@ import { useAccessGate } from "./useAccessGate.js";
 import { useJobEvents } from "./useJobEvents.js";
 import { useTimelines } from "./useTimelines.js";
 import { apiFetch } from "../api.js";
-import { ACCESS_TOKEN_KEY, readAccessToken } from "../accessToken.js";
+import {
+  ACCESS_TOKEN_KEY,
+  readAccessToken,
+  resetAccessTokenForTests,
+} from "../accessToken.js";
+import { installWriteRejectingStorage } from "../testUtils/storage.js";
 import { MAX_TERMINAL_JOBS } from "../sorters.js";
 
 // Controllable apiFetch: each call resolves with whatever the per-path map returns (or
@@ -117,6 +122,11 @@ describe("useAccessGate (sc-9750)", () => {
     setMediaTicketSpy.mockClear();
     unauthorizedHandler = null;
     window.localStorage.clear();
+    // sc-15223: accessToken.js now holds the live token in module state, which outlives an
+    // individual test. Clearing storage alone would leave a previous test's `saveToken` /
+    // `lockRemote` value in memory, so the raw `setItem` seeding below would be ignored —
+    // this restores the fresh-page-load state each test is written against.
+    resetAccessTokenForTests();
     container = document.createElement("div");
     document.body.appendChild(container);
   });
@@ -860,6 +870,149 @@ describe("useAccessGate (sc-9750)", () => {
       // The desktop counterpart (no handler at all) is pinned in
       // useAccessGate.desktop.test.jsx, which mocks isDesktop true.
       expect(typeof unauthorizedHandler).toBe("function");
+    });
+  });
+
+  // sc-15223: the SAME-TAB half of the sc-15165 divergence. `storeAccessToken` swallows a
+  // rejected write by design (private mode / storage disabled / over quota), and `saveToken`
+  // never looked at whether it landed — so the gate opened on a proven token while storage
+  // stayed empty and every `readAccessToken()` caller (`serverToken()`, `uiPreferences.js`)
+  // sent "". No storage event can ever correct that one: storage is never going to hold the
+  // value, so it lasts the whole session.
+  describe("storage-rejected writes (sc-15223)", () => {
+    const restores = [];
+    // WebKit private mode / an over-quota origin: reads and removes work, writes throw. The
+    // posture is shared with accessToken.test.js so the two suites cannot drift on what
+    // "private mode" means (see testUtils/storage.js).
+    function breakWrites() {
+      restores.push(installWriteRejectingStorage());
+    }
+
+    afterEach(() => {
+      while (restores.length) {
+        restores.pop()();
+      }
+    });
+
+    it("keeps readAccessToken() on the accepted token when the write is rejected", async () => {
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      breakWrites();
+      const { get } = mount();
+      await settle();
+
+      act(() => get().api.setPasswordDraft("private-mode-password"));
+      await act(async () => {
+        await get().api.saveToken({ preventDefault: () => {} });
+      });
+      await settle();
+
+      // The gate is fully open on a token the host proved...
+      expect(get().api.gateStatus).toBe("open");
+      expect(get().api.token).toBe("private-mode-password");
+      // ...and the OTHER reader of that same credential must agree. Before sc-15223 this
+      // was "": every ui-preference / credential / worker-restart write in the session went
+      // out unauthenticated, 401'd, and (correctly, sc-15105) never raised the gate.
+      expect(readAccessToken()).toBe("private-mode-password");
+    });
+
+    it("forgets the token in memory too when a rejected-write session locks", async () => {
+      // The mirror case, and the one that actually matters for safety: if `clearAccessToken`
+      // only tried storage, "lock" would leave the live value behind and `readAccessToken()`
+      // would keep handing the forgotten password to every caller.
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      breakWrites();
+      const { get } = mount();
+      await settle();
+
+      act(() => get().api.setPasswordDraft("private-mode-password"));
+      await act(async () => {
+        await get().api.saveToken({ preventDefault: () => {} });
+      });
+      await settle();
+      expect(readAccessToken()).toBe("private-mode-password");
+
+      act(() => get().api.lockRemote());
+      await settle();
+
+      expect(get().api.gateStatus).toBe("locked");
+      expect(get().api.token).toBe("");
+      expect(readAccessToken()).toBe("");
+    });
+
+    it("drops the live value when the host rejects a token it could not persist", async () => {
+      // The re-verify effect's rejection path calls `clearAccessToken()` for the same reason
+      // lock does — a token the host has disowned must stop being sent. With storage refusing
+      // writes, the in-memory value is the only thing holding it, so it is the only thing
+      // that can be wrong here.
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      let verify = { ok: true };
+      apiResponders.set("/api/v1/auth/verify", () => verify);
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      breakWrites();
+      const { get } = mount();
+      await settle();
+
+      act(() => get().api.setPasswordDraft("rotated-away"));
+      await act(async () => {
+        await get().api.saveToken({ preventDefault: () => {} });
+      });
+      await settle();
+      expect(get().api.gateStatus).toBe("open");
+
+      // The host rotates its password mid-session; the 401 demotes and the re-verify rejects.
+      verify = { ok: false };
+      const stale = await unauthorizedError();
+      apiResponders.set("/api/v1/jobs", () => stale);
+      await act(async () => {
+        await apiFetch("/api/v1/jobs", "rotated-away").catch(() => {});
+      });
+      await settle();
+
+      expect(get().api.gateStatus).toBe("locked");
+      expect(readAccessToken()).toBe("");
+    });
+
+    it("still adopts a cross-tab forget after this tab unlocked (sc-15165 composition)", async () => {
+      // The two stories composed, on a WORKING store — the sequence neither suite covered on
+      // its own. Every sc-15165 test seeds storage raw, so the live value stays unset and only
+      // the read-through path runs; here `saveToken` sets it first, which is what could pin
+      // the token and make the tab permanently deaf to storage events.
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      apiResponders.set("/api/v1/files/ticket", { ticket: "media-1", expiresInSeconds: 300 });
+      const { get } = mount();
+      await settle();
+
+      act(() => get().api.setPasswordDraft("unlocked-here"));
+      await act(async () => {
+        await get().api.saveToken({ preventDefault: () => {} });
+      });
+      await settle();
+      expect(get().api.gateStatus).toBe("open");
+      expect(readAccessToken()).toBe("unlocked-here");
+
+      // Another tab hits forget.
+      act(() => {
+        window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: ACCESS_TOKEN_KEY,
+            newValue: null,
+            storageArea: window.localStorage,
+          }),
+        );
+      });
+      await settle();
+
+      expect(get().api.gateStatus).toBe("locked");
+      expect(get().api.token).toBe("");
+      // Both readers, as ever: a live value left behind here would keep handing the forgotten
+      // password to serverToken() / uiPreferences.js for the rest of the session.
+      expect(readAccessToken()).toBe("");
     });
   });
 

--- a/apps/web/src/hooks/useAccessGate.desktop.test.jsx
+++ b/apps/web/src/hooks/useAccessGate.desktop.test.jsx
@@ -10,6 +10,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAccessGate } from "./useAccessGate.js";
+import { resetAccessTokenForTests } from "../accessToken.js";
 
 const apiResponders = new Map();
 let unauthorizedHandler = null;
@@ -47,6 +48,10 @@ describe("useAccessGate on the desktop shell (sc-15105)", () => {
     apiResponders.clear();
     unauthorizedHandler = null;
     window.localStorage.clear();
+    // sc-15223: the live token is module state that outlives a test, and tests here mount
+    // the gate, whose saveToken/lockRemote/re-verify paths move it. Clearing storage alone
+    // would leave that value in place and the raw seeding below would be ignored.
+    resetAccessTokenForTests();
     container = document.createElement("div");
     document.body.appendChild(container);
   });

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -414,8 +414,16 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
   // Verify the typed draft against the public /api/v1/auth/verify endpoint BEFORE
   // promoting it to the live `token`, so a wrong password keeps the gate up with an
   // inline error (instead of saving a bad token and silently failing every subsequent
-  // request). A correct password is stored to localStorage and unlocks the app; it
-  // persists across reloads. Promoting the token here flips `authenticated`, and the
+  // request). A correct password is promoted to the live token and unlocks the app.
+  //
+  // `storeAccessToken` is not checked, and deliberately so (sc-15223): persisting is
+  // best-effort — a private-mode / over-quota browser refuses the write, and refusing to
+  // unlock there would be worse than not surviving a reload. What used to make that a bug was
+  // `readAccessToken()` reading storage back, so the session's own writes went out
+  // credential-less; accessToken.js now serves the live value, so the unlock is whole either
+  // way and only the across-reloads part is lost.
+  //
+  // Promoting the token here flips `authenticated`, and the
   // [authenticated, token] effects perform the initial data load and SSE connect
   // exactly once — no explicit refreshData() call, or it would double-fetch (sc-8808).
   const saveToken = useCallback(

--- a/apps/web/src/testUtils/storage.js
+++ b/apps/web/src/testUtils/storage.js
@@ -1,0 +1,53 @@
+// Shared Web Storage fixtures for the access-token suites (sc-15223).
+//
+// `accessToken.js` promises to degrade through three distinct storage postures, and the
+// difference between them is exactly what the sc-15223 contract turns on — so a suite that
+// hand-rolls "private mode" can quietly test a different posture than it thinks:
+//
+//   - UNAVAILABLE  — the `window.localStorage` getter itself throws. Reads yield nothing to
+//                    adopt, so the live value stands.
+//   - WRITE-REJECTING — reads and removes work, `setItem` throws (WebKit private mode, an
+//                    over-quota origin). Reads answer null-for-absent, which is a real
+//                    answer. This is the posture sc-15223 is about.
+//   - HOSTILE      — every operation throws.
+//
+// Each installer returns a restore function; callers must invoke it in `afterEach`, because
+// a leaked descriptor breaks every later test in the file.
+
+function install(value) {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, ...value });
+  return function restore() {
+    if (original) {
+      Object.defineProperty(globalThis, "localStorage", original);
+    } else {
+      delete globalThis.localStorage;
+    }
+  };
+}
+
+// A store that reads and clears normally but silently refuses to persist. Backed by a real
+// Map so `getItem`/`removeItem` behave — if reads were broken too this would degenerate into
+// `installUnavailableStorage` and stop covering what it claims.
+export function installWriteRejectingStorage() {
+  const backing = new Map();
+  return install({
+    value: {
+      getItem: (key) => (backing.has(key) ? backing.get(key) : null),
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+      removeItem: (key) => backing.delete(key),
+      clear: () => backing.clear(),
+    },
+  });
+}
+
+// Storage disabled outright: touching `window.localStorage` throws.
+export function installUnavailableStorage() {
+  return install({
+    get() {
+      throw new Error("storage disabled");
+    },
+  });
+}

--- a/apps/web/src/uiPreferences.js
+++ b/apps/web/src/uiPreferences.js
@@ -33,18 +33,19 @@ import { readAccessToken } from "./accessToken.js";
 // cached one would leave every write in that session unauthenticated. (`credentials.js`'s
 // `serverToken()` is the same value under a different name — one source, in `accessToken.js`.)
 //
-// Reading storage is the right call rather than a bug to route around: it is strictly
-// fresher than the gate's state on promotion, which is the case that decides whether a
-// session's writes are authenticated at all.
+// Reading through the seam is the right call rather than a bug to route around: it is
+// strictly fresher than the gate's state on promotion, which is the case that decides whether
+// a session's writes are authenticated at all.
 //
-// The CROSS-TAB divergence that used to qualify that is closed (sc-15165): the gate now
-// subscribes to `storage` events via `subscribeAccessToken`, so a "forget" in a second tab
-// locks this one instead of leaving it live while writes here go out credential-less to a
-// 401 that (correctly) never raises the gate. One case survives, deliberately: a same-tab
-// `storeAccessToken` that the browser REJECTS (private-mode / quota — swallowed by design,
-// see the degradation note in `accessToken.js`) leaves the gate accepted with storage
-// empty, and writes here go out credential-less again. No `storage` event can fix that one;
-// it needs the gate to stop treating an unverifiable write as a successful one.
+// Both divergences this used to have with the gate's `token` state are now closed. CROSS-TAB
+// (sc-15165): the gate subscribes to `storage` events via `subscribeAccessToken`, so a
+// "forget" in a second tab locks this one instead of leaving it live while writes here go out
+// credential-less to a 401 that (correctly) never raises the gate. SAME-TAB (sc-15223):
+// `readAccessToken()` serves an in-memory live value with `localStorage` as its persistence
+// cache, so a `storeAccessToken` the browser REJECTS (private mode / quota — swallowed by
+// design, see the degradation note in `accessToken.js`) no longer leaves the gate accepted
+// while the writes here send "". No `storage` event could ever have repaired that one, which
+// is why it took a change to the read contract rather than another subscriber.
 //
 // On the desktop shell it is "" and the request still succeeds: `SCENEWORKS_TRUST_LOOPBACK`
 // bypasses the token check for loopback peers before any comparison, so local use stays


### PR DESCRIPTION
Closes [sc-15223](https://app.shortcut.com/trefry/story/15223). The same-tab remainder of the sc-15165 divergence, surfaced by that story's adversarial review.

## The bug

`storeAccessToken()` swallows a rejected `localStorage` write **by design** — WebKit private mode, disabled site storage, an over-quota origin. `readAccessToken()` read storage back, so a swallowed write split the app's two readers of the same credential for the whole session:

1. Remote browser in private mode on a LAN host that requires a password.
2. Correct password → `/api/v1/auth/verify` ok → `storeAccessToken` throws internally and is swallowed → the gate opens. Header-authenticated requests all work; the token is live in React state.
3. The user toggles the theme, picks a quant tier, or edits a service credential. Those go through `readAccessToken()` (`uiPreferences.js`, `credentials.js`'s `serverToken()`), which reads the empty store and sends `""`.
4. The 401 comes back, and `apiFetch` correctly does **not** route a credential-less 401 to the gate (sc-15105) — so nothing surfaces.

Also silently no-ops `/api/v1/worker/restart` and `/api/v1/host-capabilities`, which reach the token through `serverToken()`. Narrow and it fails **closed** (less credential sent, never more), but unlike sc-15165 it lasts the entire session: no `storage` event can repair it, because storage is never going to hold the value.

## The fix

`accessToken.js` now holds the live token in module state with `localStorage` as its **persistence cache** rather than its source — the story's mandated direction, not the cheaper report-and-warn alternative.

- `storeAccessToken`/`clearAccessToken` set the live value **before** attempting to persist, so a refused write cannot desync the session.
- `readAccessToken()` prefers it whenever this session has set one.
- `null` ("no helper has run this session" — a fresh page load) stays distinct from `""` ("this session forgot the token"), so a clear can't resurrect a stale stored value.
- The sc-15165 `storage` handler resyncs it from storage before notifying, so a peer tab's write still outranks ours — pinning the live value would have made an unlocked tab permanently deaf to cross-tab changes. That resync is skipped **only** when our own store is unreadable, where a synthetic event carries no truth to adopt.

Reload behavior is unchanged: memory resets, the read falls through to storage. In a private-mode browser the session genuinely doesn't survive a reload, which it never did.

No user-facing warning: with the divergence closed the PUTs carry the real token, so preferences **do** persist server-side. Only the localStorage instant-paint cache is missing, which costs a theme flash — not worth an inline warning on the login gate.

## Verification

`npm --prefix apps/web run lint` / `test` / `build` — all three CI web steps green (204 files, 2810 tests).

Reproduced first: 2 of the new tests failed before the fix. Coverage pins the whole-session sequence under a write-rejecting store (unlock, lock, host-rejects-mid-session) plus the sc-15165-composition case **neither suite covered** — this tab unlocks via `saveToken` (which now sets the live value), then a peer tab forgets. Six mutations run against the final state; every one goes red, including two that only the newly added tests catch.

`readAccessToken()` no longer reflects a raw `localStorage.setItem` made *after* a helper has run, so the four suites that seed sessions that way reset the module in `beforeEach` via a new `resetAccessTokenForTests()` seam. Files that only read the token, or that already `vi.resetModules()` per test, are untouched — the rule is documented on the seam. The shared private-mode storage fixture moved to `testUtils/storage.js` so the two suites can't drift on what "private mode" means.

Reviewed adversarially before shipping; every finding is addressed in the branch (the load-bearing ones: a comment that claimed a protection the guard does not actually provide for the private-mode case, and the missing hook-level composition test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)