### PR TITLE
LoRA support in the Simple UI studios (epic 15404)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -74,8 +74,14 @@ export const JOY_CAPTION_MODEL_ID = "joycaption_beta_one";
 // Lightning fast-4-step toggle (sc-10047/sc-10048, epic 10043) — the worker derives the
 // 4-step/CFG-off recipe from `advanced.lightning` for them and ignores it for the dense
 // 5B (wan_2_2) and non-Wan engines, so the UI only surfaces the toggle for these ids.
-// (Mirrors ModelManagerScreen's WAN_MOE_BASE_MODELS, which is the LoRA-pairing subset.)
 export const WAN_A14B_LIGHTNING_MODEL_IDS = new Set(["wan_2_2_t2v_14b", "wan_2_2_i2v_14b"]);
+
+// Wan A14B is a two-expert mixture, so its LoRAs come as a high/low-noise PAIR. These base
+// models accept the optional low-noise expert upload in Model Manager (sc-1991) and are the
+// ones the Simple Video Studio's LoRA hint applies to (epic 15404); the dense 5B (wan_2_2) is
+// a single-file LoRA. Same ids as WAN_A14B_LIGHTNING_MODEL_IDS above but a DIFFERENT fact —
+// that one is about the 4-step distilled sampling recipe — so they stay separate constants.
+export const WAN_MOE_PAIRED_LORA_MODEL_IDS = new Set(["wan_2_2_t2v_14b", "wan_2_2_i2v_14b"]);
 
 // Vision captioner (epic 8102, sc-8107/8108). Turns an uploaded reference image into a structured
 // Ideogram-style JSON caption (style + grounded composition) for Ideogram 4 text-to-image variations.

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
-import { terminalStatuses } from "../constants.js";
+import { WAN_MOE_PAIRED_LORA_MODEL_IDS, terminalStatuses } from "../constants.js";
 import { hasPresentCredential, loadCredentials, serverToken } from "../credentials.js";
 import {
   extractFamilies,
@@ -20,11 +20,6 @@ import { isDesktop, tauriInvoke } from "../runtime.js";
 import { tierLabel } from "../quantTier.js";
 import { suggestTier, tierFits } from "../tierSuggestion.js";
 import { safeExternalUrl } from "../urls.js";
-
-// Wan A14B is a two-expert mixture; its LoRAs come as a high/low-noise pair. These
-// base models accept the optional low-noise expert upload (sc-1991). The 5B model
-// (wan_2_2) is dense and takes a single-file LoRA.
-const WAN_MOE_BASE_MODELS = new Set(["wan_2_2_t2v_14b", "wan_2_2_i2v_14b"]);
 
 function matchesFamily(item, familyFilter) {
   if (familyFilter === "all") {
@@ -802,7 +797,7 @@ export function ModelManagerScreen() {
   // upload the low-noise expert half alongside the high-noise primary.
   const wanBaseModelOptions = models.filter((model) => model.family === "wan-video");
   const showBaseModelSelect = importForm.family === "wan-video" && wanBaseModelOptions.length > 0;
-  const isMoeBaseModel = WAN_MOE_BASE_MODELS.has(importForm.baseModel);
+  const isMoeBaseModel = WAN_MOE_PAIRED_LORA_MODEL_IDS.has(importForm.baseModel);
   const showSecondaryFileSlot = isMoeBaseModel && importForm.mode === "file";
   const moeMissingSecondary = showSecondaryFileSlot && Boolean(importForm.file) && !importForm.secondaryFile;
 

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -11,6 +11,9 @@ import { preferredResolution } from "./modelDefaults.js";
 import { buildSimpleImageRequest, referenceStrengthFor, resolveSimpleTier } from "./simpleJobs.js";
 import { useSimpleRefine } from "./useSimpleRefine.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
+import { useSimpleLoras } from "./useSimpleLoras.js";
+import { SimpleLoraField, promptWithKeyword } from "./SimpleLoraField.jsx";
+import { SimpleLoraSheet } from "./SimpleLoraSheet.jsx";
 import {
   Chips,
   RefinePanel,
@@ -43,10 +46,12 @@ export function SimpleImageStudio() {
     recentImageAssets = [],
     visibleWorkers = [],
     loras = [],
+    jobs = [],
     createLoraDownloadJob,
     activeProject,
   } = useAppContext();
-  const { breakpoint, openGuide, toast, referenceRequest, clearReferenceRequest } = useSimpleUi();
+  const { breakpoint, openSheet, closeSheet, openGuide, toast, referenceRequest, clearReferenceRequest } =
+    useSimpleUi();
   const unifiedMemoryGb = useUnifiedMemoryGb();
   const refine = useSimpleRefine("image");
 
@@ -150,6 +155,32 @@ export function SimpleImageStudio() {
     }
   }, [editLoraMissing]);
 
+  // User-picked LoRAs (epic 15404). The managed edit LoRA is excluded from the picker — it is
+  // applied automatically above, so offering it here would let the user double-add or toggle
+  // off a LoRA the edit lane requires (the advanced studio hides it from its picker too).
+  const lora = useSimpleLoras({
+    loras,
+    selectedModel,
+    jobs,
+    excludeLoraId: editLoraInstalled ? (editLora?.id ?? null) : null,
+  });
+  const openLoraPicker = () =>
+    openSheet({
+      title: "Add LoRA",
+      body: (
+        <SimpleLoraSheet
+          atLimit={lora.atLimit}
+          excludeIds={[...lora.selectedLoraIds, ...(editLoraInstalled && editLora ? [editLora.id] : [])]}
+          onAdd={(picked) => {
+            lora.addLora(picked);
+            closeSheet();
+          }}
+          onImportQueued={lora.noteImportJob}
+          selectedModel={selectedModel}
+        />
+      ),
+    });
+
   const latestJob = newestLocalJob(imageLocalJobs);
   const busy = submitting || jobIsRunning(latestJob);
   const needsSource = mode === "edit_image" && !referenceAssetId;
@@ -192,6 +223,7 @@ export function SimpleImageStudio() {
         img2imgStrength: referenceStrengthFor(selectedModel),
         // Auto-applied in edit mode; the worker's edit lane rejects the run without it.
         editLora: editLoraInstalled ? editLora : null,
+        loras: lora.serializedLoras,
         ...tier,
       });
       if (!request) {
@@ -331,6 +363,20 @@ export function SimpleImageStudio() {
           />
         </div>
         <Chips label="Variations" onChange={setVariations} options={VARIATION_OPTIONS} value={variations} />
+        {/* Last child of the settings bar, so LoRAs read as a peer of Model / Resolution /
+            Variations rather than a card of their own (sc-15370's call, applied to Simple). */}
+        <SimpleLoraField
+          atLimit={lora.atLimit}
+          availableLoras={lora.availableLoras}
+          effectiveLoraWeight={lora.effectiveLoraWeight}
+          onAddKeyword={(keyword) => setPrompt((current) => promptWithKeyword(current, keyword))}
+          onOpenPicker={openLoraPicker}
+          onRemove={lora.removeLora}
+          onWeightChange={lora.setLoraWeight}
+          pendingImports={lora.pendingImports}
+          selectedLoras={lora.selectedLoras}
+          selectedModel={selectedModel}
+        />
       </div>
 
       <StyleStrip onChange={setStyleId} value={styleId} />

--- a/apps/web/src/simple/SimpleLora.test.jsx
+++ b/apps/web/src/simple/SimpleLora.test.jsx
@@ -1,0 +1,508 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../context/AppContext.js";
+import { SimpleShell } from "./SimpleShell.jsx";
+import { MAX_USER_JOB_LORAS } from "../presetUtils.js";
+import { click, mountRoot, setFileInput, setInput, unmountRoot } from "../testUtils/dom.js";
+import { resetStartupTimingForTests } from "../startupTiming.js";
+import { promptWithKeyword } from "./SimpleLoraField.jsx";
+
+// LoRA support in the Simple studios (epic 15404). Driven through the real shell and the
+// real AppContext, so what's asserted is the payload the app would actually POST — the
+// point of the feature is that a Simple run carries the SAME `loras` array the advanced
+// studio sends, not a Simple-only shape.
+
+const IMAGE_MODEL = {
+  id: "z_image",
+  name: "Z-Image",
+  type: "image",
+  family: "z-image",
+  capabilities: ["text_to_image", "edit_image"],
+  installState: "installed",
+  limits: { resolutions: ["1024x1024"] },
+};
+
+const WAN_5B = {
+  id: "wan_2_2",
+  name: "Wan 2.2 (TI2V-5B)",
+  type: "video",
+  family: "wan-2-2",
+  capabilities: ["text_to_video"],
+  installState: "installed",
+  limits: { resolutions: ["1280x720"], durations: [5] },
+};
+
+const WAN_A14B = { ...WAN_5B, id: "wan_2_2_t2v_14b", name: "Wan 2.2 14B (T2V)" };
+const LTX = { ...WAN_5B, id: "ltx_2_3", name: "LTX-2.3", family: "ltx-video" };
+
+const GRAIN = {
+  id: "lora_grain",
+  name: "Cinematic Grain 35mm",
+  family: "z-image",
+  scope: "global",
+  installState: "installed",
+  triggerWords: ["cinegrain"],
+};
+const INK = {
+  id: "lora_ink",
+  name: "Ink Wash Portrait",
+  family: "z-image",
+  scope: "project",
+  installState: "installed",
+  defaultWeight: 0.7,
+};
+// Each of these must be invisible to the picker, for a different reason.
+const WRONG_FAMILY = { id: "lora_wan", name: "Slow Dolly", family: "wan-2-2", installState: "installed" };
+const NOT_INSTALLED = { id: "lora_pending", name: "Still Downloading", family: "z-image", installState: "missing" };
+const FAMILYLESS = { id: "lora_unknown", name: "Mystery Adapter", installState: "installed" };
+const PRESET_MANAGED = {
+  id: "lora_preset",
+  name: "Preset Owned",
+  family: "z-image",
+  installState: "installed",
+  presetManaged: true,
+};
+
+function baseContext(overrides = {}) {
+  return {
+    activeProject: { id: "project-1", name: "Default" },
+    assets: [],
+    recentImageAssets: [],
+    jobs: [],
+    imageModels: [IMAGE_MODEL],
+    videoModels: [WAN_5B, WAN_A14B],
+    audioModels: [],
+    models: [IMAGE_MODEL],
+    loras: [GRAIN, INK, WRONG_FAMILY, NOT_INSTALLED, FAMILYLESS, PRESET_MANAGED],
+    imageLocalJobs: [],
+    videoLocalJobs: [],
+    audioLocalJobs: [],
+    visibleWorkers: [],
+    macCapabilities: null,
+    theme: "light",
+    changeTheme: () => {},
+    createImageJob: vi.fn(async () => ({ id: "job-1" })),
+    createVideoJob: vi.fn(async () => ({ id: "job-2" })),
+    createAudioJob: vi.fn(async () => null),
+    createModelDownloadJob: vi.fn(async () => null),
+    createLoraDownloadJob: vi.fn(async () => null),
+    createLoraImportJob: vi.fn(async () => ({
+      id: "import-1",
+      type: "lora_import",
+      status: "queued",
+      payload: { loraId: "analog_35mm", manifestEntry: { family: "z_image" } },
+    })),
+    jobAction: vi.fn(async () => {}),
+    rememberLocalGenerationJob: vi.fn(),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    setSelectedAssetId: vi.fn(),
+    setActiveView: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderShell(root, context) {
+  return act(async () => {
+    root.render(
+      <AppContext.Provider value={context}>
+        <SimpleShell
+          accent="teal"
+          lockedToSimple={false}
+          onAccentChange={() => {}}
+          onModeChange={() => {}}
+          onSimpleDefaultChange={() => {}}
+          simpleDefault
+        />
+      </AppContext.Provider>,
+    );
+  });
+}
+
+function navButton(container, label) {
+  return [...container.querySelectorAll(".su-nav-item")].find((node) => node.textContent.startsWith(label));
+}
+
+function pickRow(container, name) {
+  return [...container.querySelectorAll(".su-lora-pick-row")].find((node) =>
+    node.textContent.startsWith(name),
+  );
+}
+
+function slotNames(container) {
+  return [...container.querySelectorAll(".su-lora-slot .su-lora-slot-meta strong")].map((node) =>
+    node.textContent.trim(),
+  );
+}
+
+// The studio's Model control is a sheet-backed select; picking from it is two clicks.
+async function selectModel(container, name) {
+  await click(container.querySelector(".su-select"));
+  await click(
+    [...container.querySelectorAll(".su-option-row")].find((node) => node.textContent.includes(name)),
+  );
+}
+
+async function openPicker(container) {
+  await click(container.querySelector(".su-lora-add"));
+}
+
+async function addLora(container, name) {
+  await openPicker(container);
+  await click(pickRow(container, name));
+}
+
+async function typePrompt(container, value) {
+  const textarea = container.querySelector("#su-image-prompt");
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+    setter.call(textarea, value);
+    textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+  });
+}
+
+describe("promptWithKeyword", () => {
+  it("appends a keyword after a comma", () => {
+    expect(promptWithKeyword("a lighthouse", "cinegrain")).toBe("a lighthouse, cinegrain");
+  });
+
+  it("is the keyword alone when the prompt is empty", () => {
+    expect(promptWithKeyword("", "cinegrain")).toBe("cinegrain");
+    expect(promptWithKeyword("   ", "cinegrain")).toBe("cinegrain");
+  });
+
+  // A second tap on the same chip must not double the keyword — the point of the chip is to
+  // get the word into the prompt once, and a trailing "x, x" is noise the model reads.
+  it("is a no-op when the keyword is already present, case-insensitively", () => {
+    expect(promptWithKeyword("a shot, cinegrain", "cinegrain")).toBe("a shot, cinegrain");
+    expect(promptWithKeyword("a shot, CineGrain", "cinegrain")).toBe("a shot, CineGrain");
+  });
+
+  it("does not leave a double comma behind a trailing one", () => {
+    expect(promptWithKeyword("a lighthouse,", "cinegrain")).toBe("a lighthouse, cinegrain");
+  });
+});
+
+describe("Simple studios — LoRA field", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    resetStartupTimingForTests();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders inside the settings bar as a peer of the other controls", async () => {
+    await renderShell(root, baseContext());
+    const bar = container.querySelector(".su-settings-bar");
+    expect(bar.querySelector(".su-lora-field")).toBeTruthy();
+    // Last child, per the design — under Variations, not above Model.
+    expect(bar.lastElementChild.classList.contains("su-lora-field")).toBe(true);
+    expect(container.querySelector(".su-lora-head > span").textContent).toBe("Installed and compatible");
+  });
+
+  // The eligibility rules are `presetUtils`' — this asserts Simple actually applies all four
+  // of them rather than listing whatever is in the catalog.
+  it("offers only installed, compatible, family-resolvable, non-preset LoRAs", async () => {
+    await renderShell(root, baseContext());
+    expect(container.querySelector(".su-lora-add-count").textContent).toBe("· 2 available");
+    await openPicker(container);
+    const offered = [...container.querySelectorAll(".su-lora-pick-row strong")].map((n) => n.textContent);
+    expect(offered).toEqual(["Cinematic Grain 35mm", "Ink Wash Portrait"]);
+  });
+
+  it("adds a LoRA from the sheet, closes it, and updates the status line", async () => {
+    await renderShell(root, baseContext());
+    await addLora(container, "Cinematic Grain 35mm");
+    expect(container.querySelector(".su-sheet")).toBeNull();
+    expect(slotNames(container)).toEqual(["Cinematic Grain 35mm"]);
+    expect(container.querySelector(".su-lora-head > span").textContent).toBe(
+      "1 selected · installed and compatible",
+    );
+    expect(container.querySelector(".su-lora-add-count").textContent).toBe("· 1 available");
+    // Weight defaults to the LoRA's own default (0.8 here, via `loraWeight`).
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("0.80");
+  });
+
+  it("seeds the slider from the LoRA's declared defaultWeight", async () => {
+    await renderShell(root, baseContext());
+    await addLora(container, "Ink Wash Portrait");
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("0.70");
+  });
+
+  it("keeps the bidirectional −2…2 weight range", async () => {
+    await renderShell(root, baseContext());
+    await addLora(container, "Cinematic Grain 35mm");
+    const slider = container.querySelector(".su-lora-weight input[type=range]");
+    expect(slider.min).toBe("-2");
+    expect(slider.max).toBe("2");
+    expect(slider.step).toBe("0.05");
+  });
+
+  it("removes a LoRA and forgets its weight override", async () => {
+    await renderShell(root, baseContext());
+    await addLora(container, "Cinematic Grain 35mm");
+    await act(async () => setInput(container.querySelector(".su-lora-weight input[type=range]"), "1.5"));
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("1.50");
+    await click(container.querySelector(".su-lora-remove"));
+    expect(slotNames(container)).toEqual([]);
+    // Re-adding starts from the LoRA's own default again, not the override we just cleared.
+    await addLora(container, "Cinematic Grain 35mm");
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("0.80");
+  });
+
+  it("appends a trigger keyword to the prompt when its chip is clicked", async () => {
+    await renderShell(root, baseContext());
+    await typePrompt(container, "portrait of a lighthouse keeper");
+    await addLora(container, "Cinematic Grain 35mm");
+    const chip = container.querySelector(".su-lora-keyword");
+    expect(chip.textContent).toBe("cinegrain");
+    await click(chip);
+    expect(container.querySelector("#su-image-prompt").value).toBe(
+      "portrait of a lighthouse keeper, cinegrain",
+    );
+    await click(chip);
+    expect(container.querySelector("#su-image-prompt").value).toBe(
+      "portrait of a lighthouse keeper, cinegrain",
+    );
+  });
+
+  it("caps user selections at MAX_USER_JOB_LORAS and says so", async () => {
+    const many = Array.from({ length: MAX_USER_JOB_LORAS + 1 }, (_, index) => ({
+      id: `lora_${index}`,
+      name: `Adapter ${index}`,
+      family: "z-image",
+      scope: "global",
+      installState: "installed",
+    }));
+    await renderShell(root, baseContext({ loras: many }));
+    for (let index = 0; index < MAX_USER_JOB_LORAS; index += 1) {
+      await addLora(container, `Adapter ${index}`);
+    }
+    expect(container.querySelector(".su-lora-note").textContent).toBe(
+      `Limit reached — ${MAX_USER_JOB_LORAS} LoRAs per run.`,
+    );
+    // The Add row itself stays live (sc-15373) — the sheet is where the reason lives.
+    expect(container.querySelector(".su-lora-add").disabled).toBe(false);
+    await openPicker(container);
+    const row = pickRow(container, `Adapter ${MAX_USER_JOB_LORAS}`);
+    expect(row.disabled).toBe(true);
+    expect(row.querySelector(".su-lora-pick-add").textContent).toBe("Limit reached");
+  });
+
+  it("sends the picked LoRAs on the generated job, in serializeLora shape", async () => {
+    const context = baseContext();
+    await renderShell(root, context);
+    await typePrompt(container, "a lighthouse");
+    await addLora(container, "Cinematic Grain 35mm");
+    await act(async () => setInput(container.querySelector(".su-lora-weight input[type=range]"), "1.25"));
+    await click([...container.querySelectorAll(".su-generate")][0]);
+    const request = context.createImageJob.mock.calls[0][0];
+    expect(request.loras).toEqual([
+      expect.objectContaining({ id: "lora_grain", name: "Cinematic Grain 35mm", scope: "global", weight: 1.25 }),
+    ]);
+  });
+
+  it("keeps a selection across a model change inside the same family", async () => {
+    await renderShell(root, baseContext());
+    await click(navButton(container, "Video"));
+    await addLora(container, "Slow Dolly");
+    expect(slotNames(container)).toEqual(["Slow Dolly"]);
+    // Wan 5B → Wan 14B share the "wan-2-2" family, so the pick is still valid.
+    await selectModel(container, "Wan 2.2 14B");
+    expect(slotNames(container)).toEqual(["Slow Dolly"]);
+  });
+
+  it("drops a selection the new model's family can't take", async () => {
+    await renderShell(root, baseContext({ videoModels: [WAN_5B, LTX] }));
+    await click(navButton(container, "Video"));
+    await addLora(container, "Slow Dolly");
+    expect(slotNames(container)).toEqual(["Slow Dolly"]);
+    await selectModel(container, "LTX-2.3");
+    expect(slotNames(container)).toEqual([]);
+    expect(container.querySelector(".su-lora-head > span").textContent).toBe("Installed and compatible");
+    // Switching BACK must not resurrect it: the id has to be gone from the selection, not
+    // merely filtered out of the render. Otherwise the picker would keep excluding a LoRA the
+    // user can no longer see selected.
+    await selectModel(container, "Wan 2.2 (TI2V-5B)");
+    expect(slotNames(container)).toEqual([]);
+    expect(container.querySelector(".su-lora-add-count").textContent).toBe("· 1 available");
+  });
+
+  // sc-11962's guard, ported: `compatibleLoras` is empty both when the catalog hasn't
+  // resolved AND when nothing matches. Pruning during the former would permanently strip a
+  // selection the user still has, so the prune only runs once both inputs are present.
+  it("does not strip a selection while the LoRA catalog is unresolved", async () => {
+    const context = baseContext();
+    await renderShell(root, context);
+    await addLora(container, "Cinematic Grain 35mm");
+    expect(slotNames(container)).toEqual(["Cinematic Grain 35mm"]);
+    await renderShell(root, baseContext({ loras: [] }));
+    await renderShell(root, baseContext());
+    expect(slotNames(container)).toEqual(["Cinematic Grain 35mm"]);
+  });
+
+  it("shows the A14B paired-expert hint only for the MoE models", async () => {
+    await renderShell(root, baseContext());
+    await click(navButton(container, "Video"));
+    // Seeded on the dense 5B — single-file LoRAs, so no hint.
+    expect(container.querySelector(".su-lora-hint")).toBeNull();
+    await selectModel(container, "Wan 2.2 14B");
+    expect(container.querySelector(".su-lora-hint").textContent).toContain(
+      "high/low-noise pair",
+    );
+  });
+
+  it("carries the picked LoRAs onto a video run", async () => {
+    const context = baseContext();
+    await renderShell(root, context);
+    await click(navButton(container, "Video"));
+    const textarea = container.querySelector("#su-video-prompt");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+      setter.call(textarea, "slow push-in");
+      textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+    await addLora(container, "Slow Dolly");
+    await click(container.querySelector(".su-generate"));
+    const request = context.createVideoJob.mock.calls[0][0];
+    expect(request.loras).toEqual([expect.objectContaining({ id: "lora_wan", weight: 0.8 })]);
+  });
+});
+
+describe("Simple studios — Add LoRA sheet import", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    resetStartupTimingForTests();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reports why the list is empty and opens the import form in the same place", async () => {
+    await renderShell(root, baseContext({ loras: [] }));
+    await openPicker(container);
+    expect(container.querySelector(".su-lora-pick-empty").textContent).toBe(
+      "No installed LoRAs match Z-Image.",
+    );
+    // sc-15373: the fix is expanded, not one more tap away.
+    expect(container.querySelector(".su-lora-import-panel")).toBeTruthy();
+  });
+
+  it("credits a still-downloading compatible LoRA in the empty message", async () => {
+    await renderShell(root, baseContext({ loras: [NOT_INSTALLED] }));
+    await openPicker(container);
+    expect(container.querySelector(".su-lora-pick-empty").textContent).toBe(
+      "No installed compatible LoRAs. Imports appear after the Queue completes.",
+    );
+  });
+
+  it("stays collapsed when there is something to pick", async () => {
+    await renderShell(root, baseContext());
+    await openPicker(container);
+    expect(container.querySelector(".su-lora-import-panel")).toBeNull();
+    await click(container.querySelector(".su-lora-import-trigger"));
+    expect(container.querySelector(".su-lora-import-panel")).toBeTruthy();
+  });
+
+  it("queues an import through the shared seam with an auto-detected family", async () => {
+    const context = baseContext();
+    await renderShell(root, context);
+    await openPicker(container);
+    await click(container.querySelector(".su-lora-import-trigger"));
+    await act(async () => {
+      setFileInput(container.querySelector(".su-lora-file-btn input"), [
+        new window.File(["x"], "analog_35mm.safetensors"),
+      ]);
+    });
+    expect(container.querySelector(".su-lora-file-name").textContent).toBe("analog_35mm.safetensors");
+    const keywordInput = container.querySelector(".su-lora-kw input");
+    await act(async () => setInput(keywordInput, "analog35"));
+    await act(async () => {
+      keywordInput.dispatchEvent(new window.KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+    });
+    expect(container.querySelector(".su-lora-kw-chip").textContent).toContain("analog35");
+
+    await click([...container.querySelectorAll(".su-accent-btn")].at(-1));
+    const payload = context.createLoraImportJob.mock.calls[0][0];
+    expect(payload.file.name).toBe("analog_35mm.safetensors");
+    expect(payload.triggerWords).toEqual(["analog35"]);
+    // Scope defaults to the open project; family is NEVER sent — the importer detects it.
+    expect(payload.scope).toBe("project");
+    expect(payload).not.toHaveProperty("family");
+    // The detected family comes back normalized (z_image → z-image).
+    expect(container.querySelector(".su-lora-import-msg--success").textContent).toBe(
+      "LoRA import queued for analog_35mm. Detected family: z-image.",
+    );
+    // Form cleared, sheet still open.
+    expect(container.querySelector(".su-lora-file-name").textContent).toBe("No file selected");
+    expect(container.querySelector(".su-sheet")).toBeTruthy();
+  });
+
+  it("surfaces an import failure rather than swallowing it", async () => {
+    const context = baseContext({
+      createLoraImportJob: vi.fn(async () => {
+        throw new Error("Uploaded LoRA file exceeds the 2GB limit");
+      }),
+    });
+    await renderShell(root, context);
+    await openPicker(container);
+    await click(container.querySelector(".su-lora-import-trigger"));
+    await act(async () => {
+      setFileInput(container.querySelector(".su-lora-file-btn input"), [
+        new window.File(["x"], "huge.safetensors"),
+      ]);
+    });
+    await click([...container.querySelectorAll(".su-accent-btn")].at(-1));
+    expect(container.querySelector(".su-lora-import-msg--error").textContent).toBe(
+      "Uploaded LoRA file exceeds the 2GB limit",
+    );
+  });
+
+  it("shows a pending slot driven by the live job feed, and clears it on completion", async () => {
+    const runningJob = {
+      id: "import-1",
+      type: "lora_import",
+      status: "queued",
+      payload: { name: "analog_35mm.safetensors", manifestEntry: { family: "z_image" } },
+    };
+    const context = baseContext({ createLoraImportJob: vi.fn(async () => runningJob) });
+    await renderShell(root, context);
+    await openPicker(container);
+    await click(container.querySelector(".su-lora-import-trigger"));
+    await act(async () => {
+      setFileInput(container.querySelector(".su-lora-file-btn input"), [
+        new window.File(["x"], "analog_35mm.safetensors"),
+      ]);
+    });
+    await click([...container.querySelectorAll(".su-accent-btn")].at(-1));
+
+    // The job has to be in the feed for the slot to exist — nothing here is local state.
+    await renderShell(root, baseContext({ ...context, jobs: [runningJob] }));
+    const pending = container.querySelector(".su-lora-slot--pending");
+    expect(pending).toBeTruthy();
+    expect(pending.querySelector("strong").textContent).toBe("analog_35mm.safetensors");
+    expect(pending.querySelector("small").textContent).toBe("importing · family detected: z-image");
+    expect(pending.querySelector(".su-job-badge--running").textContent).toBe("Queued");
+    expect(pending.querySelector(".su-bar--indeterminate")).toBeTruthy();
+
+    // Terminal ⇒ gone, with no remount and no local bookkeeping to unwind.
+    await renderShell(root, baseContext({ ...context, jobs: [{ ...runningJob, status: "completed" }] }));
+    expect(container.querySelector(".su-lora-slot--pending")).toBeNull();
+  });
+});

