### PR TITLE
fix(worker): resolve krea_realtime per-tier + wire the video-lane quant (sc-15258)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -9587,12 +9587,17 @@
         "minMemoryGb": 64,
         "repo": "SceneWorks/krea-realtime-14b-mlx",
         // Declares Q4 as this model's default tier, matching the `default: true` q4 download.
-        // ⚠️ This key does NOT select the tier for a video job: `mlx.quantize` is read by the
-        // IMAGE lane (`resolve_quant`, image_jobs/base.rs); the video lane reads only
-        // `advanced.mlxQuantize` (`resolve_mlx_dense_quant`, video_jobs/mod.rs) and today hands
-        // the engine the snapshot ROOT rather than a `<tier>/` subdir. Wiring the video lane to
-        // honor a declared default tier + descend into the tier subdir is sc-15258 (S20), which
-        // is blocked by this story. Declared here so S20 has the manifest fact to read.
+        // ⚠️ This key is DOCUMENTATION on a video entry, not the mechanism. `mlx.quantize` is read
+        // by the IMAGE lane (`resolve_quant`, image_jobs/base.rs); the video lane never consults it
+        // — and deliberately so. sc-10859 made the video lane's Q4-first default an owned carve-out
+        // from the app-wide Q8 default (there is no MLX video Q8 lever, so a silent Q8 only risks a
+        // video-runtime OOM), and letting a manifest key flip it would quietly undo that. What
+        // actually picks the tier is `krea_realtime_tier_order` (`video_jobs/krea_realtime.rs`,
+        // sc-15258), which reads `advanced.mlxQuantize` through the shared `resolve_mlx_dense_quant`
+        // and independently defaults to `q4`-first, then descends into the installed `<tier>/`
+        // subdir. The 4 here therefore AGREES with the resolver rather than driving it; a future
+        // edit to this number would NOT move the video lane. (bernini and scail2_14b declare the
+        // same thing for the same reason.)
         "quantize": 4,
         "limits": {
           "samplers": ["default"],

--- a/crates/sceneworks-core/src/jobs_store/tests/mlx_routing_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/mlx_routing_tests.rs
@@ -802,7 +802,8 @@ fn video_mode_eligibility_admits_flf_only_on_flf_capable_engines() {
 fn krea_realtime_is_mlx_routed_and_serves_exactly_its_advertised_modes() {
     assert!(
         VIDEO_MLX_ROUTED_MODELS.contains(&"krea_realtime_14b"),
-        "krea_realtime_14b must be MLX-routed — sc-8443 wired the real engine, so a missing row          makes the app claim it has none"
+        "krea_realtime_14b must be MLX-routed — sc-8443 wired the real engine, so a missing row \
+         makes the app claim it has none"
     );
 
     // The three the catalog + descriptor + worker all agree on.

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -599,6 +599,67 @@ fn every_image_model_with_a_candle_vram_block_declares_mlx_quantize() {
     }
 }
 
+/// sc-15258 — the VIDEO-lane twin of the lint above, and it enforces the opposite thing: on a video
+/// entry `mlx.quantize` is **documentation, not a control**, so it may only ever restate the default
+/// the video resolver already produces.
+///
+/// The video lane never reads `manifest.mlx.quantize`. `resolve_quant` (`image_jobs/base.rs`) is the
+/// image lane; the video lane resolves through `video_jobs::resolve_mlx_dense_quant` (shared by
+/// bernini / scail2 / krea_realtime) and the per-family tier orders, all of which key on
+/// `advanced.mlxQuantize` alone and default to **Q4**. That is not an oversight to be fixed by wiring
+/// the manifest in: sc-10859 made the video lane's q4-first default an OWNED carve-out from epic
+/// 10721's app-wide Q8 default (there is no MLX video Q8 lever, so a silent Q8 only risks a
+/// video-runtime OOM at heavy res/frame counts), and letting a manifest key flip it would quietly undo
+/// that decision for all three families at once.
+///
+/// So the invariant a video entry must satisfy is agreement: declare `4`, or declare nothing. Anything
+/// else is a manifest that documents a default the product does not honour — a lie that reads as
+/// authoritative to the next engineer and to anyone inspecting the catalog. Today all three video
+/// entries that declare the key declare `4`.
+///
+/// Mutation check: set any video entry's `mlx.quantize` to `8` (or `0`) → RED naming it.
+#[test]
+fn video_models_may_only_declare_the_mlx_quantize_the_video_lane_actually_defaults_to() {
+    /// The tier `video_jobs::resolve_mlx_dense_quant` returns for a request with no explicit
+    /// `advanced.mlxQuantize` — the only value a video entry may restate.
+    const VIDEO_LANE_DEFAULT_BITS: u64 = 4;
+
+    let mut offenders = Vec::new();
+    let mut declaring = Vec::new();
+    for model in builtin_models_manifest() {
+        if model.get("type").and_then(Value::as_str) != Some("video") {
+            continue;
+        }
+        let Some(quantize) = model.get("mlx").and_then(|mlx| mlx.get("quantize")) else {
+            continue;
+        };
+        let id = model.get("id").and_then(Value::as_str).unwrap_or("<no id>");
+        declaring.push(id.to_owned());
+        if quantize.as_u64() != Some(VIDEO_LANE_DEFAULT_BITS) {
+            offenders.push(format!("{id} (declares {quantize})"));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these `type: video` models declare an `mlx.quantize` other than {VIDEO_LANE_DEFAULT_BITS}: \
+         {offenders:?}. The video lane does NOT read `manifest.mlx.quantize` — it resolves through \
+         `resolve_mlx_dense_quant` / the per-family tier orders, which key on `advanced.mlxQuantize` \
+         and default to Q4 (sc-10750), a carve-out from epic 10721's app-wide Q8 that sc-10859 made \
+         deliberately (no MLX video Q8 lever ⇒ a silent Q8 only risks a video-runtime OOM). So a \
+         video entry may only RESTATE the Q4 default or say nothing; declaring anything else \
+         documents a default the product will not honour. If the video lane should start honouring \
+         the manifest, change the resolver and this guard together — do not change the manifest alone."
+    );
+
+    // Non-vacuity: the guard must actually be looking at entries. If a refactor moved the key or the
+    // `type` label, `declaring` would silently empty out and the assertion above would pass on air.
+    assert!(
+        declaring.contains(&"krea_realtime_14b".to_owned()),
+        "krea_realtime_14b declares mlx.quantize, so this guard must see it — an empty sweep would \
+         make the check vacuous; saw {declaring:?}"
+    );
+}
+
 /// sc-13533 — the sc-12155 lint above, strengthened from PRESENCE to COVERAGE: declaring
 /// `mlx.quantize` is not enough; the tier that declaration RESOLVES TO must itself have a measured
 /// `candle.vramGbByTier` row.

--- a/crates/sceneworks-worker/src/video_jobs/krea_realtime.rs
+++ b/crates/sceneworks-worker/src/video_jobs/krea_realtime.rs
@@ -13,9 +13,9 @@ use super::wan::{generate_video_using, local_mlx_dir, VideoGenInput};
 // cache — not its weights, so the DiT / z16 VAE / UMT5 text encoder / RoPE / schedulers are all reused
 // from stock Wan inside the engine.
 //
-// Surface (descriptor `pipeline::descriptor`, sc-8440 S7): CFG-OFF video (no negative-prompt / guidance
-// / true-cfg axis — the AR few-step denoise runs a single batch-1 forward per step), sampler
-// `self_forcing`, `supported_quants = []` (dense bf16 load — no load-time quant tier wired yet),
+// Surface (descriptor `pipeline::descriptor`, sc-8440 S7 + sc-15203 S19): CFG-OFF video (no
+// negative-prompt / guidance / true-cfg axis — the AR few-step denoise runs a single batch-1 forward
+// per step), sampler `self_forcing`, `supported_quants = [Q4, Q8]` (bf16 = their absence),
 // `supports_lora = false`, `mac_only = true`. It advertises two conditioning shapes the worker maps its
 // own reference inputs onto here:
 //   * i2v — a `Reference` still VAE-encoded to WARM the AR KV cache from clean context. The engine's
@@ -54,30 +54,362 @@ pub(super) fn krea_realtime_engine_id(model: &str) -> Option<&'static str> {
     (model == KREA_REALTIME_MODEL_ID).then_some(KREA_REALTIME_MODEL_ID)
 }
 
-/// Whether the linked Krea Realtime engine can serve this request now (resolvable weights). `mac_only`
-/// is implicit — this fn is macOS-only, and a non-mac job never reaches the route (it is rejected
-/// loudly in `run_video_generate_job`). Routed by weight availability like the other MLX engines: an
-/// unresolved snapshot falls to `VideoRoute::Stub`, whose fail-loud gate (`ensure_video_engine_
-/// weights`) then surfaces the resolver's precise error instead of a procedural fake clip.
+/// Whether the linked Krea Realtime engine can serve this request now (a resolvable, LOADABLE tier).
+/// `mac_only` is implicit — this fn is macOS-only, and a non-mac job never reaches the route (it is
+/// rejected loudly in `run_video_generate_job`). Routed by weight availability like the other MLX
+/// engines: an unresolved snapshot falls to `VideoRoute::Stub`, whose fail-loud gate
+/// (`ensure_video_engine_weights`) then surfaces the resolver's precise error instead of a procedural
+/// fake clip.
+///
+/// It asks the FULL [`resolve_krea_realtime_tier_dir_and_quant`], not just
+/// [`resolve_krea_realtime_model_dir`] (sc-15258): every published Krea file lives under a `q4/`/`q8/`/
+/// `bf16/` tier prefix, so the turnkey snapshot ROOT resolving is not evidence that anything is
+/// loadable — a repo dir holding only `README.md` (or a torn tier) would otherwise route to the engine
+/// and die inside the loader with a message about a missing `dit.safetensors`.
 #[cfg(target_os = "macos")]
-pub(super) fn krea_realtime_available(_request: &VideoRequest, settings: &Settings) -> bool {
-    resolve_krea_realtime_model_dir(settings).is_ok()
+pub(super) fn krea_realtime_available(request: &VideoRequest, settings: &Settings) -> bool {
+    resolve_krea_realtime_tier_dir_and_quant(settings, request).is_ok()
 }
 
-/// The turnkey SceneWorks Krea Realtime MLX repo (the converted transformer-only DiT snapshot +
-/// the stock Wan `t5_encoder`/`vae`/`tokenizer`). **Provisional**: the MLX rehost to the SceneWorks HF
-/// org is the gated S2 remainder (sc-8435), so the repo may not be published yet — `resolve_krea_
-/// realtime_model_dir` only ever LOOKS UP an already-downloaded snapshot in the local cache (no
-/// network fetch here; there is no on-demand quant-tier fetch because the engine advertises
-/// `supported_quants = []` and loads dense bf16), so an absent repo simply means the env override /
-/// app-managed dir are the resolvable sources until the rehost + download lands.
+/// The turnkey SceneWorks Krea Realtime MLX repo (sc-8435 S2b): the converted Krea DiT at three
+/// precisions plus the stock Wan `t5_encoder`/`vae`/`tokenizer` companions, laid out as the epic-8506
+/// quant matrix — self-contained `q4/` (default) + `q8/` + `bf16/` tier subdirs, NOT a flat root.
+/// `resolve_krea_realtime_model_dir` only ever LOOKS UP an already-downloaded snapshot in the local
+/// cache; the on-demand fetch of an explicitly-picked non-default tier is
+/// [`ensure_krea_realtime_tier_present`].
 #[cfg(target_os = "macos")]
 pub(super) const KREA_REALTIME_REPO: &str = "SceneWorks/krea-realtime-14b-mlx";
 
-/// Resolve the Krea Realtime MLX snapshot dir: env override (`SCENEWORKS_MLX_KREA_REALTIME_DIR`) →
+/// Pinned revision for [`KREA_REALTIME_REPO`] (mirrors [`SCAIL2_REVISION`](super::scail2)). The repo is
+/// a hard-coded const — no manifest/payload override reaches the on-demand `q8/` + `bf16/` fetches — so
+/// pulling the mutable `main` branch would let an upstream re-push silently swap a checkpoint we load.
+/// This is the S2b rehost commit, and it MUST equal the `revision` every `krea_realtime_14b` download
+/// entry in `builtin.models.jsonc` pins, or the on-demand fetch would materialize a SECOND snapshot dir
+/// beside the one the Model Manager installed
+/// (`krea_realtime_worker_tier_table_matches_the_shipped_manifest` pins the equality). The native
+/// downloader still verifies each file's own hash on download.
+#[cfg(target_os = "macos")]
+pub(super) const KREA_REALTIME_REVISION: &str = "e68e9a3d98187fdf6936838ffcf6df5aa48d6626";
+
+/// The files that make a **packed** (`q4/`, `q8/`) Krea Realtime tier subdir COMPLETE: the single-file
+/// packed DiT plus the stock dense Wan companions the engine opens by name
+/// (`t2v::load_text_encoder`/`load_vae`) and the `config.json` carrying the quantization manifest.
+#[cfg(target_os = "macos")]
+const KREA_REALTIME_PACKED_TIER_FILES: &[&str] = &[
+    "config.json",
+    "dit.safetensors",
+    "t5_encoder.safetensors",
+    "tokenizer.json",
+    "vae.safetensors",
+];
+
+/// The files that make the **`bf16/`** tier COMPLETE. Structurally different from the packed tiers:
+/// its DiT is a SEVEN-shard `transformer/` directory one level deeper, because a single 28.58 GB bf16
+/// blob is above the practical single-file limit the rehost emits. The engine's
+/// `t2v::open_transformer_weights` probes both layouts (`dit.safetensors` OR a `transformer/` dir), so
+/// this is a hosting shape rather than a second load path — but the *directory* handed to it must be
+/// the tier dir either way. Every shard is listed individually so a torn download (6 of 7 shards) reads
+/// INCOMPLETE and falls through, instead of resolving a tier that then dies inside the loader.
+#[cfg(target_os = "macos")]
+const KREA_REALTIME_BF16_TIER_FILES: &[&str] = &[
+    "config.json",
+    "t5_encoder.safetensors",
+    "tokenizer.json",
+    "vae.safetensors",
+    "transformer/dit-00001-of-00007.safetensors",
+    "transformer/dit-00002-of-00007.safetensors",
+    "transformer/dit-00003-of-00007.safetensors",
+    "transformer/dit-00004-of-00007.safetensors",
+    "transformer/dit-00005-of-00007.safetensors",
+    "transformer/dit-00006-of-00007.safetensors",
+    "transformer/dit-00007-of-00007.safetensors",
+];
+
+/// The published Krea Realtime quant matrix: each tier subdir keyed to the files that make it COMPLETE
+/// (mirrors [`SCAIL2_TIER_FILES`](super::scail2), but per-tier because the `bf16/` DiT is sharded a
+/// level deeper while `q4/`/`q8/` ship a flat `dit.safetensors`). Kept in lockstep with the
+/// `krea_realtime_14b` manifest `downloads[].files` — same repo, same revision, same paths — so the
+/// worker's completeness predicate cannot drift from what the Model Manager actually installs.
+#[cfg(target_os = "macos")]
+pub(super) const KREA_REALTIME_TIER_FILES: &[(&str, &[&str])] = &[
+    ("q4", KREA_REALTIME_PACKED_TIER_FILES),
+    ("q8", KREA_REALTIME_PACKED_TIER_FILES),
+    ("bf16", KREA_REALTIME_BF16_TIER_FILES),
+];
+
+/// The files that make `tier` COMPLETE, or `None` for a tier this repo does not publish. Deliberately
+/// an `Option` rather than an empty-slice fallback: `[].iter().all(..)` is `true`, so an unknown tier
+/// would otherwise read COMPLETE from an empty (or absent) directory.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_tier_files(tier: &str) -> Option<&'static [&'static str]> {
+    KREA_REALTIME_TIER_FILES
+        .iter()
+        .find(|(name, _)| *name == tier)
+        .map(|(_, files)| *files)
+}
+
+/// Map a Krea Realtime model id to its `(quant-matrix repo, pinned revision)` for the on-demand tier
+/// fetch, or `None` for any other id (mirrors [`scail2_tier_repo`](super::scail2)). Keyed here so the
+/// whole tier-resolve/fetch path routes on `krea_realtime_tier_repo(..).is_some()`.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_tier_repo(model: &str) -> Option<(&'static str, &'static str)> {
+    (model == KREA_REALTIME_MODEL_ID).then_some((KREA_REALTIME_REPO, KREA_REALTIME_REVISION))
+}
+
+/// The Krea Realtime tier search order for a request — the preferred tier first, then the fallbacks,
+/// derived from the SAME [`resolve_mlx_dense_quant`] decision that would pick a load-time quant
+/// (sc-15258). `mlxQuantize <= 0` ⇒ `bf16`-first; `>= 5` ⇒ `q8`-first; no explicit pick OR an explicit
+/// `q4` ⇒ **`q4`-first** — the dense-video Q4 default (sc-10750), which reaches the video lane here
+/// because this order is what the resolver consults, not the image lane's `manifest.mlx.quantize`.
+///
+/// **`bf16` is the last fallback in EVERY order, never omitted** — the one deliberate divergence from
+/// [`scail2_tier_order`](super::scail2), and the whole point of the story. SCAIL-2 can leave `bf16` out
+/// of the default order because a repo with no matching tier still has a legacy FLAT root to fall back
+/// on; the Krea rehost has no flat root at all. Dropping `bf16` from the default order would mean a
+/// user who deliberately installed ONLY the `bf16/` tier gets "no tier found" and then either a hard
+/// failure or — far worse — a root fallback that quantizes their dense weights to Q4 in memory. That is
+/// the silent creative-tier switch the "quant tier is a CREATIVE choice, never switch it" convention
+/// forbids. Listing it LAST keeps the other half of the guarantee: a default job never prefers the
+/// ~40 GB dense tier while a leaner one is installed, and the tier is only ever *fetched* on an
+/// explicit pick ([`ensure_krea_realtime_tier_present`]).
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_tier_order(request: &VideoRequest) -> &'static [&'static str] {
+    match resolve_mlx_dense_quant(request) {
+        None => &["bf16", "q8", "q4"],
+        Some(Quant::Q8) => &["q8", "q4", "bf16"],
+        // No explicit pick OR an explicit `q4` ⇒ q4-first (the sc-10750 dense-video default).
+        _ => &["q4", "q8", "bf16"],
+    }
+}
+
+/// The declared files of `tier` that are NOT present under `root/<tier>`, as repo-relative paths.
+/// Empty ⇒ the tier is complete. An unknown tier reports ITSELF missing rather than reporting nothing,
+/// so it can never read as complete through the empty-vec path.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_missing_tier_files(root: &Path, tier: &str) -> Vec<String> {
+    let Some(files) = krea_realtime_tier_files(tier) else {
+        return vec![format!("{tier}/ (not a published tier)")];
+    };
+    let dir = root.join(tier);
+    files
+        .iter()
+        .filter(|file| !dir.join(file).is_file())
+        .map(|file| format!("{tier}/{file}"))
+        .collect()
+}
+
+/// Whether `root/<tier>` is a COMPLETE self-contained Krea Realtime tier snapshot (all of
+/// [`krea_realtime_tier_files`]). A partially-downloaded tier — including a `bf16/` missing one of its
+/// seven DiT shards — fails this, so [`krea_realtime_tier_subdir`] falls through to another complete
+/// tier rather than half-loading. Unknown tiers are never complete.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_tier_is_complete(root: &Path, tier: &str) -> bool {
+    krea_realtime_missing_tier_files(root, tier).is_empty()
+}
+
+/// Descend a resolved Krea Realtime repo `root` into the tier subdir this request should load: the
+/// first COMPLETE tier in [`krea_realtime_tier_order`], as `(tier name, dir)`. `None` when no tier
+/// subdir is complete — a locally converted FLAT snapshot (or nothing usable at all), which the caller
+/// distinguishes.
+///
+/// The NAME rides along because the caller records it on the asset: the tier that actually loaded is
+/// not always the one the request asked for (the order falls back), and the dir's last path component
+/// is not a substitute — a flat snapshot has no tier component at all.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_tier_subdir(
+    root: &Path,
+    request: &VideoRequest,
+) -> Option<(&'static str, PathBuf)> {
+    krea_realtime_tier_order(request)
+        .iter()
+        .find(|tier| krea_realtime_tier_is_complete(root, tier))
+        .map(|tier| (*tier, root.join(tier)))
+}
+
+/// Whether `dir` itself carries a Krea Realtime DiT — i.e. it is a FLAT snapshot rather than a
+/// tier-matrix root. It asks the same two questions the engine's `t2v::open_transformer_weights` asks
+/// (a single-file `dit.safetensors` OR a sharded `transformer/` dir), so the two agree about what
+/// "loadable" means — but strictly TIGHTER, not identical: the engine probes the DiT with `exists()`
+/// while this uses `is_file()`, so a *directory* named `dit.safetensors` would satisfy the engine's
+/// check and not this one. That asymmetry runs in the safe direction (this can only refuse things the
+/// engine would fail on anyway, never admit something it would reject) and matches the per-file
+/// `is_file()` the tier-completeness check uses.
+///
+/// Only a locally converted snapshot (the `SCENEWORKS_MLX_KREA_REALTIME_DIR` override or the
+/// app-managed convert output) is ever flat; the published repo root holds only tier subdirs, so it
+/// correctly fails this and the resolver errors instead of handing the engine a dir with no weights in
+/// it.
+#[cfg(target_os = "macos")]
+fn krea_realtime_dir_has_transformer(dir: &Path) -> bool {
+    dir.join("dit.safetensors").is_file() || dir.join("transformer").is_dir()
+}
+
+/// Everything a Krea Realtime load must settle before the engine is asked for anything, resolved as
+/// ONE unit by [`resolve_krea_realtime_tier_dir_and_quant`] (sc-15258). The three travel together on
+/// purpose: splitting them back into independent lookups is exactly how the tier and the quantization
+/// come apart, which is the silent creative-tier switch this story exists to prevent.
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct KreaRealtimeLoad {
+    /// The directory handed to the engine — an installed tier subdir, or a flat snapshot root.
+    pub(super) dir: PathBuf,
+    /// The load-time quant. Always `None` for a resolved tier (the tier on disk IS the quantization).
+    pub(super) quant: Option<Quant>,
+    /// The precision the DiT will actually run at (`q4` / `q8` / `bf16`) — recorded on the asset.
+    pub(super) tier: &'static str,
+}
+
+/// Resolve the Krea Realtime model dir, load-time quant and tier label for a generation — the ONE
+/// decision that picks them together (sc-15258), which is what makes the creative-tier choice
+/// unswitchable:
+///
+/// * A COMPLETE tier subdir wins and loads with **`quant = None`**. The tier on disk IS the
+///   quantization: `q4/`/`q8/` are pre-packed (the engine recovers `bits`/`group_size` from the packed
+///   shapes and cross-checks `config.json`), and `bf16/` is dense. `mlxQuantize` selects WHICH tier,
+///   never a load-time requant — so a deliberately-installed `bf16/` is served dense even under the Q4
+///   default, and a packed tier is never asked to re-quantize (which the engine would reject loudly
+///   anyway, `load::resolve_load_time_quant`).
+/// * A FLAT snapshot (a local convert / env override with a `dit.safetensors` or `transformer/` at its
+///   root — the published repo is never flat) keeps the load-time path: the root plus
+///   [`resolve_mlx_dense_quant`], i.e. **Q4 by default** (sc-10750's dense-video convention), which the
+///   engine applies in memory after the build.
+/// * Otherwise a LOUD error naming the tiers. There is deliberately no "just hand it the root" fallback:
+///   every published file lives under a tier prefix, so a root fallback could only fail deeper inside
+///   the loader with a less actionable message.
+///
+/// `tier` names the precision that will actually run in both branches — the resolved subdir's own name,
+/// or (flat) the tier the load-time quant packs to. It is the request's ASKED-FOR tier only when those
+/// coincide, which is the point: the asset records what loaded.
+#[cfg(target_os = "macos")]
+pub(super) fn resolve_krea_realtime_tier_dir_and_quant(
+    settings: &Settings,
+    request: &VideoRequest,
+) -> WorkerResult<KreaRealtimeLoad> {
+    let root = resolve_krea_realtime_model_dir(settings)?;
+    if let Some((tier, dir)) = krea_realtime_tier_subdir(&root, request) {
+        return Ok(KreaRealtimeLoad {
+            dir,
+            quant: None,
+            tier,
+        });
+    }
+    if krea_realtime_dir_has_transformer(&root) {
+        let quant = resolve_mlx_dense_quant(request);
+        return Ok(KreaRealtimeLoad {
+            dir: root,
+            quant,
+            tier: krea_realtime_quant_tier(quant),
+        });
+    }
+    Err(WorkerError::InvalidPayload(format!(
+        "krea_realtime_14b: no complete MLX tier under {}. Install the model (or one of its q4 / q8 / \
+         bf16 quality tiers) via the Model Manager — a partially-downloaded tier is skipped, so \
+         re-running the download repairs it.",
+        root.display(),
+    )))
+}
+
+/// The tier label a LOAD-TIME quant packs a dense snapshot to (mirrors `mochi_raw_settings`'s mapping):
+/// `Q4` ⇒ `q4`, `Q8` ⇒ `q8`, no quant ⇒ the dense `bf16`. Only the flat-snapshot branch needs this — a
+/// resolved tier subdir already knows its own name.
+#[cfg(target_os = "macos")]
+fn krea_realtime_quant_tier(quant: Option<Quant>) -> &'static str {
+    match quant {
+        Some(Quant::Q4) => "q4",
+        Some(Quant::Q8) => "q8",
+        _ => "bf16",
+    }
+}
+
+/// The tier an explicit `mlxQuantize` pick would FETCH on demand, or `None` for a default / `q4` job —
+/// `q4` ships with the base install, so nothing to fetch. Split out from
+/// [`ensure_krea_realtime_tier_present`] so the "which tier does this job want?" decision is directly
+/// testable without a network or an HF cache (the sibling `mochi_wants_q8` / `mochi_wants_bf16` seam).
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_on_demand_tier(request: &VideoRequest) -> Option<&'static str> {
+    match resolve_mlx_dense_quant(request) {
+        None => Some("bf16"),
+        Some(Quant::Q8) => Some("q8"),
+        _ => None,
+    }
+}
+
+/// The repo-relative paths the on-demand fetch asks for — the tier's EXPLICIT file list, each prefixed
+/// with `<tier>/`, matching the manifest rather than a `<tier>/*` glob. `None` for an unpublished tier.
+#[cfg(target_os = "macos")]
+pub(super) fn krea_realtime_tier_fetch_files(tier: &str) -> Option<Vec<String>> {
+    Some(
+        krea_realtime_tier_files(tier)?
+            .iter()
+            .map(|file| format!("{tier}/{file}"))
+            .collect(),
+    )
+}
+
+/// On-demand fetch of a non-default Krea Realtime tier subdir (mirrors
+/// [`ensure_scail2_tier_present`](super::scail2)). The macOS default install is the lean `q4/` tier; a
+/// job that explicitly opts into a heavier one ([`krea_realtime_on_demand_tier`]) pulls just that
+/// subdir from the FIXED [`KREA_REALTIME_REVISION`] the first time it is requested, so
+/// [`krea_realtime_tier_subdir`] can resolve it instead of silently falling back to a leaner tier — the
+/// creative-tier switch again, now on the fetch side. No-op for a non-Krea model, a `q4`/default job,
+/// an already-complete tier, or a repo that isn't downloaded at all (an env-override / local-convert
+/// install has no repo to fetch from, and resolve surfaces its own clear error).
+///
+/// **Then it VERIFIES, because the fetch itself makes no per-file promise.**
+/// `ensure_hf_files_cached` does not run the sc-12283 `unmatched_patterns` per-pattern hard-fail — that
+/// lives in the user-facing model-download job (`model_jobs::run_model_download_job`) — so a pattern
+/// matching nothing remotely is silently a no-op here. Left alone, an explicitly-picked tier whose
+/// remote copy is missing a shard would download the other ten files, read INCOMPLETE, and fall back to
+/// a leaner tier: precisely the silent downgrade this function exists to prevent. So after the fetch it
+/// re-checks completeness on disk and fails loud, NAMING the missing files. That is a stronger check
+/// than the per-pattern one (it tests what actually landed, not what the remote listing matched), and
+/// it is scoped to this lane rather than changing `ensure_hf_files_cached` for the Wan / SCAIL-2 /
+/// Bernini / Mochi callers, whose documented contract is to fall back when a tier is unpublished.
+#[cfg(target_os = "macos")]
+pub(super) async fn ensure_krea_realtime_tier_present(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+) -> WorkerResult<()> {
+    let Some((repo, revision)) = krea_realtime_tier_repo(&request.model) else {
+        return Ok(());
+    };
+    let Some(tier) = krea_realtime_on_demand_tier(request) else {
+        return Ok(());
+    };
+    let Some(root) = huggingface_snapshot_dir(&settings.data_dir, repo) else {
+        return Ok(());
+    };
+    if krea_realtime_tier_is_complete(&root, tier) {
+        return Ok(());
+    }
+    let Some(files) = krea_realtime_tier_fetch_files(tier) else {
+        return Ok(());
+    };
+    crate::model_jobs::ensure_hf_files_cached(api, settings, job, repo, revision, &files).await?;
+    // Re-resolve: the fetch may have materialized a NEW snapshot dir for the pinned revision.
+    let root = huggingface_snapshot_dir(&settings.data_dir, repo).unwrap_or(root);
+    let missing = krea_realtime_missing_tier_files(&root, tier);
+    if !missing.is_empty() {
+        return Err(WorkerError::InvalidPayload(format!(
+            "krea_realtime_14b: the {tier} tier is still incomplete after downloading it from {repo} \
+             — missing {}. Falling back to a different tier would silently change the quality tier \
+             you picked, so the job stops here.",
+            missing.join(", "),
+        )));
+    }
+    Ok(())
+}
+
+/// Resolve the Krea Realtime MLX snapshot ROOT: env override (`SCENEWORKS_MLX_KREA_REALTIME_DIR`) →
 /// app-managed `<data>/models/mlx/krea_realtime` → the turnkey `SceneWorks/krea-realtime-14b-mlx`
 /// snapshot if already downloaded (mirrors `resolve_bernini_model_dir`). Errors clearly if none is
 /// present (no stub fallback).
