### PR TITLE
fix(calibration): make MLX negative control deterministic (sc-15508)

### DIFF
--- a/config/image-memory-calibration-plan.json
+++ b/config/image-memory-calibration-plan.json
@@ -13,7 +13,7 @@
         "geometry": { "width": 1024, "height": 1024, "batch": 1, "frames": 1 }
       },
       "rung": "bounded_decode",
-      "calibrationFingerprint": "qwen-vae-identical-latent-v2",
+      "calibrationFingerprint": "qwen-vae-identical-latent-v3",
       "fixture": "qwen-vae-encoded-latent-1024",
       "cases": [
         { "parameters": { "decodeTileEdge": 768, "decodeOverlap": 64 }, "expectedResult": "passed" },
@@ -23,7 +23,7 @@
         { "parameters": { "decodeTileEdge": 384, "decodeOverlap": 64 }, "expectedResult": "passed" },
         { "parameters": { "decodeTileEdge": 320, "decodeOverlap": 64 }, "expectedResult": "passed" },
         { "parameters": { "decodeTileEdge": 256, "decodeOverlap": 64 }, "expectedResult": "passed" },
-        { "parameters": { "decodeTileEdge": 256, "decodeOverlap": 32 }, "expectedResult": "failed", "negative": true }
+        { "parameters": { "decodeTileEdge": 256, "decodeOverlap": 32, "comparisonOutputBias": 0.05 }, "expectedResult": "failed", "negative": true }
       ]
     },
     {

--- a/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
@@ -269,6 +269,7 @@ fn decoded_max_mean_abs(
     right: &Array,
     comparison_output_bias: Option<f64>,
 ) -> Result<(f64, f64), String> {
+    protocol::validate_comparison_shapes(left.shape(), right.shape())?;
     let left = left
         .reshape(&[-1])
         .map_err(|error| format!("flatten baseline decode: {error}"))?;

--- a/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-image-memory-adapter/src/bin/mlx.rs
@@ -264,7 +264,11 @@ fn encoded_latent(vae: &QwenVae, width: u32, height: u32) -> Result<Array, Strin
     Ok(latent)
 }
 
-fn max_mean_abs(left: &Array, right: &Array) -> Result<(f64, f64), String> {
+fn decoded_max_mean_abs(
+    left: &Array,
+    right: &Array,
+    comparison_output_bias: Option<f64>,
+) -> Result<(f64, f64), String> {
     let left = left
         .reshape(&[-1])
         .map_err(|error| format!("flatten baseline decode: {error}"))?;
@@ -273,21 +277,7 @@ fn max_mean_abs(left: &Array, right: &Array) -> Result<(f64, f64), String> {
         .map_err(|error| format!("flatten tiled decode: {error}"))?;
     let left = left.as_slice::<f32>();
     let right = right.as_slice::<f32>();
-    if left.len() != right.len() || left.is_empty() {
-        return Err(format!(
-            "decode output length mismatch: baseline={} tiled={}",
-            left.len(),
-            right.len()
-        ));
-    }
-    let mut maximum = 0.0_f64;
-    let mut sum = 0.0_f64;
-    for (left, right) in left.iter().zip(right) {
-        let difference = f64::from((left - right).abs());
-        maximum = maximum.max(difference);
-        sum += difference;
-    }
-    Ok((maximum, sum / left.len() as f64))
+    protocol::max_mean_abs(left, right, comparison_output_bias)
 }
 
 fn sweep(parameters: &serde_json::Map<String, Value>, passed: bool) -> Value {
@@ -313,7 +303,11 @@ fn sweep(parameters: &serde_json::Map<String, Value>, passed: bool) -> Value {
         })
         .collect();
     cases.push(json!({
-        "parameters": { "decodeTileEdge": 256, "decodeOverlap": 32 },
+        "parameters": {
+            "decodeTileEdge": 256,
+            "decodeOverlap": 32,
+            "comparisonOutputBias": 0.05,
+        },
         "result": if current_edge == 256 && current_overlap == 32 {
             if passed { "passed" } else { "failed" }
         } else {
@@ -342,6 +336,8 @@ fn run(request: &Value) -> Result<Value, String> {
         );
     }
     let parameters = protocol::strategy_parameters(request)?;
+    let expected_failure = protocol::expected_failure(request);
+    let comparison_output_bias = protocol::comparison_output_bias(parameters, expected_failure)?;
     let tile_edge = protocol::parameter(request, "decodeTileEdge")?;
     let overlap = protocol::parameter(request, "decodeOverlap")?;
     let tile_edge_i32 = i32::try_from(tile_edge)
@@ -406,13 +402,19 @@ fn run(request: &Value) -> Result<Value, String> {
     let tiled_peak = get_peak_memory() as u64;
     let active = get_active_memory() as u64;
     let cache = get_cache_memory() as u64;
-    let (maximum, mean) = max_mean_abs(&baseline, &tiled)?;
-    let passed = maximum <= MAX_THRESHOLD && mean <= MEAN_THRESHOLD;
-    let expected_failure = protocol::expected_failure(request);
+    let (actual_maximum, actual_mean) = decoded_max_mean_abs(&baseline, &tiled, None)?;
+    let actual_passed = actual_maximum <= MAX_THRESHOLD && actual_mean <= MEAN_THRESHOLD;
     if expected_failure {
-        if passed {
+        if !actual_passed {
             return Err(format!(
-                "negative mutation {tile_edge}/{overlap} did not breach the identical-latent threshold: max={maximum:.6}, mean={mean:.6}"
+                "negative control requires a passing unmodified identical-latent comparison: max={actual_maximum:.6}, mean={actual_mean:.6}"
+            ));
+        }
+        let (mutated_maximum, mutated_mean) =
+            decoded_max_mean_abs(&baseline, &tiled, comparison_output_bias)?;
+        if mutated_maximum <= MAX_THRESHOLD && mutated_mean <= MEAN_THRESHOLD {
+            return Err(format!(
+                "negative mutation {tile_edge}/{overlap} did not breach the identical-latent threshold: max={mutated_maximum:.6}, mean={mutated_mean:.6}"
             ));
         }
         let blocker =
@@ -424,9 +426,9 @@ fn run(request: &Value) -> Result<Value, String> {
             json!({
                 "contract": "identical encoded latent, tiled versus untiled Qwen VAE decode",
                 "identicalLatents": true,
-                "result": "failed",
-                "maximumError": maximum,
-                "meanError": mean,
+                "result": "passed",
+                "maximumError": actual_maximum,
+                "meanError": actual_mean,
                 "maximumErrorThreshold": MAX_THRESHOLD,
                 "meanErrorThreshold": MEAN_THRESHOLD,
             }),
@@ -434,8 +436,8 @@ fn run(request: &Value) -> Result<Value, String> {
                 "parameters": parameters,
                 "measured": true,
                 "result": "failed_as_expected",
-                "maximumError": maximum,
-                "meanError": mean,
+                "maximumError": mutated_maximum,
+                "meanError": mutated_mean,
             }),
             json!({
                 "result": "passed",
@@ -464,14 +466,14 @@ fn run(request: &Value) -> Result<Value, String> {
     );
     Ok(protocol::gated_fragment(
         artifact,
-        sweep(parameters, passed),
+        sweep(parameters, actual_passed),
         blocker,
         json!({
             "contract": "identical encoded latent, tiled versus untiled Qwen VAE decode",
             "identicalLatents": true,
-            "result": if passed { "passed" } else { "failed" },
-            "maximumError": maximum,
-            "meanError": mean,
+            "result": if actual_passed { "passed" } else { "failed" },
+            "maximumError": actual_maximum,
+            "meanError": actual_mean,
             "maximumErrorThreshold": MAX_THRESHOLD,
             "meanErrorThreshold": MEAN_THRESHOLD,
         }),

--- a/crates/sceneworks-image-memory-adapter/src/lib.rs
+++ b/crates/sceneworks-image-memory-adapter/src/lib.rs
@@ -369,6 +369,12 @@ mod tests {
     }
 
     #[test]
+    fn comparison_rejects_a_non_finite_computed_accumulator() {
+        let error = max_mean_abs(&[0.0, 0.0], &[0.0, 0.0], Some(f64::MAX)).unwrap_err();
+        assert!(error.contains("mean accumulator became non-finite"));
+    }
+
+    #[test]
     fn comparison_shapes_must_match_exactly_before_flattening() {
         assert!(validate_comparison_shapes(&[1, 4, 4, 3], &[1, 4, 4, 3]).is_ok());
         let error = validate_comparison_shapes(&[1, 4, 4, 3], &[1, 8, 2, 3]).unwrap_err();

--- a/crates/sceneworks-image-memory-adapter/src/lib.rs
+++ b/crates/sceneworks-image-memory-adapter/src/lib.rs
@@ -12,6 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub const INFERENCE_PIN: &str = "d36390da51bf6a1a67f8e00a8c7d7d8a385d2f20";
 pub const QWEN_REPOSITORY: &str = "SceneWorks/qwen-image-mlx";
 pub const KREA_REPOSITORY: &str = "SceneWorks/krea-2-turbo-mlx";
+pub const COMPARISON_OUTPUT_BIAS_PARAMETER: &str = "comparisonOutputBias";
 
 pub fn request_from_stdin() -> Result<Value, String> {
     let mut input = String::new();
@@ -52,6 +53,69 @@ pub fn parameter(request: &Value, name: &str) -> Result<u32, String> {
         .and_then(Value::as_u64)
         .ok_or_else(|| format!("planned.strategy.parameters.{name} must be an integer"))?;
     u32::try_from(value).map_err(|_| format!("planned.strategy.parameters.{name} exceeds u32"))
+}
+
+pub fn comparison_output_bias(
+    parameters: &Map<String, Value>,
+    expected_failure: bool,
+) -> Result<Option<f64>, String> {
+    let bias = parameters
+        .get(COMPARISON_OUTPUT_BIAS_PARAMETER)
+        .map(|value| {
+            value.as_f64().ok_or_else(|| {
+                format!(
+                    "planned.strategy.parameters.{COMPARISON_OUTPUT_BIAS_PARAMETER} must be a number"
+                )
+            })
+        })
+        .transpose()?;
+    match (expected_failure, bias) {
+        (false, None) => Ok(None),
+        (false, Some(_)) => Err(format!(
+            "{COMPARISON_OUTPUT_BIAS_PARAMETER} is reserved for an expected-failure case"
+        )),
+        (true, None) => Err(format!(
+            "expected-failure case must declare {COMPARISON_OUTPUT_BIAS_PARAMETER}"
+        )),
+        (true, Some(value)) if value.is_finite() && value > 0.0 => Ok(Some(value)),
+        (true, Some(_)) => Err(format!(
+            "planned.strategy.parameters.{COMPARISON_OUTPUT_BIAS_PARAMETER} must be finite and greater than zero"
+        )),
+    }
+}
+
+pub fn max_mean_abs(
+    left: &[f32],
+    right: &[f32],
+    comparison_output_bias: Option<f64>,
+) -> Result<(f64, f64), String> {
+    if left.len() != right.len() || left.is_empty() {
+        return Err(format!(
+            "decode output length mismatch: baseline={} tiled={}",
+            left.len(),
+            right.len()
+        ));
+    }
+    if comparison_output_bias.is_some_and(|bias| !bias.is_finite() || bias <= 0.0) {
+        return Err("comparison output bias must be finite and greater than zero".to_owned());
+    }
+    let mut maximum = 0.0_f64;
+    let mut sum = 0.0_f64;
+    for (left, right) in left.iter().zip(right) {
+        let baseline = f64::from(*left);
+        let tiled = f64::from(*right);
+        let compared = comparison_output_bias.map_or(tiled, |bias| {
+            if tiled >= baseline {
+                tiled + bias
+            } else {
+                tiled - bias
+            }
+        });
+        let difference = (baseline - compared).abs();
+        maximum = maximum.max(difference);
+        sum += difference;
+    }
+    Ok((maximum, sum / left.len() as f64))
 }
 
 pub fn expected_failure(request: &Value) -> bool {
@@ -244,6 +308,47 @@ mod tests {
         });
         assert_eq!(parameter(&request, "decodeTileEdge").unwrap(), 512);
         assert!(parameter(&request, "decodeOverlap").is_err());
+    }
+
+    #[test]
+    fn identical_output_comparison_is_unmodified_without_a_negative_bias() {
+        let left = [0.25_f32, -0.5, 1.0];
+        let right = [0.25_f32, -0.49, 0.98];
+        let (maximum, mean) = max_mean_abs(&left, &right, None).unwrap();
+        assert!((maximum - 0.02).abs() < 1e-6);
+        assert!((mean - 0.01).abs() < 1e-6);
+    }
+
+    #[test]
+    fn deterministic_output_bias_forces_a_measured_parity_breach() {
+        let left = [0.25_f32, -0.5, 1.0];
+        let right = [0.25_f32, -0.49, 0.98];
+        let (maximum, mean) = max_mean_abs(&left, &right, Some(0.05)).unwrap();
+        assert!(maximum > 0.03);
+        assert!(mean > 0.003);
+        assert!((maximum - 0.07).abs() < 1e-6);
+        assert!((mean - 0.06).abs() < 1e-6);
+    }
+
+    #[test]
+    fn comparison_bias_is_required_only_for_expected_failures() {
+        let positive = json!({ "decodeTileEdge": 256, "decodeOverlap": 32 })
+            .as_object()
+            .unwrap()
+            .clone();
+        assert_eq!(comparison_output_bias(&positive, false).unwrap(), None);
+        assert!(comparison_output_bias(&positive, true).is_err());
+
+        let negative = json!({
+            "decodeTileEdge": 256,
+            "decodeOverlap": 32,
+            "comparisonOutputBias": 0.05
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        assert_eq!(comparison_output_bias(&negative, true).unwrap(), Some(0.05));
+        assert!(comparison_output_bias(&negative, false).is_err());
     }
 
     #[test]

--- a/crates/sceneworks-image-memory-adapter/src/lib.rs
+++ b/crates/sceneworks-image-memory-adapter/src/lib.rs
@@ -101,7 +101,12 @@ pub fn max_mean_abs(
     }
     let mut maximum = 0.0_f64;
     let mut sum = 0.0_f64;
-    for (left, right) in left.iter().zip(right) {
+    for (index, (left, right)) in left.iter().zip(right).enumerate() {
+        if !left.is_finite() || !right.is_finite() {
+            return Err(format!(
+                "decode output contains a non-finite sample at index {index}"
+            ));
+        }
         let baseline = f64::from(*left);
         let tiled = f64::from(*right);
         let compared = comparison_output_bias.map_or(tiled, |bias| {
@@ -112,10 +117,31 @@ pub fn max_mean_abs(
             }
         });
         let difference = (baseline - compared).abs();
+        if !compared.is_finite() || !difference.is_finite() {
+            return Err(format!(
+                "decode comparison produced a non-finite result at index {index}"
+            ));
+        }
         maximum = maximum.max(difference);
         sum += difference;
+        if !sum.is_finite() {
+            return Err("decode comparison mean accumulator became non-finite".to_owned());
+        }
     }
-    Ok((maximum, sum / left.len() as f64))
+    let mean = sum / left.len() as f64;
+    if !maximum.is_finite() || !mean.is_finite() {
+        return Err("decode comparison metrics must be finite".to_owned());
+    }
+    Ok((maximum, mean))
+}
+
+pub fn validate_comparison_shapes(left: &[i32], right: &[i32]) -> Result<(), String> {
+    if left != right {
+        return Err(format!(
+            "decode output shape mismatch: baseline={left:?} tiled={right:?}"
+        ));
+    }
+    Ok(())
 }
 
 pub fn expected_failure(request: &Value) -> bool {
@@ -328,6 +354,25 @@ mod tests {
         assert!(mean > 0.003);
         assert!((maximum - 0.07).abs() < 1e-6);
         assert!((mean - 0.06).abs() < 1e-6);
+    }
+
+    #[test]
+    fn comparison_rejects_non_finite_samples() {
+        for non_finite in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert!(max_mean_abs(&[non_finite], &[0.0], None)
+                .unwrap_err()
+                .contains("non-finite sample"));
+            assert!(max_mean_abs(&[0.0], &[non_finite], Some(0.05))
+                .unwrap_err()
+                .contains("non-finite sample"));
+        }
+    }
+
+    #[test]
+    fn comparison_shapes_must_match_exactly_before_flattening() {
+        assert!(validate_comparison_shapes(&[1, 4, 4, 3], &[1, 4, 4, 3]).is_ok());
+        let error = validate_comparison_shapes(&[1, 4, 4, 3], &[1, 8, 2, 3]).unwrap_err();
+        assert!(error.contains("shape mismatch"));
     }
 
     #[test]

--- a/docs/image-memory-calibration-harness.md
+++ b/docs/image-memory-calibration-harness.md
@@ -188,8 +188,12 @@ cannot upload a schema-checked evidence artifact.
 
 It loads the real pinned `QwenVae`, deterministically encodes a 1024-square gradient fixture, runs
 untiled and requested tiled decode on the identical latent, and reports the actual MLX active/cache
-measurements plus maximum/mean error. The `256/32` case becomes `negative_complete` only when its
-measured error breaches the declared threshold. Positive records remain `gated` because the pinned
+measurements plus maximum/mean error. Production cases never alter either comparison output. The
+expected-failure `256/32` case first requires that same unmodified identical-latent comparison to
+pass, retains those real measurements in `quality`, then applies the planned
+`comparisonOutputBias=0.05` away from the baseline at every comparison element. Only the resulting
+measured perturbed metrics enter `negativeMutation`, and the case becomes `negative_complete` only
+when they breach the unchanged production thresholds. Positive records remain `gated` because the pinned
 Qwen VAE seam does not expose synchronized full-pipeline conditioning/denoise
 device/wired/reclaimable phase telemetry or all required lifecycle injections.
 

--- a/scripts/image-memory-calibration-harness.test.mjs
+++ b/scripts/image-memory-calibration-harness.test.mjs
@@ -118,7 +118,7 @@ function qwenPositiveComplete() {
       rung: "bounded_decode",
       parameters: { decodeTileEdge: 512, decodeOverlap: 64 },
     },
-    calibrationFingerprint: "qwen-vae-identical-latent-v2",
+    calibrationFingerprint: "qwen-vae-identical-latent-v3",
   });
   const edges = [768, 640, 512, 448, 384, 320, 256];
   record.sweep = {
@@ -128,9 +128,21 @@ function qwenPositiveComplete() {
         parameters: { decodeTileEdge, decodeOverlap: 64 },
         result: "passed",
       })),
-      { parameters: { decodeTileEdge: 256, decodeOverlap: 32 }, result: "failed" },
+      {
+        parameters: {
+          decodeTileEdge: 256,
+          decodeOverlap: 32,
+          comparisonOutputBias: 0.05,
+        },
+        result: "failed",
+      },
     ],
     rangeVerified: true,
+  };
+  record.negativeMutation.parameters = {
+    decodeTileEdge: 256,
+    decodeOverlap: 32,
+    comparisonOutputBias: 0.05,
   };
   record.logicalCaseId = logicalCaseId(record);
   record.id = recordId(record);
@@ -290,13 +302,17 @@ test("matrix binding rejects batch and frame mismatches even when width and heig
   assert.ok(calibrationBinding(frames, cell).reasons.includes("frames-out-of-envelope"));
 });
 
-test("plan separates the seven passing Qwen overlap-64 cells from 256/32 negative", async () => {
+test("plan separates seven identical-latent positives from a deterministic output-bias negative", async () => {
   const config = JSON.parse(await readFile(new URL("../config/image-memory-calibration-plan.json", import.meta.url)));
   const cases = expandPlan(config);
   const qwen = cases.filter((item) => item.backend === "mlx");
   assert.equal(qwen.filter((item) => item.expectedResult === "passed").length, 7);
   const negative = qwen.find((item) => item.negative);
-  assert.deepEqual(negative.strategy.parameters, { decodeTileEdge: 256, decodeOverlap: 32 });
+  assert.deepEqual(negative.strategy.parameters, {
+    decodeTileEdge: 256,
+    decodeOverlap: 32,
+    comparisonOutputBias: 0.05,
+  });
 });
 
 test("Krea current v1 production truth is separate from non-promotable v2 candidates", async () => {
@@ -339,7 +355,11 @@ test("positive Qwen completion never suppresses the separate 256/32 negative pla
   const qwenRemaining = expandPlan(config, [record]).filter((item) => item.backend === "mlx");
   assert.equal(qwenRemaining.length, 1);
   assert.equal(qwenRemaining[0].negative, true);
-  assert.deepEqual(qwenRemaining[0].strategy.parameters, { decodeTileEdge: 256, decodeOverlap: 32 });
+  assert.deepEqual(qwenRemaining[0].strategy.parameters, {
+    decodeTileEdge: 256,
+    decodeOverlap: 32,
+    comparisonOutputBias: 0.05,
+  });
 });
 
 test("runtime bundle validation matches schema closure for malformed gated and nested values", () => {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -262,3 +262,21 @@ test("MLX calibration probe derives the production wired ceiling without guessin
   );
   assert.match(adapter, /"wiredLimitBytes": wired_limit\.bytes/);
 });
+
+test("MLX parity control preserves the real comparison and applies only a planned output bias", async () => {
+  const adapter = await source(
+    "crates/sceneworks-image-memory-adapter/src/bin/mlx.rs",
+  );
+  assert.match(
+    adapter,
+    /let \(actual_maximum, actual_mean\) = decoded_max_mean_abs\(&baseline, &tiled, None\)\?/,
+  );
+  assert.match(
+    adapter,
+    /decoded_max_mean_abs\(&baseline, &tiled, comparison_output_bias\)\?/,
+  );
+  assert.match(adapter, /"result": "passed",\s*"maximumError": actual_maximum,\s*"meanError": actual_mean/);
+  assert.match(adapter, /"maximumError": mutated_maximum,\s*"meanError": mutated_mean/);
+  assert.doesNotMatch(adapter, /MAX_THRESHOLD\s*=\s*[^;]*5e-2/);
+  assert.doesNotMatch(adapter, /MEAN_THRESHOLD\s*=\s*[^;]*5e-2/);
+});

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -279,4 +279,14 @@ test("MLX parity control preserves the real comparison and applies only a planne
   assert.match(adapter, /"maximumError": mutated_maximum,\s*"meanError": mutated_mean/);
   assert.doesNotMatch(adapter, /MAX_THRESHOLD\s*=\s*[^;]*5e-2/);
   assert.doesNotMatch(adapter, /MEAN_THRESHOLD\s*=\s*[^;]*5e-2/);
+  const comparison = adapter.slice(
+    adapter.indexOf("fn decoded_max_mean_abs("),
+    adapter.indexOf("fn sweep("),
+  );
+  const shapeGuard = comparison.indexOf(
+    "protocol::validate_comparison_shapes(left.shape(), right.shape())?",
+  );
+  const flatten = comparison.indexOf(".reshape(&[-1])");
+  assert.ok(shapeGuard >= 0, "MLX comparison must guard exact output shapes");
+  assert.ok(flatten > shapeGuard, "shape equality must be checked before either output is flattened");
 });


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/trefry/story/15508. Summary: preserves the unmodified identical-latent tiled/untiled Qwen VAE comparison, then applies a planned comparisonOutputBias=0.05 only to the expected-failure measurement; records raw quality and perturbed negative metrics separately; leaves the production thresholds and seven-point 64px-overlap ladder unchanged; bumps the calibration fingerprint to v3. Validation: cargo test -p sceneworks-image-memory-adapter --lib (7/7); node focused tests (30/30); npm run check (47/47); cargo check -p sceneworks-image-memory-adapter; cargo fmt --all -- --check; git diff --check; independent adversarial review PASS/high. Full npm run rust:check passed fmt, Clippy, and all tests except the unrelated existing Windows environment-sensitive apps/rust-api test tests::server::parent_death_resolves_when_watched_parent_exits_windows, which also fails alone at apps/rust-api/src/tests/server.rs:366 with freshly spawned parent reads as dead. Mac/MLX runtime validation remains required after merge; this PR does not dispatch it.