### PR TITLE
feat(worker): add measured Krea BF16 memory ladder (SC-15206)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -4279,11 +4279,11 @@
         // remain close in size once their text encoders are dropped, so their sequential peaks converge.
         "sequentialPeakGb": { "q4": 21.9, "q8": 29.4, "bf16": 39.4, "int8-convrot": 28.6 },
         // sc-15117: quality-preserving Q4 constrained-card fit ladder. Each phase is
-        // `fixedGb + perMpxGb * megapixels`; the worker adds its normal 2 GB safety reserve and selects
-        // the first sufficient rung in declaration order. Curves are conservative upper fits (+~0.1 GB
+        // `fixedGb + perMpxGb * megapixels`; the worker adds its normal 2 GiB safety reserve and selects
+        // the first sufficient rung in declaration order. Curves are conservative upper fits (+~0.1 GiB
         // calibration allowance) to rendered-device samples at 768² and 1024², seed 42, on an exclusive
         // RTX PRO 6000 Blackwell with the public q4 turnkey. Step count does not change the working set.
-        // Raw sample peaks (GB):
+        // Raw sample peaks (GiB):
         //   threeStage       768² text/denoise/decode 3.895/11.747/10.843;
         //                    1024²                         3.895/15.405/15.440
         //   tiledVae        768²                           3.895/11.747/9.702;
@@ -4293,7 +4293,7 @@
         //   streamedBlocks  768²                           3.895/3.761/4.736;
         //                    1024²                         3.895/4.063/5.676
         // sc-15205 adds the equivalent Q8 matrix from the same exclusive hardware/methodology; no Q4
-        // curve was scaled or reused. Raw Q8 phase samples (GB):
+        // curve was scaled or reused. Raw Q8 phase samples (GiB):
         //   threeStage       768² text/denoise/decode 6.345/18.357/16.514;
         //                    1024²                         6.345/22.015/16.514
         //   tiledVae         768²                          6.345/18.357/16.548;
@@ -4302,9 +4302,18 @@
         //                    1024²                         6.345/18.156/16.512
         //   streamedBlocks   768²                          6.345/6.211/4.837;
         //                    1024²                         6.847/6.757/4.132
-        // Tiled decode is a measured no-op for Q8's denoise-owned peak, so its curve intentionally
-        // cannot displace the cheaper three-stage rung. BF16 retains the established gate until it has
-        // equivalent tier-specific evidence.
+        // sc-15206 adds the dense BF16 matrix, again from direct production-weight measurements rather
+        // than scaling either packed tier. Raw BF16 phase samples (GiB):
+        //   threeStage       768² text/denoise/decode 8.694/28.390/26.413;
+        //                    1024²                         8.694/32.014/26.446
+        //   tiledVae         768²                          8.694/28.390/26.446;
+        //                    1024²                         8.560/32.014/26.446
+        //   chunkedAttention 768²                          8.527/27.552/26.414;
+        //                    1024²                         8.526/27.652/26.413
+        //   streamedBlocks   768²                          8.535/8.533/2.130;
+        //                    1024²                         8.526/8.526/3.629
+        // Tiled decode is a measured no-op for the denoise-owned Q8/BF16 peaks, so those curves
+        // intentionally cannot displace the cheaper three-stage rung.
         "turboFit": {
           // Do not extrapolate these curves into unvalidated attention shapes. In particular, 2048²
           // requires per-head query-row fallback whose CUDA byte identity has not been established.
@@ -4352,6 +4361,28 @@
                 "text": { "fixedGb": 5.80, "perMpxGb": 1.10 },
                 "denoise": { "fixedGb": 5.61, "perMpxGb": 1.20 },
                 "decode": { "fixedGb": 4.94, "perMpxGb": 0.00 }
+              }
+            },
+            "bf16": {
+              "threeStage": {
+                "text": { "fixedGb": 8.80, "perMpxGb": 0.00 },
+                "denoise": { "fixedGb": 23.83, "perMpxGb": 7.90 },
+                "decode": { "fixedGb": 26.55, "perMpxGb": 0.00 }
+              },
+              "tiledVae": {
+                "text": { "fixedGb": 8.80, "perMpxGb": 0.00 },
+                "denoise": { "fixedGb": 23.83, "perMpxGb": 7.90 },
+                "decode": { "fixedGb": 26.55, "perMpxGb": 0.00 }
+              },
+              "chunkedAttention": {
+                "text": { "fixedGb": 8.63, "perMpxGb": 0.00 },
+                "denoise": { "fixedGb": 27.53, "perMpxGb": 0.22 },
+                "decode": { "fixedGb": 26.52, "perMpxGb": 0.00 }
+              },
+              "streamedBlocks": {
+                "text": { "fixedGb": 8.64, "perMpxGb": 0.00 },
+                "denoise": { "fixedGb": 8.64, "perMpxGb": 0.00 },
+                "decode": { "fixedGb": 0.30, "perMpxGb": 3.27 }
               }
             }
           }

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4901,13 +4901,54 @@ fn capability_downtier_floor<'a>(
     }
 }
 
