### PR TITLE
fix(web): Video Editor nav dot reflects activity, not a saved timeline

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -15,6 +15,7 @@ import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
 import { FullscreenPreview, assetSeed } from "./components/assetPanels.jsx";
 import { fallbackModels, isLibraryAsset, terminalStatuses } from "./constants.js";
+import { isEditorJob } from "./jobTypes.js";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
 import { editModelForAsset, workflowModelType } from "./presetUtils.js";
 import { sortNewest, sortWorkers, upsertJobNewest } from "./sorters.js";
@@ -2818,8 +2819,11 @@ export function App() {
   // (sc-11959): it mounts on first visit and then stays mounted (hidden) thereafter.
   const keepAliveMounted = (view) => activeView === view || visitedKeepAliveViews.has(view);
   // Activity dots only — counts live in the topbar so nav button textContent stays clean.
+  // The Editor dot means editor work is IN FLIGHT (export / frame extract / timeline-
+  // initiated generation). It used to be `timelines.length > 0`, which lit permanently
+  // once a project had a single saved timeline and so never signalled activity at all.
   const activeIndicators = {
-    Editor: timelines.length > 0,
+    Editor: jobs.some((job) => !terminalStatuses.has(job.status) && isEditorJob(job)),
     Queue: queueCounts.active > 0,
   };
   // First-run gate: until at least one workspace exists, replace the studio area

--- a/apps/web/src/App.navActivity.test.jsx
+++ b/apps/web/src/App.navActivity.test.jsx
@@ -1,0 +1,126 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+
+// The Video Editor nav dot must mean "editor work is running", not "a timeline
+// exists" — the latter lit permanently after the first saved timeline was created.
+describe("sidebar activity dots", () => {
+  let container;
+  let root;
+
+  const TIMELINE = {
+    id: "timeline-1",
+    name: "Cut 1",
+    aspectRatio: "16:9",
+    fps: 30,
+    width: 1280,
+    height: 720,
+    tracks: [{ id: "track_main", name: "Main", items: [] }],
+  };
+
+  async function mount({ jobs = [], timelines = [TIMELINE] } = {}) {
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-a", name: "Project A" }]));
+      }
+      if (path.endsWith("/api/v1/jobs")) {
+        return Promise.resolve(response(jobs));
+      }
+      if (path.endsWith("/timelines")) {
+        return Promise.resolve(response(timelines));
+      }
+      if (path.match(/\/timelines\/[^/]+$/)) {
+        return Promise.resolve(response(timelines[0]));
+      }
+      return Promise.resolve(response([]));
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+    // Timelines hydrate on first navigation to the Editor route (sc-14783), so the
+    // "a timeline exists" state only becomes reachable after visiting it.
+    await navigate("Video Editor");
+  }
+
+  async function navigate(label) {
+    const button = [...container.querySelectorAll(".nav-item")].find(
+      (candidate) => candidate.textContent.trim() === label,
+    );
+    expect(button, `navigation button ${label}`).toBeTruthy();
+    await act(async () => {
+      button.click();
+    });
+    await settle();
+  }
+
+  function editorNavDot() {
+    const button = [...container.querySelectorAll("button.nav-item")].find(
+      (candidate) => candidate.textContent.trim() === "Video Editor",
+    );
+    return button?.querySelector(".nav-pulse") ?? null;
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("leaves the Video Editor dot off when a loaded timeline is idle", async () => {
+    await mount({ jobs: [{ id: "job-1", type: "image_generate", status: "running" }] });
+
+    expect(editorNavDot()).toBeNull();
+  });
+
+  it("lights the Video Editor dot while an export is in flight", async () => {
+    await mount({ jobs: [{ id: "job-1", type: "timeline_export", status: "running" }] });
+
+    expect(editorNavDot()).not.toBeNull();
+  });
+
+  it("lights the Video Editor dot for timeline-initiated generation", async () => {
+    await mount({
+      jobs: [
+        {
+          id: "job-1",
+          type: "video_generate",
+          status: "queued",
+          payload: { advanced: { timelineAction: "bridge" } },
+        },
+      ],
+    });
+
+    expect(editorNavDot()).not.toBeNull();
+  });
+
+  it("drops the Video Editor dot once the editor job reaches a terminal status", async () => {
+    await mount({ jobs: [{ id: "job-1", type: "timeline_export", status: "completed" }] });
+
+    expect(editorNavDot()).toBeNull();
+  });
+});

--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -38,6 +38,19 @@ export const NON_GPU_JOB_TYPES = new Set([
   "lora_download",
 ]);
 
+// Job types the Video Editor itself queues (timeline export + frame extraction).
+// Timeline-initiated generation (extend/bridge) rides `video_generate` and is
+// recognized by `advanced.timelineAction` instead — see `isEditorJob`.
+export const EDITOR_JOB_TYPES = new Set(["timeline_export", "frame_extract"]);
+
+// True when a job represents work the Video Editor started, either through a
+// dedicated editor job type or a timeline-initiated generation.
+export function isEditorJob(job) {
+  return (
+    EDITOR_JOB_TYPES.has(job?.type) || Boolean(job?.payload?.advanced?.timelineAction)
+  );
+}
+
 // Terminal job statuses (no further progress expected).
 export const terminalStatuses = new Set(["completed", "failed", "canceled", "interrupted"]);
 


### PR DESCRIPTION
## What does this PR do?

The sidebar activity dot next to **Video Editor** was always on. It was driven by `timelines.length > 0`, so it lit permanently once a project had a single saved timeline — it never signalled activity. Its sibling indicator (Queue) correctly reflects in-flight jobs.

This drives the Editor dot from actual editor work in flight:

- `apps/web/src/jobTypes.js` — adds `EDITOR_JOB_TYPES` (`timeline_export`, `frame_extract`) and `isEditorJob(job)`, which also recognizes timeline-initiated generation. Extend/bridge from the timeline rides `video_generate` and is identified by `payload.advanced.timelineAction`.
- `apps/web/src/App.jsx` — `Editor: jobs.some((job) => !terminalStatuses.has(job.status) && isEditorJob(job))`.

Job-type spellings mirror the backend (`crates/sceneworks-core/src/contracts.rs`: `TimelineExport => "timeline_export"`, `FrameExtract => "frame_extract"`).

## Related issue

n/a — reported directly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

New `apps/web/src/App.navActivity.test.jsx` covers four states: idle with a saved timeline (dot off), export in flight (on), timeline-initiated generation (on), terminal export (off).

Reviewer note: the test navigates to the Editor route before asserting, because timelines only hydrate on first visit to that route (sc-14783). Without that navigation the "a timeline exists" state is never reached and the off-cases pass trivially — the first draft was that false green. Mutation-checked: restoring `timelines.length > 0` fails exactly the two off-cases.

Not browser-verified — reproducing the lit state needs a live backend with an in-flight timeline export; the tests cover the transitions instead.

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed — n/a, no Rust changes
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (lint clean; 207 files / 2875 tests pass; build ok)
- [x] I ran `npm run check` (scaffold checks)
- [ ] I updated documentation where relevant — none needed
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)