### PR TITLE
fix(web): gate CFG-free editor and character axes (sc-15441)

### DIFF
--- a/apps/web/src/components/CharacterAdvancedOptions.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.jsx
@@ -38,6 +38,10 @@ export function useCharacterAdvancedOptions(
   model,
   { defaultNegativePrompt = "", identityStructureMode = "single", catalog = [] } = {},
 ) {
+  // Character generation is an image lane. Its catalog axes are opt-out so
+  // legacy entries with no `image` block retain both controls.
+  const supportsGuidance = model?.image?.supportsGuidance !== false;
+  const supportsNegativePrompt = model?.image?.supportsNegativePrompt !== false;
   const ui = model?.ui ?? {};
   const referenceStrengthDefault =
     typeof ui.referenceStrengthDefault === "number" ? ui.referenceStrengthDefault : 0.8;
@@ -68,7 +72,9 @@ export function useCharacterAdvancedOptions(
   const [scheduler, setScheduler] = React.useState(schedulerDefaultFromModel(model));
   const [schedulerShift, setSchedulerShift] = React.useState(schedulerShiftDefaultFromModel(model));
   const [seed, setSeed] = React.useState("");
-  const [negativePrompt, setNegativePrompt] = React.useState(defaultNegativePrompt);
+  const [negativePrompt, setNegativePrompt] = React.useState(
+    supportsNegativePrompt ? defaultNegativePrompt : "",
+  );
   // PiD decoder toggle (epic 7840, sc-8372): off = the model's native VAE decode; on emits
   // `advanced.usePid: true`, routing Angles/Poses decode through the optional PiD pixel-diffusion
   // decoder (2K/4K super-resolve). Mirrors the Image Studio toggle. The toggle only renders + emits
@@ -97,15 +103,17 @@ export function useCharacterAdvancedOptions(
   // Re-seed the editable negative prompt with the curated baseline when it changes
   // (e.g. switching character/panel). The user edits from that starting point.
   React.useEffect(() => {
-    setNegativePrompt(defaultNegativePrompt);
-  }, [defaultNegativePrompt]);
+    if (supportsNegativePrompt) {
+      setNegativePrompt(defaultNegativePrompt);
+    }
+  }, [defaultNegativePrompt, supportsNegativePrompt]);
 
   function buildAdvanced(base = {}) {
     const advanced = { ...base, ipAdapterScale };
     if (identityStructure) {
       advanced.controlnetConditioningScale = controlnetScale;
     }
-    if (guidance !== "" && Number.isFinite(Number(guidance))) {
+    if (supportsGuidance && guidance !== "" && Number.isFinite(Number(guidance))) {
       advanced.guidanceScale = Number(guidance);
     }
     if (steps !== "" && Number.isFinite(Number(steps))) {
@@ -160,6 +168,8 @@ export function useCharacterAdvancedOptions(
     pidTarget,
     setPidTarget,
     showPidToggle,
+    supportsGuidance,
+    supportsNegativePrompt,
     model,
     identityStructure,
     // Optional label/range override for the primary reference-strength slider (sc-8278: klein maps
@@ -202,6 +212,8 @@ export function CharacterAdvancedOptions({ state, baseWidth, baseHeight }) {
     pidTarget,
     setPidTarget,
     showPidToggle,
+    supportsGuidance,
+    supportsNegativePrompt,
     model,
     identityStructure,
     referenceStrength: referenceStrengthCfg,
@@ -257,18 +269,20 @@ export function CharacterAdvancedOptions({ state, baseWidth, baseHeight }) {
               <span>{controlnetScale.toFixed(2)}</span>
             </label>
           ) : null}
-          <label>
-            Guidance
-            <input
-              max="30"
-              min="0"
-              onChange={(event) => setGuidance(event.target.value)}
-              placeholder={guidancePlaceholder}
-              step="0.1"
-              type="number"
-              value={guidance}
-            />
-          </label>
+          {supportsGuidance ? (
+            <label>
+              Guidance
+              <input
+                max="30"
+                min="0"
+                onChange={(event) => setGuidance(event.target.value)}
+                placeholder={guidancePlaceholder}
+                step="0.1"
+                type="number"
+                value={guidance}
+              />
+            </label>
+          ) : null}
           <label>
             Steps
             <input
@@ -326,10 +340,12 @@ export function CharacterAdvancedOptions({ state, baseWidth, baseHeight }) {
               value={seed}
             />
           </label>
-          <label className="prompt-field">
-            Negative prompt
-            <textarea onChange={(event) => setNegativePrompt(event.target.value)} rows={3} value={negativePrompt} />
-          </label>
+          {supportsNegativePrompt ? (
+            <label className="prompt-field">
+              Negative prompt
+              <textarea onChange={(event) => setNegativePrompt(event.target.value)} rows={3} value={negativePrompt} />
+            </label>
+          ) : null}
           {showPidToggle ? (
             <>
               <label

--- a/apps/web/src/components/CharacterAdvancedOptions.test.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.test.jsx
@@ -168,4 +168,57 @@ describe("CharacterAdvancedOptions PiD toggle (sc-8372)", () => {
     expect(container.querySelector('[data-testid="negative"]').textContent).toBe("");
     expect(container.textContent).not.toContain("Negative prompt");
   });
+
+  it("keeps Guidance while independently hiding and suppressing Negative prompt", async () => {
+    const guided = { id: "guided" };
+    const noNegative = {
+      id: "no-negative",
+      image: { supportsGuidance: true, supportsNegativePrompt: false },
+    };
+    await act(async () =>
+      root.render(<Harness model={guided} catalog={[]} defaultNegativePrompt="baseline" />),
+    );
+    const guidance = [...container.querySelectorAll("label")].find((label) =>
+      label.textContent.trim().startsWith("Guidance"),
+    )?.querySelector("input");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set.call(guidance, "6.5");
+      guidance.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+
+    await act(async () =>
+      root.render(<Harness model={noNegative} catalog={[]} defaultNegativePrompt="hidden baseline" />),
+    );
+    expect(container.textContent).toContain("Guidance");
+    expect(container.textContent).not.toContain("Negative prompt");
+    expect(advanced().guidanceScale).toBe(6.5);
+    expect(container.querySelector('[data-testid="negative"]').textContent).toBe("");
+    expect(container.querySelector('[data-testid="raw-negative"]').textContent).toBe("baseline");
+  });
+
+  it("keeps Negative prompt while independently hiding and suppressing Guidance", async () => {
+    const guided = { id: "guided" };
+    const noGuidance = {
+      id: "no-guidance",
+      image: { supportsGuidance: false, supportsNegativePrompt: true },
+    };
+    await act(async () =>
+      root.render(<Harness model={guided} catalog={[]} defaultNegativePrompt="baseline" />),
+    );
+    const guidance = [...container.querySelectorAll("label")].find((label) =>
+      label.textContent.trim().startsWith("Guidance"),
+    )?.querySelector("input");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set.call(guidance, "6.5");
+      guidance.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+
+    await act(async () =>
+      root.render(<Harness model={noGuidance} catalog={[]} defaultNegativePrompt="visible baseline" />),
+    );
+    expect(container.textContent).not.toContain("Guidance");
+    expect(container.textContent).toContain("Negative prompt");
+    expect(advanced()).not.toHaveProperty("guidanceScale");
+    expect(container.querySelector('[data-testid="raw-negative"]').textContent).toBe("visible baseline");
+  });
 });

--- a/apps/web/src/components/CharacterAdvancedOptions.test.jsx
+++ b/apps/web/src/components/CharacterAdvancedOptions.test.jsx
@@ -19,13 +19,17 @@ const missing = [{ id: "pid_sdxl", installState: "missing" }];
 
 // Hosts the hook + presentational panel, opens the advanced section, and renders the current
 // `buildAdvanced()` output so the test can assert what the job payload would carry.
-function Harness({ model, catalog, baseWidth, baseHeight }) {
-  const state = useCharacterAdvancedOptions(model, { catalog });
+function Harness({ model, catalog, baseWidth, baseHeight, defaultNegativePrompt = "" }) {
+  const state = useCharacterAdvancedOptions(model, { catalog, defaultNegativePrompt });
   React.useEffect(() => state.setOpen(true), []); // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <>
       <CharacterAdvancedOptions state={state} baseWidth={baseWidth} baseHeight={baseHeight} />
       <output data-testid="adv">{JSON.stringify(state.buildAdvanced())}</output>
+      <output data-testid="negative">
+        {state.supportsNegativePrompt ? state.negativePrompt : ""}
+      </output>
+      <output data-testid="raw-negative">{state.negativePrompt}</output>
     </>
   );
 }
@@ -103,5 +107,65 @@ describe("CharacterAdvancedOptions PiD toggle (sc-8372)", () => {
       select.dispatchEvent(new Event("change", { bubbles: true }));
     });
     expect(pidHint()).toBe(null);
+  });
+
+  it("keeps Guidance and Negative prompt for an image model with no axis declarations", async () => {
+    await act(async () =>
+      root.render(<Harness model={{ id: "guided" }} catalog={[]} />),
+    );
+    expect(container.textContent).toContain("Guidance");
+    expect(container.textContent).toContain("Negative prompt");
+  });
+
+  it("hides and suppresses retained Guidance and Negative prompt after a CFG-free model switch", async () => {
+    const guided = { id: "guided" };
+    const cfgFree = {
+      id: "cfg-free",
+      image: { supportsGuidance: false, supportsNegativePrompt: false },
+    };
+    await act(async () =>
+      root.render(<Harness model={guided} catalog={[]} defaultNegativePrompt="curated baseline" />),
+    );
+
+    const guidance = [...container.querySelectorAll("label")].find((label) =>
+      label.textContent.trim().startsWith("Guidance"),
+    )?.querySelector("input");
+    const negative = [...container.querySelectorAll("label")].find((label) =>
+      label.textContent.trim().startsWith("Negative prompt"),
+    )?.querySelector("textarea");
+    await act(async () => {
+      const inputSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+      inputSetter.call(guidance, "7.5");
+      guidance.dispatchEvent(new window.Event("input", { bubbles: true }));
+      const textareaSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+      textareaSetter.call(negative, "blurry, low quality");
+      negative.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+    expect(advanced().guidanceScale).toBe(7.5);
+
+    await act(async () =>
+      root.render(<Harness model={cfgFree} catalog={[]} defaultNegativePrompt="curated baseline" />),
+    );
+    expect(container.textContent).not.toContain("Guidance");
+    expect(container.textContent).not.toContain("Negative prompt");
+    expect(advanced()).not.toHaveProperty("guidanceScale");
+    expect(container.querySelector('[data-testid="negative"]').textContent).toBe("");
+  });
+
+  it("does not seed a hidden negative prompt on a CFG-free model", async () => {
+    const cfgFree = {
+      id: "cfg-free",
+      image: { supportsGuidance: false, supportsNegativePrompt: false },
+    };
+    await act(async () =>
+      root.render(<Harness model={cfgFree} catalog={[]} defaultNegativePrompt="curated baseline" />),
+    );
+    expect(container.querySelector('[data-testid="raw-negative"]').textContent).toBe("");
+    await act(async () =>
+      root.render(<Harness model={cfgFree} catalog={[]} defaultNegativePrompt="updated baseline" />),
+    );
+    expect(container.querySelector('[data-testid="raw-negative"]').textContent).toBe("");
+    expect(container.querySelector('[data-testid="negative"]').textContent).toBe("");
+    expect(container.textContent).not.toContain("Negative prompt");
   });
 });

--- a/apps/web/src/components/editor/GenerationRail.axes.test.jsx
+++ b/apps/web/src/components/editor/GenerationRail.axes.test.jsx
@@ -90,4 +90,16 @@ describe("GenerationRail catalog axes (sc-15441)", () => {
     expect(container.textContent).not.toContain("Guidance");
     expect(container.textContent).not.toContain("Negative prompt");
   });
+
+  it("keeps Guidance while hiding only Negative prompt", () => {
+    render(generationState({ supportsGuidance: true, supportsNegativePrompt: false }));
+    expect(container.textContent).toContain("Guidance");
+    expect(container.textContent).not.toContain("Negative prompt");
+  });
+
+  it("keeps Negative prompt while hiding only Guidance", () => {
+    render(generationState({ supportsGuidance: false, supportsNegativePrompt: true }));
+    expect(container.textContent).not.toContain("Guidance");
+    expect(container.textContent).toContain("Negative prompt");
+  });
 });

--- a/apps/web/src/components/editor/GenerationRail.axes.test.jsx
+++ b/apps/web/src/components/editor/GenerationRail.axes.test.jsx
@@ -1,0 +1,93 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../generationStudio.jsx", () => ({
+  LoraPickerSection: () => null,
+}));
+
+import { GenerationRail } from "./GenerationRail.jsx";
+
+function generationState(capabilities) {
+  return {
+    studio: {
+      availablePresets: [],
+      selectedPresetId: null,
+      setSelectedPresetId: vi.fn(),
+    },
+    selectedModel: { id: "video-model" },
+    videoModels: [{ id: "video-model" }],
+    model: "video-model",
+    setModel: vi.fn(),
+    qualityChoices: [["balanced", "Balanced"]],
+    quality: "balanced",
+    setQuality: vi.fn(),
+    resolution: "1280x720",
+    resolutionOptions: ["1280x720"],
+    setResolution: vi.fn(),
+    fps: 24,
+    fpsOptions: [24],
+    setFps: vi.fn(),
+    duration: 6,
+    durationOptions: [6],
+    setDuration: vi.fn(),
+    motion: "Balanced",
+    motionPct: 50,
+    setMotion: vi.fn(),
+    prompt: "A fox",
+    setPrompt: vi.fn(),
+    seed: "",
+    setSeed: vi.fn(),
+    randomizeSeed: vi.fn(),
+    negativePrompt: "blurry",
+    setNegativePrompt: vi.fn(),
+    advancedOpen: true,
+    setAdvancedOpen: vi.fn(),
+    showSamplerPicker: false,
+    showSchedulerPicker: false,
+    stepsOverride: "",
+    setStepsOverride: vi.fn(),
+    guidanceOverride: "6.5",
+    setGuidanceOverride: vi.fn(),
+    lightningActive: false,
+    showTierPicker: false,
+    showLightning: false,
+    savePreset: vi.fn(),
+    ...capabilities,
+  };
+}
+
+describe("GenerationRail catalog axes (sc-15441)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(gen) {
+    act(() => {
+      root.render(<GenerationRail gen={gen} onGenerate={vi.fn()} />);
+    });
+  }
+
+  it("shows Guidance and Negative prompt when the video axes are supported", () => {
+    render(generationState({ supportsGuidance: true, supportsNegativePrompt: true }));
+    expect(container.textContent).toContain("Guidance");
+    expect(container.textContent).toContain("Negative prompt");
+  });
+
+  it("hides Guidance and Negative prompt when the video axes are absent", () => {
+    render(generationState({ supportsGuidance: false, supportsNegativePrompt: false }));
+    expect(container.textContent).not.toContain("Guidance");
+    expect(container.textContent).not.toContain("Negative prompt");
+  });
+});

