### PR TITLE
SC-15508: fix Qwen provisioning on self-hosted Mac

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -106,11 +106,11 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
           GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
+          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}@github.com/SceneWorks/inference.insteadOf"
           GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       # No MACOSX_DEPLOYMENT_TARGET override: the workspace /.cargo/config.toml pins
@@ -155,16 +155,17 @@ jobs:
             echo "input inference_revision does not match the adapter's compiled INFERENCE_PIN" >&2
             exit 1
           fi
-      - name: Set up pinned Python for Qwen provisioning
+      - name: Set up runner Python 3.12 for Qwen provisioning
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_image_memory_calibration && inputs.provision_qwen_snapshot }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: ".github/workflows/macos-mlx.yml"
+        run: |
+          command -v python3.12 >/dev/null
+          python3.12 --version | grep -E '^Python 3\.12\.'
+          python3.12 -m venv "$RUNNER_TEMP/qwen-provision-venv"
       - name: Install pinned Qwen provisioning client
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_image_memory_calibration && inputs.provision_qwen_snapshot }}
-        run: python -m pip install --disable-pip-version-check --no-input "huggingface_hub==0.36.0"
+        run: |
+          "$RUNNER_TEMP/qwen-provision-venv/bin/python" -m pip install \
+            --disable-pip-version-check --no-input "huggingface_hub==0.36.0"
       - name: Provision exact public Qwen calibration snapshot
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_image_memory_calibration && inputs.provision_qwen_snapshot }}
         env:
@@ -174,11 +175,17 @@ jobs:
           HF_HUB_DISABLE_TELEMETRY: "1"
           HF_HUB_VERBOSITY: "error"
         run: |
-          python - <<'PY'
+          "$RUNNER_TEMP/qwen-provision-venv/bin/python" - <<'PY'
           import os
           from huggingface_hub import snapshot_download
 
