### PR TITLE
fix(web): hide the dead Guidance / Negative prompt axes in Image Studio (sc-15299)

### DIFF
--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -104,6 +104,10 @@ After the think block, always provide a concise, user-facing final answer. The a
 export const fallbackModels = [
   {
     id: "z_image_turbo",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsGuidance: false, supportsNegativePrompt: false },
     name: "Z-Image-Turbo",
     type: "image",
     // No `character_image`: the worker adapter has no IP-Adapter wiring (sc-2005).
@@ -172,6 +176,10 @@ export const fallbackModels = [
   },
   {
     id: "z_image_edit",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsGuidance: false, supportsNegativePrompt: false },
     name: "Z-Image-Edit",
     type: "image",
     capabilities: ["edit_image"],
@@ -259,6 +267,10 @@ export const fallbackModels = [
   },
   {
     id: "sensenova_u1_8b",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsNegativePrompt: false },
     name: "SenseNova-U1 8B",
     type: "image",
     // character_image (sc-2016): SenseNova's it2i edit path doubles as a
@@ -279,6 +291,10 @@ export const fallbackModels = [
   },
   {
     id: "sensenova_u1_8b_fast",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsNegativePrompt: false },
     name: "SenseNova-U1 8B Fast",
     type: "image",
     // character_image (sc-2016): same wardrobe-preserving reference flow as the
@@ -308,6 +324,10 @@ export const fallbackModels = [
   },
   {
     id: "flux_schnell",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsGuidance: false, supportsNegativePrompt: false },
     name: "FLUX.1 [schnell]",
     type: "image",
     capabilities: ["text_to_image", "style_variations"],
@@ -318,6 +338,10 @@ export const fallbackModels = [
   },
   {
     id: "flux_dev",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsNegativePrompt: false },
     name: "FLUX.1 [dev]",
     type: "image",
     // character_image: XLabs FLUX IP-Adapter (sc-2011 resemblance tier).
@@ -507,6 +531,10 @@ export const fallbackModels = [
   },
   {
     id: "pulid_flux_dev",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsNegativePrompt: false },
     name: "PuLID-FLUX (FLUX.1 [dev])",
     type: "image",
     // Reference-driven only — appears solely in the "With character" picker.
@@ -570,6 +598,10 @@ export const fallbackModels = [
     // manifest/macSupport; this fallback entry only seeds the picker + per-variant
     // defaults until the live catalog loads. Recommended (the fast SD3.5 default).
     id: "sd3_5_large_turbo",
+    // Which generation AXES this engine has (sc-15299) — mirrored from the manifest `image`
+    // sub-block so the pre-catalog seed hides the same dead controls the live catalog does.
+    // ⚠️ ABSENT MEANS TRUE, so every other seed entry keeps both controls.
+    image: { supportsGuidance: false, supportsNegativePrompt: false },
     name: "Stable Diffusion 3.5 Large Turbo",
     type: "image",
     capabilities: ["text_to_image", "style_variations"],

--- a/apps/web/src/imageAxesParity.test.js
+++ b/apps/web/src/imageAxesParity.test.js
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import JSON5 from "json5";
+import { describe, expect, it } from "vitest";
+import { fallbackModels } from "./constants.js";
+
+// Manifest ↔ constants parity for the `image` capability sub-block (sc-15299).
+//
+// Image Studio hides Guidance / Negative prompt for an engine that declares
+// `image.supportsGuidance` / `image.supportsNegativePrompt` false. At runtime that comes from the
+// live catalog (seeded from config/manifests/builtin.models.jsonc), but `constants.js`
+// (`fallbackModels`) carries a HAND-MIRRORED copy used BEFORE the catalog loads. Without this
+// guard the mirror silently drifts and a CFG-free model briefly renders both dead controls on a
+// cold start. Same shape as controlModesParity.test.js.
+//
+// ⚠️ Polarity: an ABSENT `image` block means BOTH axes are supported — the opposite of `audio`.
+// So the reverse direction matters just as much: a mirror entry must not declare an axis absent
+// that the manifest says is present, or the seed would hide a live control.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = resolve(HERE, "../../../config/manifests/builtin.models.jsonc");
+
+function loadManifestModels() {
+  const parsed = JSON5.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const models = Array.isArray(parsed) ? parsed : parsed.models;
+  expect(Array.isArray(models), "manifest must expose a models array").toBe(true);
+  return models;
+}
+
+describe("image axes ↔ manifest parity (sc-15299)", () => {
+  const manifestModels = loadManifestModels();
+  const manifestById = new Map(manifestModels.map((model) => [model.id, model]));
+  const seededImageModels = fallbackModels.filter((model) => model.type === "image");
+
+  it("mirrors the manifest `image` block for every seeded image model, in both directions", () => {
+    expect(seededImageModels.length, "the seed carries image models to check").toBeGreaterThan(0);
+    for (const fallback of seededImageModels) {
+      const manifest = manifestById.get(fallback.id);
+      if (!manifest) {
+        // A seed-only entry (no manifest twin) has nothing to mirror.
+        continue;
+      }
+      expect(
+        fallback.image ?? null,
+        `${fallback.id}: the pre-catalog seed must declare the same generation axes as the manifest`,
+      ).toEqual(manifest.image ?? null);
+    }
+  });
+
+  it("keeps at least one CFG-free and one negative-free entry in the mirror", () => {
+    // Guards the guard: if the seed ever lost every declaring entry the test above would pass
+    // vacuously. These two shapes are what the polarity actually rides on.
+    const cfgFree = seededImageModels.filter((model) => model.image?.supportsGuidance === false);
+    const negativeOnly = seededImageModels.filter(
+      (model) => model.image?.supportsNegativePrompt === false && model.image?.supportsGuidance === undefined,
+    );
+    expect(cfgFree.map((model) => model.id)).toContain("flux_schnell");
+    expect(negativeOnly.map((model) => model.id)).toContain("flux_dev");
+  });
+
+  it("declares no `image` block on a seeded model that takes both axes", () => {
+    // Absent means TRUE: every guidance-taking seed entry must stay silent.
+    for (const fallback of seededImageModels) {
+      const manifest = manifestById.get(fallback.id);
+      if (manifest && manifest.image == null) {
+        expect(fallback.image, `${fallback.id} takes both axes and must declare nothing`).toBeUndefined();
+      }
+    }
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1113,7 +1113,15 @@ export function ImageStudio() {
     if (!seedsNegativeInMode(mode) || negativePrompt !== "") {
       return;
     }
-    const ui = imageModels.find((item) => item.id === model)?.ui ?? {};
+    const entry = imageModels.find((item) => item.id === model);
+    // An engine with no negative-prompt axis (sc-15299) never gets one seeded: the box is hidden
+    // for it and the value is not sent, so seeding would only plant a ghost the user cannot see.
+    // Read off the entry rather than the `supportsNegativePrompt` const below — that binding is
+    // declared later in this component body, so touching it from a dep array would be a TDZ hit.
+    if (entry?.image?.supportsNegativePrompt === false) {
+      return;
+    }
+    const ui = entry?.ui ?? {};
     if (typeof ui.defaultNegativePrompt === "string" && ui.defaultNegativePrompt) {
       setNegativePrompt(ui.defaultNegativePrompt);
     }
@@ -1196,6 +1204,25 @@ export function ImageStudio() {
   const showSamplerPicker = samplerOptions.length > 1;
   const showSchedulerPicker = schedulerOptions.length > 1;
   const showGuidanceMethodPicker = guidanceMethodOptions.length > 1;
+  // Which generation axes the selected engine actually has, declared in the manifest `image`
+  // sub-block (sc-15299) — the image-lane sibling of the `video` block sc-8445 added for Krea
+  // Realtime, and of `audio.supportsGuidance` / `audio.supportsNegativePrompt`. Neither an id check
+  // nor an engine link: the catalog says it, mirroring the engine descriptor's own
+  // `Capabilities { supports_guidance, supports_negative_prompt }` that the worker's
+  // `resolve_guidance` / `resolve_negative_prompt` already gate on (image_jobs/base.rs) — a
+  // guidance-distilled engine drops both on the floor, so offering them is a knob that does nothing.
+  //
+  // ⚠️ ABSENT MEANS TRUE, the same polarity as `video` and the OPPOSITE of `audio`. Most image
+  // engines take both a CFG scale and a negative prompt and declare nothing, so `!== false` is what
+  // keeps them byte-identical to their pre-sc-15299 behaviour; only an engine that genuinely lacks
+  // the axis declares it false.
+  //
+  // HIDDEN, not disabled: the Wan Lightning precedent in Video Studio DISABLES Steps/Guidance
+  // because that inertness is TRANSIENT (turn Lightning off and the control works again). A missing
+  // axis is permanent for the model, so a forever-dead input is just clutter — Audio Studio hides
+  // these two for the same reason (`showGuidance` / `showNegative`).
+  const supportsGuidance = selectedModel?.image?.supportsGuidance !== false;
+  const supportsNegativePrompt = selectedModel?.image?.supportsNegativePrompt !== false;
   const advancedDefaultsModel = useRef(model);
   const skipAdvancedDefaultsReset = useRef(false);
   useEffect(() => {
@@ -1760,11 +1787,15 @@ export function ImageStudio() {
     },
     buildDefaults: () => ({
       prompt,
-      negativePrompt,
+      // Same axis gate as the job payload (sc-15299): a preset saved on an engine with no
+      // negative-prompt / guidance axis must not bank a value the studio never showed and the
+      // worker never reads — applying that preset later on a guidance-taking model would
+      // resurrect a "negative prompt" the user never typed there.
+      negativePrompt: supportsNegativePrompt ? negativePrompt : "",
       resolution,
       count,
       mode,
-      guidanceScale: finiteNumberOrUndefined(guidanceOverride),
+      guidanceScale: supportsGuidance ? finiteNumberOrUndefined(guidanceOverride) : undefined,
       steps: finiteNumberOrUndefined(stepsOverride),
       sampler,
       scheduler,
@@ -2007,7 +2038,15 @@ export function ImageStudio() {
       // Shared studio settings (identical for both paths).
       resolution,
       mode,
-      negativePrompt: stackActive ? composedStack.negativePrompt : negativePrompt,
+      // An engine with no negative-prompt axis (sc-15299) gets an empty one rather than whatever a
+      // preset stack composed or a replayed recipe restored — the field is hidden for it, so
+      // sending text the user cannot see or edit (and the worker's `resolve_negative_prompt`
+      // discards anyway) would be a ghost input recorded on this job's recipe.
+      negativePrompt: supportsNegativePrompt
+        ? stackActive
+          ? composedStack.negativePrompt
+          : negativePrompt
+        : "",
       model,
       count: stackActive && composedStack.count != null ? composedStack.count : count,
       seed,
@@ -2046,7 +2085,12 @@ export function ImageStudio() {
       scheduler,
       schedulerShift,
       stepsOverride,
-      guidanceOverride,
+      // Same rule for the guidance axis (sc-15299): a CFG-free engine never receives a scale, so
+      // the override is blanked before it reaches the builder and `advanced.guidanceScale` is
+      // omitted entirely. The model-switch reset already clears it in the ordinary case, but a
+      // replayed recipe (and a preset launch) restores model + guidance together with that reset
+      // suppressed — which is the path that really leaks a stale scale onto a CFG-free engine.
+      guidanceOverride: supportsGuidance ? guidanceOverride : "",
       guidanceMethod,
       flashAttn,
       promptEnhance,
@@ -3182,10 +3226,14 @@ export function ImageStudio() {
 
           {macActiveModeBlock ? <p className="mac-gating-note">{macActiveModeBlock.text}</p> : null}
 
+          {/* `stackAddsNegative` is ANDed with the engine's negative-prompt axis (sc-15299), the
+              same way VideoStudio does it: the submit path blanks the composed negative for a
+              CFG-free engine, so previewing "+ negative prompt" would advertise a contribution
+              this job will not make. */}
           <PresetStackPreview
             generalStack={generalStack}
             composed={composedStack}
-            stackAddsNegative={stackAddsNegative}
+            stackAddsNegative={supportsNegativePrompt && stackAddsNegative}
             stackAddsCount={stackAddsCount}
           />
 
@@ -3319,21 +3367,23 @@ export function ImageStudio() {
                   value={stepsOverride}
                 />
               </label>
-              <label>
-                Guidance
-                <input
-                  min="0"
-                  max="30"
-                  onChange={(event) => setGuidanceOverride(event.target.value)}
-                  placeholder={(() => {
-                    const value = guidanceDefaultFromModel(selectedModel);
-                    return value == null ? "" : String(value);
-                  })()}
-                  step="0.1"
-                  type="number"
-                  value={guidanceOverride}
-                />
-              </label>
+              {supportsGuidance ? (
+                <label>
+                  Guidance
+                  <input
+                    min="0"
+                    max="30"
+                    onChange={(event) => setGuidanceOverride(event.target.value)}
+                    placeholder={(() => {
+                      const value = guidanceDefaultFromModel(selectedModel);
+                      return value == null ? "" : String(value);
+                    })()}
+                    step="0.1"
+                    type="number"
+                    value={guidanceOverride}
+                  />
+                </label>
+              ) : null}
               {supportsTextStyle ? (
                 <label className="text-style-gain">
                   {textStyleGainConfig?.label ?? "Text style"}
@@ -3490,10 +3540,12 @@ export function ImageStudio() {
                   <span>{upscaleSoftness.toFixed(2)}</span>
                 </label>
               ) : null}
-              <label className="prompt-field">
-                Negative prompt
-                <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
-              </label>
+              {supportsNegativePrompt ? (
+                <label className="prompt-field">
+                  Negative prompt
+                  <textarea onChange={(event) => setNegativePrompt(event.target.value)} value={negativePrompt} />
+                </label>
+              ) : null}
             </div>
           </AdvancedSection>
 

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -2458,3 +2458,230 @@ describe("ImageStudio multi-phase denoise (epic 13879 S5, sc-13885)", () => {
     expect(payload.advanced).not.toHaveProperty("phases");
   });
 });
+
+// ----------------------------------------------------------------------------------------------
+// sc-15299 — the manifest `image` sub-block gates the Guidance / Negative prompt axes.
+//
+// The image-lane sibling of the `video` block sc-8445 shipped for Krea Realtime, with the SAME
+// absent-means-TRUE polarity. Both directions are pinned here: a declaring model loses the
+// controls and stops sending the values, an undeclared model keeps everything, and the two keys
+// are independent (an embedded-guidance engine keeps Guidance while losing Negative prompt).
+//
+// ⚠️ Payload assertions are NEVER made on a freshly mounted CFG-free model — both fields default
+// to empty, so such an assertion would pass against no implementation at all. Each one runs
+// through the RECIPE REPLAY path instead, which is the real leak: it restores model + guidance +
+// negative together with the advanced-defaults reset deliberately suppressed
+// (`skipAdvancedDefaultsReset`), so a non-empty override genuinely arrives on the CFG-free model.
+// ----------------------------------------------------------------------------------------------
+describe("ImageStudio CFG-free axis gating (sc-15299)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const openAdvanced = async () => click(document.body.querySelector(".advanced-section-toggle"));
+  const generate = async () =>
+    click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Generate"));
+  const labelStartingWith = (text) =>
+    [...container.querySelectorAll("label")].find((node) => node.textContent.trim().startsWith(text));
+  const setTextarea = async (element, value) => {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+      setter.call(element, value);
+      element.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  };
+
+  // Guidance-taking baseline: declares NO `image` block at all, which is the shape of the
+  // overwhelming majority of the catalog. Absent means TRUE, so it must be untouched.
+  const GUIDED = {
+    ...Z_IMAGE,
+    id: "sdxl",
+    name: "Stable Diffusion XL",
+    family: "sdxl",
+    defaults: { resolution: "1024x1024", guidanceScale: 7 },
+  };
+
+  // Guidance-distilled: the descriptor is supports_guidance=false AND
+  // supports_negative_prompt=false, so resolve_guidance / resolve_true_cfg / resolve_negative_prompt
+  // all return None. Matches the shipped z_image_turbo / flux_schnell / krea_2_turbo declarations.
+  const CFG_FREE = {
+    ...Z_IMAGE,
+    id: "flux_schnell",
+    name: "FLUX.1 [schnell]",
+    family: "flux",
+    image: { supportsGuidance: false, supportsNegativePrompt: false },
+  };
+
+  // Embedded-guidance: a REAL guidance scale, no unconditional branch. Declares only the negative
+  // axis absent — the shape of flux_dev / ideogram_4 / flux2_dev / sensenova / sana_sprint.
+  const NO_NEGATIVE = {
+    ...Z_IMAGE,
+    id: "flux_dev",
+    name: "FLUX.1 [dev]",
+    family: "flux",
+    defaults: { resolution: "1024x1024", guidanceScale: 3.5 },
+    image: { supportsNegativePrompt: false },
+  };
+
+  it("keeps both controls, and sends both values, for a model that declares no image block", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(baseContext({ createImageJob, imageModels: [GUIDED] }));
+    await openAdvanced();
+
+    const guidance = labelStartingWith("Guidance")?.querySelector("input");
+    expect(guidance, "an undeclared model keeps Guidance — absent means TRUE").toBeTruthy();
+    await act(async () => setInput(guidance, "6.5"));
+    const negative = labelStartingWith("Negative prompt")?.querySelector("textarea");
+    expect(negative).toBeTruthy();
+    await setTextarea(negative, "blurry, low quality");
+
+    await generate();
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.negativePrompt).toBe("blurry, low quality");
+    expect(payload.advanced.guidanceScale).toBe(6.5);
+  });
+
+  it("hides both controls for a CFG-free engine and sends neither, even from a replayed recipe", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({
+        createImageJob,
+        imageModels: [GUIDED, CFG_FREE],
+        // The leak path: a recipe carries a real guidance scale AND a real negative onto the
+        // CFG-free model, with the model-switch reset suppressed. Without the gate both reach
+        // the worker (which discards them) and get recorded on this job's own recipe.
+        studioLaunch: {
+          id: "launch-1",
+          view: "Image",
+          assetId: "asset-1",
+          recipe: {
+            model: "flux_schnell",
+            mode: "text_to_image",
+            prompt: "a fox",
+            negativePrompt: "blurry, low quality",
+            rawAdapterSettings: { guidanceScale: 6.5 },
+          },
+        },
+      }),
+    );
+    await openAdvanced();
+
+    expect(labelStartingWith("Guidance")).toBeFalsy();
+    expect(labelStartingWith("Negative prompt")).toBeFalsy();
+
+    await generate();
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.model).toBe("flux_schnell");
+    expect(payload.negativePrompt).toBe("");
+    expect(payload.advanced).not.toHaveProperty("guidanceScale");
+  });
+
+  it("keeps Guidance but drops Negative prompt for an embedded-guidance engine", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await render(
+      baseContext({
+        createImageJob,
+        imageModels: [GUIDED, NO_NEGATIVE],
+        // Same replay path, so the restored negative is genuinely non-empty when the gate runs.
+        studioLaunch: {
+          id: "launch-2",
+          view: "Image",
+          assetId: "asset-2",
+          recipe: {
+            model: "flux_dev",
+            mode: "text_to_image",
+            prompt: "a fox",
+            negativePrompt: "blurry, low quality",
+            rawAdapterSettings: { guidanceScale: 4.5 },
+          },
+        },
+      }),
+    );
+    await openAdvanced();
+
+    // The two keys are independent: guidance survives, the negative box is gone.
+    expect(labelStartingWith("Guidance")?.querySelector("input")).toBeTruthy();
+    expect(labelStartingWith("Negative prompt")).toBeFalsy();
+
+    await generate();
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.model).toBe("flux_dev");
+    expect(payload.advanced.guidanceScale).toBe(4.5);
+    expect(payload.negativePrompt).toBe("");
+  });
+
+  // The seed effect (`ui.defaultNegativePrompt` → an empty negative box) must not fire for an
+  // engine with no negative axis. Asserting the SUBMITTED negative here would be a false green:
+  // the payload gate blanks it either way. The ghost is only observable once the user moves to a
+  // model that CAN take a negative — the seeded text is still in studio state and reappears in
+  // the box they can now see. That is the assertion, and it is the one that dies without the guard.
+  it("never seeds a hidden default negative that resurfaces on the next model", async () => {
+    const seeded = {
+      ...CFG_FREE,
+      id: "anima_turbo",
+      ui: { defaultNegativePrompt: "worst quality, low quality" },
+    };
+    await render(baseContext({ imageModels: [seeded, GUIDED] }));
+    await openAdvanced();
+    expect(labelStartingWith("Negative prompt")).toBeFalsy();
+
+    await act(async () => setSelect(field(container, "Model"), "sdxl"));
+    await act(async () => {});
+    const negative = labelStartingWith("Negative prompt")?.querySelector("textarea");
+    expect(negative, "the guidance-taking model shows the box again").toBeTruthy();
+    expect(negative.value).toBe("");
+  });
+
+  // A saved preset is a persisted recipe, so the same axis gate applies: banking a dead negative
+  // or guidance on a CFG-free model would resurrect it when the preset is applied elsewhere.
+  it("keeps the dead axes out of a preset saved on a CFG-free model", async () => {
+    const createPreset = vi.fn(async (payload) => ({ id: payload.id }));
+    await render(
+      baseContext({
+        createPreset,
+        imageModels: [GUIDED, CFG_FREE],
+        studioLaunch: {
+          id: "launch-3",
+          view: "Image",
+          assetId: "asset-3",
+          recipe: {
+            model: "flux_schnell",
+            mode: "text_to_image",
+            prompt: "a fox",
+            negativePrompt: "blurry, low quality",
+            rawAdapterSettings: { guidanceScale: 6.5 },
+          },
+        },
+      }),
+    );
+
+    await act(async () => setInput(nameInput(container), "My preset"));
+    await saveWithScope(container, "This project");
+    const defaults = createPreset.mock.calls[0][0].defaults;
+    // The preset builder prunes empty values, so an absent key IS the blanked negative. Without
+    // the gate this is the recipe's "blurry, low quality".
+    expect(defaults.negativePrompt ?? "").toBe("");
+    expect(defaults.guidanceScale).toBeUndefined();
+  });
+});

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -2684,4 +2684,51 @@ describe("ImageStudio CFG-free axis gating (sc-15299)", () => {
     expect(defaults.negativePrompt ?? "").toBe("");
     expect(defaults.guidanceScale).toBeUndefined();
   });
+
+  // `PresetStackPreview` is captioned "Prompt sent" and exists so the user sees exactly what the
+  // run will produce. Once submit started blanking `negativePrompt` for a CFG-free engine, the
+  // preview's `Negative:` line became a promise the payload does not keep — hence the
+  // `supportsNegativePrompt && stackAddsNegative` AND at the call site. General presets are
+  // filtered on `kind === "general"` alone, so a preset carrying `defaults.negativePrompt` is
+  // offered on every model, CFG-free included. Both directions are pinned: the SAME stack keeps
+  // the line on a negative-taking model and loses it on the CFG-free one.
+  it("drops the stack preview's Negative line on a CFG-free engine but keeps it otherwise", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    const stackPreset = {
+      id: "film_look",
+      name: "Film Look",
+      kind: "general",
+      prompt: { suffix: "Kodak Portra 400" },
+      defaults: { negativePrompt: "blurry, low quality" },
+    };
+    await render(
+      baseContext({ createImageJob, imageModels: [GUIDED, CFG_FREE], presets: [stackPreset] }),
+    );
+
+    const chip = [...container.querySelectorAll(".general-preset-chips .preset-chip")].find(
+      (el) => el.textContent.trim() === "Film Look",
+    );
+    expect(chip, "the general preset must be offered").toBeTruthy();
+    await click(chip);
+
+    // SDXL takes a negative prompt, so the preview states the contribution AND the run sends it.
+    let preview = container.querySelector(".preset-stack-preview");
+    expect(preview.textContent).toContain("Kodak Portra 400");
+    expect(preview.textContent).toContain("Negative: blurry, low quality");
+    await generate();
+    expect(createImageJob.mock.calls[0][0].negativePrompt).toBe("blurry, low quality");
+
+    // Same stack, CFG-free engine: the composed PROMPT is still shown (it is still sent), but the
+    // Negative line is gone — because the payload no longer carries it.
+    await act(async () => setSelect(field(container, "Model"), "flux_schnell"));
+    await act(async () => {});
+    preview = container.querySelector(".preset-stack-preview");
+    expect(preview.textContent).toContain("Kodak Portra 400");
+    expect(preview.textContent).not.toContain("Negative:");
+
+    await generate();
+    const payload = createImageJob.mock.calls[1][0];
+    expect(payload.model).toBe("flux_schnell");
+    expect(payload.negativePrompt).toBe("");
+  });
 });

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -438,6 +438,14 @@
     },
     {
       "id": "mage_flow_edit_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Same distilled Mage-Flow student, edit variant.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       "name": "Mage-Flow Edit-Turbo",
       "family": "mage-flow",
       "type": "image",
@@ -1029,6 +1037,14 @@
       // Mage-Flow Turbo: few-step distilled, CFG-free sibling. Its SceneWorks mirror is flat and
       // complete; q4/q8/bf16 remain load-time choices over the same installed snapshot.
       "id": "mage_flow_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. The distilled Mage-Flow variant (`is_distilled`), so both axes are absent.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       "name": "Mage-Flow Turbo",
       "family": "mage-flow",
       "type": "image",
@@ -1215,6 +1231,15 @@
     },
     {
       "id": "z_image_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Z-Image-Turbo is guidance-distilled: `mlx-gen-z-image`'s descriptor sets
+      // supports_guidance/supports_negative_prompt=false on BOTH lanes.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       // `recommended` flags the curated "getting started" set surfaced in the Setup
       // Wizard, the Models page Recommended section, and per-Studio availability gates.
       // `autoDownload: false` keeps a recommended model badged-but-unchecked in the
@@ -1508,6 +1533,15 @@
     },
     {
       "id": "z_image_edit",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. The edit variant runs on the `z_image_turbo` ENGINE (engines.rs MODEL_TABLE), so it
+      // inherits the distilled turbo capability surface verbatim.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       "name": "Z-Image-Edit",
       "family": "z-image",
       "type": "image",
@@ -2341,6 +2375,14 @@
     },
     {
       "id": "sensenova_u1_8b",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. SenseNova U1 takes a guidance scale but no negative prompt (`sensenova.rs` never
+      // reads one); the descriptor is supports_guidance=true / supports_negative_prompt=false.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "SenseNova-U1 8B",
       "family": "sensenova-u1",
       "type": "image",
@@ -2509,6 +2551,13 @@
       // engine change — only a new hosted quant-matrix re-host + this catalog entry. Not `recommended`
       // yet (pending on-device A/B vs V1). Full capability surface, identical to V1.
       "id": "sensenova_u1_8b_infographic_v2",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Same `sensenova_u1_8b` engine, same capability surface.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "SenseNova-U1 8B Infographic V2",
       "family": "sensenova-u1",
       "type": "image",
@@ -2633,6 +2682,13 @@
       // the same dense-text / stable-layout strengths. Coexists with V2 — new id, V2 stays loadable so
       // recipes/replays that pin V2 keep their output.
       "id": "sensenova_u1_8b_infographic_v3",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Same `sensenova_u1_8b` engine, same capability surface.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "SenseNova-U1 8B Infographic V3",
       "family": "sensenova-u1",
       "type": "image",
@@ -2748,6 +2804,13 @@
     },
     {
       "id": "sensenova_u1_8b_fast",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. The `sensenova_u1_8b_fast` engine advertises the same guidance-yes / negative-no surface.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "SenseNova-U1 8B Fast",
       "family": "sensenova-u1",
       "type": "image",
@@ -2908,6 +2971,13 @@
       // (distill_merged.json marker → load_fast skips the load-time merge), riding the existing
       // sensenova_u1_8b_fast engine. T2I / edit / character only (no VQA / interleave), 8 steps / cfg 1.0.
       "id": "sensenova_u1_8b_infographic_v2_fast",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Same `sensenova_u1_8b_fast` engine, same capability surface.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "SenseNova-U1 8B Infographic V2 Fast",
       "family": "sensenova-u1",
       "type": "image",
@@ -3039,6 +3109,13 @@
       // 8-step render quality on V3 is validated on-device in S3 (independent training run — not assumed
       // from V2's result).
       "id": "sensenova_u1_8b_infographic_v3_fast",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Same `sensenova_u1_8b_fast` engine, same capability surface.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "SenseNova-U1 8B Infographic V3 Fast",
       "family": "sensenova-u1",
       "type": "image",
@@ -3164,6 +3241,15 @@
     },
     {
       "id": "flux_schnell",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. FLUX.1 [schnell] is the 4-step timestep-distilled student: the `flux1_schnell`
+      // descriptor is false/false on both lanes.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       "name": "FLUX.1 [schnell]",
       "family": "flux",
       "type": "image",
@@ -3268,6 +3354,14 @@
     },
     {
       "id": "flux_dev",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. FLUX.1 [dev] carries EMBEDDED (distilled) guidance — the scale is real, so Guidance
+      // stays — but it has no unconditional branch, so `supports_negative_prompt` is false.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "FLUX.1 [dev]",
       "family": "flux",
       "type": "image",
@@ -3410,6 +3504,13 @@
     },
     {
       "id": "ideogram_4",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Embedded-guidance DiT: a real guidance scale, no negative branch.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "Ideogram 4",
       "family": "ideogram",
       "type": "image",
@@ -3591,6 +3692,14 @@
     },
     {
       "id": "ideogram_4_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. The turbo student is guidance-distilled; `ideogram_4_turbo`'s descriptor is false/false.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       "name": "Ideogram 4 Turbo",
       "family": "ideogram",
       "type": "image",
@@ -3738,6 +3847,13 @@
     },
     {
       "id": "boogu_image",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Embedded-guidance DiT: a real guidance scale, no negative branch.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       // Available (render quality validated real-weight in S5, sc-6402), but no longer in the curated
       // Recommended set. autoDownload:false because the Q8 turnkey is ~23 GB/variant — users opt in.
       "autoDownload": false,
@@ -3866,6 +3982,14 @@
     },
     {
       "id": "boogu_image_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. DMD few-step student, CFG-free by construction; `boogu_image_turbo` is false/false.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       // Available: the fast few-step variant (S5-validated); same autoDownload:false opt-in as Base.
       // No longer in the curated Recommended set. Edit stays Edit-tab-only.
       "autoDownload": false,
@@ -3980,6 +4104,13 @@
     },
     {
       "id": "boogu_image_edit",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Embedded-guidance DiT: a real guidance scale, no negative branch.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "Boogu Image Edit",
       "family": "boogu",
       "type": "image",
@@ -4061,6 +4192,15 @@
     },
     {
       "id": "krea_2_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Krea 2 Turbo is the distilled single-forward regime — `krea_turbo_raw.rs` even
+      // hard-sets `guidance: None` / `negative_prompt: None` on the turbo-on-Raw path.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       // Krea 2 Turbo (epic 7565) — Krea AI's from-scratch foundation image model, TDM-distilled to a
       // few-step (~8), CFG-free rectified-flow student: a Qwen3-VL-4B text encoder (12-layer learned
       // aggregator) + a 28-block single-stream DiT + the Qwen-Image VAE, native MLX (Apple Silicon).
@@ -5106,6 +5246,13 @@
     },
     {
       "id": "flux2_dev",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. FLUX.2 [dev] uses embedded guidance (`uses_embedded_guidance`), so no negative branch.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "FLUX.2 [dev]",
       "family": "flux2-dev",
       "type": "image",
@@ -5814,6 +5961,14 @@
     },
     {
       "id": "sd3_5_large_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. SD3.5 Large Turbo is the ADD-distilled student; `sd3_5_large_turbo` is false/false.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       // Available: the few-step distilled flagship, but no longer in the curated Recommended set.
       // autoDownload:false because it is a gated, large turnkey (mirrors the Boogu / krea_2 opt-in
       // pattern) — users acknowledge the license + opt in rather than the wizard auto-pulling it.
@@ -6220,6 +6375,14 @@
     },
     {
       "id": "sana_sprint_1600m",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. SANA-Sprint keeps its guidance scale but drops the negative branch (unlike the
+      // non-distilled `sana_1600m`, which is a true-CFG family and declares nothing).
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       // SANA-Sprint 1.6B 1024px (epic 8485 / sc-8490) — NVIDIA's few-step distillation of SANA, ported
       // natively to mlx-gen (engine id `sana_sprint_1600m`). SAME 1.6B Linear-DiT trunk (ReLU linear
       // attention + Mix-FFN + NoPE) + gemma-2-2b-it Complex-Human-Instruction (CHI) caption encoder
@@ -6608,6 +6771,15 @@
     },
     {
       "id": "anima_turbo",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. Anima Turbo is the merged CFG-free student (`Variant::Turbo.uses_cfg() == false`),
+      // unlike Base/Aesthetic which run true classifier-free guidance.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
+      },
       // Anima 2B Turbo (epic 10512 / sc-10523) — the merged CFG-free few-step student of Anima 2B. Same
       // architecture + convert-at-install flow + NC posture as the base; the guidance-distilled merged DiT
       // runs in ~10 steps CFG-free (the `anima_turbo` descriptor advertises supports_guidance=false, so
@@ -6682,10 +6854,15 @@
         "label": "Anima 2B Turbo",
         "description": "CircleStone Labs Anima 2B Turbo — the merged few-step student of Anima 2B, ported natively to MLX (Apple Silicon only). Same Cosmos-Predict2 transformer + query-token text adapter (Qwen3-0.6B) + Qwen-Image VAE, guidance-distilled to run CFG-free in ~10 steps (much faster than the 30-step base). Uses the danbooru/booru tag convention — comma-separated lowercase tags, spaces not underscores, artists prefixed with `@`; strong prompt weighting (e.g. `(chibi:2)`) works. Convert-at-install into bf16 / q8 (default) / q4 tiers. Distributed under the CircleStone Labs Non-Commercial License v1.2: non-commercial use only. Runs comfortably on a 16 GB-class Mac.",
         "recommendedFor": ["text_to_image"],
-        // Booru quality prefix + negative (sc-10523, sc-10760) — same seams as anima_base. (Turbo is CFG-free,
+        // Booru quality prefix (sc-10523, sc-10760) — same seam as anima_base. (Turbo is CFG-free,
         // so its q4 tier stays crisp — no painterly note in the description.)
+        //
+        // No `defaultNegativePrompt` (sc-15299): Turbo is the merged CFG-free student, so the worker's
+        // `resolve_negative_prompt` returns None for it and the booru negative was seeded into a box
+        // whose contents were then discarded. The same rule krea_2_turbo already follows ("Turbo is
+        // CFG-free — it must NOT carry a default negative", builtin_manifests.rs). anima_base and
+        // anima_aesthetic run true CFG and keep theirs.
         "defaultPrompt": "masterpiece, best quality, ",
-        "defaultNegativePrompt": "worst quality, low quality, score_1, score_2, score_3, artist name, blurry, jpeg artifacts, chromatic aberration",
         "promptHint": "Booru-tag model: keep the quality prefix and describe your subject as comma-separated tags (e.g. 1girl, solo, pink hair, superhero costume, cape, dynamic pose). A plain sentence renders low-effort art.",
         "promptGuide": {
           "title": "Anima Prompt Guide",
@@ -7623,6 +7800,14 @@
     },
     {
       "id": "pulid_flux_dev",
+      // Which generation AXES this engine actually has (sc-15299), the image-lane sibling of the
+      // `video` sub-block sc-8445 added for Krea Realtime. The PuLID identity lane hard-sets `negative_prompt: None` (image_jobs/pulid.rs);
+      // its FLUX.1 [dev] backbone still takes an embedded-guidance scale.
+      // ⚠️ Polarity matches `video` and is the OPPOSITE of `audio`: an ABSENT key means TRUE, so
+      // every entry that declares nothing here is byte-identical to its pre-sc-15299 behaviour.
+      "image": {
+        "supportsNegativePrompt": false
+      },
       "name": "PuLID-FLUX (FLUX.1 [dev])",
       "family": "flux",
       "type": "image",
@@ -10905,7 +11090,20 @@
         "conditioning": [
           "AudioEdit"
         ],
-        "supportsMultiSpeaker": false
+        "supportsMultiSpeaker": false,
+        // AudioStudio.jsx has read these two since the Music tab shipped, but until sc-15299 neither
+        // was declarable — the `audio` object is additionalProperties:false and the schema listed
+        // neither key, so both were permanently falsy and the Music tab's Guidance/Negative controls
+        // were hidden BY ACCIDENT rather than by declaration. Declaring them makes the hiding
+        // intentional and lets a future non-distilled music model turn them on.
+        //
+        // ⚠️ The AUDIO polarity is the opposite of `image`/`video`: absent means FALSE here, so these
+        // explicit `false`s change nothing about today's rendered UI — ACE-Step v1.5 Turbo really is
+        // guidance-distilled (`candle-audio-acestep`'s descriptor is supports_guidance=false /
+        // supports_negative_prompt=false, and its generate path never reads `req.guidance` or
+        // `req.negative_prompt`; a scale sent anyway is a typed Unsupported at the gen-core floor).
+        "supportsGuidance": false,
+        "supportsNegativePrompt": false
       },
       "downloads": [
         {

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -542,6 +542,21 @@
               }
             }
           },
+          "image": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Image-generation capability metadata (sc-15299) — the image-lane sibling of the `video` sub-block (sc-8445), declaring which generation AXES an image engine actually has so Image Studio can hide a control the worker would discard rather than offering a knob that silently does nothing. Mirrors the engine descriptor's own `Capabilities { supports_guidance, supports_negative_prompt }`, which `resolve_guidance` / `resolve_negative_prompt` in the worker's image_jobs/base.rs already gate on. Every property is OPTIONAL and, exactly like `video` but UNLIKE `audio`, an ABSENT property means TRUE: the image population is overwhelmingly guidance-taking, so absent-means-supported is the correct default and leaves an undeclared entry behaving exactly as it did before this block existed. Only a guidance-distilled engine that genuinely lacks an axis declares it false.",
+            "properties": {
+              "supportsGuidance": {
+                "type": "boolean",
+                "description": "Does the engine have a classifier-free-guidance axis? False for a guidance-distilled engine whose descriptor advertises `supports_guidance: false`, so the worker's `resolve_guidance` returns None and never forwards a scale. ABSENT MEANS TRUE. When false, Image Studio hides its Guidance control and stops emitting `advanced.guidanceScale`."
+              },
+              "supportsNegativePrompt": {
+                "type": "boolean",
+                "description": "Does the engine accept a negative prompt? An engine with no steerable unconditional branch has nothing for a negative prompt to do — `resolve_negative_prompt` returns None for any model whose descriptor advertises `supports_negative_prompt: false`. ABSENT MEANS TRUE. When false, Image Studio hides its Negative prompt field, never seeds `ui.defaultNegativePrompt` into it, and sends an empty one."
+              }
+            }
+          },
           "video": {
             "type": "object",
             "additionalProperties": false,
@@ -630,6 +645,14 @@
               "supportsStreaming": {
                 "type": "boolean",
                 "description": "Whether the model streams audio incrementally as it renders (backend Capabilities.supports_streaming, sc-12846). When true the worker drives Generator::generate_streaming so partial PCM chunks arrive before the clip finishes, and the Audio Studio reveals progressive/streaming results in the results zone. Absent/false means one-shot synthesis. The reassembly of every chunk still equals the one-shot track, so it is advisory to the STREAM SHAPE, not to correctness (sc-13675)."
+              },
+              "supportsGuidance": {
+                "type": "boolean",
+                "description": "Whether the model has a classifier-free-guidance axis (backend Capabilities.supports_guidance). Read by Audio Studio's Music tab to decide whether to render its Guidance (CFG) control; a scale sent to a model that does not advertise it is rejected as a typed Unsupported at the gen-core floor. ⚠️ Polarity here is the AUDIO one — ABSENT MEANS FALSE, the opposite of the `image` / `video` blocks — because the audio population is the reverse shape: the only music engine shipped is guidance-distilled. Declared in the schema by sc-15299; the Audio Studio read predates it, so before that fix the key could not be set at all (this object is additionalProperties:false) and the control was permanently hidden by accident rather than by declaration."
+              },
+              "supportsNegativePrompt": {
+                "type": "boolean",
+                "description": "Whether the model accepts a negative prompt (backend Capabilities.supports_negative_prompt). Read by Audio Studio's Music tab for its Negative prompt field. ABSENT MEANS FALSE — same audio polarity and the same sc-15299 history as `supportsGuidance`."
               },
               "conditioning": {
                 "type": "array",

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -1886,3 +1886,166 @@ def test_recipe_preset_schema_rejects_a_bad_id_pattern():
         error.validator == "pattern" and list(error.absolute_path) == ["presets", 0, "id"]
         for error in errors
     )
+
+
+# --------------------------------------------------------------------------------------
+# sc-15299 — the `image` capability sub-block (Guidance / Negative prompt axes).
+#
+# The image-lane sibling of the `video` block sc-8445 shipped for Krea Realtime. Image Studio
+# reads `image.supportsGuidance` / `image.supportsNegativePrompt` with ABSENT-MEANS-TRUE polarity
+# (the opposite of `audio`), so these audits pin BOTH directions: the declarations that must be
+# present, and the entries that must stay silent so the change is behaviour-neutral for them.
+#
+# Ground truth is the engine descriptor each model resolves to through
+# `crates/sceneworks-worker/src/engines.rs` MODEL_TABLE, which is exactly what the worker's
+# `resolve_guidance` / `resolve_negative_prompt` / `resolve_true_cfg` gate on.
+# --------------------------------------------------------------------------------------
+
+# Both axes absent: the engine descriptor is supports_guidance=false AND
+# supports_negative_prompt=false, so `resolve_guidance`, `resolve_true_cfg` and
+# `resolve_negative_prompt` ALL return None. Every one is a guidance-distilled student.
+IMAGE_MODELS_WITHOUT_EITHER_AXIS = frozenset(
+    {
+        "z_image_turbo",
+        "z_image_edit",  # runs on the z_image_turbo ENGINE
+        "flux_schnell",
+        "ideogram_4_turbo",
+        "boogu_image_turbo",
+        "krea_2_turbo",
+        "sd3_5_large_turbo",
+        "anima_turbo",
+        "mage_flow_turbo",
+        "mage_flow_edit_turbo",
+    }
+)
+
+# Guidance is real (embedded/distilled scale, or a bespoke lane that forwards one) but there is no
+# unconditional branch for a negative prompt to steer, so `resolve_negative_prompt` returns None.
+IMAGE_MODELS_WITHOUT_NEGATIVE_ONLY = frozenset(
+    {
+        "flux_dev",
+        "ideogram_4",
+        "boogu_image",
+        "boogu_image_edit",
+        "flux2_dev",
+        "sensenova_u1_8b",
+        "sensenova_u1_8b_infographic_v2",
+        "sensenova_u1_8b_infographic_v3",
+        "sensenova_u1_8b_fast",
+        "sensenova_u1_8b_infographic_v2_fast",
+        "sensenova_u1_8b_infographic_v3_fast",
+        "sana_sprint_1600m",
+        "pulid_flux_dev",  # image_jobs/pulid.rs hard-sets negative_prompt: None
+    }
+)
+
+
+def _image_models_by_id() -> dict:
+    return {
+        model["id"]: model
+        for model in _load_builtin_models_manifest()["models"]
+        if model.get("type") == "image"
+    }
+
+
+def test_cfg_free_image_models_declare_both_axes_absent():
+    """sc-15299: a guidance-distilled image engine declares BOTH axes false so Image Studio
+    hides Guidance and Negative prompt instead of offering knobs the worker discards."""
+    models = _image_models_by_id()
+    missing = sorted(IMAGE_MODELS_WITHOUT_EITHER_AXIS - set(models))
+    assert not missing, f"CFG-free ids no longer in the catalog: {missing}"
+    for model_id in sorted(IMAGE_MODELS_WITHOUT_EITHER_AXIS):
+        block = models[model_id].get("image")
+        assert block is not None, f"{model_id} is CFG-free but declares no `image` block"
+        assert block.get("supportsGuidance") is False, (
+            f"{model_id} is CFG-free — its engine descriptor advertises supports_guidance=false "
+            "and it is not a true-CFG family, so no guidance scale reaches the engine"
+        )
+        assert block.get("supportsNegativePrompt") is False, (
+            f"{model_id} is CFG-free — resolve_negative_prompt returns None for it"
+        )
+
+
+def test_negative_only_image_models_keep_their_guidance_axis():
+    """sc-15299: the two keys are INDEPENDENT. An embedded-guidance engine (FLUX dev, Ideogram 4,
+    SenseNova, SANA-Sprint, …) takes a real guidance scale and no negative prompt, so it must
+    declare ONLY `supportsNegativePrompt: false` — declaring guidance false too would hide a live
+    control."""
+    models = _image_models_by_id()
+    missing = sorted(IMAGE_MODELS_WITHOUT_NEGATIVE_ONLY - set(models))
+    assert not missing, f"negative-free ids no longer in the catalog: {missing}"
+    for model_id in sorted(IMAGE_MODELS_WITHOUT_NEGATIVE_ONLY):
+        block = models[model_id].get("image")
+        assert block is not None, f"{model_id} takes no negative prompt but declares no `image` block"
+        assert block.get("supportsNegativePrompt") is False, f"{model_id} must declare the negative axis absent"
+        assert "supportsGuidance" not in block, (
+            f"{model_id} DOES take a guidance scale — declaring supportsGuidance would hide a live control"
+        )
+
+
+def test_guidance_taking_image_models_declare_nothing():
+    """sc-15299 polarity guard: absent means TRUE, so every image entry that genuinely takes both
+    axes must stay silent. Includes the true-CFG Chroma family, whose descriptor reads
+    supports_guidance=false but whose Guidance control IS live — the worker forwards
+    `advanced.guidanceScale` as `true_cfg` (base.rs `uses_true_cfg`/`resolve_true_cfg`). Declaring
+    an `image` block for Chroma would break a working knob."""
+    models = _image_models_by_id()
+    declared = {model_id for model_id, model in models.items() if model.get("image") is not None}
+    expected = IMAGE_MODELS_WITHOUT_EITHER_AXIS | IMAGE_MODELS_WITHOUT_NEGATIVE_ONLY
+    assert declared == expected, (
+        "unexpected `image` declarations — every other image entry must stay silent so it keeps "
+        f"both controls: unexpected={sorted(declared - expected)}, missing={sorted(expected - declared)}"
+    )
+    for model_id in ("chroma1_hd", "chroma1_base", "chroma1_flash", "sana_1600m", "krea_2_raw", "sdxl"):
+        assert models[model_id].get("image") is None, (
+            f"{model_id} takes both axes (Chroma via true_cfg) and must declare no `image` block"
+        )
+
+
+def test_cfg_free_image_models_carry_no_default_negative_prompt():
+    """sc-15299: a model with no negative axis must not seed one — the box is hidden and the value
+    is never sent, so `ui.defaultNegativePrompt` would plant a ghost. Mirrors the krea_2_turbo rule
+    already pinned in crates/sceneworks-core/src/builtin_manifests.rs."""
+    models = _image_models_by_id()
+    for model_id in sorted(IMAGE_MODELS_WITHOUT_EITHER_AXIS | IMAGE_MODELS_WITHOUT_NEGATIVE_ONLY):
+        assert not models[model_id].get("ui", {}).get("defaultNegativePrompt"), (
+            f"{model_id} declares no negative-prompt axis, so it must not declare a default negative"
+        )
+
+
+def test_schema_rejects_an_unknown_key_inside_the_image_block():
+    """The `image` object is additionalProperties:false like its `video` sibling."""
+    manifest = _load_builtin_models_manifest()
+    target = next(model for model in manifest["models"] if model["id"] == "z_image_turbo")
+    target["image"]["supportsGuidnce"] = False
+    schema = _load_schema(SCHEMA_PATH)
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(manifest))
+    assert any("supportsGuidnce" in error.message for error in errors)
+
+
+# --------------------------------------------------------------------------------------
+# sc-15299 audio half — `audio.supportsGuidance` / `audio.supportsNegativePrompt` were READ by
+# AudioStudio.jsx but never PRODUCIBLE: the `audio` object is additionalProperties:false and the
+# schema listed neither key, so the Music tab's Guidance/Negative controls were hidden by accident
+# rather than by declaration. The schema now lists them and ACE-Step declares them.
+# --------------------------------------------------------------------------------------
+
+
+def test_audio_block_can_declare_the_guidance_axes():
+    """Mutation guard: drop either property from the schema and the shipped manifest stops
+    validating — which is exactly the state this story fixed."""
+    schema = _load_schema(SCHEMA_PATH)
+    audio_properties = schema["properties"]["models"]["items"]["properties"]["audio"]["properties"]
+    for key in ("supportsGuidance", "supportsNegativePrompt"):
+        assert audio_properties[key]["type"] == "boolean", f"audio.{key} must be declarable"
+
+
+def test_acestep_declares_its_distilled_guidance_axes_explicitly():
+    """ACE-Step v1.5 Turbo is guidance-distilled (candle-audio-acestep's descriptor is
+    supports_guidance=false / supports_negative_prompt=false, and its generate path never reads
+    either). AUDIO polarity is absent-means-FALSE, so this is UI-neutral — it makes the hiding
+    intentional and lets a future non-distilled music model turn the controls on."""
+    models = {model["id"]: model for model in _load_builtin_models_manifest()["models"]}
+    audio_block = models["acestep_v15_turbo"]["audio"]
+    assert audio_block["supportsGuidance"] is False
+    assert audio_block["supportsNegativePrompt"] is False


### PR DESCRIPTION
Closes sc-15299. The Image Studio half of the axis-honesty fix sc-8445 shipped for Video Studio (#1910), plus the latent audio bug that story asked to fold in.

## The defect

Image Studio rendered **Guidance** and **Negative prompt** for every model. A guidance-distilled engine discards both: `resolve_guidance` / `resolve_negative_prompt` in `crates/sceneworks-worker/src/image_jobs/base.rs` return `None` for any model whose gen-core descriptor advertises the axis absent. The manifest already made the honest claim; the UI contradicted it.

## The fix

The same declarative manifest mirror sc-8445 used — not an id check, not an engine link:

```jsonc
"image": { "supportsGuidance": false, "supportsNegativePrompt": false }
```

added to `packages/schemas/model-manifest.schema.json` (that object is `additionalProperties: false`, so it had to be), read in `ImageStudio.jsx` as `selectedModel?.image?.supportsGuidance !== false`.

**Polarity: ABSENT MEANS TRUE** — the same as `video`, the opposite of `audio`. The image population is overwhelmingly guidance-taking, so every entry that declares nothing is byte-identical to its previous behaviour.

**Hidden, not disabled**, deliberately: the Wan Lightning precedent *disables* Steps/Guidance because that inertness is TRANSIENT. A missing axis is permanent for the model, so a forever-dead input is clutter — Audio Studio hides these two for the same reason.

## Enumeration — from the worker routes, not the names

Each manifest image entry was resolved to its engine id through `engines.rs` `MODEL_TABLE`, then to that engine's `Capabilities { supports_guidance, supports_negative_prompt }` in the pinned inference checkout (both the `mlx-gen-*` and `candle-gen-*` registrations).

**Both axes absent (10)** — descriptor is false/false, so `resolve_guidance`, `resolve_true_cfg` *and* `resolve_negative_prompt` all return `None`:
`z_image_turbo`, `z_image_edit` (runs on the `z_image_turbo` engine), `flux_schnell`, `ideogram_4_turbo`, `boogu_image_turbo`, `krea_2_turbo`, `sd3_5_large_turbo`, `anima_turbo`, `mage_flow_turbo`, `mage_flow_edit_turbo`.

**Negative absent, guidance KEPT (13)** — a real embedded/distilled guidance scale, no unconditional branch:
`flux_dev`, `ideogram_4`, `boogu_image`, `boogu_image_edit`, `flux2_dev`, all six `sensenova_u1_8b*` entries, `sana_sprint_1600m`, and `pulid_flux_dev` (its lane hard-sets `negative_prompt: None` in `image_jobs/pulid.rs`).

### ⚠️ Chroma deliberately declares NOTHING

`chroma1_hd` / `chroma1_base` / `chroma1_flash` have `supports_guidance: false`, which looks like a match — but they are a **TRUE-CFG family**. `uses_true_cfg` (`!supports_guidance && supports_negative_prompt`) routes `advanced.guidanceScale` through `resolve_true_cfg` as `true_cfg`. Their Guidance control is **live**; declaring the axis absent would have broken a working knob. So the real gate is *"dead iff neither `guidance` nor `true_cfg` is forwarded"*, i.e. `!supports_guidance && !supports_negative_prompt` — not the descriptor flag alone.

### Divergence found and NOT acted on

`flux2_klein_9b` (and its `_kv` / `_true_v2` siblings) diverge across lanes: the mlx descriptor says `supports_negative_prompt: false`, the candle descriptor says `true` (it keys off `uses_embedded_guidance`). The manifest key is lane-agnostic, so declaring it false would hide a live control on Windows/Linux. Left undeclared; flagged as a follow-up.

## Beyond the two controls

- the `ui.defaultNegativePrompt` **seed effect** is skipped for an engine with no negative axis — and `anima_turbo`'s now-provably-dead booru negative is dropped from the manifest, the rule `krea_2_turbo` already follows;
- the **preset stack preview** stops advertising a "+ negative prompt" contribution the job will not make (`stackAddsNegative` is ANDed, as VideoStudio does);
- a **saved preset** on such a model no longer banks either value — applying it later on a guidance-taking model would have resurrected a negative the user never typed;
- **`fallbackModels`** mirrors the block for the eight declaring entries it carries, so the pre-catalog seed hides the same controls the live catalog does.

## Folded in: the half-wired audio flags

`AudioStudio.jsx:389-390` gates the Music tab's Guidance and Negative prompt on `audio.supportsGuidance` / `audio.supportsNegativePrompt` — but neither key was in the schema's `audio` object, which is `additionalProperties: false`. **They could not be set even if someone tried**, so both were permanently falsy and the controls were hidden by accident rather than by declaration.

Both are now declarable, and `acestep_v15_turbo` declares them `false` — which is true: `candle-audio-acestep`'s descriptor is false/false and its generate path never reads `req.guidance` or `req.negative_prompt`. **The audio polarity is left as-is** (absent means FALSE), so today's rendered UI is unchanged; a future non-distilled music model can now turn the controls on.

## Tests

`apps/web/src/screens/ImageStudio.test.jsx` — six new cases discriminating **both** ways:

1. a model declaring **no** `image` block keeps both controls **and sends both values** (this is the leg that stops the gate from hiding everything);
2. a CFG-free engine hides both and sends neither;
3. an embedded-guidance engine **keeps Guidance** while losing the negative — the two keys are independent;
4. no ghost default-negative seeded into a hidden box (observed by switching to a model that *can* show it — the payload gate would mask it otherwise);
5. a preset saved on a CFG-free model banks neither value;
6. the **preset-stack preview** shows its `Negative:` contribution on a negative-taking model and drops it, for the *same* active stack, once the model is switched to the CFG-free one — while still showing the composed prompt, which *is* sent.

⚠️ **No payload assertion is made on a freshly mounted CFG-free model.** Both fields default to empty and the model-switch reset clears `guidanceOverride`, so such an assertion passes against no implementation at all — the exact false green called out on the story. Cases 2, 3 and 5 run through the **recipe-replay** path instead, which restores model + guidance + negative together with the advanced-defaults reset deliberately suppressed, so a non-empty override genuinely arrives on the CFG-free model. Cases 4 and 6 do not need it: their non-empty negative comes from the `ui.defaultNegativePrompt` seed and from the active preset stack respectively, not from a field the mount defaults to empty.

`apps/web/src/imageAxesParity.test.js` — new manifest ↔ `fallbackModels` parity guard, in both directions (mirror must not add a declaration the manifest lacks, nor drop one it has).

`tests/test_builtin_manifest_audit.py` — six new audits pinning the declared set exactly (including "every other image entry stays silent", which is what makes Chroma's absence a contract rather than an oversight), the no-dead-default-negative rule, the `additionalProperties: false` guard inside the new block, and the audio half.

**Mutation checks:** ten source mutations (each gate forced true and false, each payload/preset blank removed, the seed guard removed, the preview's `supportsNegativePrompt &&` AND removed) verified RED then reverted; five manifest/schema mutations likewise. Two of these needed the test restructured before they discriminated: the seed-guard mutation was green on the first draft of that case, and the preview AND was **initially uncovered entirely** — removing it left the whole suite green. Case 6 was added specifically to close that hole, and was re-verified RED against the removal and GREEN with the guard restored.

**Status:** `npm run lint` clean; 210 web test files / 2910 tests pass; `tests/test_builtin_manifest_audit.py` 66 pass; `cargo test -p sceneworks-core --lib` 701 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