+/// Truthful Krea Turbo capability-clamp rejection. The ladder's same-tier floor prevents a silent
+/// quality downgrade, but lower installed tiers remain a valid MANUAL escape and must be named when
+/// lowering resolution cannot cross the measured fixed-weight floor.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+fn krea_turbo_capability_reject_message(
+    model: &str,
+    tier: &str,
+    needed_gb: f64,
+    available_gb: f64,
+    gpu_id: &str,
+    lower_resolution: Option<(u32, u32)>,
+    installed_smaller: &[&str],
+) -> String {
+    let mut options = Vec::new();
+    if let Some((smaller_w, smaller_h)) = lower_resolution {
+        options.push(format!(
+            "lower the output resolution to {smaller_w}x{smaller_h} or below"
+        ));
+    }
+    if !installed_smaller.is_empty() {
+        options.push(format!(
+            "select a smaller installed tier ({})",
+            installed_smaller
+                .iter()
+                .map(|candidate| candidate.to_uppercase())
+                .collect::<Vec<_>>()
+                .join(" / ")
+        ));
+    }
+    options.push("run on a GPU with more VRAM".to_owned());
+    format!(
+        "{model} at its {tier} precision floor needs {needed_gb:.2} GiB of VRAM even after every \
+         measured constrained-memory rung, but GPU {gpu_id} has {available_gb:.2} GiB available. \
+         {options}.",
+        options = options.join(", or "),
+    )
+}
+
 #[cfg(all(
     test,
     not(target_os = "macos"),
     feature = "backend-candle"
 ))]
 mod krea_turbo_memory_route_tests {
-    use super::{capability_downtier_floor, krea_turbo_memory_route};
+    use super::{
+        capability_downtier_floor, krea_turbo_capability_reject_message,
+        krea_turbo_memory_route,
+    };
 
     #[test]
     fn only_plain_turbo_text_to_image_uses_the_memory_ladder() {
@@ -4987,6 +5028,105 @@ mod krea_turbo_memory_route_tests {
             choose_downtier("q8", &candidates),
             DowntierPick::Reject { tier: "q8", .. }
         ));
+    }
+
+    #[test]
+    fn constrained_bf16_reject_never_capability_downtiers_to_q8_or_q4() {
+        use super::{choose_downtier, tier_quality_rank, DowntierPick, TierFit};
+        use crate::vram_gate::{krea_turbo_fit, KreaTurboFit, VramBudget};
+        use serde_json::Value;
+
+        let jsonc = include_str!("../../../../config/manifests/builtin.models.jsonc");
+        let parsed: Value =
+            serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(jsonc))
+                .expect("builtin model manifest parses");
+        let manifest = parsed["models"]
+            .as_array()
+            .expect("models array")
+            .iter()
+            .find(|model| model["id"].as_str() == Some("krea_2_turbo"))
+            .and_then(Value::as_object)
+            .expect("Krea 2 Turbo manifest entry");
+        let available_gb = 10.63;
+        let budget = Some(VramBudget {
+            free_gb: available_gb,
+            total_gb: available_gb,
+        });
+        let fit = |tier| match krea_turbo_fit(manifest, tier, 1024, 1024, budget, true)
+            .expect("BF16, Q8, and Q4 have measured ladder curves")
+        {
+            KreaTurboFit::Fits { .. } => TierFit::Fits,
+            KreaTurboFit::Reject { needed_gb, .. } => TierFit::TooBig {
+                needed_gb,
+                available_gb,
+            },
+        };
+        assert!(matches!(fit("bf16"), TierFit::TooBig { .. }));
+        assert_eq!(fit("q8"), TierFit::Fits);
+        assert_eq!(fit("q4"), TierFit::Fits);
+
+        let floor = capability_downtier_floor(true, "bf16", None).expect("BF16 precision floor");
+        let candidates: Vec<_> = ["bf16", "q8", "q4"]
+            .into_iter()
+            .filter(|tier| tier_quality_rank(tier) >= tier_quality_rank(floor))
+            .map(|tier| (tier, fit(tier)))
+            .collect();
+        assert!(matches!(
+            choose_downtier("bf16", &candidates),
+            DowntierPick::Reject { tier: "bf16", .. }
+        ));
+    }
+
+    #[test]
+    fn constrained_bf16_capability_reject_offers_only_truthful_manual_escapes() {
+        let immediate_below = krea_turbo_capability_reject_message(
+            "Krea 2 Turbo",
+            "bf16",
+            10.64,
+            10.63,
+            "0",
+            None,
+            &["q8", "q4"],
+        );
+        assert!(
+            immediate_below.contains("bf16 precision floor"),
+            "{immediate_below}"
+        );
+        assert!(
+            immediate_below.contains("smaller installed tier (Q8 / Q4)"),
+            "{immediate_below}"
+        );
+        assert!(
+            immediate_below.contains("needs 10.64 GiB")
+                && immediate_below.contains("has 10.63 GiB available"),
+            "immediate-below copy must preserve the measured distinction: {immediate_below}"
+        );
+        assert!(
+            !immediate_below.contains("lower the output resolution"),
+            "the fixed BF16 text floor makes resolution advice false: {immediate_below}"
+        );
+        assert!(
+            !immediate_below.contains("smallest installed tier"),
+            "{immediate_below}"
+        );
+
+        let geometry_limited = krea_turbo_capability_reject_message(
+            "Krea 2 Turbo",
+            "bf16",
+            12.0,
+            11.0,
+            "0",
+            Some((768, 768)),
+            &[],
+        );
+        assert!(
+            geometry_limited.contains("lower the output resolution to 768x768 or below"),
+            "{geometry_limited}"
+        );
+        assert!(
+            !geometry_limited.contains("select a smaller installed tier"),
+            "{geometry_limited}"
+        );
     }
 }
 