--- a/apps/web/src/components/editor/GenerationRail.jsx
+++ b/apps/web/src/components/editor/GenerationRail.jsx
@@ -215,14 +215,16 @@ export function GenerationRail({ gen, header, contextActions = [], onGenerate, g
               </button>
             </div>
           </label>
-          <label className="ve-field">
-            <span className="ve-field-label">Negative prompt</span>
-            <textarea
-              className="ve-textarea"
-              onChange={(e) => gen.setNegativePrompt(e.target.value)}
-              value={gen.negativePrompt}
-            />
-          </label>
+          {gen.supportsNegativePrompt ? (
+            <label className="ve-field">
+              <span className="ve-field-label">Negative prompt</span>
+              <textarea
+                className="ve-textarea"
+                onChange={(e) => gen.setNegativePrompt(e.target.value)}
+                value={gen.negativePrompt}
+              />
+            </label>
+          ) : null}
         </div>
 
         {/* Advanced */}
@@ -285,16 +287,18 @@ export function GenerationRail({ gen, header, contextActions = [], onGenerate, g
                     value={gen.lightningActive ? "" : gen.stepsOverride}
                   />
                 </label>
-                <label className="ve-field">
-                  <span className="ve-field-label">Guidance</span>
-                  <input
-                    className="ve-input"
-                    disabled={gen.lightningActive}
-                    onChange={(e) => gen.setGuidanceOverride(e.target.value)}
-                    placeholder={gen.lightningActive ? "off (Lightning)" : "auto"}
-                    value={gen.lightningActive ? "" : gen.guidanceOverride}
-                  />
-                </label>
+                {gen.supportsGuidance ? (
+                  <label className="ve-field">
+                    <span className="ve-field-label">Guidance</span>
+                    <input
+                      className="ve-input"
+                      disabled={gen.lightningActive}
+                      onChange={(e) => gen.setGuidanceOverride(e.target.value)}
+                      placeholder={gen.lightningActive ? "off (Lightning)" : "auto"}
+                      value={gen.lightningActive ? "" : gen.guidanceOverride}
+                    />
+                  </label>
+                ) : null}
               </div>
 
               {gen.showTierPicker ? (

--- a/apps/web/src/components/editor/useEditorGeneration.axes.test.jsx
+++ b/apps/web/src/components/editor/useEditorGeneration.axes.test.jsx
@@ -1,0 +1,140 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadStudioSettings: vi.fn(() => ({})),
+  writeStudioSettings: vi.fn(),
+  studio: { selectedPreset: null },
+}));
+
+vi.mock("../../hooks/useStudioSettings.js", () => ({
+  loadStudioSettings: mocks.loadStudioSettings,
+  useStudioSettingsWriter: (...args) => mocks.writeStudioSettings(...args),
+}));
+
+vi.mock("../generationStudio.jsx", () => ({
+  useGenerationStudio: () => ({
+    selectedPreset: mocks.studio.selectedPreset,
+    selectedPresetId: mocks.studio.selectedPreset?.id ?? null,
+    selectedLoras: [],
+    selectedLoraIds: [],
+    loraWeights: {},
+    showIncompatibleLoras: false,
+    generalStackIds: [],
+    effectiveLoraWeight: () => 1,
+  }),
+}));
+
+import { useEditorGeneration } from "./useEditorGeneration.js";
+
+const GUIDED = { id: "guided-video" };
+const CFG_FREE = {
+  id: "cfg-free-video",
+  video: { supportsGuidance: false, supportsNegativePrompt: false },
+};
+
+describe("useEditorGeneration catalog axes (sc-15441)", () => {
+  let container;
+  let root;
+  let latest;
+  let context;
+
+  function Harness({ videoModels }) {
+    latest = useEditorGeneration({ context: { ...context, videoModels } });
+    return null;
+  }
+
+  function render(videoModels) {
+    act(() => {
+      root.render(<Harness videoModels={videoModels} />);
+    });
+  }
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    mocks.loadStudioSettings.mockReturnValue({});
+    mocks.studio.selectedPreset = null;
+    context = {
+      activeProject: { id: "project-1" },
+      preferencesHydrated: true,
+      createPreset: vi.fn(async (payload) => payload),
+    };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("keeps both axes for a video model that declares no video block", async () => {
+    render([GUIDED]);
+    act(() => {
+      latest.setNegativePrompt("blurry");
+      latest.setGuidanceOverride("6.5");
+    });
+
+    expect(latest.supportsGuidance).toBe(true);
+    expect(latest.supportsNegativePrompt).toBe(true);
+    expect(latest.buildBasePayload().negativePrompt).toBe("blurry");
+    expect(latest.buildBasePayload().advanced.guidanceScale).toBe(6.5);
+
+    await act(async () => latest.savePreset("Guided"));
+    const defaults = context.createPreset.mock.calls[0][0].defaults;
+    expect(defaults.negativePrompt).toBe("blurry");
+    expect(defaults.guidanceScale).toBe(6.5);
+  });
+
+  it("suppresses retained values after switching to a CFG-free model in payload, settings, and presets", async () => {
+    render([GUIDED, CFG_FREE]);
+    act(() => {
+      latest.setNegativePrompt("blurry, low quality");
+      latest.setGuidanceOverride("7.5");
+    });
+    act(() => latest.setModel(CFG_FREE.id));
+
+    expect(latest.supportsGuidance).toBe(false);
+    expect(latest.supportsNegativePrompt).toBe(false);
+    expect(latest.buildBasePayload().negativePrompt).toBe("");
+    expect(latest.buildBasePayload().advanced).not.toHaveProperty("guidanceScale");
+
+    const settings = mocks.writeStudioSettings.mock.calls.at(-1)[2];
+    expect(settings.negativePrompt).toBe("");
+    expect(settings.guidanceScale).toBe("");
+
+    await act(async () => latest.savePreset("CFG free"));
+    const defaults = context.createPreset.mock.calls[0][0].defaults;
+    expect(defaults).not.toHaveProperty("negativePrompt");
+    expect(defaults).not.toHaveProperty("guidanceScale");
+  });
+
+  it("does not apply preset defaults for hidden axes", () => {
+    mocks.studio.selectedPreset = {
+      id: "stale-preset",
+      defaults: { negativePrompt: "ghost", guidanceScale: 9 },
+    };
+    render([CFG_FREE]);
+
+    expect(latest.negativePrompt).toBe("");
+    expect(latest.guidanceOverride).toBe("");
+    expect(latest.buildBasePayload().negativePrompt).toBe("");
+    expect(latest.buildBasePayload().advanced).not.toHaveProperty("guidanceScale");
+  });
+
+  it("filters persisted stale values restored directly onto a CFG-free model", () => {
+    mocks.loadStudioSettings.mockReturnValue({
+      model: CFG_FREE.id,
+      negativePrompt: "restored ghost",
+      guidanceScale: "8",
+    });
+    render([GUIDED, CFG_FREE]);
+
+    expect(latest.model).toBe(CFG_FREE.id);
+    expect(latest.buildBasePayload().negativePrompt).toBe("");
+    expect(latest.buildBasePayload().advanced).not.toHaveProperty("guidanceScale");
+  });
+});

--- a/apps/web/src/components/editor/useEditorGeneration.axes.test.jsx
+++ b/apps/web/src/components/editor/useEditorGeneration.axes.test.jsx
@@ -33,6 +33,14 @@ const CFG_FREE = {
   id: "cfg-free-video",
   video: { supportsGuidance: false, supportsNegativePrompt: false },
 };
+const NO_NEGATIVE = {
+  id: "no-negative-video",
+  video: { supportsGuidance: true, supportsNegativePrompt: false },
+};
+const NO_GUIDANCE = {
+  id: "no-guidance-video",
+  video: { supportsGuidance: false, supportsNegativePrompt: true },
+};
 
 describe("useEditorGeneration catalog axes (sc-15441)", () => {
   let container;
@@ -136,5 +144,69 @@ describe("useEditorGeneration catalog axes (sc-15441)", () => {
     expect(latest.model).toBe(CFG_FREE.id);
     expect(latest.buildBasePayload().negativePrompt).toBe("");
     expect(latest.buildBasePayload().advanced).not.toHaveProperty("guidanceScale");
+  });
+
+  it("suppresses only Negative prompt across switch, preset, settings, save, and payload paths", async () => {
+    const models = [GUIDED, NO_NEGATIVE];
+    render(models);
+    act(() => {
+      latest.setNegativePrompt("typed negative");
+      latest.setGuidanceOverride("6.5");
+    });
+    act(() => latest.setModel(NO_NEGATIVE.id));
+
+    mocks.studio.selectedPreset = {
+      id: "mixed-negative-preset",
+      defaults: { negativePrompt: "preset ghost", guidanceScale: 9 },
+    };
+    render(models);
+
+    expect(latest.supportsGuidance).toBe(true);
+    expect(latest.supportsNegativePrompt).toBe(false);
+    expect(latest.negativePrompt).toBe("typed negative");
+    expect(latest.guidanceOverride).toBe(9);
+    expect(latest.buildBasePayload().negativePrompt).toBe("");
+    expect(latest.buildBasePayload().advanced.guidanceScale).toBe(9);
+
+    const settings = mocks.writeStudioSettings.mock.calls.at(-1)[2];
+    expect(settings.negativePrompt).toBe("");
+    expect(settings.guidanceScale).toBe(9);
+
+    await act(async () => latest.savePreset("No negative"));
+    const defaults = context.createPreset.mock.calls[0][0].defaults;
+    expect(defaults).not.toHaveProperty("negativePrompt");
+    expect(defaults.guidanceScale).toBe(9);
+  });
+
+  it("suppresses only Guidance across switch, preset, settings, save, and payload paths", async () => {
+    const models = [GUIDED, NO_GUIDANCE];
+    render(models);
+    act(() => {
+      latest.setNegativePrompt("typed negative");
+      latest.setGuidanceOverride("6.5");
+    });
+    act(() => latest.setModel(NO_GUIDANCE.id));
+
+    mocks.studio.selectedPreset = {
+      id: "mixed-guidance-preset",
+      defaults: { negativePrompt: "preset negative", guidanceScale: 9 },
+    };
+    render(models);
+
+    expect(latest.supportsGuidance).toBe(false);
+    expect(latest.supportsNegativePrompt).toBe(true);
+    expect(latest.negativePrompt).toBe("preset negative");
+    expect(latest.guidanceOverride).toBe("6.5");
+    expect(latest.buildBasePayload().negativePrompt).toBe("preset negative");
+    expect(latest.buildBasePayload().advanced).not.toHaveProperty("guidanceScale");
+
+    const settings = mocks.writeStudioSettings.mock.calls.at(-1)[2];
+    expect(settings.negativePrompt).toBe("preset negative");
+    expect(settings.guidanceScale).toBe("");
+
+    await act(async () => latest.savePreset("No guidance"));
+    const defaults = context.createPreset.mock.calls[0][0].defaults;
+    expect(defaults.negativePrompt).toBe("preset negative");
+    expect(defaults).not.toHaveProperty("guidanceScale");
   });
 });

--- a/apps/web/src/components/editor/useEditorGeneration.js
+++ b/apps/web/src/components/editor/useEditorGeneration.js
@@ -82,6 +82,10 @@ export function useEditorGeneration({ context }) {
     () => videoModels.find((item) => item.id === model) ?? videoModels[0] ?? null,
     [videoModels, model],
   );
+  // Video generation axes are opt-out: existing catalog entries predate these
+  // flags and keep both controls unless they explicitly declare an axis absent.
+  const supportsGuidance = selectedModel?.video?.supportsGuidance !== false;
+  const supportsNegativePrompt = selectedModel?.video?.supportsNegativePrompt !== false;
 
   const studio = useGenerationStudio({
     mode: PRESET_FILTER_MODE,
@@ -207,13 +211,13 @@ export function useEditorGeneration({ context }) {
     if (defaults.duration != null) setDuration(defaults.duration);
     if (defaults.fps != null) setFps(defaults.fps);
     if (defaults.quality) setQuality(defaults.quality);
-    if (defaults.negativePrompt != null) setNegativePrompt(defaults.negativePrompt);
+    if (supportsNegativePrompt && defaults.negativePrompt != null) setNegativePrompt(defaults.negativePrompt);
     if (defaults.motion && MOTIONS.includes(defaults.motion)) setMotion(defaults.motion);
     if (defaults.sampler) setSampler(defaults.sampler);
     if (defaults.scheduler) setScheduler(defaults.scheduler);
     if (defaults.schedulerShift != null) setSchedulerShift(defaults.schedulerShift);
     if (defaults.steps != null) setStepsOverride(defaults.steps);
-    if (defaults.guidanceScale != null) setGuidanceOverride(defaults.guidanceScale);
+    if (supportsGuidance && defaults.guidanceScale != null) setGuidanceOverride(defaults.guidanceScale);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPresetId]);
 
@@ -238,13 +242,13 @@ export function useEditorGeneration({ context }) {
         duration: Number(duration),
         fps: Number(fps),
         quality,
-        negativePrompt,
+        negativePrompt: supportsNegativePrompt ? negativePrompt : "",
         motion,
         sampler,
         scheduler,
         schedulerShift: Number(schedulerShift),
         ...(stepsOverride !== "" ? { steps: Number(stepsOverride) } : {}),
-        ...(guidanceOverride !== "" ? { guidanceScale: Number(guidanceOverride) } : {}),
+        ...(supportsGuidance && guidanceOverride !== "" ? { guidanceScale: Number(guidanceOverride) } : {}),
       },
     });
     return createPreset(payload);
@@ -264,12 +268,12 @@ export function useEditorGeneration({ context }) {
       motion,
       seed,
       prompt,
-      negativePrompt,
+      negativePrompt: supportsNegativePrompt ? negativePrompt : "",
       sampler,
       scheduler,
       schedulerShift,
       steps: stepsOverride,
-      guidanceScale: guidanceOverride,
+      guidanceScale: supportsGuidance ? guidanceOverride : "",
       quantTier,
       lightning,
       advancedOpen,
@@ -306,7 +310,10 @@ export function useEditorGeneration({ context }) {
       ...(!lightningActive && stepsOverride !== "" && Number.isFinite(Number(stepsOverride))
         ? { steps: Number(stepsOverride) }
         : {}),
-      ...(!lightningActive && guidanceOverride !== "" && Number.isFinite(Number(guidanceOverride))
+      ...(supportsGuidance &&
+      !lightningActive &&
+      guidanceOverride !== "" &&
+      Number.isFinite(Number(guidanceOverride))
         ? { guidanceScale: Number(guidanceOverride) }
         : {}),
     };
@@ -319,7 +326,7 @@ export function useEditorGeneration({ context }) {
       width: width || undefined,
       height: height || undefined,
       seed: seed === "" ? null : Number(seed),
-      negativePrompt,
+      negativePrompt: supportsNegativePrompt ? negativePrompt : "",
       recipePresetId: studio.selectedPreset?.id ?? null,
       presetLorasResolvedClientSide: studio.selectedPreset ? true : undefined,
       loras: studio.selectedLoras.map((lora) => serializeLora(lora, { weight: studio.effectiveLoraWeight(lora) })),
@@ -330,6 +337,8 @@ export function useEditorGeneration({ context }) {
   return {
     studio,
     selectedModel,
+    supportsGuidance,
+    supportsNegativePrompt,
     videoModels,
     createModelDownloadJob,
     createLoraDownloadJob,

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -646,7 +646,7 @@ export function CharacterGenerationPanel({
         characterId,
         referenceAssetId,
         prompt: prompt.trim(),
-        negativePrompt: advanced.negativePrompt,
+        negativePrompt: advanced.supportsNegativePrompt ? advanced.negativePrompt : "",
         // angleSet/poses make the worker emit one image per angle/pose regardless of
         // count; count must satisfy the API's 1-8 guard, so send 1 (worker overrides).
         count: 1,

--- a/apps/web/src/screens/characterPanels.reference.test.jsx
+++ b/apps/web/src/screens/characterPanels.reference.test.jsx
@@ -221,3 +221,119 @@ describe("CharacterGenerationPanel reference selection (sc-8851)", () => {
     expect(pickedId()).toBe("ref_x");
   });
 });
+
+describe("CharacterGenerationPanel catalog axes (sc-15441)", () => {
+  let container;
+  let root;
+
+  const guided = { ...MODEL, id: "guided-image" };
+  const cfgFree = {
+    ...MODEL,
+    id: "cfg-free-image",
+    image: { supportsGuidance: false, supportsNegativePrompt: false },
+  };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  function labelStartingWith(text) {
+    return [...container.querySelectorAll("label")].find((label) =>
+      label.textContent.trim().startsWith(text),
+    );
+  }
+
+  async function mount(createImageJob) {
+    await act(async () =>
+      root.render(
+        <CharacterGenerationPanel
+          mode={{ ...TEST_MODE, defaultNegativePrompt: "curated baseline" }}
+          selectedCharacter={character}
+          model={guided}
+          models={[guided, cfgFree]}
+          catalog={[]}
+          approvedReferences={refs("ref_a")}
+          assets={[]}
+          createImageJob={createImageJob}
+          importAsset={vi.fn()}
+          addCharacterReference={vi.fn()}
+          latestAssets={[]}
+          imageLocalJobs={[]}
+          loras={[]}
+          rememberLocalGenerationJob={vi.fn()}
+        />,
+      ),
+    );
+    await act(async () =>
+      container.querySelector(".advanced-section-toggle").dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      ),
+    );
+  }
+
+  async function setControl(control, value) {
+    await act(async () => {
+      const prototype = control instanceof window.HTMLTextAreaElement
+        ? window.HTMLTextAreaElement.prototype
+        : window.HTMLInputElement.prototype;
+      Object.getOwnPropertyDescriptor(prototype, "value").set.call(control, value);
+      control.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+  }
+
+  async function selectModel(id) {
+    const select = labelStartingWith("Backbone").querySelector("select");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value").set.call(select, id);
+      select.dispatchEvent(new window.Event("change", { bubbles: true }));
+    });
+  }
+
+  async function generate() {
+    const button = [...container.querySelectorAll("button")].find(
+      (candidate) => candidate.textContent.trim() === "Generate",
+    );
+    await act(async () => button.dispatchEvent(new window.MouseEvent("click", { bubbles: true })));
+  }
+
+  it("sends both values for an undeclared image model", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await mount(createImageJob);
+    await setControl(labelStartingWith("Guidance").querySelector("input"), "6.5");
+    await setControl(labelStartingWith("Negative prompt").querySelector("textarea"), "blurry");
+    await generate();
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.model).toBe(guided.id);
+    expect(payload.negativePrompt).toBe("blurry");
+    expect(payload.advanced.guidanceScale).toBe(6.5);
+  });
+
+  it("suppresses non-empty retained values after switching to a CFG-free image model", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await mount(createImageJob);
+    await setControl(labelStartingWith("Guidance").querySelector("input"), "7.5");
+    await setControl(
+      labelStartingWith("Negative prompt").querySelector("textarea"),
+      "blurry, low quality",
+    );
+    await selectModel(cfgFree.id);
+
+    expect(labelStartingWith("Guidance")).toBeUndefined();
+    expect(labelStartingWith("Negative prompt")).toBeUndefined();
+    await generate();
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.model).toBe(cfgFree.id);
+    expect(payload.negativePrompt).toBe("");
+    expect(payload.advanced).not.toHaveProperty("guidanceScale");
+  });
+});

--- a/apps/web/src/screens/characterPanels.reference.test.jsx
+++ b/apps/web/src/screens/characterPanels.reference.test.jsx
@@ -232,6 +232,16 @@ describe("CharacterGenerationPanel catalog axes (sc-15441)", () => {
     id: "cfg-free-image",
     image: { supportsGuidance: false, supportsNegativePrompt: false },
   };
+  const noNegative = {
+    ...MODEL,
+    id: "no-negative-image",
+    image: { supportsGuidance: true, supportsNegativePrompt: false },
+  };
+  const noGuidance = {
+    ...MODEL,
+    id: "no-guidance-image",
+    image: { supportsGuidance: false, supportsNegativePrompt: true },
+  };
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -251,14 +261,14 @@ describe("CharacterGenerationPanel catalog axes (sc-15441)", () => {
     );
   }
 
-  async function mount(createImageJob) {
+  async function mount(createImageJob, models = [guided, cfgFree]) {
     await act(async () =>
       root.render(
         <CharacterGenerationPanel
           mode={{ ...TEST_MODE, defaultNegativePrompt: "curated baseline" }}
           selectedCharacter={character}
           model={guided}
-          models={[guided, cfgFree]}
+          models={models}
           catalog={[]}
           approvedReferences={refs("ref_a")}
           assets={[]}
@@ -334,6 +344,40 @@ describe("CharacterGenerationPanel catalog axes (sc-15441)", () => {
     const payload = createImageJob.mock.calls[0][0];
     expect(payload.model).toBe(cfgFree.id);
     expect(payload.negativePrompt).toBe("");
+    expect(payload.advanced).not.toHaveProperty("guidanceScale");
+  });
+
+  it("keeps Guidance while suppressing only Negative prompt after a mixed-axis switch", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await mount(createImageJob, [guided, noNegative]);
+    await setControl(labelStartingWith("Guidance").querySelector("input"), "7.5");
+    await setControl(labelStartingWith("Negative prompt").querySelector("textarea"), "typed negative");
+    await selectModel(noNegative.id);
+
+    expect(labelStartingWith("Guidance")).toBeTruthy();
+    expect(labelStartingWith("Negative prompt")).toBeUndefined();
+    await generate();
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.model).toBe(noNegative.id);
+    expect(payload.negativePrompt).toBe("");
+    expect(payload.advanced.guidanceScale).toBe(7.5);
+  });
+
+  it("keeps Negative prompt while suppressing only Guidance after a mixed-axis switch", async () => {
+    const createImageJob = vi.fn(async () => ({ id: "job-1" }));
+    await mount(createImageJob, [guided, noGuidance]);
+    await setControl(labelStartingWith("Guidance").querySelector("input"), "7.5");
+    await setControl(labelStartingWith("Negative prompt").querySelector("textarea"), "typed negative");
+    await selectModel(noGuidance.id);
+
+    expect(labelStartingWith("Guidance")).toBeUndefined();
+    expect(labelStartingWith("Negative prompt")).toBeTruthy();
+    await generate();
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.model).toBe(noGuidance.id);
+    expect(payload.negativePrompt).toBe("typed negative");
     expect(payload.advanced).not.toHaveProperty("guidanceScale");
   });
 });


### PR DESCRIPTION
## What does this PR do?

- hides Guidance and Negative prompt in the video Editor rail and image Character panels when lane-specific catalog flags are false
- filters retained, preset-restored, and settings-restored values from active CFG-free presets, settings snapshots, and job payloads
- preserves legacy behavior when capability flags are absent
- adds discriminating supported-to-CFG-free UI and payload tests, including mutation verification for every new guard

## Related issue

Shortcut sc-15441: https://app.shortcut.com/trefry/story/15441

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [x] Not platform-specific (web UI)
- focused Vitest: 4 files, 21 tests
- full web Vitest: 212 files, 2921 tests
- web lint and production build
- root npm run check: 45 tests
- mutation verification: each new UI, default/preset/settings, and payload gate caused its discriminating test to fail before restoration

## Checklist

- [x] Rust checks not applicable (no Rust touched)
- [x] I ran the full web lint, test, and build gate
- [x] I ran npm run check (scaffold checks)
- [x] Documentation not required for this targeted capability-gating fix
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change