### PR TITLE
fix(simple-ui): picker sheet jump, and studio settings that reset on navigation and relaunch

### DIFF
--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -75,6 +75,57 @@ pub(crate) struct UiPreferences {
     /// registry on load, so a detached or relocated catalog degrades to another item.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     selected_catalog_id: Option<String>,
+    /// Simple-UI studio settings — the DURABLE form of the Simple studios' own knobs (model,
+    /// prompt, resolution, LoRA picks, …). The Simple shell renders one screen at a time, so a
+    /// studio unmounts on navigation; the shell keeps a session copy, and this is what makes
+    /// that copy outlive a relaunch. The advanced studios solve the same problem with a
+    /// per-workspace `localStorage` blob (`hooks/useStudioSettings.js`), which is exactly what
+    /// the desktop shell's per-launch `127.0.0.1:<port>` origin wipes — hence the server copy
+    /// here rather than a second localStorage store.
+    ///
+    /// Shape: `{ [workspaceId]: { [studio]: { [field]: value } } }`. Keyed by WORKSPACE to match
+    /// the advanced studios: a prompt written for one project must not follow the user into
+    /// another. The field vocabulary is the frontend's and values are stored verbatim — this is
+    /// the same stance as `per_model_tier`, so adding a Simple knob needs no server change.
+    /// A PUT carrying this field replaces the whole map (the web sends the full merged map from
+    /// its cache), and a PUT without it leaves the stored map untouched.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    simple_studio: Option<BTreeMap<String, serde_json::Value>>,
+}
+
+/// Retained workspaces in `simple_studio`. The map grows by one entry per workspace the user
+/// opens a Simple studio in and nothing ever removes an entry, so without a bound a long-lived
+/// install would carry every workspace it has ever seen — each holding a full prompt — in a file
+/// re-read and rewritten on every preference write. The web prunes to the same bound on its side;
+/// this is the backstop for a client that doesn't.
+const MAX_SIMPLE_STUDIO_WORKSPACES: usize = 24;
+
+/// Serialized bytes allowed for one workspace's studio snapshot. Prompts are free text, so this
+/// bounds what a single entry can cost; an oversized entry is DROPPED rather than truncated,
+/// because a half-parsed snapshot would restore a studio into a state the user never chose.
+const MAX_SIMPLE_STUDIO_ENTRY_BYTES: usize = 64 * 1024;
+
+/// Keep the well-formed, in-budget entries of a `simple_studio` map.
+///
+/// Entries must be JSON objects (the `{ [studio]: { … } }` shape the web writes); anything else is
+/// a client bug or a hand-edited file, and storing it would hand the web back something it can't
+/// read. Over-budget entries are dropped. When more than `MAX_SIMPLE_STUDIO_WORKSPACES` survive,
+/// the retained set is the first N by key order — arbitrary but STABLE, so repeated PUTs of the
+/// same oversized map converge instead of thrashing the file.
+fn normalize_simple_studio(
+    input: BTreeMap<String, serde_json::Value>,
+) -> BTreeMap<String, serde_json::Value> {
+    input
+        .into_iter()
+        .filter(|(workspace, snapshot)| {
+            !workspace.trim().is_empty()
+                && snapshot.is_object()
+                && serde_json::to_string(snapshot)
+                    .map(|body| body.len() <= MAX_SIMPLE_STUDIO_ENTRY_BYTES)
+                    .unwrap_or(false)
+        })
+        .take(MAX_SIMPLE_STUDIO_WORKSPACES)
+        .collect()
 }
 
 /// User-selectable accent palettes. Keep in sync with web/src/accents.js.
