### PR TITLE
Move studio LoRA controls into model settings

### DIFF
--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -696,9 +696,10 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).not.toContain("Qwen Only");
     expect(container.textContent).not.toContain("Missing LoRA");
 
-    await act(async () => {
-      document.body.querySelector(".advanced-section-toggle").click();
-    });
+    const loraPicker = document.body.querySelector(".settings-bar > .lora-picker");
+    expect(loraPicker).toBeTruthy();
+    expect(document.body.querySelector(".advanced-panel .lora-picker")).toBeNull();
+    expect(loraPicker.textContent).not.toContain("Show incompatible");
 
     // Add-on-demand LoRA picker (UI-refinement 3b): open the "Add LoRA" dropdown and click a
     // compatible row to add each LoRA. built_in (scope "builtin") doesn't count toward the
@@ -730,15 +731,13 @@ describe("SceneWorks app shell", () => {
     );
     expect(fifthRow.disabled).toBe(true);
 
-    // The Show-incompatible toggle reveals incompatible LoRAs in the same dropdown.
-    await act(async () => {
-      document.body.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
-    });
+    // Incompatible and missing LoRAs stay out of the picker; there is no escape-hatch checkbox.
+    expect(document.body.querySelector('.lora-picker .checkline input[type="checkbox"]')).toBeNull();
     expect(
       [...document.body.querySelectorAll(".lora-pick-row")].some((button) =>
         button.textContent.includes("Qwen Only"),
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(container.textContent).not.toContain("Missing LoRA");
 
     await act(async () => {
@@ -802,7 +801,7 @@ describe("SceneWorks app shell", () => {
     expect(loraNames).not.toContain("Z Style");
   });
 
-  it("blocks image submit when a visible incompatible LoRA is selected", async () => {
+  it("does not expose incompatible image LoRAs or the incompatible visibility control", async () => {
     const createImageJob = vi.fn();
     root = createRoot(container);
     await act(async () => {
@@ -827,39 +826,12 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    await act(async () => {
-      document.body.querySelector(".advanced-section-toggle").click();
-    });
-    // Reveal the incompatible LoRA in the dropdown, then add it via its Add row.
-    await act(async () => {
-      document.body.querySelector('.lora-picker .checkline input[type="checkbox"]').click();
-    });
-    await act(async () => {
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
-    });
-    await act(async () => {
-      [...document.body.querySelectorAll(".lora-pick-row")]
-        .find((button) => button.textContent.includes("Qwen Only"))
-        .click();
-    });
-
-    const generate = [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Generate");
-    expect(container.textContent).toContain("Generate is blocked");
-    expect(container.textContent).toContain("Qwen Only");
-    expect(generate.disabled).toBe(true);
-
-    await act(async () => {
-      document.body.querySelector(".advanced-section-toggle").click();
-    });
-    await settle();
-
-    expect(document.body.querySelector(".advanced-section.open")).toBeTruthy();
-    expect(container.textContent).toContain("Qwen Only");
-
-    await act(async () => {
-      generate.click();
-    });
-
+    const loraPicker = document.body.querySelector(".settings-bar > .lora-picker");
+    expect(loraPicker).toBeTruthy();
+    expect(loraPicker.textContent).not.toContain("Show incompatible");
+    expect(loraPicker.textContent).not.toContain("Qwen Only");
+    expect(loraPicker.querySelector('input[type="checkbox"]')).toBeNull();
+    expect(loraPicker.querySelector(".lora-add")).toBeNull();
     expect(createImageJob).not.toHaveBeenCalled();
   });
 
@@ -919,11 +891,10 @@ describe("SceneWorks app shell", () => {
     // The preset's installed LoRA is now seeded into the visible picker (not hidden), so the
     // guidance strip no longer claims it's "applied at generation" — it's a normal selection.
     expect(container.textContent).not.toContain("Preset LoRA applied at generation");
-    // Open Advanced (where the LoRA rail lives): the preset's LoRA is a real selection sitting
-    // at the preset's weight (0.4), ready to retune.
-    await act(async () => {
-      document.body.querySelector(".advanced-section-toggle").click();
-    });
+    // The model settings container exposes the preset's LoRA as a real selection sitting at
+    // the preset's weight (0.4), ready to retune without opening Advanced.
+    expect(document.body.querySelector(".settings-bar > .lora-picker")).toBeTruthy();
+    expect(document.body.querySelector(".advanced-panel .lora-picker")).toBeNull();
     expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("0.40");
 
     await act(async () => {
@@ -1139,7 +1110,10 @@ describe("SceneWorks app shell", () => {
     await settle();
     expect(field(container, "Variations").value).toBe("2");
     expect(field(container, "GPU")).toBeUndefined();
-    expect(container.textContent).not.toContain("LoRAs");
+    expect(container.textContent).toContain("LoRAs");
+    expect(document.body.querySelector(".settings-bar > .lora-picker")).toBeTruthy();
+    expect(document.body.querySelector(".advanced-panel .lora-picker")).toBeNull();
+    expect(container.textContent).not.toContain("Show incompatible");
 
     await act(async () => {
       [...document.body.querySelectorAll(".preset-chip")]
@@ -2199,13 +2173,13 @@ describe("SceneWorks app shell", () => {
     });
     await settle();
 
-    await act(async () => {
-      document.body.querySelector(".advanced-section-toggle").click();
-    });
-    await settle();
-
     // Add-on-demand LoRA picker (UI-refinement 3b): open the dropdown. Only the ltx-video LoRA is
-    // compatible; the z-image one is filtered out.
+    // compatible; the z-image one is filtered out. It is part of the model settings rather than
+    // the Advanced disclosure, and the incompatible escape hatch is intentionally absent.
+    const videoLoraPicker = document.body.querySelector(".settings-bar > .lora-picker");
+    expect(videoLoraPicker).toBeTruthy();
+    expect(document.body.querySelector(".advanced-panel .lora-picker")).toBeNull();
+    expect(videoLoraPicker.textContent).not.toContain("Show incompatible");
     await act(async () => {
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Add LoRA").click();
     });

--- a/apps/web/src/components/editor/useEditorGeneration.js
+++ b/apps/web/src/components/editor/useEditorGeneration.js
@@ -103,7 +103,6 @@ export function useEditorGeneration({ context }) {
     setAdvancedOpen,
     initialSelectedLoraIds: saved.selectedLoraIds ?? [],
     initialLoraWeights: saved.loraWeights ?? {},
-    initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
     initialGeneralStackIds: saved.generalStackIds ?? [],
   });
 
@@ -275,7 +274,6 @@ export function useEditorGeneration({ context }) {
       advancedOpen,
       selectedLoraIds: studio.selectedLoraIds,
       loraWeights: studio.loraWeights,
-      showIncompatibleLoras: studio.showIncompatibleLoras,
       selectedPresetId: studio.selectedPresetId,
       generalStackIds: studio.generalStackIds,
     },

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -769,7 +769,7 @@ export function useSavePreset({
 }
 
 // The LoRA picker shared by both studios (sc-4196): the compatible-LoRA checklist
-// with per-LoRA weight sliders, the "Show incompatible" toggle, and the empty state.
+// with per-LoRA weight sliders and the empty state.
 // All state lives in useGenerationStudio; this is a pure presentation of its bundle.
 export function LoraPickerSection({
   selectedModel,
@@ -784,13 +784,12 @@ export function LoraPickerSection({
   setLoraWeight,
   loraEmptyMessage,
   onUpdateLora,
-  showIncompatibleControl = true,
+  showIncompatibleControl = false,
 }) {
   // Add-on-demand picker (UI-refinement 3b): only the LoRAs you've added render as
   // slots; everything else lives behind the "Add LoRA" dropdown. This replaces the
-  // checkbox-per-LoRA wall so a large library no longer floods the panel. "Show
-  // incompatible" now filters the dropdown (through compatibleLoras) instead of an
-  // always-visible list. Slot styles (.lora-stack/.lora-slot/.lora-add/
+  // checkbox-per-LoRA wall so a large library no longer floods the panel. Slot styles
+  // (.lora-stack/.lora-slot/.lora-add/
   // .lora-picker-panel/.lora-pick-row) already live in styles.css.
   const [pickerOpen, setPickerOpen] = useState(false);
   const availableLoras = compatibleLoras.filter((lora) => !selectedLoraIds.includes(lora.id));

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1300,8 +1300,6 @@ export function ImageStudio() {
     setSelectedLoraIds,
     loraWeights,
     setLoraWeights,
-    showIncompatibleLoras,
-    setShowIncompatibleLoras,
     compatibleLoras,
     selectedLoras,
     userSelectedLoraCount,
@@ -1331,7 +1329,6 @@ export function ImageStudio() {
     setAdvancedOpen,
     initialSelectedLoraIds: saved.selectedLoraIds ?? [],
     initialLoraWeights: saved.loraWeights ?? {},
-    initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
     initialGeneralStackIds: saved.generalStackIds ?? [],
   });
 
@@ -1810,7 +1807,6 @@ export function ImageStudio() {
     upscaleSoftness,
     selectedLoraIds,
     loraWeights,
-    showIncompatibleLoras,
     // Krea 2 multi-phase denoise (sc-13885): persist the editor toggle, phase list, and disclosure
     // state alongside the rest of the studio snapshot (LoRA refs are by stable id, so they survive
     // reload regardless of the selected-LoRA list's async hydration).
@@ -3136,6 +3132,18 @@ export function ImageStudio() {
                 <input min="1" max="8" onChange={(event) => setCount(Number(event.target.value))} type="number" value={count} />
               </label>
             </div>
+            <LoraPickerSection
+              selectedModel={selectedModel}
+              selectedLoras={pickerSelectedLoras}
+              selectedLoraIds={pickerSelectedLoraIds}
+              compatibleLoras={pickerCompatibleLoras}
+              userSelectedLoraCount={userSelectedLoraCount}
+              toggleLora={toggleLora}
+              effectiveLoraWeight={effectiveLoraWeight}
+              setLoraWeight={setLoraWeight}
+              loraEmptyMessage={loraEmptyMessage}
+              onUpdateLora={createLoraDownloadJob}
+            />
             {/* Style axis (sc-13135): the Style Catalog picker sits FIRST in this row, followed by the
                 model's Style presets — both are style controls, so they share one row instead of the
                 catalog picker floating in a standalone row under the composer. The Style Catalog
@@ -3462,20 +3470,6 @@ export function ImageStudio() {
                 Negative prompt
                 <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
               </label>
-              <LoraPickerSection
-                selectedModel={selectedModel}
-                selectedLoras={pickerSelectedLoras}
-                selectedLoraIds={pickerSelectedLoraIds}
-                compatibleLoras={pickerCompatibleLoras}
-                userSelectedLoraCount={userSelectedLoraCount}
-                showIncompatibleLoras={showIncompatibleLoras}
-                setShowIncompatibleLoras={setShowIncompatibleLoras}
-                toggleLora={toggleLora}
-                effectiveLoraWeight={effectiveLoraWeight}
-                setLoraWeight={setLoraWeight}
-                loraEmptyMessage={loraEmptyMessage}
-                onUpdateLora={createLoraDownloadJob}
-              />
               {/* Save-as-preset folds into Advanced with the rest of the power-user
                   knobs (UI-refinement 2b). */}
               <SavePresetPanel

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -428,8 +428,6 @@ export function VideoStudio() {
     setSelectedLoraIds,
     loraWeights,
     setLoraWeights,
-    showIncompatibleLoras,
-    setShowIncompatibleLoras,
     compatibleLoras,
     selectedLoras,
     userSelectedLoraCount,
@@ -459,7 +457,6 @@ export function VideoStudio() {
     setAdvancedOpen,
     initialSelectedLoraIds: saved.selectedLoraIds ?? [],
     initialLoraWeights: saved.loraWeights ?? {},
-    initialShowIncompatibleLoras: saved.showIncompatibleLoras ?? false,
     initialGeneralStackIds: saved.generalStackIds ?? [],
   });
   // Sampler / scheduler menus declared by the model. Video Wan torch
@@ -973,7 +970,6 @@ export function VideoStudio() {
     advancedOpen,
     selectedLoraIds,
     loraWeights,
-    showIncompatibleLoras,
     model,
     duration,
     resolution,
@@ -1698,6 +1694,18 @@ export function VideoStudio() {
                 </div>
               </label>
             </div>
+            <LoraPickerSection
+              selectedModel={selectedModel}
+              selectedLoras={selectedLoras}
+              selectedLoraIds={selectedLoraIds}
+              compatibleLoras={compatibleLoras}
+              userSelectedLoraCount={userSelectedLoraCount}
+              toggleLora={toggleLora}
+              effectiveLoraWeight={effectiveLoraWeight}
+              setLoraWeight={setLoraWeight}
+              loraEmptyMessage={loraEmptyMessage}
+              onUpdateLora={createLoraDownloadJob}
+            />
             {/* Style axis (sc-13135): the Style Catalog picker leads this row (hidden for promptless
                 image-conditioned models and for booru-tag models), followed by the model's Style
                 presets — mirrors the Image Studio. The catalog wraps the outgoing prompt
@@ -2061,20 +2069,6 @@ export function VideoStudio() {
                   <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
                 </label>
               ) : null}
-              <LoraPickerSection
-                selectedModel={selectedModel}
-                selectedLoras={selectedLoras}
-                selectedLoraIds={selectedLoraIds}
-                compatibleLoras={compatibleLoras}
-                userSelectedLoraCount={userSelectedLoraCount}
-                showIncompatibleLoras={showIncompatibleLoras}
-                setShowIncompatibleLoras={setShowIncompatibleLoras}
-                toggleLora={toggleLora}
-                effectiveLoraWeight={effectiveLoraWeight}
-                setLoraWeight={setLoraWeight}
-                loraEmptyMessage={loraEmptyMessage}
-                onUpdateLora={createLoraDownloadJob}
-              />
               {characterId ? (
                 <div className="guidance-strip">
                   <strong>Character reference</strong>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2706,9 +2706,9 @@ label {
   color: var(--text-muted);
 }
 
-/* Settings bar (UI-refinement 2b): the everyday knobs (Model / Aspect / Variations, then a
-   Style-preset row) in a bordered strip directly under the composer. Advanced holds the
-   power-user knobs. */
+/* Settings bar (UI-refinement 2b): the everyday knobs (Model / LoRAs / Aspect / Variations,
+   then a Style-preset row) in a bordered strip directly under the composer. Advanced holds
+   the power-user knobs. */
 .settings-bar {
   display: grid;
   gap: 12px;
@@ -2738,6 +2738,13 @@ label {
 .settings-field-model {
   flex: 2 1 200px;
   min-width: 160px;
+}
+
+/* LoRAs are part of model configuration, so the shared picker lives inside the settings
+   container instead of the Advanced disclosure. Keep it visually grouped with the model row. */
+.settings-bar > .lora-picker {
+  border-color: var(--border);
+  background: var(--surface);
 }
 
 .settings-field-aspect {


### PR DESCRIPTION
## What changed

- move the shared LoRA picker out of Advanced and into the primary model/settings container in both Image Studio and Video Studio
- hide the Show incompatible checkbox and stop restoring or persisting its legacy state on these generation surfaces
- keep picker results limited to installed, model-compatible LoRAs
- update regression coverage for the new placement and filtering behavior

## Why

LoRA selection is a normal part of choosing and configuring a generation model, not an advanced tuning option. Keeping it visible with the model controls makes the workflow easier to discover, while removing the incompatible escape hatch avoids presenting choices that cannot generate successfully.

## Validation

- `npm.cmd test -- --run src/App.imageGeneration.test.jsx src/screens/VideoStudio.test.jsx` (94 tests)
- `npm.cmd test -- --run src/components/editor/useEditorGeneration.tier.test.jsx src/screens/imageEditor/EditorLoraPanel.test.jsx src/screens/studioRestore.test.jsx` (18 tests)
- `npm.cmd run lint`
- `npm.cmd run build`
