### PR TITLE
feat(advanced-studios): studio settings survive a relaunch (sc-15425)

### DIFF
--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -91,28 +91,49 @@ pub(crate) struct UiPreferences {
     /// its cache), and a PUT without it leaves the stored map untouched.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     simple_studio: Option<BTreeMap<String, serde_json::Value>>,
+    /// Advanced-workspace studio settings — the same thing as `simple_studio`, for the full
+    /// workspace's Image / Video / Audio / Character / Editor studios (sc-15425).
+    ///
+    /// The advanced studios keep their settings in a per-workspace `localStorage` blob
+    /// (`hooks/useStudioSettings.js`) and survive NAVIGATION by never unmounting (`KEEP_ALIVE_VIEWS`),
+    /// so until now they lost everything on relaunch — the desktop shell's `127.0.0.1:<port>` origin
+    /// changes each launch and takes origin-keyed storage with it. This is the durable copy that
+    /// `localStorage` cache is re-seeded from on launch.
+    ///
+    /// Shape: `{ [workspaceId]: { [studio]: { [field]: value } } }`, studios being
+    /// `image`/`video`/`audio`/`character`/`editor-video`. Stored verbatim like the fields above.
+    /// The web deliberately omits its two unbounded batch fields from what it sends here; see
+    /// `MAX_STUDIO_ENTRY_BYTES`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    advanced_studio: Option<BTreeMap<String, serde_json::Value>>,
 }
 
-/// Retained workspaces in `simple_studio`. The map grows by one entry per workspace the user
-/// opens a Simple studio in and nothing ever removes an entry, so without a bound a long-lived
+/// Retained workspaces in a studio-settings map. The map grows by one entry per workspace the
+/// user opens a studio in and nothing ever removes an entry, so without a bound a long-lived
 /// install would carry every workspace it has ever seen — each holding a full prompt — in a file
 /// re-read and rewritten on every preference write. The web prunes to the same bound on its side;
 /// this is the backstop for a client that doesn't.
-const MAX_SIMPLE_STUDIO_WORKSPACES: usize = 24;
+const MAX_STUDIO_WORKSPACES: usize = 24;
 
 /// Serialized bytes allowed for one workspace's studio snapshot. Prompts are free text, so this
 /// bounds what a single entry can cost; an oversized entry is DROPPED rather than truncated,
 /// because a half-parsed snapshot would restore a studio into a state the user never chose.
-const MAX_SIMPLE_STUDIO_ENTRY_BYTES: usize = 64 * 1024;
+///
+/// The ADVANCED entry is the sizing case, not the Simple one: a Simple workspace holds ~8 fields
+/// per studio, while `ImageStudio` and `VideoStudio` each persist ~47. The web keeps its two
+/// unbounded batch fields (`batchPromptsText`, `batchVariableValues`) out of the durable copy for
+/// exactly this reason, which is what keeps a realistic advanced snapshot comfortably inside this.
+const MAX_STUDIO_ENTRY_BYTES: usize = 128 * 1024;
 
-/// Keep the well-formed, in-budget entries of a `simple_studio` map.
+/// Keep the well-formed, in-budget entries of a studio-settings map (`simple_studio` /
+/// `advanced_studio`).
 ///
 /// Entries must be JSON objects (the `{ [studio]: { … } }` shape the web writes); anything else is
 /// a client bug or a hand-edited file, and storing it would hand the web back something it can't
-/// read. Over-budget entries are dropped. When more than `MAX_SIMPLE_STUDIO_WORKSPACES` survive,
-/// the retained set is the first N by key order — arbitrary but STABLE, so repeated PUTs of the
-/// same oversized map converge instead of thrashing the file.
-fn normalize_simple_studio(
+/// read. Over-budget entries are dropped. When more than `MAX_STUDIO_WORKSPACES` survive, the
+/// retained set is the first N by key order — arbitrary but STABLE, so repeated PUTs of the same
+/// oversized map converge instead of thrashing the file.
+fn normalize_studio_settings(
     input: BTreeMap<String, serde_json::Value>,
 ) -> BTreeMap<String, serde_json::Value> {
     input
@@ -121,10 +142,10 @@ fn normalize_simple_studio(
             !workspace.trim().is_empty()
                 && snapshot.is_object()
                 && serde_json::to_string(snapshot)
-                    .map(|body| body.len() <= MAX_SIMPLE_STUDIO_ENTRY_BYTES)
+                    .map(|body| body.len() <= MAX_STUDIO_ENTRY_BYTES)
                     .unwrap_or(false)
         })
-        .take(MAX_SIMPLE_STUDIO_WORKSPACES)
+        .take(MAX_STUDIO_WORKSPACES)
         .collect()
 }
 