@@ -242,6 +293,12 @@ pub(crate) async fn set_ui_preferences(
         if let Some(per_model_tier) = payload.per_model_tier {
             prefs.per_model_tier = Some(per_model_tier);
         }
+        // Replaced wholesale ONLY when the payload carries it, like `per_model_tier` above — the
+        // web sends the full merged map from its cache, so a theme- or view-only PUT never
+        // clobbers a stored snapshot.
+        if let Some(simple_studio) = payload.simple_studio {
+            prefs.simple_studio = Some(normalize_simple_studio(simple_studio));
+        }
         if let Some(active_view) = normalize_preference_id(payload.active_view.as_deref(), 48) {
             prefs.active_view = Some(active_view);
         }
@@ -272,9 +329,85 @@ pub(crate) async fn set_ui_preferences(
 #[cfg(test)]
 mod tests {
     use super::{
-        migrate_quality_to_auto, normalize_accent, normalize_generation_quality, normalize_theme,
-        UiPreferences,
+        migrate_quality_to_auto, normalize_accent, normalize_generation_quality,
+        normalize_simple_studio, normalize_theme, UiPreferences, MAX_SIMPLE_STUDIO_ENTRY_BYTES,
+        MAX_SIMPLE_STUDIO_WORKSPACES,
     };
+    use std::collections::BTreeMap;
+
+    fn snapshot(prompt: &str) -> serde_json::Value {
+        serde_json::json!({ "image": { "prompt": prompt, "model": "z_image" } })
+    }
+
+    #[test]
+    fn normalize_simple_studio_keeps_well_formed_entries_verbatim() {
+        let mut input = BTreeMap::new();
+        input.insert("project-1".to_owned(), snapshot("a lighthouse"));
+        let kept = normalize_simple_studio(input);
+        // Values are stored verbatim — the field vocabulary belongs to the frontend, so a new
+        // Simple knob must not need a server change to survive a round trip.
+        assert_eq!(kept.get("project-1"), Some(&snapshot("a lighthouse")));
+    }
+
+    #[test]
+    fn normalize_simple_studio_drops_malformed_and_oversized_entries() {
+        let mut input = BTreeMap::new();
+        input.insert("ok".to_owned(), snapshot("fine"));
+        // Not an object: a client bug or a hand-edited file. Storing it would hand the web back
+        // something it cannot read.
+        input.insert("scalar".to_owned(), serde_json::json!("not-an-object"));
+        input.insert("null".to_owned(), serde_json::Value::Null);
+        // Blank workspace key — nothing to key a restore on.
+        input.insert("   ".to_owned(), snapshot("blank key"));
+        // Over the per-entry budget: dropped whole, never truncated.
+        input.insert(
+            "huge".to_owned(),
+            snapshot(&"x".repeat(MAX_SIMPLE_STUDIO_ENTRY_BYTES + 1)),
+        );
+
+        let kept = normalize_simple_studio(input);
+        assert_eq!(kept.keys().collect::<Vec<_>>(), vec!["ok"]);
+    }
+
+    #[test]
+    fn normalize_simple_studio_bounds_the_workspace_count_stably() {
+        let over = MAX_SIMPLE_STUDIO_WORKSPACES + 5;
+        let build = || {
+            (0..over)
+                .map(|n| (format!("project-{n:03}"), snapshot("p")))
+                .collect::<BTreeMap<_, _>>()
+        };
+        let kept = normalize_simple_studio(build());
+        assert_eq!(kept.len(), MAX_SIMPLE_STUDIO_WORKSPACES);
+        // Stable across repeated PUTs of the same map, so the file converges rather than
+        // thrashing a different retained set on every write.
+        assert_eq!(kept, normalize_simple_studio(build()));
+    }
+
+    #[test]
+    fn simple_studio_round_trips_through_serde_as_camel_case() {
+        let mut map = BTreeMap::new();
+        map.insert("project-1".to_owned(), snapshot("round trip"));
+        let prefs = UiPreferences {
+            simple_studio: Some(map),
+            ..Default::default()
+        };
+        let body = serde_json::to_string(&prefs).expect("serialize");
+        assert!(body.contains("\"simpleStudio\""));
+        let parsed: UiPreferences = serde_json::from_str(&body).expect("deserialize");
+        assert_eq!(
+            parsed
+                .simple_studio
+                .and_then(|m| m.get("project-1").cloned()),
+            Some(snapshot("round trip"))
+        );
+    }
+
+    #[test]
+    fn an_absent_simple_studio_is_omitted_from_the_stored_file() {
+        let body = serde_json::to_string(&UiPreferences::default()).expect("serialize");
+        assert!(!body.contains("simpleStudio"));
+    }
 
     #[test]
     fn normalize_theme_accepts_only_known_themes() {

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -584,6 +584,94 @@ async fn ui_preferences_per_model_tier_round_trips_and_merges() {
     assert_eq!(saved["perModelTier"]["image"]["flux_dev"], "q4");
 }
 
+/// The Simple studios' knobs persist server-side for the same reason as the tier sticky: the
+/// desktop shell's per-launch origin wipes localStorage, so a model/prompt/resolution the user
+/// chose would be forgotten every relaunch. Keyed by WORKSPACE, so a prompt written for one
+/// project never follows the user into another.
+#[tokio::test]
+async fn ui_preferences_simple_studio_round_trips_per_workspace_and_merges() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let app = create_app(settings).expect("app creates");
+
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({
+            "simpleStudio": {
+                "project-1": { "image": { "model": "z_image", "prompt": "a lighthouse" } }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        saved["simpleStudio"]["project-1"]["image"]["model"],
+        "z_image"
+    );
+
+    // Survives a "relaunch": read back from disk, which is the whole point of the field.
+    let (status, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        prefs["simpleStudio"]["project-1"]["image"]["prompt"],
+        "a lighthouse"
+    );
+
+    // A theme-only PUT MERGES — it must not clobber the stored snapshot.
+    let (status, _) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (_, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(
+        prefs["simpleStudio"]["project-1"]["image"]["model"],
+        "z_image"
+    );
+    assert_eq!(prefs["theme"], "dark");
+
+    // A second workspace arrives in the full merged map the web sends; both are kept, and the
+    // per-workspace keying means project-2's prompt is its own.
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({
+            "simpleStudio": {
+                "project-1": { "image": { "model": "z_image", "prompt": "a lighthouse" } },
+                "project-2": { "video": { "model": "wan_2_2", "prompt": "a river" } }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        saved["simpleStudio"]["project-1"]["image"]["prompt"],
+        "a lighthouse"
+    );
+    assert_eq!(
+        saved["simpleStudio"]["project-2"]["video"]["prompt"],
+        "a river"
+    );
+
+    // A malformed entry is dropped rather than stored — the web must never be handed back a
+    // snapshot shape it cannot read.
+    let (status, saved) = request(
+        app,
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "simpleStudio": { "project-3": "not-an-object" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(saved["simpleStudio"].get("project-3").is_none());
+}
+
 #[test]
 fn requires_token_only_gates_api_paths() {
     use axum::http::Method;

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -38,6 +38,7 @@ import { isAccentId } from "./accents.js";
 import { writeDefaultGenerationQuality } from "./generationQuality.js";
 import { persistNavigationPreferences, putUiPreferences } from "./uiPreferences.js";
 import { seedLastTiersFromServer } from "./lastTierStore.js";
+import { seedSimpleStudiosFromServer } from "./simpleStudioStore.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -1353,6 +1354,14 @@ export function App() {
         // even after the desktop origin — and its localStorage — changed on relaunch.
         if (prefs?.perModelTier) {
           seedLastTiersFromServer(prefs.perModelTier);
+        }
+        // Re-prime the Simple studios' settings cache from the durable server copy, for exactly
+        // the same reason as the tier sticky above: the desktop shell's per-launch origin wipes
+        // localStorage, so the model/prompt/resolution a user left in a Simple studio would be
+        // gone every relaunch. SimpleShell waits for `navigationHydrated` before reading this,
+        // so it can't race the seed and restore an empty snapshot.
+        if (prefs?.simpleStudio) {
+          seedSimpleStudiosFromServer(prefs.simpleStudio);
         }
         const persistedView = prefs?.activeView;
         if (navSections.some((section) => section.items.some((item) => item.id === persistedView))) {
@@ -3138,6 +3147,10 @@ export function App() {
             onModeChange={setUiModeOverride}
             onScreenChange={setSimpleActiveScreen}
             onSimpleDefaultChange={changeSimpleUiDefault}
+            /* The same flag that gates the durable `activeView` write: until the
+               ui-preferences GET has landed, the Simple studios must neither restore from
+               a possibly-empty cache nor write their catalog defaults over the stored copy. */
+            preferencesHydrated={navigationHydrated}
             simpleDefault={simpleUiDefault}
           />
         </AppLiveContext.Provider>

--- a/apps/web/src/simple/SimpleAudioStudio.jsx
+++ b/apps/web/src/simple/SimpleAudioStudio.jsx
@@ -6,6 +6,7 @@ import { useAudioTakePlayer } from "../components/audioTakeParts.jsx";
 import { buildSimpleAudioRequest } from "./simpleJobs.js";
 import { SimpleAudioDeck, SimpleTakeCard, takeGridColumns } from "./simpleAudioParts.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
+import { useStudioState } from "./useStudioState.js";
 import { Chips, SheetSelect, StudioRunStatus, jobIsRunning, newestLocalJob } from "./studioParts.jsx";
 
 // Simple Audio Studio (design handoff → Audio Studio redesign, epic 14361 / sc-14365).
@@ -39,11 +40,12 @@ export function SimpleAudioStudio() {
   // One transport for the screen, so loading a take always pauses the previous one.
   const player = useAudioTakePlayer();
 
-  const [mode, setMode] = useState("music");
-  const [prompt, setPrompt] = useState("");
-  const [model, setModel] = useState("");
-  const [voice, setVoice] = useState("");
-  const [duration, setDuration] = useState(8);
+  // Sticky across navigation — see the same block in SimpleImageStudio.
+  const [mode, setMode] = useStudioState("audio", "mode", "music");
+  const [prompt, setPrompt] = useStudioState("audio", "prompt", "");
+  const [model, setModel] = useStudioState("audio", "model", "");
+  const [voice, setVoice] = useStudioState("audio", "voice", "");
+  const [duration, setDuration] = useStudioState("audio", "duration", 8);
   const [submitting, setSubmitting] = useState(false);
 
   // Per-mode eligibility comes from the model's own `audio` sub-block, exactly as the
@@ -61,7 +63,7 @@ export function SimpleAudioStudio() {
     if (models.length && !models.some((entry) => entry.id === model)) {
       setModel(models[0].id);
     }
-  }, [models, model]);
+  }, [models, model, setModel]);
 
   // The Speech voice bank the selected model declares. A streaming / multi-speaker TTS
   // ships none, in which case the Voice row is simply absent (it speaks in its own voice).
@@ -74,7 +76,7 @@ export function SimpleAudioStudio() {
     if (voices.length && !voices.some((entry) => voiceId(entry) === voice)) {
       setVoice(voiceId(voices[0]));
     }
-  }, [voices, voice]);
+  }, [voices, voice, setVoice]);
 
   // Length is capped to the model's advertised `audio.maxDurationSecs` — never a hardcoded
   // ceiling. A model that declares no cap synthesizes its own natural length, so the control
@@ -95,7 +97,7 @@ export function SimpleAudioStudio() {
     if (durations.length && !durations.includes(duration)) {
       setDuration(durations[durations.length - 1]);
     }
-  }, [durations, duration]);
+  }, [durations, duration, setDuration]);
 
   const latestJob = newestLocalJob(audioLocalJobs);
   const busy = submitting || jobIsRunning(latestJob);

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -11,6 +11,7 @@ import { preferredResolution } from "./modelDefaults.js";
 import { buildSimpleImageRequest, referenceStrengthFor, resolveSimpleTier } from "./simpleJobs.js";
 import { useSimpleRefine } from "./useSimpleRefine.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
+import { useStudioState } from "./useStudioState.js";
 import { useSimpleLoras } from "./useSimpleLoras.js";
 import { SimpleLoraField, promptWithKeyword } from "./SimpleLoraField.jsx";
 import { SimpleLoraSheet } from "./SimpleLoraSheet.jsx";
@@ -55,14 +56,17 @@ export function SimpleImageStudio() {
   const unifiedMemoryGb = useUnifiedMemoryGb();
   const refine = useSimpleRefine("image");
 
-  const [mode, setMode] = useState("text_to_image");
-  const [prompt, setPrompt] = useState("");
-  const [model, setModel] = useState("");
-  const [resolution, setResolution] = useState("");
-  const [variations, setVariations] = useState(1);
-  const [styleId, setStyleId] = useState(null);
-  const [referenceAssetId, setReferenceAssetId] = useState(null);
-  const [refineOpen, setRefineOpen] = useState(false);
+  // Sticky across navigation (this studio unmounts when you leave it) — everything the user
+  // set stays set. `submitting` stays local: it belongs to an in-flight submit, not to the
+  // form, and a studio that remounted mid-request must not come back looking busy.
+  const [mode, setMode] = useStudioState("image", "mode", "text_to_image");
+  const [prompt, setPrompt] = useStudioState("image", "prompt", "");
+  const [model, setModel] = useStudioState("image", "model", "");
+  const [resolution, setResolution] = useStudioState("image", "resolution", "");
+  const [variations, setVariations] = useStudioState("image", "variations", 1);
+  const [styleId, setStyleId] = useStudioState("image", "styleId", null);
+  const [referenceAssetId, setReferenceAssetId] = useStudioState("image", "referenceAssetId", null);
+  const [refineOpen, setRefineOpen] = useStudioState("image", "refineOpen", false);
   const [submitting, setSubmitting] = useState(false);
 
   // Models that serve the active tab, under the same capability + Mac-gating predicate
@@ -84,7 +88,7 @@ export function SimpleImageStudio() {
     if (!models.some((entry) => entry.id === model)) {
       setModel(models[0].id);
     }
-  }, [models, model]);
+  }, [models, model, setModel]);
 
   const resolutions = useMemo(() => {
     const declared = selectedModel?.limits?.resolutions?.length
@@ -110,7 +114,7 @@ export function SimpleImageStudio() {
     if (resolutions.length && !resolutions.includes(resolution)) {
       setResolution(preferredResolution(selectedModel, resolutions));
     }
-  }, [resolutions, resolution, selectedModel]);
+  }, [resolutions, resolution, selectedModel, setResolution]);
 
   // Resolved against the FULL catalog, not just the picker's recent-20 list: a reference
   // routed in from the Assets preview ("Use as reference") can be any library asset.
@@ -163,6 +167,7 @@ export function SimpleImageStudio() {
     selectedModel,
     jobs,
     excludeLoraId: editLoraInstalled ? (editLora?.id ?? null) : null,
+    scope: "image",
   });
   const openLoraPicker = () =>
     openSheet({

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { imageModelServesMode } from "../modelEligibility.js";
@@ -122,6 +122,24 @@ export function SimpleImageStudio() {
     () => assets.find((asset) => asset.id === referenceAssetId) ?? null,
     [assets, referenceAssetId],
   );
+
+  // A RESTORED reference can name an asset the user has since deleted — the id outlives the
+  // library now that the studio's settings are durable. Drop it once, when the catalog has
+  // actually loaded: `assets` is empty both before the fetch lands and when the library is
+  // genuinely empty, and pruning during that window would strip a perfectly good reference
+  // (the sc-11962 guard, in the shape VideoStudio's `restoredAssetsValidatedRef` uses).
+  // Without this the tile reads "attach an image" while `needsSource` still sees an id, so
+  // edit mode stays submittable and sends a dangling reference the job then fails on.
+  const restoredReferenceValidated = useRef(false);
+  useEffect(() => {
+    if (restoredReferenceValidated.current || !assets.length) {
+      return;
+    }
+    restoredReferenceValidated.current = true;
+    setReferenceAssetId((current) =>
+      current && !assets.some((asset) => asset.id === current) ? null : current,
+    );
+  }, [assets, setReferenceAssetId]);
 
   // "Use as reference" from an asset preview lands here. Keyed on the request token so a
   // repeat pick of the SAME asset still re-arms after the user cleared it.

--- a/apps/web/src/simple/SimpleLora.test.jsx
+++ b/apps/web/src/simple/SimpleLora.test.jsx
@@ -190,6 +190,10 @@ describe("Simple studios — LoRA field", () => {
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
+    // The Simple studios now persist their settings (localStorage cache + the durable
+    // ui-preferences copy), so without this a snapshot flushed by one case restores into
+    // the next and the catalog-default assertions read the previous test's picks.
+    window.localStorage.clear();
     ({ container, root } = mountRoot());
   });
 
@@ -384,6 +388,10 @@ describe("Simple studios — Add LoRA sheet import", () => {
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
+    // The Simple studios now persist their settings (localStorage cache + the durable
+    // ui-preferences copy), so without this a snapshot flushed by one case restores into
+    // the next and the catalog-default assertions read the previous test's picks.
+    window.localStorage.clear();
     ({ container, root } = mountRoot());
   });
 

--- a/apps/web/src/simple/SimpleSheet.jsx
+++ b/apps/web/src/simple/SimpleSheet.jsx
@@ -12,7 +12,10 @@ export function SimpleSheet({ title, onClose, phone, children, labelId = "su-she
   const panelRef = useRef(null);
 
   useEffect(() => {
-    panelRef.current?.focus();
+    // `preventScroll` matters: the panel is pinned in view by CSS, so it never needs
+    // scrolling into view — but the browser would still scroll the shell to "reveal" a
+    // tall panel, yanking the whole screen behind the sheet.
+    panelRef.current?.focus({ preventScroll: true });
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -9,6 +9,7 @@ import { breakpointFor, contentMaxWidth } from "./breakpoint.js";
 import { ADVANCED_MODE } from "./uiMode.js";
 import { useContainerWidth } from "./useContainerWidth.js";
 import { SimpleUiContext } from "./SimpleUiContext.js";
+import { createStudioStateStore } from "./useStudioState.js";
 import { SimpleSheet, SimpleSheetOptions } from "./SimpleSheet.jsx";
 import { PromptGuideSheet } from "./PromptGuideSheet.jsx";
 import { SimplePreview } from "./SimplePreview.jsx";
@@ -106,6 +107,13 @@ export function SimpleShell({
     setDismissedJobIds((current) => new Set(current).add(id));
   }, []);
   const toastTimer = useRef(null);
+  // The studios' own knobs (model, prompt, resolution, LoRA picks, …), kept alive across the
+  // same unmount. A ref, not state: this is written on every keystroke and must never
+  // re-render the shell. See useStudioState.js.
+  const studioStateRef = useRef(null);
+  if (studioStateRef.current === null) {
+    studioStateRef.current = createStudioStateStore();
+  }
 
   useEffect(() => () => clearTimeout(toastTimer.current), []);
   useEffect(() => {
@@ -176,6 +184,7 @@ export function SimpleShell({
       clearReferenceRequest: () => setReferenceRequest(null),
       dismissedJobIds,
       dismissJob,
+      studioState: studioStateRef.current,
     }),
     [
       breakpoint,

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -147,8 +147,17 @@ export function SimpleShell({
       return undefined;
     }
     const store = studioStateRef.current;
-    loadSnapshotIntoStore(store, readSimpleStudioSnapshot(workspaceId));
-    setStudioEpoch((epoch) => epoch + 1);
+    const restored = readSimpleStudioSnapshot(workspaceId);
+    // Only replace the store — and only remount the studios — when there is something to
+    // restore. The remount is what discards whatever the mounted studio currently holds, so
+    // doing it unconditionally would throw away anything the user typed while the GET was in
+    // flight. That window is a loopback round trip on the desktop but a real network hop on a
+    // LAN deployment. With something stored, the stored value SHOULD win: it is the user's
+    // earlier deliberate choice, and the alternative is a studio half on defaults.
+    if (Object.keys(restored).length) {
+      loadSnapshotIntoStore(store, restored);
+      setStudioEpoch((epoch) => epoch + 1);
+    }
 
     // Debounced: a prompt is typed, and one durable write per keystroke would hammer both
     // localStorage and the disk-writing PUT. The store's coalescing queue keeps the requests

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -9,7 +9,15 @@ import { breakpointFor, contentMaxWidth } from "./breakpoint.js";
 import { ADVANCED_MODE } from "./uiMode.js";
 import { useContainerWidth } from "./useContainerWidth.js";
 import { SimpleUiContext } from "./SimpleUiContext.js";
-import { createStudioStateStore } from "./useStudioState.js";
+import {
+  createStudioStateStore,
+  loadSnapshotIntoStore,
+  snapshotFromStore,
+} from "./useStudioState.js";
+import {
+  readSimpleStudioSnapshot,
+  writeSimpleStudioSnapshot,
+} from "../simpleStudioStore.js";
 import { SimpleSheet, SimpleSheetOptions } from "./SimpleSheet.jsx";
 import { PromptGuideSheet } from "./PromptGuideSheet.jsx";
 import { SimplePreview } from "./SimplePreview.jsx";
@@ -59,6 +67,10 @@ export const SIMPLE_SCREENS = [
 const SCREEN_BY_ID = new Map(SIMPLE_SCREENS.flatMap((group) => group.items).map((item) => [item.id, item]));
 
 const TOAST_MS = 1900;
+// How long the studios go quiet before their settings are written through to the durable
+// store. Long enough that typing a prompt is one write, short enough that a hard quit a
+// moment after the last keystroke still keeps it.
+const PERSIST_DEBOUNCE_MS = 400;
 
 export function SimpleShell({
   accent,
@@ -68,6 +80,7 @@ export function SimpleShell({
   onModeChange,
   onScreenChange,
   lockedToSimple,
+  preferencesHydrated = true,
 }) {
   const {
     jobs = [],
@@ -77,6 +90,7 @@ export function SimpleShell({
     setSelectedAssetId,
     setActiveView,
     sendAssetToVideo,
+    activeProject,
   } = useAppContext();
 
   const [rootRef, width] = useContainerWidth();
@@ -114,6 +128,45 @@ export function SimpleShell({
   if (studioStateRef.current === null) {
     studioStateRef.current = createStudioStateStore();
   }
+  const workspaceId = activeProject?.id ?? null;
+  // Bumped whenever a restored snapshot is loaded into the store; used as the studios' React
+  // key so they REMOUNT and re-read it. `useStudioState` reads the store once at mount (any
+  // other rule would fight the studio's own live state), so a remount is how a restore lands.
+  const [studioEpoch, setStudioEpoch] = useState(0);
+  const persistTimer = useRef(null);
+
+  // Load this workspace's persisted studio settings, then let the studios write through.
+  //
+  // Gated on `preferencesHydrated` for the sc-11962 reason: until the ui-preferences GET has
+  // landed, the localStorage cache may be empty (a relaunched desktop app has a NEW origin and
+  // so an empty cache), the studios would seed themselves from catalog defaults, and writing
+  // those through would overwrite the durable copy before it was ever read. So no restore and
+  // no persistence happen until the durable copy has had its chance to arrive.
+  useEffect(() => {
+    if (!preferencesHydrated) {
+      return undefined;
+    }
+    const store = studioStateRef.current;
+    loadSnapshotIntoStore(store, readSimpleStudioSnapshot(workspaceId));
+    setStudioEpoch((epoch) => epoch + 1);
+
+    // Debounced: a prompt is typed, and one durable write per keystroke would hammer both
+    // localStorage and the disk-writing PUT. The store's coalescing queue keeps the requests
+    // ordered; this keeps them rare.
+    store.persist = () => {
+      clearTimeout(persistTimer.current);
+      persistTimer.current = setTimeout(() => {
+        writeSimpleStudioSnapshot(workspaceId, snapshotFromStore(store));
+      }, PERSIST_DEBOUNCE_MS);
+    };
+    return () => {
+      clearTimeout(persistTimer.current);
+      store.persist = () => {};
+      // Flush on the way out (workspace switch, or the shell unmounting on a switch to
+      // Advanced) so the last few keystrokes aren't the ones that get dropped.
+      writeSimpleStudioSnapshot(workspaceId, snapshotFromStore(store));
+    };
+  }, [preferencesHydrated, workspaceId]);
 
   useEffect(() => () => clearTimeout(toastTimer.current), []);
   useEffect(() => {
@@ -288,9 +341,13 @@ export function SimpleShell({
 
           <div className="su-body su-scroll">
             <div className="su-content">
-              {screen === "image" ? <SimpleImageStudio /> : null}
-              {screen === "video" ? <SimpleVideoStudio /> : null}
-              {screen === "audio" ? <SimpleAudioStudio /> : null}
+              {/* Keyed on `studioEpoch` so a restored snapshot — which lands asynchronously,
+                  after the ui-preferences GET — remounts the studio and is read by its state
+                  initialisers, rather than having to be pushed into already-mounted state.
+                  The advanced studios key on the workspace id for the same reason. */}
+              {screen === "image" ? <SimpleImageStudio key={studioEpoch} /> : null}
+              {screen === "video" ? <SimpleVideoStudio key={studioEpoch} /> : null}
+              {screen === "audio" ? <SimpleAudioStudio key={studioEpoch} /> : null}
               {screen === "assets" ? <SimpleAssets /> : null}
               {screen === "models" ? <SimpleModelManager /> : null}
               {screen === "queue" ? <SimpleQueue /> : null}

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -115,6 +115,10 @@ describe("SimpleShell", () => {
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
+    // The Simple studios now persist their settings (localStorage cache + the durable
+    // ui-preferences copy), so without this a snapshot flushed by one case restores into
+    // the next and the catalog-default assertions read the previous test's picks.
+    window.localStorage.clear();
     // jsdom has no ResizeObserver; the shell's measurement hook degrades to the
     // unmeasured (desktop) band, which is what these tests exercise.
     ({ container, root } = mountRoot());

--- a/apps/web/src/simple/SimpleUiContext.js
+++ b/apps/web/src/simple/SimpleUiContext.js
@@ -24,6 +24,9 @@ import { createContext, useContext } from "react";
 //   dismissedJobIds     — Set of failed-run ids the user has dismissed from a studio.
 //                         Shell-held, because the studios unmount on navigation.
 //   dismissJob(id)
+//   studioState         — Map backing `useStudioState`, so a studio's OWN knobs (model,
+//                         prompt, resolution, LoRA picks) survive that same unmount.
+//                         Shell-held for the same reason; see useStudioState.js.
 export const SimpleUiContext = createContext(null);
 
 export function useSimpleUi() {

--- a/apps/web/src/simple/SimpleVideoStudio.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.jsx
@@ -8,6 +8,7 @@ import { describeResolution, resolutionSummary } from "./aspect.js";
 import { preferredDuration, preferredVideoResolution } from "./modelDefaults.js";
 import { useSimpleRefine } from "./useSimpleRefine.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
+import { useStudioState } from "./useStudioState.js";
 import { useSimpleLoras } from "./useSimpleLoras.js";
 import { SimpleLoraField, promptWithKeyword } from "./SimpleLoraField.jsx";
 import { SimpleLoraSheet } from "./SimpleLoraSheet.jsx";
@@ -54,14 +55,15 @@ export function SimpleVideoStudio() {
   const { openSheet, closeSheet, openGuide, toast } = useSimpleUi();
   const refine = useSimpleRefine("video");
 
-  const [mode, setMode] = useState("text_to_video");
-  const [prompt, setPrompt] = useState("");
-  const [model, setModel] = useState("");
-  const [resolution, setResolution] = useState("");
-  const [duration, setDuration] = useState(5);
-  const [styleId, setStyleId] = useState(null);
-  const [sourceAssetId, setSourceAssetId] = useState(null);
-  const [refineOpen, setRefineOpen] = useState(false);
+  // Sticky across navigation — see the same block in SimpleImageStudio.
+  const [mode, setMode] = useStudioState("video", "mode", "text_to_video");
+  const [prompt, setPrompt] = useStudioState("video", "prompt", "");
+  const [model, setModel] = useStudioState("video", "model", "");
+  const [resolution, setResolution] = useStudioState("video", "resolution", "");
+  const [duration, setDuration] = useStudioState("video", "duration", 5);
+  const [styleId, setStyleId] = useStudioState("video", "styleId", null);
+  const [sourceAssetId, setSourceAssetId] = useStudioState("video", "sourceAssetId", null);
+  const [refineOpen, setRefineOpen] = useStudioState("video", "refineOpen", false);
   const [submitting, setSubmitting] = useState(false);
 
   const models = useMemo(
@@ -77,7 +79,7 @@ export function SimpleVideoStudio() {
     if (models.length && !models.some((entry) => entry.id === model)) {
       setModel(models[0].id);
     }
-  }, [models, model]);
+  }, [models, model, setModel]);
 
   const resolutions = selectedModel?.limits?.resolutions?.length
     ? selectedModel.limits.resolutions
@@ -102,7 +104,7 @@ export function SimpleVideoStudio() {
     if (resolutions.length && !resolutions.includes(resolution)) {
       setResolution(preferredVideoResolution(selectedModel, resolutions));
     }
-  }, [resolutions, resolution, selectedModel]);
+  }, [resolutions, resolution, selectedModel, setResolution]);
 
   useEffect(() => {
     if (!selectedModel) {
@@ -111,7 +113,7 @@ export function SimpleVideoStudio() {
     if (durations.length && !durations.includes(duration)) {
       setDuration(preferredDuration(selectedModel, durations));
     }
-  }, [durations, duration, selectedModel]);
+  }, [durations, duration, selectedModel, setDuration]);
 
   const sourceAsset = useMemo(
     () => recentImageAssets.find((asset) => asset.id === sourceAssetId) ?? null,
@@ -120,7 +122,7 @@ export function SimpleVideoStudio() {
 
   // User-picked LoRAs (epic 15404) — same hook, same eligibility and cap as the Image studio;
   // the video lane just has no auto-applied managed LoRA to exclude.
-  const lora = useSimpleLoras({ loras, selectedModel, jobs });
+  const lora = useSimpleLoras({ loras, selectedModel, jobs, scope: "video" });
   const openLoraPicker = () =>
     openSheet({
       title: "Add LoRA",

--- a/apps/web/src/simple/SimpleVideoStudio.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { videoModelServesMode } from "../modelEligibility.js";
@@ -115,10 +115,28 @@ export function SimpleVideoStudio() {
     }
   }, [durations, duration, selectedModel, setDuration]);
 
+  // Resolved against the FULL catalog rather than the picker's recent-20 list. That list is
+  // what the PICKER offers; a source restored from a previous session can have aged out of it
+  // while the asset is still perfectly valid, and resolving against it would blank the tile
+  // (and, below, wrongly prune the id).
   const sourceAsset = useMemo(
-    () => recentImageAssets.find((asset) => asset.id === sourceAssetId) ?? null,
-    [recentImageAssets, sourceAssetId],
+    () => assets.find((asset) => asset.id === sourceAssetId) ?? null,
+    [assets, sourceAssetId],
   );
+
+  // Same one-shot validation as the Image studio: a restored source can name an asset the
+  // user has since deleted, and `needsSource` reads the id — so without this, Image→Video
+  // stays submittable with a reference that no longer exists. Guarded on a LOADED catalog.
+  const restoredSourceValidated = useRef(false);
+  useEffect(() => {
+    if (restoredSourceValidated.current || !assets.length) {
+      return;
+    }
+    restoredSourceValidated.current = true;
+    setSourceAssetId((current) =>
+      current && !assets.some((asset) => asset.id === current) ? null : current,
+    );
+  }, [assets, setSourceAssetId]);
 
   // User-picked LoRAs (epic 15404) — same hook, same eligibility and cap as the Image studio;
   // the video lane just has no auto-applied managed LoRA to exclude.

--- a/apps/web/src/simple/simple.css
+++ b/apps/web/src/simple/simple.css
@@ -71,6 +71,21 @@
     transform: none;
   }
 }
+/* The same fade+pop for an element that is centered with `translate(-50%, -50%)`.
+   It has to carry that centering in EVERY keyframe: an animated `transform` replaces
+   the rule's own for the whole run, so a plain `su-pop` would park the card's top-left
+   corner at the container's centre (down-and-right) until the animation ended and then
+   snap it back. */
+@keyframes su-pop-centered {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
 
 @media (prefers-reduced-motion: reduce) {
   .su-root *,
@@ -2080,7 +2095,7 @@
   padding: 20px 22px 24px;
   border-radius: 18px;
   transform: translate(-50%, -50%);
-  animation: su-pop 0.2s var(--ease-out);
+  animation: su-pop-centered 0.2s var(--ease-out);
 }
 
 .su-sheet-handle {

--- a/apps/web/src/simple/useSimpleLoras.js
+++ b/apps/web/src/simple/useSimpleLoras.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import {
   MAX_USER_JOB_LORAS,
   loraHasResolvableFamily,
@@ -7,6 +7,12 @@ import {
   serializeLora,
 } from "../presetUtils.js";
 import { terminalStatuses } from "../jobTypes.js";
+import { useStudioState } from "./useStudioState.js";
+
+// Module-level so the "first time this key is seen" initial is referentially stable — a
+// fresh [] / {} per render would make the effects below see a new value every time.
+const EMPTY_IDS = [];
+const EMPTY_WEIGHTS = {};
 
 // LoRA selection for the Simple studios (epic 15404).
 //
@@ -30,14 +36,16 @@ export function loraMeta(lora) {
  * @param {string|null} [input.excludeLoraId] - a LoRA the studio applies itself and must not
  *   also offer in the picker (Simple's edit mode auto-applies Krea's managed `image_edit`
  *   LoRA — the advanced studio hides it from its picker the same way).
+ * @param {string} input.scope - the owning studio ("image" | "video"), so the picks survive
+ *   that studio's unmount on navigation without colliding with the other's.
  */
-export function useSimpleLoras({ loras = [], selectedModel, jobs = [], excludeLoraId = null }) {
-  const [selectedLoraIds, setSelectedLoraIds] = useState([]);
-  const [weightOverrides, setWeightOverrides] = useState({});
+export function useSimpleLoras({ loras = [], selectedModel, jobs = [], excludeLoraId = null, scope }) {
+  const [selectedLoraIds, setSelectedLoraIds] = useStudioState(scope, "selectedLoraIds", EMPTY_IDS);
+  const [weightOverrides, setWeightOverrides] = useStudioState(scope, "loraWeights", EMPTY_WEIGHTS);
   // Only the IDS of imports started from this studio's sheet. Status, progress and the
   // detected family are read LIVE off the job feed on every render — the pending slot must
   // not carry a second, drifting copy of what the Queue already knows.
-  const [importJobIds, setImportJobIds] = useState([]);
+  const [importJobIds, setImportJobIds] = useStudioState(scope, "loraImportJobIds", EMPTY_IDS);
 
   const compatibleLoras = useMemo(
     () =>
@@ -94,7 +102,7 @@ export function useSimpleLoras({ loras = [], selectedModel, jobs = [], excludeLo
       const kept = ids.filter((id) => compatibleLoras.some((lora) => lora.id === id));
       return kept.length === ids.length ? ids : kept;
     });
-  }, [loras.length, selectedModel, compatibleLoraKey, compatibleLoras]);
+  }, [loras.length, selectedModel, compatibleLoraKey, compatibleLoras, setSelectedLoraIds]);
 
   const effectiveLoraWeight = useCallback(
     (lora) => {
@@ -106,7 +114,7 @@ export function useSimpleLoras({ loras = [], selectedModel, jobs = [], excludeLo
 
   const addLora = useCallback((lora) => {
     setSelectedLoraIds((ids) => (ids.includes(lora.id) ? ids : [...ids, lora.id]));
-  }, []);
+  }, [setSelectedLoraIds]);
 
   const removeLora = useCallback((lora) => {
     setSelectedLoraIds((ids) => ids.filter((id) => id !== lora.id));
@@ -120,17 +128,17 @@ export function useSimpleLoras({ loras = [], selectedModel, jobs = [], excludeLo
       delete next[lora.id];
       return next;
     });
-  }, []);
+  }, [setSelectedLoraIds, setWeightOverrides]);
 
   const setLoraWeight = useCallback((id, value) => {
     setWeightOverrides((current) => ({ ...current, [id]: value }));
-  }, []);
+  }, [setWeightOverrides]);
 
   const noteImportJob = useCallback((job) => {
     if (job?.id) {
       setImportJobIds((ids) => (ids.includes(job.id) ? ids : [...ids, job.id]));
     }
-  }, []);
+  }, [setImportJobIds]);
 
   // Resolved against the live feed each render, so a slot disappears the moment the import
   // reaches a terminal status — no local progress model, no polling.

--- a/apps/web/src/simple/useStudioState.js
+++ b/apps/web/src/simple/useStudioState.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useSimpleUi } from "./SimpleUiContext.js";
 
-// Studio state that survives navigation.
+// Studio state that survives navigation AND a relaunch.
 //
 // The Simple shell renders exactly one screen at a time (`{screen === "image" ? … : null}`),
 // so every studio UNMOUNTS when you leave it and its `useState` values are gone — walk to
@@ -9,16 +9,55 @@ import { useSimpleUi } from "./SimpleUiContext.js";
 // catalog defaults. `dismissedJobIds` already lives on the shell for precisely this reason;
 // this is the same trick generalised, so a studio's own knobs get the same treatment.
 //
-// The store is a plain Map on a shell-owned ref, NOT React state: writing to it must not
-// re-render the shell (and therefore every screen) on each keystroke. The mounted studio
-// already holds the live value in its own `useState` — the store is only the carbon copy
-// that outlives it.
+// Two layers, because they solve two different problems:
+//   values  — a plain Map on a shell-owned ref, NOT React state: it is written on every
+//             keystroke and must not re-render the shell (and therefore every screen). This
+//             is what survives NAVIGATION.
+//   persist — the shell's debounced write-through to `simpleStudioStore`, which is what
+//             survives a RELAUNCH (localStorage cache + the durable ui-preferences copy).
 //
-// Session-scoped on purpose. This restores where you were while the app is open; it is not
-// a preferences store, so a relaunch still starts from the catalog defaults.
+// The mounted studio still holds the live value in its own `useState`; both layers are only
+// carbon copies that outlive it.
 
 export function createStudioStateStore() {
-  return new Map();
+  return {
+    values: new Map(),
+    // Replaced by the shell once it can persist. A no-op until then, so a studio that renders
+    // before the shell has wired durability simply doesn't write — it never throws and never
+    // pushes a half-seeded snapshot at the store.
+    persist: () => {},
+  };
+}
+
+/** The `{ [scope]: { [key]: value } }` snapshot for a store's Map — the shape the store persists. */
+export function snapshotFromStore(store) {
+  const snapshot = {};
+  for (const [id, value] of store.values) {
+    const separator = id.indexOf(":");
+    if (separator <= 0) {
+      continue;
+    }
+    const scope = id.slice(0, separator);
+    const key = id.slice(separator + 1);
+    snapshot[scope] = { ...(snapshot[scope] ?? {}), [key]: value };
+  }
+  return snapshot;
+}
+
+/** Load a persisted `{ [scope]: { [key]: value } }` snapshot into a store's Map, replacing it. */
+export function loadSnapshotIntoStore(store, snapshot) {
+  store.values.clear();
+  if (!snapshot || typeof snapshot !== "object") {
+    return;
+  }
+  for (const [scope, fields] of Object.entries(snapshot)) {
+    if (!fields || typeof fields !== "object") {
+      continue;
+    }
+    for (const [key, value] of Object.entries(fields)) {
+      store.values.set(`${scope}:${key}`, value);
+    }
+  }
 }
 
 /**
@@ -28,13 +67,17 @@ export function createStudioStateStore() {
  * @param {string} scope - the owning studio ("image" | "video" | "audio"), so two studios
  *   can each keep their own `model` without colliding.
  * @param {string} key - the field name.
- * @param {*} initial - the value used the FIRST time this scope+key is seen in a session.
+ * @param {*} initial - the value used when this scope+key has no stored value.
  */
 export function useStudioState(scope, key, initial) {
   const { studioState } = useSimpleUi();
   const id = `${scope}:${key}`;
-  // Read once, at mount. Re-reading on every render would fight the local state below.
-  const [value, setValue] = useState(() => (studioState.has(id) ? studioState.get(id) : initial));
+  // Read once, at mount. Re-reading on every render would fight the local state below — which
+  // is also why the shell REMOUNTS the studios (via a key) when a restored snapshot lands,
+  // rather than trying to push new values into already-mounted state.
+  const [value, setValue] = useState(() =>
+    studioState.values.has(id) ? studioState.values.get(id) : initial,
+  );
 
   // Write-through in an effect rather than inside the setter: a state updater may be invoked
   // more than once for a single update (StrictMode, concurrent re-render), and a Map write is
@@ -42,7 +85,8 @@ export function useStudioState(scope, key, initial) {
   const idRef = useRef(id);
   idRef.current = id;
   useEffect(() => {
-    studioState.set(idRef.current, value);
+    studioState.values.set(idRef.current, value);
+    studioState.persist();
   }, [studioState, value]);
 
   // `setValue` is React's own `useState` setter, so it is referentially stable and safe to

--- a/apps/web/src/simple/useStudioState.js
+++ b/apps/web/src/simple/useStudioState.js
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from "react";
+import { useSimpleUi } from "./SimpleUiContext.js";
+
+// Studio state that survives navigation.
+//
+// The Simple shell renders exactly one screen at a time (`{screen === "image" ? … : null}`),
+// so every studio UNMOUNTS when you leave it and its `useState` values are gone — walk to
+// Assets and back and the model/prompt/resolution you chose have been re-seeded from the
+// catalog defaults. `dismissedJobIds` already lives on the shell for precisely this reason;
+// this is the same trick generalised, so a studio's own knobs get the same treatment.
+//
+// The store is a plain Map on a shell-owned ref, NOT React state: writing to it must not
+// re-render the shell (and therefore every screen) on each keystroke. The mounted studio
+// already holds the live value in its own `useState` — the store is only the carbon copy
+// that outlives it.
+//
+// Session-scoped on purpose. This restores where you were while the app is open; it is not
+// a preferences store, so a relaunch still starts from the catalog defaults.
+
+export function createStudioStateStore() {
+  return new Map();
+}
+
+/**
+ * `useState`, but the value is written through to the shell's store and read back from it
+ * when the studio remounts.
+ *
+ * @param {string} scope - the owning studio ("image" | "video" | "audio"), so two studios
+ *   can each keep their own `model` without colliding.
+ * @param {string} key - the field name.
+ * @param {*} initial - the value used the FIRST time this scope+key is seen in a session.
+ */
+export function useStudioState(scope, key, initial) {
+  const { studioState } = useSimpleUi();
+  const id = `${scope}:${key}`;
+  // Read once, at mount. Re-reading on every render would fight the local state below.
+  const [value, setValue] = useState(() => (studioState.has(id) ? studioState.get(id) : initial));
+
+  // Write-through in an effect rather than inside the setter: a state updater may be invoked
+  // more than once for a single update (StrictMode, concurrent re-render), and a Map write is
+  // a side effect that does not belong in one.
+  const idRef = useRef(id);
+  idRef.current = id;
+  useEffect(() => {
+    studioState.set(idRef.current, value);
+  }, [studioState, value]);
+
+  // `setValue` is React's own `useState` setter, so it is referentially stable and safe to
+  // list in a dependency array — which callers must do, because exhaustive-deps only grants
+  // the implicit-stability exemption to a setter destructured straight off `useState`.
+  return [value, setValue];
+}

--- a/apps/web/src/simple/useStudioState.test.jsx
+++ b/apps/web/src/simple/useStudioState.test.jsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppContext } from "../context/AppContext.js";
 import { SimpleShell } from "./SimpleShell.jsx";
 import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+import { readSimpleStudioSnapshot, seedSimpleStudiosFromServer } from "../simpleStudioStore.js";
 
 // A studio UNMOUNTS when you navigate away (the shell renders exactly one screen), so
 // without the shell-held store every knob would be re-seeded from the catalog on the way
@@ -63,7 +64,7 @@ function baseContext(overrides = {}) {
   };
 }
 
-function renderShell(root, context) {
+function renderShell(root, context, props = {}) {
   return act(async () => {
     root.render(
       <AppContext.Provider value={context}>
@@ -74,6 +75,7 @@ function renderShell(root, context) {
           onModeChange={() => {}}
           onSimpleDefaultChange={() => {}}
           simpleDefault
+          {...props}
         />
       </AppContext.Provider>,
     );
@@ -126,6 +128,10 @@ describe("Simple studio state across navigation", () => {
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
+    // The Simple studios now persist their settings (localStorage cache + the durable
+    // ui-preferences copy), so without this a snapshot flushed by one case restores into
+    // the next and the catalog-default assertions read the previous test's picks.
+    window.localStorage.clear();
     ({ container, root } = mountRoot());
   });
 
@@ -168,6 +174,118 @@ describe("Simple studio state across navigation", () => {
 
     await click(navButton(container, "Image"));
     expect(container.querySelector("#su-image-prompt").value).toBe("image prompt");
+  });
+
+  // The relaunch half. A desktop relaunch gives the app a NEW `127.0.0.1:<port>` origin and
+  // therefore an EMPTY localStorage, so these simulate the real thing: unmount, clear the
+  // cache, seed only from the durable server copy, mount again.
+  it("restores the studio from the durable server copy after a relaunch", async () => {
+    await renderShell(root, baseContext(), { preferencesHydrated: true });
+    await typePrompt(container, "a lighthouse at dusk");
+    await openField(container, "Model");
+    await chooseOption(container, "Z-Image");
+
+    // Unmounting flushes the pending debounce, which is what a switch to Advanced (or a quit)
+    // does. Capture what would have reached the server.
+    await unmountRoot(root, container);
+    const persisted = JSON.parse(window.localStorage.getItem("sceneworks-simple-studio"));
+    expect(persisted["project-1"].image.prompt).toBe("a lighthouse at dusk");
+    expect(persisted["project-1"].image.model).toBe("z_image");
+
+    // Relaunch: the cache is gone with the old origin; only the server copy survives.
+    window.localStorage.clear();
+    seedSimpleStudiosFromServer(persisted);
+
+    ({ container, root } = mountRoot());
+    await renderShell(root, baseContext(), { preferencesHydrated: true });
+    expect(container.querySelector("#su-image-prompt").value).toBe("a lighthouse at dusk");
+    expect(fieldValue(container, "Model")).toBe("Z-Image");
+  });
+
+  it("keeps each workspace's settings separate", async () => {
+    const one = { id: "project-1", name: "One" };
+    const two = { id: "project-2", name: "Two" };
+    await renderShell(root, baseContext({ activeProject: one }), { preferencesHydrated: true });
+    await typePrompt(container, "prompt for project one");
+    await unmountRoot(root, container);
+
+    // A different workspace starts clean rather than inheriting project-1's prompt.
+    ({ container, root } = mountRoot());
+    await renderShell(root, baseContext({ activeProject: two }), { preferencesHydrated: true });
+    expect(container.querySelector("#su-image-prompt").value).toBe("");
+    await typePrompt(container, "prompt for project two");
+    await unmountRoot(root, container);
+
+    // …and returning to project-1 brings ITS prompt back, not project-2's.
+    ({ container, root } = mountRoot());
+    await renderShell(root, baseContext({ activeProject: one }), { preferencesHydrated: true });
+    expect(container.querySelector("#su-image-prompt").value).toBe("prompt for project one");
+  });
+
+  // sc-11962's failure mode, in the durable lane: on a relaunch the cache is empty and the
+  // GET is still in flight, so a studio that seeded and persisted during that window would
+  // overwrite the stored snapshot with catalog defaults before anyone had read it.
+  it("does not write catalog defaults over the stored copy before preferences hydrate", async () => {
+    await renderShell(root, baseContext(), { preferencesHydrated: false });
+    // The studio is live and has seeded itself from the catalog...
+    expect(fieldValue(container, "Model")).toBe("Anima 2B");
+    await typePrompt(container, "typed before hydration");
+    await unmountRoot(root, container);
+    // ...but nothing reached the durable store, so the copy on disk is still the user's.
+    expect(window.localStorage.getItem("sceneworks-simple-studio")).toBeNull();
+    // Leave afterEach a live root to tear down.
+    ({ container, root } = mountRoot());
+  });
+
+  it("restores once preferences hydrate, without the studio having to be revisited", async () => {
+    // A snapshot already on disk, as if written in a previous session.
+    seedSimpleStudiosFromServer({
+      "project-1": { image: { model: "z_image", prompt: "from a previous session" } },
+    });
+
+    // Mount pre-hydration: the studio shows catalog defaults, because the cache must not be
+    // trusted yet (on a real relaunch it would be empty at this point).
+    await renderShell(root, baseContext(), { preferencesHydrated: false });
+    expect(fieldValue(container, "Model")).toBe("Anima 2B");
+
+    // The GET lands. The shell remounts the studio so the restored values are read by its
+    // state initialisers — no revisit, no navigation required.
+    await renderShell(root, baseContext(), { preferencesHydrated: true });
+    expect(fieldValue(container, "Model")).toBe("Z-Image");
+    expect(container.querySelector("#su-image-prompt").value).toBe("from a previous session");
+  });
+
+  // sc-15412's open question: the reference id now outlives the library, so a restored one can
+  // name an asset the user deleted in between.
+  it("drops a restored reference whose asset no longer exists, but only once the catalog loads", async () => {
+    const REFERENCE = { id: "asset-9", type: "image", projectId: "project-1", url: "/m/a.png" };
+    seedSimpleStudiosFromServer({
+      "project-1": { image: { model: "z_image", referenceAssetId: "asset-9" } },
+    });
+
+    // Each phase reads the snapshot AFTER an unmount, because the write-through is debounced
+    // and the unmount flush is what makes the stored value observable.
+    const runWith = async (assets) => {
+      ({ container, root } = mountRoot());
+      await renderShell(root, baseContext({ assets }), { preferencesHydrated: true });
+      await unmountRoot(root, container);
+      return readSimpleStudioSnapshot("project-1").image.referenceAssetId;
+    };
+
+    // Catalog still loading (`assets` empty): the id must SURVIVE. Pruning here would strip a
+    // perfectly good reference on every cold start — that is the sc-11962 trap.
+    expect(await runWith([])).toBe("asset-9");
+
+    // Catalog loaded and the asset is still there: kept.
+    expect(await runWith([REFERENCE])).toBe("asset-9");
+
+    // Catalog loaded and the asset is gone: dropped, so the Generate gate and the tile agree
+    // instead of submitting a reference the job would fail on.
+    const other = { id: "asset-1", type: "image", projectId: "project-1", url: "/m/b.png" };
+    expect(await runWith([other])).toBeNull();
+
+    // Leave afterEach a live root to tear down.
+    ({ container, root } = mountRoot());
   });
 
   it("still re-seeds a studio the user never touched", async () => {

--- a/apps/web/src/simple/useStudioState.test.jsx
+++ b/apps/web/src/simple/useStudioState.test.jsx
@@ -1,0 +1,182 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../context/AppContext.js";
+import { SimpleShell } from "./SimpleShell.jsx";
+import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+// A studio UNMOUNTS when you navigate away (the shell renders exactly one screen), so
+// without the shell-held store every knob would be re-seeded from the catalog on the way
+// back — the model snapping to whichever entry happens to sort first. These tests drive the
+// real shell through a real round trip and assert the studio comes back as it was left.
+
+// Two models on purpose: with only one, "the selection was kept" and "the selection was
+// re-seeded to models[0]" are the same assertion and the test would pass either way.
+const Z_IMAGE = {
+  id: "z_image",
+  name: "Z-Image",
+  type: "image",
+  capabilities: ["text_to_image"],
+  installState: "installed",
+  limits: { resolutions: ["1024x1024", "1344x768"] },
+};
+const ANIMA = {
+  id: "anima_2b",
+  name: "Anima 2B",
+  type: "image",
+  capabilities: ["text_to_image"],
+  installState: "installed",
+  limits: { resolutions: ["1024x1024", "768x768"] },
+};
+
+function baseContext(overrides = {}) {
+  return {
+    activeProject: { id: "project-1", name: "Default" },
+    assets: [],
+    recentImageAssets: [],
+    jobs: [],
+    // Anima first, exactly as the catalog orders it — so a reset is visible as a snap-back.
+    imageModels: [ANIMA, Z_IMAGE],
+    videoModels: [],
+    audioModels: [],
+    models: [ANIMA, Z_IMAGE],
+    loras: [],
+    imageLocalJobs: [],
+    videoLocalJobs: [],
+    audioLocalJobs: [],
+    visibleWorkers: [],
+    macCapabilities: null,
+    theme: "light",
+    changeTheme: () => {},
+    createImageJob: vi.fn(async () => ({ id: "job-1" })),
+    createVideoJob: vi.fn(async () => null),
+    createAudioJob: vi.fn(async () => null),
+    createModelDownloadJob: vi.fn(async () => null),
+    createLoraDownloadJob: vi.fn(async () => null),
+    jobAction: vi.fn(async () => {}),
+    rememberLocalGenerationJob: vi.fn(),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    setSelectedAssetId: vi.fn(),
+    setActiveView: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderShell(root, context) {
+  return act(async () => {
+    root.render(
+      <AppContext.Provider value={context}>
+        <SimpleShell
+          accent="teal"
+          lockedToSimple={false}
+          onAccentChange={() => {}}
+          onModeChange={() => {}}
+          onSimpleDefaultChange={() => {}}
+          simpleDefault
+        />
+      </AppContext.Provider>,
+    );
+  });
+}
+
+function navButton(container, label) {
+  return [...container.querySelectorAll(".su-nav-item")].find((node) =>
+    node.textContent.startsWith(label),
+  );
+}
+
+function fieldValue(container, label) {
+  const field = [...container.querySelectorAll(".su-field")].find(
+    (node) => node.querySelector("label")?.textContent.trim() === label,
+  );
+  return field?.querySelector(".su-select span")?.textContent.trim() ?? null;
+}
+
+async function openField(container, label) {
+  const field = [...container.querySelectorAll(".su-field")].find(
+    (node) => node.querySelector("label")?.textContent.trim() === label,
+  );
+  await click(field.querySelector(".su-select"));
+}
+
+async function chooseOption(container, text) {
+  const row = [...container.querySelectorAll(".su-option-row, .su-option-tile")].find((node) =>
+    node.textContent.includes(text),
+  );
+  expect(row).toBeTruthy();
+  await click(row);
+}
+
+async function typePrompt(container, value) {
+  const textarea = container.querySelector("#su-image-prompt");
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    ).set;
+    setter.call(textarea, value);
+    textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+  });
+}
+
+describe("Simple studio state across navigation", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the picked model, prompt and resolution when you leave the studio and come back", async () => {
+    await renderShell(root, baseContext());
+
+    // Seeded from the catalog on a cold open — the first eligible model.
+    expect(fieldValue(container, "Model")).toBe("Anima 2B");
+
+    await typePrompt(container, "a lighthouse at dusk");
+    await openField(container, "Model");
+    await chooseOption(container, "Z-Image");
+    expect(fieldValue(container, "Model")).toBe("Z-Image");
+
+    await openField(container, "Resolution");
+    await chooseOption(container, "1344");
+    const size = fieldValue(container, "Resolution");
+
+    await click(navButton(container, "Queue"));
+    expect(container.querySelector("#su-image-prompt")).toBeNull();
+
+    await click(navButton(container, "Image"));
+    expect(fieldValue(container, "Model")).toBe("Z-Image");
+    expect(container.querySelector("#su-image-prompt").value).toBe("a lighthouse at dusk");
+    expect(fieldValue(container, "Resolution")).toBe(size);
+  });
+
+  it("keeps each studio's state separate", async () => {
+    await renderShell(root, baseContext());
+    await typePrompt(container, "image prompt");
+
+    await click(navButton(container, "Audio"));
+    const audioPrompt = container.querySelector("#su-audio-prompt");
+    expect(audioPrompt.value).toBe("");
+
+    await click(navButton(container, "Image"));
+    expect(container.querySelector("#su-image-prompt").value).toBe("image prompt");
+  });
+
+  it("still re-seeds a studio the user never touched", async () => {
+    await renderShell(root, baseContext());
+    await click(navButton(container, "Queue"));
+    await click(navButton(container, "Image"));
+    // Nothing was chosen, so the catalog default still applies on the way back — the store
+    // must not have persisted a half-seeded empty value.
+    expect(fieldValue(container, "Model")).toBe("Anima 2B");
+    expect(fieldValue(container, "Resolution")).toBeTruthy();
+  });
+});

--- a/apps/web/src/simple/useStudioState.test.jsx
+++ b/apps/web/src/simple/useStudioState.test.jsx
@@ -288,6 +288,17 @@ describe("Simple studio state across navigation", () => {
     ({ container, root } = mountRoot());
   });
 
+  // With nothing stored there is nothing to restore, so the hydration remount must not fire —
+  // on a LAN deployment the ui-preferences GET is a real network hop, and remounting
+  // unconditionally would discard whatever the user typed while it was in flight.
+  it("keeps what the user typed while preferences were still loading, when nothing is stored", async () => {
+    await renderShell(root, baseContext(), { preferencesHydrated: false });
+    await typePrompt(container, "typed during the GET");
+
+    await renderShell(root, baseContext(), { preferencesHydrated: true });
+    expect(container.querySelector("#su-image-prompt").value).toBe("typed during the GET");
+  });
+
   it("still re-seeds a studio the user never touched", async () => {
     await renderShell(root, baseContext());
     await click(navButton(container, "Queue"));

--- a/apps/web/src/simpleStudioStore.js
+++ b/apps/web/src/simpleStudioStore.js
@@ -1,0 +1,109 @@
+// Durable store for the Simple studios' own knobs — model, prompt, resolution, duration,
+// LoRA picks (epic 15404's fields and whatever Simple grows next).
+//
+// The Simple shell renders one screen at a time, so a studio UNMOUNTS on navigation and its
+// state dies with it. The shell keeps a session copy (see simple/useStudioState.js); this
+// module is what makes that copy outlive an app relaunch.
+//
+// WHY NOT MIRROR THE ADVANCED STUDIOS. They solve the same problem with a per-workspace
+// localStorage blob (hooks/useStudioSettings.js) plus keep-alive mounting (App.jsx's
+// KEEP_ALIVE_VIEWS), so their state never has to survive a real unmount. localStorage alone
+// does NOT survive a desktop relaunch — the shell's `127.0.0.1:<port>` origin changes every
+// launch, wiping origin-keyed storage — which is exactly the durability the Simple studios
+// need. So this follows lastTierStore.js instead: localStorage is the instant-paint cache and
+// `ui-preferences.json` is authoritative across launches.
+//
+// KEYED BY WORKSPACE, matching the advanced studios' `sceneworks-studio-<studio>-<workspaceId>`
+// namespacing. A prompt written for one project must not follow the user into another.
+
+import { persistNavigationPreferences } from "./uiPreferences.js";
+
+const STORAGE_KEY = "sceneworks-simple-studio";
+
+// Keep in sync with MAX_SIMPLE_STUDIO_WORKSPACES in apps/rust-api/src/preferences.rs. Nothing
+// ever removes a workspace entry, so without a bound a long-lived install would carry every
+// project it has ever opened — each holding a full prompt. Pruning here rather than relying on
+// the server's backstop keeps the localStorage cache and the durable copy the same shape.
+const MAX_WORKSPACES = 24;
+
+const DEFAULT_WORKSPACE = "default";
+
+function workspaceKey(workspaceId) {
+  return workspaceId ?? DEFAULT_WORKSPACE;
+}
+
+function readAll() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    // localStorage unavailable (private mode, quota, non-DOM env) — no restore this session.
+    return {};
+  }
+}
+
+function writeAll(map) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable — the server copy below is still attempted, so the settings
+    // can come back on the next launch even when the cache can't hold them now.
+  }
+}
+
+// Drop the oldest entries once the map exceeds the bound. `touched` is moved to the end first
+// so the workspace the user is actually in is never the one evicted.
+function prune(map, touched) {
+  const keys = Object.keys(map).filter((key) => key !== touched);
+  const kept = keys.slice(Math.max(0, keys.length - (MAX_WORKSPACES - 1)));
+  const next = {};
+  for (const key of kept) {
+    next[key] = map[key];
+  }
+  next[touched] = map[touched];
+  return next;
+}
+
+// Seed the localStorage instant-paint cache from the durable server copy on launch (App.jsx,
+// after GET /api/v1/ui-preferences). Without this, a relaunched desktop app reads an empty
+// cache — its origin, and therefore its localStorage, changed — and every studio would come
+// back on catalog defaults. The server map is authoritative; the cache only ever mirrors it.
+export function seedSimpleStudiosFromServer(map) {
+  if (map && typeof map === "object") {
+    writeAll(map);
+  }
+}
+
+/**
+ * The stored `{ [studio]: { [field]: value } }` snapshot for a workspace, or `{}` when none.
+ * Read fresh from localStorage on every call, so a value seeded from the server after launch
+ * is picked up without this module holding its own copy.
+ */
+export function readSimpleStudioSnapshot(workspaceId) {
+  const entry = readAll()[workspaceKey(workspaceId)];
+  return entry && typeof entry === "object" ? entry : {};
+}
+
+/**
+ * Record a workspace's full studio snapshot: localStorage now, server best-effort.
+ *
+ * The PUT goes through `persistNavigationPreferences`, which coalesces patches and keeps at
+ * most one request in flight — so a burst of typing collapses instead of racing, and an older
+ * delayed response can't land on top of a newer snapshot. Callers still debounce; this is the
+ * ordering guarantee, not the rate limit.
+ */
+export function writeSimpleStudioSnapshot(workspaceId, snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return;
+  }
+  const key = workspaceKey(workspaceId);
+  const map = readAll();
+  map[key] = snapshot;
+  const pruned = prune(map, key);
+  writeAll(pruned);
+  // Fire-and-forget: the cache write already succeeded, so a failed PUT costs only durability
+  // across the next relaunch. The PUT is a GATED write, so it goes through the token-attaching
+  // seam (sc-15136) rather than a hand-rolled credential-less apiFetch.
+  persistNavigationPreferences({ simpleStudio: pruned }).catch(() => {});
+}


### PR DESCRIPTION
Two Simple UI bugs reported from the desktop app, plus the durable-persistence follow-on the owner asked for. Closes sc-15412 (epic sc-15404's known gap).

## 1. The picker sheet opens off-centre, then jumps

**Symptom:** opening the model selector or Add LoRA makes the screen jump. On a short list (Resolution) the cause is visible — the dialog appears in the lower right, then moves to the centre. On a long list it also throws the whole screen upward.

**Cause:** `.su-sheet` centres itself on desktop with `transform: translate(-50%, -50%)`, but its open animation `su-pop` animated `transform` from `translateY(8px) scale(0.98)` to `none`. An animated `transform` *replaces* the rule's own for the entire run, so for the full 200ms the centering was gone and the card's top-left corner sat exactly on the container's centre point.

Measured against the real component in a 1280×720 shell:

| animation time | position |
|---|---|
| 0ms | left 640, top 360, bottom **922** |
| 199ms | left 640, top 360 |
| settled | left 415, top 93 |

The sheet ran from the centre down to y=922 — ~200px below the fold — then snapped up-left. The taller the panel, the further past the fold it reached, which is why the model and Add LoRA pickers were the worst.

**Fix:** a `su-pop-centered` keyframe that carries the centering in every frame. t=0 is now 415/93, settling at 410/79 — no repositioning at any point. Plain `su-pop` is left alone for the toast, which has no base transform to clobber.

The whole-screen upward jump was the same defect's second-order effect: `SimpleSheet` focuses its panel on open, and focusing an element hanging below the fold makes the browser scroll the shell to reveal it. The geometry fix removes the cause; `preventScroll: true` makes it structural.

## 2. Studio settings reset on navigation

**Cause:** the shell renders one screen at a time (`{screen === "image" ? <SimpleImageStudio /> : null}`), so every studio unmounts on navigation and its `useState` dies. On return the seeding effect re-picks `models[0]` — hence "always Anima 2B".

**Fix:** `dismissedJobIds` already lives on the shell for exactly this reason ("because the studios unmount on navigation"). This generalises that — a `useStudioState` hook backed by a shell-owned `Map`, a ref rather than state so keystrokes don't re-render the shell.

## 3. …and reset on relaunch (sc-15412)

**A note on "mirror the Advanced UI":** that turned out to be the wrong target, and it's worth stating why. The advanced studios are localStorage-only (`hooks/useStudioSettings.js`) and survive navigation by never unmounting (`App.jsx` `KEEP_ALIVE_VIEWS`). Copying them would have reintroduced the exact loss being fixed — the desktop shell's `127.0.0.1:<port>` origin changes every launch and takes origin-keyed storage with it.

So this follows `lastTierStore.js`, the established pattern for a preference that must outlive a relaunch: localStorage as the instant-paint cache, a new `simpleStudio` field on `ui-preferences.json` as the authority. Keyed by **workspace**, matching the advanced studios' namespacing — a prompt written for one project must not follow the user into another.

**The anti-clobber window.** On a relaunch the cache is empty and the ui-preferences GET is still in flight, so a studio that seeded from the catalog and persisted during that window would overwrite the stored snapshot before anything read it — sc-11962's failure mode in the durable lane. `SimpleShell` takes `preferencesHydrated` (the same `navigationHydrated` flag that already gates the durable `activeView` write) and does **neither** a restore **nor** any persistence until it flips. When it does, the studios remount via a `studioEpoch` key so restored values are read by their state initialisers rather than pushed into live state.

**Deleted references.** sc-15412 asked what happens to a restored reference whose asset was since deleted — it was a real defect. `needsSource` gates on the raw id, not the resolved asset, so edit mode stayed submittable and sent a dangling id the job would fail on. Both studios now validate a restored id once the catalog has actually loaded, guarded because `assets` is empty both pre-fetch and when the library is genuinely empty. Found while there: the Video studio resolved its source tile against the picker's recent-20 list, so a restored source that had aged out would blank the tile and then be wrongly pruned; it now resolves against the full catalog, as Image already did.

**Persisted:** mode, prompt, model, resolution, variations/duration, style, reference/source asset, refine panel, LoRA picks + weights + pending imports. **Not persisted:** `submitting` — it belongs to an in-flight request, and a studio that remounted mid-submit must not come back looking busy.

## Reviewer notes

- **Server field is stored verbatim** — the frontend owns the vocabulary, same stance as `perModelTier`, so a new Simple knob needs no server change. Bounded at 24 workspaces / 64KB per entry on both sides, since nothing removes a workspace entry and prompts are free text. Over-budget entries are dropped whole rather than truncated: a half-parsed snapshot would restore a studio into a state the user never chose.
- Write-through is debounced 400ms with a flush on unmount, and the PUT goes through the token-attaching coalescer (`persistNavigationPreferences`), not a hand-rolled credential-less fetch — sc-15136's rule.
- The explicit setter entries in dependency arrays aren't noise: they're React `useState` setters and referentially stable, but exhaustive-deps only exempts a setter destructured straight off `useState`. Preferred over a suppression.
- Existing shell tests gained a `localStorage.clear()` — persistence now works, so a snapshot flushed by one case would restore into the next.
- The Advanced UI's `styles.css` was scanned for the same centered-transform-vs-animation pattern; it has none, so fix 1 is correctly scoped to Simple.

## Verification

- Bug 1 measured in the browser against the real component and CSS — old behaviour reproduced, new behaviour confirmed centred at every frame, focus verified to land on the dialog with all scroll offsets at 0.
- 8 tests drive the real shell: navigation round trip, per-studio isolation, relaunch (unmount → clear cache → seed from server → remount), per-workspace isolation, the pre-hydration no-clobber guard, restore-on-hydration, deleted-reference prune.
- **Mutation-checked:** removing the hydration gate fails 2 tests; removing the remount key fails 3; removing the loaded-catalog guard fails the prune test; bypassing the store fails the 2 navigation tests. No test passes for the wrong reason.
- Rust: 5 unit tests + 1 end-to-end merge test on `preferences.rs`.
- `origin/main` merged in before verifying. Post-merge: **2883 web tests / 208 files** green, `npm run rust:check` exit 0, eslint clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)