-          cache_dir = os.path.join(
+          huggingface_cache = os.path.join(
+              os.environ["HOME"],
+              ".cache",
+              "huggingface",
+              "hub",
+          )
+          application_cache = os.path.join(
               os.environ["HOME"],
               "Library",
               "Application Support",
@@ -187,6 +194,15 @@ jobs:
               "cache",
               "huggingface",
               "hub",
+          )
+          repository_cache = os.path.join(
+              huggingface_cache,
+              "models--SceneWorks--qwen-image-mlx",
+          )
+          cache_dir = (
+              huggingface_cache
+              if os.path.isdir(repository_cache)
+              else application_cache
           )
           snapshot_download(
               repo_id="SceneWorks/qwen-image-mlx",
@@ -236,7 +252,7 @@ jobs:
         with:
           repository: SceneWorks/inference
           ref: ${{ inputs.inference_revision }}
-          token: ${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}
+          token: ${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}
           path: .calibration/inference
           persist-credentials: false
       - name: Build and run the authoritative MLX calibration adapter

--- a/docs/image-memory-calibration-harness.md
+++ b/docs/image-memory-calibration-harness.md
@@ -155,7 +155,8 @@ override those locations when the runner cache lives elsewhere. The override is 
 must still end in the fixed
 repository/exact-revision `/models--SceneWorks--qwen-image-mlx/snapshots/<exact-revision>/bf16`
 suffix. The dispatch validates but never prints the resolved path, checks out the exact inference
-revision, builds the release adapter, runs the authoritative provider through the harness,
+revision using `SCENEWORKS_INFERENCE_READ_TOKEN` when configured and the workflow's scoped token
+otherwise, builds the release adapter, runs the authoritative provider through the harness,
 schema-checks the raw bundle, and uploads it as a workflow artifact. The workflow
 cannot prove in advance that the private runner has the requested snapshot; an absent exact
 directory fails before model load. GitHub only accepts `workflow_dispatch` input schemas from a
@@ -164,13 +165,17 @@ post-merge.
 
 When both canonical roots are absent, explicitly set `provision_qwen_snapshot=true` on the same
 calibration dispatch. Provisioning is rejected unless `run_image_memory_calibration=true`. That
-opt-in lane uses pinned Python 3.12 tooling and `huggingface_hub==0.36.0` to resumably and
-idempotently download only `bf16/**` from the fixed public `SceneWorks/qwen-image-mlx` repository
-at the exact `qwen_revision`. It uses no token and writes only to the canonical SceneWorks
-application-data Hugging Face cache. Progress and paths are not logged. Because the snapshot is
-approximately 57 GiB, only a provisioning dispatch receives the extended four-hour job timeout;
-ordinary MLX CI and non-provisioning calibration retain the 45-minute ceiling. A provisioning or
-calibration failure cannot upload a schema-checked evidence artifact.
+opt-in lane validates the self-hosted runner's Python 3.12 prerequisite, creates an isolated
+job-local virtual environment, and pins `huggingface_hub==0.36.0` to resumably and idempotently
+download only `bf16/**` from the fixed public `SceneWorks/qwen-image-mlx` repository at the exact
+`qwen_revision`. It uses no token and writes to the canonical SceneWorks application-data Hugging
+Face cache unless the fixed repository already exists in the standard Hugging Face cache; in that
+case it resumes there and reuses existing blobs. The pinned client always verifies and resumes the
+requested `bf16/**` files rather than treating a progressively created snapshot directory as
+complete. Progress and paths are not logged. Because the snapshot is approximately 57 GiB, only a
+provisioning dispatch receives the extended four-hour job timeout; ordinary MLX CI and
+non-provisioning calibration retain the 45-minute ceiling. A provisioning or calibration failure
+cannot upload a schema-checked evidence artifact.
 
 It loads the real pinned `QwenVae`, deterministically encodes a 1024-square gradient fixture, runs
 untiled and requested tiled decode on the identical latent, and reports the actual MLX active/cache

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -145,11 +145,16 @@ test("macOS image-memory calibration dispatch is opt-in and secret-scoped", asyn
   assert.match(workflow, /if \[\[ -d "\$QWEN_HF_ROOT" \]\]; then/);
   assert.match(workflow, /elif \[\[ -d "\$QWEN_APP_ROOT" \]\]; then/);
   assert.doesNotMatch(workflow, /\bfind\b.*qwen|\bls\b.*qwen/i);
+  assert.match(workflow, /command -v python3\.12 >\/dev\/null/);
+  assert.match(workflow, /python3\.12 --version \| grep -E '\^Python 3\\\.12\\\.'/);
   assert.match(
     workflow,
-    /actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/,
+    /python3\.12 -m venv "\$RUNNER_TEMP\/qwen-provision-venv"/,
   );
-  assert.match(workflow, /python-version: "3\.12"/);
+  assert.match(
+    workflow,
+    /"\$RUNNER_TEMP\/qwen-provision-venv\/bin\/python" -m pip install/,
+  );
   assert.match(workflow, /huggingface_hub==0\.36\.0/);
   assert.match(workflow, /from huggingface_hub import snapshot_download/);
   assert.match(workflow, /repo_id="SceneWorks\/qwen-image-mlx"/);
@@ -158,18 +163,25 @@ test("macOS image-memory calibration dispatch is opt-in and secret-scoped", asyn
   assert.match(workflow, /token=False/);
   assert.match(workflow, /HF_HUB_DISABLE_IMPLICIT_TOKEN: "1"/);
   assert.match(workflow, /HF_HUB_DISABLE_PROGRESS_BARS: "1"/);
+  assert.match(workflow, /repository_cache = os\.path\.join\(/);
+  assert.match(
+    workflow,
+    /huggingface_cache\s+if os\.path\.isdir\(repository_cache\)\s+else application_cache/,
+  );
+  assert.doesNotMatch(workflow, /raise SystemExit\(0\)/);
   assert.match(
     workflow,
     /"Library",\s+"Application Support",\s+"SceneWorks",\s+"data",\s+"cache",\s+"huggingface",\s+"hub"/,
   );
   const provisioning = workflow.slice(
-    workflow.indexOf("- name: Set up pinned Python for Qwen provisioning"),
+    workflow.indexOf("- name: Set up runner Python 3.12 for Qwen provisioning"),
     workflow.indexOf("- name: Resolve exact Qwen calibration snapshot"),
   );
   assert.doesNotMatch(
     provisioning,
     /secrets\.|HF_TOKEN|HUGGING_FACE_HUB_TOKEN|QWEN_REPOSITORY|local_dir/,
   );
+  assert.doesNotMatch(provisioning, /actions\/setup-python/);
   assert.equal(
     provisioning.split('repo_id="SceneWorks/qwen-image-mlx"').length - 1,
     1,
@@ -188,6 +200,20 @@ test("macOS image-memory calibration dispatch is opt-in and secret-scoped", asyn
   assert.match(
     workflow,
     /cargo build --release --locked -p sceneworks-image-memory-adapter/,
+  );
+  const inferenceCheckout = workflow.slice(
+    workflow.indexOf("- name: Check out the exact inference calibration source"),
+    workflow.indexOf("- name: Build and run the authoritative MLX calibration adapter"),
+  );
+  assert.match(inferenceCheckout, /repository: SceneWorks\/inference/);
+  assert.match(inferenceCheckout, /ref: \$\{\{ inputs\.inference_revision \}\}/);
+  assert.match(
+    inferenceCheckout,
+    /token: \$\{\{ secrets\.SCENEWORKS_INFERENCE_READ_TOKEN \|\| github\.token \}\}/,
+  );
+  assert.match(
+    workflow,
+    /x-access-token:\$\{\{ secrets\.SCENEWORKS_INFERENCE_READ_TOKEN \|\| github\.token \}\}@github\.com\/SceneWorks\/inference\.insteadOf/,
   );
   assert.match(workflow, /--backend mlx/);
   assert.match(workflow, /--provider mlx-qwen-vae-decode/);


### PR DESCRIPTION
## Summary

- replace the failing hosted-toolcache Python action with the self-hosted runner Python 3.12 prerequisite and isolated job-local venv
- retain exact `huggingface_hub==0.36.0`; reuse/resume an existing standard repository cache or fall back to app-data cache without treating partial snapshot directories as complete
- use `SCENEWORKS_INFERENCE_READ_TOKEN` when configured and the scoped workflow token otherwise for the exact public inference checkout
- preserve the fixed public repository/revision/tier, token prohibition for model download, canonical root resolver, and success-only artifact guard

## Reproduction

- Dispatch 30361138440 passed worker build/tests/clippy and identity validation, then `actions/setup-python` failed because its self-hosted installer attempted `mkdir /Users/runner` on the `/Users/michael` runner. No provisioning/model execution/artifact occurred.
- Dispatch 30361821702 passed worker build/tests/clippy and the exact cache resolver, then cross-repository checkout failed `Input required and not supplied: token` because `SCENEWORKS_INFERENCE_READ_TOKEN` is unset. `SceneWorks/inference` is public; no adapter execution/artifact occurred.

## Validation

- `node --test scripts/platform-review-contracts.test.mjs` (10/10)
- `npm run check` (45/45)
- workflow YAML parse and actionlint
- `git diff --check`
- Python 3.12 venv creation/execution smoke
- fresh independent review after each correction; latest exact-head review pending

## Runtime gate

After merge, rerun `provision_qwen_snapshot=true` on final `main`. The pinned client will verify/resume the already exact standard cache without a duplicate 54 GiB download, then the adapter must produce a schema-checked MLX artifact. No gated evidence will be promoted.

Shortcut: https://app.shortcut.com/trefry/story/15508