### PR TITLE
SC-15508: use runner Python for Qwen provisioning

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -155,16 +155,18 @@ jobs:
             echo "input inference_revision does not match the adapter's compiled INFERENCE_PIN" >&2
             exit 1
           fi
-      - name: Set up pinned Python for Qwen provisioning
+      - name: Create isolated Qwen provisioning environment
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_image_memory_calibration && inputs.provision_qwen_snapshot }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: ".github/workflows/macos-mlx.yml"
-      - name: Install pinned Qwen provisioning client
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_image_memory_calibration && inputs.provision_qwen_snapshot }}
-        run: python -m pip install --disable-pip-version-check --no-input "huggingface_hub==0.36.0"
+        run: |
+          if ! command -v python3 >/dev/null 2>&1; then
+            echo "python3 is required to provision the Qwen calibration snapshot" >&2
+            exit 1
+          fi
+          python3 --version
+          python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 8) else "python3 >= 3.8 is required")'
+          python3 -m venv "$RUNNER_TEMP/qwen-provision-venv"
+          "$RUNNER_TEMP/qwen-provision-venv/bin/python" -m pip install \
+            --disable-pip-version-check --no-input "huggingface_hub==0.36.0"
       - name: Provision exact public Qwen calibration snapshot
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_image_memory_calibration && inputs.provision_qwen_snapshot }}
         env:
@@ -174,7 +176,7 @@ jobs:
           HF_HUB_DISABLE_TELEMETRY: "1"
           HF_HUB_VERBOSITY: "error"
         run: |
-          python - <<'PY'
+          "$RUNNER_TEMP/qwen-provision-venv/bin/python" - <<'PY'
           import os
           from huggingface_hub import snapshot_download
 

--- a/docs/image-memory-calibration-harness.md
+++ b/docs/image-memory-calibration-harness.md
@@ -164,10 +164,12 @@ post-merge.
 
 When both canonical roots are absent, explicitly set `provision_qwen_snapshot=true` on the same
 calibration dispatch. Provisioning is rejected unless `run_image_memory_calibration=true`. That
-opt-in lane uses pinned Python 3.12 tooling and `huggingface_hub==0.36.0` to resumably and
-idempotently download only `bf16/**` from the fixed public `SceneWorks/qwen-image-mlx` repository
-at the exact `qwen_revision`. It uses no token and writes only to the canonical SceneWorks
-application-data Hugging Face cache. Progress and paths are not logged. Because the snapshot is
+opt-in lane verifies the runner's existing `python3` without printing its path, creates an isolated
+`$RUNNER_TEMP/qwen-provision-venv`, and installs `huggingface_hub==0.36.0` with that venv's
+interpreter. It then resumably and idempotently downloads only `bf16/**` from the fixed public
+`SceneWorks/qwen-image-mlx` repository at the exact `qwen_revision`. It uses no token and writes
+only to the canonical SceneWorks application-data Hugging Face cache. Progress and paths are not
+logged. Because the snapshot is
 approximately 57 GiB, only a provisioning dispatch receives the extended four-hour job timeout;
 ordinary MLX CI and non-provisioning calibration retain the 45-minute ceiling. A provisioning or
 calibration failure cannot upload a schema-checked evidence artifact.

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -145,11 +145,21 @@ test("macOS image-memory calibration dispatch is opt-in and secret-scoped", asyn
   assert.match(workflow, /if \[\[ -d "\$QWEN_HF_ROOT" \]\]; then/);
   assert.match(workflow, /elif \[\[ -d "\$QWEN_APP_ROOT" \]\]; then/);
   assert.doesNotMatch(workflow, /\bfind\b.*qwen|\bls\b.*qwen/i);
+  assert.doesNotMatch(workflow, /actions\/setup-python@/);
+  assert.match(workflow, /command -v python3 >\/dev\/null 2>&1/);
+  assert.match(workflow, /python3 --version/);
   assert.match(
     workflow,
-    /actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/,
+    /python3 -m venv "\$RUNNER_TEMP\/qwen-provision-venv"/,
   );
-  assert.match(workflow, /python-version: "3\.12"/);
+  assert.match(
+    workflow,
+    /"\$RUNNER_TEMP\/qwen-provision-venv\/bin\/python" -m pip install/,
+  );
+  assert.match(
+    workflow,
+    /"\$RUNNER_TEMP\/qwen-provision-venv\/bin\/python" - <<'PY'/,
+  );
   assert.match(workflow, /huggingface_hub==0\.36\.0/);
   assert.match(workflow, /from huggingface_hub import snapshot_download/);
   assert.match(workflow, /repo_id="SceneWorks\/qwen-image-mlx"/);
@@ -163,7 +173,7 @@ test("macOS image-memory calibration dispatch is opt-in and secret-scoped", asyn
     /"Library",\s+"Application Support",\s+"SceneWorks",\s+"data",\s+"cache",\s+"huggingface",\s+"hub"/,
   );
   const provisioning = workflow.slice(
-    workflow.indexOf("- name: Set up pinned Python for Qwen provisioning"),
+    workflow.indexOf("- name: Create isolated Qwen provisioning environment"),
     workflow.indexOf("- name: Resolve exact Qwen calibration snapshot"),
   );
   assert.doesNotMatch(


### PR DESCRIPTION
## Summary

- remove `actions/setup-python` from Qwen provisioning on the self-hosted Mac
- preflight the runner's existing `python3` without printing its path
- create an isolated `$RUNNER_TEMP/qwen-provision-venv`
- install and invoke pinned `huggingface_hub==0.36.0` through that venv

## Context

Provisioning run `30361138440` failed before any model download because `actions/setup-python`
attempted to create `/Users/runner` on the self-hosted `/Users/michael` runner.

This change removes that host-layout assumption. It does not broaden provisioning:

- opt-in calibration-plus-provision dispatch only
- fixed public `SceneWorks/qwen-image-mlx` repository
- exact prevalidated revision and `bf16/**`
- canonical SceneWorks application-data Hugging Face cache
- `token=False`, no implicit token, no provisioning secret
- 240-minute timeout only for provisioning
- success-only evidence upload

## Validation

- workflow YAML parse
- focused platform contract tests (10/10)
- full `npm.cmd run check` (45/45)
- `git diff --check`
- DCO sign-off
- independent exact-head review

## Follow-up gate

Keep SC-15508 In Review. After merge, re-run the same exact provisioning-plus-calibration
dispatch. Do not start downstream stories or promote evidence unless the resulting artifact passes
the existing schema and evidence rules.
