### PR TITLE
SC-15508: resolve canonical SceneWorks MLX cache

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -135,7 +135,20 @@ jobs:
             echo "qwen_repository must be the fixed SceneWorks/qwen-image-mlx calibration artifact" >&2
             exit 1
           fi
-          QWEN_ROOT="${QWEN_ROOT_OVERRIDE:-$HOME/.cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/$QWEN_REVISION/bf16}"
+          if [[ -n "$QWEN_ROOT_OVERRIDE" ]]; then
+            QWEN_ROOT="$QWEN_ROOT_OVERRIDE"
+          else
+            QWEN_HF_ROOT="$HOME/.cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/$QWEN_REVISION/bf16"
+            QWEN_APP_ROOT="$HOME/Library/Application Support/SceneWorks/data/cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/$QWEN_REVISION/bf16"
+            if [[ -d "$QWEN_HF_ROOT" ]]; then
+              QWEN_ROOT="$QWEN_HF_ROOT"
+            elif [[ -d "$QWEN_APP_ROOT" ]]; then
+              QWEN_ROOT="$QWEN_APP_ROOT"
+            else
+              echo "the exact Qwen calibration snapshot is not available on this runner" >&2
+              exit 1
+            fi
+          fi
           if [[ ! -d "$QWEN_ROOT" ]]; then
             echo "the exact Qwen calibration snapshot is not available on this runner" >&2
             exit 1

--- a/docs/image-memory-calibration-harness.md
+++ b/docs/image-memory-calibration-harness.md
@@ -144,10 +144,14 @@ gh workflow run macos-mlx.yml --ref main \
   -f qwen_revision=<exact-artifact-revision>
 ```
 
-The runner resolves only the fixed `SceneWorks/qwen-image-mlx` artifact. By default it derives
-`$HOME/.cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/<exact-revision>/bf16`;
-the optional `SCENEWORKS_QWEN_IMAGE_ROOT` repository secret can override that one path when the
-runner cache lives elsewhere. The override is canonicalized and must still end in the fixed
+The runner resolves only the fixed `SceneWorks/qwen-image-mlx` artifact. Without an override it
+checks exactly two canonical locations, in order:
+`$HOME/.cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/<exact-revision>/bf16`,
+then
+`$HOME/Library/Application Support/SceneWorks/data/cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/<exact-revision>/bf16`.
+It does not scan other directories. The optional `SCENEWORKS_QWEN_IMAGE_ROOT` repository secret can
+override those locations when the runner cache lives elsewhere. The override is canonicalized and
+must still end in the fixed
 repository/exact-revision `/models--SceneWorks--qwen-image-mlx/snapshots/<exact-revision>/bf16`
 suffix. The dispatch validates but never prints the resolved path, checks out the exact inference
 revision, builds the release adapter, runs the authoritative provider through the harness,

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -119,6 +119,20 @@ test("macOS image-memory calibration dispatch is opt-in and secret-scoped", asyn
     workflow,
     /models--SceneWorks--qwen-image-mlx\/snapshots\/\$QWEN_REVISION\/bf16/,
   );
+  const huggingFaceRoot =
+    "$HOME/.cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/$QWEN_REVISION/bf16";
+  const sceneWorksRoot =
+    "$HOME/Library/Application Support/SceneWorks/data/cache/huggingface/hub/models--SceneWorks--qwen-image-mlx/snapshots/$QWEN_REVISION/bf16";
+  assert.equal(workflow.split(huggingFaceRoot).length - 1, 1);
+  assert.equal(workflow.split(sceneWorksRoot).length - 1, 1);
+  assert.ok(workflow.indexOf(huggingFaceRoot) < workflow.indexOf(sceneWorksRoot));
+  assert.match(
+    workflow,
+    /if \[\[ -n "\$QWEN_ROOT_OVERRIDE" \]\]; then\s+QWEN_ROOT="\$QWEN_ROOT_OVERRIDE"\s+else/,
+  );
+  assert.match(workflow, /if \[\[ -d "\$QWEN_HF_ROOT" \]\]; then/);
+  assert.match(workflow, /elif \[\[ -d "\$QWEN_APP_ROOT" \]\]; then/);
+  assert.doesNotMatch(workflow, /\bfind\b.*qwen|\bls\b.*qwen/i);
   assert.match(
     workflow,
     /QWEN_REPOSITORY" != "SceneWorks\/qwen-image-mlx"/,


### PR DESCRIPTION
## Summary

- keep the optional `SCENEWORKS_QWEN_IMAGE_ROOT` secret override canonical-suffix-bound
- without an override, try exactly the standard Hugging Face cache and the SceneWorks application cache, in that order
- preserve fail-closed behavior without printing paths or scanning arbitrary directories

## Context

Post-merge MLX dispatch `30356804004` failed before adapter execution because the exact
`SceneWorks/qwen-image-mlx` bf16 snapshot was absent from the standard
`$HOME/.cache/huggingface` location. No calibration artifact was produced.

The SceneWorks macOS application uses the second canonical root under
`$HOME/Library/Application Support/SceneWorks/data/cache/huggingface`. This follow-up checks that
exact repository/revision/tier path without broadening discovery.

If neither canonical root exists after this change lands, the dispatch will continue to fail
before adapter execution and the genuine prerequisite is provisioning the approximately 57 GiB
model snapshot on the runner.

## Validation

- workflow YAML parse
- focused platform contract tests (10/10)
- full `npm.cmd run check` (45/45)
- `git diff --check`
- DCO sign-off

## Follow-up gate

Keep SC-15508 In Review. After merge, re-dispatch the guarded MLX calibration workflow with the
same exact inference and Qwen revisions. Do not promote a record unless it is schema-valid under
the existing evidence rules.