+///
+/// This is the repo/override root, NOT the directory the engine loads: the published layout is a quant
+/// matrix, so callers go through [`resolve_krea_realtime_tier_dir_and_quant`], which descends into the
+/// installed tier.
 #[cfg(target_os = "macos")]
 pub(super) fn resolve_krea_realtime_model_dir(settings: &Settings) -> WorkerResult<PathBuf> {
     if let Some(dir) = local_mlx_dir(
@@ -119,8 +451,15 @@ pub(super) fn krea_realtime_video_task(request: &VideoRequest) -> &'static str {
 }
 
 /// Raw-settings recorded on a real MLX Krea Realtime asset (mirrors `bernini_raw_settings`).
+///
+/// `kreaRealtimeTier` names the tier that actually **LOADED**, not the one the request asked for — the
+/// `mochiTier` convention (sc-15258). The two genuinely diverge now that this lane resolves tiers: an
+/// explicit `mlxQuantize: 8` with only `q4/` on disk falls back to q4, and a DEFAULT job with only
+/// `bf16/` installed loads bf16 dense. Without this stamp the sidecar would still carry the request's
+/// verbatim `advanced.mlxQuantize`, so an asset could claim `8` for a clip rendered at q4 — provenance
+/// drift on a field a user reads to reproduce a result.
 #[cfg(target_os = "macos")]
-pub(super) fn krea_realtime_raw_settings(request: &VideoRequest) -> Value {
+pub(super) fn krea_realtime_raw_settings(request: &VideoRequest, tier: &str) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
     raw.insert("model".to_owned(), Value::String(request.model.clone()));
@@ -129,6 +468,11 @@ pub(super) fn krea_realtime_raw_settings(request: &VideoRequest) -> Value {
     raw.insert(
         "kreaRealtimeTask".to_owned(),
         Value::String(krea_realtime_video_task(request).to_owned()),
+    );
+    // The precision the DiT actually ran at — authoritative over the request's `mlxQuantize`.
+    raw.insert(
+        "kreaRealtimeTier".to_owned(),
+        Value::String(tier.to_owned()),
     );
     Value::Object(raw)
 }
@@ -218,9 +562,15 @@ pub(super) async fn resolve_krea_realtime_conditioning(
 /// shared `generate_video` heartbeat funnel. The supplied media resolves to the engine conditioning
 /// ([`resolve_krea_realtime_conditioning`]) — empty for t2v, a `Reference` still for i2v (strength
 /// no-op), a `VideoClip` source for v2v (strength honored). CFG off: no negative prompt / guidance
-/// (the engine advertises none), `steps` from the advanced `steps` knob (else the engine default),
-/// dense bf16 load (`supported_quants = []`, so `quant = None`). Frame count uses the Wan 1-mod-4
-/// stride coercion — the DiT + z16 VAE ARE stock Wan 2.1, so the Wan stride is exactly right.
+/// (the engine advertises none), `steps` from the advanced `steps` knob (else the engine default).
+/// The model dir, the load-time `quant` and the tier label come from the single
+/// [`resolve_krea_realtime_tier_dir_and_quant`] decision (sc-15258): the installed tier subdir with
+/// `quant = None`, or a flat local snapshot with the Q4-default load-time quant. Frame count uses the
+/// Wan 1-mod-4 stride coercion — the DiT + z16 VAE ARE stock Wan 2.1, so the Wan stride is exactly
+/// right.
+///
+/// Returns the decoded clip plus the tier that actually LOADED, so the caller records it on the asset
+/// without re-resolving (the `generate_scail2` → `lightning` shape).
 ///
 /// Runs through the `generate_video` → `generate_video_using` funnel so a long/multi-minute AR job
 /// drives `heartbeat(...)` and is NOT marked `interrupted` by the ~90 s API stale-sweep, and so the
@@ -242,7 +592,7 @@ pub(super) async fn generate_krea_realtime(
     project_path: &Path,
     engine_id: &'static str,
     backend: &str,
-) -> WorkerResult<DecodedVideo> {
+) -> WorkerResult<(DecodedVideo, &'static str)> {
     generate_krea_realtime_using(
         api,
         settings,
@@ -273,18 +623,22 @@ pub(super) async fn generate_krea_realtime_using(
     load_generator: impl FnOnce(&str, &LoadSpec) -> gen_core::Result<Box<dyn Generator>>
         + Send
         + 'static,
-) -> WorkerResult<DecodedVideo> {
+) -> WorkerResult<(DecodedVideo, &'static str)> {
     let conditioning =
         resolve_krea_realtime_conditioning(api, settings, job, request, project_path).await?;
-    let model_dir = resolve_krea_realtime_model_dir(settings)?;
+    // Krea Realtime quant matrix (sc-15258, epic 8506 shape): an explicitly picked q8/bf16 tier is
+    // fetched on demand before resolving (no-op for a default job or an already-present tier), then the
+    // tier subdir AND the load-time quant come out of ONE decision — a resolved tier loads exactly as
+    // it sits on disk (`quant = None`), a flat local snapshot keeps the Q4-default load-time quant.
+    ensure_krea_realtime_tier_present(api, settings, job, request).await?;
+    let load = resolve_krea_realtime_tier_dir_and_quant(settings, request)?;
+    let tier = load.tier;
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
         engine_id,
-        model_dir,
-        // Dense bf16 load: the engine advertises `supported_quants = []`, so never request a load-time
-        // quant (a Q4/Q8 request would be capability-dishonest until a tier is wired).
-        quant: None,
+        model_dir: load.dir,
+        quant: load.quant,
         conditioning,
         prompt: request.prompt.clone(),
         // CFG off: the engine advertises no negative-prompt / guidance axis, so leave both unset.
@@ -299,7 +653,7 @@ pub(super) async fn generate_krea_realtime_using(
         // No adapters: `supports_lora = false` (LoRA is the S15 seam — see the doc comment).
         ..VideoGenInput::default()
     };
-    generate_video_using(
+    let decoded = generate_video_using(
         api,
         settings,
         job,
@@ -308,5 +662,6 @@ pub(super) async fn generate_krea_realtime_using(
         input,
         load_generator,
     )
-    .await
+    .await?;
+    Ok((decoded, tier))
 }

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -677,20 +677,23 @@ pub(crate) async fn run_video_generate_job(
                 // shipped checkpoint is Wan 2.1 T2V 14B weight-for-weight. `generate_krea_realtime` maps
                 // the supplied media to the engine conditioning (a reference still → i2v `Reference`,
                 // strength no-op; a source clip → v2v `VideoClip`, strength honored; else t2v) and drives
-                // the shared `generate_video` heartbeat funnel. CFG off; dense bf16; no LoRA yet (S15).
+                // the shared `generate_video` heartbeat funnel. CFG off; no LoRA yet (S15). It resolves
+                // the installed quant tier and returns which one LOADED, so the record names the tier
+                // that actually ran rather than the one the request asked for (sc-15258).
+                let (decoded, tier) = generate_krea_realtime(
+                    api,
+                    settings,
+                    job,
+                    &request,
+                    &project_path,
+                    engine_id,
+                    backend,
+                )
+                .await?;
                 (
-                    generate_krea_realtime(
-                        api,
-                        settings,
-                        job,
-                        &request,
-                        &project_path,
-                        engine_id,
-                        backend,
-                    )
-                    .await?,
+                    decoded,
                     KREA_REALTIME_ADAPTER,
-                    krea_realtime_raw_settings(&request),
+                    krea_realtime_raw_settings(&request, tier),
                     None,
                 )
             }

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -2746,7 +2746,20 @@ fn mochi_routes_to_the_mochi_engine_and_never_degrades_to_a_fake_video() {
 fn krea_fake_model_dir(tag: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("krea_{tag}_{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(dir.join("config.json"), "{}").unwrap();
+    // A FLAT locally-converted snapshot: `config.json` is what `local_mlx_dir` counts, and
+    // `dit.safetensors` (+ the stock Wan companions) is what makes it actually loadable — the
+    // `krea_realtime_dir_has_transformer` probe the resolver runs, mirroring the engine's own
+    // `t2v::open_transformer_weights`. A `config.json`-only dir would resolve as a model dir and then
+    // die inside the loader, so the fixture must carry weights (sc-15258).
+    for file in [
+        "config.json",
+        "dit.safetensors",
+        "t5_encoder.safetensors",
+        "tokenizer.json",
+        "vae.safetensors",
+    ] {
+        std::fs::write(dir.join(file), "{}").unwrap();
+    }
     dir
 }
 
@@ -2987,7 +3000,11 @@ fn krea_realtime_using_hands_the_engine_the_mapped_t2v_request() {
     .expect("krea t2v generation runs through the funnel against the probe");
 
     // The clip came back through the funnel — the generate path structurally ran the heartbeat loop.
+    let (decoded, tier) = decoded;
     assert!(!decoded.frames.is_empty());
+    // The fixture is a flat snapshot with no explicit `mlxQuantize`, so the dense-video Q4 default
+    // is what loads — and the arm reports it for the asset stamp.
+    assert_eq!(tier, "q4");
 
     let seen = probe.request.lock().unwrap();
     let gen = seen.as_ref().expect("the arm reached the engine");
@@ -3007,6 +3024,928 @@ fn krea_realtime_using_hands_the_engine_the_mapped_t2v_request() {
 
     drop(seen);
     std::fs::remove_dir_all(&model_dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Krea Realtime quant matrix (sc-15258, S20): per-tier resolution + the one-decision quant.
+// ---------------------------------------------------------------------------
+
+/// A Krea Realtime `VideoRequest` carrying `advanced` — the tier selector's only input.
+#[cfg(target_os = "macos")]
+fn krea_tier_request(advanced: Value) -> VideoRequest {
+    request(json!({
+        "projectId": "p",
+        "model": "krea_realtime_14b",
+        "mode": "text_to_video",
+        "prompt": "p",
+        "advanced": advanced,
+    }))
+}
+
+/// The directory a `LoadSpec`'s weights point at. `WeightsSource` has no `PartialEq`, so the model
+/// dir that reached the engine is compared through this rather than `assert_eq!` on the enum.
+#[cfg(target_os = "macos")]
+fn spec_weights_dir(spec: &LoadSpec) -> PathBuf {
+    match &spec.weights {
+        WeightsSource::Dir(dir) => dir.clone(),
+        WeightsSource::File(file) => panic!("a video load is a Dir source, got the file {file:?}"),
+    }
+}
+
+/// Write a COMPLETE Krea Realtime tier subdir under `root` — every file in that tier's own
+/// `KREA_REALTIME_TIER_FILES` row, including the `bf16/` tier's NESTED seven-shard `transformer/`.
+#[cfg(target_os = "macos")]
+fn write_complete_krea_tier(root: &Path, tier: &str) {
+    let files = krea_realtime_tier_files(tier).expect("a published krea tier");
+    for file in files {
+        let path = root.join(tier).join(file);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"x").unwrap();
+    }
+}
+
+/// The worker's hard-coded tier table IS the shipped manifest — same repo, same pinned revision, same
+/// exact file paths per tier. The worker resolves a tier by checking those files on disk while the
+/// Model Manager downloads whatever `builtin.models.jsonc` declares, so any drift between the two
+/// silently produces a tier that installs but never resolves (or resolves while torn).
+///
+/// This is what closes the loop the sc-8444 layout test opened: that one pins the manifest against the
+/// PUBLISHED repo; this one pins the WORKER against the manifest.
+///
+/// Mutation checks (each verified RED): rename any `bf16/transformer/dit-…` shard in
+/// `KREA_REALTIME_BF16_TIER_FILES`; drop `config.json` from the packed row; change one hex digit of
+/// `KREA_REALTIME_REVISION`.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_worker_tier_table_matches_the_shipped_manifest() {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc present");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
+    let model = manifest["models"]
+        .as_array()
+        .expect("models array")
+        .iter()
+        .find(|model| model["id"].as_str() == Some("krea_realtime_14b"))
+        .expect("krea_realtime_14b present in the builtin catalog");
+
+    let downloads = model["downloads"]
+        .as_array()
+        .expect("krea_realtime_14b declares downloads");
+    let mut seen: Vec<&str> = Vec::new();
+    for entry in downloads {
+        let variant = entry["variant"]
+            .as_str()
+            .expect("every krea download is a tier variant");
+        seen.push(variant);
+        assert_eq!(
+            entry["repo"].as_str(),
+            Some(KREA_REALTIME_REPO),
+            "{variant}: the worker fetches from KREA_REALTIME_REPO, so the manifest must install from it"
+        );
+        assert_eq!(
+            entry["revision"].as_str(),
+            Some(KREA_REALTIME_REVISION),
+            "{variant}: a worker pin that differs from the manifest's would materialize a SECOND \
+             snapshot dir beside the installed one"
+        );
+        let declared: Vec<String> = entry["files"]
+            .as_array()
+            .expect("explicit file paths")
+            .iter()
+            .map(|file| file.as_str().expect("a file path").to_owned())
+            .collect();
+        let expected: Vec<String> = krea_realtime_tier_files(variant)
+            .unwrap_or_else(|| panic!("{variant} is declared in the manifest but not in the worker's KREA_REALTIME_TIER_FILES"))
+            .iter()
+            .map(|file| format!("{variant}/{file}"))
+            .collect();
+        let (mut declared, mut expected) = (declared, expected);
+        declared.sort();
+        expected.sort();
+        assert_eq!(
+            declared, expected,
+            "{variant}: the worker's completeness predicate must check exactly the files the \
+             manifest installs"
+        );
+    }
+    seen.sort();
+    let mut tiers: Vec<&str> = KREA_REALTIME_TIER_FILES
+        .iter()
+        .map(|(tier, _)| *tier)
+        .collect();
+    tiers.sort();
+    assert_eq!(
+        seen, tiers,
+        "the worker must know every published tier and no others"
+    );
+
+    // The bf16 row is the structurally different one — assert its shape directly so a future edit
+    // that "simplifies" it to the flat packed row cannot pass by accident.
+    let bf16 = krea_realtime_tier_files("bf16").expect("bf16 is published");
+    assert_eq!(
+        bf16.iter()
+            .filter(|file| file.starts_with("transformer/"))
+            .count(),
+        7,
+        "the bf16 DiT is a 7-shard transformer/ directory, not a flat dit.safetensors"
+    );
+    assert!(
+        !bf16.contains(&"dit.safetensors"),
+        "the bf16 tier has no flat DiT"
+    );
+    assert!(
+        krea_realtime_tier_files("q4")
+            .expect("q4 is published")
+            .contains(&"dit.safetensors"),
+        "the packed tiers DO ship a flat single-file DiT"
+    );
+    assert_eq!(
+        krea_realtime_tier_files("q6"),
+        None,
+        "an unpublished tier must have NO file list — an empty one would read COMPLETE from an \
+         empty directory"
+    );
+}
+
+/// The tier search order comes from the SAME `resolve_mlx_dense_quant` decision that would pick a
+/// load-time quant, and — the sc-15258 trap — `bf16` is in EVERY order rather than only the explicit
+/// one. The Krea rehost has no flat root to fall back on (unlike SCAIL-2), so dropping `bf16` from the
+/// default order is exactly how a deliberately-installed bf16 tier becomes unreachable and gets
+/// silently re-quantized to the Q4 default.
+///
+/// Mutation checks (each verified RED): drop `"bf16"` from the default arm; flip the default arm to
+/// `bf16`-first; make the `Some(Q8)` arm fall back to `q8` only.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_tier_order_tracks_the_quant_and_never_drops_bf16() {
+    let default = krea_tier_request(json!({}));
+    let q4 = krea_tier_request(json!({ "mlxQuantize": 4 }));
+    let q8 = krea_tier_request(json!({ "mlxQuantize": 8 }));
+    let bf16 = krea_tier_request(json!({ "mlxQuantize": 0 }));
+
+    // The dense-video Q4 default (sc-10750) reaching the VIDEO lane: no explicit pick ⇒ q4-first.
+    assert_eq!(krea_realtime_tier_order(&default), &["q4", "q8", "bf16"]);
+    assert_eq!(krea_realtime_tier_order(&q4), &["q4", "q8", "bf16"]);
+    assert_eq!(krea_realtime_tier_order(&q8), &["q8", "q4", "bf16"]);
+    assert_eq!(krea_realtime_tier_order(&bf16), &["bf16", "q8", "q4"]);
+
+    // One decision: the order's head is the tier the shared resolver would have quantized to.
+    for (req, head) in [(&default, "q4"), (&q4, "q4"), (&q8, "q8"), (&bf16, "bf16")] {
+        assert_eq!(krea_realtime_tier_order(req)[0], head);
+    }
+    assert_eq!(resolve_mlx_dense_quant(&default), Some(Quant::Q4));
+    assert_eq!(resolve_mlx_dense_quant(&q8), Some(Quant::Q8));
+    assert_eq!(resolve_mlx_dense_quant(&bf16), None);
+
+    // EVERY order can still reach EVERY published tier — the no-silent-switch precondition.
+    for req in [&default, &q4, &q8, &bf16] {
+        let order = krea_realtime_tier_order(req);
+        for (tier, _) in KREA_REALTIME_TIER_FILES {
+            assert!(
+                order.contains(tier),
+                "{tier} must be reachable from every tier order — the Krea rehost has no flat root \
+                 fallback, so an omitted tier is an unloadable install"
+            );
+        }
+    }
+}
+
+/// Each tier resolves to its OWN subdir — including the bf16 tier, whose DiT lives one level deeper in
+/// a seven-shard `transformer/` dir — and a torn tier is skipped rather than half-loaded.
+///
+/// Mutation checks (each verified RED): resolve `root` instead of `root.join(tier)`; make
+/// `krea_realtime_tier_is_complete` return `true` for an unknown tier; drop the per-tier file lookup so
+/// bf16 is checked against the packed row (a bf16 dir would then read INCOMPLETE).
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_tier_subdir_resolves_each_tier_including_the_sharded_bf16() {
+    let root = std::env::temp_dir().join(format!("sw_krea_tier_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&root).unwrap();
+    let default = krea_tier_request(json!({}));
+    let q8_req = krea_tier_request(json!({ "mlxQuantize": 8 }));
+    let bf16_req = krea_tier_request(json!({ "mlxQuantize": 0 }));
+
+    // A bare root (the published repo before any tier is installed) resolves nothing.
+    assert_eq!(krea_realtime_tier_subdir(&root, &default), None);
+
+    // q4 only: every request falls back to it (there is nothing else on disk).
+    write_complete_krea_tier(&root, "q4");
+    assert_eq!(
+        krea_realtime_tier_subdir(&root, &default),
+        Some(("q4", root.join("q4")))
+    );
+    assert_eq!(
+        krea_realtime_tier_subdir(&root, &q8_req),
+        Some(("q4", root.join("q4")))
+    );
+
+    // A torn q8 (config.json only) is skipped — not resolved and then failed inside the loader.
+    std::fs::create_dir_all(root.join("q8")).unwrap();
+    std::fs::write(root.join("q8").join("config.json"), b"x").unwrap();
+    assert!(!krea_realtime_tier_is_complete(&root, "q8"));
+    assert_eq!(
+        krea_realtime_missing_tier_files(&root, "q8"),
+        vec![
+            "q8/dit.safetensors",
+            "q8/t5_encoder.safetensors",
+            "q8/tokenizer.json",
+            "q8/vae.safetensors",
+        ],
+        "the loud-failure path must NAME what a torn tier is missing"
+    );
+    assert_eq!(
+        krea_realtime_tier_subdir(&root, &q8_req),
+        Some(("q4", root.join("q4")))
+    );
+
+    // Completed q8 wins for an explicit q8 pick; a default job still resolves q4-first.
+    write_complete_krea_tier(&root, "q8");
+    assert_eq!(
+        krea_realtime_tier_subdir(&root, &q8_req),
+        Some(("q8", root.join("q8")))
+    );
+    assert_eq!(
+        krea_realtime_tier_subdir(&root, &default),
+        Some(("q4", root.join("q4")))
+    );
+
+    // bf16: the nested transformer/ layout resolves to the TIER dir (what the engine's
+    // `open_transformer_weights` probes), and the shards really are one level below it.
+    write_complete_krea_tier(&root, "bf16");
+    let (name, resolved) = krea_realtime_tier_subdir(&root, &bf16_req).expect("bf16 resolves");
+    assert_eq!(
+        name, "bf16",
+        "the resolved tier names ITSELF — the asset records this"
+    );
+    assert_eq!(resolved, root.join("bf16"));
+    assert!(
+        resolved
+            .join("transformer/dit-00004-of-00007.safetensors")
+            .is_file(),
+        "the resolved dir must be the tier dir the sharded DiT hangs off"
+    );
+    assert!(
+        !resolved.join("dit.safetensors").exists(),
+        "the bf16 tier deliberately has no flat DiT — resolving the tier dir is what makes it loadable"
+    );
+    // Still q4-first for a default job even with all three installed: the tier order prefers the
+    // lean tier, it does not merely take whatever exists.
+    assert_eq!(
+        krea_realtime_tier_subdir(&root, &default),
+        Some(("q4", root.join("q4")))
+    );
+
+    // Losing ONE of the seven bf16 shards makes the tier incomplete — the sc-13513 "installed but
+    // unloadable" class — so an explicit bf16 pick falls through to q8 instead.
+    std::fs::remove_file(root.join("bf16/transformer/dit-00004-of-00007.safetensors")).unwrap();
+    assert!(!krea_realtime_tier_is_complete(&root, "bf16"));
+    assert_eq!(
+        krea_realtime_missing_tier_files(&root, "bf16"),
+        vec!["bf16/transformer/dit-00004-of-00007.safetensors"],
+        "a torn bf16 must name the exact missing shard, not just report incomplete"
+    );
+    assert_eq!(
+        krea_realtime_tier_subdir(&root, &bf16_req),
+        Some(("q8", root.join("q8")))
+    );
+
+    // An unpublished tier is never complete, even as a real (empty) directory.
+    std::fs::create_dir_all(root.join("q6")).unwrap();
+    assert!(!krea_realtime_tier_is_complete(&root, "q6"));
+    assert!(
+        !krea_realtime_missing_tier_files(&root, "q6").is_empty(),
+        "an unpublished tier must report ITSELF missing — an empty vec would read COMPLETE"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// 🔴 The story's trap, end to end: a user who deliberately installed ONLY the **bf16** tier must get
+/// bf16 **dense**, never the Q4 default applied to it in memory. The tier dir and the load-time quant
+/// come out of ONE decision, so a resolved tier always loads exactly as it sits on disk
+/// (`quantize: None`) — `mlxQuantize` picks WHICH tier, never a requant.
+///
+/// Discriminating rather than "asserts None everywhere": the same default request against a q4 install
+/// resolves the q4 dir, and a FLAT snapshot in the same test does get `Some(Q4)` — so a resolver that
+/// simply always returned `None`, or always returned the root, fails here.
+///
+/// Mutation checks (each verified RED): return `resolve_mlx_dense_quant(request)` alongside a resolved
+/// tier; drop `"bf16"` from the default tier order (⇒ the bf16-only install falls to the root branch).
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_bf16_install_is_served_dense_not_downgraded_to_q4() {
+    let root = std::env::temp_dir().join(format!("sw_krea_bf16_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&root).unwrap();
+    // `local_mlx_dir` counts an override dir only when it holds a `config.json`; the tier matrix's
+    // own config.json files live inside the tier dirs, so the fixture carries a root marker.
+    std::fs::write(root.join("config.json"), "{}").unwrap();
+    write_complete_krea_tier(&root, "bf16");
+    let settings = Settings {
+        data_dir: root.join("unused-data-dir"),
+        ..offline_settings()
+    };
+    let default = krea_tier_request(json!({}));
+
+    temp_env_var(
+        "SCENEWORKS_MLX_KREA_REALTIME_DIR",
+        root.to_str().unwrap(),
+        || {
+            let load = resolve_krea_realtime_tier_dir_and_quant(&settings, &default)
+                .expect("a bf16-only install is loadable");
+            assert_eq!(
+                load.dir,
+                root.join("bf16"),
+                "the ONLY installed tier must be the one resolved, even under the Q4 default"
+            );
+            assert_eq!(
+                load.quant, None,
+                "a deliberately-installed bf16 tier must load DENSE — quantizing it to Q4 in memory \
+                 is the silent creative-tier switch this story exists to prevent"
+            );
+            assert_eq!(
+                load.tier, "bf16",
+                "the asset must record the tier that LOADED — a default job's `advanced` says \
+                 nothing about bf16, so only this stamp tells the user what actually ran"
+            );
+            // An explicit bf16 pick agrees, and the route is live (not Stub).
+            let explicit = krea_tier_request(json!({ "mlxQuantize": 0 }));
+            let explicit_load =
+                resolve_krea_realtime_tier_dir_and_quant(&settings, &explicit).unwrap();
+            assert_eq!(explicit_load.dir, root.join("bf16"));
+            assert_eq!(explicit_load.quant, None);
+            assert_eq!(explicit_load.tier, "bf16");
+            assert!(krea_realtime_available(&default, &settings));
+
+            // Now install q4 too: the SAME default request moves to q4 — proving the bf16 answer
+            // above was the tier order resolving, not a constant.
+            write_complete_krea_tier(&root, "q4");
+            let load = resolve_krea_realtime_tier_dir_and_quant(&settings, &default).unwrap();
+            assert_eq!(load.dir, root.join("q4"));
+            assert_eq!(
+                load.quant, None,
+                "a packed tier is never asked to re-quantize"
+            );
+            assert_eq!(load.tier, "q4");
+
+            // 🔴 The provenance case this stamp exists for: an explicit `mlxQuantize: 8` with only
+            // q4/bf16 on disk FALLS BACK — so the asset's own `advanced` would claim 8 while the
+            // clip rendered at q4. The stamp must contradict the request, not echo it.
+            let asked_q8 = krea_tier_request(json!({ "mlxQuantize": 8 }));
+            let fell_back = resolve_krea_realtime_tier_dir_and_quant(&settings, &asked_q8).unwrap();
+            assert_eq!(fell_back.tier, "q4", "q8 was asked for; q4 is what loaded");
+            let raw = krea_realtime_raw_settings(&asked_q8, fell_back.tier);
+            assert_eq!(
+                raw.get("kreaRealtimeTier").and_then(Value::as_str),
+                Some("q4"),
+                "the sidecar must name the tier that ran, not the one requested"
+            );
+            assert_eq!(
+                raw.get("mlxQuantize").and_then(Value::as_i64),
+                Some(8),
+                "the request's own knob is still recorded verbatim — the tier stamp is what \
+                 disambiguates it, so both must be present and DIFFERENT here"
+            );
+        },
+    );
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// A FLAT snapshot (a local convert / env override with the DiT at its root — the only layout that has
+/// no tier to speak for it) keeps the load-time quant path, and its default is **Q4**: sc-10750's
+/// dense-video convention, which reaches the video lane through `resolve_mlx_dense_quant` here.
+///
+/// This is the assertion that discriminates against the shipped behaviour before this story: the arm
+/// hard-coded `quant: None`, so a default job loaded a ~28 GB dense DiT. The end-to-end leg drives the
+/// real generate path and reads the `LoadSpec` that reached the engine, not just the resolver.
+///
+/// Mutation checks (each verified RED): restore `quant: None` in `generate_krea_realtime_using`; make
+/// the flat branch return `None` instead of `resolve_mlx_dense_quant(request)`.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_flat_snapshot_takes_the_q4_dense_video_default() {
+    let flat = krea_fake_model_dir("flatquant");
+    let settings = Settings {
+        data_dir: flat.join("unused-data-dir"),
+        ..offline_settings()
+    };
+
+    let probe = ArmProbe::default();
+    let loader = probe.loader();
+    let job = krea_job_snapshot();
+    let req = request(json!({
+        "projectId": "p",
+        "model": "krea_realtime_14b",
+        "mode": "text_to_video",
+        "prompt": "p",
+        "duration": 2.0,
+        "fps": 24
+    }));
+
+    let loaded_tier = temp_env_var(
+        "SCENEWORKS_MLX_KREA_REALTIME_DIR",
+        flat.to_str().unwrap(),
+        || {
+            // The resolver's own answers, across the whole `mlxQuantize` axis.
+            for (advanced, expected) in [
+                (json!({}), Some(Quant::Q4)),
+                (json!({ "mlxQuantize": 4 }), Some(Quant::Q4)),
+                (json!({ "mlxQuantize": 8 }), Some(Quant::Q8)),
+                (json!({ "mlxQuantize": 0 }), None),
+            ] {
+                let load = resolve_krea_realtime_tier_dir_and_quant(
+                    &settings,
+                    &krea_tier_request(advanced.clone()),
+                )
+                .expect("a flat snapshot is loadable");
+                assert_eq!(load.dir, flat, "a flat snapshot loads from its own root");
+                assert_eq!(
+                    load.quant, expected,
+                    "flat snapshot with advanced {advanced}: the load-time quant must follow \
+                     mlxQuantize, defaulting to Q4"
+                );
+                // A flat snapshot has no tier dir to name itself, so the stamp comes from the
+                // quant that will pack it — the `mochiTier` mapping.
+                assert_eq!(
+                    load.tier,
+                    match expected {
+                        Some(Quant::Q4) => "q4",
+                        Some(Quant::Q8) => "q8",
+                        _ => "bf16",
+                    },
+                    "flat snapshot with advanced {advanced}: the recorded tier must be the \
+                     precision the DiT actually runs at"
+                );
+            }
+
+            // …and what actually reaches the engine for a DEFAULT job.
+            let (_, tier) = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime builds")
+                .block_on(generate_krea_realtime_using(
+                    &ApiClient::new(&settings),
+                    &settings,
+                    &job,
+                    &req,
+                    &flat,
+                    "krea_realtime_14b",
+                    "mlx",
+                    loader,
+                ))
+                .expect("krea t2v generation runs through the funnel against the probe");
+            tier
+        },
+    );
+    assert_eq!(
+        loaded_tier, "q4",
+        "the arm must report the tier it loaded so the caller can stamp the asset"
+    );
+
+    let seen = probe.spec.lock().unwrap();
+    let spec = seen.as_ref().expect("the arm loaded an engine");
+    assert_eq!(
+        spec.quantize,
+        Some(Quant::Q4),
+        "a default krea job must reach the engine at Q4 — the shipped arm hard-coded `quant: None`, \
+         so a default job loaded the dense ~28 GB DiT"
+    );
+    assert_eq!(spec_weights_dir(spec), flat);
+
+    drop(seen);
+    std::fs::remove_dir_all(&flat).ok();
+}
+
+/// A resolved TIER reaches the engine as the tier DIR with `quantize: None` — the loadability half of
+/// the release gate. Before this story the arm handed the engine the snapshot ROOT, where
+/// `t2v::open_transformer_weights` finds neither `dit.safetensors` nor `transformer/`, so nothing Krea
+/// shipped could load at all.
+///
+/// Mutation check (verified RED): hand `resolve_krea_realtime_model_dir(settings)?` to `VideoGenInput`
+/// instead of the tier-resolved dir.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_hands_the_engine_the_installed_tier_dir_not_the_snapshot_root() {
+    let root = std::env::temp_dir().join(format!("sw_krea_arm_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("config.json"), "{}").unwrap();
+    write_complete_krea_tier(&root, "q4");
+    let settings = Settings {
+        data_dir: root.join("unused-data-dir"),
+        ..offline_settings()
+    };
+    let probe = ArmProbe::default();
+    let loader = probe.loader();
+    let job = krea_job_snapshot();
+    let req = request(json!({
+        "projectId": "p",
+        "model": "krea_realtime_14b",
+        "mode": "text_to_video",
+        "prompt": "p",
+        "duration": 2.0,
+        "fps": 24
+    }));
+
+    temp_env_var(
+        "SCENEWORKS_MLX_KREA_REALTIME_DIR",
+        root.to_str().unwrap(),
+        || {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime builds")
+                .block_on(generate_krea_realtime_using(
+                    &ApiClient::new(&settings),
+                    &settings,
+                    &job,
+                    &req,
+                    &root,
+                    "krea_realtime_14b",
+                    "mlx",
+                    loader,
+                ))
+                .expect("krea t2v generation runs through the funnel against the probe");
+        },
+    );
+
+    let seen = probe.spec.lock().unwrap();
+    let spec = seen.as_ref().expect("the arm loaded an engine");
+    assert_eq!(
+        spec_weights_dir(spec),
+        root.join("q4"),
+        "the engine must be handed the installed TIER dir — every published Krea file lives under a \
+         q4/ / q8/ / bf16/ prefix, so the snapshot root holds no weights at all"
+    );
+    assert_eq!(
+        spec.quantize, None,
+        "a pre-packed tier loads exactly as it sits on disk"
+    );
+
+    drop(seen);
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// A tier-matrix root with NO complete tier fails loudly and actionably — it must never fall back to
+/// handing the engine the root, which holds no weights and would surface as an opaque loader error.
+/// The route degrades to `Stub`, whose fail-loud gate then reports it.
+///
+/// Mutation check (verified RED): add a `_ => Ok((root, resolve_mlx_dense_quant(request)))` fallback
+/// to `resolve_krea_realtime_tier_dir_and_quant`.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_torn_install_fails_loudly_instead_of_resolving_the_root() {
+    let root = std::env::temp_dir().join(format!("sw_krea_torn_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&root).unwrap();
+    // The published repo root: a card + tier dirs, no weights of its own. `config.json` is the
+    // `local_mlx_dir` marker so the ROOT resolves — the point is that resolving the root is not
+    // enough, which is exactly the bug this story fixes.
+    std::fs::write(root.join("config.json"), "{}").unwrap();
+    std::fs::write(root.join("README.md"), "# card").unwrap();
+    // A torn q4: everything but the DiT.
+    std::fs::create_dir_all(root.join("q4")).unwrap();
+    for file in ["config.json", "t5_encoder.safetensors", "tokenizer.json"] {
+        std::fs::write(root.join("q4").join(file), b"x").unwrap();
+    }
+    let settings = Settings {
+        data_dir: root.join("unused-data-dir"),
+        ..offline_settings()
+    };
+    let req = krea_tier_request(json!({}));
+
+    temp_env_var(
+        "SCENEWORKS_MLX_KREA_REALTIME_DIR",
+        root.to_str().unwrap(),
+        || {
+            // The root itself DOES resolve — so a test that only checked `resolve_..._model_dir`
+            // would be green here. That is the false green this story was filed against.
+            assert!(resolve_krea_realtime_model_dir(&settings).is_ok());
+
+            let err = resolve_krea_realtime_tier_dir_and_quant(&settings, &req)
+                .expect_err("a torn install must not resolve");
+            let WorkerError::InvalidPayload(message) = err else {
+                panic!("expected an actionable InvalidPayload");
+            };
+            assert!(
+                message.contains("krea_realtime_14b")
+                    && message.contains("q4")
+                    && message.contains("bf16")
+                    && message.contains("Model Manager"),
+                "the error must name the model, the tiers, and what to do: {message}"
+            );
+            assert!(!krea_realtime_available(&req, &settings));
+            assert_eq!(resolve_video_route(&req, &settings), VideoRoute::Stub);
+            assert!(ensure_video_engine_weights(&req, &settings).is_err());
+
+            // Completing the tier flips every one of those.
+            write_complete_krea_tier(&root, "q4");
+            let load = resolve_krea_realtime_tier_dir_and_quant(&settings, &req).unwrap();
+            assert_eq!(load.dir, root.join("q4"));
+            assert_eq!(load.quant, None);
+            assert_eq!(load.tier, "q4");
+            assert!(krea_realtime_available(&req, &settings));
+        },
+    );
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// The tier matrix installed the way users actually get it — the pinned HF snapshot under the data
+/// dir, with no env override in play. Pins that `resolve_krea_realtime_model_dir`'s HF branch feeds the
+/// tier descent (the production path), not just the override branch the other tests exercise.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_resolves_the_tier_from_a_downloaded_hf_snapshot() {
+    let hub = std::env::temp_dir().join(format!("sw_krea_hub_{}", Uuid::new_v4().simple()));
+    let repo_dir = hub.join(format!(
+        "models--{}",
+        sceneworks_core::hf_home::safe_repo_dir_name(KREA_REALTIME_REPO)
+            .expect("the krea repo slug")
+    ));
+    let snapshot = repo_dir.join("snapshots").join(KREA_REALTIME_REVISION);
+    std::fs::create_dir_all(&snapshot).unwrap();
+    std::fs::write(snapshot.join("README.md"), "# card").unwrap();
+    write_complete_krea_tier(&snapshot, "q8");
+    std::fs::create_dir_all(repo_dir.join("refs")).unwrap();
+    std::fs::write(repo_dir.join("refs").join("main"), KREA_REALTIME_REVISION).unwrap();
+
+    let settings = Settings {
+        data_dir: hub.join("data"),
+        ..offline_settings()
+    };
+    // The HF cache dir is its own axis: a pinned `data_dir` alone does NOT make it hermetic.
+    temp_env_vars(
+        &[
+            ("SCENEWORKS_MLX_KREA_REALTIME_DIR", ""),
+            ("HF_HUB_CACHE", hub.to_str().unwrap()),
+            ("HUGGINGFACE_HUB_CACHE", ""),
+            ("HF_HOME", ""),
+        ],
+        || {
+            // Only q8 is installed, so even a DEFAULT (q4-first) job resolves it — and dense-loads
+            // nothing: it is served as the packed tier it is.
+            let load =
+                resolve_krea_realtime_tier_dir_and_quant(&settings, &krea_tier_request(json!({})))
+                    .expect("the downloaded q8 tier resolves");
+            assert_eq!(load.dir, snapshot.join("q8"));
+            assert_eq!(load.quant, None);
+            assert_eq!(load.tier, "q8");
+            // The ROOT resolves too — which is precisely why resolving it was never enough.
+            assert_eq!(
+                resolve_krea_realtime_model_dir(&settings).unwrap(),
+                snapshot
+            );
+        },
+    );
+    std::fs::remove_dir_all(&hub).ok();
+}
+
+/// The on-demand tier fetch is gated on the request's tier toggle — the krea twin of
+/// `mochi_on_demand_tier_fetch_is_gated_on_the_toggle`, and it matters more here: krea's opt-in tiers
+/// are 27 GB (q8) and 40 GB (bf16), so a default job that wanted one would drag an enormous
+/// unrequested download into every generation.
+///
+/// This tests the decision DIRECTLY. Both end-to-end tests only ever reach
+/// `ensure_krea_realtime_tier_present`'s default arm — and their fixtures point `data_dir` at a
+/// non-existent dir, so `huggingface_snapshot_dir` returns `None` and the function exits before the
+/// tier mapping is even consulted. A mutation making a DEFAULT job want q8/bf16, or dropping the
+/// `{tier}/` prefix from the fetched paths, would stay GREEN through them.
+///
+/// Mutation checks (each verified RED): make the `_` arm return `Some("q8")`; swap the `None`/`Q8`
+/// arms; drop the `{tier}/` prefix in `krea_realtime_tier_fetch_files`.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_on_demand_tier_fetch_is_gated_on_the_toggle() {
+    // Default ⇒ nothing to fetch: q4 ships with the base install.
+    assert_eq!(
+        krea_realtime_on_demand_tier(&krea_tier_request(json!({}))),
+        None
+    );
+    // An explicit q4 pick is still the base install.
+    assert_eq!(
+        krea_realtime_on_demand_tier(&krea_tier_request(json!({ "mlxQuantize": 4 }))),
+        None
+    );
+    // q8 toggle ⇒ q8 ONLY (never bf16 too — that would drag 40 GB on a 27 GB request).
+    assert_eq!(
+        krea_realtime_on_demand_tier(&krea_tier_request(json!({ "mlxQuantize": 8 }))),
+        Some("q8")
+    );
+    // bf16 toggle ⇒ bf16 only.
+    assert_eq!(
+        krea_realtime_on_demand_tier(&krea_tier_request(json!({ "mlxQuantize": 0 }))),
+        Some("bf16")
+    );
+    // A numeric STRING is the same toggle (the shared resolver parses both forms).
+    assert_eq!(
+        krea_realtime_on_demand_tier(&krea_tier_request(json!({ "mlxQuantize": "8" }))),
+        Some("q8")
+    );
+
+    // The fetched paths are the tier's EXPLICIT file list, each prefixed with `<tier>/` — the same
+    // paths the manifest declares, not a `<tier>/*` glob.
+    assert_eq!(
+        krea_realtime_tier_fetch_files("q8").expect("q8 is published"),
+        vec![
+            "q8/config.json",
+            "q8/dit.safetensors",
+            "q8/t5_encoder.safetensors",
+            "q8/tokenizer.json",
+            "q8/vae.safetensors",
+        ]
+    );
+    // bf16 fetches its NESTED shards, individually — the packed row would miss the transformer/ dir
+    // entirely, leaving an "installed" tier with no DiT.
+    let bf16 = krea_realtime_tier_fetch_files("bf16").expect("bf16 is published");
+    assert_eq!(bf16.len(), 11);
+    assert!(bf16.contains(&"bf16/transformer/dit-00007-of-00007.safetensors".to_owned()));
+    assert!(
+        bf16.iter().all(|file| file.starts_with("bf16/")),
+        "every fetched path must be tier-prefixed, or the fetch pulls the wrong files: {bf16:?}"
+    );
+    assert_eq!(krea_realtime_tier_fetch_files("q6"), None);
+}
+
+/// 🔴 The guarantee the on-demand fetch's own doc makes, exercised against a stub hub whose `q8/` tier
+/// is MISSING its DiT — the "published but torn remotely" case.
+///
+/// This is the hole the fetch would otherwise have. `ensure_hf_files_cached` does NOT run the sc-12283
+/// `unmatched_patterns` per-pattern hard-fail (that lives in `model_jobs::run_model_download_job`), so
+/// a declared path matching nothing remotely is silently a no-op: the other four q8 files land, the
+/// tier reads INCOMPLETE, and `krea_realtime_tier_subdir` quietly serves q4 instead — the exact silent
+/// tier downgrade this lane exists to prevent, arriving through the back door. So the fetch verifies on
+/// disk afterwards and fails loud, NAMING the missing file.
+///
+/// The stub serves the HF tree + file bytes AND the worker's own progress endpoint, so the whole fetch
+/// path runs for real (resolve → download → verify) rather than being mocked out at the seam.
+///
+/// Mutation checks (each verified RED): delete the post-fetch verification block; make it `warn!`
+/// instead of returning `Err`; have it check the request's tier instead of the fetched one.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_fetch_of_a_remotely_torn_tier_fails_loudly_instead_of_downgrading() {
+    use axum::body::Body;
+    use axum::http::{Response, StatusCode};
+    use axum::Router;
+
+    let hub = std::env::temp_dir().join(format!("sw_krea_fetch_{}", Uuid::new_v4().simple()));
+    let repo_dir = hub.join(format!(
+        "models--{}",
+        sceneworks_core::hf_home::safe_repo_dir_name(KREA_REALTIME_REPO)
+            .expect("the krea repo slug")
+    ));
+    let snapshot = repo_dir.join("snapshots").join(KREA_REALTIME_REVISION);
+    // The repo IS downloaded (so `huggingface_snapshot_dir` resolves and the fetch is attempted) but
+    // holds only the default q4 tier — a q8 job must fetch q8.
+    std::fs::create_dir_all(&snapshot).unwrap();
+    write_complete_krea_tier(&snapshot, "q4");
+    std::fs::create_dir_all(repo_dir.join("refs")).unwrap();
+    std::fs::write(repo_dir.join("refs").join("main"), KREA_REALTIME_REVISION).unwrap();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime builds");
+
+    // A stub hub whose q8 tier is missing `dit.safetensors` — every other declared file resolves.
+    let served: Vec<String> = krea_realtime_tier_fetch_files("q8")
+        .expect("q8 is published")
+        .into_iter()
+        .filter(|file| file != "q8/dit.safetensors")
+        .collect();
+    let job_json = serde_json::to_string(&krea_job_snapshot()).expect("job snapshot serializes");
+    let address = runtime.block_on(async move {
+        let app = Router::new().fallback(move |uri: axum::http::Uri| {
+            let served = served.clone();
+            let job_json = job_json.clone();
+            async move {
+                let path = uri.path().to_owned();
+                if path.contains("/tree/") {
+                    let entries: Vec<Value> = served
+                        .iter()
+                        .map(|file| json!({ "type": "file", "path": file, "size": 4 }))
+                        .collect();
+                    return Response::builder()
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::to_string(&entries).expect("tree serializes"),
+                        ))
+                        .expect("response");
+                }
+                if path.ends_with("/progress") {
+                    return Response::builder()
+                        .header("content-type", "application/json")
+                        .body(Body::from(job_json))
+                        .expect("response");
+                }
+                if path.contains("/resolve/") {
+                    return Response::builder()
+                        .header("content-length", "4")
+                        .body(Body::from(b"xxxx".to_vec()))
+                        .expect("response");
+                }
+                Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::empty())
+                    .expect("response")
+            }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("address");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        address
+    });
+    let base = format!("http://{address}");
+
+    let settings = Settings {
+        data_dir: hub.join("data"),
+        api_url: base.clone(),
+        huggingface_base_url: base,
+        ..offline_settings()
+    };
+    let job = krea_job_snapshot();
+    let q8_req = krea_tier_request(json!({ "mlxQuantize": 8 }));
+
+    let error = temp_env_vars(
+        &[
+            ("SCENEWORKS_MLX_KREA_REALTIME_DIR", ""),
+            ("HF_HUB_CACHE", hub.to_str().unwrap()),
+            ("HUGGINGFACE_HUB_CACHE", ""),
+            ("HF_HOME", ""),
+        ],
+        || {
+            runtime.block_on(ensure_krea_realtime_tier_present(
+                &ApiClient::new(&settings),
+                &settings,
+                &job,
+                &q8_req,
+            ))
+        },
+    )
+    .expect_err("a remotely-torn tier must not be accepted");
+
+    let WorkerError::InvalidPayload(message) = error else {
+        panic!("expected an actionable InvalidPayload, got {error:?}");
+    };
+    assert!(
+        message.contains("q8/dit.safetensors"),
+        "the failure must NAME the file that never arrived: {message}"
+    );
+    assert!(
+        message.contains("q8"),
+        "the failure must name the tier the user picked: {message}"
+    );
+    // The other four q8 files DID land — proving the fetch really ran and it is the verification,
+    // not a transport error, that refused the job.
+    for file in ["config.json", "tokenizer.json", "vae.safetensors"] {
+        assert!(
+            snapshot.join("q8").join(file).is_file(),
+            "the fetch should have downloaded q8/{file}"
+        );
+    }
+    std::fs::remove_dir_all(&hub).ok();
+}
+
+/// The Krea tier repo must pin an exact commit (not the mutable `main`) so an upstream re-push can't
+/// swap a checkpoint the on-demand fetch loads (mirrors the Wan / SCAIL-2 pins), and
+/// `krea_realtime_tier_repo` routes only the krea id to it.
+#[cfg(target_os = "macos")]
+#[test]
+fn krea_realtime_tier_revision_is_a_pinned_commit_not_main() {
+    assert_ne!(
+        KREA_REALTIME_REVISION, "main",
+        "the Krea tier repo must pin a fixed revision before release"
+    );
+    assert_eq!(
+        KREA_REALTIME_REVISION.len(),
+        40,
+        "a pinned HF revision is a 40-char commit sha"
+    );
+    assert!(
+        KREA_REALTIME_REVISION
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "the pinned Krea revision must be lowercase hex"
+    );
+    assert_eq!(
+        krea_realtime_tier_repo("krea_realtime_14b"),
+        Some((KREA_REALTIME_REPO, KREA_REALTIME_REVISION))
+    );
+    for other in ["scail2_14b", "wan_2_2", "bernini", "krea_2_turbo"] {
+        assert_eq!(
+            krea_realtime_tier_repo(other),
+            None,
+            "{other} must not route to the Krea Realtime tier repo"
+        );
+    }
 }
 
 /// The on-demand tier fetches are gated on the request's tier toggle — the "fetched on demand if

--- a/crates/sceneworks-worker/src/video_jobs/wan.rs
+++ b/crates/sceneworks-worker/src/video_jobs/wan.rs
@@ -5,7 +5,7 @@ use super::prelude::*;
 #[cfg(target_os = "macos")]
 use super::{
     bernini::{bernini_engine_id, resolve_bernini_model_dir},
-    krea_realtime::{krea_realtime_engine_id, resolve_krea_realtime_model_dir},
+    krea_realtime::{krea_realtime_engine_id, resolve_krea_realtime_tier_dir_and_quant},
     ltx::{ltx_engine_id, resolve_keyframe_conditioning, resolve_ltx_model_dir},
     mochi::{mochi_engine_id, resolve_mochi_model_dir},
     scail2::{resolve_scail2_model_dir, scail2_engine_id},
@@ -153,9 +153,12 @@ pub(crate) fn ensure_video_engine_weights(
     // Krea Realtime 14B (epic 8431 / sc-8443). Without this arm a Krea job whose weights don't resolve
     // falls to `VideoRoute::Stub` and the user is handed a PROCEDURAL FAKE VIDEO instead of the
     // resolver's precise "download the snapshot" error — the silent degradation sc-4176 added this gate
-    // to prevent.
+    // to prevent. It asks the TIER resolver, not `resolve_krea_realtime_model_dir` (sc-15258): every
+    // published Krea file lives under a `q4/`/`q8/`/`bf16/` prefix, so a resolvable snapshot ROOT is no
+    // evidence of loadable weights — a torn install would otherwise pass this gate and, since
+    // `krea_realtime_available` refuses it, get the fake clip anyway.
     if krea_realtime_engine_id(&request.model).is_some() {
-        resolve_krea_realtime_model_dir(settings)?;
+        resolve_krea_realtime_tier_dir_and_quant(settings, request)?;
     }
     Ok(())
 }


### PR DESCRIPTION
**sc-15258 (S20) — epic 8431.** This is the second half of a **release gate**: S11 (#1908) made `krea_realtime_14b` selectable; without this nothing it ships can load.

## The bug

Every published Krea file lives under a `q4/` / `q8/` / `bf16/` tier prefix — and the bf16 DiT one level deeper still, at `bf16/transformer/dit-0000{1..7}-of-00007.safetensors`. But `resolve_krea_realtime_model_dir` returned the snapshot **ROOT**, so `t2v::open_transformer_weights` looked for `dit.safetensors` or `transformer/` directly under it and found **neither**. The arm also hard-coded `quant: None` behind a now-stale `supported_quants = []` comment (S19 shipped `[Q4, Q8]`).

## Tier resolution

`krea_realtime_tier_repo` / `krea_realtime_tier_order` / `KREA_REALTIME_TIER_FILES` (+ a pinned `KREA_REALTIME_REVISION`) mirror the `scail2_*` pattern, and `resolve_krea_realtime_tier_dir_and_quant` descends into the installed tier.

`KREA_REALTIME_TIER_FILES` is **per-tier**, not one flat list, because bf16 is structurally different — no `dit.safetensors`, a seven-shard `transformer/` instead. Each shard is listed individually, so a tier that lost six of seven reads INCOMPLETE and falls through rather than resolving and then dying inside the loader (the sc-13513 / sc-14432 "installed but unloadable" class). `krea_realtime_tier_files` returns `Option`, deliberately not an empty-slice fallback: `[].iter().all(..)` is `true`, so an unknown tier would otherwise read COMPLETE from an empty directory.

## The trap: one decision, no silent tier switch

The tier subdir and the requested quant come out of **one** function:

* A complete tier subdir wins and loads with **`quant = None`** — the tier on disk IS the quantization (`q4`/`q8` are pre-packed, `bf16` is dense). `mlxQuantize` selects WHICH tier, never a load-time requant. So a deliberately-installed `bf16/` is served dense **even under the Q4 default**.
* A flat local snapshot (env override / local convert — the published repo is never flat) keeps the load-time path plus `resolve_mlx_dense_quant`, i.e. **Q4 by default**.
* Otherwise a **loud** error naming the tiers. There is no root fallback.

**`bf16` is the last fallback in EVERY tier order** — the one deliberate divergence from `scail2_tier_order`. SCAIL-2 can leave it out because a repo with no matching tier still has a legacy FLAT root to fall back on; the Krea rehost has none. Omitting it would make a bf16-only install unreachable and then quantize it to Q4 — exactly the creative-tier switch. Listing it *last* keeps the other half: a default job never prefers the ~40 GB tier while a leaner one exists, and bf16 is only ever *fetched* on an explicit pick.

## Where the "dense-video default = Q4" item actually landed — and what I deliberately did NOT do

S19 correctly found that `manifest.mlx.quantize` is read by the **image** lane only. The default now reaches the video lane through the tier order (`q4`-first) and, for a flat snapshot, through `resolve_mlx_dense_quant`'s `None => Q4` arm.

I did **not** wire `manifest.mlx.quantize` into `resolve_mlx_dense_quant`, and that is a decision, not a gap. It would be behaviour-neutral today (I checked: every video entry that declares the key — bernini, scail2_14b, krea_realtime_14b — declares `4`, the resolver's existing default), but `resolve_mlx_dense_quant` is shared by all three, and sc-10859 made the video lane's Q4-first default an **owned carve-out** from epic 10721's app-wide Q8 (no MLX video Q8 lever ⇒ a silent Q8 only risks a video-runtime OOM, owner-confirmed 2026-07-11). Making a manifest key able to flip that would quietly undo it. Instead, S11's inline `⚠️` note — which currently says "the video lane doesn't read this; sc-15258 will fix it", and would read as *"S20 didn't do its job"* once merged — is rewritten to state what actually picks the tier.

## Also fixed, found while wiring this

`krea_realtime_available` and the `ensure_video_engine_weights` fail-loud gate both asked only whether the snapshot ROOT resolved. With a tier layout that is no evidence of loadable weights, so a torn install passed the sc-4176 gate and got a **procedural fake video**. Both now ask the tier resolver.

## Tests — 15 mutations, each verified RED

New in `video_jobs/tests.rs`:

- `krea_realtime_worker_tier_table_matches_the_shipped_manifest` — worker table vs `builtin.models.jsonc` (repo, pinned revision, exact per-tier paths, tier set). Closes the loop the sc-8444 layout test opened: that one pins the manifest against the published repo, this pins the worker against the manifest.
- `krea_realtime_tier_order_tracks_the_quant_and_never_drops_bf16`
- `krea_realtime_tier_subdir_resolves_each_tier_including_the_sharded_bf16` — incl. a torn q8, a bf16 missing shard 4, and an unpublished tier
- `krea_realtime_bf16_install_is_served_dense_not_downgraded_to_q4` — 🔴 the trap. Discriminating, not "asserts None everywhere": installing q4 alongside moves the same default request to q4, and the flat-snapshot test does get `Some(Q4)`.
- `krea_realtime_flat_snapshot_takes_the_q4_dense_video_default` — resolver across the whole `mlxQuantize` axis **plus** the `LoadSpec` that reached the engine
- `krea_realtime_hands_the_engine_the_installed_tier_dir_not_the_snapshot_root` — the loadability half
- `krea_realtime_torn_install_fails_loudly_instead_of_resolving_the_root` — asserts the root *does* resolve, which is the false green this story was filed against
- `krea_realtime_resolves_the_tier_from_a_downloaded_hf_snapshot` — the production path (pinned HF snapshot, no env override, HF cache env pinned since a `data_dir` alone is not hermetic)
- `krea_realtime_tier_revision_is_a_pinned_commit_not_main`

`krea_fake_model_dir` now writes a real flat snapshot — a `config.json`-only dir resolved as a model dir and then died in the loader, so the old fixture could not have caught this.

Mutations checked RED: bf16 shard renamed · revision digit changed · unknown tier ⇒ `Some(&[])` · `bf16` dropped from the default order · default order flipped bf16-first · q8 arm loses its bf16 fallback · a resolved tier also gets a load-time quant · the ROOT handed back instead of the tier dir · root fallback instead of the loud error · flat branch drops the load-time quant · the arm ignores the resolved quant · completeness skips the nested shards · `krea_realtime_available` reverts to root-only · the fail-loud gate reverts to root-only · the tier descent removed from the HF path.

## Ran locally

`cargo test --workspace --exclude sceneworks-desktop --no-fail-fast` (exit 0, 24 binaries) · `cargo fmt --all --check` · `cargo clippy --workspace --exclude sceneworks-desktop --all-targets -D warnings` · `npm run check` · `npm run check:license-coverage` · `pytest -m "not e2e"` (80 passed) · `check-download-patterns --model krea_realtime_14b` (21/21). Every gate re-run after the manifest comment edit.

**Excluded:** `sceneworks-desktop` — its Tauri build script fails in any worktree lacking staged `binaries/sceneworks-api-*` (pre-existing, unrelated). CI carries it.

The first CI run went red on **`dataset_catalogs::graceful_catalog_shutdown_drains_and_public_restart_resumes_checkpoint` only** — the known flake filed as sc-15293, unrelated to this diff.

Also rolls in the S11 review nit: the stray ~10-space run in the `mlx_routing_tests.rs:803` panic message (a string literal wrapped without a trailing `\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)