### PR TITLE
Image & Video Studio settings-panel cleanup (epic 15368)

### DIFF
--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -831,7 +831,16 @@ describe("SceneWorks app shell", () => {
     expect(loraPicker.textContent).not.toContain("Show incompatible");
     expect(loraPicker.textContent).not.toContain("Qwen Only");
     expect(loraPicker.querySelector('input[type="checkbox"]')).toBeNull();
-    expect(loraPicker.querySelector(".lora-add")).toBeNull();
+    // Add LoRA stays available with nothing compatible (sc-15373) — it opens the picker, which
+    // says WHY the list is empty and carries the in-place import form.
+    const addButton = loraPicker.querySelector(".lora-add");
+    expect(addButton).toBeTruthy();
+    expect(addButton.disabled).toBe(false);
+    expect(addButton.dataset.count).toBe("· 0 available");
+    await act(async () => addButton.click());
+    expect(loraPicker.querySelector(".lora-pick-row")).toBeNull();
+    expect(loraPicker.textContent).toContain("No installed LoRAs match");
+    expect(loraPicker.querySelector(".studio-lora-import")).toBeTruthy();
     expect(createImageJob).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -1124,7 +1124,7 @@ describe("SceneWorks app shell", () => {
 
     // With no preset selected the guidance strip renders nothing (the visible controls
     // already describe the run); it only appears once a preset is active.
-    expect(document.body.querySelector(".guidance-strip")).toBeNull();
+    expect(document.body.querySelector(".style-axis-guidance")).toBeNull();
     expect(field(container, "Variations").value).toBe("4");
 
     await act(async () => {

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -517,7 +517,7 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     // No preset selected → no guidance strip (it only appears when a preset is active).
-    expect(document.body.querySelector(".guidance-strip")).toBeNull();
+    expect(document.body.querySelector(".style-axis-guidance")).toBeNull();
     expect(container.textContent).not.toContain("LTX Story");
   });
 

--- a/apps/web/src/components/ControlPanel.jsx
+++ b/apps/web/src/components/ControlPanel.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
 import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
 import { ControlOverlayPicker } from "./ControlOverlayPicker.jsx";
-import { Icon } from "./Icons.jsx";
+import { AdvancedSection } from "./AdvancedSection.jsx";
 
 // Strict-control panel for the text-to-image studios (epic 8236, sc-8245). One picker gated by the
 // selected backbone's supported control modes (`ui.controlModes`, mirrored from the manifest /
@@ -59,8 +59,9 @@ export function ControlPanel({
   const modes = Array.isArray(supportedModes) ? supportedModes : [];
   // Collapsed by default (this is a large, optional section on an already-busy page); the user opts
   // in when they want to lock structure. The whole body — mode tabs, overlay selector, pose picker,
-  // control-strength slider — folds under one disclosure that looks and behaves like the shared
-  // Advanced toggle (design handoff sc-8245 Fix 1). Local-only state (Advanced doesn't persist).
+  // control-strength slider — folds under the app's ONE canonical disclosure (studio-cleanup sc-15369;
+  // the bespoke `.control-panel-toggle` header it used to draw is gone). Local-only state, matching
+  // Advanced, which doesn't persist either.
   const [open, setOpen] = useState(false);
   if (!modes.length) {
     return null;
@@ -69,123 +70,112 @@ export function ControlPanel({
   const scaleCfg = controlScaleConfig ?? {};
 
   return (
-    <div className={`control-panel${open ? " open" : " collapsed"}`}>
-      <button
-        aria-expanded={open}
-        className="advanced-toggle control-panel-toggle"
-        onClick={() => setOpen((prev) => !prev)}
-        type="button"
+    <AdvancedSection
+      className="control-panel"
+      hint="lock pose, edges, or depth to a reference"
+      label="Structure control"
+      onToggle={() => setOpen((prev) => !prev)}
+      open={open}
+    >
+      <p className="control-panel-desc">
+        Lock the output's pose, edges, or depth to a reference.
+      </p>
+      <div
+        className="control-mode-tabs"
+        role="tablist"
+        aria-label="Control type"
       >
-        <Icon.ChevDown
-          className={open ? "control-panel-chev" : "control-panel-chev collapsed"}
-          size={14}
-        />
-        Structure control
-      </button>
-
-      {open ? (
-        <>
-          <p className="control-panel-desc">
-            Lock the output's pose, edges, or depth to a reference.
-          </p>
-          <div
-            className="control-mode-tabs"
-            role="tablist"
-            aria-label="Control type"
+        {modes.map((mode) => (
+          <button
+            aria-pressed={mode === activeMode}
+            className={
+              mode === activeMode
+                ? "control-mode-tab active"
+                : "control-mode-tab"
+            }
+            key={mode}
+            onClick={() => onControlModeChange?.(mode)}
+            role="tab"
+            type="button"
           >
-            {modes.map((mode) => (
-              <button
-                aria-pressed={mode === activeMode}
-                className={
-                  mode === activeMode
-                    ? "control-mode-tab active"
-                    : "control-mode-tab"
-                }
-                key={mode}
-                onClick={() => onControlModeChange?.(mode)}
-                role="tab"
-                type="button"
-              >
-                {MODE_LABELS[mode] ?? mode}
-              </button>
-            ))}
-          </div>
+            {MODE_LABELS[mode] ?? mode}
+          </button>
+        ))}
+      </div>
 
-          {activeMode === "pose" ? (
-            poseBlockText ? (
-              <p className="mac-gating-note">{poseBlockText}</p>
-            ) : (
-              <div className="control-pose-section">
-                {controlOverlayBaseModel ? (
-                  <ControlOverlayPicker
-                    baseModel={controlOverlayBaseModel}
-                    onOverlayChange={onOverlayChange}
-                    selectedOverlayId={selectedOverlayId}
-                  />
-                ) : null}
-                <PoseLibraryPicker
-                  categoryFilter
-                  loadUserPoses={loadUserPoses}
-                  onClear={onClearPoses}
-                  onToggle={onTogglePose}
-                  selectedIds={selectedPoseIds}
-                />
-                <p className="muted">
-                  Selecting poses generates one image per pose (overrides
-                  Variations).
-                </p>
-              </div>
-            )
-          ) : (
-            <div className="control-image-section">
-              <ImageEditSourcePickerField
-                assets={controlImageAssets}
-                buttonLabel="Select image"
-                characters={characters}
-                clearable
-                emptyLabel={`No ${activeMode} control image selected`}
-                importAsset={importAsset}
-                label={
-                  activeMode === "canny" ? "Edge/canny source" : "Depth source"
-                }
-                onChange={onControlImageChange}
-                projectId={projectId}
-                value={controlImageAssetId}
+      {activeMode === "pose" ? (
+        poseBlockText ? (
+          <p className="mac-gating-note">{poseBlockText}</p>
+        ) : (
+          <div className="control-pose-section">
+            {controlOverlayBaseModel ? (
+              <ControlOverlayPicker
+                baseModel={controlOverlayBaseModel}
+                onOverlayChange={onOverlayChange}
+                selectedOverlayId={selectedOverlayId}
               />
-              <label className="checkline">
-                <input
-                  checked={Boolean(controlImagePassthrough)}
-                  onChange={(event) =>
-                    onControlImagePassthroughChange?.(event.target.checked)
-                  }
-                  type="checkbox"
-                />
-                Use this image as the control map directly (skip preprocessing)
-              </label>
-              <p className="muted">
-                {controlImagePassthrough
-                  ? `Your image is fed in verbatim as the ${activeMode} map — supply an already-prepared ${activeMode} map.`
-                  : `The worker auto-derives the ${activeMode} map from your image before generating.`}
-              </p>
-            </div>
-          )}
-
-          <label className="reference-strength control-scale">
-            {scaleCfg.label ?? "Control strength"}
-            <input
-              max={scaleCfg.max ?? 2}
-              min={scaleCfg.min ?? 0}
-              onChange={(event) =>
-                onControlScaleChange?.(Number(event.target.value))
-              }
-              step={scaleCfg.step ?? 0.05}
-              type="range"
-              value={controlScale}
+            ) : null}
+            <PoseLibraryPicker
+              categoryFilter
+              loadUserPoses={loadUserPoses}
+              onClear={onClearPoses}
+              onToggle={onTogglePose}
+              selectedIds={selectedPoseIds}
             />
-            <span>{Number(controlScale).toFixed(2)}</span>
+            <p className="muted">
+              Selecting poses generates one image per pose (overrides
+              Variations).
+            </p>
+          </div>
+        )
+      ) : (
+        <div className="control-image-section">
+          <ImageEditSourcePickerField
+            assets={controlImageAssets}
+            buttonLabel="Select image"
+            characters={characters}
+            clearable
+            emptyLabel={`No ${activeMode} control image selected`}
+            importAsset={importAsset}
+            label={
+              activeMode === "canny" ? "Edge/canny source" : "Depth source"
+            }
+            onChange={onControlImageChange}
+            projectId={projectId}
+            value={controlImageAssetId}
+          />
+          <label className="checkline">
+            <input
+              checked={Boolean(controlImagePassthrough)}
+              onChange={(event) =>
+                onControlImagePassthroughChange?.(event.target.checked)
+              }
+              type="checkbox"
+            />
+            Use this image as the control map directly (skip preprocessing)
           </label>
-        </>
-      ) : null}
-    </div>
+          <p className="muted">
+            {controlImagePassthrough
+              ? `Your image is fed in verbatim as the ${activeMode} map — supply an already-prepared ${activeMode} map.`
+              : `The worker auto-derives the ${activeMode} map from your image before generating.`}
+          </p>
+        </div>
+      )}
+
+      <label className="reference-strength control-scale">
+        {scaleCfg.label ?? "Control strength"}
+        <input
+          max={scaleCfg.max ?? 2}
+          min={scaleCfg.min ?? 0}
+          onChange={(event) =>
+            onControlScaleChange?.(Number(event.target.value))
+          }
+          step={scaleCfg.step ?? 0.05}
+          type="range"
+          value={controlScale}
+        />
+        <span>{Number(controlScale).toFixed(2)}</span>
+      </label>
+    </AdvancedSection>
   );
 }

--- a/apps/web/src/components/ControlPanel.test.jsx
+++ b/apps/web/src/components/ControlPanel.test.jsx
@@ -56,7 +56,7 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
   // the gated inner content (tabs, pose/upload, slider) mounts. Most tests below assert on that
   // content, so they render then expand.
   async function toggle() {
-    const head = container.querySelector(".control-panel-toggle");
+    const head = container.querySelector(".control-panel .advanced-section-toggle");
     await act(async () => {
       head.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
@@ -111,7 +111,7 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
   it("is collapsed by default and expands on clicking the toggle", async () => {
     await render(<ControlPanel {...baseProps()} />);
     // Collapsed: the disclosure toggle is present but the gated inner content is not mounted.
-    const head = container.querySelector(".control-panel-toggle");
+    const head = container.querySelector(".control-panel .advanced-section-toggle");
     expect(head).not.toBeNull();
     expect(head.getAttribute("aria-expanded")).toBe("false");
     expect(tabLabels()).toEqual([]);

--- a/apps/web/src/components/StudioLoraImportPanel.jsx
+++ b/apps/web/src/components/StudioLoraImportPanel.jsx
@@ -1,0 +1,209 @@
+import React, { useMemo, useState } from "react";
+import { KeywordTagEditor } from "./KeywordTagEditor.jsx";
+import { modelLoraFamilies, normalizeLoraFamily } from "../presetUtils.js";
+
+// In-studio LoRA import (studio-cleanup sc-15373). The Model Manager's Import LoRA form, lifted
+// into the studio's Add-LoRA picker so a user who has no compatible LoRA — the exact moment the
+// picker tells them so — can import one without leaving the screen. Same `.models-accent-band
+// .models-import-panel` chrome, same `createLoraImportJob` seam, same trigger-keyword/notes
+// metadata; the Wan A14B two-expert slot stays a Model Manager concern (it needs the base-model
+// picker that goes with it), so this form covers the single-file / URL cases.
+//
+// Rendered as a <div role="group">, NOT a <form>: the studio screen is already one <form> and
+// nested forms are invalid HTML, so the submit rides a click handler instead.
+export function StudioLoraImportPanel({ models = [], activeProject, createLoraImportJob }) {
+  const families = useMemo(
+    () => Array.from(new Set(models.flatMap((model) => modelLoraFamilies(model)).filter(Boolean))).sort(),
+    [models],
+  );
+  const [form, setForm] = useState({
+    // Default to file upload, matching Model Manager: most LoRAs are a file the user already has.
+    mode: "file",
+    sourceUrl: "",
+    file: null,
+    name: "",
+    scope: activeProject ? "project" : "global",
+    family: "",
+    triggerKeywords: [],
+    notes: "",
+  });
+  const [importing, setImporting] = useState(false);
+  const [message, setMessage] = useState({ tone: "neutral", text: "" });
+  // Re-mounts the file input so choosing the same file twice still emits a change event.
+  const [fileInputKey, setFileInputKey] = useState(0);
+
+  const isFileImport = form.mode === "file";
+  const patch = (changes) => setForm((current) => ({ ...current, ...changes }));
+  const importDisabled =
+    importing ||
+    !createLoraImportJob ||
+    (form.scope === "project" && !activeProject) ||
+    (isFileImport ? !form.file : !form.sourceUrl.trim());
+
+  async function submit() {
+    if (importDisabled) {
+      return;
+    }
+    setImporting(true);
+    setMessage({
+      tone: "neutral",
+      text: isFileImport ? "Uploading LoRA file before queueing import." : "",
+    });
+    try {
+      const job = await createLoraImportJob({
+        ...(isFileImport ? { file: form.file } : { sourceUrl: form.sourceUrl.trim() }),
+        name: form.name.trim() || undefined,
+        scope: form.scope,
+        triggerWords: form.triggerKeywords,
+        notes: form.notes.trim() || undefined,
+        ...(form.family ? { family: form.family } : {}),
+      });
+      const loraId = job?.payload?.loraId;
+      const resolvedFamily = job?.payload?.manifestEntry?.family;
+      // Report the detected family in the same normalized vocabulary the dropdown uses.
+      const detectionNote =
+        !form.family && resolvedFamily ? ` Detected family: ${normalizeLoraFamily(resolvedFamily)}.` : "";
+      patch({ sourceUrl: "", file: null, name: "", triggerKeywords: [], notes: "" });
+      setFileInputKey((current) => current + 1);
+      setMessage({
+        tone: "success",
+        text: `${loraId ? `LoRA import queued for ${loraId}.` : "LoRA import queued."}${detectionNote}`,
+      });
+    } catch (err) {
+      setMessage({ tone: "error", text: err.message });
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div className="models-accent-band models-import-panel studio-lora-import" role="group" aria-label="Import LoRA">
+      <div className="models-accent-band-head">
+        <span className="models-accent-dot" aria-hidden="true" />
+        <p className="eyebrow">Import LoRA</p>
+        <span className="models-accent-band-caption">Add a LoRA from a URL or file — auto-detects family</span>
+      </div>
+      <div className="segmented-control compact-segment" role="group" aria-label="LoRA import source">
+        <button
+          className={form.mode === "url" ? "active" : ""}
+          disabled={importing}
+          onClick={() => patch({ mode: "url" })}
+          type="button"
+        >
+          URL
+        </button>
+        <button
+          className={form.mode === "file" ? "active" : ""}
+          disabled={importing}
+          onClick={() => patch({ mode: "file" })}
+          type="button"
+        >
+          Upload
+        </button>
+      </div>
+      <div className="models-import-grid">
+        <label>
+          Scope
+          <select disabled={importing} onChange={(event) => patch({ scope: event.target.value })} value={form.scope}>
+            <option value="global">Global</option>
+            <option disabled={!activeProject} value="project">
+              Project
+            </option>
+          </select>
+        </label>
+        <label>
+          Family
+          <select
+            disabled={importing || !families.length}
+            onChange={(event) => patch({ family: event.target.value })}
+            value={form.family}
+          >
+            {families.length ? (
+              <>
+                <option value="">Auto-detect</option>
+                {families.map((family) => (
+                  <option key={family} value={family}>
+                    {family}
+                  </option>
+                ))}
+              </>
+            ) : (
+              <option value="">No model families</option>
+            )}
+          </select>
+        </label>
+        {isFileImport ? (
+          <label>
+            LoRA File
+            <span className="file-picker-row">
+              <span className="file-upload-button">
+                Choose
+                <input
+                  accept=".safetensors,.ckpt,.pt,.bin"
+                  disabled={importing}
+                  key={fileInputKey}
+                  onChange={(event) => patch({ file: event.target.files?.[0] ?? null })}
+                  type="file"
+                />
+              </span>
+              <span className="selected-file-name">{form.file?.name ?? "No file selected"}</span>
+            </span>
+          </label>
+        ) : (
+          <label>
+            Source URL
+            <input
+              disabled={importing}
+              onChange={(event) => patch({ sourceUrl: event.target.value })}
+              placeholder="https://..."
+              value={form.sourceUrl}
+            />
+          </label>
+        )}
+        <label>
+          Name
+          <input
+            disabled={importing}
+            onChange={(event) => patch({ name: event.target.value })}
+            placeholder="Optional"
+            value={form.name}
+          />
+        </label>
+        <button disabled={importDisabled} onClick={submit} type="button">
+          {importing ? (isFileImport ? "Uploading" : "Queueing...") : "Queue import"}
+        </button>
+      </div>
+      <div className="lora-import-metadata">
+        <label>
+          Trigger keywords
+          <KeywordTagEditor
+            disabled={importing}
+            onChange={(triggerKeywords) => patch({ triggerKeywords })}
+            placeholder="e.g. sksStyle — press Enter or comma to add"
+            value={form.triggerKeywords}
+          />
+        </label>
+        <label>
+          Notes
+          <textarea
+            disabled={importing}
+            onChange={(event) => patch({ notes: event.target.value })}
+            placeholder="How to use this LoRA — keyword combinations, recommended weight, and other tips."
+            rows={2}
+            value={form.notes}
+          />
+        </label>
+      </div>
+      {form.scope === "project" && !activeProject ? (
+        <p className="helper-copy">Open a project before importing a project LoRA.</p>
+      ) : null}
+      {message.text ? (
+        <p className={message.tone === "success" ? "inline-success" : "inline-warning"}>{message.text}</p>
+      ) : null}
+      <p className="helper-copy">
+        Imported LoRAs land in your library and become selectable here once the import job completes — no trip to
+        Model Manager.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/StudioLoraImportPanel.test.jsx
+++ b/apps/web/src/components/StudioLoraImportPanel.test.jsx
@@ -1,0 +1,121 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, setInput, setSelect, unmountRoot } from "../testUtils/dom.js";
+import { StudioLoraImportPanel } from "./StudioLoraImportPanel.jsx";
+
+// sc-15373 — the Model Manager import form, lifted into the studio's Add-LoRA picker. What must
+// hold: it is NOT a <form> (the studio screen is already one, and nested forms are invalid), it
+// submits through the same `createLoraImportJob` seam with the same payload shape, and it clears
+// itself for a second import.
+const models = [
+  { id: "z_image_turbo", family: "z-image" },
+  { id: "qwen_image", family: "qwen-image" },
+];
+
+const button = (container, text) =>
+  [...container.querySelectorAll("button")].find((node) => node.textContent.trim() === text);
+const labelled = (container, text) =>
+  [...container.querySelectorAll("label")]
+    .find((node) => node.textContent.trim().startsWith(text))
+    ?.querySelector("input, select, textarea");
+
+describe("StudioLoraImportPanel", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(props = {}) {
+    await act(async () => {
+      root.render(
+        <StudioLoraImportPanel
+          activeProject={{ id: "project-1", name: "Noir" }}
+          createLoraImportJob={vi.fn()}
+          models={models}
+          {...props}
+        />,
+      );
+    });
+  }
+
+  it("renders as a group, never a nested form", async () => {
+    await render();
+    expect(container.querySelector("form")).toBeNull();
+    expect(container.querySelector('[role="group"][aria-label="Import LoRA"]')).toBeTruthy();
+  });
+
+  it("offers Auto-detect plus every model family", async () => {
+    await render();
+    expect([...labelled(container, "Family").options].map((option) => option.value)).toEqual([
+      "",
+      "qwen-image",
+      "z-image",
+    ]);
+  });
+
+  it("queues a URL import with the trigger keywords and clears for the next one", async () => {
+    const createLoraImportJob = vi.fn(async () => ({
+      payload: { loraId: "harbor_dusk", manifestEntry: { family: "z_image" } },
+    }));
+    await render({ createLoraImportJob });
+
+    await click(button(container, "URL"));
+    await act(async () => setInput(labelled(container, "Source URL"), "https://example.test/harbor.safetensors"));
+    const keywords = container.querySelector(".kw-input");
+    await act(async () => setInput(keywords, "sksStyle"));
+    await act(async () => {
+      keywords.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+    });
+    await click(button(container, "Queue import"));
+
+    expect(createLoraImportJob).toHaveBeenCalledTimes(1);
+    expect(createLoraImportJob.mock.calls[0][0]).toMatchObject({
+      sourceUrl: "https://example.test/harbor.safetensors",
+      scope: "project",
+      triggerWords: ["sksStyle"],
+    });
+    // The detected family is reported in the dropdown's own normalized vocabulary.
+    expect(container.textContent).toContain("LoRA import queued for harbor_dusk.");
+    expect(container.textContent).toContain("Detected family: z-image.");
+    expect(labelled(container, "Source URL").value).toBe("");
+  });
+
+  it("cannot submit an empty source, or a project import with no project open", async () => {
+    const createLoraImportJob = vi.fn();
+    await render({ createLoraImportJob, activeProject: null });
+
+    expect(button(container, "Queue import").disabled).toBe(true);
+    await click(button(container, "URL"));
+    await act(async () => setInput(labelled(container, "Source URL"), "https://example.test/harbor.safetensors"));
+    // With no project open the panel defaults to global scope, so the URL alone unblocks it.
+    expect(labelled(container, "Scope").value).toBe("global");
+    expect(button(container, "Queue import").disabled).toBe(false);
+
+    await act(async () => setSelect(labelled(container, "Scope"), "project"));
+    expect(button(container, "Queue import").disabled).toBe(true);
+    expect(container.textContent).toContain("Open a project before importing a project LoRA.");
+    expect(createLoraImportJob).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the import error instead of clearing the form", async () => {
+    const createLoraImportJob = vi.fn(async () => {
+      throw new Error("Unsupported adapter format");
+    });
+    await render({ createLoraImportJob });
+
+    await click(button(container, "URL"));
+    await act(async () => setInput(labelled(container, "Source URL"), "https://example.test/bad.safetensors"));
+    await click(button(container, "Queue import"));
+
+    expect(container.querySelector(".inline-warning").textContent).toContain("Unsupported adapter format");
+    expect(labelled(container, "Source URL").value).toBe("https://example.test/bad.safetensors");
+  });
+});

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -131,6 +131,9 @@ export function StyleAxisRow({
   // standalone card below the settings bar (studio-cleanup sc-15371).
   presetPromptParts = [],
   presetLoraDetails = [],
+  // The save-as-preset control, rendered inline at the end of the preset-chip row instead of
+  // buried in Advanced (studio-cleanup sc-15372). Omit it and the row is chips only.
+  savePreset = null,
 }) {
   return (
     <>
@@ -154,6 +157,7 @@ export function StyleAxisRow({
                 {preset.name ?? preset.id}
               </button>
             ))}
+            {savePreset}
           </div>
         </div>
         <PresetGuidanceStrip
@@ -721,7 +725,12 @@ export function useSavePreset({
   // with their weights; the seed is intentionally left out so the preset stays
   // reusable. The backend additionally enforces id uniqueness and model/workflow +
   // LoRA compatibility, surfaced here via err.message.
-  async function handleSaveAsPreset() {
+  // `scopeOverride` lets a caller pick the scope and save in one gesture (the studio's
+  // save-as-preset dropdown, sc-15372) without waiting a render for `setPresetScope` to land.
+  // Anything that isn't a real scope — notably a click event, when this is wired straight to
+  // onClick — falls back to the current state.
+  async function handleSaveAsPreset(scopeOverride) {
+    const scope = scopeOverride === "project" || scopeOverride === "global" ? scopeOverride : presetScope;
     const trimmed = presetName.trim();
     if (!trimmed) {
       setPresetSaveMessage({ tone: "error", text: "Name the preset before saving." });
@@ -736,7 +745,7 @@ export function useSavePreset({
       setPresetSaveMessage({ tone: "error", text: guardMessage });
       return;
     }
-    if (presetScope === "project" && !activeProject) {
+    if (scope === "project" && !activeProject) {
       setPresetSaveMessage({ tone: "error", text: "Open a project first, or save to all projects." });
       return;
     }
@@ -746,7 +755,7 @@ export function useSavePreset({
     }
     const payload = buildStudioPresetPayload({
       name: trimmed,
-      scope: presetScope,
+      scope,
       mode,
       model,
       loras: selectedLoras.map((lora) => ({ id: lora.id, weight: effectiveLoraWeight(lora) })),
@@ -760,7 +769,7 @@ export function useSavePreset({
       setPresetName("");
       setPresetSaveMessage({
         tone: "success",
-        text: `Saved "${trimmed}" to ${presetScope === "project" ? "this project" : "all projects"}.`,
+        text: `Saved "${trimmed}" to ${scope === "project" ? "this project" : "all projects"}.`,
       });
     } catch (err) {
       setPresetSaveMessage({ tone: "error", text: err.message });
@@ -930,9 +939,12 @@ export function LoraPickerSection({
   );
 }
 
-// The "Save as Preset" panel shared by both studios (sc-4196): name field, save
-// button, project/global scope segment, and the inline save message. The actual
-// save handler differs per studio (different payloads), so it's passed as onSave.
+// The "Save as preset" control shared by both studios (sc-4196). It lives INLINE in the
+// style-preset chip row (studio-cleanup sc-15372) rather than stacked inside Advanced: a fixed
+// name field plus a dropdown whose menu IS the scope choice — picking "This project" or "All
+// projects" both sets the scope and confirms the save, so the wide project/global segment is gone.
+// The actual save handler differs per studio (different payloads), so it's passed as onSave; it
+// takes the chosen scope so the save never races `setPresetScope`.
 export function SavePresetPanel({
   presetName,
   setPresetName,
@@ -952,66 +964,114 @@ export function SavePresetPanel({
   // an unsaveable mode surfaces the tooltip as an always-visible chip.
   const saveDraft = useMemo(() => ({ presetName, saveDisabled, saveTitle }), [presetName, saveDisabled, saveTitle]);
   const saveValidity = useValidation(savePresetDialogValidation, saveDraft, undefined);
+  const [scopeMenuOpen, setScopeMenuOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!scopeMenuOpen) {
+      return undefined;
+    }
+    function onDocMouseDown(event) {
+      if (!containerRef.current?.contains(event.target)) {
+        setScopeMenuOpen(false);
+      }
+    }
+    function onDocKey(event) {
+      if (event.key === "Escape") {
+        setScopeMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onDocKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onDocKey);
+    };
+  }, [scopeMenuOpen]);
+
+  function saveWithScope(scope) {
+    setScopeMenuOpen(false);
+    setPresetScope(scope);
+    onSave(scope);
+  }
+
+  const saveBlocked = savingPreset || !saveValidity.ready;
   return (
-    <div className="save-preset">
-      <div className="save-preset-row">
-        <input
-          aria-label="Preset name"
-          className="save-preset-name"
-          disabled={savingPreset}
-          onChange={(event) => {
-            setPresetName(event.target.value);
-            if (presetSaveMessage.text) {
-              setPresetSaveMessage({ tone: "neutral", text: "" });
-            }
-          }}
-          onKeyDown={(event) => {
-            if (event.key === "Enter") {
-              event.preventDefault();
-              onSave();
-            }
-          }}
-          placeholder="Name this setup…"
-          value={presetName}
-        />
+    <>
+      <span className="style-axis-divider" aria-hidden="true" />
+      <input
+        aria-label="Preset name"
+        className="save-preset-name"
+        disabled={savingPreset}
+        onChange={(event) => {
+          setPresetName(event.target.value);
+          if (presetSaveMessage.text) {
+            setPresetSaveMessage({ tone: "neutral", text: "" });
+          }
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onSave(presetScope);
+          }
+        }}
+        placeholder="Name this setup…"
+        value={presetName}
+      />
+      <div className="compact-selector save-preset-scope-picker" ref={containerRef}>
         <button
+          aria-expanded={scopeMenuOpen}
+          aria-haspopup="menu"
           className="save-preset-btn"
-          disabled={savingPreset || !saveValidity.ready}
-          onClick={onSave}
+          disabled={saveBlocked}
+          onClick={() => setScopeMenuOpen((value) => !value)}
           title={saveTitle}
           type="button"
         >
-          <Icon.Preset size={14} /> {savingPreset ? "Saving…" : "Save as Preset"}
+          <Icon.Preset size={13} />
+          {savingPreset ? "Saving…" : "Save as preset"}
+          <Icon.ChevDown className="chev" size={13} />
         </button>
+        {scopeMenuOpen ? (
+          <div className="compact-selector-menu" role="menu" aria-label="Preset scope">
+            <button
+              className={presetScope === "project" ? "compact-selector-item active" : "compact-selector-item"}
+              disabled={!activeProject}
+              onClick={() => saveWithScope("project")}
+              role="menuitem"
+              type="button"
+            >
+              <span className="compact-selector-label">
+                <strong>This project</strong>
+                <span>{activeProject ? `Only ${activeProject.name ?? activeProject.id}` : "Open a project first"}</span>
+              </span>
+            </button>
+            <button
+              className={presetScope === "global" ? "compact-selector-item active" : "compact-selector-item"}
+              onClick={() => saveWithScope("global")}
+              role="menuitem"
+              type="button"
+            >
+              <span className="compact-selector-label">
+                <strong>All projects</strong>
+                <span>Available everywhere</span>
+              </span>
+            </button>
+          </div>
+        ) : null}
       </div>
-      <ValidationSummary issues={saveValidity.surfaced} label="Save-preset errors" />
-      <div className="save-preset-scope scope-segment" role="radiogroup" aria-label="Preset scope">
-        <button
-          aria-checked={presetScope === "project"}
-          className={presetScope === "project" ? "active" : ""}
-          disabled={!activeProject}
-          onClick={() => setPresetScope("project")}
-          role="radio"
-          type="button"
-        >
-          <Icon.Folder size={13} /> This project
-        </button>
-        <button
-          aria-checked={presetScope === "global"}
-          className={presetScope === "global" ? "active" : ""}
-          onClick={() => setPresetScope("global")}
-          role="radio"
-          type="button"
-        >
-          <Icon.Stars size={13} /> All projects
-        </button>
-      </div>
-      {presetSaveMessage.text ? (
-        <p className={presetSaveMessage.tone === "success" ? "inline-success" : "inline-warning"}>
-          {presetSaveMessage.text}
-        </p>
+      {/* Errors and the save confirmation wrap onto their own full-width line under the chips. */}
+      {saveValidity.surfaced.length || presetSaveMessage.text ? (
+        <div className="style-axis-row-break">
+          <ValidationSummary issues={saveValidity.surfaced} label="Save-preset errors" />
+          {presetSaveMessage.text ? (
+            <p className={presetSaveMessage.tone === "success" ? "inline-success" : "inline-warning"}>
+              {presetSaveMessage.text}
+            </p>
+          ) : null}
+        </div>
       ) : null}
-    </div>
+    </>
   );
 }
 

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -807,6 +807,10 @@ export function LoraPickerSection({
   loraEmptyMessage,
   onUpdateLora,
   showIncompatibleControl = false,
+  // Optional node appended to the open picker — the studios pass the in-place Import LoRA form
+  // (studio-cleanup sc-15373) so "no compatible LoRAs" has a fix right where it is reported. The
+  // editor rails omit it and keep a list-only picker.
+  importPanel = null,
 }) {
   // Add-on-demand picker (UI-refinement 3b): only the LoRAs you've added render as
   // slots; everything else lives behind the "Add LoRA" dropdown. This replaces the
@@ -847,94 +851,95 @@ export function LoraPickerSection({
         </label>
       ) : null}
 
-      {!selectedLoras.length && !availableLoras.length ? (
-        <div className="empty-panel compact-panel">{loraEmptyMessage}</div>
-      ) : (
-        <>
-          {selectedLoras.length ? (
-            <div className="lora-stack">
-              {selectedLoras.map((lora) => {
-                const weight = effectiveLoraWeight(lora);
+      {selectedLoras.length ? (
+        <div className="lora-stack">
+          {selectedLoras.map((lora) => {
+            const weight = effectiveLoraWeight(lora);
+            return (
+              <div className="lora-slot" key={lora.id}>
+                <div className="lora-slot-head">
+                  <span className="lora-slot-meta">
+                    <strong>{lora.name ?? lora.id}{lora.updateAvailable ? <StudioUpdateBadge item={lora} /> : null}</strong>
+                    <small>{loraMeta(lora)}</small>
+                  </span>
+                  <button
+                    aria-label={`Remove ${lora.name ?? lora.id}`}
+                    className="lora-slot-remove"
+                    onClick={() => toggleLora(lora)}
+                    title="Remove"
+                    type="button"
+                  >
+                    ×
+                  </button>
+                </div>
+                <StudioUpdateNotice item={lora} kind="LoRA" onUpdate={onUpdateLora} />
+                <LoraKeywordSummary lora={lora} />
+                <div className="lora-slot-weight">
+                  <label>
+                    <span>Weight</span>
+                    <span className="lora-slot-weight-value">{weight.toFixed(2)}</span>
+                  </label>
+                  <input
+                    aria-label={`${lora.name ?? lora.id} weight`}
+                    max={LORA_WEIGHT_MAX}
+                    min={LORA_WEIGHT_MIN}
+                    onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
+                    step={LORA_WEIGHT_STEP}
+                    type="range"
+                    value={weight}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {/* Always enabled (studio-cleanup sc-15373): with nothing available the picker is exactly
+          where the user needs to be — it explains WHY the list is empty and (in the studios)
+          carries the import form that fixes it. Disabling it left a dead end. */}
+      <button
+        className="lora-add"
+        data-count={`· ${availableLoras.length} available`}
+        onClick={() => setPickerOpen((open) => !open)}
+        type="button"
+      >
+        <Icon.Plus size={15} />
+        <span>Add LoRA</span>
+      </button>
+
+      {pickerOpen ? (
+        <div className="lora-picker-panel">
+          {availableLoras.length ? (
+            <div className="lora-picker-list">
+              {availableLoras.map((lora) => {
+                const disabled = lora.scope !== "builtin" && atUserLimit;
                 return (
-                  <div className="lora-slot" key={lora.id}>
-                    <div className="lora-slot-head">
-                      <span className="lora-slot-meta">
-                        <strong>{lora.name ?? lora.id}{lora.updateAvailable ? <StudioUpdateBadge item={lora} /> : null}</strong>
-                        <small>{loraMeta(lora)}</small>
-                      </span>
-                      <button
-                        aria-label={`Remove ${lora.name ?? lora.id}`}
-                        className="lora-slot-remove"
-                        onClick={() => toggleLora(lora)}
-                        title="Remove"
-                        type="button"
-                      >
-                        ×
-                      </button>
-                    </div>
-                    <StudioUpdateNotice item={lora} kind="LoRA" onUpdate={onUpdateLora} />
-                    <LoraKeywordSummary lora={lora} />
-                    <div className="lora-slot-weight">
-                      <label>
-                        <span>Weight</span>
-                        <span className="lora-slot-weight-value">{weight.toFixed(2)}</span>
-                      </label>
-                      <input
-                        aria-label={`${lora.name ?? lora.id} weight`}
-                        max={LORA_WEIGHT_MAX}
-                        min={LORA_WEIGHT_MIN}
-                        onChange={(event) => setLoraWeight(lora.id, Number(event.target.value))}
-                        step={LORA_WEIGHT_STEP}
-                        type="range"
-                        value={weight}
-                      />
-                    </div>
-                  </div>
+                  <button
+                    className="lora-pick-row"
+                    disabled={disabled}
+                    key={lora.id}
+                    onClick={() => {
+                      toggleLora(lora);
+                      setPickerOpen(false);
+                    }}
+                    type="button"
+                  >
+                    <span className="lora-slot-meta">
+                      <strong>{lora.name ?? lora.id}{lora.updateAvailable ? <StudioUpdateBadge item={lora} /> : null}</strong>
+                      <small>{loraMeta(lora)}</small>
+                    </span>
+                    <span className="lora-pick-add">{disabled ? "Limit reached" : "Add"}</span>
+                  </button>
                 );
               })}
             </div>
-          ) : null}
-
-          <button
-            className="lora-add"
-            data-count={`· ${availableLoras.length} available`}
-            disabled={!availableLoras.length}
-            onClick={() => setPickerOpen((open) => !open)}
-            type="button"
-          >
-            <Icon.Plus size={15} />
-            <span>Add LoRA</span>
-          </button>
-
-          {pickerOpen && availableLoras.length ? (
-            <div className="lora-picker-panel">
-              <div className="lora-picker-list">
-                {availableLoras.map((lora) => {
-                  const disabled = lora.scope !== "builtin" && atUserLimit;
-                  return (
-                    <button
-                      className="lora-pick-row"
-                      disabled={disabled}
-                      key={lora.id}
-                      onClick={() => {
-                        toggleLora(lora);
-                        setPickerOpen(false);
-                      }}
-                      type="button"
-                    >
-                      <span className="lora-slot-meta">
-                        <strong>{lora.name ?? lora.id}{lora.updateAvailable ? <StudioUpdateBadge item={lora} /> : null}</strong>
-                        <small>{loraMeta(lora)}</small>
-                      </span>
-                      <span className="lora-pick-add">{disabled ? "Limit reached" : "Add"}</span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ) : null}
-        </>
-      )}
+          ) : (
+            <p className="lora-pick-empty">{loraEmptyMessage}</p>
+          )}
+          {importPanel}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -801,11 +801,14 @@ export function LoraPickerSection({
 
   return (
     <section className="lora-picker" aria-label="LoRA selection">
-      <div>
-        <strong>LoRAs</strong>
+      {/* Eyebrow + status, not a card heading (studio-cleanup sc-15370): inside the settings bar
+          this reads as a peer of the Model and Style sections, so the label uses the same
+          `.settings-bar-label` scale they do. */}
+      <div className="lora-picker-head">
+        <span className="settings-bar-label">LoRAs</span>
         <span>
           {selectedLoras.length
-            ? `${selectedLoras.length} selected`
+            ? `${selectedLoras.length} selected · installed and compatible`
             : selectedModel
               ? "Installed and compatible"
               : "Choose a model"}

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -127,19 +127,27 @@ export function StyleAxisRow({
   generalStackIds,
   onToggleGeneral,
   noPresetValue,
+  // The "what this preset adds" line, rendered as the last row of this grid rather than a
+  // standalone card below the settings bar (studio-cleanup sc-15371).
+  presetPromptParts = [],
+  presetLoraDetails = [],
 }) {
   return (
     <>
-      <div className="settings-bar-styles settings-bar-style-axis">
+      <div
+        className={`settings-bar-styles settings-bar-style-axis${available ? "" : " settings-bar-style-axis-single"}`}
+      >
         {available ? (
           <div className="style-axis-field style-axis-catalog">
             <span className="settings-bar-label">Style</span>
-            <StylePicker groups={groups} selectedId={styleId} onSelect={onStyleChange} label="Style" />
+            <div className="style-axis-control">
+              <StylePicker groups={groups} selectedId={styleId} onSelect={onStyleChange} label="Style" />
+            </div>
           </div>
         ) : null}
         <div className="style-axis-field style-axis-presets">
           <span className="settings-bar-label">Style preset</span>
-          <div className="preset-chips">
+          <div className="style-axis-control preset-chips">
             <button className={!selectedPreset ? "preset-chip active" : "preset-chip"} onClick={() => onPresetChange(noPresetValue)} type="button">None</button>
             {presets.map((preset) => (
               <button className={selectedPreset?.id === preset.id ? "preset-chip active" : "preset-chip"} key={preset.id} onClick={() => onPresetChange(preset.id)} type="button">
@@ -148,6 +156,11 @@ export function StyleAxisRow({
             ))}
           </div>
         </div>
+        <PresetGuidanceStrip
+          presetLoraDetails={presetLoraDetails}
+          presetPromptParts={presetPromptParts}
+          selectedPreset={selectedPreset}
+        />
       </div>
       {generalPresets.length ? (
         <div className="settings-bar-styles">
@@ -1040,7 +1053,9 @@ export function PresetStackPreview({ generalStack, composed, stackAddsNegative, 
   );
 }
 
-// The "what this preset adds" strip shown under the preset picker in both studios.
+// The "what this preset adds" strip shown under the preset picker in both studios. It is the last
+// row of the style-axis grid (studio-cleanup sc-15371), not a card of its own — hence
+// `.style-axis-guidance` rather than the bordered `.guidance-strip`.
 export function PresetGuidanceStrip({ selectedPreset, presetPromptParts, presetLoraDetails }) {
   // Nothing to say when no preset is active — the visible controls already describe the run.
   if (!selectedPreset) {
@@ -1051,7 +1066,7 @@ export function PresetGuidanceStrip({ selectedPreset, presetPromptParts, presetL
   // they aren't installed, so the user knows to import them before the preset fully applies.
   const missingLoras = presetLoraDetails.filter((lora) => lora.missing);
   return (
-    <div className="guidance-strip">
+    <div className="style-axis-guidance">
       <strong>{selectedPreset.ui?.description ?? "Preset defaults active"}</strong>
       <span>
         {presetPromptParts.length ? `Adds: ${presetPromptParts.join(", ")}` : "No prompt fragments"}

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -96,9 +96,11 @@ export function useQuantTierPicker({
   };
 }
 
-export function TierPickerField({ value, onChange, items, tierSwitching, tierLabel, title, warning }) {
+// `className` lets the studios render this as a settings-bar cell (`settings-field`) instead of an
+// Advanced-panel label (studio-cleanup sc-15374) without a wrapper element around the <label>.
+export function TierPickerField({ value, onChange, items, tierSwitching, tierLabel, title, warning, className = "" }) {
   return (
-    <label className="quant-tier-picker" title={title}>
+    <label className={`quant-tier-picker${className ? ` ${className}` : ""}`} title={title}>
       Quant tier
       <select onChange={(event) => onChange(event.target.value)} value={value}>
         {items.map((item) => (

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -3055,44 +3055,6 @@ export function ImageStudio() {
           </div>
         ) : null}
 
-        {/* Strict-control panel (epic 8236, sc-8245): pose / canny / depth structure lock for the
-            text-to-image backbones whose `ui.controlModes` advertises it. Hidden when the backbone
-            supports no strict control. Pose reuses the library picker (one image per pose); canny/depth
-            take an uploaded control image + a preprocess-vs-use-as-is toggle. The request wiring lives in
-            submit() — controlMode / sourceAssetId|advanced.controlImage / advanced.controlScale. */}
-        {showControlPanel ? (
-          <div className="studio-source-band">
-            <ControlPanel
-              supportedModes={controlModes}
-              controlMode={activeControlMode}
-              onControlModeChange={setControlMode}
-              selectedPoseIds={selectedPoseIds}
-              onTogglePose={(id) =>
-                setSelectedPoseIds((ids) =>
-                  ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id],
-                )
-              }
-              onClearPoses={() => setSelectedPoseIds([])}
-              loadUserPoses={loadUserPoses}
-              poseBlockText={macPoseBlock ? macPoseBlock.text : null}
-              controlImageAssetId={controlImageAssetId}
-              onControlImageChange={setControlImageAssetId}
-              controlImagePassthrough={controlImagePassthrough}
-              onControlImagePassthroughChange={setControlImagePassthrough}
-              controlImageAssets={editImageAssets}
-              importAsset={importAsset}
-              projectId={activeProject?.id}
-              characters={characters}
-              controlScaleConfig={controlScaleConfig}
-              controlScale={effectiveControlScale}
-              onControlScaleChange={setControlScale}
-              controlOverlayBaseModel={controlOverlayBaseModel}
-              selectedOverlayId={controlOverlayId}
-              onOverlayChange={setControlOverlayId}
-            />
-          </div>
-        ) : null}
-
           {/* Generation settings (UI-refinement 2b): the everyday knobs — Model, Aspect,
               Variations, Style preset — sit in a bar directly under the composer instead of a
               detached right rail. Power-user knobs fold into Advanced below; the results area
@@ -3185,6 +3147,44 @@ export function ImageStudio() {
             stackAddsNegative={stackAddsNegative}
             stackAddsCount={stackAddsCount}
           />
+
+          {/* Strict-control panel (epic 8236, sc-8245): pose / canny / depth structure lock for the
+              text-to-image backbones whose `ui.controlModes` advertises it. Hidden when the backbone
+              supports no strict control. Pose reuses the library picker (one image per pose); canny/depth
+              take an uploaded control image + a preprocess-vs-use-as-is toggle. The request wiring lives in
+              submit() — controlMode / sourceAssetId|advanced.controlImage / advanced.controlScale.
+              Sits directly above Advanced (studio-cleanup sc-15369): it is a disclosure of the same
+              kind, so it belongs beside the other one rather than in a source band above the settings. */}
+          {showControlPanel ? (
+            <ControlPanel
+              supportedModes={controlModes}
+              controlMode={activeControlMode}
+              onControlModeChange={setControlMode}
+              selectedPoseIds={selectedPoseIds}
+              onTogglePose={(id) =>
+                setSelectedPoseIds((ids) =>
+                  ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id],
+                )
+              }
+              onClearPoses={() => setSelectedPoseIds([])}
+              loadUserPoses={loadUserPoses}
+              poseBlockText={macPoseBlock ? macPoseBlock.text : null}
+              controlImageAssetId={controlImageAssetId}
+              onControlImageChange={setControlImageAssetId}
+              controlImagePassthrough={controlImagePassthrough}
+              onControlImagePassthroughChange={setControlImagePassthrough}
+              controlImageAssets={editImageAssets}
+              importAsset={importAsset}
+              projectId={activeProject?.id}
+              characters={characters}
+              controlScaleConfig={controlScaleConfig}
+              controlScale={effectiveControlScale}
+              onControlScaleChange={setControlScale}
+              controlOverlayBaseModel={controlOverlayBaseModel}
+              selectedOverlayId={controlOverlayId}
+              onOverlayChange={setControlOverlayId}
+            />
+          ) : null}
 
           <AdvancedSection
             hint="cleared values → model default"

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -4,6 +4,7 @@ import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia, assetUrl } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { AdvancedSection } from "../components/AdvancedSection.jsx";
+import { StudioLoraImportPanel } from "../components/StudioLoraImportPanel.jsx";
 import { MultiPhaseEditor } from "../components/MultiPhaseEditor.jsx";
 import {
   buildTurboFinishPhases,
@@ -284,6 +285,7 @@ export function ImageStudio() {
     imageDescribe,
     createModelDownloadJob,
     createLoraDownloadJob,
+    createLoraImportJob,
     deleteAsset,
     purgeAsset,
     gpuOptions,
@@ -3104,6 +3106,13 @@ export function ImageStudio() {
               setLoraWeight={setLoraWeight}
               loraEmptyMessage={loraEmptyMessage}
               onUpdateLora={createLoraDownloadJob}
+              importPanel={(
+                <StudioLoraImportPanel
+                  activeProject={activeProject}
+                  createLoraImportJob={createLoraImportJob}
+                  models={models}
+                />
+              )}
             />
             {/* Style axis (sc-13135): the Style Catalog picker sits FIRST in this row, followed by the
                 model's Style presets — both are style controls, so they share one row instead of the

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -112,7 +112,6 @@ import {
 import {
   LoraPickerSection,
   onPromptKeyDown,
-  PresetGuidanceStrip,
   PresetStackPreview,
   SavePresetPanel,
   ModeTabs,
@@ -3124,6 +3123,8 @@ export function ImageStudio() {
               generalStackIds={generalStackIds}
               onToggleGeneral={toggleGeneralPreset}
               noPresetValue={noPresetId}
+              presetPromptParts={presetPromptParts}
+              presetLoraDetails={presetLoraDetails}
             />
           </div>
 
@@ -3134,12 +3135,6 @@ export function ImageStudio() {
           <StyledPromptPreview active={stylePreviewActive} composedPrompt={styledPreviewPrompt} />
 
           {macActiveModeBlock ? <p className="mac-gating-note">{macActiveModeBlock.text}</p> : null}
-
-          <PresetGuidanceStrip
-            selectedPreset={selectedPreset}
-            presetPromptParts={presetPromptParts}
-            presetLoraDetails={presetLoraDetails}
-          />
 
           <PresetStackPreview
             generalStack={generalStack}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -3094,6 +3094,26 @@ export function ImageStudio() {
                 Variations
                 <input min="1" max="8" onChange={(event) => setCount(Number(event.target.value))} type="number" value={count} />
               </label>
+              {/* Quant tier belongs with the everyday model knobs, not buried in Advanced
+                  (studio-cleanup sc-15374): it names the build that will actually load. */}
+              {showTierPicker ? (
+                <TierPickerField
+                  className="settings-field settings-field-tier"
+                  value={quantTier}
+                  onChange={handleTierChange}
+                  items={tierPickerItems}
+                  tierSwitching={tierSwitching}
+                  tierLabel={tierLabel}
+                  title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation. Tiers you haven't downloaded are shown but disabled — install them from the Models page to enable."
+                  warning={tierBelowFloor ? (
+                    <span className="field-hint quant-tier-floor-note">
+                      {tierLabel(quantTier)} is below the {tierLabel(qualityFloor)} recommended for{" "}
+                      {selectedModel?.name ?? "this model"} — it can look washed or lose fine detail
+                      here (quantization error is amplified under CFG). Your pick is honored.
+                    </span>
+                  ) : null}
+                />
+              ) : null}
             </div>
             <LoraPickerSection
               selectedModel={selectedModel}
@@ -3368,23 +3388,6 @@ export function ImageStudio() {
                   />
                   Enhance prompt
                 </label>
-              ) : null}
-              {showTierPicker ? (
-                <TierPickerField
-                  value={quantTier}
-                  onChange={handleTierChange}
-                  items={tierPickerItems}
-                  tierSwitching={tierSwitching}
-                  tierLabel={tierLabel}
-                  title="Switch which installed quant tier generates, for A/B comparison. Higher precision = larger memory footprint; switching a heavy tier reloads it before the next generation. Tiers you haven't downloaded are shown but disabled — install them from the Models page to enable."
-                  warning={tierBelowFloor ? (
-                    <span className="field-hint quant-tier-floor-note">
-                      {tierLabel(quantTier)} is below the {tierLabel(qualityFloor)} recommended for{" "}
-                      {selectedModel?.name ?? "this model"} — it can look washed or lose fine detail
-                      here (quantization error is amplified under CFG). Your pick is honored.
-                    </span>
-                  ) : null}
-                />
               ) : null}
               {precisionToggle && !showTierPicker ? (
                 <label

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -3125,6 +3125,19 @@ export function ImageStudio() {
               noPresetValue={noPresetId}
               presetPromptParts={presetPromptParts}
               presetLoraDetails={presetLoraDetails}
+              savePreset={(
+                <SavePresetPanel
+                  presetName={presetName}
+                  setPresetName={setPresetName}
+                  savingPreset={savingPreset}
+                  presetSaveMessage={presetSaveMessage}
+                  setPresetSaveMessage={setPresetSaveMessage}
+                  onSave={handleSaveAsPreset}
+                  presetScope={presetScope}
+                  setPresetScope={setPresetScope}
+                  activeProject={activeProject}
+                />
+              )}
             />
           </div>
 
@@ -3465,19 +3478,6 @@ export function ImageStudio() {
                 Negative prompt
                 <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
               </label>
-              {/* Save-as-preset folds into Advanced with the rest of the power-user
-                  knobs (UI-refinement 2b). */}
-              <SavePresetPanel
-                presetName={presetName}
-                setPresetName={setPresetName}
-                savingPreset={savingPreset}
-                presetSaveMessage={presetSaveMessage}
-                setPresetSaveMessage={setPresetSaveMessage}
-                onSave={handleSaveAsPreset}
-                presetScope={presetScope}
-                setPresetScope={setPresetScope}
-                activeProject={activeProject}
-              />
             </div>
           </AdvancedSection>
 

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -2179,7 +2179,8 @@ describe("ImageStudio strict-control panel (epic 8236, sc-8245)", () => {
     [...document.body.querySelectorAll(".control-mode-tab")].find((b) => b.textContent.trim() === label);
   // The structure-control panel is collapsed by default; expand it so the gated inner content
   // (mode tabs, control-image upload, slider) mounts before the assertions below.
-  const expandControlPanel = async () => click(document.body.querySelector(".control-panel-toggle"));
+  const expandControlPanel = async () =>
+    click(document.body.querySelector(".control-panel .advanced-section-toggle"));
   const generate = async () =>
     click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
 

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1109,8 +1109,9 @@ describe("ImageStudio model picker capability gating", () => {
 
   it("shows ALL possible tiers, disabling the un-installed ones (sc-8515, availability guard)", async () => {
     await render(baseContext({ imageModels: [matrixModel(["q4", "bf16"])], macCapabilities: MAC_CAPS }));
-    await openAdvanced(container);
     await act(async () => {});
+    // Quant tier is an everyday settings-bar knob, not an Advanced one (sc-15374).
+    expect(document.body.querySelector(".settings-bar-row label.quant-tier-picker")).toBeTruthy();
     const picker = tierPicker(container);
     expect(picker).toBeTruthy();
     const options = [...picker.options].map((o) => o.value);

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -65,9 +65,19 @@ function baseContext(overrides = {}) {
   };
 }
 
+// Save-as-preset is an inline pair in the style-preset row (sc-15372): the dropdown opens a
+// scope menu, and picking a scope both sets it and fires the save.
 const saveButton = (container) =>
-  [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
+  [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as preset"));
 const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
+const saveWithScope = async (container, scopeLabel) => {
+  await click(saveButton(container));
+  await click(
+    [...container.querySelectorAll(".save-preset-scope-picker .compact-selector-item")].find((b) =>
+      b.textContent.includes(scopeLabel),
+    ),
+  );
+};
 const field = (container, labelText) => {
   const label = [...container.querySelectorAll("label")].find((node) =>
     node.textContent.trim().startsWith(labelText),
@@ -126,12 +136,10 @@ describe("ImageStudio Save as Preset", () => {
     const context = baseContext();
     await render(context);
 
-    // Save-as-preset now lives inside the Advanced panel (UI-refinement 2b).
-    await click(document.body.querySelector(".advanced-section-toggle"));
     const input = nameInput(container);
     expect(input).toBeTruthy();
     await act(async () => setInput(input, "Atrium Look"));
-    await click(saveButton(container));
+    await saveWithScope(container, "This project");
 
     expect(context.createPreset).toHaveBeenCalledTimes(1);
     const payload = context.createPreset.mock.calls[0][0];
@@ -163,9 +171,8 @@ describe("ImageStudio Save as Preset", () => {
     });
     await render(context);
 
-    await click(document.body.querySelector(".advanced-section-toggle"));
     await act(async () => setInput(nameInput(container), "Atrium Look"));
-    await click(saveButton(container));
+    await saveWithScope(container, "This project");
 
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -6,6 +6,7 @@ import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { AdvancedSection } from "../components/AdvancedSection.jsx";
+import { StudioLoraImportPanel } from "../components/StudioLoraImportPanel.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { PromptGuideModal } from "../components/PromptGuideModal.jsx";
@@ -122,6 +123,7 @@ export function VideoStudio() {
     refinePrompt,
     createModelDownloadJob,
     createLoraDownloadJob,
+    createLoraImportJob,
     deleteAsset,
     purgeAsset,
     gpuOptions,
@@ -1704,6 +1706,13 @@ export function VideoStudio() {
               setLoraWeight={setLoraWeight}
               loraEmptyMessage={loraEmptyMessage}
               onUpdateLora={createLoraDownloadJob}
+              importPanel={(
+                <StudioLoraImportPanel
+                  activeProject={activeProject}
+                  createLoraImportJob={createLoraImportJob}
+                  models={models}
+                />
+              )}
             />
             {/* Style axis (sc-13135): the Style Catalog picker leads this row (hidden for promptless
                 image-conditioned models and for booru-tag models), followed by the model's Style

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1723,6 +1723,21 @@ export function VideoStudio() {
               noPresetValue={noPresetId}
               presetPromptParts={presetPromptParts}
               presetLoraDetails={presetLoraDetails}
+              savePreset={(
+                <SavePresetPanel
+                  presetName={presetName}
+                  setPresetName={setPresetName}
+                  savingPreset={savingPreset}
+                  presetSaveMessage={presetSaveMessage}
+                  setPresetSaveMessage={setPresetSaveMessage}
+                  onSave={handleSaveAsPreset}
+                  presetScope={presetScope}
+                  setPresetScope={setPresetScope}
+                  activeProject={activeProject}
+                  saveDisabled={!VIDEO_PRESET_MODES.includes(mode)}
+                  saveTitle={VIDEO_PRESET_MODES.includes(mode) ? undefined : "Presets are available in Image→Video, Text→Video, or First/Last mode."}
+                />
+              )}
             />
           </div>
 
@@ -2072,21 +2087,6 @@ export function VideoStudio() {
                   </span>
                 </div>
               ) : null}
-              {/* Save-as-preset folds into Advanced with the rest of the power-user
-                  knobs, matching Image Studio. Gated to the presetable video modes. */}
-              <SavePresetPanel
-                presetName={presetName}
-                setPresetName={setPresetName}
-                savingPreset={savingPreset}
-                presetSaveMessage={presetSaveMessage}
-                setPresetSaveMessage={setPresetSaveMessage}
-                onSave={handleSaveAsPreset}
-                presetScope={presetScope}
-                setPresetScope={setPresetScope}
-                activeProject={activeProject}
-                saveDisabled={!VIDEO_PRESET_MODES.includes(mode)}
-                saveTitle={VIDEO_PRESET_MODES.includes(mode) ? undefined : "Presets are available in Image→Video, Text→Video, or First/Last mode."}
-              />
               {/* Video upscale (super-resolve an existing clip) folds into Advanced — it
                   previously lived in the render rail this layout removes. It operates on a
                   selected existing asset, independent of the current generation payload. */}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -47,7 +47,6 @@ import {
 import {
   LoraPickerSection,
   onPromptKeyDown,
-  PresetGuidanceStrip,
   PresetStackPreview,
   SavePresetPanel,
   ModeTabs,
@@ -1722,6 +1721,8 @@ export function VideoStudio() {
               generalStackIds={generalStackIds}
               onToggleGeneral={toggleGeneralPreset}
               noPresetValue={noPresetId}
+              presetPromptParts={presetPromptParts}
+              presetLoraDetails={presetLoraDetails}
             />
           </div>
 
@@ -1729,12 +1730,6 @@ export function VideoStudio() {
               from the same base the submit uses so it can never drift. Sits under the Style axis row.
               Hidden when no style applies. */}
           <StyledPromptPreview active={styleApplied} composedPrompt={composedStylePrompt} />
-
-          <PresetGuidanceStrip
-            selectedPreset={selectedPreset}
-            presetPromptParts={presetPromptParts}
-            presetLoraDetails={presetLoraDetails}
-          />
 
           {/* `stackAddsNegative` is ANDed with the engine's negative-prompt axis (sc-8445). This
               panel is captioned "Prompt sent" and exists so the user sees exactly what will be

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -380,6 +380,17 @@ export function VideoStudio() {
   const showClipStrength =
     ["extend_clip", "video_bridge"].includes(mode) ||
     (mode === "video_to_video" && selectedModel?.adapter === "krea_realtime");
+  // `quality` (fast/balanced/best) is read by exactly ONE adapter: `svd_steps` (video_jobs/svd.rs)
+  // maps it to 15/25/30 inference steps. Every other video engine — LTX, Wan, Bernini, Krea
+  // Realtime — never reads the key, so this gates on the ADAPTER for the same reason
+  // `showClipStrength` does: a knob that does nothing on the selected model shouldn't be shown
+  // (sc-15398). The field itself stays in the payload, the snapshot, and preset defaults —
+  // recipe replay round-trips it — so this hides the control, it does not drop the value.
+  //
+  // Note the manifest `steps[quality]` override `svd_steps` documents is dead: every `steps` in
+  // builtin.models.jsonc is a scalar, so the builtin ladder always wins. And an explicit
+  // `advanced.steps` beats quality outright, which is why the control says so.
+  const showQualitySegment = selectedModel?.adapter === "svd_video";
   // Which generation axes the selected engine actually has, declared in the manifest `video`
   // sub-block (sc-8445) — the video-lane mirror of how Audio Studio reads `audio.supportsGuidance`
   // / `audio.supportsNegativePrompt`. Neither an id check nor an engine link: the catalog says it.
@@ -1950,23 +1961,28 @@ export function VideoStudio() {
                   ) : null}
                 </>
               ) : null}
-              <label className="video-quality-field">
-                Quality
-                <div className="quality-segment" role="radiogroup" aria-label="Quality">
-                  {qualityChoices.map(([value, label]) => (
-                    <button
-                      aria-checked={quality === value}
-                      className={quality === value ? "active" : ""}
-                      key={value}
-                      onClick={() => setQuality(value)}
-                      role="radio"
-                      type="button"
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </label>
+              {showQualitySegment ? (
+                <label
+                  className="video-quality-field"
+                  title="Step-count preset for Stable Video Diffusion: Draft 15, Balanced 25, Final 30. An explicit Steps value below overrides it."
+                >
+                  Quality
+                  <div className="quality-segment" role="radiogroup" aria-label="Quality">
+                    {qualityChoices.map(([value, label]) => (
+                      <button
+                        aria-checked={quality === value}
+                        className={quality === value ? "active" : ""}
+                        key={value}
+                        onClick={() => setQuality(value)}
+                        role="radio"
+                        type="button"
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </label>
+              ) : null}
               {showTorchQuantization ? (
                 <label>
                   Quantization

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1677,23 +1677,26 @@ export function VideoStudio() {
                   ))}
                 </select>
               </label>
-              <label className="settings-field">
-                Quality
-                <div className="quality-segment" role="radiogroup" aria-label="Quality">
-                  {qualityChoices.map(([value, label]) => (
-                    <button
-                      aria-checked={quality === value}
-                      className={quality === value ? "active" : ""}
-                      key={value}
-                      onClick={() => setQuality(value)}
-                      role="radio"
-                      type="button"
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </label>
+              {/* Quant tier, not the abstract Fast/Balanced/Best segment (studio-cleanup
+                  sc-15374): the settings bar names the concrete thing that will load. Quality
+                  itself is still a live payload/preset field and moves to Advanced. */}
+              {showTierPicker ? (
+                <TierPickerField
+                  className="settings-field settings-field-tier"
+                  value={quantTier}
+                  onChange={handleTierChange}
+                  items={tierPickerItems}
+                  tierSwitching={tierSwitching}
+                  tierLabel={tierLabel}
+                  title="Switch which installed MLX quant tier generates. Higher precision uses more memory; switching a heavy tier reloads it before the next generation."
+                  warning={tierHasMemoryRisk ? (
+                    <span className="field-hint quant-tier-memory-note">
+                      Higher MLX video tiers may run out of memory on long or high-resolution clips.
+                      Your pick is honored.
+                    </span>
+                  ) : null}
+                />
+              ) : null}
             </div>
             <LoraPickerSection
               selectedModel={selectedModel}
@@ -1947,22 +1950,23 @@ export function VideoStudio() {
                   ) : null}
                 </>
               ) : null}
-              {showTierPicker ? (
-                <TierPickerField
-                  value={quantTier}
-                  onChange={handleTierChange}
-                  items={tierPickerItems}
-                  tierSwitching={tierSwitching}
-                  tierLabel={tierLabel}
-                  title="Switch which installed MLX quant tier generates. Higher precision uses more memory; switching a heavy tier reloads it before the next generation."
-                  warning={tierHasMemoryRisk ? (
-                    <span className="field-hint quant-tier-memory-note">
-                      Higher MLX video tiers may run out of memory on long or high-resolution clips.
-                      Your pick is honored.
-                    </span>
-                  ) : null}
-                />
-              ) : null}
+              <label className="video-quality-field">
+                Quality
+                <div className="quality-segment" role="radiogroup" aria-label="Quality">
+                  {qualityChoices.map(([value, label]) => (
+                    <button
+                      aria-checked={quality === value}
+                      className={quality === value ? "active" : ""}
+                      key={value}
+                      onClick={() => setQuality(value)}
+                      role="radio"
+                      type="button"
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </label>
               {showTorchQuantization ? (
                 <label>
                   Quantization

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -100,6 +100,77 @@ const openAdvanced = async (container) => {
   }
 };
 
+// sc-15398 — `quality` (fast/balanced/best) is read by exactly ONE adapter: `svd_steps` maps it to
+// 15/25/30 inference steps for `svd_video`. Every other video engine ignores the key, so the
+// control is gated on the adapter that honors it. This pair is what makes the gate meaningful:
+// asserting only the hidden case would pass just as well if the segment were deleted outright.
+describe("VideoStudio Quality segment adapter gate (sc-15398)", () => {
+  let container;
+  let root;
+
+  const SVD = {
+    id: "svd",
+    name: "Stable Video Diffusion",
+    type: "video",
+    family: "svd",
+    adapter: "svd_video",
+    capabilities: ["image_to_video"],
+    promptless: true,
+    defaults: { duration: 4, fps: 7, resolution: "1024x576", quality: "balanced" },
+    limits: {},
+    quantization: {},
+    loraCompatibility: {},
+    ui: {},
+  };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("shows Quality in Advanced for the SVD adapter, which honors it", async () => {
+    await render(baseContext({ videoModels: [SVD] }));
+    await openAdvanced(container);
+
+    const segment = container.querySelector(".quality-segment");
+    expect(segment).toBeTruthy();
+    expect([...segment.querySelectorAll("button")].map((b) => b.textContent.trim())).toEqual([
+      "Draft",
+      "Balanced",
+      "Final",
+    ]);
+  });
+
+  it("hides Quality for an adapter that never reads the key", async () => {
+    await render(baseContext({ videoModels: [LTX] }));
+    await openAdvanced(container);
+
+    expect(container.querySelector(".quality-segment")).toBeNull();
+    // The Steps override — which beats `quality` even on SVD — is still there, so the run is not
+    // left without a way to trade speed for fidelity.
+    expect(
+      [...container.querySelectorAll("label")].some((label) => label.textContent.trim().startsWith("Steps")),
+    ).toBe(true);
+  });
+});
+
 describe("VideoStudio Save as Preset", () => {
   let container;
   let root;
@@ -945,11 +1016,12 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
     );
 
     // Quant tier is an everyday settings-bar knob, not an Advanced one (sc-15374) — no disclosure
-    // needs opening, and the abstract Fast/Balanced/Best segment no longer sits in that row.
+    // needs opening. Quality is gone from that row entirely, and on a Bernini (non-SVD) adapter it
+    // is not in Advanced either (sc-15398) — nothing reads the key there.
     expect(container.querySelector(".settings-bar-row label.quant-tier-picker")).toBeTruthy();
     expect(container.querySelector(".settings-bar-row .quality-segment")).toBeNull();
     await openAdvanced();
-    expect(container.querySelector(".advanced-panel .quality-segment")).toBeTruthy();
+    expect(container.querySelector(".quality-segment")).toBeNull();
 
     // All bits-based tiers appear (NVFP4 filtered on MLX); bf16 is declared-but-not-installed → disabled.
     expect([...tierPicker().options].map((option) => option.value)).toEqual(["q4", "q8", "bf16"]);

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -78,11 +78,21 @@ async function doubleClick(element) {
 const buttonWithText = (root, text) =>
   [...root.querySelectorAll("button")].find((b) => b.textContent.trim() === text);
 
+// Save-as-preset is an inline pair in the style-preset row (sc-15372): the dropdown opens a
+// scope menu, and picking a scope both sets it and fires the save.
 const saveButton = (container) =>
-  [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as Preset"));
+  [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Save as preset"));
 const nameInput = (container) => container.querySelector('input[aria-label="Preset name"]');
-// Save-as-Preset folds into the Advanced disclosure (collapsed by default), matching
-// Image Studio — open it before touching the preset controls.
+const saveWithScope = async (container, scopeLabel) => {
+  await click(saveButton(container));
+  await click(
+    [...container.querySelectorAll(".save-preset-scope-picker .compact-selector-item")].find((b) =>
+      b.textContent.includes(scopeLabel),
+    ),
+  );
+};
+// The Advanced disclosure is collapsed by default — open it before touching a knob that lives
+// inside it.
 const openAdvanced = async (container) => {
   const toggle = container.querySelector(".advanced-section-toggle");
   if (toggle) {
@@ -129,12 +139,11 @@ describe("VideoStudio Save as Preset", () => {
   it("snapshots the video config into a text_to_video preset without the seed", async () => {
     const context = baseContext();
     await render(context);
-    await openAdvanced(container);
 
     const input = nameInput(container);
     expect(input).toBeTruthy();
     await act(async () => setInput(input, "Push In"));
-    await click(saveButton(container));
+    await saveWithScope(container, "This project");
 
     expect(context.createPreset).toHaveBeenCalledTimes(1);
     const payload = context.createPreset.mock.calls[0][0];
@@ -165,10 +174,9 @@ describe("VideoStudio Save as Preset", () => {
       ],
     });
     await render(context);
-    await openAdvanced(container);
 
     await act(async () => setInput(nameInput(container), "Push In"));
-    await click(saveButton(container));
+    await saveWithScope(container, "This project");
 
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -943,7 +943,13 @@ describe("VideoStudio MLX quant-tier picker (sc-12165)", () => {
         macCapabilities: MAC_CAPS,
       }),
     );
+
+    // Quant tier is an everyday settings-bar knob, not an Advanced one (sc-15374) — no disclosure
+    // needs opening, and the abstract Fast/Balanced/Best segment no longer sits in that row.
+    expect(container.querySelector(".settings-bar-row label.quant-tier-picker")).toBeTruthy();
+    expect(container.querySelector(".settings-bar-row .quality-segment")).toBeNull();
     await openAdvanced();
+    expect(container.querySelector(".advanced-panel .quality-segment")).toBeTruthy();
 
     // All bits-based tiers appear (NVFP4 filtered on MLX); bf16 is declared-but-not-installed → disabled.
     expect([...tierPicker().options].map((option) => option.value)).toEqual(["q4", "q8", "bf16"]);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2771,6 +2771,13 @@ label {
   min-width: 82px;
 }
 
+/* Quant tier sits with Model / Aspect / Variations (studio-cleanup sc-15374). Its warning wraps
+   full-width under the select rather than stretching the cell. */
+.settings-field-tier {
+  flex: 1 1 130px;
+  min-width: 120px;
+}
+
 .settings-field select,
 .settings-field input {
   width: 100%;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5512,28 +5512,36 @@ input.dataset-name-input.boxed:focus {
   min-height: 36px;
 }
 
-/* "Save as Preset" — inline sidebar control that snapshots the current setup. */
-.save-preset {
-  display: grid;
-  gap: 8px;
+/* "Save as preset" — an inline pair at the end of the style-preset chip row (studio-cleanup
+   sc-15372): a fixed-width name field and a dropdown whose menu carries the scope. Both are
+   chip-height so they sit on the chips' baseline rather than reading as a separate panel. */
+.style-axis-divider {
+  width: 1px;
+  height: 22px;
+  margin: 0 4px;
+  background: var(--border);
+  flex: 0 0 auto;
 }
 
-.save-preset-row {
-  display: flex;
-  gap: 8px;
-  align-items: stretch;
+/* Full-width wrap point inside the flex chip row: errors and the save confirmation get their
+   own line under the chips instead of squeezing in beside them. */
+.style-axis-row-break {
+  flex: 0 0 100%;
+  display: grid;
+  gap: 6px;
 }
 
 .save-preset-name {
-  flex: 1;
+  width: 140px;
+  flex: 0 0 auto;
   min-width: 0;
-  min-height: 34px;
+  height: 30px;
   padding: 0 11px;
-  border-radius: var(--r-sm);
+  border-radius: var(--r-pill);
   border: 1px solid var(--border);
-  background: var(--surface-2);
+  background: var(--surface);
   color: var(--text);
-  font-size: 13px;
+  font-size: 12px;
 }
 
 .save-preset-name:focus {
@@ -5541,24 +5549,38 @@ input.dataset-name-input.boxed:focus {
   border-color: var(--accent);
 }
 
+.save-preset-scope-picker {
+  flex: 0 0 auto;
+}
+
 .save-preset-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   white-space: nowrap;
-  min-height: 34px;
-  padding: 0 13px;
-  border: 0;
-  border-radius: var(--r-sm);
-  background: var(--accent);
-  color: var(--accent-fg);
-  font-size: 12.5px;
+  height: 30px;
+  padding: 0 10px 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 12px;
   font-weight: 600;
-  transition: filter var(--t-fast), opacity var(--t-fast);
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast), opacity var(--t-fast);
+}
+
+.save-preset-btn .chev {
+  opacity: 0.6;
 }
 
 .save-preset-btn:hover:not(:disabled) {
-  filter: brightness(1.05);
+  background: var(--accent-soft);
+  border-color: transparent;
+  color: var(--accent-strong);
+}
+
+[data-theme="dark"] .save-preset-btn:hover:not(:disabled) {
+  color: var(--accent);
 }
 
 .save-preset-btn:disabled {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7095,6 +7095,14 @@ details[open] > summary.lora-scope-group-heading::before,
   cursor: pointer;
 }
 
+/* The same import band embedded in a studio's Add-LoRA picker (studio-cleanup sc-15373). It sits
+   inside an already-padded panel, so it runs a notch tighter than the Model Manager copy. */
+.studio-lora-import {
+  gap: 11px;
+  padding: 13px;
+  border-radius: var(--r-md);
+}
+
 /* Full-width trigger-keyword + notes fields below the import grid (epic 10328). */
 .lora-import-metadata {
   display: grid;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4203,35 +4203,17 @@ label {
   height: 14px;
 }
 
-/* Strict-control panel (epic 8236, sc-8245): pose / canny / depth structure lock. Reuses the
-   .studio-source-band shell, .reference-strength slider, .checkline toggle, and .asset-picker-field /
-   .pose-library inner surfaces; only the mode tabs + section spacing are panel-specific. */
-.control-panel {
-  display: grid;
+/* Strict-control panel (epic 8236, sc-8245): pose / canny / depth structure lock. The shell is now
+   the shared .advanced-section disclosure (studio-cleanup sc-15369) — this class only carries the
+   body-specific spacing. .reference-strength slider, .checkline toggle, and .asset-picker-field /
+   .pose-library inner surfaces are reused as before; the mode tabs are panel-specific. */
+.control-panel > .advanced-section-body {
   gap: 12px;
 }
 
-/* Section header reuses the shared .advanced-toggle disclosure look (13px/500/muted). The
-   whole Structure Control body folds under it; the chevron points down when open and rotates
-   -90deg when collapsed (design handoff sc-8245 Fix 1). */
-.control-panel-toggle {
-  justify-self: start;
-  margin-left: -6px;
-}
-
-.control-panel-chev {
-  flex: 0 0 auto;
-  transition: transform 0.18s ease;
-}
-
-.control-panel-chev.collapsed {
-  transform: rotate(-90deg);
-}
-
-/* The former section caption, now a quiet helper line inside the expanded body, indented to
-   align under the label text (past the chevron). */
+/* Section caption: a quiet helper line leading the disclosure body. */
 .control-panel-desc {
-  margin: 0 0 0 20px;
+  margin: 0;
   font-size: 12px;
   color: var(--text-faint);
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2741,10 +2741,24 @@ label {
 }
 
 /* LoRAs are part of model configuration, so the shared picker lives inside the settings
-   container instead of the Advanced disclosure. Keep it visually grouped with the model row. */
+   container instead of the Advanced disclosure. It is a SECTION of that container, not a card
+   inside it (studio-cleanup sc-15370): same hairline separator the Style axis uses, so LoRAs,
+   Model and Style all read as peers. Other consumers (the editor rails) keep the card. */
 .settings-bar > .lora-picker {
-  border-color: var(--border);
-  background: var(--surface);
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 12px 0 0;
+  gap: 8px;
+}
+
+.lora-picker-head {
+  align-items: baseline;
+}
+
+.lora-picker-head > span:last-child {
+  font-size: 11px;
 }
 
 .settings-field-aspect {
@@ -8488,13 +8502,16 @@ details[open] > summary.lora-scope-group-heading::before,
   gap: 10px;
 }
 
+/* Tightened to the settings-bar type scale (studio-cleanup sc-15370): a selected LoRA is one
+   compact row of the model panel, not a card of its own. Applied to every consumer so the slot
+   reads the same in the editor rails. */
 .lora-slot {
   border: 1px solid var(--border);
-  border-radius: var(--r-md);
+  border-radius: var(--r-sm);
   background: var(--surface);
-  padding: 12px 14px;
+  padding: 9px 11px;
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .lora-slot-head {
@@ -8505,7 +8522,7 @@ details[open] > summary.lora-scope-group-heading::before,
 }
 
 .lora-slot-head strong {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
 }
 
@@ -8528,8 +8545,8 @@ details[open] > summary.lora-scope-group-heading::before,
 }
 
 .lora-slot-remove {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   display: grid;
   place-items: center;
   border-radius: var(--r-sm);
@@ -8558,7 +8575,7 @@ details[open] > summary.lora-scope-group-heading::before,
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--text-muted);
 }
 
@@ -8581,12 +8598,13 @@ details[open] > summary.lora-scope-group-heading::before,
   align-items: center;
   justify-content: center;
   gap: 6px;
-  padding: 14px;
-  border: 1.5px dashed var(--border-strong);
-  border-radius: var(--r-md);
+  height: 34px;
+  padding: 0 12px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-sm);
   color: var(--text-muted);
   background: transparent;
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
   transition: border-color var(--t-fast), color var(--t-fast), background var(--t-fast);
 }
@@ -8595,7 +8613,7 @@ details[open] > summary.lora-scope-group-heading::before,
   content: attr(data-count);
   opacity: 0.7;
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: 11px;
   margin-left: 4px;
 }
 
@@ -8616,11 +8634,11 @@ details[open] > summary.lora-scope-group-heading::before,
 
 .lora-picker-panel {
   border: 1px solid var(--border);
-  border-radius: var(--r-md);
+  border-radius: var(--r-sm);
   background: var(--bg-2);
-  padding: 12px 14px;
+  padding: 8px;
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .lora-picker-panel > strong {
@@ -8638,12 +8656,12 @@ details[open] > summary.lora-scope-group-heading::before,
   justify-content: space-between;
   align-items: center;
   gap: 8px;
-  padding: 9px 12px;
+  padding: 7px 10px;
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface);
   text-align: left;
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
   transition: border-color var(--t-fast);
 }
@@ -8677,7 +8695,7 @@ details[open] > summary.lora-scope-group-heading::before,
 /* Mono weight readout in an added LoRA slot's Weight header row. */
 .lora-slot-weight-value {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--text);
 }
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2801,27 +2801,60 @@ label {
 }
 
 /* Style axis row (sc-13135): the Style Catalog picker and the model's Style presets share one row —
-   catalog first, presets filling the remaining width and wrapping under it on narrow viewports. */
+   catalog first, presets filling the remaining width. A GRID rather than a flex row
+   (studio-cleanup sc-15371) so the two columns' eyebrows and controls line up instead of sitting
+   at whatever offset their differing control heights produce. The preset-description row spans
+   both columns at the bottom. */
 .settings-bar-style-axis {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: minmax(240px, auto) minmax(0, 1fr);
   gap: 16px 20px;
-  align-items: flex-start;
+  align-items: start;
+}
+
+/* No Style Catalog for this model — the presets column takes the whole width. */
+.settings-bar-style-axis-single {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .style-axis-field {
   display: grid;
   gap: 7px;
   align-content: start;
-}
-
-.style-axis-catalog {
-  flex: 0 0 auto;
-}
-
-.style-axis-presets {
-  flex: 1 1 240px;
   min-width: 0;
+}
+
+/* One shared control-row height so the pill and the chip row bottom out together. */
+.style-axis-control {
+  min-height: 44px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* The preset description: the grid's last row, a hairline under the two columns rather than a
+   floating bordered card between the settings bar and Advanced. */
+.style-axis-guidance {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 3px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  font-size: 12.5px;
+}
+
+.style-axis-guidance strong {
+  font-weight: 600;
+}
+
+.style-axis-guidance span {
+  color: var(--text-muted);
+}
+
+@media (max-width: 720px) {
+  .settings-bar-style-axis {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .refine-control {


### PR DESCRIPTION
Implements the `design/Image Studio cleanup.zip` handoff (`design_handoff_studio_cleanup/`) in `apps/web`. Six commits, one per story under [epic 15368](https://app.shortcut.com/trefry/epic/15368).

| Story | Change |
| --- | --- |
| [sc-15369](https://app.shortcut.com/trefry/story/15369) | Structure control renders in the canonical `AdvancedSection` and moves from its `.studio-source-band` above the settings bar to sit directly above Advanced |
| [sc-15370](https://app.shortcut.com/trefry/story/15370) | LoRAs becomes a hairline-separated section of the settings bar, not a card inside it — same `.settings-bar-label` eyebrow as Model/Style, tighter slots, 34px dashed Add LoRA |
| [sc-15371](https://app.shortcut.com/trefry/story/15371) | Style / Style preset align on one two-column grid; the preset description folds in as the grid's full-width last row instead of a floating `.guidance-strip` card |
| [sc-15372](https://app.shortcut.com/trefry/story/15372) | Save as preset moves out of Advanced and inline into the style-preset chip row: a 140px name input plus a dropdown whose menu carries the scope |
| [sc-15373](https://app.shortcut.com/trefry/story/15373) | Add LoRA always opens its picker, and the picker embeds the Model Manager's Import LoRA form |
| [sc-15374](https://app.shortcut.com/trefry/story/15374) | Quant tier joins the settings-bar model row in both studios; Video's abstract Quality segment moves to Advanced |
| [sc-15398](https://app.shortcut.com/trefry/story/15398) | Quality segment is gated on `svd_video`, the only adapter that reads it |

## One deviation from the handoff, flagged

The README says Video Studio's `Fast / Balanced / Best` Quality segment is **removed**. This PR **relocates it to Advanced** instead, because `quality` is still a submitted payload field, a persisted snapshot field, and a preset default.

**Correction to an earlier version of this description**, after tracing the field end to end: I first wrote that deleting the segment "would silently pin *every* render." That was overstated. `quality` has exactly one consumer in the worker — [`svd_steps()`](https://github.com/SceneWorks/SceneWorks/blob/main/crates/sceneworks-worker/src/video_jobs/svd.rs#L143), which maps `fast|balanced|best` → 15/25/30 inference steps for the SVD adapter (`image_to_video`-only, promptless). Every other video engine ignores it. Two further caveats: the `modelManifestEntry.steps[quality]` override that `svd_steps` documents is dead code — every `steps` key in `builtin.models.jsonc` is a scalar, never a quality-keyed object — and `advanced.steps` beats quality outright, which Video Studio's Advanced already exposes. So the real blast radius is: SVD renders where Steps is left blank.

**Resolved — [sc-15398](https://app.shortcut.com/trefry/story/15398) folds the gate into this PR.** The segment now renders only for the `svd_video` adapter, matching the existing `adapter === "krea_realtime"` clip-strength and `adapter === "ltx_video"` guidance gates on the same screen. The field still rides the payload, the snapshot, and preset defaults, so recipe replay round-trips unchanged — this hides a control, it drops no value. Deleting the field outright would need a migration and is deliberately not done here.

## Notes

- `LoraPickerSection` is shared with `EditorLoraPanel` and `GenerationRail`. The slot restyle is shared on purpose (one component, one look); the Import LoRA panel is opt-in via an `importPanel` prop, so the editor rails keep a list-only picker.
- `StudioLoraImportPanel` renders as a `role="group"` div, not a `<form>` — the studio screen is already one `<form>` and nested forms are invalid.
- `handleSaveAsPreset` now takes the chosen scope so the dropdown's set-scope-and-save gesture can't read a stale `presetScope`.
- No new design tokens; everything reuses existing classes/variables in `apps/web/src/styles.css`.

## Verification

- `npm run lint` and `npx vitest run --environment jsdom` in `apps/web`: 205 files / 2841 tests green.
- New `VideoStudio` test pair for the Quality gate: present for `svd_video` (with the Draft/Balanced/Final labels), absent for a non-SVD adapter while the Steps override remains. Asserting only the hidden case would pass equally well if the segment had simply been deleted, so both halves are required.
- New `StudioLoraImportPanel.test.jsx` (5 tests) covers the not-a-form constraint, the payload shape, the disabled/blocked cases, and error surfacing.
- Existing tests updated where they asserted the old DOM — plus new location assertions so the Quant-tier move and the always-enabled Add LoRA can't silently regress.
- Layout verified in the browser against a temporary harness mounting the real components with the real stylesheet (light + dark), since the studios need a running backend. Harness deleted; the tree is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