@@ -297,7 +318,10 @@ pub(crate) async fn set_ui_preferences(
         // web sends the full merged map from its cache, so a theme- or view-only PUT never
         // clobbers a stored snapshot.
         if let Some(simple_studio) = payload.simple_studio {
-            prefs.simple_studio = Some(normalize_simple_studio(simple_studio));
+            prefs.simple_studio = Some(normalize_studio_settings(simple_studio));
+        }
+        if let Some(advanced_studio) = payload.advanced_studio {
+            prefs.advanced_studio = Some(normalize_studio_settings(advanced_studio));
         }
         if let Some(active_view) = normalize_preference_id(payload.active_view.as_deref(), 48) {
             prefs.active_view = Some(active_view);
@@ -330,8 +354,8 @@ pub(crate) async fn set_ui_preferences(
 mod tests {
     use super::{
         migrate_quality_to_auto, normalize_accent, normalize_generation_quality,
-        normalize_simple_studio, normalize_theme, UiPreferences, MAX_SIMPLE_STUDIO_ENTRY_BYTES,
-        MAX_SIMPLE_STUDIO_WORKSPACES,
+        normalize_studio_settings, normalize_theme, UiPreferences, MAX_STUDIO_ENTRY_BYTES,
+        MAX_STUDIO_WORKSPACES,
     };
     use std::collections::BTreeMap;
 
@@ -340,17 +364,17 @@ mod tests {
     }
 
     #[test]
-    fn normalize_simple_studio_keeps_well_formed_entries_verbatim() {
+    fn normalize_studio_settings_keeps_well_formed_entries_verbatim() {
         let mut input = BTreeMap::new();
         input.insert("project-1".to_owned(), snapshot("a lighthouse"));
-        let kept = normalize_simple_studio(input);
+        let kept = normalize_studio_settings(input);
         // Values are stored verbatim — the field vocabulary belongs to the frontend, so a new
         // Simple knob must not need a server change to survive a round trip.
         assert_eq!(kept.get("project-1"), Some(&snapshot("a lighthouse")));
     }
 
     #[test]
-    fn normalize_simple_studio_drops_malformed_and_oversized_entries() {
+    fn normalize_studio_settings_drops_malformed_and_oversized_entries() {
         let mut input = BTreeMap::new();
         input.insert("ok".to_owned(), snapshot("fine"));
         // Not an object: a client bug or a hand-edited file. Storing it would hand the web back
@@ -362,26 +386,26 @@ mod tests {
         // Over the per-entry budget: dropped whole, never truncated.
         input.insert(
             "huge".to_owned(),
-            snapshot(&"x".repeat(MAX_SIMPLE_STUDIO_ENTRY_BYTES + 1)),
+            snapshot(&"x".repeat(MAX_STUDIO_ENTRY_BYTES + 1)),
         );
 
-        let kept = normalize_simple_studio(input);
+        let kept = normalize_studio_settings(input);
         assert_eq!(kept.keys().collect::<Vec<_>>(), vec!["ok"]);
     }
 
     #[test]
-    fn normalize_simple_studio_bounds_the_workspace_count_stably() {
-        let over = MAX_SIMPLE_STUDIO_WORKSPACES + 5;
+    fn normalize_studio_settings_bounds_the_workspace_count_stably() {
+        let over = MAX_STUDIO_WORKSPACES + 5;
         let build = || {
             (0..over)
                 .map(|n| (format!("project-{n:03}"), snapshot("p")))
                 .collect::<BTreeMap<_, _>>()
         };
-        let kept = normalize_simple_studio(build());
-        assert_eq!(kept.len(), MAX_SIMPLE_STUDIO_WORKSPACES);
+        let kept = normalize_studio_settings(build());
+        assert_eq!(kept.len(), MAX_STUDIO_WORKSPACES);
         // Stable across repeated PUTs of the same map, so the file converges rather than
         // thrashing a different retained set on every write.
-        assert_eq!(kept, normalize_simple_studio(build()));
+        assert_eq!(kept, normalize_studio_settings(build()));
     }
 
     #[test]
@@ -407,6 +431,33 @@ mod tests {
     fn an_absent_simple_studio_is_omitted_from_the_stored_file() {
         let body = serde_json::to_string(&UiPreferences::default()).expect("serialize");
         assert!(!body.contains("simpleStudio"));
+        assert!(!body.contains("advancedStudio"));
+    }
+
+    /// The two studio maps are INDEPENDENT fields sharing one normalizer (sc-15425). A PUT
+    /// carrying one must not disturb the other — the Simple shell and the advanced workspace
+    /// write on their own schedules and would otherwise erase each other.
+    #[test]
+    fn simple_and_advanced_studio_are_independent_fields() {
+        let mut simple = BTreeMap::new();
+        simple.insert("project-1".to_owned(), snapshot("simple side"));
+        let mut advanced = BTreeMap::new();
+        advanced.insert("project-1".to_owned(), snapshot("advanced side"));
+        let prefs = UiPreferences {
+            simple_studio: Some(simple),
+            advanced_studio: Some(advanced),
+            ..Default::default()
+        };
+        let body = serde_json::to_string(&prefs).expect("serialize");
+        let parsed: UiPreferences = serde_json::from_str(&body).expect("deserialize");
+        assert_eq!(
+            parsed.simple_studio.unwrap()["project-1"],
+            snapshot("simple side")
+        );
+        assert_eq!(
+            parsed.advanced_studio.unwrap()["project-1"],
+            snapshot("advanced side")
+        );
     }
 
     #[test]

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -672,6 +672,69 @@ async fn ui_preferences_simple_studio_round_trips_per_workspace_and_merges() {
     assert!(saved["simpleStudio"].get("project-3").is_none());
 }
 
+/// sc-15425: the advanced studios get the same durable treatment, in their own field. The two
+/// maps must not clobber each other — the Simple shell and the advanced workspace write on
+/// independent schedules, and the server replaces each field wholesale.
+#[tokio::test]
+async fn ui_preferences_advanced_studio_is_independent_of_simple_studio() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let app = create_app(settings).expect("app creates");
+
+    let (status, _) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "simpleStudio": { "p1": { "image": { "prompt": "from simple" } } } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // An advanced-only PUT must leave the Simple map alone.
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "advancedStudio": { "p1": { "video": { "prompt": "from advanced" } } } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        saved["simpleStudio"]["p1"]["image"]["prompt"],
+        "from simple"
+    );
+    assert_eq!(
+        saved["advancedStudio"]["p1"]["video"]["prompt"],
+        "from advanced"
+    );
+
+    // Both survive a "relaunch".
+    let (_, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(
+        prefs["simpleStudio"]["p1"]["image"]["prompt"],
+        "from simple"
+    );
+    assert_eq!(
+        prefs["advancedStudio"]["p1"]["video"]["prompt"],
+        "from advanced"
+    );
+
+    // Malformed advanced entries are dropped, and dropping them does not touch Simple.
+    let (status, saved) = request(
+        app,
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "advancedStudio": { "p2": "not-an-object" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(saved["advancedStudio"].get("p2").is_none());
+    assert_eq!(
+        saved["simpleStudio"]["p1"]["image"]["prompt"],
+        "from simple"
+    );
+}
+
 #[test]
 fn requires_token_only_gates_api_paths() {
     use axum::http::Method;

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -39,6 +39,7 @@ import { writeDefaultGenerationQuality } from "./generationQuality.js";
 import { persistNavigationPreferences, putUiPreferences } from "./uiPreferences.js";
 import { seedLastTiersFromServer } from "./lastTierStore.js";
 import { seedSimpleStudiosFromServer } from "./simpleStudioStore.js";
+import { seedStudioSettingsFromServer } from "./hooks/useStudioSettings.js";
 import {
   dropUpscaledVariants,
   findFoldedAssetById,
@@ -523,6 +524,10 @@ export function App() {
   const [activeProject, setActiveProject] = useState(null);
   const [activeView, setActiveView] = useState("Library");
   const [navigationHydrated, setNavigationHydrated] = useState(false);
+  // Bumped when the durable studio snapshot is seeded into the localStorage cache (sc-15425).
+  // Part of the kept-alive studios' React key, so a studio that mounted before the seed landed
+  // remounts and re-reads it. See the seed call in the ui-preferences effect.
+  const [studioRestoreEpoch, setStudioRestoreEpoch] = useState(0);
   const [simpleActiveScreen, setSimpleActiveScreen] = useState("image");
   // Selective lazy keep-alive (sc-11959): the set of keep-alive views the user has
   // visited at least once. A view mounts on first visit (activeView === view) and,
@@ -1362,6 +1367,17 @@ export function App() {
         // so it can't race the seed and restore an empty snapshot.
         if (prefs?.simpleStudio) {
           seedSimpleStudiosFromServer(prefs.simpleStudio);
+        }
+        // The advanced studios' equivalent (sc-15425). Seeded BEFORE `setActiveView` below, on
+        // purpose: restoring the view can mount a keep-alive studio in the same commit, and that
+        // studio reads `loadStudioSettings` synchronously at mount — so the cache has to already
+        // hold the durable copy or it would come up on defaults and never re-read.
+        if (prefs?.advancedStudio && seedStudioSettingsFromServer(prefs.advancedStudio) > 0) {
+          // Remount the kept-alive studios so a studio the user opened BEFORE this landed
+          // re-reads the now-seeded cache — being keep-alive, it never would on its own. Only
+          // when something was actually restored, so the common case (nothing stored yet)
+          // doesn't throw away what they typed while the GET was in flight.
+          setStudioRestoreEpoch((epoch) => epoch + 1);
         }
         const persistedView = prefs?.activeView;
         if (navSections.some((section) => section.items.some((item) => item.id === persistedView))) {
@@ -3081,7 +3097,13 @@ export function App() {
     // drives the app-wide data-theme rather than a screen-local override.
     theme,
     changeTheme,
+    // Whether the durable ui-preferences GET has landed (sc-15425). The studios gate their
+    // settings WRITER on it: until it resolves the localStorage cache may be empty (a relaunched
+    // desktop app has a new origin), and persisting catalog defaults during that window would
+    // overwrite the stored snapshot before anything read it.
+    preferencesHydrated: navigationHydrated,
   }), [
+    navigationHydrated,
     activeProject, mediaAssets, openPreview, sendAssetToImage, sendAssetToVideo,
     activeTimeline, timelines, selectedTimelineId, setSelectedTimelineId, setActiveTimeline, isActiveTimelineDirty,
     createTimeline, saveTimeline, exportTimeline, extractTimelineFrame, queueTimelineVideoJob,
@@ -3326,25 +3348,25 @@ export function App() {
             "Use in Studio" injection still fires on an already-mounted studio. */}
         {keepAliveMounted("Image") ? (
           <KeepAlivePane active={activeView === "Image"}>
-            <ImageStudio key={activeProject?.id ?? "default"} />
+            <ImageStudio key={`${activeProject?.id ?? "default"}:${studioRestoreEpoch}`} />
           </KeepAlivePane>
         ) : null}
 
         {keepAliveMounted("Video") ? (
           <KeepAlivePane active={activeView === "Video"}>
-            <VideoStudio key={activeProject?.id ?? "default"} />
+            <VideoStudio key={`${activeProject?.id ?? "default"}:${studioRestoreEpoch}`} />
           </KeepAlivePane>
         ) : null}
 
         {keepAliveMounted("Audio") ? (
           <KeepAlivePane active={activeView === "Audio"}>
-            <AudioStudio key={activeProject?.id ?? "default"} />
+            <AudioStudio key={`${activeProject?.id ?? "default"}:${studioRestoreEpoch}`} />
           </KeepAlivePane>
         ) : null}
 
         {keepAliveMounted("Characters") ? (
           <KeepAlivePane active={activeView === "Characters"}>
-            <CharacterStudio key={activeProject?.id ?? "default"} />
+            <CharacterStudio key={`${activeProject?.id ?? "default"}:${studioRestoreEpoch}`} />
           </KeepAlivePane>
         ) : null}
 
@@ -3394,6 +3416,12 @@ export function App() {
 
         {keepAliveMounted("Editor") ? (
           <KeepAlivePane active={activeView === "Editor"}>
+            {/* Deliberately NOT keyed on the studio restore epoch (sc-15425), unlike the four
+                studios. The Editor holds timeline edit state and live scratch-op claims
+                (registerEditorScratchClaim), so remounting it to recover its `editor-video`
+                generation settings would risk discarding real editing work and leaking a claim —
+                a far worse trade than the settings it would recover. It picks up a restored
+                snapshot on its next mount instead. */}
             <EditorScreen />
           </KeepAlivePane>
         ) : null}

--- a/apps/web/src/components/editor/useEditorGeneration.js
+++ b/apps/web/src/components/editor/useEditorGeneration.js
@@ -47,6 +47,7 @@ export function useEditorGeneration({ context }) {
     createPreset,
     createModelDownloadJob,
     createLoraDownloadJob,
+    preferencesHydrated,
   } = context;
 
   const projectId = activeProject?.id ?? null;
@@ -277,7 +278,8 @@ export function useEditorGeneration({ context }) {
       selectedPresetId: studio.selectedPresetId,
       generalStackIds: studio.generalStackIds,
     },
-    videoModels.length > 0,
+    // Plus ui-preferences hydration (sc-15425) — see the same gate in ImageStudio.
+    preferencesHydrated && videoModels.length > 0,
   );
 
   // The generation fields common to every editor action. The screen merges this with the

--- a/apps/web/src/hooks/useStudioSettings.durable.test.jsx
+++ b/apps/web/src/hooks/useStudioSettings.durable.test.jsx
@@ -1,0 +1,150 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The durable half of the advanced studio settings (sc-15425). localStorage alone does not
+// survive a desktop relaunch — the shell's `127.0.0.1:<port>` origin changes each launch and
+// takes origin-keyed storage with it — so the settings are mirrored into `ui-preferences.json`
+// and re-seeded into the cache on launch. These tests cover the seam, not the studios.
+const persistNavigationPreferences = vi.fn(() => Promise.resolve());
+vi.mock("../uiPreferences.js", () => ({
+  persistNavigationPreferences: (...args) => persistNavigationPreferences(...args),
+  putUiPreferences: vi.fn(() => Promise.resolve()),
+}));
+
+const { loadStudioSettings, seedStudioSettingsFromServer, useStudioSettingsWriter } =
+  await import("./useStudioSettings.js");
+
+function Harness({ settings, ready = true, studio = "image", workspace = "ws-1" }) {
+  useStudioSettingsWriter(studio, workspace, settings, ready);
+  return null;
+}
+
+/** The `advancedStudio` map from the most recent PUT, or null if none was sent. */
+function lastSentMap() {
+  const call = persistNavigationPreferences.mock.calls.at(-1);
+  return call ? call[0].advancedStudio : null;
+}
+
+describe("advanced studio settings are durable (sc-15425)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    window.localStorage.clear();
+    persistNavigationPreferences.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    window.localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  async function render(element) {
+    await act(async () => {
+      root.render(element);
+    });
+    // The write-through is debounced; advance past it.
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+  }
+
+  it("mirrors a studio snapshot into the durable map, keyed by workspace", async () => {
+    await render(<Harness settings={{ prompt: "a fox", model: "z_image" }} />);
+    expect(lastSentMap()["ws-1"].image).toMatchObject({ prompt: "a fox", model: "z_image" });
+  });
+
+  it("restores the cache from the durable copy after a relaunch", async () => {
+    await render(<Harness settings={{ prompt: "a fox", model: "z_image" }} />);
+    const durable = lastSentMap();
+
+    // Relaunch: new origin, so the cache is gone. Only the server copy survives.
+    window.localStorage.clear();
+    expect(loadStudioSettings("image", "ws-1")).toEqual({});
+
+    expect(seedStudioSettingsFromServer(durable)).toBeGreaterThan(0);
+    expect(loadStudioSettings("image", "ws-1")).toMatchObject({
+      prompt: "a fox",
+      model: "z_image",
+    });
+  });
+
+  // The sizing constraint that drove the design: ImageStudio persists ~47 fields, two of them
+  // unbounded free text. Including them would push a workspace past the server's per-entry
+  // budget, at which point the entry is dropped WHOLE and nothing restores.
+  it("keeps the unbounded batch fields OUT of the durable copy but IN the cache", async () => {
+    await render(
+      <Harness
+        settings={{
+          prompt: "a fox",
+          batchPromptsText: "line one\nline two\nline three",
+          batchVariableValues: { subject: ["a", "b"] },
+        }}
+      />,
+    );
+    const sent = lastSentMap()["ws-1"].image;
+    expect(sent.prompt).toBe("a fox");
+    expect(sent).not.toHaveProperty("batchPromptsText");
+    expect(sent).not.toHaveProperty("batchVariableValues");
+
+    // Still in the cache, which is what serves within-session navigation.
+    const cached = loadStudioSettings("image", "ws-1");
+    expect(cached.batchPromptsText).toBe("line one\nline two\nline three");
+  });
+
+  // sc-11962's window, one step further out: before the ui-preferences GET lands the cache may
+  // be empty, so a studio persisting during that window would overwrite the durable copy with
+  // catalog defaults before anything had read it.
+  it("writes nothing at all while `ready` is false", async () => {
+    await render(<Harness ready={false} settings={{ prompt: "typed before hydration" }} />);
+    expect(persistNavigationPreferences).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("sceneworks-studio-image-ws-1")).toBeNull();
+  });
+
+  it("keeps workspaces separate in the durable map", async () => {
+    await render(<Harness settings={{ prompt: "one" }} workspace="ws-1" />);
+    await render(<Harness settings={{ prompt: "two" }} workspace="ws-2" />);
+    const map = lastSentMap();
+    expect(map["ws-1"].image.prompt).toBe("one");
+    expect(map["ws-2"].image.prompt).toBe("two");
+  });
+
+  it("carries every studio scope in one map", async () => {
+    await render(<Harness settings={{ prompt: "img" }} studio="image" />);
+    await render(<Harness settings={{ prompt: "vid" }} studio="video" />);
+    await render(<Harness settings={{ activeTab: "looks" }} studio="character" />);
+    const entry = lastSentMap()["ws-1"];
+    expect(entry.image.prompt).toBe("img");
+    expect(entry.video.prompt).toBe("vid");
+    expect(entry.character.activeTab).toBe("looks");
+  });
+
+  // The cache holds fields the durable copy deliberately doesn't, so seeding MERGES rather than
+  // replaces — otherwise every launch would drop an in-progress batch sheet.
+  it("merges the seed into the cache instead of replacing it", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-image-ws-1",
+      JSON.stringify({ batchPromptsText: "kept", prompt: "stale" }),
+    );
+    seedStudioSettingsFromServer({ "ws-1": { image: { prompt: "restored", model: "z_image" } } });
+    const cached = loadStudioSettings("image", "ws-1");
+    expect(cached.prompt).toBe("restored");
+    expect(cached.model).toBe("z_image");
+    expect(cached.batchPromptsText).toBe("kept");
+  });
+
+  it("ignores a malformed durable map rather than corrupting the cache", async () => {
+    expect(seedStudioSettingsFromServer(null)).toBe(0);
+    expect(seedStudioSettingsFromServer({ "ws-1": "not-an-object" })).toBe(0);
+    expect(seedStudioSettingsFromServer({ "ws-1": { image: 42 } })).toBe(0);
+    expect(loadStudioSettings("image", "ws-1")).toEqual({});
+  });
+});

--- a/apps/web/src/hooks/useStudioSettings.js
+++ b/apps/web/src/hooks/useStudioSettings.js
@@ -1,12 +1,35 @@
 import { useEffect } from "react";
+import { persistNavigationPreferences } from "../uiPreferences.js";
 
 // Per-workspace "last used" settings for the Image / Video studios, so leaving a
 // studio and coming back restores the prompt, model, resolution, length, advanced
 // options, LoRAs and preset exactly as they were — scoped to the active workspace.
 const PREFIX = "sceneworks-studio";
 
+// Studios that participate. Needed because the durable copy is ONE map keyed by workspace
+// (`{ [workspaceId]: { [studio]: {…} } }`) while the cache is one localStorage key per
+// (studio, workspace) — seeding has to know which keys to write, and there is no way to
+// enumerate them from the map alone without trusting its contents.
+const STUDIOS = ["image", "video", "audio", "character", "editor-video"];
+
+// Kept OUT of the durable copy (sc-15425). Both are unbounded free text — a batch sheet can
+// hold hundreds of prompts — and `ImageStudio` alone persists ~47 fields, so including them
+// would push a workspace past the server's per-entry budget, at which point the entry is
+// dropped WHOLE and the user's whole studio silently fails to restore. They stay in the
+// localStorage cache, which is what actually serves within-session navigation; the contract is
+// "your setup comes back after a relaunch, an in-progress batch sheet doesn't".
+const NON_DURABLE_FIELDS = ["batchPromptsText", "batchVariableValues"];
+
+const DEFAULT_WORKSPACE = "default";
+// Keep in sync with MAX_STUDIO_WORKSPACES in apps/rust-api/src/preferences.rs.
+const MAX_WORKSPACES = 24;
+
+function workspaceKey(workspaceId) {
+  return workspaceId ?? DEFAULT_WORKSPACE;
+}
+
 function storageKey(studio, workspaceId) {
-  return `${PREFIX}-${studio}-${workspaceId ?? "default"}`;
+  return `${PREFIX}-${studio}-${workspaceKey(workspaceId)}`;
 }
 
 // Read the saved snapshot once at mount. Returns {} when nothing is stored or
@@ -21,6 +44,92 @@ export function loadStudioSettings(studio, workspaceId) {
   }
 }
 
+/**
+ * Seed the localStorage cache from the durable server copy on launch (App.jsx, after
+ * GET /api/v1/ui-preferences).
+ *
+ * Without this the advanced studios lose everything on a desktop relaunch: the shell's
+ * `127.0.0.1:<port>` origin changes each launch and takes origin-keyed storage with it, so the
+ * cache `loadStudioSettings` reads is empty even though the user never cleared anything.
+ * The server map is authoritative across launches; the cache only ever mirrors it.
+ *
+ * Merges per (studio, workspace) rather than replacing: the non-durable batch fields live ONLY
+ * in the cache, so a blind overwrite would drop an in-progress batch sheet on every launch of a
+ * session that hadn't yet re-saved it.
+ *
+ * @returns {number} how many (studio, workspace) snapshots were written. The caller remounts the
+ *   kept-alive studios only when this is non-zero: a studio the user opened BEFORE the GET landed
+ *   read an empty cache and, being keep-alive, would never re-read on its own. Remounting
+ *   unconditionally would instead discard whatever they had typed in that window for nothing.
+ */
+export function seedStudioSettingsFromServer(map) {
+  if (!map || typeof map !== "object") {
+    return 0;
+  }
+  let written = 0;
+  for (const [workspace, perStudio] of Object.entries(map)) {
+    if (!perStudio || typeof perStudio !== "object") {
+      continue;
+    }
+    for (const studio of STUDIOS) {
+      const restored = perStudio[studio];
+      if (!restored || typeof restored !== "object") {
+        continue;
+      }
+      const cached = loadStudioSettings(studio, workspace);
+      writeCache(studio, workspace, { ...cached, ...restored });
+      written += 1;
+    }
+  }
+  return written;
+}
+
+function writeCache(studio, workspaceId, settings) {
+  try {
+    window.localStorage.setItem(storageKey(studio, workspaceId), JSON.stringify(settings));
+  } catch {
+    // localStorage unavailable — settings just won't persist this session.
+  }
+}
+
+// Rebuild the whole `{ [workspaceId]: { [studio]: {…} } }` map from the cache, minus the
+// non-durable fields, and send it. The server replaces the field wholesale (it does not
+// deep-merge), so the payload has to be the full map — same contract as `perModelTier`.
+function persistToServer(touchedWorkspace) {
+  const map = {};
+  let keys;
+  try {
+    keys = Object.keys(window.localStorage);
+  } catch {
+    return;
+  }
+  for (const key of keys) {
+    if (!key.startsWith(`${PREFIX}-`)) {
+      continue;
+    }
+    const studio = STUDIOS.find((entry) => key.startsWith(`${PREFIX}-${entry}-`));
+    if (!studio) {
+      continue;
+    }
+    const workspace = key.slice(`${PREFIX}-${studio}-`.length);
+    const settings = loadStudioSettings(studio, workspace);
+    const durable = { ...settings };
+    for (const field of NON_DURABLE_FIELDS) {
+      delete durable[field];
+    }
+    map[workspace] = { ...(map[workspace] ?? {}), [studio]: durable };
+  }
+  // Bound the map the same way the server does, keeping the workspace being written.
+  const others = Object.keys(map).filter((key) => key !== touchedWorkspace);
+  const dropped = others.slice(0, Math.max(0, others.length - (MAX_WORKSPACES - 1)));
+  for (const key of dropped) {
+    delete map[key];
+  }
+  // Fire-and-forget: the cache write already succeeded, so a failed PUT costs only durability
+  // across the next relaunch. Routed through the coalescing, token-attaching seam (sc-15136).
+  persistNavigationPreferences({ advancedStudio: map }).catch(() => {});
+}
+
 // Persist `settings` for the workspace whenever they change. Serializing on every
 // render is cheap for a couple dozen fields and lets the effect skip writes when
 // nothing actually changed.
@@ -32,16 +141,22 @@ export function loadStudioSettings(studio, workspaceId) {
 // the clobber permanent. While `ready` is false we leave the stored snapshot untouched
 // (it already holds the restored values); the studio flips `ready` true once its
 // catalog has loaded, at which point the current (settled) state is persisted normally.
+//
+// `ready` now ALSO has to cover ui-preferences hydration (sc-15425), for the same reason one
+// step further out: on a relaunch the cache is empty until the GET lands, so a studio the user
+// opened before then would persist its catalog defaults over the durable copy before anything
+// had read it. Callers pass `preferencesHydrated && <their catalog gate>`.
 export function useStudioSettingsWriter(studio, workspaceId, settings, ready = true) {
   const serialized = JSON.stringify(settings);
   useEffect(() => {
     if (!ready) {
-      return;
+      return undefined;
     }
-    try {
-      window.localStorage.setItem(storageKey(studio, workspaceId), serialized);
-    } catch {
-      // localStorage unavailable — settings just won't persist this session.
-    }
+    writeCache(studio, workspaceId, JSON.parse(serialized));
+    // Debounced: the advanced studios re-serialize on every keystroke, and one durable write
+    // per character would hammer a disk-writing PUT. The queue keeps requests ordered; this
+    // keeps them rare.
+    const timer = setTimeout(() => persistToServer(workspaceKey(workspaceId)), 400);
+    return () => clearTimeout(timer);
   }, [studio, workspaceId, serialized, ready]);
 }

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -222,6 +222,7 @@ export function AudioStudio() {
     savedVoices = [],
     createSavedVoice,
     deleteSavedVoice,
+    preferencesHydrated,
   } = useAppContext();
 
   // Last-used settings for this workspace, restored on mount. The component is keyed by workspace in
@@ -615,7 +616,8 @@ export function AudioStudio() {
       matchStrength,
       advancedOpen,
     },
-    audioModels.length > 0,
+    // Plus ui-preferences hydration (sc-15425) — see the same gate in ImageStudio.
+    preferencesHydrated && audioModels.length > 0,
   );
 
   // A human-readable capability summary so the capability-driven nature of the settings is visible

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -170,6 +170,7 @@ export function CharacterStudio() {
     createTrainingDataset,
     openDatasetInLibrary,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
+    preferencesHydrated,
   } = useAppContext();
   const latestAssets = latestImageAssets;
   // Mac UI gating (sc-3486): hide torch-only models from the angle/pose/test pickers.
@@ -237,7 +238,10 @@ export function CharacterStudio() {
   const [activeTab, setActiveTab] = useState(() =>
     CHARACTER_TAB_IDS.includes(savedSettings.activeTab) ? savedSettings.activeTab : DEFAULT_CHARACTER_TAB,
   );
-  useStudioSettingsWriter("character", activeProject?.id ?? null, { activeTab });
+  // Gated on ui-preferences hydration (sc-15425): this writer had no gate because the tab is
+  // not catalog-derived, but it still must not persist the DEFAULT tab over a stored one during
+  // the window before the durable copy has arrived.
+  useStudioSettingsWriter("character", activeProject?.id ?? null, { activeTab }, preferencesHydrated);
   const tabRefs = useRef({});
   const activeTabIndex = CHARACTER_TABS.findIndex(([id]) => id === activeTab);
   // Roving-tabindex keyboard nav, matching the TrainingStudio tablist: arrows wrap,

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -313,6 +313,7 @@ export function ImageStudio() {
     updateAssetStatus,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
     visibleWorkers = [],
+    preferencesHydrated,
   } = useAppContext();
   // Krea 2 INT8-ConvRot eligibility (sc-9300, epic 9083): the candle-only tier is offered ONLY when a
   // live worker advertises the `int8_convrot` capability — which the worker emits solely on the candle
@@ -1838,7 +1839,10 @@ export function ImageStudio() {
   // transient defaults-reset during the restart-restore/settle window can't be
   // persisted over the restored snapshot. When there are no models the studio shows
   // the availability gate (no editable form), so nothing meaningful is lost by waiting.
-  imageModels.length > 0);
+  // ALSO gated on ui-preferences hydration (sc-15425): before the GET lands the localStorage
+  // cache may be empty (a relaunched desktop app has a new origin), and persisting through it
+  // would overwrite the durable copy with catalog defaults before anything read it.
+  preferencesHydrated && imageModels.length > 0);
 
   // Each stacked run carries its already-resolved completed assets + the
   // expected count, which the WorkerProgressCard image-grid variant uses to

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -149,6 +149,7 @@ export function VideoStudio() {
     videoModels,
     models = [],
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
+    preferencesHydrated,
   } = useAppContext();
   // Prompt-refinement model catalog entry (sc-5605) — drives the "download the
   // refinement model" affordance in RefinePromptControl when Refine fails because the
@@ -1022,7 +1023,8 @@ export function VideoStudio() {
   // Suppress the live writer until the video catalog has loaded (sc-11962), so a transient
   // defaults-reset during the restart-restore/settle window can't overwrite the restored
   // snapshot before the async catalogs settle.
-  videoModels.length > 0);
+  // Plus ui-preferences hydration (sc-15425) — see the same gate in ImageStudio.
+  preferencesHydrated && videoModels.length > 0);
 
   useEffect(() => {
     if (mode !== "replace_person") {


### PR DESCRIPTION
Gives the advanced workspace the durability the Simple studios got in sc-15412. Closes [sc-15425](https://app.shortcut.com/trefry/story/15425).

> **Stacked on #1924** — based on `claude/desktop-simple-ui-dialog-jump-12940f`, because it builds on the `preferences.rs` bounds helper added there. Merge #1924 first; this will retarget to `main` automatically.

## Why not just copy what Advanced already does

Worth stating, because "make Advanced mirror Simple" sounds like it should be symmetric and isn't. Advanced persists two ways today, **neither durable across a relaunch**:

- `hooks/useStudioSettings.js` — a per-workspace localStorage blob.
- `App.jsx` `KEEP_ALIVE_VIEWS` — studios mount on first visit and stay mounted-but-hidden, which is what actually makes navigation lossless.

The desktop shell's `127.0.0.1:<port>` origin changes every launch and takes origin-keyed storage with it, so every advanced studio came back on catalog defaults after a restart. localStorage stays as the instant-paint cache; a new `advancedStudio` field on `ui-preferences.json` becomes the authority, re-seeded into the cache on launch — the `lastTierStore.js` pattern.

## Why this is a small change

All five consumers (`image`, `video`, `audio`, `character`, `editor-video`) already go through **one 47-line module** with exactly one read and one write, already keyed `(studio, workspaceId)`, and its `ready` gate is exactly the hook the durable lane needs. **No studio's state handling is touched.**

## The sizing constraint that shaped the design

Measured: `ImageStudio` and `VideoStudio` each persist **47 fields**, two of them unbounded free text — `batchPromptsText` and `batchVariableValues`, and a batch sheet can hold hundreds of prompts. Including those would push a workspace past the server's per-entry budget, and an over-budget entry is dropped **whole** — which reads to the user as "my settings didn't come back", with no explanation.

So the two batch fields are **excluded from the durable copy** and stay in the cache, which is what actually serves within-session navigation. Contract: *your setup comes back after a relaunch; an in-progress batch sheet doesn't.* The per-entry bound is raised to 128KB, since the advanced snapshot — not the Simple one — is now the sizing case.

This is a judgement call and easy to reverse if you'd rather persist everything and raise the bound instead.

## Hydration

Same clobber window as sc-15412, one step further out: before the ui-preferences GET lands the cache may be empty, so a studio opened in that window would persist its catalog defaults over the durable copy before anything read it. Every writer's `ready` now also requires `preferencesHydrated`, published on the app context rather than prop-drilled through five screens. **CharacterStudio gains a gate it never had** — its tab isn't catalog-derived, but it must still not write the default tab over a stored one.

The seed runs **before** `setActiveView` in the same `.then`, so a studio mounted by the restored view already sees a seeded cache. For the remaining race — a user who opens a studio before the GET resolves — the four studios carry a restore epoch in their key and remount, but **only when something was actually restored**, so the common case doesn't discard what they typed while the GET was in flight.

**`EditorScreen` is deliberately NOT keyed on that epoch**, unlike the studios: it holds timeline edit state and live scratch-op claims (`registerEditorScratchClaim`), so remounting it to recover *generation settings* would risk discarding real editing work and leaking a claim. It picks up a restored snapshot on its next mount instead.

Seeding **merges** into the cache rather than replacing it, because the non-durable batch fields live only there — a blind overwrite would drop an in-progress batch sheet on every launch.

## Reviewer notes

- **This is a behaviour change for the primary workspace, not a bug fix.** Advanced navigation already worked; the difference is that a prompt from a previous session now reappears on launch. Flagged before building; proceeding was the owner's call.
- `preferencesHydrated` being absent reads as falsy → "never persist". That's fail-**closed** (won't clobber) rather than fail-open, which is the right default if the plumbing ever breaks.
- The two studio maps are independent `ui-preferences` fields sharing one normalizer, so the Simple shell and the advanced workspace can't erase each other. Covered by a test on both sides.

## Verification

- 8 new tests on the seam: durable mirroring, relaunch restore, batch-field exclusion, the `ready` gate writing nothing at all, per-workspace isolation, all-scopes-in-one-map, merge-not-replace on seed, malformed-map tolerance.
- **Mutation-checked:** dropping the batch-field exclusion fails 1; making the seed replace instead of merge fails 1.
- Rust: a shared-normalizer independence test plus an end-to-end merge test proving an advanced-only PUT leaves `simpleStudio` untouched.
- **2892 web tests / 209 files** green, eslint clean, `npm run rust:check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)