### PR TITLE
SC-15508: preserve MLX probe sample integrity

### DIFF
--- a/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
@@ -62,7 +62,11 @@ fn resolve_wired_limit(
     kernel_limit_bytes: Option<&str>,
     mlx_default_memory_limit: usize,
 ) -> Result<WiredLimit, String> {
-    if let Some(bytes) = positive_integer(override_bytes, "SCENEWORKS_MLX_WIRED_LIMIT_BYTES")? {
+    if let Some(value) = override_bytes {
+        let bytes = integer(value, "SCENEWORKS_MLX_WIRED_LIMIT_BYTES")?;
+        if bytes == 0 {
+            return Err("SCENEWORKS_MLX_WIRED_LIMIT_BYTES must be greater than zero".to_owned());
+        }
         return Ok(WiredLimit {
             bytes,
             source: "SCENEWORKS_MLX_WIRED_LIMIT_BYTES",
@@ -131,11 +135,12 @@ fn probe() -> Result<Value, String> {
     let override_bytes = std::env::var("SCENEWORKS_MLX_WIRED_LIMIT_BYTES").ok();
     let iogpu_limit_mb = sysctl("iogpu.wired_limit_mb").ok();
     let kernel_limit_bytes = sysctl("kern.memorystatus_wired_mem_limit").ok();
+    let mlx_default_memory_limit = get_memory_limit();
     let wired_limit = resolve_wired_limit(
         override_bytes.as_deref(),
         iogpu_limit_mb.as_deref(),
         kernel_limit_bytes.as_deref(),
-        get_memory_limit(),
+        mlx_default_memory_limit,
     )?;
     Ok(json!({
         "hardware": {
@@ -148,7 +153,7 @@ fn probe() -> Result<Value, String> {
             "chip": sysctl("machdep.cpu.brand_string")?,
             "osVersion": command("/usr/bin/sw_vers", &["-productVersion"])?,
             "metalDevice": metal_device()?,
-            "mlxMemoryLimitBytes": get_memory_limit(),
+            "mlxMemoryLimitBytes": mlx_default_memory_limit,
             "wiredLimitBytes": wired_limit.bytes,
         }
     }))
@@ -215,6 +220,15 @@ mod tests {
         assert!(resolve_wired_limit(Some("not-a-number"), None, None, 1_000)
             .unwrap_err()
             .contains("SCENEWORKS_MLX_WIRED_LIMIT_BYTES"));
+    }
+
+    #[test]
+    fn wired_limit_rejects_zero_explicit_override() {
+        assert!(
+            resolve_wired_limit(Some("0"), Some("456"), Some("789"), 1_000)
+                .unwrap_err()
+                .contains("SCENEWORKS_MLX_WIRED_LIMIT_BYTES must be greater than zero")
+        );
     }
 
     #[test]

--- a/docs/image-memory-calibration-harness.md
+++ b/docs/image-memory-calibration-harness.md
@@ -139,7 +139,8 @@ It resolves the wired ceiling from the explicit override first, then the host's 
 the untouched MLX default memory limit. MLX documents that default as 1.5 times Metal's recommended
 working-set size, so the final fallback uses `get_memory_limit() / 3 * 2`, matching the production
 worker's current-host derivation and rounding down to remain at or below the ceiling. The selected
-source is recorded in `hardware.probe` and must resolve to a nonzero value.
+source is recorded in `hardware.probe` and must resolve to a nonzero value. A present explicit
+override must parse as a positive byte count; malformed or zero values fail closed.
 
 After this workflow change is present on the repository default branch, the self-hosted macOS ARM64
 NAX runner can execute the same adapter through a guarded manual dispatch:

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -243,5 +243,22 @@ test("MLX calibration probe derives the production wired ceiling without guessin
     /u64::try_from\(mlx_default_memory_limit\)[\s\S]*?\/ 3[\s\S]*?\* 2/,
   );
   assert.match(adapter, /source: "mlx_default_memory_limit\/1\.5"/);
+  const probe = adapter.slice(
+    adapter.indexOf("fn probe()"),
+    adapter.indexOf("#[cfg(test)]"),
+  );
+  assert.equal(probe.match(/get_memory_limit\(\)/g)?.length, 1);
+  assert.match(
+    probe,
+    /let mlx_default_memory_limit = get_memory_limit\(\);/,
+  );
+  assert.match(
+    probe,
+    /"mlxMemoryLimitBytes": mlx_default_memory_limit/,
+  );
+  assert.match(
+    adapter,
+    /SCENEWORKS_MLX_WIRED_LIMIT_BYTES must be greater than zero/,
+  );
   assert.match(adapter, /"wiredLimitBytes": wired_limit\.bytes/);
 });


### PR DESCRIPTION
Follow-up to merged #1949 addressing the two independent exact-head review findings before any authoritative rerun. The probe now captures get_memory_limit once and uses that identical sample for both wired-ceiling derivation and mlxMemoryLimitBytes evidence. A present SCENEWORKS_MLX_WIRED_LIMIT_BYTES override must parse and be greater than zero; zero remains an unavailable sentinel only for host sysctls. Adds an explicit-zero Mac unit test, source-contract assertions for single-sample recording, and docs. Local validation: focused contracts 11/11, full npm run check 46/46, cargo fmt and git diff checks clean. Independent exact-head review is in progress.