--- a/apps/web/src/simple/SimpleLoraField.jsx
+++ b/apps/web/src/simple/SimpleLoraField.jsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { Icon } from "../components/Icons.jsx";
+import {
+  LORA_WEIGHT_MAX,
+  LORA_WEIGHT_MIN,
+  LORA_WEIGHT_STEP,
+  MAX_USER_JOB_LORAS,
+  normalizeLoraFamily,
+} from "../presetUtils.js";
+import { percent } from "../formatting.js";
+import { loraMeta } from "./useSimpleLoras.js";
+import { useSimpleUi } from "./SimpleUiContext.js";
+
+// The Simple studios' LoRA control (epic 15404). Rendered as the LAST child of the existing
+// `.su-settings-bar`, so it reads as a peer of Model / Resolution / Variations rather than a
+// card of its own — the same call `LoraPickerSection` made when it moved into the advanced
+// settings bar (sc-15370).
+
+/**
+ * Append a trigger keyword to a prompt, unless it's already in there.
+ *
+ * Surfacing keywords is only useful if they can reach the prompt: a trigger word does
+ * nothing to the generation while it sits in a chip. Matching is case-insensitive so a
+ * second tap is a no-op rather than a duplicate.
+ *
+ * @returns {string} the new prompt (the original when the keyword is already present).
+ */
+export function promptWithKeyword(prompt, keyword) {
+  const word = String(keyword ?? "").trim();
+  const current = String(prompt ?? "");
+  if (!word || current.toLowerCase().includes(word.toLowerCase())) {
+    return current;
+  }
+  return current.trim() ? `${current.trimEnd().replace(/,$/, "")}, ${word}` : word;
+}
+
+export function SimpleLoraField({
+  selectedModel,
+  selectedLoras,
+  availableLoras,
+  atLimit,
+  effectiveLoraWeight,
+  onRemove,
+  onWeightChange,
+  onAddKeyword,
+  onOpenPicker,
+  pendingImports = [],
+  hint = null,
+}) {
+  const { breakpoint } = useSimpleUi();
+  // Pointer-accurate copy: "tap" is wrong on a desktop pointer, "click" is wrong on a phone.
+  const keywordHint = breakpoint === "phone" ? "tap to add to prompt" : "click to add to prompt";
+
+  return (
+    <div className="su-field su-lora-field">
+      <div className="su-lora-head">
+        <label>LoRAs</label>
+        {/* Status copy lifted verbatim from LoraPickerSection so the two surfaces can't drift. */}
+        <span>
+          {selectedLoras.length
+            ? `${selectedLoras.length} selected · installed and compatible`
+            : selectedModel
+              ? "Installed and compatible"
+              : "Choose a model"}
+        </span>
+      </div>
+
+      {selectedLoras.length || pendingImports.length ? (
+        <div className="su-lora-stack">
+          {selectedLoras.map((lora) => {
+            const name = lora.name ?? lora.id;
+            const weight = effectiveLoraWeight(lora);
+            const keywords = Array.isArray(lora.triggerWords) ? lora.triggerWords : [];
+            return (
+              <div className="su-lora-slot" key={lora.id}>
+                <div className="su-lora-slot-head">
+                  <span className="su-lora-slot-meta">
+                    <strong>{name}</strong>
+                    <small>{loraMeta(lora)}</small>
+                  </span>
+                  <button
+                    aria-label={`Remove ${name}`}
+                    className="su-lora-remove"
+                    onClick={() => onRemove(lora)}
+                    title="Remove"
+                    type="button"
+                  >
+                    ×
+                  </button>
+                </div>
+                {/* Notes are deliberately NOT shown here — Simple surfaces only the keywords,
+                    because those are the part the user has to act on. Notes stay in the
+                    advanced LoraKeywordSummary. */}
+                {keywords.length ? (
+                  <div className="su-lora-keywords">
+                    {keywords.map((keyword) => (
+                      <button
+                        className="su-lora-keyword"
+                        key={keyword}
+                        onClick={() => onAddKeyword(keyword)}
+                        title="Add to prompt"
+                        type="button"
+                      >
+                        {keyword}
+                      </button>
+                    ))}
+                    <span className="su-lora-keyword-hint">{keywordHint}</span>
+                  </div>
+                ) : null}
+                <div className="su-lora-weight">
+                  <label>
+                    <span>Weight</span>
+                    <span className="su-lora-weight-value">{weight.toFixed(2)}</span>
+                  </label>
+                  {/* The −2…2 band is deliberate and shared with every other weight surface
+                      (presetUtils): slider-style LoRAs are trained to run negative, so clamping
+                      to 0…1 here would make half of them unusable from Simple. */}
+                  <input
+                    aria-label={`${name} weight`}
+                    max={LORA_WEIGHT_MAX}
+                    min={LORA_WEIGHT_MIN}
+                    onChange={(event) => onWeightChange(lora.id, Number(event.target.value))}
+                    step={LORA_WEIGHT_STEP}
+                    type="range"
+                    value={weight}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          {pendingImports.map((job) => (
+            <PendingLoraSlot job={job} key={job.id} />
+          ))}
+        </div>
+      ) : null}
+
+      {/* Always enabled, even at 0 available (sc-15373): the sheet is where the reason AND the
+          fix (the import form) live, so disabling this would be a dead end. */}
+      <button className="su-lora-add" onClick={onOpenPicker} type="button">
+        <Icon.Plus size={15} />
+        <span>Add LoRA</span>
+        <span className="su-lora-add-count">· {availableLoras.length} available</span>
+      </button>
+      {atLimit ? (
+        <p className="su-lora-note">Limit reached — {MAX_USER_JOB_LORAS} LoRAs per run.</p>
+      ) : null}
+      {hint ? (
+        <p className="su-lora-hint">
+          <Icon.Info size={13} />
+          <span>{hint}</span>
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+// An import this studio started that hasn't finished yet. Everything shown is read off the
+// live job feed (the same one the Queue renders) — this component holds no state of its own,
+// so it can't drift from the Queue's account of the same job.
+function PendingLoraSlot({ job }) {
+  const name = job.payload?.name ?? job.payload?.loraId ?? job.payload?.fileName ?? "LoRA import";
+  const family = job.payload?.manifestEntry?.family;
+  const progress = Number(job.progress);
+  const hasProgress = Number.isFinite(progress) && progress > 0;
+  return (
+    <div className="su-lora-slot su-lora-slot--pending">
+      <div className="su-lora-slot-head">
+        <span className="su-lora-slot-meta">
+          <strong>{name}</strong>
+          <small>{family ? `importing · family detected: ${normalizeLoraFamily(family)}` : "importing"}</small>
+        </span>
+        <span className="su-job-badge su-job-badge--running">Queued</span>
+      </div>
+      {/* Indeterminate until the job reports a percentage, then a real width — the same rule
+          SimpleJobCard follows, so a 0% bar never reads as "stuck". */}
+      <div className={hasProgress ? "su-bar" : "su-bar su-bar--indeterminate"}>
+        <span style={hasProgress ? { width: percent(progress) } : undefined} />
+      </div>
+      <p className="su-lora-note">Becomes selectable here when the Queue completes.</p>
+    </div>
+  );
+}

--- a/apps/web/src/simple/SimpleLoraSheet.jsx
+++ b/apps/web/src/simple/SimpleLoraSheet.jsx
@@ -1,0 +1,327 @@
+import React, { useMemo, useState } from "react";
+import { Icon } from "../components/Icons.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import {
+  loraHasResolvableFamily,
+  loraMatchesModel,
+  normalizeLoraFamily,
+} from "../presetUtils.js";
+import { loraMeta } from "./useSimpleLoras.js";
+
+// The Add LoRA sheet body (epic 15404): the picker list plus a collapsed inline import,
+// rendered inside Simple's ONE sheet chrome (`SimpleSheet`).
+//
+// The LoRA catalog is read LIVE from `useAppContext()` rather than handed in by the studio.
+// The sheet descriptor is held in shell state, so a body captured at open time would freeze
+// the list — and the one thing that must update while this is open is exactly that list: an
+// import queued from the panel below has to appear here when it completes.
+
+const FILE_ACCEPT = ".safetensors,.ckpt,.pt,.bin";
+
+/**
+ * @param {object} props
+ * @param {object|null} props.selectedModel
+ * @param {string[]} props.excludeIds - already-selected ids plus any LoRA the studio applies
+ *   itself (Simple's managed `image_edit` LoRA), which must never be offered here.
+ * @param {boolean} props.atLimit - at MAX_USER_JOB_LORAS.
+ * @param {(lora: object) => void} props.onAdd - adds the LoRA AND closes the sheet.
+ * @param {(job: object) => void} [props.onImportQueued]
+ */
+export function SimpleLoraSheet({ selectedModel, excludeIds = [], atLimit, onAdd, onImportQueued }) {
+  const { loras = [], createLoraImportJob, activeProject } = useAppContext();
+  const excluded = useMemo(() => new Set(excludeIds), [excludeIds]);
+
+  // The same eligibility predicate `useSimpleLoras` applies, over the live catalog. It is a
+  // filter over `presetUtils`, not a re-implementation: `loraMatchesModel` owns family
+  // matching and `loraHasResolvableFamily` owns the fail-closed unknown-family rule.
+  const availableLoras = useMemo(
+    () =>
+      loras.filter((lora) => {
+        if (lora.presetManaged || lora.installState === "missing" || excluded.has(lora.id)) {
+          return false;
+        }
+        return loraHasResolvableFamily(lora) && loraMatchesModel(lora, selectedModel);
+      }),
+    [loras, selectedModel, excluded],
+  );
+
+  const hasPendingCompatibleLoras =
+    Boolean(selectedModel) &&
+    loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
+  const emptyMessage = !selectedModel
+    ? "No model selected"
+    : hasPendingCompatibleLoras
+      ? "No installed compatible LoRAs. Imports appear after the Queue completes."
+      : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
+
+  // Nothing to pick ⇒ the import form starts open (sc-15373). The reason the list is empty
+  // and the fix for it belong in the same place; a collapsed row would hide the fix behind
+  // one more tap at exactly the moment it's needed.
+  const [importOpen, setImportOpen] = useState(availableLoras.length === 0);
+
+  return (
+    <>
+      {availableLoras.length ? (
+        <div className="su-lora-pick-list">
+          {availableLoras.map((lora) => {
+            // Builtins don't count against the user cap (they're auto-applied), so they stay
+            // pickable at the limit — the same rule the advanced picker's rows use.
+            const disabled = lora.scope !== "builtin" && atLimit;
+            return (
+              <button
+                className="su-lora-pick-row"
+                disabled={disabled}
+                key={lora.id}
+                onClick={() => onAdd(lora)}
+                type="button"
+              >
+                <span className="su-lora-pick-meta">
+                  <strong>{lora.name ?? lora.id}</strong>
+                  <small>{loraMeta(lora)}</small>
+                </span>
+                <span className="su-lora-pick-add">{disabled ? "Limit reached" : "Add"}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="su-lora-pick-empty">{emptyMessage}</p>
+      )}
+
+      <LoraImportSection
+        activeProject={activeProject}
+        createLoraImportJob={createLoraImportJob}
+        onOpenChange={setImportOpen}
+        onQueued={onImportQueued}
+        open={importOpen}
+      />
+    </>
+  );
+}
+
+// Model Manager's Import LoRA form reduced to the two cases Simple exposes — a file the user
+// already has, or a URL. Scope and Family are NOT surfaced: the importer auto-detects the
+// family and reports it back on the job, and the scope default (`project` when one is open,
+// else `global`) is the one `StudioLoraImportPanel` already uses.
+//
+// A <div role="group">, not a <form>: this can end up nested inside a screen that is already
+// a form, and nested forms are invalid HTML — so the submit rides a click handler.
+function LoraImportSection({ open, onOpenChange, activeProject, createLoraImportJob, onQueued }) {
+  const [form, setForm] = useState({
+    // Upload by default, matching Model Manager: most LoRAs are a file the user already has.
+    mode: "file",
+    sourceUrl: "",
+    file: null,
+    name: "",
+    triggerKeywords: [],
+  });
+  const [draftKeyword, setDraftKeyword] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [message, setMessage] = useState({ tone: "neutral", text: "" });
+  // Re-mounts the file input so choosing the SAME file twice still emits a change event.
+  const [fileInputKey, setFileInputKey] = useState(0);
+
+  const isFileImport = form.mode === "file";
+  const patch = (changes) => setForm((current) => ({ ...current, ...changes }));
+  const scope = activeProject ? "project" : "global";
+  const importDisabled =
+    importing || !createLoraImportJob || (isFileImport ? !form.file : !form.sourceUrl.trim());
+
+  const addKeyword = (raw) => {
+    const token = String(raw ?? "").trim();
+    setDraftKeyword("");
+    if (!token || form.triggerKeywords.some((keyword) => keyword.toLowerCase() === token.toLowerCase())) {
+      return;
+    }
+    patch({ triggerKeywords: [...form.triggerKeywords, token] });
+  };
+
+  const removeKeyword = (index) => {
+    patch({ triggerKeywords: form.triggerKeywords.filter((_, position) => position !== index) });
+  };
+
+  async function submit() {
+    if (importDisabled) {
+      return;
+    }
+    setImporting(true);
+    setMessage({
+      tone: "neutral",
+      text: isFileImport ? "Uploading LoRA file before queueing import." : "",
+    });
+    try {
+      const job = await createLoraImportJob({
+        ...(isFileImport ? { file: form.file } : { sourceUrl: form.sourceUrl.trim() }),
+        name: form.name.trim() || undefined,
+        scope,
+        triggerWords: form.triggerKeywords,
+      });
+      const loraId = job?.payload?.loraId;
+      // No `family` was sent, so whatever the importer detected is news — report it in the
+      // same normalized vocabulary every other surface uses.
+      const resolvedFamily = job?.payload?.manifestEntry?.family;
+      const detectionNote = resolvedFamily ? ` Detected family: ${normalizeLoraFamily(resolvedFamily)}.` : "";
+      patch({ sourceUrl: "", file: null, name: "", triggerKeywords: [] });
+      setFileInputKey((current) => current + 1);
+      setMessage({
+        tone: "success",
+        text: `${loraId ? `LoRA import queued for ${loraId}.` : "LoRA import queued."}${detectionNote}`,
+      });
+      onQueued?.(job);
+    } catch (err) {
+      // Never swallowed: the import surface is the only place this reason is shown.
+      setMessage({ tone: "error", text: err.message });
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <div aria-label="Import LoRA" className="su-lora-import" role="group">
+      <button
+        aria-expanded={open}
+        className="su-lora-import-trigger"
+        onClick={() => onOpenChange(!open)}
+        type="button"
+      >
+        <span aria-hidden="true" className="su-guide-num">
+          <Icon.Plus size={14} />
+        </span>
+        <span className="su-lora-import-label">
+          <strong>Import a LoRA</strong>
+          <small>From a URL or a file — family and scope are detected</small>
+        </span>
+        <span className={open ? "su-lora-import-chev open" : "su-lora-import-chev"}>
+          <Icon.ChevDown size={14} />
+        </span>
+      </button>
+
+      {open ? (
+        <div className="su-lora-import-panel">
+          <div aria-label="LoRA import source" className="su-switch" role="group">
+            <button
+              className={form.mode === "url" ? "active" : ""}
+              disabled={importing}
+              onClick={() => patch({ mode: "url" })}
+              type="button"
+            >
+              URL
+            </button>
+            <button
+              className={isFileImport ? "active" : ""}
+              disabled={importing}
+              onClick={() => patch({ mode: "file" })}
+              type="button"
+            >
+              Upload
+            </button>
+          </div>
+
+          {isFileImport ? (
+            <label className="su-lora-import-row">
+              LoRA file
+              <span className="su-lora-file">
+                <span className="su-lora-file-btn">
+                  Choose
+                  <input
+                    accept={FILE_ACCEPT}
+                    disabled={importing}
+                    key={fileInputKey}
+                    onChange={(event) => patch({ file: event.target.files?.[0] ?? null })}
+                    type="file"
+                  />
+                </span>
+                <span className="su-lora-file-name">{form.file?.name ?? "No file selected"}</span>
+              </span>
+            </label>
+          ) : (
+            <label className="su-lora-import-row">
+              Source URL
+              <input
+                className="su-input"
+                disabled={importing}
+                onChange={(event) => patch({ sourceUrl: event.target.value })}
+                placeholder="https://..."
+                value={form.sourceUrl}
+              />
+            </label>
+          )}
+
+          <label className="su-lora-import-row">
+            Name
+            <input
+              className="su-input"
+              disabled={importing}
+              onChange={(event) => patch({ name: event.target.value })}
+              placeholder="Optional"
+              value={form.name}
+            />
+          </label>
+
+          {/* KeywordTagEditor's behavior in Simple dress: commit on Enter or comma, and
+              Backspace on an empty draft removes the last chip. */}
+          <label className="su-lora-import-row">
+            Trigger keywords
+            {/* The wrapping <label> already focuses the draft input on a click anywhere in
+                the box, so the chips need no focus handler of their own. */}
+            <span className="su-lora-kw">
+              {form.triggerKeywords.map((keyword, index) => (
+                <span className="su-lora-kw-chip" key={`${keyword}-${index}`}>
+                  {keyword}
+                  <button
+                    aria-label={`Remove ${keyword}`}
+                    disabled={importing}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      removeKeyword(index);
+                    }}
+                    type="button"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              <input
+                disabled={importing}
+                onBlur={() => addKeyword(draftKeyword)}
+                onChange={(event) => setDraftKeyword(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === ",") {
+                    event.preventDefault();
+                    addKeyword(draftKeyword);
+                  } else if (event.key === "Backspace" && draftKeyword === "" && form.triggerKeywords.length) {
+                    event.preventDefault();
+                    removeKeyword(form.triggerKeywords.length - 1);
+                  }
+                }}
+                placeholder={form.triggerKeywords.length ? "" : "e.g. sksStyle — press Enter or comma to add"}
+                value={draftKeyword}
+              />
+            </span>
+          </label>
+
+          <button
+            className={importing ? "su-accent-btn busy" : "su-accent-btn"}
+            disabled={importDisabled}
+            onClick={submit}
+            type="button"
+          >
+            {importing ? (isFileImport ? "Uploading" : "Queueing…") : "Queue import"}
+          </button>
+          {importing ? (
+            <div className="su-bar su-bar--indeterminate">
+              <span />
+            </div>
+          ) : null}
+          {message.text ? (
+            <p className={`su-lora-import-msg su-lora-import-msg--${message.tone}`}>{message.text}</p>
+          ) : null}
+          <p className="su-lora-import-help">
+            Imported LoRAs land in your library and become selectable here once the import job completes — no
+            trip to Model Manager.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -301,14 +301,20 @@ export function SimpleShell({
 
         {sheet ? (
           <SimpleSheet onClose={() => setSheet(null)} phone={phone} title={sheet.title}>
-            <SimpleSheetOptions
-              kind={sheet.kind}
-              onSelect={(value) => {
-                sheet.onSelect(value);
-                setSheet(null);
-              }}
-              options={sheet.options}
-            />
+            {/* A screen may supply its own body (the Add LoRA picker + import, epic 15404)
+                instead of the three option shapes. The chrome — bottom sheet vs centered card,
+                Escape, backdrop, focus — is the same either way, which is the point: Simple
+                has ONE sheet. */}
+            {sheet.body ?? (
+              <SimpleSheetOptions
+                kind={sheet.kind}
+                onSelect={(value) => {
+                  sheet.onSelect(value);
+                  setSheet(null);
+                }}
+                options={sheet.options}
+              />
+            )}
           </SimpleSheet>
         ) : null}
 

--- a/apps/web/src/simple/SimpleUiContext.js
+++ b/apps/web/src/simple/SimpleUiContext.js
@@ -10,6 +10,7 @@ import { createContext, useContext } from "react";
 //   breakpoint  "phone" | "tablet" | "desktop"
 //   goTo(screenId)
 //   openSheet({ title, kind, options, onSelect })  — kind: "list" | "grid" | "pills"
+//   openSheet({ title, body })                     — a screen-supplied body in the same chrome
 //   closeSheet()
 //   openGuide()
 //   openPreview(asset, { play })  — `play: true` opens an audio asset already playing

--- a/apps/web/src/simple/SimpleVideoStudio.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.jsx
@@ -2,11 +2,15 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { videoModelServesMode } from "../modelEligibility.js";
+import { WAN_MOE_PAIRED_LORA_MODEL_IDS } from "../constants.js";
 import { buildSimpleVideoRequest } from "./simpleJobs.js";
 import { describeResolution, resolutionSummary } from "./aspect.js";
 import { preferredDuration, preferredVideoResolution } from "./modelDefaults.js";
 import { useSimpleRefine } from "./useSimpleRefine.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
+import { useSimpleLoras } from "./useSimpleLoras.js";
+import { SimpleLoraField, promptWithKeyword } from "./SimpleLoraField.jsx";
+import { SimpleLoraSheet } from "./SimpleLoraSheet.jsx";
 import {
   Chips,
   RefinePanel,
@@ -29,6 +33,10 @@ import {
 
 const DEFAULT_DURATIONS = [3, 5, 8, 10];
 const DEFAULT_RESOLUTIONS = ["1280x720", "720x1280", "720x720", "854x480"];
+// Context, not a warning (design handoff): the pairing is how the model works, not something
+// the user got wrong, so it reads as a hint line rather than a bordered notice.
+const MOE_LORA_HINT =
+  "Wan 2.2 A14B LoRAs are trained as a high/low-noise pair — selecting one loads both experts.";
 
 export function SimpleVideoStudio() {
   const {
@@ -39,9 +47,11 @@ export function SimpleVideoStudio() {
     videoLocalJobs = [],
     assets = [],
     recentImageAssets = [],
+    loras = [],
+    jobs = [],
     activeProject,
   } = useAppContext();
-  const { openGuide, toast } = useSimpleUi();
+  const { openSheet, closeSheet, openGuide, toast } = useSimpleUi();
   const refine = useSimpleRefine("video");
 
   const [mode, setMode] = useState("text_to_video");
@@ -108,6 +118,26 @@ export function SimpleVideoStudio() {
     [recentImageAssets, sourceAssetId],
   );
 
+  // User-picked LoRAs (epic 15404) — same hook, same eligibility and cap as the Image studio;
+  // the video lane just has no auto-applied managed LoRA to exclude.
+  const lora = useSimpleLoras({ loras, selectedModel, jobs });
+  const openLoraPicker = () =>
+    openSheet({
+      title: "Add LoRA",
+      body: (
+        <SimpleLoraSheet
+          atLimit={lora.atLimit}
+          excludeIds={lora.selectedLoraIds}
+          onAdd={(picked) => {
+            lora.addLora(picked);
+            closeSheet();
+          }}
+          onImportQueued={lora.noteImportJob}
+          selectedModel={selectedModel}
+        />
+      ),
+    });
+
   const latestJob = newestLocalJob(videoLocalJobs);
   const busy = submitting || jobIsRunning(latestJob);
   const needsSource = mode === "image_to_video" && !sourceAssetId;
@@ -132,6 +162,7 @@ export function SimpleVideoStudio() {
         duration,
         styleId,
         sourceAssetId,
+        loras: lora.serializedLoras,
       });
       if (!request) {
         toast("That resolution isn’t valid");
@@ -269,6 +300,19 @@ export function SimpleVideoStudio() {
           onChange={setDuration}
           options={durations.map((value) => ({ value, label: `${value}s` }))}
           value={duration}
+        />
+        <SimpleLoraField
+          atLimit={lora.atLimit}
+          availableLoras={lora.availableLoras}
+          effectiveLoraWeight={lora.effectiveLoraWeight}
+          hint={WAN_MOE_PAIRED_LORA_MODEL_IDS.has(selectedModel?.id) ? MOE_LORA_HINT : null}
+          onAddKeyword={(keyword) => setPrompt((current) => promptWithKeyword(current, keyword))}
+          onOpenPicker={openLoraPicker}
+          onRemove={lora.removeLora}
+          onWeightChange={lora.setLoraWeight}
+          pendingImports={lora.pendingImports}
+          selectedLoras={lora.selectedLoras}
+          selectedModel={selectedModel}
         />
       </div>
 

--- a/apps/web/src/simple/simple.css
+++ b/apps/web/src/simple/simple.css
@@ -756,6 +756,462 @@
   font-weight: 700;
 }
 
+/* ---------- LoRA field (settings-bar row + Add LoRA sheet) ---------- */
+
+.su-lora-field {
+  gap: 7px;
+}
+
+/* Label + status on one baseline, matching the advanced `.lora-picker-head`. */
+.su-lora-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.su-lora-head > span {
+  font-size: 11px;
+  color: var(--text-faint);
+  text-align: right;
+}
+
+.su-lora-stack {
+  display: grid;
+  gap: 7px;
+}
+
+.su-lora-slot {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+}
+
+/* A queued import isn't a selection yet — the dashed accent edge says "on its way". */
+.su-lora-slot--pending {
+  border-style: dashed;
+  border-color: color-mix(in oklch, var(--accent) 45%, var(--border));
+}
+
+.su-lora-slot-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.su-lora-slot-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.su-lora-slot-meta strong {
+  display: block;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-lora-slot-meta small {
+  display: block;
+  margin-top: 1px;
+  font-size: 10.5px;
+  color: var(--text-faint);
+}
+
+.su-lora-remove {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--r-xs);
+  background: var(--surface);
+  color: var(--text-faint);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease-out), color var(--t-fast) var(--ease-out);
+}
+
+.su-lora-remove:hover {
+  border-color: color-mix(in oklch, var(--danger) 45%, var(--border));
+  color: color-mix(in oklch, var(--danger) 75%, var(--text));
+}
+
+.su-lora-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+
+/* Buttons, not labels: a trigger word does nothing until it is in the prompt, so the whole
+   point of showing one is being able to put it there. */
+.su-lora-keyword {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease-out), background var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.su-lora-keyword:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.su-lora-keyword-hint {
+  font-size: 10px;
+  color: var(--text-faint);
+}
+
+.su-lora-weight {
+  display: grid;
+  gap: 3px;
+}
+
+.su-lora-weight > label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.su-lora-weight-value {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.su-lora-weight input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.su-lora-add {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: var(--control-h);
+  padding: 0 11px;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--accent-strong);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease-out), background var(--t-fast) var(--ease-out);
+}
+
+.su-lora-add:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.su-lora-add-count {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-faint);
+}
+
+.su-lora-note {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+/* Context, not a warning — so no border, no danger/warm tint. */
+.su-lora-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.su-lora-hint svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--text-faint);
+}
+
+/* ---------- Add LoRA sheet body ---------- */
+
+.su-lora-pick-list {
+  display: grid;
+  gap: 4px;
+}
+
+.su-lora-pick-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 11px 12px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.su-lora-pick-row:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.su-lora-pick-row:disabled {
+  cursor: default;
+}
+
+.su-lora-pick-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.su-lora-pick-meta strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-lora-pick-meta small {
+  display: block;
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+.su-lora-pick-add {
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.su-lora-pick-row:disabled .su-lora-pick-add {
+  color: var(--text-faint);
+}
+
+.su-lora-pick-empty {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.su-lora-import {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.su-lora-import-trigger {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 6px 0;
+  border: 0;
+  background: none;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.su-lora-import-label {
+  flex: 1;
+  min-width: 0;
+}
+
+.su-lora-import-label strong {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.su-lora-import-label small {
+  display: block;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.su-lora-import-chev {
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--text-faint);
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.su-lora-import-chev.open {
+  transform: rotate(180deg);
+}
+
+.su-lora-import-panel {
+  display: grid;
+  gap: 10px;
+  margin-top: 6px;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
+
+.su-lora-import-row {
+  display: grid;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.su-lora-import-row .su-input {
+  width: 100%;
+}
+
+.su-lora-file {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* The real <input type="file"> is hidden inside this span, so the visible control is a
+   button-shaped label rather than the browser's own widget. */
+.su-lora-file-btn {
+  display: inline-flex;
+  align-items: center;
+  height: var(--control-h);
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.su-lora-file-btn input {
+  display: none;
+}
+
+.su-lora-file-name {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 400;
+  color: var(--text-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.su-lora-kw {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  min-height: var(--control-h);
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+}
+
+.su-lora-kw input {
+  flex: 1;
+  min-width: 120px;
+  border: 0;
+  background: none;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  font-weight: 400;
+}
+
+.su-lora-kw input:focus-visible {
+  outline: none;
+}
+
+.su-lora-kw-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-pill);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+}
+
+.su-lora-kw-chip button {
+  border: 0;
+  background: none;
+  color: var(--text-faint);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.su-lora-import-msg {
+  margin: 0;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.su-lora-import-msg--neutral {
+  color: var(--text-muted);
+}
+
+.su-lora-import-msg--success {
+  color: color-mix(in oklch, var(--success) 74%, var(--text));
+}
+
+.su-lora-import-msg--error {
+  color: var(--danger);
+}
+
+.su-lora-import-help {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
 /* ---------- Style strip ---------- */
 
 .su-style-strip {

--- a/apps/web/src/simple/simpleJobs.js
+++ b/apps/web/src/simple/simpleJobs.js
@@ -171,6 +171,9 @@ export function referenceStrengthFor(model) {
  * @param {number} [input.img2imgStrength] - from referenceStrengthFor(selectedModel).
  * @param {object|null} [input.editLora] - the model's managed `image_edit`-role LoRA catalog entry
  *   (findModelEditLora), auto-applied in edit mode. Null for models needing none.
+ * @param {object[]} [input.loras] - already-serialized picker selections (epic 15404). The
+ *   Simple LoRA field produces `serializeLora(lora, { weight })` entries, so this is the same
+ *   array the advanced studio sends for the same picks.
  * @param {string} [input.quantTier] / @param {boolean} [input.tierExplicit] - from resolveSimpleTier.
  * @returns {object|null} the payload for createImageJob, or null when the resolution is invalid.
  */
@@ -185,6 +188,7 @@ export function buildSimpleImageRequest({
   supportsImg2img = false,
   img2imgStrength = DEFAULT_IMG2IMG_STRENGTH,
   editLora = null,
+  loras: selectedLoras = [],
   quantTier = "",
   tierExplicit = false,
 }) {
@@ -203,7 +207,15 @@ export function buildSimpleImageRequest({
   // manages this for the user rather than exposing it in the LoRA picker, which is exactly the
   // Simple behavior; it just has to actually be applied. `serializeLora` round-trips
   // `conditioningRole`, which is what the worker's role check reads.
-  const loras = editing && editLora ? [serializeLora(editLora)] : [];
+  //
+  // It rides on TOP of the user's picks and is de-duplicated by id, mirroring ImageStudio's
+  // `buildLorasPayload`: it is not a picker entry, but it does occupy one of the run's
+  // MAX_JOB_LORAS_TOTAL slots — which is exactly why the picker's own cap is the lower
+  // MAX_USER_JOB_LORAS.
+  const loras = [...selectedLoras];
+  if (editing && editLora && !loras.some((entry) => entry.id === editLora.id)) {
+    loras.push(serializeLora(editLora));
+  }
   return buildImageJobRequest({
     ...IMAGE_DEFAULTS,
     loras,
@@ -241,6 +253,9 @@ export function buildSimpleVideoRequest({
   duration,
   styleId,
   sourceAssetId,
+  // Already-serialized picker selections (epic 15404) — `serializeLora(lora, { weight })`,
+  // the same entries VideoStudio posts.
+  loras = [],
 }) {
   const size = parseResolutionPair(resolution);
   if (!size) {
@@ -278,7 +293,7 @@ export function buildSimpleVideoRequest({
     referenceClipAssetId: null,
     personTrackId: null,
     replacementMode: "face_only",
-    loras: [],
+    loras,
     advanced: {
       resolution,
       ...(styleApplied ? { styleId, stylePrompt: prompt } : {}),

--- a/apps/web/src/simple/simpleJobs.test.js
+++ b/apps/web/src/simple/simpleJobs.test.js
@@ -243,6 +243,40 @@ describe("buildSimpleImageRequest", () => {
     expect(request.loras).toEqual([]);
   });
 
+  // The Simple LoRA field (epic 15404) hands over already-serialized entries, so the builder's
+  // only job is to carry them and stack the managed edit LoRA on top.
+  const PICKED = { id: "lora_grain", name: "Cinematic Grain 35mm", scope: "global", weight: 1.25 };
+
+  it("carries the picked LoRAs onto a text run", () => {
+    const request = buildSimpleImageRequest({ ...base, loras: [PICKED] });
+    expect(request.loras).toEqual([PICKED]);
+  });
+
+  it("stacks the managed edit LoRA on top of the user's picks", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      mode: "edit_image",
+      referenceAssetId: "asset-7",
+      editLora: KREA_EDIT_LORA,
+      loras: [PICKED],
+    });
+    expect(request.loras.map((entry) => entry.id)).toEqual(["lora_grain", "krea2_identity_edit"]);
+  });
+
+  // The picker hides the managed edit LoRA, but a payload rebuilt from a restored selection
+  // could still carry it — sending it twice would burn a second of the run's five slots on a
+  // duplicate. Mirrors ImageStudio's `buildLorasPayload` dedupe.
+  it("does not send the managed edit LoRA twice when it is already in the picks", () => {
+    const request = buildSimpleImageRequest({
+      ...base,
+      mode: "edit_image",
+      referenceAssetId: "asset-7",
+      editLora: KREA_EDIT_LORA,
+      loras: [{ id: "krea2_identity_edit", weight: 0.9 }],
+    });
+    expect(request.loras).toEqual([{ id: "krea2_identity_edit", weight: 0.9 }]);
+  });
+
   it("emits no img2img fields at all when nothing is armed", () => {
     const request = buildSimpleImageRequest({ ...base, supportsImg2img: true });
     expect(request.referenceAssetId).toBeNull();
@@ -338,6 +372,12 @@ describe("buildSimpleVideoRequest", () => {
     const request = buildSimpleVideoRequest(base);
     expect(Object.keys(request.advanced)).toEqual(["resolution"]);
     expect(request.presetPromptResolvedClientSide).toBeUndefined();
+  });
+
+  it("carries the picked LoRAs, and still sends an empty array when there are none", () => {
+    const picked = { id: "lora_dolly", name: "Slow Dolly Push", scope: "global", weight: 0.75 };
+    expect(buildSimpleVideoRequest({ ...base, loras: [picked] }).loras).toEqual([picked]);
+    expect(buildSimpleVideoRequest(base).loras).toEqual([]);
   });
 });
 

--- a/apps/web/src/simple/useSimpleLoras.js
+++ b/apps/web/src/simple/useSimpleLoras.js
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  MAX_USER_JOB_LORAS,
+  loraHasResolvableFamily,
+  loraMatchesModel,
+  loraWeight,
+  serializeLora,
+} from "../presetUtils.js";
+import { terminalStatuses } from "../jobTypes.js";
+
+// LoRA selection for the Simple studios (epic 15404).
+//
+// This deliberately MIRRORS `useGenerationStudio`'s LoRA bundle rather than inventing a
+// second contract: same eligibility predicates, same per-user cap, same prune guard, same
+// weight fallback. Simple shows fewer knobs — no "Show incompatible", no scope/family
+// pickers — but a Simple run's `loras` array is the array the advanced studio would send
+// for the same picks.
+
+/** `scope · family` (or just the scope) — the same meta line `LoraPickerSection` renders. */
+export function loraMeta(lora) {
+  const scope = lora.scope ?? "global";
+  return lora.family ? `${scope} · ${lora.family}` : scope;
+}
+
+/**
+ * @param {object} input
+ * @param {object[]} input.loras - the live LoRA catalog from `useAppContext()`.
+ * @param {object|null} input.selectedModel - the studio's resolved catalog model.
+ * @param {object[]} [input.jobs] - the live job feed, for pending `lora_import` runs.
+ * @param {string|null} [input.excludeLoraId] - a LoRA the studio applies itself and must not
+ *   also offer in the picker (Simple's edit mode auto-applies Krea's managed `image_edit`
+ *   LoRA — the advanced studio hides it from its picker the same way).
+ */
+export function useSimpleLoras({ loras = [], selectedModel, jobs = [], excludeLoraId = null }) {
+  const [selectedLoraIds, setSelectedLoraIds] = useState([]);
+  const [weightOverrides, setWeightOverrides] = useState({});
+  // Only the IDS of imports started from this studio's sheet. Status, progress and the
+  // detected family are read LIVE off the job feed on every render — the pending slot must
+  // not carry a second, drifting copy of what the Queue already knows.
+  const [importJobIds, setImportJobIds] = useState([]);
+
+  const compatibleLoras = useMemo(
+    () =>
+      loras.filter((lora) => {
+        if (lora.presetManaged || lora.installState === "missing") {
+          return false;
+        }
+        if (excludeLoraId && lora.id === excludeLoraId) {
+          return false;
+        }
+        // Fails CLOSED on an unknown family (sc-10509): the API's generate-time gate 400s on
+        // an empty family, so a family-less LoRA would be a dead-end selection. Simple has no
+        // "Show incompatible" escape hatch, so this is unconditional here.
+        if (!loraHasResolvableFamily(lora)) {
+          return false;
+        }
+        return loraMatchesModel(lora, selectedModel);
+      }),
+    [loras, selectedModel, excludeLoraId],
+  );
+  const compatibleLoraKey = useMemo(() => compatibleLoras.map((lora) => lora.id).join("|"), [compatibleLoras]);
+
+  const selectedLoras = useMemo(
+    () => selectedLoraIds.map((id) => compatibleLoras.find((lora) => lora.id === id)).filter(Boolean),
+    [selectedLoraIds, compatibleLoras],
+  );
+  const availableLoras = useMemo(
+    () => compatibleLoras.filter((lora) => !selectedLoraIds.includes(lora.id)),
+    [compatibleLoras, selectedLoraIds],
+  );
+  const userSelectedLoraCount = selectedLoras.filter((lora) => lora.scope !== "builtin").length;
+  const atLimit = userSelectedLoraCount >= MAX_USER_JOB_LORAS;
+
+  const hasPendingCompatibleLoras =
+    Boolean(selectedModel) &&
+    loras.some((lora) => lora.installState === "missing" && loraMatchesModel(lora, selectedModel));
+  // Verbatim from `LoraPickerSection` minus its "Show incompatible" branch, which Simple
+  // doesn't expose.
+  const loraEmptyMessage = !selectedModel
+    ? "No model selected"
+    : hasPendingCompatibleLoras
+      ? "No installed compatible LoRAs. Imports appear after the Queue completes."
+      : `No installed LoRAs match ${selectedModel.name ?? selectedModel.id}.`;
+
+  // Drop selections that fall out of the compatible set on a model change. Guarded on loaded
+  // inputs exactly as sc-11962 guards the advanced prune: `compatibleLoras` is empty both when
+  // the catalog hasn't resolved AND when the model hasn't, and running the filter during that
+  // window would strip selections permanently.
+  useEffect(() => {
+    if (!loras.length || !selectedModel) {
+      return;
+    }
+    setSelectedLoraIds((ids) => {
+      const kept = ids.filter((id) => compatibleLoras.some((lora) => lora.id === id));
+      return kept.length === ids.length ? ids : kept;
+    });
+  }, [loras.length, selectedModel, compatibleLoraKey, compatibleLoras]);
+
+  const effectiveLoraWeight = useCallback(
+    (lora) => {
+      const override = weightOverrides[lora.id];
+      return Number.isFinite(override) ? override : loraWeight(lora);
+    },
+    [weightOverrides],
+  );
+
+  const addLora = useCallback((lora) => {
+    setSelectedLoraIds((ids) => (ids.includes(lora.id) ? ids : [...ids, lora.id]));
+  }, []);
+
+  const removeLora = useCallback((lora) => {
+    setSelectedLoraIds((ids) => ids.filter((id) => id !== lora.id));
+    // The override goes with it, so re-adding the LoRA starts from its own default again
+    // rather than silently inheriting a weight the user set for a selection they removed.
+    setWeightOverrides((current) => {
+      if (!(lora.id in current)) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[lora.id];
+      return next;
+    });
+  }, []);
+
+  const setLoraWeight = useCallback((id, value) => {
+    setWeightOverrides((current) => ({ ...current, [id]: value }));
+  }, []);
+
+  const noteImportJob = useCallback((job) => {
+    if (job?.id) {
+      setImportJobIds((ids) => (ids.includes(job.id) ? ids : [...ids, job.id]));
+    }
+  }, []);
+
+  // Resolved against the live feed each render, so a slot disappears the moment the import
+  // reaches a terminal status — no local progress model, no polling.
+  const pendingImports = useMemo(
+    () =>
+      importJobIds
+        .map((id) => jobs.find((job) => job.id === id))
+        .filter((job) => Boolean(job) && !terminalStatuses.has(job.status)),
+    [importJobIds, jobs],
+  );
+
+  // The outgoing payload entries — the same `serializeLora` shape the advanced studios send.
+  const serializedLoras = useMemo(
+    () => selectedLoras.map((lora) => serializeLora(lora, { weight: effectiveLoraWeight(lora) })),
+    [selectedLoras, effectiveLoraWeight],
+  );
+
+  return {
+    selectedLoraIds,
+    selectedLoras,
+    compatibleLoras,
+    availableLoras,
+    userSelectedLoraCount,
+    atLimit,
+    loraEmptyMessage,
+    effectiveLoraWeight,
+    addLora,
+    removeLora,
+    setLoraWeight,
+    noteImportJob,
+    pendingImports,
+    serializedLoras,
+  };
+}


### PR DESCRIPTION
Recreates the `design/LoRA support in Simple UI.zip` handoff (epic [sc-15404](https://app.shortcut.com/trefry/epic/15404)) inside `apps/web`. LoRAs were only reachable from the Advanced workspace and Model Manager; the Simple shell exposed none, and `buildSimpleImageRequest` / `buildSimpleVideoRequest` hardcoded `loras: []`.

Simple's rule holds: **the reduced surface is which knobs are shown, not what gets submitted.** The control emits the same `serializeLora(lora, { weight })` entries the advanced studios send.

## What landed

- **LoRA field** as the last child of the existing `.su-settings-bar` in Image + Video — slots with `scope · family`, remove ×, a −2…2 weight slider, and the `Add LoRA` row with its `· n available` count. Status copy is lifted verbatim from `LoraPickerSection`.
- **Trigger-keyword chips are buttons** — clicking one appends the keyword to the prompt (case-insensitive no-op if already present). That is the whole reason keywords are surfaced; a trigger word does nothing while it sits in a chip. Notes stay out of Simple.
- **Add LoRA sheet** in Simple's one `SimpleSheet` chrome, with the picker list and `loraEmptyMessage` verbatim.
- **Inline LoRA import** collapsed inside that sheet (URL / Upload, name, trigger keywords), through the same `createLoraImportJob` seam Model Manager posts. Scope and Family aren't exposed — the importer detects the family and reports it back.
- **Pending-import slot** driven entirely from the live job feed the Queue renders.
- **Video-only A14B hint** for the models whose LoRAs come as a high/low-noise pair.

## Notes for review

- `SimpleShell`'s sheet descriptor gained an optional `body`, so a screen can supply its own content in the one sheet chrome. The LoRA sheet body reads `loras` live from `useAppContext()` rather than taking it as a prop — the descriptor lives in shell state, so a captured list would freeze exactly when it must update (an import completing while the sheet is open).
- Eligibility is not re-implemented: `loraMatchesModel` / `loraHasResolvableFamily` / `presetManaged` / `installState`. The prune guard is sc-11962's, ported.
- The cap is `MAX_USER_JOB_LORAS` (4), not the mock's 5 — the mock's extra slot is the one Simple's edit mode auto-fills with Krea's managed `image_edit` LoRA. That LoRA is excluded from the picker and de-duplicated in the payload.
- `ModelManagerScreen`'s local `WAN_MOE_BASE_MODELS` moved to `constants.js` so the video hint and the paired-upload slot share one definition. Behavior unchanged.

## Known gap — filed, not buried

The handoff says selections "persist with the rest of the studio's snapshot". **There is no such snapshot.** `SimpleShell` unmounts each studio on navigation, so prompt, model, resolution, style and the armed reference all reset today — this predates the LoRA work. LoRA-only persistence was deliberately not built: restoring a LoRA against a model that reset to the catalog default would be worse than resetting both. Tracked as [sc-15412](https://app.shortcut.com/trefry/story/15412) with the open questions (session vs durable, per-project, and the desktop-localStorage constraint).

## Verification

- `npm test` in `apps/web`: 2871 passed / 206 files. `npx eslint src`: clean.
- 24 new tests in `SimpleLora.test.jsx`, driven through the real shell and `AppContext` so the assertions are on the actual outgoing payload. Both prune cases were mutation-checked — they pin different things and each fails on its own mutation.
- Visually checked against `screenshots/01`–`10` at all three measured bands (desktop / phone bottom sheet) plus dark theme, via a temporary Vite entry over a fake context (removed before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
