### PR TITLE
docs+tooling(memory-strategy): target design for the shared pipeline, and the dual-backend story split (sc-15448)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,7 @@ __marimo__/
 
 # Local Windows build convenience script (loads vcvars + NVCC_CCBIN, runs tauri build)
 build.bat
+
+# One-off Shortcut migration run state (sc-15812)
+.shortcut-split-state.json
+.shortcut-split-plan.json

--- a/docs/memory-strategy-pipeline-target-design.md
+++ b/docs/memory-strategy-pipeline-target-design.md
@@ -1,0 +1,739 @@
+# The shared memory-strategy pipeline — target design
+
+**Status:** proposal, not ratified. Supersedes nothing until agreed.
+**Reference implementation:** MLX `z_image_turbo`. Every other model/backend refactors onto this.
+**Scope:** the epic remains the 53 image catalog entries. The *vocabulary* is lane-neutral by design
+(§13) so video and audio can adopt without a second contract; whether the ladder itself transfers is
+unproven and explicitly not claimed here.
+**Relationship to existing docs:** extends [`image-memory-strategy-contract.md`](image-memory-strategy-contract.md) (SC-15449) and epic [15448](https://app.shortcut.com/trefry/epic/15448).
+
+---
+
+## 0. The one-sentence goal
+
+**One pipeline decides, once, per request, which quality-preserving strategy runs — and every fact
+that decision rests on is declared in exactly one place.**
+
+Everything below is a consequence of that sentence. Where today's code has a fact written in three
+places, or a second pipeline making the same decision differently, this design removes the duplicate
+rather than reconciling it.
+
+### What "candle" means in this document
+
+Candle is an **adopter**, not a constraint. No current candle behaviour justifies a design choice
+here. Where candle is mentioned it is to scope migration work, never to shape the contract. The same
+applies to any MLX family other than z-image: the reference implementation is built first, proven,
+and then everything else moves onto it.
+
+---
+
+## 1. What a rung is, and what it is not
+
+A **rung** is a *quality-preserving execution strategy* that bounds a specific memory peak.
+
+Two properties are definitional:
+
+1. **It preserves the output.** Same precision, same schedule, same seed, same conditioning, same
+   output geometry. Byte-identical where the operation permits; a documented deterministic tolerance
+   where it does not.
+2. **It is an execution choice, not a weight choice.** It changes *how* a render runs, not *what
+   weights exist*.
+
+Anything failing either test is **not a rung** and must not enter the ladder:
+
+| thing | why it is not a rung | where it belongs |
+|---|---|---|
+| Quantization tier (q4/q8/bf16) | changes precision | user-facing creative choice, chosen before memory selection |
+| Control-branch packing | load-time weight transformation | tier integrity — §7 |
+| Resolution reduction | changes the requested output | nowhere — §6 |
+
+### The two rung families
+
+The ladder currently flattens two structurally different things into one ordered enum. The design
+makes the distinction explicit, because it determines what each rung must declare.
+
+| family | rungs | bounds | lifetime of the thing it bounds |
+|---|---|---|---|
+| **Scratch-bounding** | 2 Bounded decode, 3 Bounded attention | activations, tiles, score matrices | born and dies inside one request |
+| **Residency-bounding** | 1 Staged residency, 4 Bounded transformer residency | materialized weights | persists across requests unless explicitly released |
+
+Scratch-bounding rungs have no preconditions — they can always run. Residency-bounding rungs must
+be able to *release* what they bound, which is the entire source of today's load-time/request-time
+seam.
+
+---
+
+## 2. The four facts every rung declares
+
+Each rung declares exactly four things, each in exactly one place, each derived everywhere else.
+
+| fact | answers | owner | scope | shape |
+|---|---|---|---|---|
+| **Availability** | Can *this loaded model* execute this rung at all? | provider, built per `LoadSpec` | static, per load | `Implemented` / `StructurallyNotApplicable` / `Missing` |
+| **Prerequisites** | Which rungs must also engage for this one to mean anything? | the shared contract, declared per rung | static | explicit edge set — **never** derived from enum order |
+| **Engagement** | Is this rung on for *this request*, and with what parameters? | worker selection → `GenerationMemory` | per request | one boolean + its owned parameters |
+| **Cost rank** | What order does the selector try rungs in? | worker | policy | the normative order of `ImageMemoryStrategy::ALL` |
+
+### The invariant that makes it checkable
+
+> **A rung that cannot deliver its bound is never selected, and never recorded.**
+
+Availability is the mechanism that enforces this. A typed `Error::Unsupported` at the provider is a
+**backstop for a selector bug**, not a control-flow path — if it fires in production, the selector
+is wrong, and that is a defect rather than a fallback.
+
+The corollary is the honesty rule that motivates the whole epic: a rung that silently degrades
+writes a calibration row for a run that saved nothing. That is a false green, and it is worse than
+an error.
+
+---
+
+## 3. The ladder, restated
+
+| # | rung | family | bounds | availability facts | engagement knob | parameters |
+|---|---|---|---|---|---|---|
+| 0 | Resident | — | nothing | always | *(absence of all others)* | — |
+| 1 | Staged residency | residency | weights across phases | model has a separable phase-A component | `stage_residency` | — |
+| 2 | Bounded decode | scratch | decoder scratch | decoder is tileable | `tile_vae_decode` | `decode_tile_edge`, `decode_overlap` |
+| 3 | Bounded attention | scratch | attention scratch | attention is chunkable | `chunk_attention` | `attention_chunk_size` |
+| 4 | Bounded transformer residency | residency | trunk weights | weights are **re-openable** from a snapshot | `stream_transformer_blocks` | `transformer_window_size` |
+
+### The prerequisite graph — explicit, and small
+
+```
+rung 1  →  (none)
+rung 2  →  (none)
+rung 3  →  (none)
+rung 4  →  requires rung 1 ENGAGED in the same request
+```
+
+That is the entire graph. Two things follow:
+
+**Rungs 2 and 3 depend on nothing.** Bounding decode scratch or attention scratch is correct whether
+or not the text encoder was shed. Today's numeric-order walk asserts otherwise, and that is the
+latent trap described in §5.
+
+**Rung 4's single edge is a correctness constraint, not a cost ordering.** A block window bounds
+nothing if the trunk is already materialized — it *adds* a copy on top. This is the fact currently
+encoded three separate times (§9).
+
+### Cost-order defaults are a different thing, and must stay separate
+
+A rung-4 selection today also sets `tile_vae_decode` and `chunk_attention`. That is **not** a
+dependency — it is the selector's cost-order policy: *if you needed the most expensive rung, you
+would have taken the cheaper ones on the way up.* The epic already words it as defeasible:
+
+> "Strategies are cumulative unless a provider documents and verifies a cheaper equivalent composition."
+
+So the design keeps them apart:
+
+- **Prerequisite** — enforced by the contract. Violating it is an error.
+- **Cost-order default** — applied by the selector. A provider may publish a verified cheaper
+  composition and opt out, with evidence.
+
+Conflating these is what makes today's `validate_selection` reject compositions that are perfectly
+correct.
+
+---
+
+## 4. Reshaping rung 1
+
+### What is wrong today
+
+Rung 1 is the only rung with **no engagement knob**. `GenerationMemory` has three booleans — one
+each for rungs 2, 3 and 4 — and nothing for rung 1. Staging is gated on `Residency::is_sequential()`,
+which comes from the *load-time* `LoadSpec::offload_policy`.
+
+Three consequences, all live:
+
+1. **Selecting rung 1 per request on a `Resident`-loaded generator silently does nothing.**
+   `z_image_generation_memory` maps rung 1 to an all-false `GenerationMemory` for exactly this
+   reason. There is nothing to turn on.
+2. **It is inert but declared `Implemented`.** Rung 4 declares `Missing` off the *identical* fact
+   (`streamable` requires `OffloadPolicy::Sequential`). Same input, opposite answers, one file apart.
+3. **Residency policy is fixed for the life of the generator.** A warm generator cannot serve a
+   constrained request, and a staged generator pays re-load on every request forever — including the
+   ones that had headroom.
+
+### The target: rung 1 becomes a full member
+
+**Residency becomes a per-request decision.** `GenerationMemory` gains `stage_residency: bool`, and
+rung 1 declares availability and engagement like every other rung.
+
+This is a smaller change than it sounds, because the machinery already exists. `Residency` today is
+a two-variant enum:
+
+```rust
+Inner::Resident(pair)       // holds built components
+Inner::Sequential(loaders)  // holds two closures; builds per run, frees after
+```
+
+Under `Sequential`, the heavy bundle is **already** rebuilt on every `run`. The per-request capability
+is present and gated behind a load-time enum. The target is the *union* of the two variants:
+
+```rust
+pub struct Residency<Text, Heavy> {
+    loaders: SeqLoaders<Text, Heavy>,        // always held — cheap, two boxed closures
+    warm:    Option<ResidentPair<Text, Heavy>>, // held iff currently warm
+}
+```
+
+Per request:
+
+| `stage_residency` | behaviour |
+|---|---|
+| `false` | if `warm.is_none()`, run the loaders and **store** the products; borrow and run the resident path |
+| `true` | if `warm.is_some()`, **drop it** and `clear_cache()`; run the staged loader path; leave `warm` empty |
+
+### Eviction is not a new cost — it is the cost sequential loading always had
+
+Staging frees nothing unless the staged components are released. That has always been true: it is
+what `mempolicy` means by "only the cross-request weight cache is lost." Request-scoping does not
+add a cost; it changes **who pays and when**.
+
+Today a load-time policy gives exactly two fixed regimes:
+
+| regime | every request | can any request stage? |
+|---|---|---|
+| `Resident` | warm, no reload | no |
+| `Sequential` | reloads | yes — but *all* of them, always |
+
+Request-scoped residency is Pareto-better than both:
+
+- **vs `Resident`** — identical when no request stages; strictly more capable when one does.
+- **vs `Sequential`** — identical when every request stages; strictly cheaper when some don't.
+
+So the ledger only improves. What is genuinely new is **variance, not cost**: the reload's *timing*
+becomes data-dependent. A 1024² (warm) → 2048² (staged) → 1024² sequence pays a reload on the third
+render that fixed-`Resident` would not. Same cost category, unpredictable placement.
+
+That is a telemetry and explainability requirement, not a design objection:
+
+- The worker records cache eviction alongside the selected strategy, so "why was that render slow"
+  is answerable.
+- The existing contract rule already covers the safety half: *"each transition must either leave the
+  warm cache reusable or invalidate it atomically."*
+
+**Two things the union type must not lose.** Both already exist in the current drivers:
+
+1. **Materialize before shed.** Under MLX's lazy graph an un-evaluated output keeps its producer's
+   weights referenced, so a drop before the `eval` frees nothing. `run_staged` encodes this at both
+   phase boundaries and it must survive the refactor intact.
+2. **Drop before load.** Evicting warm and loading staged must not overlap, or the transition peak
+   exceeds both regimes it sits between.
+
+**Concurrency is not a hazard.** `LoadSpec`'s own documentation records that the crate runs
+single-device because the MLX default device is not thread-safe, and the worker serializes jobs per
+thread. Eviction cannot race a live borrow.
+
+### What `LoadSpec::offload_policy` becomes — **ignored by image providers, not deleted**
+
+An earlier draft of this document said "deleted." That is wrong, and the audit says why:
+`offload_policy` has consumers outside the image lane.
+
+| lane | crates |
+|---|---|
+| image | ~20 mlx-gen / candle-gen crates |
+| **video** | `mlx-gen-wan`, `mlx-gen-ltx`, `candle-gen-wan`, `candle-gen-svd` |
+| **audio** | `candle-audio-stable-audio-3` |
+
+Deleting the field is a cross-lane change well outside a 53-image-entry epic.
+
+**The target instead:** for an image provider that has adopted the ladder, `offload_policy` is
+**ignored** — rung 1's authority is `GenerationMemory::stage_residency` and nothing else. The field
+remains in `LoadSpec` for the video and audio lanes, unchanged, and is deleted only when they
+migrate.
+
+This keeps one authority per fact. The field is *not* retained for image providers as a "warm-up
+hint" — that would re-create exactly the two-place ambiguity this design removes. Deferring the load
+entirely is also strictly better: nothing loads until a request has been selected, so model
+switching gets faster.
+
+### What this unlocks for rung 4
+
+Rung 4's availability currently carries two facts. With residency per request, one of them
+disappears:
+
+```rust
+// today
+let streamable = matches!(spec.weights, WeightsSource::Dir(_))
+    && matches!(spec.offload_policy, OffloadPolicy::Sequential);
+
+// target
+let streamable = matches!(spec.weights, WeightsSource::Dir(_));
+```
+
+The `Sequential` clause becomes the declared prerequisite edge `rung 4 → rung 1`. The provider stops
+hand-maintaining it, and `resolve_block_window`'s check reverts to the pure backstop it is already
+documented as being.
+
+**One capability change removes the load-time coupling from both residency-bounding rungs.**
+
+### The mutation seam — settled by the existing trait
+
+`run_staged` is `&self` today, and a per-request warm cache needs to mutate. This is not a judgment
+call: `Generator::generate(&self, …)` is the trait every provider in the workspace implements, so
+`&mut self` would mean changing that signature everywhere — a large blast radius unrelated to this
+epic.
+
+**Interior mutability**, therefore: `warm: Mutex<Option<ResidentPair<Text, Heavy>>>` inside
+`Residency`. It is uncontended in practice because the worker already serializes jobs per thread,
+and it keeps `Residency` `Sync` without touching `Generator`.
+
+---
+
+## 5. Prerequisites become explicit
+
+### The problem
+
+`gen_core::validate_selection` derives dependency from the enum's numeric order:
+
+```rust
+for rung in ImageMemoryStrategy::ALL.into_iter().filter(|rung| *rung < selection.strategy) {
+    if matches!(support, Some(Missing) | None) { return Err(Error::Unsupported(...)); }
+}
+```
+
+Three sites read the order, and they encode **two different policies**:
+
+| site | policy on a `Missing` lower rung |
+|---|---|
+| `gen_core::validate_selection` prerequisite walk | **fatal** — `Error::Unsupported` |
+| `gen_core::validate_selected_parameters` | tolerant — guards on `implemented(...)`, stops requiring that rung's parameters |
+| `sceneworks_worker::image_memory::select_strategy` | tolerant — `continue`s past any non-`Implemented` rung, keeps looking |
+
+The selector and the validator **already contradict each other**: `select_strategy` will return rung
+2 on a contract where rung 1 is `Missing`, and `validate_selection` will hard-error on exactly that
+selection. It is unreachable today only because no provider ever declares a lower rung `Missing`.
+
+Any honest declaration at the bottom of the ladder trips it.
+
+### The fix
+
+Replace the order-derived walk with the declared graph from §3. Concretely:
+
+- Each rung's capability carries `requires: &[ImageMemoryStrategy]` — empty for rungs 1, 2, 3;
+  `[StagedResidency]` for rung 4.
+- `validate_selection` walks *that*, not `< selection.strategy`.
+- `validate_selected_parameters` and `select_strategy` need **no change** — they already implement
+  the tolerant policy the graph implies. The fix makes three sites agree rather than adding a fourth
+  opinion.
+
+---
+
+## 6. Resolution reduction is deleted, not relocated
+
+### Position
+
+**Never silently change the requested output.** If the requested geometry cannot be rendered, the
+system either does not offer it, or refuses it with a truthful, measured alternative. It does not
+quietly produce something smaller.
+
+This is already the epic's stated non-negotiable — *"If nothing fits, reject before OOM with
+truthful, measured alternatives"* — and the contract doc already constrains the advice:
+*"Advice may name only a lower geometry or strategy that has verified evidence."*
+
+`Lever::ResolutionReduction` predates both and contradicts them.
+
+### It is live today, on one route
+
+`mlx-gen-krea/src/model_control.rs:325` calls `plan_control_resolution`, which returns a smaller
+16-aligned `(render_width, render_height)` when the requested size does not fit. On substitution it
+emits an `eprintln!` — **stderr only**. Not the API response, not telemetry, not the UI.
+
+So a `krea_2_turbo_control` request for 1024² can return 768², and the requester is never told.
+The code comment calls this "never a SILENT capability drop" because it prints to stderr; from the
+user's side it is exactly a silent drop.
+
+### The replacement — three surfaces, none of which alter the request
+
+**1. Do not offer what cannot be rendered.** Resolution choices presented in the UI are filtered by
+the same measured evidence the selector uses. This is the existing SC-15613 work (backend-aware web
+memory surfaces) — today four independent copies of one transient-headroom measurement drive these
+surfaces, and none of them read the calibration contract.
+
+**2. Refuse, with a measured alternative.** A request for an unreachable geometry is rejected before
+the render with a typed error naming a geometry that has *verified* evidence — not an estimate, not
+a guess. `plan_control_resolution`'s existing `Err` arm is already this shape; it just fires two
+scales too late.
+
+**3. Record it.** The rejection reason, the requested geometry, and the named alternative go to
+telemetry, so "users keep asking for a size we can't serve" becomes visible rather than absorbed.
+
+### Disposition
+
+- `Lever::ResolutionReduction` — deleted.
+- `plan_control_resolution` — deleted. Its `fits()` predicate survives as a **feasibility check**:
+  same arithmetic, but it answers *"can we?"* and never answers *"then do this instead."*
+- `CONTROL_RESOLUTION_SCALES`, `scale_render_dim` — deleted.
+- The `eprintln!` substitution notice — deleted along with the substitution.
+
+---
+
+## 7. Branch quantization is not a lever — it is how packing works
+
+### Position
+
+**No component is resident above the user's selected tier unless a declared, measured exception says
+otherwise.** Choosing q8 or q4 *is* a memory decision; carrying any component at bf16 defeats it.
+
+This is [SC-15799](https://app.shortcut.com/trefry/story/15799), and it is already the written norm
+in the manifest: *"every component is packed at the chosen tier."*
+
+### Why `BranchQuant` is a workaround wearing a lever's clothes
+
+`mempolicy`'s own doc describes it as *"pack the control branch **to the base quant tier** at load
+time."* That is the invariant, implemented as an escalation step. Reading it against the numbers:
+
+- q8 is measured **near-lossless** and saves **8.4 GiB**. There is no quality argument for defaulting
+  to bf16 when the user asked for q8.
+- It is load-time-only — *"it cannot be re-packed mid-render"* — which is what an install-time
+  artifact choice looks like, not a runtime lever.
+- It sits **last** in the escalation order, so a constrained machine engages residency and decode
+  tiling first to claw back single-digit GiB while 8.4 GiB of unrequested precision sits in the
+  branch the entire time.
+
+Qwen already publishes its ControlNet per tier (q4 0.99 GB / q8 1.87 GB / bf16 3.51 GB), so the
+compliant shape ships today.
+
+### The one real carve-out
+
+q4 branch quant is measured *"pose-locked; non-pose details drift."* So a q4 base floors its branch
+at **q8** — a declared, measured exception, which is exactly what the invariant permits. It is not a
+hole in the rule; it is the rule working.
+
+### Disposition
+
+- `Lever::BranchQuant` — deleted.
+- `should_quantize_control_branch` — deleted. The branch's tier is decided by the installed artifact.
+- The q4→q8 floor — declared in the manifest with its quality evidence attached.
+
+---
+
+## 8. `mempolicy` is deleted entirely
+
+Not thinned. Deleted. Every one of its four levers has a home elsewhere, and its decision function
+duplicates the shared selector.
+
+| `Lever` | disposition |
+|---|---|
+| `SequentialResidency` | **is** rung 1 (§4) |
+| `VaeDecodeTiling` | **is** rung 2 |
+| `BranchQuant` | not a lever — tier integrity (§7) |
+| `ResolutionReduction` | not a lever — refuse or don't offer (§6) |
+
+With all four gone, `plan_memory_adaptation`, `StagePeaks`, `LaneLevers` and `MemoryPlan` have
+nothing left to decide. Their job — *given a budget and shape-derived peaks, pick the lightest
+sufficient setting* — is `sceneworks_worker::image_memory::select_strategy`'s job. The contract doc
+already forbids the duplication:
+
+> "Providers may reject a selected strategy defensively, but must not contain a second least-cost
+> selector."
+
+### What survives, and must not be lost
+
+`mlx-gen-krea/src/memory.rs` is **two things welded together**, and only one of them is redundant:
+
+- **The escalation policy half** — the `plan_memory_adaptation` call sites. Deleted.
+- **The cost model half** — first-principles param counts re-fit on real weights on a 128 GB Metal
+  Mac (SC-11847), with measured slopes ~44 (bf16) / ~61 (q4) B/(token·hidden) for denoise and
+  ~5211 B/px for decode, under an over-predict/never-under-shoot convention. **This is expensive,
+  calibrated evidence and it survives**, retargeted to produce provider estimates that feed
+  `select_strategy` as ordinary candidates.
+
+Deleting the cost model along with the policy would discard the most costly artifact in the module.
+
+### Blast radius
+
+`plan_memory_adaptation` has exactly one consumer: `mlx-gen-krea/src/memory.rs`. The "backend-neutral
+escalation core both backends share" is used by one model on one backend — which is itself the
+argument that the shared selector, not this, is the pipeline.
+
+---
+
+## 9. What makes it obviously correct
+
+### The single-encoding audit
+
+The test this design holds itself to is countable: **every fact is declared once and derived
+everywhere else.** Current scores:
+
+| fact | encodings today | where | target |
+|---|---|---|---|
+| rung 4 needs a non-materialized trunk | **3** | `streamable`, numeric-order walk, `resolve_block_window` | **1** — prerequisite edge |
+| rung 1 is inert under `Resident` | **0** | prose in a module doc; declared nowhere | **0 needed** — the condition ceases to exist |
+| the escalation order | **2** | `ImageMemoryStrategy::ALL`, `mempolicy::Lever` | **1** |
+| the control branch's tier | **2** | installed artifact, `BranchQuant` lever | **1** |
+| the attention budget constant | **2** | `gen_core::attention_budget`, candle's copy | **1** (SC-15796) |
+| what a `Missing` lower rung means | **2 policies / 3 sites** | fatal vs tolerant | **1** |
+
+A fact scoring >1 is a place two implementations can disagree without the compiler noticing. A fact
+scoring 0 is a rule nothing enforces.
+
+### Test discipline
+
+Two failure modes this codebase has already produced, both of which the reference implementation
+must actively guard against:
+
+**Mutation-check every test that pins a shared contract.** SC-15793's own kernel-binding test was
+near-vacuous — it iterated the shared table, but only one row was small enough to run in a unit test
+and that row happened to be non-chunking, so it stayed green while the kernel forked its arithmetic.
+The mutation run is what caught it.
+
+**A test asserting a default value is a false green.** If the assertion passes because the field was
+never set, it proves nothing. Every conformance assertion must be shown red under a deliberate
+perturbation.
+
+### Evidence honesty
+
+Unchanged from the epic, restated because this design depends on it: a green result covers only the
+parameter range exercised, dynamic evidence is authoritative only from suitable hardware, and a
+calibration-fingerprint mismatch makes evidence stale. **A rung that engaged but saved nothing must
+never produce a calibration row.**
+
+---
+
+## 10. Selection, end to end
+
+```
+1. REQUEST arrives with geometry, tier, mode, overlay, seed.
+        │  tier is a creative choice, already made — the pipeline never changes it
+        ▼
+2. FEASIBILITY. Is this geometry renderable on this machine, by ANY rung, with verified evidence?
+        ├─ no  → REFUSE with a measured alternative that has verified evidence.  ✋ STOP
+        └─ yes → continue.        (never substitute a different geometry)
+        ▼
+3. CANDIDATES. Provider submits a per-rung estimate from its cost model.
+        ▼
+4. SELECT. Worker walks the normative cost order 0→4, skipping rungs that are
+   unavailable or lack verified evidence, and takes the cheapest that fits the live budget.
+        ▼
+5. VALIDATE. Contract checks the selection: availability, declared PREREQUISITES
+   (not enum order), and parameter domain.
+        │  a failure here is a SELECTOR BUG, not a fallback
+        ▼
+6. ENGAGE. Selection maps to GenerationMemory:
+        stage_residency / tile_vae_decode / chunk_attention / stream_transformer_blocks
+        + the parameters each rung owns.
+        ▼
+7. RUN. Provider executes. Cancellation and error paths synchronize and release
+   active phases and windows.
+        ▼
+8. RECORD. Telemetry: requested + effective tier, selected strategy and parameters,
+   phase peaks, live budget, cache eviction, evidence revision, exclusion reasons.
+```
+
+Step 2 is the change that makes §6 real: feasibility is answered *before* selection, and its only
+two answers are "proceed at the requested geometry" and "refuse."
+
+---
+
+## 11. Migration order
+
+Sequenced so that nothing is measured twice and no story is blocked on a decision it cannot make.
+
+| # | work | why here |
+|---|---|---|
+| 0 | **Rename to the lane-neutral vocabulary** (§13) — `gen_core::memory_strategy`, `Memory*`, `MEMORY_CALIBRATION_ABI`, `harnessVersion` → `sceneworks-memory-v3` | Purely mechanical, and it invalidates prior evidence via the `harnessVersion` const. Committed records today: **zero**. After the calibration wave: hundreds. |
+| 1 | **Explicit prerequisites** — replace the numeric-order walk with the declared graph | Unblocks everything. Rung 1 cannot be declared honestly while the walk treats it as a hard prerequisite for rungs 2–4. |
+| 2 | **Rung 1 reshape** — `Residency` union with a `Mutex` warm slot, `stage_residency` on `GenerationMemory`, image providers stop reading `LoadSpec::offload_policy` | The core capability. Simplifies rung 4's availability as a side effect. The field itself stays for the video/audio lanes. |
+| 3 | **Feasibility + refusal** — delete `plan_control_resolution`, keep its predicate as a feasibility check | Independent of 1–2; removes the live output-substitution defect. |
+| 4 | **Tier integrity (SC-15799)** — branch follows the base tier, q4→q8 floor declared | **Must precede control-lane calibration.** Repacking the branch invalidates every measured control peak and fingerprint. |
+| 5 | **Delete `mempolicy`** — retarget Krea's cost model to submit candidates | Requires 1–4; all four levers must have homes first. |
+| 6 | **z-image reference certification** — all rungs, all tiers, mutation-checked, evidence promoted | The template is not a template until it is proven. |
+| 7 | **Refactor adopters onto it** — other MLX families, then candle | Only after 6. |
+
+Step 4's placement is not cosmetic: calibration is the epic's stated dominant cost, and repacking
+after measuring means paying for those measurements twice.
+
+---
+
+## 12. Decisions — resolved
+
+All four are settled. Two were answered by the code, two are recommendations.
+
+### D1 — mutation seam: **interior mutability** *(settled by the code)*
+
+`Generator::generate(&self, …)` is implemented by every provider in the workspace. `&mut self` would
+change that trait everywhere for an unrelated reason. So: `warm: Mutex<Option<ResidentPair<..>>>`
+inside `Residency`, uncontended because the worker serializes per thread. See §4.
+
+### D2 — `LoadSpec::offload_policy`: **ignored by image providers, not deleted** *(settled by the code)*
+
+The field has consumers in the **video** lane (`mlx-gen-wan`, `mlx-gen-ltx`, `candle-gen-wan`,
+`candle-gen-svd`) and the **audio** lane (`candle-audio-stable-audio-3`). Deleting it is a cross-lane
+change outside this epic's scope. Image providers that adopt the ladder ignore it entirely; the field
+is deleted when the other lanes migrate. See §4.
+
+### D3 — is eviction refusable? **No, not in production** *(recommendation)*
+
+A "stage but keep the warm cache" mode saves nothing by construction — the staged components are
+still resident. Engaging rung 1 under it would write a rung-1 calibration row for a run that bounded
+nothing, which is precisely the false green the invariant in §2 exists to prevent.
+
+If A/B measurement needs the arm, it is a **calibration-only field**, not a production lever.
+`GenerationMemory::calibration_error_phase` is the existing precedent: a field production selectors
+leave `None`, so every ordinary request is a `None` comparison away from being unaffected.
+
+### D4 — may a refusal name a tier? **No — geometry or strategy only** *(recommendation)*
+
+Two independent reasons:
+
+1. The contract already constrains it: *"Advice may name only a lower geometry or strategy that has
+   verified evidence."* Tier is not in that list.
+2. Tier is a creative choice. A memory pipeline that suggests one — even as information — becomes a
+   tier-recommendation engine operating on memory grounds, and the boundary between "informing" and
+   "nudging" is not one the code can hold.
+
+Tier availability is an existing, separate surface. Keeping them apart is what stops the memory
+pipeline from acquiring an opinion about image quality.
+
+---
+
+## 13. Naming — the vocabulary becomes lane-neutral
+
+**Decision: drop `Image` from every type, and name the module `gen_core::memory_strategy`.**
+
+Nothing in the ladder is image-specific. Rung 1 sheds a conditioning component; rung 2 bounds decoder
+scratch; rung 3 bounds attention; rung 4 bounds transformer residency. Video and audio have all four.
+The `Image` prefix records which lane happened to be built first, not what the contract covers.
+
+**The epic's scope does not change.** It remains the 53 image catalog entries. Only the vocabulary
+generalizes, so video and audio can adopt without a second contract.
+
+### Why not bare `gen_core::memory`
+
+Five crates already have a `memory` module, meaning two unrelated things: `mlx_gen::memory` is the
+MLX allocator interface (`safe_budget_gib`, `clear_cache`, `apply_memory_cap_env`), while
+`mlx-gen-sam2::memory` is SAM2's *model* memory bank. Every MLX provider file imports the first one,
+so `gen_core::memory` would sit next to it in the same `use` block. `memory_strategy` collides with
+nothing and says what it is.
+
+The **types** stay bare — `MemoryStrategy`, `MemoryBudget`, `MemoryPhase` — because none of them
+collide. The existing bare `Memory*` names in the workspace (`MemoryEncoder`, `MemoryAttention`,
+`MemoryTokens`, `MemoryFeatures`, `MemoryProfile`, `MemoryConfig`) are all SAM2/model-bank concepts
+in other crates, and `MemoryPlan` is deleted by §8.
+
+### The Rust surface — mechanical
+
+`gen_core::image_memory` exports **36 public items**, every one prefixed `ImageMemory*`, plus
+`IMAGE_MEMORY_CALIBRATION_ABI`. The rename is a prefix strip with no judgment calls:
+
+```
+gen_core::image_memory              →  gen_core::memory_strategy
+IMAGE_MEMORY_CALIBRATION_ABI        →  MEMORY_CALIBRATION_ABI
+ImageMemoryStrategy                 →  MemoryStrategy
+ImageMemoryProviderContract         →  MemoryProviderContract
+ImageMemorySelection                →  MemorySelection
+ImageMemoryEvidence                 →  MemoryEvidence
+…and 30 more, identically
+sceneworks_worker::image_memory     →  sceneworks_worker::memory_strategy
+```
+
+`GenerationMemory` is already lane-neutral and does not change.
+
+### The SceneWorks surface — file and crate names, not payloads
+
+| kind | items |
+|---|---|
+| crate | `sceneworks-image-memory-adapter` → `sceneworks-memory-adapter` (+ `Cargo.toml`, `Cargo.lock`, workspace manifest, `docker/rust.Dockerfile`) |
+| schemas | `packages/schemas/image-memory-{matrix,calibration}.schema.json` |
+| generated | `docs/generated/image-memory-{matrix.json,matrix.md,calibration-evidence.json}` |
+| scripts | `generate-image-memory-matrix.mjs`, `image-memory-calibration-harness.mjs`, + their tests |
+| tests | `tests/test_image_memory_matrix.py` |
+| docs | `image-memory-strategy-contract.md`, `image-memory-calibration-harness.md`, this file |
+
+**What does *not* change: the JSON payloads.** There are zero `imageMemory*` keys in
+`config/manifests/builtin.models.jsonc` or in either schema. No manifest migration, no key rewrite.
+
+**What does change in content**, and it is exactly two things:
+
+1. The schema `$id` URLs — `https://sceneworks.ai/schemas/image-memory-*.schema.json`.
+2. The `harnessVersion` **const**, asserted twice in the calibration schema:
+   `"sceneworks-image-memory-v2"` → `"sceneworks-memory-v3"`.
+
+### The timing argument, precisely
+
+That `harnessVersion` const is embedded in every emitted record, so bumping it invalidates all prior
+evidence. **That is not a cost — it is the mechanism working.** The const is already the epic's
+stale-evidence gate, and a vocabulary change is exactly the kind of thing it exists to invalidate.
+The rename rides a versioning path that is already designed.
+
+The cost is only the evidence that has to be re-captured, and right now that is nearly nothing:
+
+- `docs/generated/image-memory-calibration-evidence.json` contains **`"records": []`** — 92 bytes.
+- The ~9 real records (1 Candle/RTX, 8 MLX/M5 Max) live in gated CI artifacts, unpromoted.
+
+After the calibration wave there will be hundreds, each bound to a revision pair. **Do this before
+any calibration story starts** — it is step 0 in §11 for that reason.
+
+### What video and audio adoption would still need to check
+
+The vocabulary generalizes. Whether the *ladder* does is unproven, and this design does not claim it.
+Three things to establish before either lane adopts, flagged so they are not assumed:
+
+1. **Rung 2 for video is temporal as well as spatial.** `gen_core::tiling` already serves candle
+   video (ltx / mochi / svd / wan), and the epic already words rung 2 as "spatial or temporal." But
+   SC-15325 is a temporal tile-context/overlap defect, so video's rung 2 has a known open issue that
+   image's does not.
+2. **Wan's MoE expert swap may not be either residency rung.** Swapping experts per step is
+   weight-residency bounding, but it is neither "shed a phase" (rung 1) nor "window the trunk"
+   (rung 4). The likely answer mirrors SC-15794: a **component scope** on rung 4 rather than a fifth
+   rung. That should be decided on evidence, not assumed.
+3. **Audio already uses `OffloadPolicy::Sequential`** (`candle-audio-stable-audio-3`), so it has
+   rung 1 in the old shape and would need the same reshape §4 describes.
+
+---
+
+## 13. Portability to the video and audio lanes
+
+**Intent:** the same ladder serves video and audio once the image lane is through. This section
+records what that requires, so the image work does not quietly foreclose it.
+
+### The mechanism already ports — rung 2 proves it
+
+`gen_core::tiling` — the only rung whose planner is fully shared today — is a port of the
+`mlx_video` LTX and Wan tiling references. It carries `temporal_scale`, `causal_temporal` and
+`writable_frame_cap`, and its consumers already span both lanes:
+
+| lane | consumers |
+|---|---|
+| image | `qwen-image`, `sana`, `sdxl`, `z-image` |
+| video | `ltx`, `mochi`, `svd`, `wan`, `krea-realtime`, `scail2` |
+
+Rung 2 was never image-only. Nothing in §2 (the four facts), §3's graph shape, §6 (never substitute
+output), §7 (tier integrity), §8 (one pipeline) or §9 (single-encoding) is image-specific either.
+
+### Three things that do not port
+
+**1. The naming and the calibration ABI — cheap now, expensive after calibration.**
+The contract is image-named throughout: ~25 public `ImageMemory*` types and
+`IMAGE_MEMORY_CALIBRATION_ABI`. An ABI bump makes existing evidence stale *by design*. Today there
+are three provider adopters and near-zero promoted evidence; every one of the 53 calibration stories
+adds records keyed to this ABI. **Rename before the calibration wave, not after.**
+
+**2. The contract asserts the ladder has exactly five rungs.**
+`ImageMemoryStrategy::ALL: [Self; 5]`, and `conformance_errors` rejects any contract whose
+`strategies.len()` differs — so every provider must declare all five. A sixth rung is a breaking
+change to every declaration. Two candidates video plausibly needs, neither of which is any current
+rung:
+
+- **KV-cache bounding.** Krea Realtime 14B measures 7.14 GiB of KV cache — activations, so
+  quantization does not shrink it. It is scratch, but unlike attention scratch it *persists across
+  steps*, so rung 3 does not reach it.
+- **Expert residency.** Wan A14B swaps between two expert weight sets mid-denoise. Residency-bounding,
+  partitioned by expert rather than by block — a sibling of rung 4, not an instance of it.
+
+**3. `ImageMemoryGeometry` carries an image's axes.** Video needs frames; audio needs duration.
+
+### Audio's structural difference — streaming output
+
+Audio can emit incrementally. A provider still streaming output cannot release its decoder, which
+directly conflicts with rung 1's "completed phases are released before the next materializes." Rung 1
+for a streaming lane needs either a later release point or a declared exclusion.
+
+### §6 extends verbatim, on a different axis
+
+**Never silently drop frames, shorten a clip, or truncate audio duration.** Same rule, same three
+surfaces: do not offer what cannot be rendered, refuse with a measured alternative, record the
+refusal.

--- a/docs/memory-strategy-pipeline-target-design.md
+++ b/docs/memory-strategy-pipeline-target-design.md
@@ -76,7 +76,14 @@ Each rung declares exactly four things, each in exactly one place, each derived 
 
 ### The invariant that makes it checkable
 
-> **A rung that cannot deliver its bound is never selected, and never recorded.**
+> **A rung — or a parameter of one — that cannot move the REQUEST peak is never selected by
+> default, and never recorded as a saving.**
+
+The unit is the **request** peak, not a phase peak. A strategy that halves one phase while a
+different phase still binds the request has saved the user nothing, and a calibration row claiming
+otherwise is a false green. SC-15794 is the worked example: rung 4's text-encoder scope cuts the
+z-image conditioning phase 2.718 → 1.455 GiB (−46.5%) and moves the request peak by **0.0%**, because
+decode binds every tier at ~4.365 GiB. The capability is real and published; the default is not it.
 
 Availability is the mechanism that enforces this. A typed `Error::Unsupported` at the provider is a
 **backstop for a selector bug**, not a control-flow path — if it fires in production, the selector
@@ -96,7 +103,13 @@ an error.
 | 1 | Staged residency | residency | weights across phases | model has a separable phase-A component | `stage_residency` | — |
 | 2 | Bounded decode | scratch | decoder scratch | decoder is tileable | `tile_vae_decode` | `decode_tile_edge`, `decode_overlap` |
 | 3 | Bounded attention | scratch | attention scratch | attention is chunkable | `chunk_attention` | `attention_chunk_size` |
-| 4 | Bounded transformer residency | residency | trunk weights | weights are **re-openable** from a snapshot | `stream_transformer_blocks` | `transformer_window_size` |
+| 4 | Bounded transformer residency | residency | trunk weights | weights are **re-openable** from a snapshot | `stream_transformer_blocks` | `transformer_window_size`, `transformer_window_component` |
+
+Rung 4's `transformer_window_component` (`Dit` / `TextEncoder` / `Both`, SC-15794) is a **parameter
+with a published candidate domain**, exactly like `decode_tile_edges` and `attention_chunk_sizes` —
+not a new axis. Availability stays one verdict per rung; which transformer the window applies to is
+chosen within it. This is the shape any future component scope should take, including Wan's MoE
+expert residency (§13).
 
 ### The prerequisite graph — explicit, and small
 
@@ -248,6 +261,38 @@ This keeps one authority per fact. The field is *not* retained for image provide
 hint" — that would re-create exactly the two-place ambiguity this design removes. Deferring the load
 entirely is also strictly better: nothing loads until a request has been selected, so model
 switching gets faster.
+
+### Amendment (SC-15794 / PR #323): the loader must take residency as an argument
+
+PR #323 makes the loader choose the **form** of a component from the load policy:
+
+```rust
+// z-image loader.rs
+let streamable = matches!(spec_text.offload_policy, OffloadPolicy::Sequential);
+load_text_encoder_only(root, spec_text.quantize, streamable)
+```
+
+A streamable encoder holds no resident layers, so it is ~2× slower under `Resident` (measured
+250/148/165 ms resident vs 445/428/419 ms streamed) — a real regression the PR pins a test against.
+The gate is correct **given a load-time policy**. Under request-scoped residency it cannot stand: the
+loader runs before the request exists.
+
+**The fix is already precedented in the same type.** `Residency::sequential` takes
+`load_heavy: impl Fn(bool) -> Result<Heavy>` — the `bool` is `use_pid`, a *per-request* flag threaded
+into a loader closure. `streamable` becomes a second such argument:
+
+```rust
+load_text:  impl Fn(bool /* streamable */) -> Result<Text>
+load_heavy: impl Fn(bool /* use_pid */, bool /* streamable */) -> Result<Heavy>
+```
+
+The request's selected strategy decides the form; the loader builds it. No form is chosen before a
+request exists, and the 2× resident regression is structurally unreachable because a request that
+did not select a streaming scope never asks for a streamable component.
+
+**The warm-cache consequence is the one already declared.** A warm *non*-streamable encoder cannot
+serve a request that selects the text-encoder scope, so that request evicts and rebuilds — the same
+eviction rung 1 already declares, for the same reason. No new cost category.
 
 ### What this unlocks for rung 4
 
@@ -460,7 +505,7 @@ everywhere else.** Current scores:
 
 | fact | encodings today | where | target |
 |---|---|---|---|
-| rung 4 needs a non-materialized trunk | **3** | `streamable`, numeric-order walk, `resolve_block_window` | **1** — prerequisite edge |
+| rung 4 needs a non-materialized trunk | **4** *(was 3)* | `streamable`, numeric-order walk, `resolve_block_window`, **+ the loader's `streamable` flag (PR #323)** | **1** — prerequisite edge |
 | rung 1 is inert under `Resident` | **0** | prose in a module doc; declared nowhere | **0 needed** — the condition ceases to exist |
 | the escalation order | **2** | `ImageMemoryStrategy::ALL`, `mempolicy::Lever` | **1** |
 | the control branch's tier | **2** | installed artifact, `BranchQuant` lever | **1** |

--- a/scripts/split-memory-strategy-stories.mjs
+++ b/scripts/split-memory-strategy-stories.mjs
@@ -41,6 +41,12 @@ const FAMILY_GATES = [15507, 15508, 15750, 15804, 15799, 15812];
 const MLX = "mlx";
 const CANDLE = "candle";
 
+// A new Candle twin ALWAYS starts in To Do. It must never inherit its MLX twin's workflow state:
+// the twin's state reflects work done on a Mac, and copying it would mark Candle work complete that
+// nobody has done — the exact false green this epic exists to prevent. (This bit: SC-15510 is Done,
+// so its twin SC-15815 was created Done, which in turn made its two children read as unblocked.)
+const TODO_STATE = 500000007;
+
 // ── invariants the matrix must satisfy before we touch anything ────────────────────────────────
 const EXPECT = {
   totalModels: 53,
@@ -203,7 +209,7 @@ async function apply(plan) {
         story_type: twin.story_type,
         epic_id: EPIC_ID,
         group_id: twin.group_id ?? undefined,
-        workflow_state_id: twin.workflow_state_id,
+        workflow_state_id: TODO_STATE,
         description: `## ${SCOPE_CANDLE(mlxId)}\n\n---\n\n${twin.description}`,
       },
       tok,
@@ -287,6 +293,14 @@ async function verify(plan) {
     const mlx = byId.get(m.mlxStory);
     if (mlx && !mlx.name.endsWith("— MLX/Metal")) problems.push(`SC-${m.mlxStory}: not rescoped to MLX`);
   }
+  // No Candle work has been done yet, so a Candle twin in a completed state is a bug, not progress.
+  // RELAX THIS the day genuine Candle evidence starts landing — but not before, because the state
+  // was silently inherited from the MLX twin once already (SC-15815) and read as finished work.
+  for (const twin of [...Object.values(state.candleFamilies), ...Object.values(state.candleModels)]) {
+    const s = byId.get(twin);
+    if (s?.completed) problems.push(`SC-${twin}: Candle twin is marked complete but no Candle work has landed`);
+  }
+
   // The mlx-only set must be untouched: a Candle twin there could never be closed.
   for (const m of plan.mlxOnly) {
     if (state.candleModels[m.mlxStory]) problems.push(`SC-${m.mlxStory} (${m.model}): mlx-only but has a Candle twin`);

--- a/scripts/split-memory-strategy-stories.mjs
+++ b/scripts/split-memory-strategy-stories.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+// Split every dual-backend memory-strategy story into an MLX twin and a Candle twin (sc-15812).
+//
+// WHY A SCRIPT: the split is ~230 discrete Shortcut writes. The MCP surface available to an agent
+// offers no idempotency, no transaction, and ambiguous failures, so a hand pass reliably produces
+// silent misses in exactly the metadata whose purpose is stopping Candle work from being lost.
+//
+// This script is:
+//   * PURE in --dry-run     — reads only the generated matrix; needs no token, writes nothing.
+//   * IDEMPOTENT in --apply — every created object is recorded in a state file and re-checked
+//                             against the live API, so a re-run after any failure resumes cleanly.
+//   * TWO-PHASE             — nothing predicts a server-assigned id; cross-references are patched
+//                             from the recorded id map after creation.
+//   * VERIFIABLE in --verify — diffs the live story graph against what the matrix says must exist.
+//
+// Usage:
+//   node scripts/split-memory-strategy-stories.mjs --dry-run
+//   SHORTCUT_API_TOKEN=... node scripts/split-memory-strategy-stories.mjs --apply
+//   SHORTCUT_API_TOKEN=... node scripts/split-memory-strategy-stories.mjs --verify
+//
+// The token is read from the environment and is never logged, echoed, or written to the state file.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, "..");
+const MATRIX = resolve(REPO, "docs/generated/image-memory-matrix.json");
+const STATE = resolve(REPO, ".shortcut-split-state.json");
+const PLAN = resolve(REPO, ".shortcut-split-plan.json");
+
+const EPIC_ID = 15448;
+const API = "https://api.app.shortcut.com/api/v3";
+
+// Upstream gates every Candle family story inherits from its MLX twin. Kept explicit rather than
+// copied from the twin's links, because the twin also carries links we must NOT clone (its own
+// model-story children, which the Candle family gets fresh).
+const FAMILY_GATES = [15507, 15508, 15750, 15804, 15799, 15812];
+
+const MLX = "mlx";
+const CANDLE = "candle";
+
+// ── invariants the matrix must satisfy before we touch anything ────────────────────────────────
+const EXPECT = {
+  totalModels: 53,
+  dualModels: 33,
+  mlxOnlyModels: 20,
+  candleOnlyModels: 0,
+  dualFamilies: 14,
+  mlxOnlyFamilies: 6,
+};
+
+function die(message) {
+  console.error(`\n  FAIL  ${message}\n`);
+  process.exit(1);
+}
+
+// ── phase A: plan, computed purely from the generated matrix ───────────────────────────────────
+function buildPlan() {
+  if (!existsSync(MATRIX)) die(`matrix not found at ${MATRIX}`);
+  const matrix = JSON.parse(readFileSync(MATRIX, "utf8"));
+
+  const byModel = new Map();
+  for (const cell of matrix.cells ?? []) {
+    let entry = byModel.get(cell.modelId);
+    if (!entry) {
+      entry = {
+        model: cell.modelId,
+        mlxStory: cell.owningModelStory,
+        family: cell.owningFamilyStory,
+        backends: new Set(),
+      };
+      byModel.set(cell.modelId, entry);
+    }
+    entry.backends.add(cell.backend);
+    // A model whose cells disagree about ownership means the generator changed under us.
+    if (entry.mlxStory !== cell.owningModelStory || entry.family !== cell.owningFamilyStory) {
+      die(`${cell.modelId}: cells disagree about owning story/family — regenerate the matrix`);
+    }
+  }
+
+  const models = [...byModel.values()].map((m) => ({ ...m, backends: [...m.backends].sort() }));
+  const dualModels = models.filter((m) => m.backends.length > 1).sort((a, b) => a.mlxStory - b.mlxStory);
+  const mlxOnly = models.filter((m) => m.backends.length === 1 && m.backends[0] === MLX);
+  const candleOnly = models.filter((m) => m.backends.length === 1 && m.backends[0] === CANDLE);
+
+  const dualFamilies = [...new Set(dualModels.map((m) => m.family))].sort((a, b) => a - b);
+  const allFamilies = [...new Set(models.map((m) => m.family))];
+  const mlxOnlyFamilies = allFamilies.filter((f) => !dualFamilies.includes(f)).sort((a, b) => a - b);
+
+  // Assert the shape BEFORE any write. A drifted catalog must stop the run, not silently
+  // half-apply — the whole point of the split is a trustworthy graph.
+  const actual = {
+    totalModels: models.length,
+    dualModels: dualModels.length,
+    mlxOnlyModels: mlxOnly.length,
+    candleOnlyModels: candleOnly.length,
+    dualFamilies: dualFamilies.length,
+    mlxOnlyFamilies: mlxOnlyFamilies.length,
+  };
+  for (const [key, want] of Object.entries(EXPECT)) {
+    if (actual[key] !== want) {
+      die(
+        `invariant ${key}: matrix says ${actual[key]}, sc-15812 says ${want}.\n` +
+          `        The catalog changed. Re-derive the split and update EXPECT before applying.`,
+      );
+    }
+  }
+  // A dual model whose family is not itself dual would strand the Candle story with no parent.
+  for (const m of dualModels) {
+    if (!dualFamilies.includes(m.family)) die(`${m.model}: dual model under non-dual family SC-${m.family}`);
+  }
+
+  return { models, dualModels, mlxOnly, candleOnly, dualFamilies, mlxOnlyFamilies, actual };
+}
+
+// ── Shortcut client — minimal, rate-limited, never logs the token ───────────────────────────────
+function token() {
+  const t = process.env.CLAUDE_SHORTCUT_MCP_TOKEN || process.env.SHORTCUT_API_TOKEN;
+  if (!t) {
+    die(
+      "No token. Set CLAUDE_SHORTCUT_MCP_TOKEN (or SHORTCUT_API_TOKEN).\n" +
+        "        --dry-run needs no token; --apply and --verify do.",
+    );
+  }
+  return t;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function api(method, path, body, tok) {
+  // Shortcut allows 200 req/min; stay well under it rather than discovering the limit mid-migration.
+  await sleep(350);
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: { "Content-Type": "application/json", "Shortcut-Token": tok },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    // Deliberately does not include the request body: story descriptions are large and a failure
+    // dump that scrolls the real error off screen is how a 409 gets mistaken for a duplicate.
+    throw new Error(`${method} ${path} -> ${res.status} ${res.statusText} ${text.slice(0, 300)}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+function loadState() {
+  return existsSync(STATE) ? JSON.parse(readFileSync(STATE, "utf8")) : { candleFamilies: {}, candleModels: {}, rescoped: [], links: [] };
+}
+function saveState(state) {
+  writeFileSync(STATE, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+const SCOPE_MLX = (twinId) =>
+  `BACKEND SCOPE — MLX/Metal ONLY. Evidence must be produced on a Mac. The Candle/CUDA half of ` +
+  `this work is SC-${twinId} and is NOT covered here; do not mark this story Done on the strength ` +
+  `of Candle results, and do not close SC-${twinId} from a Mac.`;
+
+const SCOPE_CANDLE = (twinId) =>
+  `BACKEND SCOPE — Candle/CUDA ONLY. Evidence must be produced on CUDA hardware. The MLX/Metal ` +
+  `half is SC-${twinId}. Split from it under sc-15812 because a dual-backend story cannot be ` +
+  `completed on one machine, which is how Candle work goes missing once MLX is green.`;
+
+function candleName(mlxName) {
+  return `${mlxName} — Candle/CUDA`;
+}
+function mlxName(name) {
+  return name.endsWith(" — MLX/Metal") ? name : `${name} — MLX/Metal`;
+}
+
+// ── phase B: apply ─────────────────────────────────────────────────────────────────────────────
+async function apply(plan) {
+  const tok = token();
+  const state = loadState();
+
+  // Resolve every twin we intend to create, so a re-run adopts what already exists instead of
+  // creating a second copy. Names are the natural key; they are unique within the epic.
+  const epicStories = await api("GET", `/epics/${EPIC_ID}/stories`, null, tok);
+  const byName = new Map(epicStories.map((s) => [s.name, s]));
+
+  const createTwin = async (mlxId, kind) => {
+    if (state[kind][mlxId]) {
+      const existing = epicStories.find((s) => s.id === state[kind][mlxId]);
+      if (existing) return state[kind][mlxId];
+      console.warn(`  state names SC-${state[kind][mlxId]} for SC-${mlxId} but it is gone; recreating`);
+    }
+    const twin = await api("GET", `/stories/${mlxId}`, null, tok);
+    const name = candleName(mlxName(twin.name).replace(" — MLX/Metal", ""));
+    const adopted = byName.get(name);
+    if (adopted) {
+      state[kind][mlxId] = adopted.id;
+      saveState(state);
+      console.log(`  adopt   SC-${adopted.id}  ${name}`);
+      return adopted.id;
+    }
+    const created = await api(
+      "POST",
+      "/stories",
+      {
+        name,
+        story_type: twin.story_type,
+        epic_id: EPIC_ID,
+        group_id: twin.group_id ?? undefined,
+        workflow_state_id: twin.workflow_state_id,
+        description: `## ${SCOPE_CANDLE(mlxId)}\n\n---\n\n${twin.description}`,
+      },
+      tok,
+    );
+    // The HARD AC calibration task (epic comment 15674) must exist on BOTH twins; a Candle story
+    // without it can be closed on harness output alone, which is the defect that task exists for.
+    for (const task of twin.tasks ?? []) {
+      await api("POST", `/stories/${created.id}/tasks`, { description: task.description }, tok);
+    }
+    state[kind][mlxId] = created.id;
+    saveState(state);
+    console.log(`  create  SC-${created.id}  ${name}`);
+    return created.id;
+  };
+
+  const link = async (subject, object) => {
+    const key = `${subject}->${object}`;
+    if (state.links.includes(key)) return;
+    try {
+      await api("POST", "/story-links", { subject_id: subject, verb: "blocks", object_id: object }, tok);
+    } catch (error) {
+      // A 409 here is ambiguous: it may mean "already linked" or a genuine failure. Verify against
+      // the live story rather than assuming, because assuming is how an edge silently goes missing.
+      const live = await api("GET", `/stories/${object}`, null, tok);
+      const present = (live.story_links ?? []).some((l) => l.subject_id === subject && l.object_id === object);
+      if (!present) throw error;
+    }
+    state.links.push(key);
+    saveState(state);
+  };
+
+  const rescope = async (mlxId, twinId) => {
+    if (state.rescoped.includes(mlxId)) return;
+    const story = await api("GET", `/stories/${mlxId}`, null, tok);
+    if (story.name !== mlxName(story.name)) {
+      await api("PUT", `/stories/${mlxId}`, { name: mlxName(story.name) }, tok);
+    }
+    // A TASK, not a description edit: the descriptions are generated by sc-15506, and epic comment
+    // 15674 established that convention so regeneration does not clobber hand edits.
+    const already = (story.tasks ?? []).some((t) => t.description.startsWith("BACKEND SCOPE"));
+    if (!already) await api("POST", `/stories/${mlxId}/tasks`, { description: SCOPE_MLX(twinId) }, tok);
+    state.rescoped.push(mlxId);
+    saveState(state);
+    console.log(`  rescope SC-${mlxId} -> MLX/Metal`);
+  };
+
+  console.log("\nFamilies");
+  for (const familyId of plan.dualFamilies) {
+    const twinId = await createTwin(familyId, "candleFamilies");
+    for (const gate of FAMILY_GATES) await link(gate, twinId);
+    await rescope(familyId, twinId);
+  }
+
+  console.log("\nModels");
+  for (const m of plan.dualModels) {
+    const twinId = await createTwin(m.mlxStory, "candleModels");
+    const candleFamily = state.candleFamilies[m.family];
+    if (!candleFamily) die(`no Candle family recorded for SC-${m.family}; re-run after families succeed`);
+    await link(candleFamily, twinId);
+    await rescope(m.mlxStory, twinId);
+  }
+
+  console.log(`\nApplied. State: ${STATE}`);
+}
+
+// ── phase C: verify ────────────────────────────────────────────────────────────────────────────
+async function verify(plan) {
+  const tok = token();
+  const state = loadState();
+  const epicStories = await api("GET", `/epics/${EPIC_ID}/stories`, null, tok);
+  const byId = new Map(epicStories.map((s) => [s.id, s]));
+  const problems = [];
+
+  for (const familyId of plan.dualFamilies) {
+    const twin = state.candleFamilies[familyId];
+    if (!twin || !byId.has(twin)) problems.push(`family SC-${familyId}: no Candle twin`);
+  }
+  for (const m of plan.dualModels) {
+    const twin = state.candleModels[m.mlxStory];
+    if (!twin || !byId.has(twin)) problems.push(`model SC-${m.mlxStory} (${m.model}): no Candle twin`);
+    const mlx = byId.get(m.mlxStory);
+    if (mlx && !mlx.name.endsWith("— MLX/Metal")) problems.push(`SC-${m.mlxStory}: not rescoped to MLX`);
+  }
+  // The mlx-only set must be untouched: a Candle twin there could never be closed.
+  for (const m of plan.mlxOnly) {
+    if (state.candleModels[m.mlxStory]) problems.push(`SC-${m.mlxStory} (${m.model}): mlx-only but has a Candle twin`);
+    const s = byId.get(m.mlxStory);
+    if (s && s.name.endsWith("— MLX/Metal")) problems.push(`SC-${m.mlxStory}: mlx-only should not be renamed`);
+  }
+
+  if (problems.length) {
+    console.error(`\n  ${problems.length} problem(s):`);
+    for (const p of problems) console.error(`    - ${p}`);
+    process.exit(1);
+  }
+  console.log(`\n  OK — ${plan.dualFamilies.length} family twins, ${plan.dualModels.length} model twins, ${plan.mlxOnly.length} mlx-only untouched.`);
+}
+
+// ── main ───────────────────────────────────────────────────────────────────────────────────────
+const mode = process.argv.find((a) => ["--dry-run", "--apply", "--verify"].includes(a)) ?? "--dry-run";
+const plan = buildPlan();
+
+if (mode === "--dry-run") {
+  console.log("\nInvariants (matrix vs sc-15812)");
+  for (const [k, v] of Object.entries(plan.actual)) console.log(`  ok  ${k.padEnd(18)} ${v}`);
+
+  console.log(`\nWould create ${plan.dualFamilies.length} Candle family stories:`);
+  for (const f of plan.dualFamilies) {
+    const kids = plan.dualModels.filter((m) => m.family === f);
+    console.log(`  SC-${f} -> Candle twin, blocking ${kids.length} model twin(s)`);
+  }
+  console.log(`\nWould create ${plan.dualModels.length} Candle model stories:`);
+  for (const m of plan.dualModels) console.log(`  SC-${m.mlxStory}  fam SC-${m.family}  ${m.model}`);
+
+  console.log(`\nWould rescope ${plan.dualFamilies.length + plan.dualModels.length} existing stories to MLX/Metal.`);
+  console.log(`Would leave UNTOUCHED: ${plan.mlxOnly.length} mlx-only models, ${plan.mlxOnlyFamilies.length} mlx-only families (SC-${plan.mlxOnlyFamilies.join(", SC-")}).`);
+
+  const writes =
+    (plan.dualFamilies.length + plan.dualModels.length) * 2 +
+    plan.dualFamilies.length * FAMILY_GATES.length +
+    plan.dualModels.length +
+    (plan.dualFamilies.length + plan.dualModels.length);
+  console.log(`\nApprox ${writes} writes. Re-runnable; state in ${STATE}`);
+
+  writeFileSync(PLAN, `${JSON.stringify(plan, null, 2)}\n`);
+  console.log(`Plan written to ${PLAN}`);
+} else if (mode === "--apply") {
+  await apply(plan);
+} else {
+  await verify(plan);
+}


### PR DESCRIPTION
Docs and tooling only — no runtime code. Adds the target design for one shared memory-strategy pipeline, and the script that split epic 15448's dual-backend stories per backend.

## `docs/memory-strategy-pipeline-target-design.md`

Target design using MLX `z_image_turbo` as the reference implementation everything else refactors onto. Thirteen sections; no open decisions.

- **Four facts per rung**, each declared in exactly one place: availability (per `LoadSpec`), prerequisites (an explicit graph, **not** the enum's numeric order), engagement (per request), cost rank (worker-owned).
- **Rung 1 becomes request-scoped.** It is the only rung with no engagement knob today, so selecting it on a `Resident` generator silently does nothing. MLX image providers stop reading `LoadSpec::offload_policy`; the field stays for the video and audio lanes, which still consume it.
- **`gen_core::mempolicy` is deleted, not thinned.** All four of its levers have homes elsewhere. Krea's measured cost model survives as a provider estimator — it is the most expensive artifact in that module.
- **Resolution reduction is deleted, not relocated.** `mlx-gen-krea` renders `krea_2_turbo_control` at a smaller size when the request does not fit, announced only via `eprintln!` to stderr. Never substitute the requested output geometry: refuse with a measured alternative, or do not offer it.
- **Vocabulary becomes lane-neutral** (`gen_core::memory_strategy`, `Memory*`) so video and audio adopt without a second contract. Epic scope stays the 53 image entries.

## `scripts/split-memory-strategy-stories.mjs`

A dual-backend story cannot be completed on one machine — MLX evidence is authoritative only from a Mac, Candle only from CUDA hardware — so once the MLX half is green the Candle half goes missing. This splits them.

Scripted rather than done by hand because the pass is ~400 API calls, and a hand pass at that volume drops edges in exactly the metadata whose purpose is stopping work from being lost.

- `--dry-run` is pure: reads only the generated matrix, needs no token, and **aborts** if the catalog no longer matches the shape sc-15812 specifies.
- `--apply` is idempotent: twins are adopted by name if present, state is flushed after every object, and link 409s are re-checked against the live story rather than assumed to mean "already linked".
- `--verify` diffs the live graph and fails on a missing twin, an un-rescoped MLX story, *or* an mlx-only story that wrongly acquired one.

Applied: 14 family + 33 model twins, 47 stories rescoped to MLX/Metal, 20 mlx-only models and 6 mlx-only families untouched. Epic 102 → 149.

### One defect found and fixed in the same branch

The split initially copied `workflow_state_id` from each MLX twin. SC-15510 is Done, so its Candle twin was created **Done** — a new story with no CUDA work reading as complete, which is the false green this epic exists to prevent. Twins now use a `TODO_STATE` constant and never inherit state; `--verify` fails if any Candle twin is complete. All 47 audited; one was affected.

## Not in this PR

SC-15812's generator half. `generate-image-memory-matrix.mjs` still assigns `owningModelStory` per model and copies it onto every cell regardless of backend, so all 2,260 candle cells still name MLX-scoped stories. The three-change spec and the complete backend-keyed ID mapping are on SC-15812 as a comment.

## Verification

`npm run check` green — exit 0, 48/48 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)