@@ -5515,24 +5655,35 @@ async fn generate_candle_stream(
                 needed_gb,
                 available_gb,
             } => {
-                let resolution_option = if krea_turbo_ladder {
-                    crate::vram_gate::krea_turbo_smaller_fit(
-                            &request.model_manifest_entry,
+                if krea_turbo_ladder {
+                    let lower_resolution = crate::vram_gate::krea_turbo_smaller_fit(
+                        &request.model_manifest_entry,
+                        smallest,
+                        width,
+                        height,
+                        budget,
+                        krea_allow_streamed_blocks,
+                    );
+                    let installed_smaller: Vec<&'static str> =
+                        installed_tier_keys(request, settings)
+                            .into_iter()
+                            .filter(|candidate| {
+                                tier_quality_rank(candidate) < tier_quality_rank(smallest)
+                            })
+                            .collect();
+                    return Err(WorkerError::InvalidPayload(
+                        krea_turbo_capability_reject_message(
+                            &request.model,
                             smallest,
-                            width,
-                            height,
-                            budget,
-                            krea_allow_streamed_blocks,
-                        )
-                    .map(|(smaller_w, smaller_h)| {
-                        format!(
-                            "Lower the output resolution to {smaller_w}x{smaller_h} or below, or "
-                        )
-                    })
-                    .unwrap_or_default()
-                } else {
-                    "Lower the output resolution, or ".to_owned()
-                };
+                            needed_gb,
+                            available_gb,
+                            &settings.gpu_id,
+                            lower_resolution,
+                            &installed_smaller,
+                        ),
+                    ));
+                }
+                let resolution_option = "Lower the output resolution, or ";
                 return Err(WorkerError::InvalidPayload(format!(
                     "{model} needs ~{needed} GB of VRAM even at the smallest installed tier it can run \
                      ({smallest}) but GPU {gpu} has ~{available} GB available. {resolution_option}Run \

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -461,11 +461,15 @@ fn image_review_wiring_remains_single_route_lazy_and_adapter_aware() {
     );
     assert_eq!(
         candle_stream.matches("installed_tier_keys(").count(),
-        3,
-        "the generic candle lane probes tiers only in its three reject arms"
+        4,
+        "the generic candle lane probes tiers only in its capability-floor, Krea-ladder, sequential, \
+         and resident reject arms"
     );
+    let capability_reject = candle_stream
+        .find("DowntierPick::Reject")
+        .expect("capability-floor reject");
     let krea_reject = candle_stream
-        .find("KreaTurboFit::Reject")
+        .find("KreaTurboFit::Reject { phases")
         .expect("Krea ladder reject");
     let sequential_reject = candle_stream
         .find("if let Some(seq_gb) =")
@@ -478,11 +482,13 @@ fn image_review_wiring_remains_single_route_lazy_and_adapter_aware() {
         .map(|(offset, _)| offset)
         .collect();
     assert!(
-        krea_reject < probes[0]
-            && probes[0] < sequential_reject
-            && sequential_reject < probes[1]
-            && probes[1] < too_big_reject
-            && too_big_reject < probes[2],
+        capability_reject < probes[0]
+            && probes[0] < krea_reject
+            && krea_reject < probes[1]
+            && probes[1] < sequential_reject
+            && sequential_reject < probes[2]
+            && probes[2] < too_big_reject
+            && too_big_reject < probes[3],
         "installed-tier walks must stay below their reject decisions"
     );
 

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -1272,21 +1272,6 @@ mod tests {
             None,
             "do not claim a lower-resolution escape when no shipped measured shape fits"
         );
-        assert_eq!(
-            krea_turbo_fit(
-                &manifest,
-                "bf16",
-                1024,
-                1024,
-                Some(VramBudget {
-                    free_gb: 48.0,
-                    total_gb: 48.0,
-                }),
-                true,
-            ),
-            None,
-            "BF16 retains the established resident/sequential gate until it has its own matrix"
-        );
     }
 
     #[test]
@@ -1322,6 +1307,112 @@ mod tests {
                     predicted_gb >= measured_gb && predicted_gb < measured_gb + 1.0,
                     "{rung:?} {edge}² {phase}: curve {predicted_gb:.3} must conservatively cover \
                      measured {measured_gb:.3} without an unrelated tier-derived margin"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn builtin_krea_bf16_curves_keep_bf16_and_select_only_measured_useful_rungs() {
+        let manifest = builtin_krea_turbo_manifest();
+        let fit = |free_gb| {
+            krea_turbo_fit(
+                &manifest,
+                "bf16",
+                1024,
+                1024,
+                Some(VramBudget {
+                    free_gb,
+                    total_gb: free_gb,
+                }),
+                true,
+            )
+        };
+        assert!(matches!(
+            fit(48.0),
+            Some(KreaTurboFit::Fits {
+                rung: KreaTurboRung::ThreeStage,
+                ..
+            })
+        ));
+        assert!(matches!(
+            fit(31.0),
+            Some(KreaTurboFit::Fits {
+                rung: KreaTurboRung::ChunkedAttention,
+                ..
+            })
+        ));
+        assert!(matches!(
+            fit(12.0),
+            Some(KreaTurboFit::Fits {
+                rung: KreaTurboRung::StreamedBlocks,
+                ..
+            })
+        ));
+
+        let three_stage =
+            krea_rung_phase_peaks(&manifest, "bf16", KreaTurboRung::ThreeStage, 1024, 1024)
+                .expect("BF16 three-stage evidence");
+        let tiled = krea_rung_phase_peaks(&manifest, "bf16", KreaTurboRung::TiledVae, 1024, 1024)
+            .expect("BF16 tiled-VAE evidence");
+        assert!(
+            tiled.peak_gb() >= three_stage.peak_gb(),
+            "the measured BF16 tiled-VAE no-op must never displace the cheaper three-stage rung"
+        );
+
+        assert!(matches!(
+            fit(10.64),
+            Some(KreaTurboFit::Fits {
+                rung: KreaTurboRung::StreamedBlocks,
+                ..
+            })
+        ));
+        assert!(matches!(fit(10.63), Some(KreaTurboFit::Reject { .. })));
+        let immediate_below = Some(VramBudget {
+            free_gb: 10.63,
+            total_gb: 10.63,
+        });
+        assert_eq!(
+            krea_turbo_smaller_fit(&manifest, "bf16", 1024, 1024, immediate_below, true),
+            None,
+            "BF16's measured streamed text floor is resolution-independent, so reject copy must not \
+             promise that lowering resolution can cross the immediate-below boundary"
+        );
+    }
+
+    #[test]
+    fn builtin_krea_bf16_curves_conservatively_cover_every_measured_phase_sample() {
+        let manifest = builtin_krea_turbo_manifest();
+        let samples = [
+            (KreaTurboRung::ThreeStage, 768, [8.694, 28.390, 26.413]),
+            (KreaTurboRung::ThreeStage, 1024, [8.694, 32.014, 26.446]),
+            (KreaTurboRung::TiledVae, 768, [8.694, 28.390, 26.446]),
+            (KreaTurboRung::TiledVae, 1024, [8.560, 32.014, 26.446]),
+            (
+                KreaTurboRung::ChunkedAttention,
+                768,
+                [8.527, 27.552, 26.414],
+            ),
+            (
+                KreaTurboRung::ChunkedAttention,
+                1024,
+                [8.526, 27.652, 26.413],
+            ),
+            (KreaTurboRung::StreamedBlocks, 768, [8.535, 8.533, 2.130]),
+            (KreaTurboRung::StreamedBlocks, 1024, [8.526, 8.526, 3.629]),
+        ];
+        for (rung, edge, measured) in samples {
+            let predicted = krea_rung_phase_peaks(&manifest, "bf16", rung, edge, edge)
+                .expect("every published BF16 matrix cell has a curve");
+            for (phase, predicted_gb, measured_gb) in [
+                ("text", predicted.text_gb, measured[0]),
+                ("denoise", predicted.denoise_gb, measured[1]),
+                ("decode", predicted.decode_gb, measured[2]),
+            ] {
+                assert!(
+                    predicted_gb >= measured_gb && predicted_gb < measured_gb + 1.0,
+                    "{rung:?} {edge}² {phase}: curve {predicted_gb:.3} must conservatively cover \
+                     measured {measured_gb:.3} without a lower-tier-derived margin"
                 );
             }
         }

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -120,7 +120,7 @@
       "type": "object",
       "required": ["fixedGb", "perMpxGb"],
       "additionalProperties": false,
-      "description": "Conservative phase VRAM curve in base-10 GB: fixedGb + perMpxGb * output megapixels.",
+      "description": "Conservative phase VRAM curve in GiB (legacy field suffix Gb): fixedGb + perMpxGb * output megapixels. NVIDIA budgets are sourced from nvidia-smi MiB and divided by 1024.",
       "properties": {
         "fixedGb": { "type": "number", "minimum": 0 },
         "perMpxGb": { "type": "number", "minimum": 0 }

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -1324,7 +1324,7 @@ def test_z_image_turbo_manifest_has_mlx_block():
 
 
 def test_krea_2_turbo_candle_vram_tiers_match_measured_peaks():
-    """sc-12126/sc-13108: never regress the directly measured standard-tier peaks."""
+    """sc-12126/sc-13108/sc-15206: pin resident peaks and every measured Turbo ladder tier."""
     manifest = _load_builtin_models_manifest()
     krea = next(model for model in manifest["models"] if model["id"] == "krea_2_turbo")
     measured_tiers = {
@@ -1335,6 +1335,38 @@ def test_krea_2_turbo_candle_vram_tiers_match_measured_peaks():
         "q4": 25.7,
         "q8": 35.2,
         "bf16": 47.2,
+    }
+    turbo_fit = krea["candle"]["turboFit"]
+    assert turbo_fit["maxMeasuredPixels"] == 1024 * 1024
+    assert set(turbo_fit["phaseCurvesByTier"]) == {"q4", "q8", "bf16"}
+    for tier in ("q4", "q8", "bf16"):
+        assert set(turbo_fit["phaseCurvesByTier"][tier]) == {
+            "threeStage",
+            "tiledVae",
+            "chunkedAttention",
+            "streamedBlocks",
+        }
+    assert turbo_fit["phaseCurvesByTier"]["bf16"] == {
+        "threeStage": {
+            "text": {"fixedGb": 8.80, "perMpxGb": 0.00},
+            "denoise": {"fixedGb": 23.83, "perMpxGb": 7.90},
+            "decode": {"fixedGb": 26.55, "perMpxGb": 0.00},
+        },
+        "tiledVae": {
+            "text": {"fixedGb": 8.80, "perMpxGb": 0.00},
+            "denoise": {"fixedGb": 23.83, "perMpxGb": 7.90},
+            "decode": {"fixedGb": 26.55, "perMpxGb": 0.00},
+        },
+        "chunkedAttention": {
+            "text": {"fixedGb": 8.63, "perMpxGb": 0.00},
+            "denoise": {"fixedGb": 27.53, "perMpxGb": 0.22},
+            "decode": {"fixedGb": 26.52, "perMpxGb": 0.00},
+        },
+        "streamedBlocks": {
+            "text": {"fixedGb": 8.64, "perMpxGb": 0.00},
+            "denoise": {"fixedGb": 8.64, "perMpxGb": 0.00},
+            "decode": {"fixedGb": 0.30, "perMpxGb": 3.27},
+        },
     }
 
 


### PR DESCRIPTION
## Summary

- add directly measured dense-BF16 phase curves for every Krea 2 Turbo constrained-memory rung
- preserve the requested BF16 tier through the reject/downtier policy and pin the immediate-below boundary
- audit all measured tiers/rungs, conservatively cover every 768²/1024² BF16 phase sample, and make the legacy `Gb` curve fields' GiB contract explicit

The Q8 parent #1902 and paired provider SceneWorks/inference#283 have merged. This PR is rebased directly onto current `main`; current SceneWorks resolves the provider at inference commit `2471fb59e02c7b126b9aba32c83bef0c62f1516e`.

## Real BF16 CUDA evidence

Hardware: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, GPU UUID `GPU-b1a31911-c7b4-2901-3d8b-9a62e228bfc0`, 97,887 MiB, driver 596.36, VBIOS 98.02.6a.00.03. Shipping BF16 snapshot revision `d009674080cc1bccf2b629d834c34bf5eccdb723` (33.228 GiB) was resolved through the production cache. Measurements used the production-weight Candle provider at inference commit `43d61e2399f0bc94367849c5fd71140b864e946e` from the paired PR's validated history; post-rebase source gates compile and test the final `2471fb59` provider pin.

Measured phase peaks in GiB (`text / denoise / decode`):

| rung | 768² | 1024² |
|---|---:|---:|
| three-stage | 8.694 / 28.390 / 26.413 | 8.694 / 32.014 / 26.446 |
| tiled VAE | 8.694 / 28.390 / 26.446 | 8.560 / 32.014 / 26.446 |
| chunked attention | 8.527 / 27.552 / 26.414 | 8.526 / 27.652 / 26.413 |
| streamed blocks | 8.535 / 8.533 / 2.130 | 8.526 / 8.526 / 3.629 |

- Resident 1024² observed peak: 47.2 GiB.
- Resident and three-stage RGB are byte-identical: SHA-256 `4F02F22638BC4AF4540126FB2A7BF91A5C8B3575418FA6EBD278955496993619`.
- Tiled-VAE, chunked-attention, and streamed-block outputs are byte-identical: SHA-256 `C7167BF4C978B13A310B8D909E6B5382503B1321D85125D0FD7F175EA83995F7`.
- Tiled-versus-resident quality: MAD 0.046175/255, PSNR 54.832210 dB, boundary MAD 0.059907 versus interior MAD 0.042595.
- A Q8 model swap followed by two canonical BF16 streamed renders (1024², 8 steps, seed 42) passed in one process: 36.806 s and 37.593 s; both repeats measured 8.528 / 8.528 / 3.629 GiB. Peak process working set was 25.199 GiB and peak private memory was 9.007 GiB with no repeat growth or allocator OOM.
- Typed cancellation scheduled after 2 s completed approximately 2.238 s after the trigger.

## Acceptance mapping

- BF16 stays BF16: the production provider loads the dense BF16 directory, the capability floor excludes Q8/Q4, and the new regression test proves a BF16 reject cannot silently select a packed tier.
- Least-cost sufficient rung: boundary tests select three-stage, chunked attention, then streamed blocks as budgets fall; 10.64 GiB admits the measured best rung and 10.63 GiB rejects without promising a smaller resolution that cannot cross the fixed BF16 text floor.
- Parity and quality: resident/staged byte identity, constrained-rung byte identity, and tiled quality metrics are recorded above.
- Repeat/model-swap/cancellation/CPU staging: recorded above.
- Q4/Q8 and Raw/edit/control production routing are unchanged; manifest audits cover all three tier matrices.

## Validation

- `cargo fmt --all -- --check`
- `python -m pytest -q tests/test_builtin_manifest_audit.py` — 59 passed
- `npm.cmd run check` — 15 passed
- `npm.cmd run rust:check:neither` — clippy passed with warnings denied
- exact reject-probe architecture test
- `git diff --check`
- real dense-BF16 CUDA rung matrix, parity, repeat/model-swap, memory, and cancellation runs described above
- independent adversarial review — PASS after resolving truthful manual-tier advice and exact 10.64-versus-10.63 GiB boundary copy

## Remaining runtime blocker

This PR intentionally remains a draft and SC-15206 remains **In Progress**. The available host has approximately 96 GiB free at normal idle and therefore naturally selects Resident. Forced rung selection was used only to measure and validate the constrained implementation; it is **not** claimed as acceptance criterion 1. Before this story can close, a real NVIDIA GPU whose normal idle free VRAM selects a constrained BF16 rung must complete the canonical 1024², 8-step, seed-42 render without a synthetic cap or environment override.
