### PR TITLE
SC-15508: derive MLX wired ceiling from runtime policy

### DIFF
--- a/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
@@ -67,6 +67,7 @@ fn metal_device() -> Result<String, String> {
 
 fn probe() -> Result<Value, String> {
     let memory_bytes = integer(&sysctl("hw.memsize")?, "hw.memsize")?;
+    let mlx_memory_limit = get_memory_limit() as u64;
     let wired_limit = std::env::var("SCENEWORKS_MLX_WIRED_LIMIT_BYTES")
         .ok()
         .and_then(|value| value.parse().ok())
@@ -75,9 +76,14 @@ fn probe() -> Result<Value, String> {
                 .ok()
                 .and_then(|value| value.parse().ok())
         })
+        // MLX's untouched default memory limit is 1.5x Metal's
+        // recommendedMaxWorkingSetSize. This is the same current-host policy
+        // derivation used by the production worker before it mutates the MLX
+        // limit. Divide before multiplying so rounding stays below the ceiling.
+        .or_else(|| Some(mlx_memory_limit / 3 * 2))
         .filter(|value: &u64| *value > 0)
         .ok_or_else(|| {
-            "cannot resolve a nonzero wired ceiling; set SCENEWORKS_MLX_WIRED_LIMIT_BYTES from the current host policy"
+            "cannot resolve a nonzero wired ceiling from the host sysctl or MLX default memory limit; set SCENEWORKS_MLX_WIRED_LIMIT_BYTES from the current host policy"
                 .to_owned()
         })?;
     Ok(json!({
@@ -88,7 +94,7 @@ fn probe() -> Result<Value, String> {
             "chip": sysctl("machdep.cpu.brand_string")?,
             "osVersion": command("/usr/bin/sw_vers", &["-productVersion"])?,
             "metalDevice": metal_device()?,
-            "mlxMemoryLimitBytes": get_memory_limit(),
+            "mlxMemoryLimitBytes": mlx_memory_limit,
             "wiredLimitBytes": wired_limit,
         }
     }))

--- a/docs/image-memory-calibration-harness.md
+++ b/docs/image-memory-calibration-harness.md
@@ -126,12 +126,17 @@ The MLX adapter requires:
 SCENEWORKS_QWEN_IMAGE_ROOT=/absolute/path/to/Qwen-Image-snapshot
 SCENEWORKS_QWEN_IMAGE_REPOSITORY=SceneWorks/qwen-image-mlx
 SCENEWORKS_QWEN_IMAGE_REVISION=<resolved immutable artifact revision>
-# Only when the host sysctl does not expose a nonzero current wired ceiling:
+# Optional explicit current-host policy override:
 SCENEWORKS_MLX_WIRED_LIMIT_BYTES=<current host wired ceiling>
 ```
 
 The adapter canonicalizes the root and requires the fixed
 `/models--SceneWorks--qwen-image-mlx/snapshots/<exact-revision>/bf16` suffix before loading.
+It resolves the wired ceiling from the explicit override first, then the host
+`kern.memorystatus_wired_mem_limit` sysctl, and finally the untouched MLX default memory limit.
+MLX documents that default as 1.5 times Metal's recommended working-set size, so the final fallback
+uses `get_memory_limit() / 3 * 2`, matching the production worker's current-host derivation and
+rounding down to remain at or below the ceiling. The selected source must resolve to a nonzero value.
 
 After this workflow change is present on the repository default branch, the self-hosted macOS ARM64
 NAX runner can execute the same adapter through a guarded manual dispatch:

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -230,3 +230,17 @@ test("macOS image-memory calibration dispatch is opt-in and secret-scoped", asyn
     /if: \$\{\{ success\(\) && github\.event_name == 'workflow_dispatch' && inputs\.run_image_memory_calibration \}\}/,
   );
 });
+
+test("MLX calibration probe derives the production wired ceiling without guessing", async () => {
+  const adapter = await source(
+    "crates/sceneworks-image-memory-adapter/src/bin/mlx.rs",
+  );
+  assert.match(adapter, /let mlx_memory_limit = get_memory_limit\(\) as u64;/);
+  assert.match(adapter, /sysctl\("kern\.memorystatus_wired_mem_limit"\)/);
+  assert.match(
+    adapter,
+    /\.or_else\(\|\| Some\(mlx_memory_limit \/ 3 \* 2\)\)/,
+  );
+  assert.match(adapter, /\.filter\(\|value: &u64\| \*value > 0\)/);
+  assert.match(adapter, /"mlxMemoryLimitBytes": mlx_memory_limit/);
+});


### PR DESCRIPTION
Fixes the fail-closed wired-ceiling preflight reproduced by authoritative Mac run 30364511777. When the explicit override and host sysctl are absent, the adapter now derives the ceiling from the untouched MLX default memory limit using the same downward-rounded /3*2 policy as the production worker, still rejecting zero and recording the exact sampled limit. Adds documentation and a source contract test. Local validation: focused contracts 11/11; full npm run check 46/46; cargo fmt and git diff checks clean. Independent exact-head review is in progress.