### PR TITLE
feat(web): surface Krea Realtime 14B in Video Studio (sc-8445)

### DIFF
--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -145,6 +145,10 @@ const CAPABILITY_LABELS = {
   interleave: "Interleaved",
   image_to_video: "Image to Video",
   text_to_video: "Text to Video",
+  // sc-8445: Krea Realtime advertises text/image/video-to-video, and without this row its third
+  // chip fell to the humanized fallback ("video to video") — visibly out of style beside the two
+  // title-cased siblings on the same card.
+  video_to_video: "Video to Video",
   first_last_frame: "First / Last Frame",
   extend_clip: "Extend Clip",
   video_bridge: "Video Bridge",

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -690,6 +690,28 @@ describe("ModelManagerScreen type-grouped layout", () => {
     expect(chips).toEqual(["Text to Image", "Style Variations"]);
   });
 
+  // sc-8445: Krea Realtime is the first catalog model to advertise all three video generation
+  // capabilities on one card, and `video_to_video` had no CAPABILITY_LABELS row — so its third
+  // chip fell to the humanized fallback and read "video to video" beside two title-cased siblings.
+  // Asserting the whole array (not just the new entry) keeps the three reading as one set.
+  it("title-cases the video_to_video chip alongside its siblings", async () => {
+    await render({
+      models: [
+        {
+          id: "krea_realtime_14b",
+          name: "Krea Realtime 14B",
+          type: "video",
+          family: "krea-realtime",
+          capabilities: ["text_to_video", "image_to_video", "video_to_video"],
+          installState: "missing",
+        },
+      ],
+    });
+    await selectTab(container, "Video Models");
+    const chips = [...container.querySelectorAll(".model-capabilities .chip")].map((c) => c.textContent);
+    expect(chips).toEqual(["Text to Video", "Image to Video", "Video to Video"]);
+  });
+
   it("offers a Fix action when a cached model is incomplete", async () => {
     const createModelDownloadJob = vi.fn();
     await render({

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -379,6 +379,23 @@ export function VideoStudio() {
   const showClipStrength =
     ["extend_clip", "video_bridge"].includes(mode) ||
     (mode === "video_to_video" && selectedModel?.adapter === "krea_realtime");
+  // Which generation axes the selected engine actually has, declared in the manifest `video`
+  // sub-block (sc-8445) — the video-lane mirror of how Audio Studio reads `audio.supportsGuidance`
+  // / `audio.supportsNegativePrompt`. Neither an id check nor an engine link: the catalog says it.
+  //
+  // ⚠️ ABSENT MEANS TRUE, the opposite polarity to the audio block. Every other video model takes
+  // both a CFG scale and a negative prompt and declares nothing, so `!== false` is what keeps them
+  // byte-identical to their pre-sc-8445 behaviour; only an engine that genuinely lacks the axis
+  // declares it false. Krea Realtime is the one that does: it is CFG-free (Self-Forcing baked
+  // guidance out), so `generate_krea_realtime` runs a single batch-1 forward, sets
+  // `negative_prompt: None`, and never forwards a guidance scale.
+  //
+  // HIDDEN, not disabled: the lightning precedent below disables Steps/Guidance because that
+  // inertness is TRANSIENT (turn Lightning off and the control works again). A missing axis is
+  // permanent for the model, so a forever-dead input is just clutter — Audio Studio hides these two
+  // for the same reason (`showGuidance` / `showNegative`).
+  const supportsGuidance = selectedModel?.video?.supportsGuidance !== false;
+  const supportsNegativePrompt = selectedModel?.video?.supportsNegativePrompt !== false;
   const implementedMode = [
     "image_to_video",
     "text_to_video",
@@ -1211,7 +1228,10 @@ export function VideoStudio() {
         // (stack-folded) prompt LAST — send that composed string verbatim. Falls back to the plain
         // stack-folded / raw prompt when no style is applied.
         prompt: styleApplied ? composedStylePrompt : stackActive ? composedStack.prompt : prompt,
-        negativePrompt: stackActive ? composedStack.negativePrompt : negativePrompt,
+        // An engine with no negative-prompt axis gets an empty one rather than whatever a preset
+        // stack composed — the field is hidden for it, so sending text the user cannot see or edit
+        // (and the worker discards anyway) would be a ghost input on the recipe.
+        negativePrompt: supportsNegativePrompt ? (stackActive ? composedStack.negativePrompt : negativePrompt) : "",
         model,
         duration: Number(duration),
         fps: Number(fps),
@@ -1312,7 +1332,10 @@ export function VideoStudio() {
           ...(!lightningActive && stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
             ? { steps: Number(stepsOverride) }
             : {}),
-          ...(!lightningActive && guidanceOverride !== "" && Number.isFinite(Number(guidanceOverride))
+          ...(supportsGuidance &&
+          !lightningActive &&
+          guidanceOverride !== "" &&
+          Number.isFinite(Number(guidanceOverride))
             ? { guidanceScale: Number(guidanceOverride) }
             : {}),
           // LTX native guidance knobs (epic 1753 sc-1769). Only emitted for
@@ -1983,23 +2006,25 @@ export function VideoStudio() {
                   value={lightningActive ? "" : stepsOverride}
                 />
               </label>
-              <label>
-                Guidance
-                <input
-                  min="0"
-                  max="30"
-                  disabled={lightningActive}
-                  onChange={(event) => setGuidanceOverride(event.target.value)}
-                  placeholder={lightningActive ? "off (Lightning)" : (() => {
-                    const value = guidanceDefaultFromModel(selectedModel);
-                    return value == null ? "" : String(value);
-                  })()}
-                  step="0.1"
-                  title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set guidance." : undefined}
-                  type="number"
-                  value={lightningActive ? "" : guidanceOverride}
-                />
-              </label>
+              {supportsGuidance ? (
+                <label>
+                  Guidance
+                  <input
+                    min="0"
+                    max="30"
+                    disabled={lightningActive}
+                    onChange={(event) => setGuidanceOverride(event.target.value)}
+                    placeholder={lightningActive ? "off (Lightning)" : (() => {
+                      const value = guidanceDefaultFromModel(selectedModel);
+                      return value == null ? "" : String(value);
+                    })()}
+                    step="0.1"
+                    title={lightningActive ? "Governed by Lightning (fast 4-step). Turn Lightning off to set guidance." : undefined}
+                    type="number"
+                    value={lightningActive ? "" : guidanceOverride}
+                  />
+                </label>
+              ) : null}
               <label>
                 Character
                 <select onChange={(event) => setCharacterId(event.target.value)} value={characterId}>
@@ -2022,10 +2047,12 @@ export function VideoStudio() {
                   ))}
                 </select>
               </label>
-              <label className="prompt-field">
-                Negative prompt
-                <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
-              </label>
+              {supportsNegativePrompt ? (
+                <label className="prompt-field">
+                  Negative prompt
+                  <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
+                </label>
+              ) : null}
               <LoraPickerSection
                 selectedModel={selectedModel}
                 selectedLoras={selectedLoras}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -300,9 +300,9 @@ export function VideoStudio() {
   const [ltxVideoStg, setLtxVideoStg] = useState(saved.videoStgGuidanceScale ?? "");
   const [ltxVideoRescale, setLtxVideoRescale] = useState(saved.videoRescaleScale ?? "");
   // Clip-conditioning strengths for the LTX IC-LoRA extend/bridge paths (sc-3522,
-  // sc-3755). The worker reads these from `advanced` (default 1.0 when absent):
-  // the source/left clip uses videoConditioningStrength, the bridge right clip
-  // uses bridgeRightVideoConditioningStrength.
+  // sc-3755) and for Krea Realtime's video_to_video (sc-8445). The worker reads these from
+  // `advanced` (default 1.0 when absent): the source/left clip uses videoConditioningStrength,
+  // the bridge right clip uses bridgeRightVideoConditioningStrength.
   const [videoConditioningStrength, setVideoConditioningStrength] = useState(saved.videoConditioningStrength ?? "");
   const [bridgeRightVideoConditioningStrength, setBridgeRightVideoConditioningStrength] = useState(
     saved.bridgeRightVideoConditioningStrength ?? "",
@@ -364,6 +364,21 @@ export function VideoStudio() {
   // 4-step recipe, so the manual Steps/Guidance inputs are disabled to reflect that.
   const showLightning = WAN_A14B_LIGHTNING_MODEL_IDS.has(selectedModel?.id);
   const lightningActive = showLightning && lightning;
+  // Clip-conditioning strength (`advanced.videoConditioningStrength`). The LTX/Wan IC-LoRA clip
+  // modes always honor it, so those two modes show it for whichever model serves them. The
+  // `video_to_video` tab is different: the key is honored there ONLY by Krea Realtime, whose v2v
+  // drives a strength-controlled autoregressive init (`FewStepSchedule::for_strength`, wired in
+  // `video_jobs/krea_realtime.rs::krea_realtime_conditioning`). Bernini — the other v2v model —
+  // never reads the key, so gating on the ADAPTER keeps the control off a model that would
+  // silently ignore it, the same shape as the `adapter === "ltx_video"` guidance knobs below.
+  //
+  // Krea's image_to_video deliberately gets NO strength control: an i2v reference still only warms
+  // the AR KV cache and the engine reads the image alone, never `strength` — a documented no-op
+  // (sc-8440 / sc-8443), pinned worker-side by `krea_realtime_conditioning` emitting
+  // `strength: None`. Showing it there would be a knob that does nothing.
+  const showClipStrength =
+    ["extend_clip", "video_bridge"].includes(mode) ||
+    (mode === "video_to_video" && selectedModel?.adapter === "krea_realtime");
   const implementedMode = [
     "image_to_video",
     "text_to_video",
@@ -1312,10 +1327,12 @@ export function VideoStudio() {
           ...(selectedModel?.adapter === "ltx_video" && ltxVideoRescale !== "" && Number.isFinite(Number(ltxVideoRescale))
             ? { videoRescaleScale: Number(ltxVideoRescale) }
             : {}),
-          // LTX IC-LoRA clip-conditioning strengths (sc-3522, sc-3755). The worker
-          // reads these from `advanced`, defaulting to 1.0 when absent — extend uses
-          // the source-clip strength, bridge uses both left and right.
-          ...(["extend_clip", "video_bridge"].includes(mode) &&
+          // Clip-conditioning strengths (sc-3522, sc-3755; sc-8445 for Krea Realtime v2v). The
+          // worker reads these from `advanced`, defaulting to 1.0 when absent — extend uses the
+          // source-clip strength, bridge uses both left and right, and Krea Realtime's v2v uses
+          // the source-clip strength. `showClipStrength` is the same predicate that renders the
+          // control, so the payload can never carry a strength the user was never offered.
+          ...(showClipStrength &&
           videoConditioningStrength !== "" &&
           Number.isFinite(Number(videoConditioningStrength))
             ? { videoConditioningStrength: Number(videoConditioningStrength) }
@@ -1842,7 +1859,7 @@ export function VideoStudio() {
                   </label>
                 </>
               ) : null}
-              {["extend_clip", "video_bridge"].includes(mode) ? (
+              {showClipStrength ? (
                 <>
                   <label>
                     {mode === "video_bridge" ? "Left clip strength" : "Clip strength"}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1728,10 +1728,18 @@ export function VideoStudio() {
             presetLoraDetails={presetLoraDetails}
           />
 
+          {/* `stackAddsNegative` is ANDed with the engine's negative-prompt axis (sc-8445). This
+              panel is captioned "Prompt sent" and exists so the user sees exactly what will be
+              generated; general presets are filtered on `kind === "general"` alone, so a preset
+              carrying `defaults.negativePrompt` reaches a CFG-free model too. Since submit now sends
+              `negativePrompt: ""` for such a model, showing the stack's `Negative:` line here would
+              assert something that is NOT sent — the same false-copy class this story exists to
+              remove. (Only the negative needs the guard: the preview's other extras are aspect and
+              count, which every video engine honors.) */}
           <PresetStackPreview
             generalStack={generalStack}
             composed={composedStack}
-            stackAddsNegative={stackAddsNegative}
+            stackAddsNegative={supportsNegativePrompt && stackAddsNegative}
             stackAddsCount={stackAddsCount}
           />
 

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1878,6 +1878,95 @@ describe("VideoStudio Krea Realtime 14B surface (sc-8445)", () => {
     expect(payload.advanced.guidanceScale).toBe(6.5);
   });
 
+  // SVD is the OTHER video engine with no guidance / negative axis: `generate_svd`
+  // (video_jobs/svd.rs) hard-sets `negative_prompt: None` and `guidance: None` because it drives
+  // its own frame-wise CFG ramp. `promptless` already hid its prompt field; these two controls
+  // stayed visible and permanently dead until sc-8445. Same `video` block, no new machinery.
+  const SVD = {
+    id: "svd",
+    name: "Stable Video Diffusion",
+    type: "video",
+    family: "svd",
+    adapter: "svd_video",
+    capabilities: ["image_to_video"],
+    promptless: true,
+    video: { supportsGuidance: false, supportsNegativePrompt: false },
+    defaults: { duration: 4, resolution: "1024x576", fps: 7 },
+    limits: {},
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+
+  it("hides both axes for SVD too, and the manifest says so", async () => {
+    const manifestPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../../config/manifests/builtin.models.jsonc",
+    );
+    const manifest = JSON5.parse(readFileSync(manifestPath, "utf8"));
+    const models = Array.isArray(manifest) ? manifest : manifest.models;
+
+    // The fixture is honest about the shipped entry…
+    const shippedSvd = models.find((entry) => entry.id === "svd");
+    expect(shippedSvd?.video).toEqual(SVD.video);
+
+    // …and the polarity claim the manifest/schema comments make is checked against the real
+    // population rather than trusted: exactly these two entries declare the block, every other
+    // video model declares nothing and therefore keeps both controls.
+    const videoEntries = models.filter((entry) => entry.type === "video");
+    const declaring = videoEntries.filter((entry) => entry.video).map((entry) => entry.id).sort();
+    expect(declaring).toEqual(["krea_realtime_14b", "svd"]);
+    expect(videoEntries.length - declaring.length).toBe(8);
+
+    const context = baseContext({ videoModels: [SVD] });
+    await render(context);
+    await ensureAdvancedOpen();
+    expect(labelStartingWith("Guidance")).toBeFalsy();
+    expect(labelStartingWith("Negative prompt")).toBeFalsy();
+  });
+
+  // ⚠️ Regression guard for a bug this PR introduced. `PresetStackPreview` is captioned
+  // "Prompt sent" and exists so the user sees exactly what will be generated. Once submit started
+  // sending `negativePrompt: ""` for a CFG-free engine, the preview's `Negative:` line became a
+  // claim about something that is NOT sent. General presets are filtered on `kind === "general"`
+  // alone, so a preset carrying `defaults.negativePrompt` reaches Krea.
+  it("drops the stack preview's Negative line on a CFG-free engine but keeps it otherwise", async () => {
+    const stackPreset = {
+      id: "film_look",
+      name: "Film Look",
+      kind: "general",
+      prompt: { suffix: "Kodak Portra 400" },
+      defaults: { negativePrompt: "blurry, low quality" },
+    };
+    const context = baseContext({ videoModels: [BERNINI_V2V, KREA], presets: [stackPreset] });
+    await render(context);
+
+    const chip = [...container.querySelectorAll(".general-preset-chips .preset-chip")].find(
+      (el) => el.textContent.trim() === "Film Look",
+    );
+    expect(chip, "the general preset must be offered").toBeTruthy();
+    await click(chip);
+
+    // Bernini takes a negative prompt, so the preview states it AND the run sends it.
+    let preview = container.querySelector(".preset-stack-preview");
+    expect(preview.textContent).toContain("Kodak Portra 400");
+    expect(preview.textContent).toContain("Negative: blurry, low quality");
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].negativePrompt).toBe("blurry, low quality");
+
+    // Same stack, CFG-free engine: the composed PROMPT is still shown (it is still sent), but the
+    // Negative line is gone — because the payload no longer carries it.
+    await act(async () => setSelect(selectLabelled("Model"), "krea_realtime_14b"));
+    preview = container.querySelector(".preset-stack-preview");
+    expect(preview.textContent).toContain("Kodak Portra 400");
+    expect(preview.textContent).not.toContain("Negative:");
+
+    await click(buttonWithText(container, "Render clip"));
+    const payload = context.createVideoJob.mock.calls[1][0];
+    expect(payload.model).toBe("krea_realtime_14b");
+    expect(payload.negativePrompt).toBe("");
+  });
+
   it("submits Krea in each of its three advertised modes", async () => {
     const context = baseContext({
       videoModels: [KREA],

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1,4 +1,9 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import React, { act } from "react";
+import JSON5 from "json5";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { click, mountRoot, setInput, setSelect, unmountRoot } from "../testUtils/dom.js";
 
@@ -1465,5 +1470,344 @@ describe("VideoStudio runtime text-encoder selector (sc-13800)", () => {
     const advanced = context.createVideoJob.mock.calls[0][0].advanced;
     expect(advanced.textEncoderModel).toBe(AMORAL_ENCODER.id);
     expect(advanced.useUncensoredEnhancer).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// Krea Realtime 14B — the Video Studio surface (sc-8445, epic 8431 S12).
+//
+// The catalog entry (sc-8444) drives most of this screen generically, so these tests exist to
+// PIN that the generic path actually lands the model's real numbers, and to guard the one place
+// the generic path is not enough: the `video_to_video` clip-strength knob.
+//
+// Krea's three capabilities split three ways on `advanced.videoConditioningStrength`:
+//   * text_to_video  — no conditioning media, no strength.
+//   * image_to_video — the reference still only warms the AR KV cache; the engine reads the image
+//                      and never `strength` (`krea_realtime_conditioning` emits `strength: None`).
+//                      A documented NO-OP, so the control must stay hidden there.
+//   * video_to_video — the source clip drives a strength-controlled AR init, so the worker DOES
+//                      read the key (default 1.0). Before this story the control rendered only for
+//                      extend_clip/video_bridge, so the knob was unreachable and every Krea v2v ran
+//                      at 1.0 whatever the user wanted.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+describe("VideoStudio Krea Realtime 14B surface (sc-8445)", () => {
+  let container;
+  let root;
+
+  const ALL_VIDEO_MODES = [
+    "image_to_video",
+    "text_to_video",
+    "first_last_frame",
+    "extend_clip",
+    "video_bridge",
+    "replace_person",
+    "video_to_video",
+    "reference_to_video",
+    "reference_video_to_video",
+    "multi_video_to_video",
+    "ads2v",
+    "animate_character",
+  ];
+
+  const KREA_CAPABILITIES = ["text_to_video", "image_to_video", "video_to_video"];
+
+  // Transcribed from `config/manifests/builtin.models.jsonc`. The first test below holds every
+  // field of this fixture to the SHIPPED entry, so the behavioural tests cannot pass against a
+  // fixture that has drifted away from what a user's catalog actually serves.
+  const KREA = {
+    id: "krea_realtime_14b",
+    name: "Krea Realtime 14B",
+    type: "video",
+    family: "krea-realtime",
+    adapter: "krea_realtime",
+    capabilities: KREA_CAPABILITIES,
+    defaults: {
+      duration: 4,
+      fps: 24,
+      resolution: "832x480",
+      quality: "balanced",
+      steps: 6,
+      sampler: "default",
+      scheduler: "default",
+    },
+    limits: {
+      durations: [2, 3, 4, 5],
+      recommendedMaxDuration: 5,
+      hardMaxDuration: 5,
+      fps: [24],
+      requiresDimensionsMultipleOf: 16,
+      resolutions: ["832x480", "480x832", "1280x720", "720x1280"],
+      samplers: ["default"],
+      schedulers: ["default"],
+    },
+    quantization: {},
+    loraCompatibility: { families: ["krea-realtime"], types: ["style", "motion", "character", "enhance"] },
+    ui: {},
+    macSupport: {
+      supported: true,
+      features: {
+        videoModes: Object.fromEntries(
+          ALL_VIDEO_MODES.map((value) => [value, KREA_CAPABILITIES.includes(value)]),
+        ),
+      },
+    },
+  };
+
+  // Bernini also serves `video_to_video`, but its worker route never reads
+  // `videoConditioningStrength` — the discriminator that proves the new control is gated on the
+  // ENGINE and not merely on the mode.
+  const BERNINI_V2V = {
+    id: "bernini",
+    name: "Bernini",
+    type: "video",
+    family: "bernini",
+    adapter: "bernini",
+    capabilities: ["text_to_video", "video_to_video"],
+    defaults: { duration: 5, resolution: "848x480", fps: 16 },
+    limits: { durations: [3, 4, 5], fps: [16], resolutions: ["848x480", "480x848"] },
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+
+  // The Wan A14B engine that DOES carry the Lightning toggle — the discriminator for "Krea has no
+  // lightning LoRA", so the assertion cannot pass just because the toggle never renders anywhere.
+  const WAN_A14B = {
+    id: "wan_2_2_t2v_14b",
+    name: "Wan 2.2 T2V A14B",
+    type: "video",
+    family: "wan-video",
+    adapter: "wan_video",
+    capabilities: ["text_to_video"],
+    defaults: { duration: 5, resolution: "832x480", fps: 16 },
+    limits: { durations: [3, 4, 5], fps: [16], resolutions: ["832x480"] },
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+
+  const MAC_CAPS = {
+    macGatingActive: true,
+    platform: "darwin",
+    notAvailableLabel: "Not available on Mac (MLX only)",
+    features: {},
+    training: { supportedKernels: [], lokrOnWanSupported: false },
+  };
+
+  const still = { id: "img_still", type: "image", projectId: "project_1", displayName: "Opening Still" };
+  const clip = { id: "vid_src", type: "video", projectId: "project_1", displayName: "Source Clip" };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const modeButton = (label) => buttonWithText(container.querySelector(".mode-control"), label);
+  const labelStartingWith = (text) =>
+    [...container.querySelectorAll("label")].find((el) => el.textContent.trim().startsWith(text));
+  const selectLabelled = (text) => labelStartingWith(text)?.querySelector("select");
+  const optionValues = (select) => [...select.options].map((option) => option.value);
+  const clipStrengthInput = () => labelStartingWith("Clip strength")?.querySelector("input");
+  // The disclosure's open state survives a re-render into the same root, so a blind toggle would
+  // CLOSE it on the second model of a two-model discriminator test. Open only when it is shut.
+  const ensureAdvancedOpen = async () => {
+    const toggle = container.querySelector(".advanced-section-toggle");
+    if (toggle && toggle.getAttribute("aria-expanded") !== "true") {
+      await click(toggle);
+    }
+  };
+
+  it("keeps the fixture identical to the shipped krea_realtime_14b manifest entry", () => {
+    const manifestPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../../../config/manifests/builtin.models.jsonc",
+    );
+    const manifest = JSON5.parse(readFileSync(manifestPath, "utf8"));
+    const models = Array.isArray(manifest) ? manifest : manifest.models;
+    const shipped = models.find((entry) => entry.id === "krea_realtime_14b");
+
+    expect(shipped, "krea_realtime_14b must be in builtin.models.jsonc").toBeTruthy();
+    expect(shipped.adapter).toBe(KREA.adapter);
+    expect(shipped.family).toBe(KREA.family);
+    expect(shipped.type).toBe("video");
+    expect(shipped.capabilities).toEqual(KREA.capabilities);
+    expect(shipped.defaults).toEqual(KREA.defaults);
+    expect(shipped.limits).toEqual(KREA.limits);
+  });
+
+  it("offers Krea Realtime in the picker with exactly its three capability tabs enabled", async () => {
+    await render(baseContext({ videoModels: [KREA], macCapabilities: MAC_CAPS }));
+
+    const picker = selectLabelled("Model");
+    expect(optionValues(picker)).toEqual(["krea_realtime_14b"]);
+    expect(picker.value).toBe("krea_realtime_14b");
+
+    // Mode tabs are gated at the MODE level under Mac gating, so a tab is enabled exactly when
+    // some available model serves it. With Krea the only model, that is exactly its capabilities.
+    const enabled = ALL_VIDEO_MODES.filter((value) => {
+      const label = {
+        text_to_video: "Text → Video",
+        image_to_video: "Image → Video",
+        first_last_frame: "First → Last",
+        extend_clip: "Extend",
+        video_bridge: "Bridge",
+        replace_person: "Replace person",
+        video_to_video: "Video → Video",
+        reference_to_video: "Reference → Video",
+        reference_video_to_video: "Reference + Video",
+        multi_video_to_video: "Multi-Clip → Video",
+        ads2v: "Clip + Ref Video",
+        animate_character: "Animate character",
+      }[value];
+      return !modeButton(label).disabled;
+    });
+    expect(enabled.sort()).toEqual([...KREA_CAPABILITIES].sort());
+  });
+
+  it("surfaces the manifest's own duration / fps / resolution / steps, not the screen's fallbacks", async () => {
+    await render(baseContext({ videoModels: [KREA], macCapabilities: MAC_CAPS }));
+    await ensureAdvancedOpen();
+
+    const durations = selectLabelled("Duration");
+    // `limits.durations[0]` is 2 and the DEFAULT is 4 — asserting the selected value is 4 is
+    // therefore a real discriminator, not the "first entry is the default" tautology.
+    expect(optionValues(durations)).toEqual(["2", "3", "4", "5"]);
+    expect(durations.value).toBe("4");
+    expect(durations.value).not.toBe(String(KREA.limits.durations[0]));
+    // The screen falls back to [4, 6, 8, 10] when a model declares no durations; Krea's lattice
+    // shares none of its endpoints, so a broken wiring shows up here rather than passing silently.
+    expect(optionValues(durations)).not.toEqual(["4", "6", "8", "10"]);
+
+    const fps = selectLabelled("Frames");
+    // The screen's fallback fps menu is [24, 25, 30] and Krea's is the single 24 — same trap:
+    // the VALUE 24 alone would pass under the fallback, the one-entry MENU would not.
+    expect(optionValues(fps)).toEqual(["24"]);
+    expect(fps.value).toBe("24");
+
+    const resolutions = selectLabelled("Resolution");
+    expect(optionValues(resolutions)).toEqual(["832x480", "480x832", "1280x720", "720x1280"]);
+    expect(resolutions.value).toBe("832x480");
+
+    // The Advanced steps control reflects the model's own few-step recipe as its placeholder.
+    const steps = labelStartingWith("Steps").querySelector("input");
+    expect(steps.placeholder).toBe("6");
+    expect(steps.disabled).toBe(false);
+  });
+
+  it("shows no Lightning toggle for Krea while still showing it for a Wan A14B engine", async () => {
+    await render(baseContext({ videoModels: [KREA], macCapabilities: MAC_CAPS }));
+    await ensureAdvancedOpen();
+    expect(container.textContent).not.toContain("Lightning");
+
+    // Same screen, same disclosure, a model that DOES carry the toggle — so the assertion above
+    // cannot be passing merely because the control was removed or renamed.
+    await render(baseContext({ videoModels: [WAN_A14B] }));
+    await ensureAdvancedOpen();
+    expect(container.textContent).toContain("Lightning");
+  });
+
+  it("offers the clip strength for Krea video_to_video and sends it", async () => {
+    const context = baseContext({
+      videoModels: [KREA],
+      macCapabilities: MAC_CAPS,
+      assets: [clip],
+      selectedAsset: clip,
+    });
+    await render(context);
+    await click(modeButton("Video → Video"));
+    await ensureAdvancedOpen();
+
+    const strength = clipStrengthInput();
+    expect(strength, "Krea v2v must expose the clip strength the worker reads").toBeTruthy();
+    await act(async () => setInput(strength, "0.65"));
+    await click(buttonWithText(container, "Render clip"));
+
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload).toMatchObject({ mode: "video_to_video", model: "krea_realtime_14b", sourceClipAssetId: "vid_src" });
+    expect(payload.advanced.videoConditioningStrength).toBe(0.65);
+  });
+
+  it("hides the clip strength on a v2v model whose worker route ignores it", async () => {
+    const context = baseContext({ videoModels: [BERNINI_V2V], assets: [clip], selectedAsset: clip });
+    await render(context);
+    await click(modeButton("Video → Video"));
+    await ensureAdvancedOpen();
+
+    // Same mode, different engine: Bernini's v2v never reads `videoConditioningStrength`, so the
+    // control must not appear — the gate is the adapter, not the tab.
+    expect(clipStrengthInput()).toBeFalsy();
+
+    await click(buttonWithText(container, "Render clip"));
+    expect(context.createVideoJob.mock.calls[0][0].advanced.videoConditioningStrength).toBeUndefined();
+  });
+
+  it("hides the clip strength for Krea image_to_video, whose strength is a documented no-op", async () => {
+    const context = baseContext({
+      videoModels: [KREA],
+      macCapabilities: MAC_CAPS,
+      assets: [still],
+      selectedAsset: still,
+    });
+    await render(context);
+    await click(modeButton("Image → Video"));
+    await ensureAdvancedOpen();
+
+    // The i2v reference still only warms the AR KV cache — the engine reads the image and never
+    // `strength`. Offering the knob here would be a control that silently does nothing.
+    expect(clipStrengthInput()).toBeFalsy();
+
+    await click(buttonWithText(container, "Render clip"));
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload).toMatchObject({ mode: "image_to_video", model: "krea_realtime_14b", sourceAssetId: "img_still" });
+    expect(payload.advanced.videoConditioningStrength).toBeUndefined();
+  });
+
+  it("submits Krea in each of its three advertised modes", async () => {
+    const context = baseContext({
+      videoModels: [KREA],
+      macCapabilities: MAC_CAPS,
+      assets: [still, clip],
+    });
+    await render(context);
+
+    // text_to_video — the default tab, no conditioning media.
+    await click(buttonWithText(container, "Render clip"));
+
+    await click(modeButton("Image → Video"));
+    await click(buttonWithText(container, "Select image"));
+    let modal = document.querySelector(".asset-picker-modal");
+    await click([...modal.querySelectorAll('[role="option"]')].find((el) => el.textContent.includes("Opening Still")));
+    await click(buttonWithText(modal, "Use Selection"));
+    await click(buttonWithText(container, "Render clip"));
+
+    await click(modeButton("Video → Video"));
+    await click(buttonWithText(container, "Select clip"));
+    modal = document.querySelector(".asset-picker-modal");
+    await click([...modal.querySelectorAll('[role="option"]')].find((el) => el.textContent.includes("Source Clip")));
+    await click(buttonWithText(modal, "Use Selection"));
+    await click(buttonWithText(container, "Render clip"));
+
+    const modes = context.createVideoJob.mock.calls.map(([payload]) => payload.mode);
+    expect(modes).toEqual(["text_to_video", "image_to_video", "video_to_video"]);
+    for (const [payload] of context.createVideoJob.mock.calls) {
+      expect(payload.model).toBe("krea_realtime_14b");
+    }
   });
 });

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -1521,6 +1521,9 @@ describe("VideoStudio Krea Realtime 14B surface (sc-8445)", () => {
     family: "krea-realtime",
     adapter: "krea_realtime",
     capabilities: KREA_CAPABILITIES,
+    // Krea Realtime is CFG-free, so it declares BOTH axes absent (sc-8445). Every other video model
+    // declares no `video` block at all, and absent means TRUE — see the supportsGuidance derivation.
+    video: { supportsGuidance: false, supportsNegativePrompt: false },
     defaults: {
       duration: 4,
       fps: 24,
@@ -1650,6 +1653,7 @@ describe("VideoStudio Krea Realtime 14B surface (sc-8445)", () => {
     expect(shipped.capabilities).toEqual(KREA.capabilities);
     expect(shipped.defaults).toEqual(KREA.defaults);
     expect(shipped.limits).toEqual(KREA.limits);
+    expect(shipped.video).toEqual(KREA.video);
   });
 
   it("offers Krea Realtime in the picker with exactly its three capability tabs enabled", async () => {
@@ -1777,6 +1781,101 @@ describe("VideoStudio Krea Realtime 14B surface (sc-8445)", () => {
     const payload = context.createVideoJob.mock.calls[0][0];
     expect(payload).toMatchObject({ mode: "image_to_video", model: "krea_realtime_14b", sourceAssetId: "img_still" });
     expect(payload.advanced.videoConditioningStrength).toBeUndefined();
+  });
+
+  // acceptance item 1's install-state half. `videoModels` is what App.jsx has ALREADY filtered
+  // through `generationModelsForType` (installState complete), so a krea that is still `missing`
+  // reaches this screen as an empty picker list plus a catalog entry to offer — exactly the shape
+  // reproduced here. Without this the only evidence for the krea-specific gate was a browser
+  // session nobody can re-run.
+  it("gates the studio and offers Krea for download when it is not installed", async () => {
+    const missingKrea = { ...KREA, installState: "missing", downloadSizeLabel: "18.9 GB" };
+    const context = baseContext({
+      videoModels: [],
+      models: [missingKrea],
+      macCapabilities: MAC_CAPS,
+    });
+    await render(context);
+
+    const gate = container.querySelector(".model-availability-gate");
+    expect(gate, "an empty video picker must render the availability gate").toBeTruthy();
+    expect(gate.textContent).toContain("Video Studio needs a video model");
+    // The studio body is replaced, not merely annotated.
+    expect(container.querySelector(".mode-control")).toBeFalsy();
+
+    // Krea is offered specifically — `videoModelUsable` accepts it (video type, Mac-supported,
+    // serves >=1 mode), so the gate names it rather than falling back to "nothing supports this".
+    const offers = [...gate.querySelectorAll(".model-availability-offer")].map((el) => el.textContent);
+    expect(offers.length).toBe(1);
+    expect(offers[0]).toContain("Krea Realtime 14B");
+    expect(offers[0]).toContain("18.9 GB");
+  });
+
+  // sc-8445 major: Krea is CFG-free — `generate_krea_realtime` sets `negative_prompt: None` and
+  // never forwards a guidance scale — so offering either control would be a knob that silently does
+  // nothing. Driven off the manifest `video` block, not an id check.
+  //
+  // ⚠️ The payload half is asserted after the values have actually been SET on another model and
+  // carried across the model switch. Both fields persist in studio state (and restore from a
+  // recipe), so a user who sets guidance on Bernini and switches to Krea really does arrive here
+  // with a non-empty override — which is the leak the gate has to plug. Asserting on a freshly
+  // mounted Krea would assert the empty default and pass against no implementation at all.
+  it("hides Guidance and Negative prompt for a CFG-free engine and sends neither", async () => {
+    const context = baseContext({ videoModels: [BERNINI_V2V, KREA] });
+    await render(context);
+    await ensureAdvancedOpen();
+
+    // On the guidance-taking model first: set both, so the state is genuinely non-empty.
+    await act(async () => setInput(labelStartingWith("Guidance").querySelector("input"), "7.5"));
+    const negative = labelStartingWith("Negative prompt").querySelector("textarea");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+      setter.call(negative, "blurry, low quality");
+      negative.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+
+    // Switch to the CFG-free engine. Both controls go away…
+    await act(async () => setSelect(selectLabelled("Model"), "krea_realtime_14b"));
+    await ensureAdvancedOpen();
+    expect(labelStartingWith("Guidance")).toBeFalsy();
+    expect(labelStartingWith("Negative prompt")).toBeFalsy();
+
+    // …and neither retained value reaches the worker.
+    await click(buttonWithText(container, "Render clip"));
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload.model).toBe("krea_realtime_14b");
+    expect(payload.negativePrompt).toBe("");
+    expect(payload.advanced.guidanceScale).toBeUndefined();
+  });
+
+  // The other half of the same rule, and the reason `!== false` rather than `=== true`: a video
+  // model that declares NO `video` block keeps both controls, so this change is behaviour-neutral
+  // for Wan / LTX / SCAIL-2 / Bernini. Without this leg the test above would also pass against an
+  // implementation that hid the pair for every model.
+  //
+  // Bernini rather than the Wan A14B fixture on purpose: `wan_2_2_t2v_14b` is in
+  // WAN_A14B_LIGHTNING_MODEL_IDS, and Lightning defaults ON and suppresses guidance itself — so it
+  // would have proved nothing about the new `video` gate.
+  it("keeps Guidance and Negative prompt for a model that declares no video axes", async () => {
+    const context = baseContext({ videoModels: [BERNINI_V2V] });
+    await render(context);
+    await ensureAdvancedOpen();
+
+    const guidance = labelStartingWith("Guidance")?.querySelector("input");
+    expect(guidance).toBeTruthy();
+    await act(async () => setInput(guidance, "6.5"));
+    const negative = labelStartingWith("Negative prompt")?.querySelector("textarea");
+    expect(negative).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+      setter.call(negative, "blurry");
+      negative.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+
+    await click(buttonWithText(container, "Render clip"));
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload.negativePrompt).toBe("blurry");
+    expect(payload.advanced.guidanceScale).toBe(6.5);
   });
 
   it("submits Krea in each of its three advertised modes", async () => {

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -9377,6 +9377,23 @@
         "image_to_video",
         "video_to_video"
       ],
+      // Which generation AXES this engine actually has (sc-8445), the video-lane sibling of the
+      // `audio` sub-block. Krea Realtime is CFG-FREE: the Self-Forcing distillation baked guidance
+      // out, so `generate_krea_realtime` runs a single batch-1 forward, sets `negative_prompt: None`
+      // and never forwards a guidance scale (video_jobs/krea_realtime.rs). Declaring that here lets
+      // Video Studio HIDE both controls instead of offering knobs the worker discards — and makes
+      // this entry's own `ui.description` ("CFG-off, so there is no negative prompt or guidance
+      // control") a true statement about the shipped UI rather than an aspiration.
+      //
+      // ⚠️ Polarity is the OPPOSITE of the `audio` block's: an ABSENT key here means TRUE. Every
+      // other video entry (Wan / LTX / SCAIL-2 / Bernini) genuinely takes both, so absent-means-
+      // supported is the correct default for the video population AND leaves all of them behaving
+      // exactly as they did before this block existed. Only an engine that truly lacks an axis
+      // declares it false. The schema says the same thing.
+      "video": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       "downloads": [
         // macOS quant matrix (epic 8506 shape, mirroring scail2_14b): each tier is a SEPARATE
         // user-selectable artifact tagged with a `variant`; `q4` (default) installs when no tier

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -7949,6 +7949,15 @@
       // any text prompt. The Video Studio keys off this to drop the prompt
       // requirement (the prompt field stays hidden/optional).
       "promptless": true,
+      // Same story as the text prompt, for the other two axes (sc-8445): `generate_svd`
+      // (video_jobs/svd.rs) hard-sets `negative_prompt: None` and `guidance: None` because the
+      // engine drives its own frame-wise CFG ramp — there is no scale to set and no unconditional
+      // branch to steer. `promptless` already hid the prompt field; without this block the Guidance
+      // and Negative prompt controls stayed visible and permanently dead.
+      "video": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       "downloads": [
         {
           // Diffusers checkpoint (img2vid-XT): UNet + VAE + CLIP image encoder.
@@ -9385,11 +9394,12 @@
       // this entry's own `ui.description` ("CFG-off, so there is no negative prompt or guidance
       // control") a true statement about the shipped UI rather than an aspiration.
       //
-      // ⚠️ Polarity is the OPPOSITE of the `audio` block's: an ABSENT key here means TRUE. Every
-      // other video entry (Wan / LTX / SCAIL-2 / Bernini) genuinely takes both, so absent-means-
-      // supported is the correct default for the video population AND leaves all of them behaving
-      // exactly as they did before this block existed. Only an engine that truly lacks an axis
-      // declares it false. The schema says the same thing.
+      // ⚠️ Polarity is the OPPOSITE of the `audio` block's: an ABSENT key here means TRUE. Of the
+      // ten video entries, EIGHT genuinely take both (the Wan family, both LTX entries, SCAIL-2 and
+      // Bernini) and declare nothing; the two that do not — this entry and `svd`, whose engine
+      // drives its own frame-wise CFG ramp — declare it false right here. So absent-means-supported
+      // is the correct default for the majority AND leaves those eight behaving exactly as they did
+      // before this block existed. The schema says the same thing.
       "video": {
         "supportsGuidance": false,
         "supportsNegativePrompt": false

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -491,15 +491,15 @@
           "video": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Video-generation capability metadata (sc-8445, epic 8431) — the video-lane sibling of the `audio` sub-block, declaring which generation AXES a video engine actually has so Video Studio can hide a control the worker would discard rather than offering a knob that silently does nothing. Every property is OPTIONAL and, unlike `audio`, an ABSENT property means TRUE: the video population is overwhelmingly guidance-taking (Wan / LTX / SCAIL-2 / Bernini all read a CFG scale and a negative prompt), so absent-means-supported is the correct default for them and leaves an undeclared entry behaving exactly as it did before this block existed. Only a model that genuinely lacks an axis declares it false.",
+            "description": "Video-generation capability metadata (sc-8445, epic 8431) — the video-lane sibling of the `audio` sub-block, declaring which generation AXES a video engine actually has so Video Studio can hide a control the worker would discard rather than offering a knob that silently does nothing. Every property is OPTIONAL and, unlike `audio`, an ABSENT property means TRUE: the video population is majority guidance-taking — eight of the ten shipped video entries (the Wan family, both LTX entries, SCAIL-2, Bernini) read a CFG scale and a negative prompt and declare nothing — so absent-means-supported is the correct default for them and leaves an undeclared entry behaving exactly as it did before this block existed. The two that genuinely lack the axes declare them false: `krea_realtime_14b` (Self-Forcing distilled it out) and `svd` (its engine drives its own frame-wise CFG ramp).",
             "properties": {
               "supportsGuidance": {
                 "type": "boolean",
-                "description": "Does the engine have a classifier-free-guidance axis? False for a CFG-free distilled engine — krea_realtime_14b's Self-Forcing distillation baked guidance out, so the worker runs a single batch-1 forward and never forwards a guidance scale. ABSENT MEANS TRUE. When false, Video Studio hides its Guidance control and stops emitting `advanced.guidanceScale`."
+                "description": "Does the engine have a classifier-free-guidance axis? False when the engine exposes no guidance scale at all: krea_realtime_14b's Self-Forcing distillation baked guidance out (a single batch-1 forward), and svd drives its own frame-wise CFG ramp — `generate_svd` hard-sets `guidance: None`. ABSENT MEANS TRUE. When false, Video Studio hides its Guidance control and stops emitting `advanced.guidanceScale`."
               },
               "supportsNegativePrompt": {
                 "type": "boolean",
-                "description": "Does the engine accept a negative prompt? A CFG-free engine has no unconditional branch to steer, so there is nothing for a negative prompt to do (`generate_krea_realtime` sets `negative_prompt: None`). ABSENT MEANS TRUE. When false, Video Studio hides its Negative prompt field and sends an empty one."
+                "description": "Does the engine accept a negative prompt? An engine with no steerable unconditional branch has nothing for a negative prompt to do — both `generate_krea_realtime` and `generate_svd` hard-set `negative_prompt: None`. ABSENT MEANS TRUE. When false, Video Studio hides its Negative prompt field and sends an empty one."
               }
             }
           },

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -488,6 +488,21 @@
               }
             }
           },
+          "video": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Video-generation capability metadata (sc-8445, epic 8431) — the video-lane sibling of the `audio` sub-block, declaring which generation AXES a video engine actually has so Video Studio can hide a control the worker would discard rather than offering a knob that silently does nothing. Every property is OPTIONAL and, unlike `audio`, an ABSENT property means TRUE: the video population is overwhelmingly guidance-taking (Wan / LTX / SCAIL-2 / Bernini all read a CFG scale and a negative prompt), so absent-means-supported is the correct default for them and leaves an undeclared entry behaving exactly as it did before this block existed. Only a model that genuinely lacks an axis declares it false.",
+            "properties": {
+              "supportsGuidance": {
+                "type": "boolean",
+                "description": "Does the engine have a classifier-free-guidance axis? False for a CFG-free distilled engine — krea_realtime_14b's Self-Forcing distillation baked guidance out, so the worker runs a single batch-1 forward and never forwards a guidance scale. ABSENT MEANS TRUE. When false, Video Studio hides its Guidance control and stops emitting `advanced.guidanceScale`."
+              },
+              "supportsNegativePrompt": {
+                "type": "boolean",
+                "description": "Does the engine accept a negative prompt? A CFG-free engine has no unconditional branch to steer, so there is nothing for a negative prompt to do (`generate_krea_realtime` sets `negative_prompt: None`). ABSENT MEANS TRUE. When false, Video Studio hides its Negative prompt field and sends an empty one."
+              }
+            }
+          },
           "audio": {
             "type": "object",
             "additionalProperties": false,


### PR DESCRIPTION
S12 of epic 8431 — the user-visible vertical slice for Krea Realtime 14B.

## What already worked, before any change

Verified empirically in a running browser against the real catalog (rust-api on an isolated `HF_HOME`/data dir with the `q4` + `q8` tiers staged, `SCENEWORKS_MLX_REQUIRED=1`), not inferred from the code:

- The model is **selectable** in the Video Studio picker and gated correctly on install state — `installState: missing` routes it to the `ModelAvailabilityGate`, `installed` puts it in the picker.
- **Text → Video, Image → Video and Video → Video are the only enabled tabs**; the other nine are disabled under Mac gating, straight off `macSupport.features.videoModes`.
- Duration **2/3/4/5s with 4s selected**, fps menu **[24]**, the four resolutions with **832×480** selected, Steps placeholder **6**, **no** Lightning toggle, the **q4/q8/bf16** tier picker, the `durationHint`, and the prompt guide — all catalog-driven, no code change needed.

So the diff is deliberately small. The story asked for the whole surface; most of it is the sc-8444 manifest entry doing its job.

## The one real gap

Krea's `video_to_video` drives a **strength-controlled** autoregressive init, and the worker reads `advanced.videoConditioningStrength` (default 1.0) — see `krea_realtime_conditioning` in `crates/sceneworks-worker/src/video_jobs/krea_realtime.rs`. But the control rendered only for `extend_clip` / `video_bridge`, so the knob was **unreachable**: every Krea v2v ran at 1.0 no matter what the user wanted.

`showClipStrength` now also covers `video_to_video` on the `krea_realtime` adapter. The payload gate is the *same predicate* as the render gate, so a strength can never be sent that the user was never offered.

Three deliberate non-behaviours, each pinned by a test:

| case | behaviour | why |
|---|---|---|
| Krea `image_to_video` | control **hidden** | the reference still only warms the AR KV cache; the engine reads the image and never `strength` — `krea_realtime_conditioning` emits `strength: None`. A documented no-op (sc-8440/sc-8443), so offering the knob would be a control that does nothing. |
| Bernini `video_to_video` | control **hidden** | Bernini's route never reads the key. The gate is the **adapter**, not the tab. |
| Krea `text_to_video` | control **hidden** | no conditioning media. |

## Also

`video_to_video` gets a `CAPABILITY_LABELS` row. Krea is the first catalog model to advertise all three video capabilities on one Model Manager card, and its third chip was falling to the humanized fallback — reading `video to video` beside two title-cased siblings.

## Browser verification

Real Chrome against a real rust-api, on the **worktree** tree (confirmed by the vite process cwd, since `preview_start` is known to serve the main checkout in a worktree). Confirmed: the model appears and is selectable; the three tabs and only those are enabled; the defaults/limits above; the new Clip strength appears in v2v and **not** in t2v or i2v; and the Model Manager card renders three tiers with the corrected chips.

## Tests

A `VideoStudio Krea Realtime 14B surface (sc-8445)` suite whose fixture is **held to the shipped manifest entry** (adapter, family, capabilities, defaults, limits) — so the behavioural tests below cannot pass against a fixture that has drifted from what a user's catalog actually serves.

- picker + **exactly** the three capability tabs enabled
- the catalog defaults asserted against *the screen's own fallbacks* rather than against themselves: `[2,3,4,5]` vs the `[4,6,8,10]` fallback, the single-entry `[24]` menu vs the `[24,25,30]` fallback (the **value** 24 alone would pass under the fallback), and the 4s default explicitly asserted to differ from `limits.durations[0]` — `limits[0]` is not the default
- no Lightning toggle, with a Wan A14B **discriminator in the same test** so it cannot pass merely because the control was renamed
- v2v strength shown + sent; hidden on Bernini v2v; hidden on Krea i2v
- a submit in each of the three advertised modes
- ModelManagerScreen: the three chips as one title-cased set

**12 mutations, each individually verified RED then reverted:** krea v2v arm dropped · v2v widened to every model · strength offered for i2v · payload keeps the old mode gate · durations fall back · fps falls back · steps placeholder loses the model default · mode tabs never disabled · krea added to the Wan lightning set · manifest default duration drifted to `limits[0]` · manifest drops `video_to_video` · the `video_to_video` label row reverted.

## Ran locally

Full `apps/web` vitest (204 files / 2827 tests, `--environment jsdom` — the known worktree symlinked-`node_modules` artifact) · `npm run check` · `npm run check:license-coverage` · eslint on the changed files. **No Rust touched**, so the workspace suite was not re-run; CI carries it.

## Follow-up filed, not buried

**sc-15299** — Video Studio and Image Studio render **Guidance** and **Negative prompt** for every model, including CFG-free ones that ignore both (`krea_realtime_14b`, and equally `krea_2_turbo` / `z_image_turbo` / `flux_schnell` / `sd3_5_large_turbo`). Krea's own `ui.description` already promises *"there is no negative prompt or guidance control"*, which the UI contradicts. Not fixed here on purpose: fixing it for krea alone with an id check would leave its own image sibling behaving the opposite way on the adjacent screen, and the real signal (`Capabilities.supports_guidance` / `supports_negative_prompt`, already read by the worker) does not reach the catalog at all. Audio Studio already does it properly off `audio.supportsGuidance`; video/image need the same seam.

Not merging — the coordinator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)