### PR TITLE
SC-15508: harden Mac wired ceiling provenance

### DIFF
--- a/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
@@ -43,6 +43,67 @@ fn integer(value: &str, label: &str) -> Result<u64, String> {
         .map_err(|error| format!("parse {label}={value:?}: {error}"))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct WiredLimit {
+    bytes: u64,
+    source: &'static str,
+}
+
+fn positive_integer(value: Option<&str>, label: &str) -> Result<Option<u64>, String> {
+    value
+        .map(|value| integer(value, label))
+        .transpose()
+        .map(|value| value.filter(|value| *value > 0))
+}
+
+fn resolve_wired_limit(
+    override_bytes: Option<&str>,
+    iogpu_limit_mb: Option<&str>,
+    kernel_limit_bytes: Option<&str>,
+    mlx_default_memory_limit: usize,
+) -> Result<WiredLimit, String> {
+    if let Some(bytes) = positive_integer(override_bytes, "SCENEWORKS_MLX_WIRED_LIMIT_BYTES")? {
+        return Ok(WiredLimit {
+            bytes,
+            source: "SCENEWORKS_MLX_WIRED_LIMIT_BYTES",
+        });
+    }
+    if let Some(megabytes) = positive_integer(iogpu_limit_mb, "iogpu.wired_limit_mb")? {
+        let bytes = megabytes
+            .checked_mul(1024 * 1024)
+            .ok_or_else(|| "iogpu.wired_limit_mb overflows bytes".to_owned())?;
+        return Ok(WiredLimit {
+            bytes,
+            source: "iogpu.wired_limit_mb",
+        });
+    }
+    if let Some(bytes) = positive_integer(kernel_limit_bytes, "kern.memorystatus_wired_mem_limit")?
+    {
+        return Ok(WiredLimit {
+            bytes,
+            source: "kern.memorystatus_wired_mem_limit",
+        });
+    }
+
+    // MLX documents its untouched default memory limit as 1.5x the device's
+    // recommendedMaxWorkingSetSize. This is the same real-hardware-validated derivation used by
+    // the worker when the host has no explicit wired policy (sc-12178).
+    let bytes = u64::try_from(mlx_default_memory_limit)
+        .map_err(|_| "MLX default memory limit does not fit u64".to_owned())?
+        / 3
+        * 2;
+    if bytes == 0 {
+        return Err(
+            "cannot resolve a nonzero wired ceiling from host policy or the MLX default memory limit"
+                .to_owned(),
+        );
+    }
+    Ok(WiredLimit {
+        bytes,
+        source: "mlx_default_memory_limit/1.5",
+    })
+}
+
 fn metal_device() -> Result<String, String> {
     let raw = command(
         "/usr/sbin/system_profiler",
@@ -67,37 +128,101 @@ fn metal_device() -> Result<String, String> {
 
 fn probe() -> Result<Value, String> {
     let memory_bytes = integer(&sysctl("hw.memsize")?, "hw.memsize")?;
-    let mlx_memory_limit = get_memory_limit() as u64;
-    let wired_limit = std::env::var("SCENEWORKS_MLX_WIRED_LIMIT_BYTES")
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .or_else(|| {
-            sysctl("kern.memorystatus_wired_mem_limit")
-                .ok()
-                .and_then(|value| value.parse().ok())
-        })
-        // MLX's untouched default memory limit is 1.5x Metal's
-        // recommendedMaxWorkingSetSize. This is the same current-host policy
-        // derivation used by the production worker before it mutates the MLX
-        // limit. Divide before multiplying so rounding stays below the ceiling.
-        .or_else(|| Some(mlx_memory_limit / 3 * 2))
-        .filter(|value: &u64| *value > 0)
-        .ok_or_else(|| {
-            "cannot resolve a nonzero wired ceiling from the host sysctl or MLX default memory limit; set SCENEWORKS_MLX_WIRED_LIMIT_BYTES from the current host policy"
-                .to_owned()
-        })?;
+    let override_bytes = std::env::var("SCENEWORKS_MLX_WIRED_LIMIT_BYTES").ok();
+    let iogpu_limit_mb = sysctl("iogpu.wired_limit_mb").ok();
+    let kernel_limit_bytes = sysctl("kern.memorystatus_wired_mem_limit").ok();
+    let wired_limit = resolve_wired_limit(
+        override_bytes.as_deref(),
+        iogpu_limit_mb.as_deref(),
+        kernel_limit_bytes.as_deref(),
+        get_memory_limit(),
+    )?;
     Ok(json!({
         "hardware": {
-            "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit",
+            "probe": format!(
+                "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired={}",
+                wired_limit.source
+            ),
             "memoryBytes": memory_bytes,
             "model": sysctl("hw.model")?,
             "chip": sysctl("machdep.cpu.brand_string")?,
             "osVersion": command("/usr/bin/sw_vers", &["-productVersion"])?,
             "metalDevice": metal_device()?,
-            "mlxMemoryLimitBytes": mlx_memory_limit,
-            "wiredLimitBytes": wired_limit,
+            "mlxMemoryLimitBytes": get_memory_limit(),
+            "wiredLimitBytes": wired_limit.bytes,
         }
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wired_limit_prefers_explicit_bytes() {
+        assert_eq!(
+            resolve_wired_limit(Some("123"), Some("456"), Some("789"), 999).unwrap(),
+            WiredLimit {
+                bytes: 123,
+                source: "SCENEWORKS_MLX_WIRED_LIMIT_BYTES",
+            }
+        );
+    }
+
+    #[test]
+    fn wired_limit_converts_iogpu_megabytes() {
+        assert_eq!(
+            resolve_wired_limit(None, Some("57344"), Some("789"), 999).unwrap(),
+            WiredLimit {
+                bytes: 57344 * 1024 * 1024,
+                source: "iogpu.wired_limit_mb",
+            }
+        );
+    }
+
+    #[test]
+    fn wired_limit_rejects_iogpu_byte_overflow() {
+        let megabytes = u64::MAX.to_string();
+        assert!(resolve_wired_limit(None, Some(&megabytes), None, 1_000)
+            .unwrap_err()
+            .contains("iogpu.wired_limit_mb overflows bytes"));
+    }
+
+    #[test]
+    fn wired_limit_uses_kernel_bytes_when_iogpu_is_unset() {
+        assert_eq!(
+            resolve_wired_limit(None, Some("0"), Some("789"), 999).unwrap(),
+            WiredLimit {
+                bytes: 789,
+                source: "kern.memorystatus_wired_mem_limit",
+            }
+        );
+    }
+
+    #[test]
+    fn wired_limit_derives_default_mlx_ceiling_without_host_override() {
+        assert_eq!(
+            resolve_wired_limit(None, Some("0"), None, 1_000).unwrap(),
+            WiredLimit {
+                bytes: 666,
+                source: "mlx_default_memory_limit/1.5",
+            }
+        );
+    }
+
+    #[test]
+    fn wired_limit_rejects_invalid_explicit_override() {
+        assert!(resolve_wired_limit(Some("not-a-number"), None, None, 1_000)
+            .unwrap_err()
+            .contains("SCENEWORKS_MLX_WIRED_LIMIT_BYTES"));
+    }
+
+    #[test]
+    fn wired_limit_rejects_zero_everywhere() {
+        assert!(resolve_wired_limit(None, Some("0"), Some("0"), 0)
+            .unwrap_err()
+            .contains("cannot resolve a nonzero wired ceiling"));
+    }
 }
 
 fn encoded_latent(vae: &QwenVae, width: u32, height: u32) -> Result<Array, String> {

--- a/docs/image-memory-calibration-harness.md
+++ b/docs/image-memory-calibration-harness.md
@@ -126,17 +126,20 @@ The MLX adapter requires:
 SCENEWORKS_QWEN_IMAGE_ROOT=/absolute/path/to/Qwen-Image-snapshot
 SCENEWORKS_QWEN_IMAGE_REPOSITORY=SceneWorks/qwen-image-mlx
 SCENEWORKS_QWEN_IMAGE_REVISION=<resolved immutable artifact revision>
-# Optional explicit current-host policy override:
+# Optional explicit byte override. Otherwise the adapter uses the configured
+# iogpu/kernel policy, then derives recommendedMaxWorkingSetSize from MLX's
+# untouched default memory limit using the worker's real-hardware-validated rule.
 SCENEWORKS_MLX_WIRED_LIMIT_BYTES=<current host wired ceiling>
 ```
 
 The adapter canonicalizes the root and requires the fixed
 `/models--SceneWorks--qwen-image-mlx/snapshots/<exact-revision>/bf16` suffix before loading.
-It resolves the wired ceiling from the explicit override first, then the host
-`kern.memorystatus_wired_mem_limit` sysctl, and finally the untouched MLX default memory limit.
-MLX documents that default as 1.5 times Metal's recommended working-set size, so the final fallback
-uses `get_memory_limit() / 3 * 2`, matching the production worker's current-host derivation and
-rounding down to remain at or below the ceiling. The selected source must resolve to a nonzero value.
+It resolves the wired ceiling from the explicit override first, then the host's configured
+`iogpu.wired_limit_mb`, then the legacy `kern.memorystatus_wired_mem_limit` byte sysctl, and finally
+the untouched MLX default memory limit. MLX documents that default as 1.5 times Metal's recommended
+working-set size, so the final fallback uses `get_memory_limit() / 3 * 2`, matching the production
+worker's current-host derivation and rounding down to remain at or below the ceiling. The selected
+source is recorded in `hardware.probe` and must resolve to a nonzero value.
 
 After this workflow change is present on the repository default branch, the self-hosted macOS ARM64
 NAX runner can execute the same adapter through a guarded manual dispatch:

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -235,12 +235,13 @@ test("MLX calibration probe derives the production wired ceiling without guessin
   const adapter = await source(
     "crates/sceneworks-image-memory-adapter/src/bin/mlx.rs",
   );
-  assert.match(adapter, /let mlx_memory_limit = get_memory_limit\(\) as u64;/);
+  assert.match(adapter, /sysctl\("iogpu\.wired_limit_mb"\)/);
   assert.match(adapter, /sysctl\("kern\.memorystatus_wired_mem_limit"\)/);
+  assert.match(adapter, /\.checked_mul\(1024 \* 1024\)/);
   assert.match(
     adapter,
-    /\.or_else\(\|\| Some\(mlx_memory_limit \/ 3 \* 2\)\)/,
+    /u64::try_from\(mlx_default_memory_limit\)[\s\S]*?\/ 3[\s\S]*?\* 2/,
   );
-  assert.match(adapter, /\.filter\(\|value: &u64\| \*value > 0\)/);
-  assert.match(adapter, /"mlxMemoryLimitBytes": mlx_memory_limit/);
+  assert.match(adapter, /source: "mlx_default_memory_limit\/1\.5"/);
+  assert.match(adapter, /"wiredLimitBytes": wired_limit\.bytes/);
 });


### PR DESCRIPTION
## Summary
- build on merged #1948 with the actual configured `iogpu.wired_limit_mb` policy before legacy/default fallbacks
- fail closed on malformed values and checked MiB-to-byte overflow
- record the selected wired-ceiling source in `hardware.probe`
- add seven resolver unit tests and preserve/update the platform contract

## Runtime failure addressed
Authoritative Mac run 30364511777 passed MLX build/tests/Clippy, exact Qwen resolution, and exact inference checkout, then failed at adapter probe because this host has `iogpu.wired_limit_mb=0` and no `kern.memorystatus_wired_mem_limit`. The allocator-derived fallback now succeeds on the target M5 Max and reports `wired=mlx_default_memory_limit/1.5` with `wiredLimitBytes=87044670532`.

## Validation
- `cargo test --locked -p sceneworks-image-memory-adapter --features mlx --bin image-memory-mlx-adapter` (7/7)
- targeted adapter Clippy with `-D warnings`
- `node --test scripts/platform-review-contracts.test.mjs` (11/11)
- `npm run check` (46/46)
- `cargo fmt --all -- --check`
- `git diff --check`
- live adapter probe on Apple M5 Max / macOS 26.5.2
- independent adversarial review: PASS, high confidence, no findings

Final real-weight calibration rerun remains required after merge before SC-15508 closes.