### PR TITLE
feat(workflow-share): sanitized share envelope + allow-list sanitizer (sc-15946)

### DIFF
--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod training;
 pub mod training_store;
 pub mod video_request;
 pub mod voice_store;
+pub mod workflow_share;
 
 pub const API_PREFIX: &str = "/api/v1";
 pub const HEALTH_ROUTE: &str = "/health";

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -164,6 +164,12 @@ pub struct WorkflowUpscale {
 /// older reader; here that would defeat the whole point — an envelope arriving from outside
 /// must be reduced to the fields we classify, on parse as well as on build. Unknown keys are
 /// dropped in both directions.
+///
+/// Dropping unknown KEYS is only half of it: the strings under the keys we *do* declare are
+/// still attacker-chosen in a file that came from a stranger. `reduce_workflow_share` runs the
+/// same value-level guards on parse as on build — the path check on every label, `owner/name`
+/// validation on `loras[].repo`, the closed [`INPUT_KINDS`] vocabulary on `inputs[].kind`, and
+/// a bounded producer block.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkflowShare {
@@ -223,7 +229,9 @@ pub enum WorkflowShareError {
     /// The marker is present but names a workflow kind this reader does not handle
     /// (the image reader handed a video envelope, sc-15956).
     UnsupportedKind { found: String, supported: String },
-    /// `schemaVersion` is missing or not a non-negative integer.
+    /// `schemaVersion` is absent (or explicitly `null`). A key that IS present but is not a
+    /// whole number is [`Self::Malformed`] instead — telling someone a field they can see in
+    /// the file is missing sends them looking in the wrong place.
     MissingSchemaVersion,
     /// The file's contract version is newer than this build's. Names both versions so the
     /// user is told to update rather than shown a parse failure.
@@ -305,7 +313,9 @@ pub enum AdvancedShape {
     /// fields. The free-form `caption` object is dropped — its serialized form already rides
     /// in `runtimePrompt` and in the top-level `prompt`.
     StructuredPrompt,
-    /// The pose-library selection, reduced to keypoints. Pose library ids do not travel.
+    /// The pose-library selection, reduced to its numeric coordinate arrays ([`POSE_FIELDS`]:
+    /// `keypoints`, `hands`, `face` — all three drive the rendered skeleton). Pose-library ids,
+    /// and anything else the picker attached, do not travel.
     Poses,
     /// The Krea multi-phase denoise list, reduced to `{ steps, guidance, loras:[{index, weight}] }`.
     Phases,
@@ -446,7 +456,8 @@ pub const ADVANCED_KEY_RULES: &[AdvancedKeyRule] = &[
     allow(
         "poses",
         AdvancedShape::Poses,
-        "Authored pose selection. Keypoints travel; the pose-library ids that named them do not.",
+        "Authored pose selection. The numeric coordinate arrays the worker renders travel \
+         (keypoints, hands, face); the pose-library ids that named them do not.",
     ),
     allow(
         "faceRestore",
@@ -529,60 +540,188 @@ pub fn advanced_key_rule(key: &str) -> Option<&'static AdvancedKeyRule> {
 // Path shapes
 // ---------------------------------------------------------------------------
 
-/// True when `value` looks like a filesystem location.
+/// True when `value` looks like a filesystem location — absolute OR relative.
 ///
-/// Belt to the allow-list's braces: no allow-listed `advanced` key legitimately holds a path,
-/// so any value that looks like one is dropped even from a key that is otherwise in. Covers
-/// POSIX absolutes, Windows drive letters (anywhere in the string, which catches
-/// `"loaded from C:\\Users\\…"`), UNC shares, `file://` URLs and `~` expansions.
+/// Belt to the allow-list's braces: no allow-listed `advanced` key and no classified top-level
+/// label legitimately holds a path, so any value that looks like one is dropped even from a key
+/// that is otherwise in. The story's line is "every filesystem path without exception", so this
+/// deliberately errs toward dropping: a false positive costs one label, a false negative ships
+/// the user's home directory — and therefore their name — inside every copy of the image.
+///
+/// Recognized:
+///
+/// * a backslash **anywhere** — every Windows location has one, absolute (`C:\Users\…`),
+///   relative (`models\weights\x`), traversing (`..\..\Users\…`), UNC (`\\server\share`),
+///   drive-relative (`c:secret\file`) or environment-expanded (`%USERPROFILE%\x`);
+/// * a POSIX absolute (`/etc/passwd`) and `~` / `~user` home expansions;
+/// * a bare drive prefix `X:` at a token boundary, with or without a following separator, so
+///   `C:foo` is caught and the URL scheme in `https://…` is not;
+/// * a `..` traversal segment and a leading `./`;
+/// * a multi-segment relative POSIX path (`assets/images/x.png`) — three or more segments and
+///   no URL scheme. Two segments is a Hugging Face repo id (`acme/mira`) and stays;
+/// * `file://`, including percent-encoded (`file%3A%2F%2FD%3A%2Fx`).
 ///
 /// Deliberately NOT applied to the authored prose fields (`prompt`, `negativePrompt`,
 /// `stylePrompt`, the structured prompt's `intent` / `runtimePrompt`): those are what the user
 /// typed, and silently mangling a prompt because it mentions a directory would be worse than
-/// the leak it prevents — the user authored it and can see it.
+/// the leak it prevents — the user authored it and can see it. That exemption is pinned by
+/// `authored_prose_travels_verbatim_even_when_it_names_a_path` in the integration tests.
 #[must_use]
 pub fn is_path_shaped(value: &str) -> bool {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return false;
     }
-    if trimmed.to_ascii_lowercase().contains("file://") {
+    if looks_like_a_location(trimmed) {
         return true;
     }
-    if trimmed.starts_with('/') || trimmed.starts_with('\\') {
-        return true;
-    }
-    if trimmed.starts_with("~/") || trimmed.starts_with("~\\") {
-        return true;
-    }
-    // A drive-letter prefix anywhere: `C:\`, `d:/`.
-    let bytes = trimmed.as_bytes();
-    for index in 0..bytes.len().saturating_sub(2) {
-        let letter = bytes[index];
-        if !letter.is_ascii_alphabetic() {
-            continue;
+    // Percent-encoding is not a disguise: `file%3A%2F%2FD%3A%2Fx` is `file://D:/x`. Decoded
+    // repeatedly, bounded, so a double-encoded `%252F` cannot hide one round deeper.
+    let mut decoded = trimmed.to_owned();
+    for _ in 0..PERCENT_DECODE_ROUNDS {
+        let next = percent_decode_separators(&decoded);
+        if next == decoded {
+            break;
         }
-        // Only when the letter starts a token, so `https://x` is not read as a drive.
-        if index > 0 && (bytes[index - 1].is_ascii_alphanumeric() || bytes[index - 1] == b':') {
-            continue;
-        }
-        if bytes[index + 1] == b':' && (bytes[index + 2] == b'\\' || bytes[index + 2] == b'/') {
+        decoded = next;
+        if looks_like_a_location(decoded.trim()) {
             return true;
         }
     }
     false
 }
 
+/// How many times [`is_path_shaped`] re-decodes percent escapes before giving up. Two is enough
+/// for `%252F`; the bound is what keeps a pathological value from spinning.
+const PERCENT_DECODE_ROUNDS: usize = 3;
+
+/// The path-shape rules themselves, run once on the raw value and once on its
+/// separator-decoded form (see [`is_path_shaped`]).
+fn looks_like_a_location(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if lower.contains("file://") {
+        return true;
+    }
+    // A backslash anywhere. Nothing this guard protects legitimately contains one.
+    if value.contains('\\') {
+        return true;
+    }
+    if value.starts_with('/') {
+        return true;
+    }
+    // `~/models/x` and `~michael/x` alike.
+    if value.starts_with('~') && value.contains('/') {
+        return true;
+    }
+    // A drive prefix at a token boundary. A SINGLE letter before the colon is what separates a
+    // drive (`c:`) from a URL scheme (`https:`), and no trailing separator is required — the
+    // drive-relative `C:foo` resolves against the process's per-drive cwd and is still a path.
+    let is_drive_token = |token: &str| {
+        let bytes = token.as_bytes();
+        bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+    };
+    if lower
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != ':')
+        .any(is_drive_token)
+    {
+        return true;
+    }
+    let segments: Vec<&str> = value.split('/').collect();
+    if segments.contains(&"..") {
+        return true;
+    }
+    if segments.len() > 1 && segments[0] == "." {
+        return true;
+    }
+    // A relative POSIX tree. Two segments is an HF repo id and stays; a URL is not a location on
+    // THIS machine, so `https://host/a/b/c` is left alone.
+    !lower.contains("://")
+        && segments
+            .iter()
+            .filter(|segment| !segment.is_empty())
+            .count()
+            >= 3
+}
+
+/// Decode only the percent escapes that matter to [`looks_like_a_location`], so an encoded
+/// separator cannot walk a path past the guard. Not a general URL decoder and not meant to be.
+fn percent_decode_separators(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let mut out = String::with_capacity(value.len());
+    let mut index = 0;
+    while index < chars.len() {
+        if chars[index] == '%' && index + 2 < chars.len() {
+            let decoded = match (
+                chars[index + 1].to_ascii_lowercase(),
+                chars[index + 2].to_ascii_lowercase(),
+            ) {
+                ('3', 'a') => Some(':'),
+                ('2', 'f') => Some('/'),
+                ('5', 'c') => Some('\\'),
+                ('7', 'e') => Some('~'),
+                ('2', 'e') => Some('.'),
+                // `%25` is the escape for `%` itself — the one that makes `%252F` a
+                // double-encoded separator. Without it the second decode round has nothing left
+                // to do and `%252F` walks straight through.
+                ('2', '5') => Some('%'),
+                _ => None,
+            };
+            if let Some(character) = decoded {
+                out.push(character);
+                index += 3;
+                continue;
+            }
+        }
+        out.push(chars[index]);
+        index += 1;
+    }
+    out
+}
+
+/// The longest a classified label may be. A bound on every free string an outside envelope can
+/// put under a key we declare — a model slug, a style id, a LoRA display name, the producer
+/// block. Generous for anything legitimate and finite for anything else.
+const LABEL_MAX_CHARS: usize = 200;
+
+/// One non-prose label, reduced: trimmed, bounded, and dropped when it is empty, holds a
+/// control character, or is path-shaped.
+///
+/// The single guard [`build_workflow_share`] and [`parse_workflow_share`] both run, so the two
+/// directions cannot drift apart: an envelope that arrives from outside is reduced by exactly
+/// the rules that built ours.
+fn shareable_label(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().count() > LABEL_MAX_CHARS
+        || trimmed.chars().any(char::is_control)
+        || is_path_shaped(trimmed)
+    {
+        return None;
+    }
+    Some(trimmed.to_owned())
+}
+
 /// A Hugging Face repo id (`owner/name`) and nothing else — never a path, never a URL.
+///
+/// Load-bearing beyond tidiness: a repo id is joined into a cache directory name
+/// (`models--owner--name`), and sc-15952's "install the missing LoRA" action acts on whatever
+/// this returns. `.` and `-` and `_` are legal INSIDE a segment, so a segment must additionally
+/// start with an alphanumeric — otherwise `../x` reads as the perfectly-shaped repo id `..`/`x`.
 fn hf_repo_id(value: &str) -> Option<String> {
     let trimmed = value.trim();
+    if trimmed.chars().count() > LABEL_MAX_CHARS {
+        return None;
+    }
     let mut segments = trimmed.split('/');
     let (Some(owner), Some(name), None) = (segments.next(), segments.next(), segments.next())
     else {
         return None;
     };
     let segment_ok = |segment: &str| {
-        !segment.is_empty()
+        segment
+            .chars()
+            .next()
+            .is_some_and(|first| first.is_ascii_alphanumeric())
             && segment.chars().all(|character| {
                 character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
             })
@@ -638,7 +777,10 @@ pub fn build_workflow_share(asset: &Asset, job_payload: &JsonObject) -> Workflow
             .unwrap_or(&Map::new()),
     );
 
-    WorkflowShare {
+    // Every value goes out through the SAME reducer an incoming envelope comes in through
+    // (`reduce_workflow_share`), so the build side cannot grow a field the parse side does not
+    // guard — which is exactly how the top-level labels below escaped the path check before.
+    reduce_workflow_share(WorkflowShare {
         kind: WORKFLOW_KIND_IMAGE.to_owned(),
         schema_version: WORKFLOW_SHARE_SCHEMA_VERSION,
         producer: WorkflowProducer::default(),
@@ -650,14 +792,14 @@ pub fn build_workflow_share(asset: &Asset, job_payload: &JsonObject) -> Workflow
         width: u32_field("width").or(asset.file.width),
         height: u32_field("height").or(asset.file.height),
         count: u32_field("count"),
-        style_preset: string_field("stylePreset").filter(|value| !value.is_empty()),
-        style_id: string_field("styleId").filter(|value| !value.is_empty()),
-        fit_mode: string_field("fitMode").filter(|value| !value.is_empty()),
+        style_preset: string_field("stylePreset"),
+        style_id: string_field("styleId"),
+        fit_mode: string_field("fitMode"),
         upscale: sanitize_upscale(job_payload.get("upscale")),
         loras: sanitize_loras(job_payload.get("loras")),
         inputs: describe_inputs(job_payload),
         advanced,
-    }
+    })
 }
 
 /// Input images by shape. Reads the ids only to count them; no id ever reaches the envelope.
@@ -713,9 +855,7 @@ fn describe_inputs(job_payload: &JsonObject) -> Vec<WorkflowInput> {
         let control_mode = advanced
             .and_then(|advanced| advanced.get("controlMode"))
             .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-            .filter(|value| !is_path_shaped(value))
-            .map(str::to_owned);
+            .and_then(shareable_label);
         inputs.push(WorkflowInput {
             kind: INPUT_KIND_CONTROL.to_owned(),
             count: 1,
@@ -743,8 +883,7 @@ fn sanitize_upscale(value: Option<&Value>) -> Option<WorkflowUpscale> {
         engine: upscale
             .get("engine")
             .and_then(Value::as_str)
-            .filter(|engine| !engine.is_empty() && !is_path_shaped(engine))
-            .map(str::to_owned),
+            .and_then(shareable_label),
         softness: upscale.get("softness").and_then(Value::as_f64),
     })
 }
@@ -756,7 +895,7 @@ fn sanitize_loras(value: Option<&Value>) -> Vec<WorkflowLora> {
     entries
         .iter()
         .filter_map(Value::as_object)
-        .map(|entry| {
+        .filter_map(|entry| {
             // The catalog entry's `source` is `{ provider, repo, file }` for a Hugging Face
             // LoRA and `{ provider: "local", path }` for an imported one. Only the repo id
             // travels — never `path`, never `file`, never `installedPath`/`sourcePath`.
@@ -768,20 +907,152 @@ fn sanitize_loras(value: Option<&Value>) -> Vec<WorkflowLora> {
                 })
                 .and_then(|source| source.get("repo"))
                 .and_then(Value::as_str)
-                .and_then(hf_repo_id);
-            WorkflowLora {
-                name: entry
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|name| !name.is_empty() && !is_path_shaped(name))
-                    .map(str::to_owned),
+                .map(str::to_owned);
+            // `reduce_lora` is the shared guard — `hf_repo_id` on the repo, the path check on
+            // the name — so a repo id that arrives in an envelope is validated exactly as one
+            // read out of a job payload is.
+            reduce_lora(WorkflowLora {
+                name: entry.get("name").and_then(Value::as_str).map(str::to_owned),
                 weight: entry.get("weight").and_then(Value::as_f64),
                 repo,
-            }
+            })
         })
-        .filter(|lora| lora.name.is_some() || lora.weight.is_some() || lora.repo.is_some())
         .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Value-level reduction (shared by build and parse)
+// ---------------------------------------------------------------------------
+
+/// The four input kinds, in the order [`describe_inputs`] emits them. An `inputs[].kind`
+/// outside this set is not something a reader can act on, so it does not survive a parse.
+pub const INPUT_KINDS: &[&str] = &[
+    INPUT_KIND_SOURCE,
+    INPUT_KIND_REFERENCE,
+    INPUT_KIND_MASK,
+    INPUT_KIND_CONTROL,
+];
+
+/// Reduce every VALUE in an envelope to what the contract allows.
+///
+/// The typed struct reduces at KEY granularity only — it drops fields we do not declare, which
+/// is not the same as trusting the ones we do. An envelope that arrived from outside carries
+/// attacker-chosen strings under keys we *do* declare, and `loras[].repo` is the sharpest edge:
+/// a Hugging Face repo id is joined into a cache path (`models--owner--name`), so sc-15952's
+/// "install the missing LoRA" action would otherwise inherit whatever traversal string the file
+/// contained. Both directions run this one function so the guards cannot drift apart.
+fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
+    let WorkflowShare {
+        kind,
+        schema_version,
+        producer,
+        mode,
+        model,
+        prompt,
+        negative_prompt,
+        seed,
+        width,
+        height,
+        count,
+        style_preset,
+        style_id,
+        fit_mode,
+        upscale,
+        loras,
+        inputs,
+        advanced,
+    } = share;
+    WorkflowShare {
+        kind,
+        schema_version,
+        producer: reduce_producer(producer),
+        mode: shareable_label(&mode).unwrap_or_default(),
+        model: shareable_label(&model).unwrap_or_default(),
+        // Authored prose, exempt on purpose — see `is_path_shaped`.
+        prompt,
+        negative_prompt,
+        seed,
+        width,
+        height,
+        count,
+        style_preset: style_preset.as_deref().and_then(shareable_label),
+        style_id: style_id.as_deref().and_then(shareable_label),
+        fit_mode: fit_mode.as_deref().and_then(shareable_label),
+        upscale: upscale.map(|upscale| WorkflowUpscale {
+            enabled: upscale.enabled,
+            factor: upscale.factor,
+            engine: upscale.engine.as_deref().and_then(shareable_label),
+            softness: upscale.softness.filter(|value| value.is_finite()),
+        }),
+        loras: loras.into_iter().filter_map(reduce_lora).collect(),
+        inputs: inputs.into_iter().filter_map(reduce_input).collect(),
+        advanced: sanitize_advanced(&advanced),
+    }
+}
+
+/// One LoRA reference, reduced. An entry left with nothing to say is dropped entirely.
+fn reduce_lora(lora: WorkflowLora) -> Option<WorkflowLora> {
+    let reduced = WorkflowLora {
+        name: lora.name.as_deref().and_then(shareable_label),
+        weight: lora.weight.filter(|weight| weight.is_finite()),
+        // `owner/name` and nothing else. This is the value sc-15952 turns into a cache path.
+        repo: lora.repo.as_deref().and_then(hf_repo_id),
+    };
+    (reduced.name.is_some() || reduced.weight.is_some() || reduced.repo.is_some())
+        .then_some(reduced)
+}
+
+/// One input descriptor, reduced. A kind outside [`INPUT_KINDS`] is dropped — the shape list is
+/// a closed vocabulary, not free text.
+fn reduce_input(input: WorkflowInput) -> Option<WorkflowInput> {
+    if !INPUT_KINDS.contains(&input.kind.as_str()) {
+        return None;
+    }
+    Some(WorkflowInput {
+        control_mode: input.control_mode.as_deref().and_then(shareable_label),
+        kind: input.kind,
+        count: input.count,
+    })
+}
+
+/// The producer block, bounded. In an envelope from outside these are three free strings, so a
+/// name that is not a plain label, a URL that is not `http(s)`, or a version that is not strict
+/// `MAJOR.MINOR.PATCH` is reduced to empty rather than echoed to the user as provenance.
+fn reduce_producer(producer: WorkflowProducer) -> WorkflowProducer {
+    WorkflowProducer {
+        name: shareable_label(&producer.name).unwrap_or_default(),
+        url: shareable_label(&producer.url)
+            .filter(|url| is_web_url(url))
+            .unwrap_or_default(),
+        version: shareable_label(&producer.version)
+            .filter(|version| is_strict_semver(version))
+            .unwrap_or_default(),
+    }
+}
+
+/// An `http`/`https` URL with no whitespace in it. Deliberately narrow: the producer URL is the
+/// one URL the envelope carries, and anything else there is provenance nobody vouched for.
+fn is_web_url(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    (lower.starts_with("https://") || lower.starts_with("http://"))
+        && !value.chars().any(char::is_whitespace)
+}
+
+/// Strict `MAJOR.MINOR.PATCH` — the same shape `PRODUCER_VERSION` is asserted to have, applied
+/// to a version that arrived from somewhere else.
+fn is_strict_semver(value: &str) -> bool {
+    let mut parts = value.split('.');
+    let (Some(major), Some(minor), Some(patch), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    [major, minor, patch].iter().all(|part| {
+        !part.is_empty()
+            && part.len() <= 6
+            && part.bytes().all(|byte| byte.is_ascii_digit())
+            && (*part == "0" || !part.starts_with('0'))
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -857,25 +1128,30 @@ fn sanitize_structured_prompt(value: &Value) -> Option<Value> {
     (!out.is_empty()).then_some(Value::Object(out))
 }
 
+/// The pose fields the worker's `parse_poses` actually reads
+/// (`crates/sceneworks-worker/src/image_jobs/base.rs`). All three are pure coordinate arrays
+/// with nothing identifying in them, and `hands` / `face` change the rendered skeleton — and so
+/// the image — exactly as `keypoints` does. Dropping them would cost reproduction fidelity for
+/// zero privacy gain. What does NOT travel is the pose-library `id` that named the entry, and
+/// anything else the picker attached to it.
+const POSE_FIELDS: &[&str] = &["keypoints", "hands", "face"];
+
 fn sanitize_poses(value: &Value) -> Option<Value> {
     let poses = value.as_array()?;
     // The entry count is load-bearing (poses replace `count` variations), so an entry whose
-    // keypoints are missing or malformed still occupies its slot as an empty object.
+    // coordinates are missing or malformed still occupies its slot as an empty object.
     let sanitized: Vec<Value> = poses
         .iter()
         .map(|pose| {
-            let keypoints = pose
-                .as_object()
-                .and_then(|pose| pose.get("keypoints"))
-                .filter(|keypoints| is_numeric_tree(keypoints));
-            match keypoints {
-                Some(keypoints) => {
-                    let mut out = JsonObject::new();
-                    out.insert("keypoints".to_owned(), keypoints.clone());
-                    Value::Object(out)
+            let mut out = JsonObject::new();
+            if let Some(pose) = pose.as_object() {
+                for field in POSE_FIELDS {
+                    if let Some(numbers) = pose.get(*field).filter(|value| is_numeric_tree(value)) {
+                        out.insert((*field).to_owned(), numbers.clone());
+                    }
                 }
-                None => Value::Object(JsonObject::new()),
             }
+            Value::Object(out)
         })
         .collect();
     (!sanitized.is_empty()).then_some(Value::Array(sanitized))
@@ -971,12 +1247,21 @@ pub fn parse_workflow_share(value: &Value) -> Result<WorkflowShare, WorkflowShar
         });
     }
 
-    let schema_version = object
-        .get("schemaVersion")
-        .ok_or(WorkflowShareError::MissingSchemaVersion)?
-        .as_u64()
-        .and_then(|version| u32::try_from(version).ok())
-        .ok_or(WorkflowShareError::MissingSchemaVersion)?;
+    // Present-but-wrong and absent are different problems with different fixes, so they get
+    // different sentences: telling someone a field they can see in the file is "missing" sends
+    // them looking in the wrong place. An explicit `null` counts as absent, which is what a
+    // writer that omitted the field usually means.
+    let schema_version = match object.get("schemaVersion") {
+        None | Some(Value::Null) => return Err(WorkflowShareError::MissingSchemaVersion),
+        Some(present) => present
+            .as_u64()
+            .and_then(|version| u32::try_from(version).ok())
+            .ok_or_else(|| WorkflowShareError::Malformed {
+                field: "schemaVersion".to_owned(),
+                detail: "must be a whole number (the contract version the file was written with)"
+                    .to_owned(),
+            })?,
+    };
     if schema_version > WORKFLOW_SHARE_SCHEMA_VERSION {
         return Err(WorkflowShareError::UnsupportedSchemaVersion {
             file: schema_version,
@@ -989,12 +1274,10 @@ pub fn parse_workflow_share(value: &Value) -> Result<WorkflowShare, WorkflowShar
             field: field_from_serde_error(&error),
             detail: error.to_string(),
         })?;
-    // An envelope that arrived from outside is sanitized on the way IN as well: a hostile or
-    // simply older writer's `advanced` is reduced by the same allow-list the builder uses.
-    Ok(WorkflowShare {
-        advanced: sanitize_advanced(&share.advanced),
-        ..share
-    })
+    // An envelope that arrived from outside is reduced on the way IN by the same function that
+    // reduced ours on the way OUT — at VALUE granularity, not only key granularity. Dropping
+    // the keys we do not declare says nothing about the strings under the keys we do.
+    Ok(reduce_workflow_share(share))
 }
 
 /// Best-effort field name out of a serde error, so the message names something the user can
@@ -1282,6 +1565,173 @@ mod tests {
         }
     }
 
+    /// The guard used to test only the FIRST character for `\` and only recognized a drive
+    /// letter when a separator followed it, so every one of these travelled verbatim out of an
+    /// allow-listed key — and the relative-Windows ones carry the OS username. The story's line
+    /// is "every filesystem path without exception", so each of these is pinned here.
+    #[test]
+    fn is_path_shaped_catches_relative_traversing_and_drive_relative_locations() {
+        for path in [
+            // Relative Windows, no leading separator.
+            "Users\\Michael\\Desktop\\secret.png",
+            "models\\weights\\x.safetensors",
+            // Traversal, both separators.
+            "..\\..\\Users\\Michael",
+            "../../etc/passwd",
+            "./local/thing",
+            // Drive-relative: a drive prefix with NO separator after it.
+            "C:foo",
+            "c:secret\\file",
+            // Environment expansion.
+            "%USERPROFILE%\\x",
+            // A relative POSIX tree.
+            "assets/images/x.png",
+            // `~user` as well as `~/`.
+            "~michael/x",
+            // Percent-encoded `file://D:/x`, single- and double-encoded.
+            "file%3A%2F%2FD%3A%2Fx",
+            "FILE%3a%2F%2FD%3A%2fx",
+            "file%253A%252F%252FD%253A%252Fx",
+            "Users%5CMichael%5CDesktop%5Cx.png",
+        ] {
+            assert!(is_path_shaped(path), "{path:?} should read as a path");
+        }
+    }
+
+    /// The other half of the guard: a check this aggressive must not eat legitimate labels.
+    /// Everything here is a real value the envelope carries.
+    #[test]
+    fn is_path_shaped_keeps_legitimate_labels() {
+        for safe in [
+            "euler",
+            "dpmpp_2m",
+            "beta",
+            "cfg_pp",
+            "1024x1024",
+            "2k",
+            // Hugging Face repo ids are `owner/name` — two segments, and they stay.
+            "acme/mira",
+            "acme/foggy-coast",
+            "stabilityai/stable-diffusion-xl-base-1.0",
+            "https://github.com/SceneWorks/SceneWorks",
+            "https://huggingface.co/acme/mira/tree/main",
+            "text_to_image",
+            "krea_2_turbo",
+            "z_image_turbo",
+            "seedvr2",
+            "noir_bloom",
+            "cinematic",
+            "crop",
+            "canny",
+            "three_quarter_left",
+            "",
+        ] {
+            assert!(!is_path_shaped(safe), "{safe:?} should not read as a path");
+        }
+    }
+
+    #[test]
+    fn prose_keys_carry_what_the_user_typed_even_when_it_names_a_path() {
+        // The deliberate exemption, pinned. `stylePrompt` and the structured prompt's `intent` /
+        // `runtimePrompt` are the same class as the top-level `prompt`, which the story puts IN:
+        // silently mangling authored text because it mentions a directory would be worse than the
+        // leak it prevents, and the user can see what they typed.
+        let advanced = json!({
+            "stylePrompt": "C:\\Users\\Michael\\Desktop\\secret_project\\brief.txt",
+            "structuredPrompt": {
+                "intent": "/home/michael/clients/acme/nda.md",
+                "runtimePrompt": "see ..\\..\\briefs\\acme.json"
+            },
+            "sampler": "C:\\Users\\Michael\\samplers\\euler.json"
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        assert_eq!(
+            sanitized["stylePrompt"],
+            json!("C:\\Users\\Michael\\Desktop\\secret_project\\brief.txt")
+        );
+        let recipe = sanitized["structuredPrompt"].as_object().expect("object");
+        assert_eq!(recipe["intent"], json!("/home/michael/clients/acme/nda.md"));
+        assert_eq!(
+            recipe["runtimePrompt"],
+            json!("see ..\\..\\briefs\\acme.json")
+        );
+        // A NON-prose key next to them is still guarded — the exemption is per key, not global.
+        assert!(!sanitized.contains_key("sampler"));
+        assert_eq!(PROSE_KEYS, ["stylePrompt", "intent", "runtimePrompt"]);
+    }
+
+    #[test]
+    fn top_level_labels_are_path_guarded_like_advanced_ones() {
+        let mut payload = payload_fixture();
+        for (key, value) in [
+            ("mode", "C:\\modes\\evil"),
+            ("model", "C:\\models\\evil"),
+            ("stylePreset", "\\\\server\\styles\\x"),
+            ("styleId", "../../etc/passwd"),
+            ("fitMode", "/etc/passwd"),
+        ] {
+            payload.insert(key.to_owned(), json!(value));
+        }
+        payload.insert(
+            "upscale".to_owned(),
+            json!({ "enabled": true, "engine": "E:\\engines\\seedvr2" }),
+        );
+        let share = build_workflow_share(&asset_fixture(), &payload);
+        assert_eq!(share.mode, "");
+        assert_eq!(share.model, "");
+        assert_eq!(share.style_preset, None);
+        assert_eq!(share.style_id, None);
+        assert_eq!(share.fit_mode, None);
+        assert_eq!(share.upscale.as_ref().expect("upscale").engine, None);
+        let encoded = serde_json::to_string(&share).expect("serializes");
+        for leak in ["evil", "server", "etc/passwd", "engines"] {
+            assert!(!encoded.contains(leak), "{leak} leaked into the envelope");
+        }
+    }
+
+    #[test]
+    fn poses_keep_every_numeric_coordinate_array_the_worker_renders() {
+        // `hands` and `face` change the rendered skeleton exactly as `keypoints` does and hold
+        // nothing but coordinates, so dropping them would cost fidelity for no privacy gain.
+        let advanced = json!({
+            "poses": [{
+                "id": "pose_local_uuid",
+                "label": "Standing, arms out",
+                "keypoints": [[0.1, 0.2], [0.3, 0.4]],
+                "hands": [[[0.5, 0.6]], [[0.7, 0.8]]],
+                "face": [[0.9, 1.0]],
+                "sourcePath": "C:\\poses\\a.json"
+            }]
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        let pose = sanitized["poses"][0].as_object().expect("object");
+        assert_eq!(
+            pose.keys().collect::<Vec<_>>(),
+            vec!["face", "hands", "keypoints"]
+        );
+        let encoded = serde_json::to_string(&sanitized).expect("serializes");
+        for leak in ["pose_local_uuid", "Standing", "sourcePath", "C:\\\\poses"] {
+            assert!(!encoded.contains(leak), "{leak} leaked into the envelope");
+        }
+
+        // A non-numeric `hands`/`face` is not coordinates and does not travel.
+        let smuggled = json!({
+            "poses": [{ "keypoints": [[0.1, 0.2]], "hands": "C:\\hands\\a.json", "face": { "path": "/x" } }]
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&smuggled);
+        let pose = sanitized["poses"][0].as_object().expect("object");
+        assert_eq!(pose.keys().collect::<Vec<_>>(), vec!["keypoints"]);
+    }
+
     #[test]
     fn parse_rejects_a_missing_marker() {
         let error = parse_workflow_share(&json!({ "schemaVersion": 1 }))
@@ -1374,5 +1824,183 @@ mod tests {
         assert_eq!(share.advanced.keys().collect::<Vec<_>>(), vec!["steps"]);
         let encoded = serde_json::to_string(&share).expect("serializes");
         assert!(!encoded.contains("somethingNew"));
+    }
+
+    /// Dropping unknown KEYS is only half the job: every string under a key we DO declare is
+    /// attacker-chosen in a file that came from a stranger. `loras[].repo` is the sharpest edge
+    /// — sc-15952 joins a repo id into a Hugging Face cache path — so a traversal string there
+    /// must not survive the parse. Nothing here is echoed back out.
+    #[test]
+    fn parse_reduces_a_hostile_envelope_instead_of_echoing_it() {
+        let hostile = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": {
+                "name": "SceneWorks (build C:\\Users\\Michael\\src)",
+                "url": "file:///D:/exfil.html",
+                "version": "0.8.1-dirty-MICHAELS-PC"
+            },
+            "mode": "..\\..\\Users\\Michael",
+            "model": "C:\\models\\evil",
+            "prompt": "a lighthouse",
+            "stylePreset": "\\\\server\\styles\\x",
+            "styleId": "../../etc/passwd",
+            "fitMode": "/etc/passwd",
+            "upscale": { "enabled": true, "factor": 2, "engine": "E:\\engines\\seedvr2" },
+            "loras": [
+                { "name": "Foggy Coast", "weight": 0.65, "repo": "../../../etc/passwd" },
+                { "name": "C:\\Users\\Michael\\loras\\x", "repo": "acme/mira" },
+                { "name": "..\\..\\Users\\Michael\\loras", "weight": 0.4, "repo": "acme/../../etc" },
+                { "name": "/etc/passwd", "repo": "../x" }
+            ],
+            "inputs": [
+                { "kind": "source", "count": 1 },
+                { "kind": "C:\\Users\\Michael", "count": 1 },
+                { "kind": "control", "count": 1, "controlMode": "/etc/passwd" }
+            ],
+            "advanced": { "steps": 8, "sampler": "C:\\Users\\Michael\\euler.json" }
+        });
+        let share = parse_workflow_share(&hostile).expect("a hostile envelope still parses");
+
+        assert_eq!(share.mode, "");
+        assert_eq!(share.model, "");
+        assert_eq!(share.style_preset, None);
+        assert_eq!(share.style_id, None);
+        assert_eq!(share.fit_mode, None);
+        assert_eq!(share.upscale.as_ref().expect("upscale").engine, None);
+
+        // `repo` is validated as `owner/name`, exactly as it is on build. The fourth entry had
+        // nothing left to say once its name and repo were dropped, so it does not travel at all.
+        assert_eq!(share.loras.len(), 3);
+        assert_eq!(share.loras[0].repo, None);
+        assert_eq!(share.loras[0].name.as_deref(), Some("Foggy Coast"));
+        assert_eq!(share.loras[1].repo.as_deref(), Some("acme/mira"));
+        assert_eq!(share.loras[1].name, None);
+        assert_eq!(share.loras[2].repo, None);
+        assert_eq!(share.loras[2].name, None);
+        assert_eq!(share.loras[2].weight, Some(0.4));
+
+        // `.` and `-` are legal inside an HF segment, so `../x` is the shape a naive
+        // `owner/name` check waves through. A segment must start with an alphanumeric.
+        for rejected in [
+            "../x",
+            "acme/..",
+            "./x",
+            "../../../etc/passwd",
+            "acme/../../etc",
+            "/acme/mira",
+            "acme",
+            "",
+        ] {
+            assert_eq!(hf_repo_id(rejected), None, "{rejected:?} is not a repo id");
+        }
+        for accepted in [
+            "acme/mira",
+            "acme/foggy-coast",
+            "stabilityai/stable-diffusion-xl-base-1.0",
+        ] {
+            assert_eq!(hf_repo_id(accepted).as_deref(), Some(accepted));
+        }
+
+        // An `inputs[].kind` outside the closed vocabulary is not something a reader can act on.
+        let kinds: Vec<&str> = share
+            .inputs
+            .iter()
+            .map(|input| input.kind.as_str())
+            .collect();
+        assert_eq!(kinds, vec![INPUT_KIND_SOURCE, INPUT_KIND_CONTROL]);
+        assert_eq!(share.inputs[1].control_mode, None);
+
+        // The producer block is provenance nobody vouched for; a name, URL or version that is
+        // not the shape we publish is reduced to empty rather than shown to the user as fact.
+        assert_eq!(share.producer.name, "");
+        assert_eq!(share.producer.url, "");
+        assert_eq!(share.producer.version, "");
+
+        assert_eq!(share.advanced.keys().collect::<Vec<_>>(), vec!["steps"]);
+
+        let encoded = serde_json::to_string(&share).expect("serializes");
+        for leak in [
+            "Michael", "C:\\\\", "E:\\\\", "etc", "file://", "server", "evil", "exfil", "dirty",
+        ] {
+            assert!(
+                !encoded.contains(leak),
+                "{leak} survived the parse: {encoded}"
+            );
+        }
+    }
+
+    /// A well-formed producer block from another build travels intact — the reduction bounds the
+    /// block, it does not erase it (the whole point of recording the producer is a bug report
+    /// that says which build wrote the file).
+    #[test]
+    fn parse_keeps_a_well_formed_producer_block_from_another_build() {
+        let other = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "99.12.0" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "p"
+        });
+        let share = parse_workflow_share(&other).expect("parses");
+        assert_eq!(share.producer.name, PRODUCER_NAME);
+        assert_eq!(share.producer.url, PRODUCER_URL);
+        assert_eq!(share.producer.version, "99.12.0");
+    }
+
+    #[test]
+    fn parse_distinguishes_a_malformed_schema_version_from_a_missing_one() {
+        let envelope = |version: Value| {
+            let mut object = JsonObject::new();
+            object.insert(
+                WORKFLOW_SHARE_MARKER_KEY.to_owned(),
+                json!(WORKFLOW_KIND_IMAGE),
+            );
+            if !version.is_null() {
+                object.insert("schemaVersion".to_owned(), version);
+            }
+            Value::Object(object)
+        };
+
+        // Absent (and an explicit null, which a writer that omitted the field usually means).
+        for missing in [Value::Null, json!(null)] {
+            assert_eq!(
+                parse_workflow_share(&envelope(missing)).expect_err("no schemaVersion"),
+                WorkflowShareError::MissingSchemaVersion
+            );
+        }
+        assert_eq!(
+            parse_workflow_share(&json!({
+                "sceneworksWorkflow": "image",
+                "schemaVersion": null
+            }))
+            .expect_err("null schemaVersion"),
+            WorkflowShareError::MissingSchemaVersion
+        );
+
+        // Present but the wrong shape — a different problem with a different fix, so a
+        // different sentence. Telling someone a field they can SEE is missing sends them
+        // looking in the wrong place.
+        for malformed in [json!("1"), json!(-1), json!(1.5), json!([1]), json!({})] {
+            let error = parse_workflow_share(&envelope(malformed.clone()))
+                .expect_err("malformed schemaVersion");
+            assert_eq!(
+                error,
+                WorkflowShareError::Malformed {
+                    field: "schemaVersion".to_owned(),
+                    detail:
+                        "must be a whole number (the contract version the file was written with)"
+                            .to_owned(),
+                },
+                "{malformed} should read as malformed, not missing"
+            );
+            let message = error.to_string();
+            assert!(message.contains("schemaVersion"), "{message}");
+            assert!(
+                !message.contains("missing"),
+                "a present-but-wrong version must not be reported as missing: {message}"
+            );
+        }
     }
 }

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -1,0 +1,1378 @@
+//! The sanitized workflow share envelope (sc-15946, epic 15945).
+//!
+//! A generated image that leaves the app — pasted into Discord, attached to a bug report,
+//! posted anywhere — takes its recipe with it only if the recipe is *inside the file*. The
+//! local sidecar (`<media>.sceneworks.json` + `recipes/<id>.recipe.json`) dies at the first
+//! copy-paste, which is the whole reason this envelope exists. This module owns the
+//! contract; the PNG chunk writer (sc-15947) and the drag-to-load reader (sc-15952) build
+//! on top of it. No file I/O and no PNG work happens here.
+//!
+//! Modeled on `apps/web/src/promptBatchIO.js` (sc-9954), which already solves this shape for
+//! prompt batches: a versioned envelope under a marker key, authored content only, ids /
+//! paths / timestamps stripped, and descriptive errors on parse rather than a silent default.
+//!
+//! # Two versions, deliberately not one
+//!
+//! * [`WorkflowShare::schema_version`] — the *contract* version. Bumped only when a field
+//!   changes meaning or disappears. This is the only thing [`parse_workflow_share`] branches
+//!   on.
+//! * [`WorkflowProducer::version`] — the *build* that wrote the file, straight from
+//!   `CARGO_PKG_VERSION` (the `[workspace.package] version` that `scripts/sync-version.mjs`
+//!   keeps in lockstep with the web/desktop manifests). It never drives parsing. It exists so
+//!   a bug report is actionable: "this came out of 0.8.1, which still had the old scheduler
+//!   default".
+//!
+//! The producer version is the ONE field the allow-list below cannot protect, because it is a
+//! field we deliberately include. So it must be the released version string and nothing else —
+//! never `git describe`, never a dirty-tree suffix, never a CI build number, never anything
+//! path- or host-derived. `0.8.1-dirty-Michael` would walk straight into every shared image.
+//! [`PRODUCER_VERSION`] is `env!("CARGO_PKG_VERSION")` for exactly that reason, and a test
+//! asserts it is strict `MAJOR.MINOR.PATCH`.
+//!
+//! # Allow-list, never a deny-list
+//!
+//! `advanced` (cloned verbatim into an asset's `rawAdapterSettings`) is untyped and grows
+//! whenever someone adds a knob to `apps/web/src/imageJobAdvanced.js`. A deny-list leaks every
+//! future field by default, so [`ADVANCED_KEY_RULES`] classifies every key the builder can emit
+//! and anything unclassified is dropped. `crates/sceneworks-core/tests/workflow_share.rs`
+//! parses that JS file and fails the build when a key is neither allow-listed nor explicitly
+//! denied — a new knob can neither silently leak nor silently vanish.
+//!
+//! The line between in and out is *what to make* vs *what this machine can afford*:
+//! sampler / steps / guidance / PiD describe the intended output and travel; quant tier,
+//! flash-attention and the requested GPU describe this install's hardware budget and do not.
+//! Ids, paths, project and machine names, and timestamps never travel. Note the asymmetry
+//! with the producer block: build identity is in, *installation* identity is out.
+//!
+//! # Input images by shape, not by id
+//!
+//! A recipe that needs a source / reference / mask / control image records **that it needs
+//! one, and of what kind** ([`WorkflowInput`]) — never a dangling local UUID. That is what
+//! lets sc-15952 render a useful missing-inputs panel without leaking ids or bloating the
+//! file with base64.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::contracts::{Asset, JsonObject};
+
+/// Marker key the envelope is published under. Its presence is what makes a blob
+/// identifiable as ours (the `promptBatchIO` marker-key pattern).
+pub const WORKFLOW_SHARE_MARKER_KEY: &str = "sceneworksWorkflow";
+
+/// Marker value for the image lane. The value names the workflow *kind* so the video half
+/// (sc-15956) can share the marker key without a reader having to sniff the body.
+pub const WORKFLOW_KIND_IMAGE: &str = "image";
+
+/// The contract version. Bump ONLY on a breaking field change — an additive field does not
+/// need it (an older reader drops what it does not know). [`parse_workflow_share`] branches
+/// on this and on nothing else.
+pub const WORKFLOW_SHARE_SCHEMA_VERSION: u32 = 1;
+
+/// Producer name. Names the software, never the installation.
+pub const PRODUCER_NAME: &str = "SceneWorks";
+
+/// Canonical repository URL, so a file that reaches someone with no context is
+/// self-identifying.
+pub const PRODUCER_URL: &str = "https://github.com/SceneWorks/SceneWorks";
+
+/// The released build that wrote the file — the workspace version, at compile time.
+///
+/// `sceneworks-core` inherits `version.workspace = true`, so this is the root `Cargo.toml`
+/// `[workspace.package] version` verbatim. Deliberately NOT derived from git, the environment,
+/// the build host or the build path; see the module docs.
+pub const PRODUCER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Identifies the software that wrote the envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowProducer {
+    pub name: String,
+    pub url: String,
+    /// Semver of the build that wrote the file. Never parsed against; see the module docs.
+    pub version: String,
+}
+
+impl Default for WorkflowProducer {
+    fn default() -> Self {
+        Self {
+            name: PRODUCER_NAME.to_owned(),
+            url: PRODUCER_URL.to_owned(),
+            version: PRODUCER_VERSION.to_owned(),
+        }
+    }
+}
+
+/// The kind of input image a recipe needs, recorded WITHOUT the local asset id that supplied
+/// it. `count` is how many of that kind the original run used.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowInput {
+    /// One of [`INPUT_KIND_SOURCE`], [`INPUT_KIND_REFERENCE`], [`INPUT_KIND_MASK`],
+    /// [`INPUT_KIND_CONTROL`].
+    pub kind: String,
+    pub count: u32,
+    /// For [`INPUT_KIND_CONTROL`]: the conditioning the map feeds (`canny`, `depth`, …), when
+    /// the original run named one. Never a path or an id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_mode: Option<String>,
+}
+
+/// The image an edit starts from (`sourceAssetId`).
+pub const INPUT_KIND_SOURCE: &str = "source";
+/// Identity / style reference image(s) (`referenceAssetId`, `referenceAssetIds`).
+pub const INPUT_KIND_REFERENCE: &str = "reference";
+/// Inpaint mask (`maskAssetId`).
+pub const INPUT_KIND_MASK: &str = "mask";
+/// A pre-made control map fed verbatim (`advanced.controlImage`).
+pub const INPUT_KIND_CONTROL: &str = "control";
+
+/// A LoRA the run applied, reduced to what another install can act on: the display name, the
+/// weight, and the Hugging Face repo id when the catalog entry resolved to one. No local id,
+/// no installed path, no source path.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowLora {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
+    /// `owner/name` on Hugging Face, when the payload's catalog entry named one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+}
+
+/// The upscale pass, when the run enabled one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowUpscale {
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub factor: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub softness: Option<f64>,
+}
+
+/// The portable, sanitized workflow of one generated image.
+///
+/// Deliberately has NO `#[serde(flatten)] extra` bucket, unlike the sidecar contracts in
+/// [`crate::contracts`]. Those preserve unknown keys so a newer writer's fields survive an
+/// older reader; here that would defeat the whole point — an envelope arriving from outside
+/// must be reduced to the fields we classify, on parse as well as on build. Unknown keys are
+/// dropped in both directions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowShare {
+    /// The marker key. Its value names the workflow kind ([`WORKFLOW_KIND_IMAGE`]).
+    #[serde(rename = "sceneworksWorkflow")]
+    pub kind: String,
+    /// The contract version — the ONLY field the parser branches on.
+    pub schema_version: u32,
+    pub producer: WorkflowProducer,
+    pub mode: String,
+    /// The model catalog slug (`z_image_turbo`), never a resolved weights location.
+    pub model: String,
+    pub prompt: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub negative_prompt: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style_preset: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fit_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upscale: Option<WorkflowUpscale>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub loras: Vec<WorkflowLora>,
+    /// Input images by shape, never by id.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<WorkflowInput>,
+    /// The allow-listed subset of the request's `advanced` map. See [`ADVANCED_KEY_RULES`].
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub advanced: JsonObject,
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Why an envelope could not be read. Every variant carries enough detail to show the user a
+/// sentence, which is the point: a workflow that arrived from a stranger's PNG must never
+/// surface as a raw serde message or, worse, silently default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkflowShareError {
+    /// The text was not JSON at all.
+    InvalidJson(String),
+    /// The JSON parsed but is not an object (an array, a bare string, …).
+    NotAnObject,
+    /// No `sceneworksWorkflow` marker key — this blob was not written by us.
+    MissingMarker,
+    /// The marker is present but names a workflow kind this reader does not handle
+    /// (the image reader handed a video envelope, sc-15956).
+    UnsupportedKind { found: String, supported: String },
+    /// `schemaVersion` is missing or not a non-negative integer.
+    MissingSchemaVersion,
+    /// The file's contract version is newer than this build's. Names both versions so the
+    /// user is told to update rather than shown a parse failure.
+    UnsupportedSchemaVersion { file: u32, supported: u32 },
+    /// A declared field is present but the wrong shape.
+    Malformed { field: String, detail: String },
+}
+
+impl fmt::Display for WorkflowShareError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidJson(detail) => {
+                write!(f, "Not a valid SceneWorks workflow: invalid JSON ({detail}).")
+            }
+            Self::NotAnObject => write!(
+                f,
+                "Not a valid SceneWorks workflow: the workflow must be a JSON object."
+            ),
+            Self::MissingMarker => write!(
+                f,
+                "This file is not a SceneWorks workflow (no `{WORKFLOW_SHARE_MARKER_KEY}` marker)."
+            ),
+            Self::UnsupportedKind { found, supported } => write!(
+                f,
+                "This is a `{found}` SceneWorks workflow; this reader handles `{supported}` workflows."
+            ),
+            Self::MissingSchemaVersion => write!(
+                f,
+                "This SceneWorks workflow is missing its `schemaVersion`, so it cannot be read safely."
+            ),
+            Self::UnsupportedSchemaVersion { file, supported } => write!(
+                f,
+                "This workflow was written with schema version {file}; this build of {PRODUCER_NAME} reads version {supported}. Update {PRODUCER_NAME} to load it."
+            ),
+            Self::Malformed { field, detail } => write!(
+                f,
+                "This SceneWorks workflow is malformed: `{field}` {detail}."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for WorkflowShareError {}
+
+// ---------------------------------------------------------------------------
+// The `advanced` allow-list
+// ---------------------------------------------------------------------------
+
+/// Whether a key travels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdvancedDisposition {
+    /// Authored generation intent — travels.
+    Allow,
+    /// Install-specific, identifying, or otherwise not shareable — dropped, on purpose.
+    Deny,
+}
+
+/// Where a key comes from, so the coverage lint knows which rules it can hold the JS builder
+/// accountable for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdvancedKeySource {
+    /// Emitted by `buildImageJobAdvanced` in `apps/web/src/imageJobAdvanced.js`. The coverage
+    /// lint asserts these match the JS source exactly, in both directions.
+    StudioBuilder,
+    /// Stamped onto `advanced` by the API after the request arrives (recipe-preset resolution
+    /// in `apps/rust-api/src/generation.rs`). Classified here for the record; the lint does
+    /// not expect to find them in the JS.
+    Server,
+}
+
+/// How an allowed value is reduced. Anything that does not match its shape is dropped rather
+/// than passed through — that is what stops an object (and any path inside it) from being
+/// smuggled under an allow-listed scalar key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdvancedShape {
+    /// String, number or bool. Path-shaped strings are dropped (see [`is_path_shaped`]).
+    Scalar,
+    /// The structured-prompt recipe (`apps/web/src/ideogramCaption.js`), reduced to its scalar
+    /// fields. The free-form `caption` object is dropped — its serialized form already rides
+    /// in `runtimePrompt` and in the top-level `prompt`.
+    StructuredPrompt,
+    /// The pose-library selection, reduced to keypoints. Pose library ids do not travel.
+    Poses,
+    /// The Krea multi-phase denoise list, reduced to `{ steps, guidance, loras:[{index, weight}] }`.
+    Phases,
+}
+
+/// One classified `advanced` key.
+#[derive(Debug, Clone, Copy)]
+pub struct AdvancedKeyRule {
+    pub key: &'static str,
+    pub disposition: AdvancedDisposition,
+    pub shape: AdvancedShape,
+    pub source: AdvancedKeySource,
+    /// Why. Read by a human deciding where a NEW knob belongs.
+    pub reason: &'static str,
+}
+
+const fn allow(key: &'static str, shape: AdvancedShape, reason: &'static str) -> AdvancedKeyRule {
+    AdvancedKeyRule {
+        key,
+        disposition: AdvancedDisposition::Allow,
+        shape,
+        source: AdvancedKeySource::StudioBuilder,
+        reason,
+    }
+}
+
+const fn deny(key: &'static str, reason: &'static str) -> AdvancedKeyRule {
+    AdvancedKeyRule {
+        key,
+        disposition: AdvancedDisposition::Deny,
+        shape: AdvancedShape::Scalar,
+        source: AdvancedKeySource::StudioBuilder,
+        reason,
+    }
+}
+
+const fn deny_server(key: &'static str, reason: &'static str) -> AdvancedKeyRule {
+    AdvancedKeyRule {
+        key,
+        disposition: AdvancedDisposition::Deny,
+        shape: AdvancedShape::Scalar,
+        source: AdvancedKeySource::Server,
+        reason,
+    }
+}
+
+/// Every `advanced` key, classified.
+///
+/// The load-bearing table. `crates/sceneworks-core/tests/workflow_share.rs` parses
+/// `apps/web/src/imageJobAdvanced.js` and fails when a key the builder can emit is missing
+/// here — so a new knob is a compile-time decision, not a silent leak and not a silent loss.
+///
+/// The rule of thumb when classifying a new key: does it describe **what to make** (travels)
+/// or **what this machine can afford to make it with** (does not)?
+pub const ADVANCED_KEY_RULES: &[AdvancedKeyRule] = &[
+    allow(
+        "resolution",
+        AdvancedShape::Scalar,
+        "The authored output geometry label (\"1024x1024\") the studio control was set to.",
+    ),
+    allow(
+        "structuredPrompt",
+        AdvancedShape::StructuredPrompt,
+        "Authored prompt content for structured-caption models; reduced to its scalar fields.",
+    ),
+    allow("sampler", AdvancedShape::Scalar, "Authored sampler choice."),
+    allow(
+        "scheduler",
+        AdvancedShape::Scalar,
+        "Authored scheduler choice.",
+    ),
+    allow(
+        "schedulerShift",
+        AdvancedShape::Scalar,
+        "Authored time-shift (mu) for the curated schedule.",
+    ),
+    allow(
+        "steps",
+        AdvancedShape::Scalar,
+        "Authored step-count override.",
+    ),
+    allow(
+        "guidanceScale",
+        AdvancedShape::Scalar,
+        "Authored guidance override.",
+    ),
+    allow(
+        "guidanceMethod",
+        AdvancedShape::Scalar,
+        "Authored guidance method (CFG / CFG++).",
+    ),
+    allow(
+        "enhancePrompt",
+        AdvancedShape::Scalar,
+        "Authored caption-upsampling opt-in — changes the prompt the model sees.",
+    ),
+    allow(
+        "usePid",
+        AdvancedShape::Scalar,
+        "Authored decoder choice: PiD changes the produced image, and is the output's \
+         non-commercial marker. Unlike a quant tier it is not a memory accommodation.",
+    ),
+    allow(
+        "pidTarget",
+        AdvancedShape::Scalar,
+        "Authored PiD output tier (2k / 4k) — output geometry, not a hardware budget.",
+    ),
+    allow(
+        "ipAdapterScale",
+        AdvancedShape::Scalar,
+        "Authored reference strength.",
+    ),
+    allow(
+        "controlnetConditioningScale",
+        AdvancedShape::Scalar,
+        "Authored identity-structure strength (InstantID).",
+    ),
+    allow(
+        "trueCfgScale",
+        AdvancedShape::Scalar,
+        "Authored variation strength.",
+    ),
+    allow(
+        "strength",
+        AdvancedShape::Scalar,
+        "Authored img2img strength.",
+    ),
+    allow(
+        "textStyleGain",
+        AdvancedShape::Scalar,
+        "Authored Krea text-style tap-reweight gain.",
+    ),
+    allow(
+        "viewAngle",
+        AdvancedShape::Scalar,
+        "Authored head-angle label.",
+    ),
+    allow(
+        "poses",
+        AdvancedShape::Poses,
+        "Authored pose selection. Keypoints travel; the pose-library ids that named them do not.",
+    ),
+    allow(
+        "faceRestore",
+        AdvancedShape::Scalar,
+        "Authored face-restoration opt-in.",
+    ),
+    allow(
+        "controlMode",
+        AdvancedShape::Scalar,
+        "Authored control type (canny / depth / …). The control IMAGE rides as an input shape.",
+    ),
+    allow(
+        "controlScale",
+        AdvancedShape::Scalar,
+        "Authored control-lock strength.",
+    ),
+    allow(
+        "styleId",
+        AdvancedShape::Scalar,
+        "The catalog style the user picked.",
+    ),
+    allow(
+        "stylePrompt",
+        AdvancedShape::Scalar,
+        "The raw pre-style prompt, so a reader sees what was actually typed.",
+    ),
+    allow(
+        "phases",
+        AdvancedShape::Phases,
+        "Authored multi-phase denoise schedule; LoRA references are indices into this \
+         request's own list, not ids.",
+    ),
+    deny(
+        "flashAttn",
+        "A backend kernel toggle — describes what this install's attention path can do, \
+         not what to make.",
+    ),
+    deny(
+        "mlxQuantize",
+        "Quant tier: a memory accommodation for THIS machine. The receiving install picks \
+         its own.",
+    ),
+    deny(
+        "mlxQuantizeExplicit",
+        "Marks a deliberate tier pick on this install; meaningless and misleading elsewhere.",
+    ),
+    deny(
+        "convRot",
+        "The INT8-ConvRot tier selector — the same hardware-budget class as `mlxQuantize`.",
+    ),
+    deny(
+        "quantTier",
+        "Named out explicitly by sc-15946: install-specific and fingerprinting.",
+    ),
+    deny(
+        "controlImage",
+        "A local asset id. The fact that a control image is needed rides in `inputs` instead.",
+    ),
+    deny(
+        "controlWeights",
+        "A trained-overlay id plus the resolved weights PATH the API stamps onto it.",
+    ),
+    deny_server(
+        "recipePresetId",
+        "A local preset id stamped by the API; it resolves to nothing on another install.",
+    ),
+    deny_server(
+        "presetMissingLoras",
+        "Local LoRA ids the API could not resolve on THIS install.",
+    ),
+];
+
+/// The rule for `key`, if it is classified.
+#[must_use]
+pub fn advanced_key_rule(key: &str) -> Option<&'static AdvancedKeyRule> {
+    ADVANCED_KEY_RULES.iter().find(|rule| rule.key == key)
+}
+
+// ---------------------------------------------------------------------------
+// Path shapes
+// ---------------------------------------------------------------------------
+
+/// True when `value` looks like a filesystem location.
+///
+/// Belt to the allow-list's braces: no allow-listed `advanced` key legitimately holds a path,
+/// so any value that looks like one is dropped even from a key that is otherwise in. Covers
+/// POSIX absolutes, Windows drive letters (anywhere in the string, which catches
+/// `"loaded from C:\\Users\\…"`), UNC shares, `file://` URLs and `~` expansions.
+///
+/// Deliberately NOT applied to the authored prose fields (`prompt`, `negativePrompt`,
+/// `stylePrompt`, the structured prompt's `intent` / `runtimePrompt`): those are what the user
+/// typed, and silently mangling a prompt because it mentions a directory would be worse than
+/// the leak it prevents — the user authored it and can see it.
+#[must_use]
+pub fn is_path_shaped(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.to_ascii_lowercase().contains("file://") {
+        return true;
+    }
+    if trimmed.starts_with('/') || trimmed.starts_with('\\') {
+        return true;
+    }
+    if trimmed.starts_with("~/") || trimmed.starts_with("~\\") {
+        return true;
+    }
+    // A drive-letter prefix anywhere: `C:\`, `d:/`.
+    let bytes = trimmed.as_bytes();
+    for index in 0..bytes.len().saturating_sub(2) {
+        let letter = bytes[index];
+        if !letter.is_ascii_alphabetic() {
+            continue;
+        }
+        // Only when the letter starts a token, so `https://x` is not read as a drive.
+        if index > 0 && (bytes[index - 1].is_ascii_alphanumeric() || bytes[index - 1] == b':') {
+            continue;
+        }
+        if bytes[index + 1] == b':' && (bytes[index + 2] == b'\\' || bytes[index + 2] == b'/') {
+            return true;
+        }
+    }
+    false
+}
+
+/// A Hugging Face repo id (`owner/name`) and nothing else — never a path, never a URL.
+fn hf_repo_id(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    let mut segments = trimmed.split('/');
+    let (Some(owner), Some(name), None) = (segments.next(), segments.next(), segments.next())
+    else {
+        return None;
+    };
+    let segment_ok = |segment: &str| {
+        !segment.is_empty()
+            && segment.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
+            })
+    };
+    (segment_ok(owner) && segment_ok(name)).then(|| trimmed.to_owned())
+}
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+/// Build the sanitized envelope for one generated asset.
+///
+/// `job_payload` is the job row's `payload_json` — the exact `ImageJobRequest` the API stored,
+/// NOT the asset's `recipe`. The recipe is lossy: `sourceAssetId`, `referenceAssetIds`,
+/// `maskAssetId`, `fitMode` and `upscale` are split between `lineage` and the untyped
+/// `rawAdapterSettings` (see `crate::project_store::build_image_sidecar_parts`).
+///
+/// `asset` supplies the two things the payload cannot: the media kind, and the seed of THIS
+/// image — the payload carries the whole batch's `seeds`, and only the sidecar knows which one
+/// produced the file being shared.
+#[must_use]
+pub fn build_workflow_share(asset: &Asset, job_payload: &JsonObject) -> WorkflowShare {
+    let string_field = |key: &str| {
+        job_payload
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    };
+    let u32_field = |key: &str| {
+        job_payload
+            .get(key)
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+    };
+
+    let mode = string_field("mode").unwrap_or_else(|| asset.recipe.mode.as_str().to_owned());
+    let model = string_field("model").unwrap_or_else(|| asset.recipe.model.clone());
+    let prompt = string_field("prompt").unwrap_or_else(|| asset.recipe.prompt.clone());
+    let negative_prompt =
+        string_field("negativePrompt").unwrap_or_else(|| asset.recipe.negative_prompt.clone());
+
+    // The sidecar's seed — not the payload's. `payload.seed` is the batch BASE and
+    // `payload.seeds` is the whole batch; only the sidecar knows which one rendered the file
+    // being shared. The batch list never travels: the other images are not this share's
+    // business. (`Recipe::seed` is a required field, so there is nothing to fall back to.)
+    let seed = Some(asset.recipe.seed);
+
+    let advanced = sanitize_advanced(
+        job_payload
+            .get("advanced")
+            .and_then(Value::as_object)
+            .unwrap_or(&Map::new()),
+    );
+
+    WorkflowShare {
+        kind: WORKFLOW_KIND_IMAGE.to_owned(),
+        schema_version: WORKFLOW_SHARE_SCHEMA_VERSION,
+        producer: WorkflowProducer::default(),
+        mode,
+        model,
+        prompt,
+        negative_prompt,
+        seed,
+        width: u32_field("width").or(asset.file.width),
+        height: u32_field("height").or(asset.file.height),
+        count: u32_field("count"),
+        style_preset: string_field("stylePreset").filter(|value| !value.is_empty()),
+        style_id: string_field("styleId").filter(|value| !value.is_empty()),
+        fit_mode: string_field("fitMode").filter(|value| !value.is_empty()),
+        upscale: sanitize_upscale(job_payload.get("upscale")),
+        loras: sanitize_loras(job_payload.get("loras")),
+        inputs: describe_inputs(job_payload),
+        advanced,
+    }
+}
+
+/// Input images by shape. Reads the ids only to count them; no id ever reaches the envelope.
+fn describe_inputs(job_payload: &JsonObject) -> Vec<WorkflowInput> {
+    let has_id = |key: &str| {
+        job_payload
+            .get(key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    let id_list_len = |key: &str| {
+        job_payload
+            .get(key)
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter(|value| value.as_str().is_some_and(|value| !value.trim().is_empty()))
+                    .count()
+            })
+            .unwrap_or(0)
+    };
+
+    let mut inputs = Vec::new();
+    if has_id("sourceAssetId") {
+        inputs.push(WorkflowInput {
+            kind: INPUT_KIND_SOURCE.to_owned(),
+            count: 1,
+            control_mode: None,
+        });
+    }
+    let references = usize::from(has_id("referenceAssetId")) + id_list_len("referenceAssetIds");
+    if references > 0 {
+        inputs.push(WorkflowInput {
+            kind: INPUT_KIND_REFERENCE.to_owned(),
+            count: u32::try_from(references).unwrap_or(u32::MAX),
+            control_mode: None,
+        });
+    }
+    if has_id("maskAssetId") {
+        inputs.push(WorkflowInput {
+            kind: INPUT_KIND_MASK.to_owned(),
+            count: 1,
+            control_mode: None,
+        });
+    }
+    let advanced = job_payload.get("advanced").and_then(Value::as_object);
+    let control_image = advanced
+        .and_then(|advanced| advanced.get("controlImage"))
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    if control_image {
+        let control_mode = advanced
+            .and_then(|advanced| advanced.get("controlMode"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .filter(|value| !is_path_shaped(value))
+            .map(str::to_owned);
+        inputs.push(WorkflowInput {
+            kind: INPUT_KIND_CONTROL.to_owned(),
+            count: 1,
+            control_mode,
+        });
+    }
+    inputs
+}
+
+fn sanitize_upscale(value: Option<&Value>) -> Option<WorkflowUpscale> {
+    let upscale = value?.as_object()?;
+    let enabled = upscale
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    Some(WorkflowUpscale {
+        enabled: true,
+        factor: upscale
+            .get("factor")
+            .and_then(Value::as_u64)
+            .and_then(|factor| u32::try_from(factor).ok()),
+        engine: upscale
+            .get("engine")
+            .and_then(Value::as_str)
+            .filter(|engine| !engine.is_empty() && !is_path_shaped(engine))
+            .map(str::to_owned),
+        softness: upscale.get("softness").and_then(Value::as_f64),
+    })
+}
+
+fn sanitize_loras(value: Option<&Value>) -> Vec<WorkflowLora> {
+    let Some(entries) = value.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    entries
+        .iter()
+        .filter_map(Value::as_object)
+        .map(|entry| {
+            // The catalog entry's `source` is `{ provider, repo, file }` for a Hugging Face
+            // LoRA and `{ provider: "local", path }` for an imported one. Only the repo id
+            // travels — never `path`, never `file`, never `installedPath`/`sourcePath`.
+            let repo = entry
+                .get("source")
+                .and_then(Value::as_object)
+                .filter(|source| {
+                    source.get("provider").and_then(Value::as_str) == Some("huggingface")
+                })
+                .and_then(|source| source.get("repo"))
+                .and_then(Value::as_str)
+                .and_then(hf_repo_id);
+            WorkflowLora {
+                name: entry
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty() && !is_path_shaped(name))
+                    .map(str::to_owned),
+                weight: entry.get("weight").and_then(Value::as_f64),
+                repo,
+            }
+        })
+        .filter(|lora| lora.name.is_some() || lora.weight.is_some() || lora.repo.is_some())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The sanitizer
+// ---------------------------------------------------------------------------
+
+/// Reduce a request's `advanced` map to its allow-listed, shape-checked subset.
+///
+/// Unclassified keys are dropped, not passed through — that is the whole design (see
+/// [`ADVANCED_KEY_RULES`]).
+#[must_use]
+pub fn sanitize_advanced(advanced: &JsonObject) -> JsonObject {
+    let mut out = JsonObject::new();
+    for (key, value) in advanced {
+        let Some(rule) = advanced_key_rule(key) else {
+            continue;
+        };
+        if rule.disposition != AdvancedDisposition::Allow {
+            continue;
+        }
+        let sanitized = match rule.shape {
+            AdvancedShape::Scalar => sanitize_scalar(key, value),
+            AdvancedShape::StructuredPrompt => sanitize_structured_prompt(value),
+            AdvancedShape::Poses => sanitize_poses(value),
+            AdvancedShape::Phases => sanitize_phases(value),
+        };
+        if let Some(sanitized) = sanitized {
+            out.insert(key.clone(), sanitized);
+        }
+    }
+    out
+}
+
+/// The prose keys inside a sanitized value that are what the user typed, and so are exempt
+/// from the path-shape guard (see [`is_path_shaped`]).
+const PROSE_KEYS: &[&str] = &["stylePrompt", "intent", "runtimePrompt"];
+
+fn sanitize_scalar(key: &str, value: &Value) -> Option<Value> {
+    match value {
+        Value::String(text) => {
+            if !PROSE_KEYS.contains(&key) && is_path_shaped(text) {
+                return None;
+            }
+            Some(Value::String(text.clone()))
+        }
+        Value::Number(_) | Value::Bool(_) => Some(value.clone()),
+        // An object or array under a scalar key is the smuggling channel this guard exists to
+        // close: it is how a path reaches the file through a key that is otherwise allowed.
+        _ => None,
+    }
+}
+
+fn sanitize_structured_prompt(value: &Value) -> Option<Value> {
+    let recipe = value.as_object()?;
+    // `caption` is the model-authored structured JSON — a free-form nested object, so it
+    // cannot be allow-listed key by key. Nothing is lost: `runtimePrompt` is its serialized
+    // form and is exactly what the top-level `prompt` already carries.
+    const FIELDS: &[&str] = &[
+        "version",
+        "intent",
+        "magicPromptBackend",
+        "edited",
+        "runtimePrompt",
+    ];
+    let mut out = JsonObject::new();
+    for field in FIELDS {
+        if let Some(field_value) = recipe.get(*field) {
+            if let Some(sanitized) = sanitize_scalar(field, field_value) {
+                out.insert((*field).to_owned(), sanitized);
+            }
+        }
+    }
+    (!out.is_empty()).then_some(Value::Object(out))
+}
+
+fn sanitize_poses(value: &Value) -> Option<Value> {
+    let poses = value.as_array()?;
+    // The entry count is load-bearing (poses replace `count` variations), so an entry whose
+    // keypoints are missing or malformed still occupies its slot as an empty object.
+    let sanitized: Vec<Value> = poses
+        .iter()
+        .map(|pose| {
+            let keypoints = pose
+                .as_object()
+                .and_then(|pose| pose.get("keypoints"))
+                .filter(|keypoints| is_numeric_tree(keypoints));
+            match keypoints {
+                Some(keypoints) => {
+                    let mut out = JsonObject::new();
+                    out.insert("keypoints".to_owned(), keypoints.clone());
+                    Value::Object(out)
+                }
+                None => Value::Object(JsonObject::new()),
+            }
+        })
+        .collect();
+    (!sanitized.is_empty()).then_some(Value::Array(sanitized))
+}
+
+/// True when `value` is made only of numbers, nulls and arrays of them — the shape pose
+/// keypoints have. Anything with a string in it is not keypoints and does not travel.
+fn is_numeric_tree(value: &Value) -> bool {
+    match value {
+        Value::Number(_) | Value::Null => true,
+        Value::Array(values) => values.iter().all(is_numeric_tree),
+        _ => false,
+    }
+}
+
+fn sanitize_phases(value: &Value) -> Option<Value> {
+    let phases = value.as_array()?;
+    let sanitized: Vec<Value> = phases
+        .iter()
+        .filter_map(Value::as_object)
+        .map(|phase| {
+            let mut out = JsonObject::new();
+            for field in ["steps", "guidance"] {
+                if let Some(number) = phase.get(field).filter(|value| value.is_number()) {
+                    out.insert(field.to_owned(), number.clone());
+                }
+            }
+            // Phase LoRA references are indices into THIS request's own `loras` list, so they
+            // carry no id and stay meaningful next to the sanitized `loras` above.
+            if let Some(loras) = phase.get("loras").and_then(Value::as_array) {
+                let entries: Vec<Value> = loras
+                    .iter()
+                    .filter_map(Value::as_object)
+                    .filter_map(|lora| {
+                        let mut entry = JsonObject::new();
+                        for field in ["index", "weight"] {
+                            if let Some(number) = lora.get(field).filter(|value| value.is_number())
+                            {
+                                entry.insert(field.to_owned(), number.clone());
+                            }
+                        }
+                        entry.contains_key("index").then_some(Value::Object(entry))
+                    })
+                    .collect();
+                out.insert("loras".to_owned(), Value::Array(entries));
+            }
+            Value::Object(out)
+        })
+        .collect();
+    (!sanitized.is_empty()).then_some(Value::Array(sanitized))
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+/// Parse an envelope out of a JSON string (a PNG text chunk, a dropped file).
+///
+/// # Errors
+/// Returns a [`WorkflowShareError`] describing what is wrong, in a sentence fit to show a
+/// user. Never panics and never silently defaults.
+pub fn parse_workflow_share_json(text: &str) -> Result<WorkflowShare, WorkflowShareError> {
+    let value: Value = serde_json::from_str(text)
+        .map_err(|error| WorkflowShareError::InvalidJson(error.to_string()))?;
+    parse_workflow_share(&value)
+}
+
+/// Parse an envelope out of already-decoded JSON.
+///
+/// The version gate runs BEFORE the body is deserialized, and it branches on `schemaVersion`
+/// alone — `producer.version` is recorded, never interpreted. A file from a newer contract
+/// gets [`WorkflowShareError::UnsupportedSchemaVersion`] naming both versions, so the user is
+/// told to update rather than shown a field-level parse failure.
+///
+/// # Errors
+/// See [`WorkflowShareError`].
+pub fn parse_workflow_share(value: &Value) -> Result<WorkflowShare, WorkflowShareError> {
+    let object = value.as_object().ok_or(WorkflowShareError::NotAnObject)?;
+
+    let marker = object
+        .get(WORKFLOW_SHARE_MARKER_KEY)
+        .ok_or(WorkflowShareError::MissingMarker)?;
+    let kind = marker
+        .as_str()
+        .ok_or_else(|| WorkflowShareError::Malformed {
+            field: WORKFLOW_SHARE_MARKER_KEY.to_owned(),
+            detail: "must be a workflow-kind string".to_owned(),
+        })?;
+    if kind != WORKFLOW_KIND_IMAGE {
+        return Err(WorkflowShareError::UnsupportedKind {
+            found: kind.to_owned(),
+            supported: WORKFLOW_KIND_IMAGE.to_owned(),
+        });
+    }
+
+    let schema_version = object
+        .get("schemaVersion")
+        .ok_or(WorkflowShareError::MissingSchemaVersion)?
+        .as_u64()
+        .and_then(|version| u32::try_from(version).ok())
+        .ok_or(WorkflowShareError::MissingSchemaVersion)?;
+    if schema_version > WORKFLOW_SHARE_SCHEMA_VERSION {
+        return Err(WorkflowShareError::UnsupportedSchemaVersion {
+            file: schema_version,
+            supported: WORKFLOW_SHARE_SCHEMA_VERSION,
+        });
+    }
+
+    let share: WorkflowShare =
+        serde_json::from_value(value.clone()).map_err(|error| WorkflowShareError::Malformed {
+            field: field_from_serde_error(&error),
+            detail: error.to_string(),
+        })?;
+    // An envelope that arrived from outside is sanitized on the way IN as well: a hostile or
+    // simply older writer's `advanced` is reduced by the same allow-list the builder uses.
+    Ok(WorkflowShare {
+        advanced: sanitize_advanced(&share.advanced),
+        ..share
+    })
+}
+
+/// Best-effort field name out of a serde error, so the message names something the user can
+/// look for rather than only a byte offset.
+fn field_from_serde_error(error: &serde_json::Error) -> String {
+    let text = error.to_string();
+    text.split('`')
+        .nth(1)
+        .map_or_else(|| "workflow".to_owned(), str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn asset_fixture() -> Asset {
+        serde_json::from_value(json!({
+            "schemaVersion": 1,
+            "id": "asset_123",
+            "projectId": "project_abc",
+            "generationSetId": "genset_xyz",
+            "type": "image",
+            "displayName": "Mist over hills #1",
+            "createdAt": "2026-07-29T13:00:00Z",
+            "file": {
+                "path": "assets/images/2026-07-29_z_image_turbo_mist_0001.png",
+                "mimeType": "image/png",
+                "width": 1024,
+                "height": 1024,
+                "duration": null,
+                "fps": null
+            },
+            "status": { "favorite": false, "rating": 0, "rejected": false, "trashed": false },
+            "recipe": {
+                "mode": "text_to_image",
+                "model": "z_image_turbo",
+                "adapter": "z_image_diffusers",
+                "prompt": "mist over hills",
+                "negativePrompt": "blurry",
+                "seed": 4242,
+                "loras": [],
+                "stylePreset": "cinematic",
+                "normalizedSettings": {},
+                "rawAdapterSettings": {}
+            },
+            "lineage": {
+                "parents": [],
+                "sourceAssetId": null,
+                "sourceTimestamp": null,
+                "jobId": "job_999"
+            }
+        }))
+        .expect("asset fixture parses")
+    }
+
+    fn payload_fixture() -> JsonObject {
+        json!({
+            "projectId": "project_abc",
+            "projectName": "Michael's Secret Film",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "negativePrompt": "blurry",
+            "model": "z_image_turbo",
+            "count": 4,
+            "seed": 990001,
+            "seeds": [990001, 990002, 990003, 990004],
+            "width": 1024,
+            "height": 1024,
+            "stylePreset": "cinematic",
+            "fitMode": "crop",
+            "advanced": { "steps": 8, "sampler": "euler" }
+        })
+        .as_object()
+        .cloned()
+        .expect("payload fixture is an object")
+    }
+
+    #[test]
+    fn producer_version_is_the_workspace_version() {
+        let share = build_workflow_share(&asset_fixture(), &payload_fixture());
+        assert_eq!(share.producer.name, PRODUCER_NAME);
+        assert_eq!(share.producer.url, PRODUCER_URL);
+        assert_eq!(share.producer.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn seed_comes_from_the_rendered_asset_not_the_batch_base() {
+        let share = build_workflow_share(&asset_fixture(), &payload_fixture());
+        assert_eq!(share.seed, Some(4242));
+        let encoded = serde_json::to_string(&share).expect("serializes");
+        assert!(
+            !encoded.contains("seeds"),
+            "the batch seed list must not travel"
+        );
+        assert!(
+            !encoded.contains("990002"),
+            "another image's seed must not travel"
+        );
+    }
+
+    #[test]
+    fn unclassified_advanced_keys_are_dropped() {
+        let advanced = json!({
+            "steps": 8,
+            "aBrandNewKnobNobodyClassified": "leaky",
+            "quantTier": "nvfp4",
+            "mlxQuantize": 4,
+            "flashAttn": false,
+            "controlWeights": { "overlayId": "overlay_1" }
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        assert_eq!(sanitized.keys().collect::<Vec<_>>(), vec!["steps"]);
+    }
+
+    #[test]
+    fn scalar_keys_reject_smuggled_objects_and_paths() {
+        let advanced = json!({
+            "sampler": { "path": "C:\\Users\\Michael\\samplers\\x.json" },
+            "scheduler": "/home/michael/schedules/x",
+            "steps": 8
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        assert_eq!(sanitized.keys().collect::<Vec<_>>(), vec!["steps"]);
+    }
+
+    #[test]
+    fn structured_prompt_keeps_scalars_and_drops_the_free_form_caption() {
+        let advanced = json!({
+            "structuredPrompt": {
+                "version": 1,
+                "intent": "a lighthouse",
+                "caption": { "compositional_deconstruction": { "subject": "lighthouse" } },
+                "magicPromptBackend": null,
+                "edited": true,
+                "runtimePrompt": "{\"subject\":\"lighthouse\"}"
+            }
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        let recipe = sanitized["structuredPrompt"].as_object().expect("object");
+        assert!(recipe.contains_key("intent"));
+        assert!(recipe.contains_key("runtimePrompt"));
+        assert!(recipe.contains_key("edited"));
+        assert!(!recipe.contains_key("caption"));
+        // `magicPromptBackend: null` is not a scalar we carry.
+        assert!(!recipe.contains_key("magicPromptBackend"));
+    }
+
+    #[test]
+    fn poses_keep_keypoints_and_drop_library_ids() {
+        let advanced = json!({
+            "poses": [
+                { "id": "pose_local_uuid", "keypoints": [[0.1, 0.2], [0.3, 0.4]] },
+                { "id": "pose_other" }
+            ]
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        let poses = sanitized["poses"].as_array().expect("array");
+        assert_eq!(poses.len(), 2, "pose count is load-bearing");
+        assert!(poses[0]["keypoints"].is_array());
+        assert!(poses[0].get("id").is_none());
+        assert!(poses[1].as_object().expect("object").is_empty());
+        let encoded = serde_json::to_string(&sanitized).expect("serializes");
+        assert!(!encoded.contains("pose_local_uuid"));
+    }
+
+    #[test]
+    fn phases_keep_numeric_schedule_and_lora_indices() {
+        let advanced = json!({
+            "phases": [
+                { "steps": 4, "guidance": 1.0, "loras": [{ "index": 0, "weight": 0.8 }], "note": "x" },
+                { "steps": 4, "loras": [{ "id": "lora_local_uuid" }] }
+            ]
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        let phases = sanitized["phases"].as_array().expect("array");
+        assert_eq!(phases[0]["loras"][0]["index"], json!(0));
+        assert!(phases[0].get("note").is_none());
+        assert_eq!(phases[1]["loras"].as_array().expect("array").len(), 0);
+        let encoded = serde_json::to_string(&sanitized).expect("serializes");
+        assert!(!encoded.contains("lora_local_uuid"));
+    }
+
+    #[test]
+    fn loras_keep_name_weight_and_hf_repo_only() {
+        let payload = json!({
+            "mode": "text_to_image",
+            "prompt": "p",
+            "model": "z_image_turbo",
+            "loras": [
+                {
+                    "id": "lora_local_uuid",
+                    "name": "Mira Character LoRA",
+                    "weight": 0.8,
+                    "installedPath": "C:\\Users\\Michael\\loras\\mira",
+                    "sourcePath": "/mnt/data/mira.safetensors",
+                    "source": { "provider": "huggingface", "repo": "acme/mira", "file": "v1.safetensors" }
+                },
+                {
+                    "id": "lora_local_2",
+                    "name": "Local Import",
+                    "weight": 0.5,
+                    "source": { "provider": "local", "path": "loras/local.safetensors" }
+                }
+            ]
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let share = build_workflow_share(&asset_fixture(), &payload);
+        assert_eq!(share.loras.len(), 2);
+        assert_eq!(share.loras[0].repo.as_deref(), Some("acme/mira"));
+        assert_eq!(share.loras[0].weight, Some(0.8));
+        assert_eq!(share.loras[1].repo, None);
+        let encoded = serde_json::to_string(&share).expect("serializes");
+        for leak in [
+            "lora_local_uuid",
+            "installedPath",
+            "sourcePath",
+            "v1.safetensors",
+            "loras/local.safetensors",
+        ] {
+            assert!(!encoded.contains(leak), "{leak} leaked into the envelope");
+        }
+    }
+
+    #[test]
+    fn upscale_travels_only_when_enabled() {
+        let mut payload = payload_fixture();
+        payload.insert(
+            "upscale".to_owned(),
+            json!({ "enabled": false, "factor": 2, "engine": "seedvr2" }),
+        );
+        assert!(build_workflow_share(&asset_fixture(), &payload)
+            .upscale
+            .is_none());
+        payload.insert(
+            "upscale".to_owned(),
+            json!({ "enabled": true, "factor": 2, "engine": "seedvr2", "softness": 0.25 }),
+        );
+        let upscale = build_workflow_share(&asset_fixture(), &payload)
+            .upscale
+            .expect("upscale travels");
+        assert_eq!(upscale.factor, Some(2));
+        assert_eq!(upscale.engine.as_deref(), Some("seedvr2"));
+        assert_eq!(upscale.softness, Some(0.25));
+    }
+
+    #[test]
+    fn is_path_shaped_matches_the_four_path_families() {
+        for path in [
+            "/home/michael/x.png",
+            "C:\\Users\\Michael\\x.png",
+            "engine loaded from D:/models/x",
+            "\\\\fileserver\\share\\x.png",
+            "file:///D:/x.png",
+            "~/models/x.png",
+        ] {
+            assert!(is_path_shaped(path), "{path} should read as a path");
+        }
+        for safe in [
+            "euler",
+            "1024x1024",
+            "acme/mira",
+            "https://github.com/SceneWorks/SceneWorks",
+            "2k",
+            "",
+        ] {
+            assert!(!is_path_shaped(safe), "{safe} should not read as a path");
+        }
+    }
+
+    #[test]
+    fn parse_rejects_a_missing_marker() {
+        let error = parse_workflow_share(&json!({ "schemaVersion": 1 }))
+            .expect_err("no marker must not parse");
+        assert_eq!(error, WorkflowShareError::MissingMarker);
+        assert!(error.to_string().contains("sceneworksWorkflow"));
+    }
+
+    #[test]
+    fn parse_rejects_non_objects_and_bad_json() {
+        assert_eq!(
+            parse_workflow_share(&json!([1, 2, 3])).expect_err("array"),
+            WorkflowShareError::NotAnObject
+        );
+        assert!(matches!(
+            parse_workflow_share_json("{not json").expect_err("bad json"),
+            WorkflowShareError::InvalidJson(_)
+        ));
+    }
+
+    #[test]
+    fn parse_names_both_versions_on_an_unknown_schema_version() {
+        let future = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": WORKFLOW_SHARE_SCHEMA_VERSION + 7,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "9.9.9" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "p"
+        });
+        let error = parse_workflow_share(&future).expect_err("future version must not parse");
+        assert_eq!(
+            error,
+            WorkflowShareError::UnsupportedSchemaVersion {
+                file: WORKFLOW_SHARE_SCHEMA_VERSION + 7,
+                supported: WORKFLOW_SHARE_SCHEMA_VERSION,
+            }
+        );
+        let message = error.to_string();
+        assert!(message.contains(&(WORKFLOW_SHARE_SCHEMA_VERSION + 7).to_string()));
+        assert!(message.contains(&WORKFLOW_SHARE_SCHEMA_VERSION.to_string()));
+        assert!(message.contains("Update SceneWorks"));
+    }
+
+    #[test]
+    fn parse_reports_a_malformed_body_instead_of_panicking() {
+        let malformed = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": ["not", "a", "string"]
+        });
+        assert!(matches!(
+            parse_workflow_share(&malformed).expect_err("malformed body"),
+            WorkflowShareError::Malformed { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_another_workflow_kind() {
+        let video = json!({
+            "sceneworksWorkflow": "video",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "image_to_video",
+            "model": "wan_5b",
+            "prompt": "p"
+        });
+        assert!(matches!(
+            parse_workflow_share(&video).expect_err("video envelope"),
+            WorkflowShareError::UnsupportedKind { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_re_sanitizes_advanced_from_an_outside_writer() {
+        let hostile = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "p",
+            "advanced": { "steps": 8, "controlWeights": { "path": "C:\\evil" } },
+            "somethingNew": "dropped"
+        });
+        let share = parse_workflow_share(&hostile).expect("parses");
+        assert_eq!(share.advanced.keys().collect::<Vec<_>>(), vec!["steps"]);
+        let encoded = serde_json::to_string(&share).expect("serializes");
+        assert!(!encoded.contains("somethingNew"));
+    }
+}

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -558,7 +558,9 @@ pub fn advanced_key_rule(key: &str) -> Option<&'static AdvancedKeyRule> {
 ///   `C:foo` is caught and the URL scheme in `https://…` is not;
 /// * a `..` traversal segment and a leading `./`;
 /// * a multi-segment relative POSIX path (`assets/images/x.png`) — three or more segments and
-///   no URL scheme. Two segments is a Hugging Face repo id (`acme/mira`) and stays;
+///   no URL scheme. Two segments is a Hugging Face repo id (`acme/mira`) and stays, and a slash
+///   written with a space beside it is a human list separator, not a path separator (see
+///   [`relative_tree_segments`]);
 /// * `file://`, including percent-encoded (`file%3A%2F%2FD%3A%2Fx`).
 ///
 /// Deliberately NOT applied to the authored prose fields (`prompt`, `negativePrompt`,
@@ -635,12 +637,44 @@ fn looks_like_a_location(value: &str) -> bool {
     }
     // A relative POSIX tree. Two segments is an HF repo id and stays; a URL is not a location on
     // THIS machine, so `https://host/a/b/c` is left alone.
-    !lower.contains("://")
-        && segments
-            .iter()
-            .filter(|segment| !segment.is_empty())
-            .count()
-            >= 3
+    !lower.contains("://") && relative_tree_segments(value) >= 3
+}
+
+/// How many PATH segments `value` has, counting only slashes that could be path separators.
+///
+/// A filesystem separator is never written with a space beside it; a human list separator almost
+/// always is. `"PiD 1.5 Decoder (FLUX.1 / Boogu / Chroma / Z-Image)"` — a real
+/// `config/manifests/builtin.models.jsonc` display name — is one label, not a four-deep tree, and
+/// the same free-label class travels for real in `loras[].name`: without this a LoRA the user
+/// named `"Ghibli watercolor / soft light / pastel"` would be dropped from their own share with
+/// no signal to anyone.
+///
+/// Narrowed at the SLASH, deliberately not at the segment: ignoring any segment that contains
+/// whitespace would also stop catching `Documents/Secret Project/render 1.png`, which is a real
+/// relative path and does leak a name. Only a slash with whitespace on one side or the other
+/// stops separating.
+fn relative_tree_segments(value: &str) -> usize {
+    let characters: Vec<char> = value.chars().collect();
+    let is_space = |index: usize| {
+        characters
+            .get(index)
+            .is_some_and(|next: &char| next.is_whitespace())
+    };
+    let mut segments = 0;
+    let mut segment_len = 0_usize;
+    for (index, character) in characters.iter().enumerate() {
+        let separates =
+            *character == '/' && !(index > 0 && is_space(index - 1)) && !is_space(index + 1);
+        if separates {
+            // Empty segments do not count, so `a//b` is two and a leading `/` opens none —
+            // exactly what the `split('/').filter(non-empty)` this replaced did.
+            segments += usize::from(segment_len > 0);
+            segment_len = 0;
+        } else {
+            segment_len += 1;
+        }
+    }
+    segments + usize::from(segment_len > 0)
 }
 
 /// Decode only the percent escapes that matter to [`looks_like_a_location`], so an encoded
@@ -699,6 +733,36 @@ fn shareable_label(value: &str) -> Option<String> {
         return None;
     }
     Some(trimmed.to_owned())
+}
+
+/// The longest an authored prose field may be — `prompt`, `negativePrompt`, `stylePrompt` and
+/// the structured prompt's `intent` / `runtimePrompt`.
+///
+/// Distinct from and 100× [`LABEL_MAX_CHARS`] on purpose: a label is a slug and prose is
+/// paragraphs. 20,000 characters is roughly 3,000 words. The longest thing this field class
+/// legitimately holds is `runtimePrompt`, the serialized structured-prompt recipe, which runs to
+/// a few kilobytes at its most verbose; a hand-typed prompt is two orders of magnitude shorter.
+/// So the cap cannot truncate anything real, while still bounding what an envelope from a
+/// stranger can hand sc-15952 to render: five prose fields × 20 k is ~100 kB worst case, which
+/// keeps a PNG text chunk a text chunk rather than a payload.
+const PROSE_MAX_CHARS: usize = 20_000;
+
+/// Authored prose, reduced. Unlike [`shareable_label`] this keeps what the user typed —
+/// including a path, which is the deliberate exemption [`is_path_shaped`] documents — and only
+/// bounds it.
+///
+/// On the BUILD side these strings are the user's own and this is a no-op. On the PARSE side
+/// they are attacker-chosen, which is the epic's trust boundary: the reader (sc-15952) renders
+/// them, so a value carrying ANSI escapes or several megabytes of text must not arrive intact.
+/// Newlines and tabs survive — a multi-line prompt is normal and mangling it would be the very
+/// harm the prose exemption exists to prevent — but every other control character is dropped.
+fn shareable_prose(value: &str) -> String {
+    let stripped: String = value
+        .chars()
+        .filter(|character| !character.is_control() || matches!(character, '\n' | '\t'))
+        .take(PROSE_MAX_CHARS)
+        .collect();
+    stripped.trim().to_owned()
 }
 
 /// A Hugging Face repo id (`owner/name`) and nothing else — never a path, never a URL.
@@ -770,12 +834,14 @@ pub fn build_workflow_share(asset: &Asset, job_payload: &JsonObject) -> Workflow
     // business. (`Recipe::seed` is a required field, so there is nothing to fall back to.)
     let seed = Some(asset.recipe.seed);
 
-    let advanced = sanitize_advanced(
-        job_payload
-            .get("advanced")
-            .and_then(Value::as_object)
-            .unwrap_or(&Map::new()),
-    );
+    // Raw on purpose: `reduce_workflow_share` runs `sanitize_advanced`, and sanitizing here as
+    // well would be the same pass twice — harmless only for as long as every rule stays
+    // idempotent, which is not a property worth depending on.
+    let advanced = job_payload
+        .get("advanced")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
 
     // Every value goes out through the SAME reducer an incoming envelope comes in through
     // (`reduce_workflow_share`), so the build side cannot grow a field the parse side does not
@@ -968,9 +1034,11 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
         producer: reduce_producer(producer),
         mode: shareable_label(&mode).unwrap_or_default(),
         model: shareable_label(&model).unwrap_or_default(),
-        // Authored prose, exempt on purpose — see `is_path_shaped`.
-        prompt,
-        negative_prompt,
+        // Authored prose: exempt from the PATH check on purpose (see `is_path_shaped`), but not
+        // from the other two bounds — on the way IN this is a stranger's text, and sc-15952
+        // renders it.
+        prompt: shareable_prose(&prompt),
+        negative_prompt: shareable_prose(&negative_prompt),
         seed,
         width,
         height,
@@ -1088,15 +1156,20 @@ pub fn sanitize_advanced(advanced: &JsonObject) -> JsonObject {
 
 /// The prose keys inside a sanitized value that are what the user typed, and so are exempt
 /// from the path-shape guard (see [`is_path_shaped`]).
+///
+/// Exempt from the PATH check only. They are still bounded and control-stripped by
+/// [`shareable_prose`], because on the parse side they are a stranger's strings.
 const PROSE_KEYS: &[&str] = &["stylePrompt", "intent", "runtimePrompt"];
 
 fn sanitize_scalar(key: &str, value: &Value) -> Option<Value> {
     match value {
         Value::String(text) => {
-            if !PROSE_KEYS.contains(&key) && is_path_shaped(text) {
-                return None;
+            if PROSE_KEYS.contains(&key) {
+                return Some(Value::String(shareable_prose(text)));
             }
-            Some(Value::String(text.clone()))
+            // Everything else under a scalar key is a slug — the same class as a top-level
+            // label, so it gets the same bound rather than only the path check.
+            shareable_label(text).map(Value::String)
         }
         Value::Number(_) | Value::Bool(_) => Some(value.clone()),
         // An object or array under a scalar key is the smuggling channel this guard exists to
@@ -1630,6 +1703,69 @@ mod tests {
         }
     }
 
+    /// A slash with a space beside it is how a person separates a LIST, and the tally read three
+    /// of those as a three-deep tree. `config/manifests/builtin.models.jsonc` is the proof it
+    /// happens for real — the PiD decoder display names below are shipped values. Those three do
+    /// not travel (the envelope carries the model SLUG), but `loras[].name` is exactly the same
+    /// class of free display label and DOES travel, so this was silent data loss waiting for a
+    /// user who names a LoRA the way people name things.
+    #[test]
+    fn a_slash_written_with_a_space_beside_it_is_a_list_separator() {
+        for label in [
+            // Shipped display names, verbatim from the builtin model manifest.
+            "PiD 1.5 Decoder (FLUX.1 / Boogu / Chroma / Z-Image)",
+            "PiD 1.5 Decoder (FLUX.2 / Lens / Ideogram 4)",
+            "PiD Decoder (SDXL / RealVisXL / Kolors)",
+            // The class that actually travels: a LoRA the user named themselves.
+            "Ghibli watercolor / soft light / pastel",
+            "Realism / Photoreal",
+            "A/B test",
+            "acme/mira",
+            "https://huggingface.co/acme/mira/tree/main",
+        ] {
+            assert!(!is_path_shaped(label), "{label:?} is a label, not a path");
+        }
+        // Narrowed at the SLASH and not at the segment, so a real relative path keeps tripping
+        // it even when its directories have spaces in their names.
+        for path in [
+            "assets/images/x.png",
+            "models/weights/x.safetensors",
+            "../../etc/passwd",
+            "Documents/Secret Project/render 1.png",
+            "a/b/c",
+        ] {
+            assert!(is_path_shaped(path), "{path:?} should still read as a path");
+        }
+        // The tally itself: empty segments never counted and still do not.
+        assert_eq!(relative_tree_segments("a//b"), 2);
+        assert_eq!(relative_tree_segments("/a/b/"), 2);
+        assert_eq!(relative_tree_segments("A / B / C"), 1);
+    }
+
+    /// The field the narrowing is FOR. A dropped `loras[].name` is invisible to everyone: the
+    /// user picked those words and no signal says they went missing.
+    #[test]
+    fn a_lora_named_with_a_spaced_slash_list_still_travels() {
+        const NAME: &str = "Ghibli watercolor / soft light / pastel";
+        let mut payload = payload_fixture();
+        payload.insert(
+            "loras".to_owned(),
+            json!([
+                { "name": NAME, "weight": 0.7, "source": { "provider": "huggingface", "repo": "acme/mira" } },
+                { "name": "loras/local/x.safetensors", "weight": 0.4 }
+            ]),
+        );
+        let share = build_workflow_share(&asset_fixture(), &payload);
+        assert_eq!(share.loras[0].name.as_deref(), Some(NAME));
+        // The other direction is untouched: a real relative tree in the same field still goes.
+        assert_eq!(share.loras[1].name, None);
+
+        // And it survives the trust boundary, so a shared image reloads with the name intact.
+        let envelope = serde_json::to_value(&share).expect("serializes");
+        let parsed = parse_workflow_share(&envelope).expect("parses");
+        assert_eq!(parsed.loras[0].name.as_deref(), Some(NAME));
+    }
+
     #[test]
     fn prose_keys_carry_what_the_user_typed_even_when_it_names_a_path() {
         // The deliberate exemption, pinned. `stylePrompt` and the structured prompt's `intent` /
@@ -1661,6 +1797,114 @@ mod tests {
         // A NON-prose key next to them is still guarded — the exemption is per key, not global.
         assert!(!sanitized.contains_key("sampler"));
         assert_eq!(PROSE_KEYS, ["stylePrompt", "intent", "runtimePrompt"]);
+    }
+
+    /// The prose exemption is from the PATH check and from nothing else. A prompt is
+    /// user-authored on the way out and attacker-chosen on the way in — the epic's trust
+    /// boundary — and sc-15952 renders it, so a value carrying terminal escapes or megabytes of
+    /// text must not arrive intact.
+    #[test]
+    fn prose_from_outside_is_control_stripped_and_bounded() {
+        let hostile = |prose: &str| {
+            json!({
+                "sceneworksWorkflow": "image",
+                "schemaVersion": 1,
+                "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+                "mode": "text_to_image",
+                "model": "z_image_turbo",
+                "prompt": prose,
+                "negativePrompt": prose,
+                "advanced": {
+                    "stylePrompt": prose,
+                    "structuredPrompt": { "intent": prose, "runtimePrompt": prose }
+                }
+            })
+        };
+        let prose_fields = |share: &WorkflowShare| {
+            let recipe = share.advanced["structuredPrompt"]
+                .as_object()
+                .expect("structuredPrompt object");
+            vec![
+                share.prompt.clone(),
+                share.negative_prompt.clone(),
+                share.advanced["stylePrompt"]
+                    .as_str()
+                    .expect("stylePrompt string")
+                    .to_owned(),
+                recipe["intent"].as_str().expect("intent").to_owned(),
+                recipe["runtimePrompt"]
+                    .as_str()
+                    .expect("runtimePrompt")
+                    .to_owned(),
+            ]
+        };
+
+        // Control characters: the ESC that starts an ANSI sequence, a NUL and a BEL all go.
+        // Newlines and tabs stay — a multi-line prompt is normal, and mangling one would be the
+        // very harm the prose exemption exists to prevent.
+        let share = parse_workflow_share(&hostile(
+            "  a lighthouse\u{1b}[31m in fog\u{0}\u{7}\r\n\tsecond line  ",
+        ))
+        .expect("parses");
+        for value in prose_fields(&share) {
+            assert_eq!(value, "a lighthouse[31m in fog\n\tsecond line");
+            assert!(
+                !value
+                    .chars()
+                    .any(|c| c.is_control() && c != '\n' && c != '\t'),
+                "a control character survived: {value:?}"
+            );
+        }
+
+        // Several megabytes of prose is not a prompt, it is a payload.
+        let absurd = "x".repeat(4 * 1024 * 1024);
+        let share = parse_workflow_share(&hostile(&absurd)).expect("parses");
+        for value in prose_fields(&share) {
+            assert_eq!(value.chars().count(), PROSE_MAX_CHARS);
+        }
+
+        // The bound is prose-sized, not label-sized: the two must never be conflated.
+        assert_eq!(PROSE_MAX_CHARS, 20_000);
+        assert_eq!(PROSE_MAX_CHARS, LABEL_MAX_CHARS * 100);
+    }
+
+    /// The other half: a bound this blunt must not touch anything real. A prompt far longer than
+    /// anyone types, with the newlines and tabs a structured recipe carries, comes back byte for
+    /// byte — on the way out AND on the way back in.
+    #[test]
+    fn a_realistic_long_prompt_survives_byte_for_byte() {
+        let prompt = format!(
+            "{}\n\tshot on 35mm, volumetric light",
+            "a lighthouse in heavy fog, cinematic, rain on the lens, ".repeat(30)
+        );
+        assert!(prompt.chars().count() > 1_500, "the fixture must be long");
+        assert!(prompt.chars().count() < PROSE_MAX_CHARS);
+
+        let mut payload = payload_fixture();
+        payload.insert("prompt".to_owned(), json!(prompt));
+        payload.insert("negativePrompt".to_owned(), json!(prompt));
+        payload.insert(
+            "advanced".to_owned(),
+            json!({
+                "stylePrompt": prompt,
+                "structuredPrompt": { "intent": prompt, "runtimePrompt": prompt }
+            }),
+        );
+        let share = build_workflow_share(&asset_fixture(), &payload);
+        assert_eq!(share.prompt, prompt);
+        assert_eq!(share.negative_prompt, prompt);
+        assert_eq!(share.advanced["stylePrompt"], json!(prompt));
+
+        let envelope = serde_json::to_value(&share).expect("serializes");
+        let parsed = parse_workflow_share(&envelope).expect("parses");
+        assert_eq!(parsed.prompt, prompt);
+        assert_eq!(parsed.negative_prompt, prompt);
+        assert_eq!(parsed.advanced["stylePrompt"], json!(prompt));
+        let recipe = parsed.advanced["structuredPrompt"]
+            .as_object()
+            .expect("structuredPrompt object");
+        assert_eq!(recipe["intent"], json!(prompt));
+        assert_eq!(recipe["runtimePrompt"], json!(prompt));
     }
 
     #[test]

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -1367,6 +1367,23 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// The keys of a JSON object, sorted, so an assertion about WHICH keys survived the
+    /// allow-list cannot accidentally assert the order they came out in.
+    ///
+    /// `serde_json::Map` is a `BTreeMap` (sorted iteration) with the `preserve_order` feature
+    /// off and an `IndexMap` (insertion order) with it on — and Cargo unifies features across
+    /// every crate being built, so the SAME map iterates differently under `cargo test -p
+    /// sceneworks-core` than under the workspace build the `parity` job runs (`sceneworks-worker`
+    /// → `sceneworks-gen-core` → `core-llm` turns `preserve_order` on). An assertion written as an
+    /// ordered `Vec` therefore passes locally and fails in CI while the sanitizer is correct in
+    /// both. Sorting here makes these assertions say what they mean — the key SET — under either
+    /// configuration.
+    fn sorted_keys(object: &JsonObject) -> Vec<&str> {
+        let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        keys
+    }
+
     fn asset_fixture() -> Asset {
         serde_json::from_value(json!({
             "schemaVersion": 1,
@@ -1466,7 +1483,7 @@ mod tests {
         .cloned()
         .expect("object");
         let sanitized = sanitize_advanced(&advanced);
-        assert_eq!(sanitized.keys().collect::<Vec<_>>(), vec!["steps"]);
+        assert_eq!(sorted_keys(&sanitized), vec!["steps"]);
     }
 
     #[test]
@@ -1480,7 +1497,7 @@ mod tests {
         .cloned()
         .expect("object");
         let sanitized = sanitize_advanced(&advanced);
-        assert_eq!(sanitized.keys().collect::<Vec<_>>(), vec!["steps"]);
+        assert_eq!(sorted_keys(&sanitized), vec!["steps"]);
     }
 
     #[test]
@@ -1955,10 +1972,7 @@ mod tests {
         .expect("object");
         let sanitized = sanitize_advanced(&advanced);
         let pose = sanitized["poses"][0].as_object().expect("object");
-        assert_eq!(
-            pose.keys().collect::<Vec<_>>(),
-            vec!["face", "hands", "keypoints"]
-        );
+        assert_eq!(sorted_keys(pose), vec!["face", "hands", "keypoints"]);
         let encoded = serde_json::to_string(&sanitized).expect("serializes");
         for leak in ["pose_local_uuid", "Standing", "sourcePath", "C:\\\\poses"] {
             assert!(!encoded.contains(leak), "{leak} leaked into the envelope");
@@ -1973,7 +1987,7 @@ mod tests {
         .expect("object");
         let sanitized = sanitize_advanced(&smuggled);
         let pose = sanitized["poses"][0].as_object().expect("object");
-        assert_eq!(pose.keys().collect::<Vec<_>>(), vec!["keypoints"]);
+        assert_eq!(sorted_keys(pose), vec!["keypoints"]);
     }
 
     #[test]
@@ -2065,7 +2079,7 @@ mod tests {
             "somethingNew": "dropped"
         });
         let share = parse_workflow_share(&hostile).expect("parses");
-        assert_eq!(share.advanced.keys().collect::<Vec<_>>(), vec!["steps"]);
+        assert_eq!(sorted_keys(&share.advanced), vec!["steps"]);
         let encoded = serde_json::to_string(&share).expect("serializes");
         assert!(!encoded.contains("somethingNew"));
     }
@@ -2161,7 +2175,7 @@ mod tests {
         assert_eq!(share.producer.url, "");
         assert_eq!(share.producer.version, "");
 
-        assert_eq!(share.advanced.keys().collect::<Vec<_>>(), vec!["steps"]);
+        assert_eq!(sorted_keys(&share.advanced), vec!["steps"]);
 
         let encoded = serde_json::to_string(&share).expect("serializes");
         for leak in [

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -9,7 +9,9 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
 
+use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
 use sceneworks_core::contracts::{Asset, JsonObject};
+use sceneworks_core::jsonc::strip_jsonc_comments;
 use sceneworks_core::workflow_share::{
     build_workflow_share, is_path_shaped, parse_workflow_share, AdvancedKeySource, WorkflowShare,
     ADVANCED_KEY_RULES, PRODUCER_URL, PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
@@ -184,6 +186,43 @@ fn the_builder_reproduces_the_golden_envelope() {
         golden,
         "builder output drifted from the golden fixture.\nActual:\n{}",
         serde_json::to_string_pretty(&encoded).expect("pretty")
+    );
+}
+
+/// The sanitizer runs in exactly ONE place, and it is the reducer both directions share.
+///
+/// `build_workflow_share` used to sanitize `advanced` and then hand the result to
+/// `reduce_workflow_share`, which sanitizes it again. Every rule is idempotent today, so that
+/// cost nothing but a second pass — and that is precisely why no assertion could see it. It is
+/// pinned here as source structure because the failure it invites is a future shape rule that is
+/// NOT idempotent (a truncation, a normalization, a de-duplication) quietly applying twice on
+/// the build side and once on the parse side, which would put the two directions out of sync in
+/// the one function written to keep them in step.
+#[test]
+fn the_builder_leaves_advanced_sanitizing_to_the_single_reducer() {
+    let source = read_repo_file("crates/sceneworks-core/src/workflow_share.rs").replace('\r', "");
+    // Comments stripped, so this reads CALLS and not the prose explaining them.
+    let body = |name: &str| {
+        let start = source
+            .find(&format!("fn {name}("))
+            .unwrap_or_else(|| panic!("workflow_share.rs no longer defines {name}"));
+        let rest = &source[start..];
+        let end = rest
+            .find("\n}\n")
+            .unwrap_or_else(|| panic!("could not find the end of {name}"));
+        strip_comments(&rest[..end])
+    };
+
+    assert!(
+        !body("build_workflow_share").contains("sanitize_advanced("),
+        "`build_workflow_share` sanitizes `advanced` before handing it to \
+         `reduce_workflow_share`, which sanitizes it again. Pass the raw map through and let the \
+         reducer's single call do it."
+    );
+    assert!(
+        body("reduce_workflow_share").contains("sanitize_advanced("),
+        "the reducer stopped sanitizing `advanced`, so nothing does — this test's other half \
+         would then pass while the allow-list was bypassed entirely"
     );
 }
 
@@ -628,6 +667,54 @@ fn authored_prose_travels_verbatim_even_when_it_names_a_path() {
         .collect::<BTreeSet<&str>>(),
         "only the authored prose fields may carry a path"
     );
+}
+
+/// The false-positive half, pinned against REAL data rather than a hand-picked corpus.
+///
+/// The relative-tree tally read `"PiD 1.5 Decoder (FLUX.1 / Boogu / Chroma / Z-Image)"` — a
+/// display name shipped in `config/manifests/builtin.models.jsonc` — as a four-deep path,
+/// because it counted a ` / ` list separator as a path separator. Those display names do not
+/// themselves travel (the envelope carries the model SLUG), but `loras[].name` is exactly this
+/// class of free human label and DOES travel, and a dropped LoRA name is silent: the user chose
+/// those words and nothing tells them the name went missing. So the manifest's own labels stand
+/// in as the corpus of what people actually type.
+#[test]
+fn shipped_display_labels_that_list_with_slashes_are_not_path_shaped() {
+    let source = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("the builtin model manifest is embedded");
+    let manifest: Value = serde_json::from_str(&strip_jsonc_comments(source))
+        .expect("builtin.models.jsonc parses as JSON");
+
+    let mut strings = Vec::new();
+    collect_strings(&manifest, String::from("$"), &mut strings);
+    let listed: Vec<&String> = strings
+        .iter()
+        .filter(|(pointer, _)| {
+            [".name", ".label", ".displayName"]
+                .iter()
+                .any(|suffix| pointer.ends_with(suffix))
+        })
+        .map(|(_, value)| value)
+        .filter(|value| value.contains(" / "))
+        .collect();
+
+    assert!(
+        listed.len() >= 5,
+        "the manifest no longer carries the ` / ` display labels this test pins ({} found). If \
+         they were renamed, retarget this test at the labels that replaced them — do not delete \
+         it: it is the only place the guard meets real human labels.",
+        listed.len()
+    );
+    for label in listed {
+        assert!(
+            !is_path_shaped(label),
+            "the shipped display label {label:?} reads as a filesystem path, so the same shape in \
+             a `loras[].name` would be dropped from the user's own share with no signal"
+        );
+    }
 }
 
 /// The shipped guard must never be WEAKER than the sniffer this file asserts with.

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -1,0 +1,842 @@
+//! Contract tests for the sanitized workflow share envelope (sc-15946, epic 15945).
+//!
+//! The two load-bearing ones are [`every_advanced_key_the_studio_can_emit_is_classified`] —
+//! which parses `apps/web/src/imageJobAdvanced.js` so a new knob cannot silently leak OR
+//! silently vanish — and [`no_value_in_a_built_envelope_is_path_shaped`], which seeds the
+//! request with paths on purpose and asserts none of them reach the file.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+use sceneworks_core::contracts::{Asset, JsonObject};
+use sceneworks_core::workflow_share::{
+    build_workflow_share, parse_workflow_share, AdvancedKeySource, WorkflowShare,
+    ADVANCED_KEY_RULES, PRODUCER_URL, PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
+};
+use serde_json::{json, Value};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn read_repo_file(relative_path: &str) -> String {
+    let path = repo_root().join(relative_path);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Golden input
+// ---------------------------------------------------------------------------
+
+/// A generated asset's sidecar, in the shape `project_store::build_image_sidecar_parts` writes.
+fn golden_asset() -> Asset {
+    serde_json::from_value(json!({
+        "schemaVersion": 1,
+        "id": "asset_9f2c",
+        "projectId": "project_7a10",
+        "generationSetId": "genset_31bb",
+        "type": "image",
+        "displayName": "Lighthouse in fog #2",
+        "createdAt": "2026-07-29T13:04:11Z",
+        "file": {
+            "path": "assets/images/2026-07-29_krea_2_turbo_lighthouse_0002.png",
+            "mimeType": "image/png",
+            "width": 1024,
+            "height": 1024,
+            "duration": null,
+            "fps": null
+        },
+        "status": { "favorite": true, "rating": 4, "rejected": false, "trashed": false },
+        "recipe": {
+            "mode": "edit_image",
+            "model": "krea_2_turbo",
+            "adapter": "flux_diffusers",
+            "prompt": "a lighthouse in heavy fog, cinematic",
+            "negativePrompt": "text, watermark",
+            "seed": 880412,
+            "loras": [],
+            "stylePreset": "cinematic",
+            "normalizedSettings": {},
+            "rawAdapterSettings": {}
+        },
+        "lineage": {
+            "parents": ["asset_source_1"],
+            "sourceAssetId": "asset_source_1",
+            "sourceTimestamp": null,
+            "jobId": "job_5c8e"
+        }
+    }))
+    .expect("golden asset parses")
+}
+
+/// The job row's `payload_json` for that asset — the exact `ImageJobRequest` the API stored,
+/// including the fields it stamps on (`modelManifestEntry`, `seeds`, the resolved geometry).
+fn golden_payload() -> JsonObject {
+    json!({
+        "projectId": "project_7a10",
+        "projectName": "Michael's Unreleased Film",
+        "mode": "edit_image",
+        "prompt": "a lighthouse in heavy fog, cinematic",
+        "negativePrompt": "text, watermark",
+        "model": "krea_2_turbo",
+        "count": 2,
+        "seed": 880411,
+        "seeds": [880411, 880412],
+        "width": 1024,
+        "height": 1024,
+        "stylePreset": "cinematic",
+        "styleId": "noir_bloom",
+        "fitMode": "crop",
+        "characterId": "character_c001",
+        "characterLookId": "look_l001",
+        "sourceAssetId": "asset_source_1",
+        "referenceAssetIds": ["asset_ref_1", "asset_ref_2"],
+        "maskAssetId": "asset_mask_1",
+        "upscale": { "enabled": true, "factor": 2, "engine": "seedvr2", "softness": 0.25 },
+        "modelManifestEntry": {
+            "id": "krea_2_turbo",
+            "installPath": "E:\\models\\krea_2_turbo",
+            "downloads": [{ "repo": "kreaai/krea-2-turbo" }]
+        },
+        "loras": [{
+            "id": "lora_1f0d",
+            "name": "Foggy Coast",
+            "weight": 0.65,
+            "installedPath": "E:\\loras\\foggy-coast",
+            "sourcePath": "/mnt/nas/loras/foggy-coast.safetensors",
+            "source": { "provider": "huggingface", "repo": "acme/foggy-coast", "file": "v2.safetensors" }
+        }],
+        "advanced": {
+            "resolution": "1024x1024",
+            "sampler": "euler",
+            "scheduler": "beta",
+            "schedulerShift": 1.15,
+            "steps": 28,
+            "guidanceScale": 3.5,
+            "guidanceMethod": "cfg_pp",
+            "strength": 0.55,
+            "styleId": "noir_bloom",
+            "stylePrompt": "a lighthouse in heavy fog",
+            "controlMode": "canny",
+            "controlScale": 0.9,
+            "controlImage": "asset_control_1",
+            "controlWeights": { "overlayId": "overlay_7", "path": "E:\\overlays\\pose.safetensors" },
+            "quantTier": "nvfp4",
+            "mlxQuantize": 4,
+            "flashAttn": false,
+            "recipePresetId": "preset_local_1"
+        }
+    })
+    .as_object()
+    .cloned()
+    .expect("golden payload is an object")
+}
+
+fn golden_fixture_path() -> PathBuf {
+    repo_root()
+        .join("tests")
+        .join("fixtures")
+        .join("workflow_share")
+        .join("image-workflow-share.json")
+}
+
+fn load_golden_fixture() -> Value {
+    let path = golden_fixture_path();
+    let payload = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    serde_json::from_str(&payload)
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Golden fixture + round trip (matching tests/contract_roundtrip.rs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn golden_envelope_round_trips_without_field_drift() {
+    let original = load_golden_fixture();
+    let typed: WorkflowShare =
+        serde_json::from_value(original.clone()).expect("golden envelope deserializes");
+    let encoded = serde_json::to_value(typed).expect("golden envelope serializes");
+
+    assert_eq!(
+        encoded, original,
+        "the golden workflow-share envelope drifted after a typed round-trip"
+    );
+}
+
+#[test]
+fn the_builder_reproduces_the_golden_envelope() {
+    let built = build_workflow_share(&golden_asset(), &golden_payload());
+    let encoded = serde_json::to_value(&built).expect("built envelope serializes");
+    let mut golden = load_golden_fixture();
+    // The fixture pins the SHAPE, so a release version bump is not drift: the producer version
+    // is asserted against `CARGO_PKG_VERSION` and the workspace manifest in
+    // `producer_version_is_strict_semver_and_matches_the_workspace` instead.
+    golden["producer"]["version"] = json!(PRODUCER_VERSION);
+
+    assert_eq!(
+        encoded,
+        golden,
+        "builder output drifted from the golden fixture.\nActual:\n{}",
+        serde_json::to_string_pretty(&encoded).expect("pretty")
+    );
+}
+
+#[test]
+fn the_golden_envelope_parses_back_through_the_reader() {
+    let golden = load_golden_fixture();
+    let parsed = parse_workflow_share(&golden).expect("the golden envelope parses");
+    assert_eq!(
+        serde_json::to_value(&parsed).expect("re-serializes"),
+        golden,
+        "parsing the golden envelope changed it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Producer block
+// ---------------------------------------------------------------------------
+
+#[test]
+fn producer_version_is_strict_semver_and_matches_the_workspace() {
+    let share = build_workflow_share(&golden_asset(), &golden_payload());
+    let version = share.producer.version;
+
+    assert_eq!(version, PRODUCER_VERSION);
+
+    // Strict MAJOR.MINOR.PATCH. A dirty-tree suffix (`0.8.1-dirty`), build metadata
+    // (`0.8.1+ci.42`), a `v` prefix or a hostname must all fail here — that string ships in
+    // every image and is the one field the allow-list cannot catch.
+    let parts: Vec<&str> = version.split('.').collect();
+    assert_eq!(
+        parts.len(),
+        3,
+        "producer.version must be MAJOR.MINOR.PATCH, got {version:?}"
+    );
+    for part in &parts {
+        assert!(
+            !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()),
+            "producer.version segment {part:?} is not numeric ({version:?}) — a git describe, \
+             dirty-tree suffix, CI build number or hostname must never reach the envelope"
+        );
+        assert!(
+            *part == "0" || !part.starts_with('0'),
+            "producer.version segment {part:?} has a leading zero ({version:?})"
+        );
+    }
+
+    // The canonical repo URL, and nothing derived from this machine.
+    assert_eq!(share.producer.url, PRODUCER_URL);
+    assert_eq!(share.producer.name, "SceneWorks");
+
+    // The workspace version is the single source of truth (scripts/sync-version.mjs keeps the
+    // web/desktop manifests in lockstep with it).
+    let workspace_version = read_repo_file("Cargo.toml")
+        .lines()
+        .skip_while(|line| line.trim() != "[workspace.package]")
+        .find_map(|line| {
+            line.strip_prefix("version")
+                .and_then(|rest| rest.split('"').nth(1))
+                .map(str::to_owned)
+        })
+        .expect("root Cargo.toml declares [workspace.package] version");
+    assert_eq!(
+        version, workspace_version,
+        "producer.version must be the workspace version"
+    );
+}
+
+#[test]
+fn the_parser_branches_on_schema_version_and_never_on_producer_version() {
+    let base = serde_json::to_value(build_workflow_share(&golden_asset(), &golden_payload()))
+        .expect("serializes");
+
+    // A wildly different producer.version is irrelevant to parsing: same schemaVersion, so it
+    // reads, and it reads to the SAME workflow.
+    let mut alien_build = base.clone();
+    alien_build["producer"]["version"] = json!("99.0.0");
+    let parsed =
+        parse_workflow_share(&alien_build).expect("producer.version must not gate parsing");
+    assert_eq!(parsed.producer.version, "99.0.0");
+    assert_eq!(parsed.prompt, base["prompt"].as_str().expect("prompt"));
+
+    // Our own producer.version with a future schemaVersion must be rejected — proving the
+    // branch is on schemaVersion alone and not on the build string.
+    let mut future_contract = base;
+    future_contract["schemaVersion"] = json!(WORKFLOW_SHARE_SCHEMA_VERSION + 1);
+    let error = parse_workflow_share(&future_contract)
+        .expect_err("a future schemaVersion must be rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains(&(WORKFLOW_SHARE_SCHEMA_VERSION + 1).to_string())
+            && message.contains(&WORKFLOW_SHARE_SCHEMA_VERSION.to_string()),
+        "the error must name both versions, got: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Coverage lint
+// ---------------------------------------------------------------------------
+
+const ADVANCED_BUILDER_PATH: &str = "apps/web/src/imageJobAdvanced.js";
+
+#[test]
+fn every_advanced_key_the_studio_can_emit_is_classified() {
+    let source = read_repo_file(ADVANCED_BUILDER_PATH);
+    let emitted = emitted_advanced_keys(&source);
+
+    // A sanity floor: if the extractor ever stops understanding the file (a refactor to a
+    // different builder shape, a move), it must fail loudly rather than pass with an empty set.
+    assert!(
+        emitted.len() >= 25,
+        "only {} keys were extracted from {ADVANCED_BUILDER_PATH} — the extractor no longer \
+         understands that file, so this lint is not protecting anything. Fix \
+         `emitted_advanced_keys` in this test.",
+        emitted.len()
+    );
+    for anchor in ["sampler", "steps", "styleId", "poses", "resolution"] {
+        assert!(
+            emitted.contains(anchor),
+            "the extractor missed the known key `{anchor}` in {ADVANCED_BUILDER_PATH}"
+        );
+    }
+
+    let classified: BTreeSet<String> = ADVANCED_KEY_RULES
+        .iter()
+        .map(|rule| rule.key.to_owned())
+        .collect();
+    let from_builder: BTreeSet<String> = ADVANCED_KEY_RULES
+        .iter()
+        .filter(|rule| rule.source == AdvancedKeySource::StudioBuilder)
+        .map(|rule| rule.key.to_owned())
+        .collect();
+
+    let unclassified: Vec<&String> = emitted.difference(&classified).collect();
+    assert!(
+        unclassified.is_empty(),
+        "buildImageJobAdvanced can emit {unclassified:?}, which `ADVANCED_KEY_RULES` in \
+         crates/sceneworks-core/src/workflow_share.rs does not classify.\n\
+         A new advanced knob must be classified before it ships: add it to the table as \
+         `allow(..)` if it describes WHAT TO MAKE (it travels in shared images) or `deny(..)` \
+         if it describes WHAT THIS MACHINE CAN AFFORD (tier, kernel, GPU) or names anything \
+         local (an id, a path, a preset). Either way write the reason — an unclassified key \
+         is dropped silently today and that is exactly what this lint exists to stop."
+    );
+
+    let stale: Vec<&String> = from_builder.difference(&emitted).collect();
+    assert!(
+        stale.is_empty(),
+        "`ADVANCED_KEY_RULES` classifies {stale:?} as coming from buildImageJobAdvanced, but \
+         {ADVANCED_BUILDER_PATH} no longer emits them.\n\
+         Either the knob was removed (drop the rule) or it moved to the server (re-tag the \
+         rule `AdvancedKeySource::Server`). A rule that no longer matches its source is a \
+         classification nobody is maintaining."
+    );
+
+    // The rules table must not carry a key twice with two dispositions.
+    assert_eq!(
+        classified.len(),
+        ADVANCED_KEY_RULES.len(),
+        "`ADVANCED_KEY_RULES` has duplicate keys"
+    );
+    // Every rule explains itself — the failure message above tells an author to write one.
+    for rule in ADVANCED_KEY_RULES {
+        assert!(
+            rule.reason.len() > 20,
+            "rule for `{}` needs a real reason",
+            rule.key
+        );
+    }
+}
+
+#[test]
+fn the_key_extractor_reads_a_representative_builder() {
+    // Pins the extractor itself against the exact JS shapes `imageJobAdvanced.js` uses:
+    // shorthand keys, `key: value`, conditional spreads, a spread nested inside a spread,
+    // an object VALUE (whose keys are not advanced keys), a call argument object (likewise),
+    // and string literals that must not be mistaken for keys.
+    let source = r#"
+export function buildImageJobAdvanced(state) {
+  const { resolution, sampler } = state;
+  return {
+    resolution,
+    // A comment naming notAKey: 1
+    /* block comment: alsoNotAKey: 2 */
+    ...(sampler && sampler !== "default" ? { sampler } : {}),
+    ...(steps !== "" ? { steps: Number(steps) } : {}),
+    ...(flashAttn ? {} : { flashAttn: false }),
+    ...(tier !== null
+      ? {
+          mlxQuantize: tierQuantize(tier),
+          ...(tierExplicit ? { mlxQuantizeExplicit: true } : {}),
+        }
+      : {}),
+    ...(pidTarget === "2k" ? { pidTarget: "2k" } : {}),
+    ...(posePayload.length ? { poses: posePayload, faceRestore } : {}),
+    ...(overlayId ? { controlWeights: { overlayId: controlOverlayId } } : {}),
+    ...(sendStructured ? { structuredPrompt: buildRecipe({ intent: a, caption: b }) } : {}),
+  };
+}
+"#;
+    let keys = emitted_advanced_keys(source);
+    let expected: BTreeSet<String> = [
+        "resolution",
+        "sampler",
+        "steps",
+        "flashAttn",
+        "mlxQuantize",
+        "mlxQuantizeExplicit",
+        "pidTarget",
+        "poses",
+        "faceRestore",
+        "controlWeights",
+        "structuredPrompt",
+    ]
+    .iter()
+    .map(|key| (*key).to_owned())
+    .collect();
+    assert_eq!(keys, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Leak tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_value_in_a_built_envelope_is_path_shaped() {
+    let mut payload = golden_payload();
+    let advanced = payload
+        .get_mut("advanced")
+        .and_then(Value::as_object_mut)
+        .expect("advanced object");
+    // Seeded on purpose: paths under allow-listed keys, under denied keys, under keys nobody
+    // has classified, and nested inside an object smuggled under a scalar key.
+    for (key, value) in [
+        ("sampler", json!("C:\\Users\\Michael\\samplers\\euler.json")),
+        ("scheduler", json!("/home/michael/schedules/beta")),
+        ("controlScale", json!("file:///D:/maps/canny.png")),
+        ("resolution", json!("~/renders/1024x1024")),
+        (
+            "steps",
+            json!({ "path": "\\\\fileserver\\share\\steps.json" }),
+        ),
+        (
+            "someFutureKnob",
+            json!("E:\\models\\future\\weights.safetensors"),
+        ),
+        ("weightsPath", json!("/opt/sceneworks/weights.safetensors")),
+        (
+            "poses",
+            json!([{ "id": "pose_1", "keypoints": "C:\\poses\\a.json" }]),
+        ),
+    ] {
+        advanced.insert(key.to_owned(), value);
+    }
+
+    let share = build_workflow_share(&golden_asset(), &payload);
+    let encoded = serde_json::to_value(&share).expect("serializes");
+
+    let mut offenders = Vec::new();
+    collect_strings(&encoded, String::from("$"), &mut offenders);
+    for (pointer, value) in &offenders {
+        // `producer.url` is the ONE URL the envelope deliberately carries. It names the
+        // software's repository, never this installation.
+        if pointer == "$.producer.url" {
+            continue;
+        }
+        assert!(
+            !looks_like_a_path(value),
+            "{pointer} = {value:?} is path-shaped and must never reach a shared image"
+        );
+    }
+
+    // And nothing from the seeded values survived as a substring anywhere.
+    let text = serde_json::to_string(&encoded).expect("serializes");
+    for fragment in [
+        "Michael",
+        "C:\\\\",
+        "/home/",
+        "file://",
+        "fileserver",
+        "E:\\\\",
+        "/opt/",
+        "safetensors",
+    ] {
+        assert!(
+            !text.contains(fragment),
+            "{fragment:?} leaked into the envelope: {text}"
+        );
+    }
+}
+
+#[test]
+fn input_ids_become_shape_descriptors_with_zero_id_leakage() {
+    let mut payload = golden_payload();
+    payload.insert("referenceAssetId".to_owned(), json!("asset_ref_solo"));
+    let share = build_workflow_share(&golden_asset(), &payload);
+
+    let kinds: Vec<(&str, u32, Option<&str>)> = share
+        .inputs
+        .iter()
+        .map(|input| {
+            (
+                input.kind.as_str(),
+                input.count,
+                input.control_mode.as_deref(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        kinds,
+        vec![
+            ("source", 1, None),
+            ("reference", 3, None),
+            ("mask", 1, None),
+            ("control", 1, Some("canny")),
+        ]
+    );
+
+    let text = serde_json::to_string(&share).expect("serializes");
+    for id in [
+        "asset_source_1",
+        "asset_ref_1",
+        "asset_ref_2",
+        "asset_ref_solo",
+        "asset_mask_1",
+        "asset_control_1",
+        "asset_9f2c",
+        "project_7a10",
+        "genset_31bb",
+        "job_5c8e",
+        "character_c001",
+        "look_l001",
+        "lora_1f0d",
+        "overlay_7",
+        "preset_local_1",
+        "Michael's Unreleased Film",
+        "2026-07-29T13:04:11Z",
+        "nvfp4",
+        "krea_2_turbo\\\\", // the install path's model dir, not the catalog slug
+    ] {
+        assert!(!text.contains(id), "{id} leaked into the envelope: {text}");
+    }
+
+    // The catalog slug itself IS in — it names a model, not an installation.
+    assert_eq!(share.model, "krea_2_turbo");
+}
+
+#[test]
+fn denied_top_level_request_fields_never_travel() {
+    let share = build_workflow_share(&golden_asset(), &golden_payload());
+    let encoded = serde_json::to_value(&share).expect("serializes");
+    let object = encoded.as_object().expect("envelope is an object");
+    for denied in [
+        "projectId",
+        "projectName",
+        "jobId",
+        "assetId",
+        "generationSetId",
+        "characterId",
+        "characterLookId",
+        "requestedGpu",
+        "quantTier",
+        "tierExplicit",
+        "modelManifestEntry",
+        "seeds",
+        "createdAt",
+        "recipePresetId",
+    ] {
+        assert!(
+            !object.contains_key(denied),
+            "`{denied}` must not be a top-level envelope field"
+        );
+    }
+    for denied in [
+        "quantTier",
+        "mlxQuantize",
+        "flashAttn",
+        "controlWeights",
+        "controlImage",
+    ] {
+        assert!(
+            !share.advanced.contains_key(denied),
+            "`advanced.{denied}` must not travel"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn collect_strings(value: &Value, pointer: String, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::String(text) => out.push((pointer, text.clone())),
+        Value::Array(values) => {
+            for (index, item) in values.iter().enumerate() {
+                collect_strings(item, format!("{pointer}[{index}]"), out);
+            }
+        }
+        Value::Object(map) => {
+            for (key, item) in map {
+                collect_strings(item, format!("{pointer}.{key}"), out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// An independent path sniffer for the assertion side, deliberately written without reusing
+/// `workflow_share::is_path_shaped` so a bug in that function cannot hide behind itself.
+fn looks_like_a_path(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if lower.contains("file://") {
+        return true;
+    }
+    if value.starts_with('/') || value.starts_with('\\') || value.starts_with("~/") {
+        return true;
+    }
+    if value.contains('\\') {
+        return true;
+    }
+    // `X:/…` or `X:\…` where the letter is not part of a URL scheme.
+    lower
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != ':')
+        .any(|token| {
+            let bytes = token.as_bytes();
+            bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+        })
+}
+
+// ---------------------------------------------------------------------------
+// The JS key extractor
+// ---------------------------------------------------------------------------
+
+/// Every key `buildImageJobAdvanced` can put into the `advanced` payload.
+///
+/// A small brace-aware scanner rather than a regex, because the builder's whole shape is
+/// conditional spreads: `...(cond ? { key: value } : {})` contributes a TOP-LEVEL advanced
+/// key from brace depth two, while `{ controlWeights: { overlayId } }` and a call argument
+/// object like `buildStructuredPromptRecipe({ intent })` do not. A regex cannot tell those
+/// apart, and getting it wrong in the permissive direction would make this lint pass on a key
+/// that is never emitted while missing one that is.
+///
+/// Rule: a brace is an "emit scope" when it is the return object itself, or when it is an
+/// object literal at the top level of a spread expression (`...( … )`) written inside another
+/// emit scope — which covers BOTH branches of the `cond ? { a } : { b }` the builder uses.
+/// Only identifiers in key position inside an emit scope count.
+fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
+    let body = builder_return_body(source);
+    let chars: Vec<char> = body.chars().collect();
+    let mut keys = BTreeSet::new();
+    // (is_emit_scope, expecting_a_key)
+    let mut scopes: Vec<(bool, bool)> = vec![(true, true)];
+    // Open spread expressions, as (open scope count, paren depth at the `...`). Nested,
+    // because `...(a ? { k, ...(b ? { j } : {}) } : {})` happens.
+    let mut spreads: Vec<(usize, usize)> = Vec::new();
+    let mut paren_depth = 0_usize;
+    let mut index = 0;
+
+    while index < chars.len() {
+        let character = chars[index];
+        if character.is_whitespace() {
+            index += 1;
+            continue;
+        }
+        match character {
+            '{' => {
+                let in_spread = spreads
+                    .last()
+                    .is_some_and(|(scope_count, _)| *scope_count == scopes.len());
+                let is_emit = in_spread && scopes.last().is_some_and(|(emit, _)| *emit);
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = false;
+                }
+                scopes.push((is_emit, true));
+                index += 1;
+            }
+            '}' => {
+                scopes.pop();
+                index += 1;
+                if scopes.is_empty() {
+                    break;
+                }
+            }
+            '(' => {
+                paren_depth += 1;
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = false;
+                }
+                index += 1;
+            }
+            ')' => {
+                paren_depth = paren_depth.saturating_sub(1);
+                while spreads
+                    .last()
+                    .is_some_and(|(_, spread_paren)| *spread_paren >= paren_depth)
+                {
+                    spreads.pop();
+                }
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = false;
+                }
+                index += 1;
+            }
+            ',' => {
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = true;
+                }
+                index += 1;
+            }
+            '.' => {
+                if index + 2 < chars.len() && chars[index + 1] == '.' && chars[index + 2] == '.' {
+                    if scopes.last().is_some_and(|(emit, _)| *emit) {
+                        spreads.push((scopes.len(), paren_depth));
+                    }
+                    index += 3;
+                } else {
+                    index += 1;
+                }
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = false;
+                }
+            }
+            '"' | '\'' | '`' => {
+                index = skip_string(&chars, index);
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = false;
+                }
+            }
+            character if is_identifier_start(character) => {
+                let start = index;
+                while index < chars.len() && is_identifier_char(chars[index]) {
+                    index += 1;
+                }
+                let (is_emit, expecting) = *scopes.last().expect("a scope is always open");
+                if is_emit && expecting {
+                    let mut lookahead = index;
+                    while lookahead < chars.len() && chars[lookahead].is_whitespace() {
+                        lookahead += 1;
+                    }
+                    if lookahead < chars.len() && matches!(chars[lookahead], ':' | ',' | '}') {
+                        keys.insert(chars[start..index].iter().collect::<String>());
+                    }
+                }
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = false;
+                }
+            }
+            _ => {
+                if let Some(scope) = scopes.last_mut() {
+                    scope.1 = false;
+                }
+                index += 1;
+            }
+        }
+    }
+    keys
+}
+
+/// The text inside `buildImageJobAdvanced`'s `return { … }`, comments removed.
+fn builder_return_body(source: &str) -> String {
+    let stripped = strip_comments(source);
+    let function_at = stripped
+        .find("function buildImageJobAdvanced")
+        .unwrap_or_else(|| {
+            panic!(
+                "`buildImageJobAdvanced` is gone from {ADVANCED_BUILDER_PATH} — this coverage \
+                 lint must be pointed at wherever the advanced payload is built now"
+            )
+        });
+    let return_at = stripped[function_at..]
+        .find("return {")
+        .map(|offset| function_at + offset + "return ".len())
+        .expect("buildImageJobAdvanced returns an object literal");
+
+    let chars: Vec<char> = stripped[return_at..].chars().collect();
+    let mut depth = 0_usize;
+    let mut index = 0;
+    let mut end = None;
+    while index < chars.len() {
+        match chars[index] {
+            '"' | '\'' | '`' => {
+                index = skip_string(&chars, index);
+                continue;
+            }
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(index);
+                    break;
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    let end = end.expect("the returned object literal is balanced");
+    chars[1..end].iter().collect()
+}
+
+/// Blank out `//` and `/* */` comments without disturbing string literals.
+fn strip_comments(source: &str) -> String {
+    let chars: Vec<char> = source.chars().collect();
+    let mut out = String::with_capacity(source.len());
+    let mut index = 0;
+    while index < chars.len() {
+        let character = chars[index];
+        match character {
+            '/' if index + 1 < chars.len() && chars[index + 1] == '/' => {
+                while index < chars.len() && chars[index] != '\n' {
+                    index += 1;
+                }
+            }
+            '/' if index + 1 < chars.len() && chars[index + 1] == '*' => {
+                index += 2;
+                while index + 1 < chars.len() && !(chars[index] == '*' && chars[index + 1] == '/') {
+                    index += 1;
+                }
+                index = (index + 2).min(chars.len());
+                out.push(' ');
+            }
+            '"' | '\'' | '`' => {
+                let end = skip_string(&chars, index);
+                out.extend(&chars[index..end]);
+                index = end;
+            }
+            _ => {
+                out.push(character);
+                index += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Index just past the string literal starting at `start`.
+fn skip_string(chars: &[char], start: usize) -> usize {
+    let quote = chars[start];
+    let mut index = start + 1;
+    while index < chars.len() {
+        match chars[index] {
+            '\\' => index += 2,
+            character if character == quote => return index + 1,
+            _ => index += 1,
+        }
+    }
+    chars.len()
+}
+
+fn is_identifier_start(character: char) -> bool {
+    character.is_ascii_alphabetic() || character == '_' || character == '$'
+}
+
+fn is_identifier_char(character: char) -> bool {
+    is_identifier_start(character) || character.is_ascii_digit()
+}

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -158,6 +158,14 @@ fn load_golden_fixture() -> Value {
 // Golden fixture + round trip (matching tests/contract_roundtrip.rs)
 // ---------------------------------------------------------------------------
 
+// The three tests below compare parsed `Value`s and MUST keep doing so — never serialized text,
+// and never a byte comparison against the fixture file. `serde_json::Map` is a `BTreeMap`
+// (sorted) or an `IndexMap` (insertion-ordered) depending on the `preserve_order` feature, which
+// Cargo unifies across the workspace, so the same envelope serializes its keys in a different
+// ORDER under `cargo test -p sceneworks-core` than under the workspace build the `parity` job
+// runs. `Value` equality is order-independent under both; a text comparison would not be, and
+// would fail in exactly one of the two configurations while nothing was wrong (sc-15946).
+
 #[test]
 fn golden_envelope_round_trips_without_field_drift() {
     let original = load_golden_fixture();

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use sceneworks_core::contracts::{Asset, JsonObject};
 use sceneworks_core::workflow_share::{
-    build_workflow_share, parse_workflow_share, AdvancedKeySource, WorkflowShare,
+    build_workflow_share, is_path_shaped, parse_workflow_share, AdvancedKeySource, WorkflowShare,
     ADVANCED_KEY_RULES, PRODUCER_URL, PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
 };
 use serde_json::{json, Value};
@@ -403,13 +403,84 @@ export function buildImageJobAdvanced(state) {
     assert_eq!(keys, expected);
 }
 
+/// A builder shaped the way the scanner cannot read, so the tests below can hand it one.
+fn builder_with_return_body(body: &str) -> String {
+    format!("export function buildImageJobAdvanced(state) {{\n  return {{\n{body}\n  }};\n}}\n")
+}
+
+#[test]
+#[should_panic(expected = "cannot read")]
+fn the_key_extractor_refuses_a_spread_of_a_call_expression() {
+    // Verified against the real lint: adding this line plus a helper returning
+    // `{ secretLocalPathKnob: state.weightsPath }` made the whole coverage lint PASS SILENTLY —
+    // the `>= 25` floor and all five anchors still resolved while the new knob became invisible.
+    emitted_advanced_keys(&builder_with_return_body(
+        "    resolution,\n    ...buildFutureKnobs(state),",
+    ));
+}
+
+#[test]
+#[should_panic(expected = "cannot read")]
+fn the_key_extractor_refuses_a_spread_of_a_bare_identifier() {
+    // A parenthesis-less spread also used to leave a spread open forever, so the next nested
+    // object VALUE would have been read as an emit scope — quiet corruption, not just a miss.
+    emitted_advanced_keys(&builder_with_return_body(
+        "    resolution,\n    ...defaults,\n    ...(a ? { controlWeights: { overlayId } } : {}),",
+    ));
+}
+
+#[test]
+#[should_panic(expected = "contains no object literal")]
+fn the_key_extractor_refuses_a_spread_with_no_object_literal_in_it() {
+    emitted_advanced_keys(&builder_with_return_body(
+        "    resolution,\n    ...(buildFutureKnobs(state)),",
+    ));
+}
+
 // ---------------------------------------------------------------------------
 // Leak tests
 // ---------------------------------------------------------------------------
 
+/// Every value in a built envelope, checked against an INDEPENDENTLY written path sniffer.
+///
+/// The seeds are the point: the guard only ever gets as strong as what this test throws at it,
+/// and the first cut seeded only absolute paths — which is exactly the subset the first cut of
+/// `is_path_shaped` already caught, so the two could agree while both being wrong. The relative,
+/// traversing and drive-relative seeds below are the ones that used to travel verbatim, and the
+/// top-level ones (`model`, `stylePreset`, `styleId`, `fitMode`, `mode`) cover the fields that
+/// were copied with no check at all while `advanced.styleId` — literally the same value — was
+/// guarded.
+///
+/// The deliberate PROSE exemption is not seeded here; it is pinned by
+/// [`authored_prose_travels_verbatim_even_when_it_names_a_path`] so that each test asserts one
+/// thing.
 #[test]
 fn no_value_in_a_built_envelope_is_path_shaped() {
     let mut payload = golden_payload();
+    // Top-level request fields, copied straight onto the envelope. `mode` and `model` are
+    // required strings, so a path-shaped one reduces to empty rather than vanishing.
+    for (key, value) in [
+        ("mode", "..\\..\\Users\\Michael"),
+        ("model", "C:\\models\\evil"),
+        ("stylePreset", "\\\\fileserver\\styles\\x"),
+        ("styleId", "../../etc/passwd"),
+        ("fitMode", "/etc/passwd"),
+    ] {
+        payload.insert(key.to_owned(), json!(value));
+    }
+    payload.insert(
+        "upscale".to_owned(),
+        json!({ "enabled": true, "factor": 2, "engine": "E:\\engines\\seedvr2" }),
+    );
+    payload.insert(
+        "loras".to_owned(),
+        json!([{
+            "name": "Users\\Michael\\Desktop\\coast.safetensors",
+            "weight": 0.65,
+            "source": { "provider": "huggingface", "repo": "../../../etc/passwd" }
+        }]),
+    );
+
     let advanced = payload
         .get_mut("advanced")
         .and_then(Value::as_object_mut)
@@ -434,6 +505,18 @@ fn no_value_in_a_built_envelope_is_path_shaped() {
             "poses",
             json!([{ "id": "pose_1", "keypoints": "C:\\poses\\a.json" }]),
         ),
+        // The escapes the first cut of the guard let through, one per family.
+        ("guidanceMethod", json!("Users\\Michael\\Desktop\\cfg.json")),
+        ("viewAngle", json!("..\\..\\Users\\Michael")),
+        ("schedulerShift", json!("../../etc/passwd")),
+        // A drive-RELATIVE path: a drive prefix with no separator after it.
+        ("controlMode", json!("C:foo")),
+        ("styleId", json!("c:secret\\noir")),
+        ("faceRestore", json!("%USERPROFILE%\\restore.json")),
+        ("textStyleGain", json!("~michael/gain.json")),
+        // Percent-encoded `file://D:/x`.
+        ("trueCfgScale", json!("file%3A%2F%2FD%3A%2Fx")),
+        ("ipAdapterScale", json!("assets/images/michael/x.png")),
     ] {
         advanced.insert(key.to_owned(), value);
     }
@@ -460,17 +543,155 @@ fn no_value_in_a_built_envelope_is_path_shaped() {
     for fragment in [
         "Michael",
         "C:\\\\",
+        "c:secret",
+        "C:foo",
         "/home/",
         "file://",
+        "file%3A",
         "fileserver",
         "E:\\\\",
         "/opt/",
         "safetensors",
+        "USERPROFILE",
+        "etc/passwd",
+        "..",
+        "~",
     ] {
         assert!(
             !text.contains(fragment),
             "{fragment:?} leaked into the envelope: {text}"
         );
+    }
+}
+
+/// The one deliberate exception to "every filesystem path without exception", made explicit.
+///
+/// `stylePrompt` and the structured prompt's `intent` / `runtimePrompt` are the same class as
+/// the top-level `prompt`, which the story puts IN: they are what the user typed. Silently
+/// mangling authored text because it mentions a directory would be worse than the leak it
+/// prevents — the user wrote it and can see it before sharing. That decision was previously
+/// implicit in a `PROSE_KEYS` constant no test seeded; this pins it in both directions.
+#[test]
+fn authored_prose_travels_verbatim_even_when_it_names_a_path() {
+    const STYLE_PROMPT: &str = "C:\\Users\\Michael\\Desktop\\secret_project\\brief.txt";
+    const INTENT: &str = "/home/michael/clients/acme/nda.md";
+    const RUNTIME_PROMPT: &str = "rendered from ..\\..\\briefs\\acme.json";
+    const PROMPT: &str = "a lighthouse, per D:\\briefs\\fog.md";
+    const NEGATIVE_PROMPT: &str = "no text, nothing like \\\\fileserver\\rejects\\list.txt";
+
+    let mut payload = golden_payload();
+    payload.insert("prompt".to_owned(), json!(PROMPT));
+    payload.insert("negativePrompt".to_owned(), json!(NEGATIVE_PROMPT));
+    let advanced = payload
+        .get_mut("advanced")
+        .and_then(Value::as_object_mut)
+        .expect("advanced object");
+    advanced.insert("stylePrompt".to_owned(), json!(STYLE_PROMPT));
+    advanced.insert(
+        "structuredPrompt".to_owned(),
+        json!({ "intent": INTENT, "runtimePrompt": RUNTIME_PROMPT }),
+    );
+
+    let share = build_workflow_share(&golden_asset(), &payload);
+    assert_eq!(share.prompt, PROMPT);
+    assert_eq!(share.negative_prompt, NEGATIVE_PROMPT);
+    assert_eq!(share.advanced["stylePrompt"], json!(STYLE_PROMPT));
+    let recipe = share.advanced["structuredPrompt"]
+        .as_object()
+        .expect("structuredPrompt object");
+    assert_eq!(recipe["intent"], json!(INTENT));
+    assert_eq!(recipe["runtimePrompt"], json!(RUNTIME_PROMPT));
+
+    // The exemption is per key, not a hole in the guard: a NON-prose neighbour with the same
+    // text is still dropped, and the exempt pointers are exactly these five.
+    let mut offenders = Vec::new();
+    collect_strings(
+        &serde_json::to_value(&share).expect("serializes"),
+        String::from("$"),
+        &mut offenders,
+    );
+    let path_shaped: BTreeSet<&str> = offenders
+        .iter()
+        .filter(|(_, value)| looks_like_a_path(value))
+        .map(|(pointer, _)| pointer.as_str())
+        .collect();
+    assert_eq!(
+        path_shaped,
+        [
+            "$.prompt",
+            "$.negativePrompt",
+            "$.advanced.stylePrompt",
+            "$.advanced.structuredPrompt.intent",
+            "$.advanced.structuredPrompt.runtimePrompt",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<&str>>(),
+        "only the authored prose fields may carry a path"
+    );
+}
+
+/// The shipped guard must never be WEAKER than the sniffer this file asserts with.
+///
+/// That inversion is exactly how the first cut shipped: [`looks_like_a_path`] already treated
+/// any backslash as a path while `is_path_shaped` tested only the FIRST character, so the two
+/// disagreed on every relative Windows path — and the property test passed anyway, because its
+/// seeds happened to be precisely the subset both agreed on. A seed corpus can only ever fail to
+/// notice that; the relationship itself has to be asserted, so it is asserted here.
+///
+/// The other direction is deliberately NOT asserted: the shipped guard is allowed to be
+/// stricter (it also catches relative POSIX trees and percent-encoded `file://`), because the
+/// cost of a false positive is one dropped label and the cost of a false negative is a username
+/// inside every copy of a shared image.
+#[test]
+fn the_shipped_path_guard_is_never_weaker_than_the_independent_sniffer() {
+    for value in [
+        // Paths, one per family.
+        "/home/michael/x.png",
+        "C:\\Users\\Michael\\x.png",
+        "Users\\Michael\\Desktop\\secret.png",
+        "models\\weights\\x.safetensors",
+        "..\\..\\Users\\Michael",
+        "../../etc/passwd",
+        "./local/thing",
+        "C:foo",
+        "c:secret\\file",
+        "%USERPROFILE%\\x",
+        "assets/images/x.png",
+        "~/models/x.png",
+        "~michael/x",
+        "\\\\fileserver\\share\\x.png",
+        "file:///D:/x.png",
+        "file%3A%2F%2FD%3A%2Fx",
+        "engine loaded from D:/models/x",
+        // Legitimate values, which neither may flag.
+        "euler",
+        "dpmpp_2m",
+        "beta",
+        "cfg_pp",
+        "1024x1024",
+        "2k",
+        "acme/mira",
+        "acme/foggy-coast",
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        "https://github.com/SceneWorks/SceneWorks",
+        "text_to_image",
+        "krea_2_turbo",
+        "seedvr2",
+        "noir_bloom",
+        "cinematic",
+        "crop",
+        "canny",
+        "",
+    ] {
+        if looks_like_a_path(value) {
+            assert!(
+                is_path_shaped(value),
+                "the shipped `is_path_shaped` misses {value:?}, which this file's independent \
+                 sniffer flags — so the leak tests here are checking a guard weaker than their \
+                 own assertion and a bug in it can hide behind itself. Strengthen \
+                 `workflow_share::is_path_shaped`; do NOT weaken `looks_like_a_path`."
+            );
+        }
     }
 }
 
@@ -630,15 +851,26 @@ fn looks_like_a_path(value: &str) -> bool {
 /// object literal at the top level of a spread expression (`...( … )`) written inside another
 /// emit scope — which covers BOTH branches of the `cond ? { a } : { b }` the builder uses.
 /// Only identifiers in key position inside an emit scope count.
+///
+/// # Fails loud, never quiet
+///
+/// The scanner understands ONE shape, and a lint that silently understands nothing is worse
+/// than no lint: `...buildFutureKnobs(state)` in the return object would contribute no keys, the
+/// `>= 25` floor and every anchor would still resolve, and a brand-new knob would stop
+/// travelling with zero signal. So a spread this scanner cannot follow — a bare identifier
+/// (`...defaults,`), a call expression, or a parenthesized expression with no object literal in
+/// it — PANICS with instructions instead of scanning past it. Fail-safe on the privacy axis
+/// (the key is dropped, not leaked) is only half of what this lint is for; the other half is
+/// noticing that a knob went missing.
 fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
     let body = builder_return_body(source);
     let chars: Vec<char> = body.chars().collect();
     let mut keys = BTreeSet::new();
     // (is_emit_scope, expecting_a_key)
     let mut scopes: Vec<(bool, bool)> = vec![(true, true)];
-    // Open spread expressions, as (open scope count, paren depth at the `...`). Nested,
-    // because `...(a ? { k, ...(b ? { j } : {}) } : {})` happens.
-    let mut spreads: Vec<(usize, usize)> = Vec::new();
+    // Open spread expressions, as (open scope count, paren depth at the `...`, produced an
+    // object literal). Nested, because `...(a ? { k, ...(b ? { j } : {}) } : {})` happens.
+    let mut spreads: Vec<(usize, usize, bool)> = Vec::new();
     let mut paren_depth = 0_usize;
     let mut index = 0;
 
@@ -652,8 +884,11 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
             '{' => {
                 let in_spread = spreads
                     .last()
-                    .is_some_and(|(scope_count, _)| *scope_count == scopes.len());
+                    .is_some_and(|(scope_count, _, _)| *scope_count == scopes.len());
                 let is_emit = in_spread && scopes.last().is_some_and(|(emit, _)| *emit);
+                if let (true, Some(spread)) = (is_emit, spreads.last_mut()) {
+                    spread.2 = true;
+                }
                 if let Some(scope) = scopes.last_mut() {
                     scope.1 = false;
                 }
@@ -676,10 +911,18 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
             }
             ')' => {
                 paren_depth = paren_depth.saturating_sub(1);
-                while spreads
-                    .last()
-                    .is_some_and(|(_, spread_paren)| *spread_paren >= paren_depth)
-                {
+                while let Some((_, spread_paren, produced)) = spreads.last().copied() {
+                    if spread_paren < paren_depth {
+                        break;
+                    }
+                    assert!(
+                        produced,
+                        "a spread in buildImageJobAdvanced's return object contains no object \
+                         literal, so `emitted_advanced_keys` in this test scanned past it and \
+                         contributed nothing. Every key inside it is invisible to this lint. \
+                         Write the spread as `...(cond ? {{ key }} : {{}})`, or teach the \
+                         scanner the new shape."
+                    );
                     spreads.pop();
                 }
                 if let Some(scope) = scopes.last_mut() {
@@ -696,7 +939,27 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
             '.' => {
                 if index + 2 < chars.len() && chars[index + 1] == '.' && chars[index + 2] == '.' {
                     if scopes.last().is_some_and(|(emit, _)| *emit) {
-                        spreads.push((scopes.len(), paren_depth));
+                        // The scanner follows `...( … )` and nothing else. A bare identifier or
+                        // a call would leave a spread open forever — the next nested object
+                        // VALUE would then read as an emit scope — so refuse rather than guess.
+                        let mut lookahead = index + 3;
+                        while lookahead < chars.len() && chars[lookahead].is_whitespace() {
+                            lookahead += 1;
+                        }
+                        assert!(
+                            chars.get(lookahead) == Some(&'('),
+                            "buildImageJobAdvanced spreads something `emitted_advanced_keys` in \
+                             this test cannot read: a bare identifier or a call expression \
+                             (`...{}`). Every key it contributes is invisible to this lint, so a \
+                             new knob would silently stop travelling. Write it as \
+                             `...(cond ? {{ key }} : {{}})`, or teach the scanner the new shape.",
+                            chars[lookahead..]
+                                .iter()
+                                .take(24)
+                                .collect::<String>()
+                                .trim_end()
+                        );
+                        spreads.push((scopes.len(), paren_depth, false));
                     }
                     index += 3;
                 } else {
@@ -739,6 +1002,12 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
             }
         }
     }
+    assert!(
+        spreads.is_empty(),
+        "a spread in buildImageJobAdvanced's return object never closed, so \
+         `emitted_advanced_keys` in this test lost track of the builder's shape. Fix the \
+         scanner rather than letting it scan a shape it does not understand."
+    );
     keys
 }
 

--- a/tests/fixtures/workflow_share/image-workflow-share.json
+++ b/tests/fixtures/workflow_share/image-workflow-share.json
@@ -1,0 +1,53 @@
+{
+  "sceneworksWorkflow": "image",
+  "schemaVersion": 1,
+  "producer": {
+    "name": "SceneWorks",
+    "url": "https://github.com/SceneWorks/SceneWorks",
+    "version": "0.8.1"
+  },
+  "mode": "edit_image",
+  "model": "krea_2_turbo",
+  "prompt": "a lighthouse in heavy fog, cinematic",
+  "negativePrompt": "text, watermark",
+  "seed": 880412,
+  "width": 1024,
+  "height": 1024,
+  "count": 2,
+  "stylePreset": "cinematic",
+  "styleId": "noir_bloom",
+  "fitMode": "crop",
+  "upscale": {
+    "enabled": true,
+    "factor": 2,
+    "engine": "seedvr2",
+    "softness": 0.25
+  },
+  "loras": [
+    {
+      "name": "Foggy Coast",
+      "weight": 0.65,
+      "repo": "acme/foggy-coast"
+    }
+  ],
+  "inputs": [
+    { "kind": "source", "count": 1 },
+    { "kind": "reference", "count": 2 },
+    { "kind": "mask", "count": 1 },
+    { "kind": "control", "count": 1, "controlMode": "canny" }
+  ],
+  "advanced": {
+    "resolution": "1024x1024",
+    "sampler": "euler",
+    "scheduler": "beta",
+    "schedulerShift": 1.15,
+    "steps": 28,
+    "guidanceScale": 3.5,
+    "guidanceMethod": "cfg_pp",
+    "strength": 0.55,
+    "styleId": "noir_bloom",
+    "stylePrompt": "a lighthouse in heavy fog",
+    "controlMode": "canny",
+    "controlScale": 0.9
+  }
+}


### PR DESCRIPTION
Keystone story for epic 15945 (**Shareable assets: sanitized workflow embedded in the image**). Defines the contract every other story in the epic builds on. Pure types plus the sanitizer — no file I/O and no PNG work.

Story: [sc-15946](https://app.shortcut.com/trefry/story/15946)

## What changed

New `crates/sceneworks-core/src/workflow_share.rs`:

- **`WorkflowShare`** — the versioned envelope. Flat, modeled on `apps/web/src/promptBatchIO.js` (sc-9954): published under the `sceneworksWorkflow` marker key, plus `schemaVersion` and a `producer` block. The marker's *value* names the workflow kind (`"image"`) so the video half (sc-15956) can share the key without a reader having to sniff the body.
- **`build_workflow_share(asset, job_payload)`** — builds it from an asset sidecar plus the job row's `payload_json`.
- **`sanitize_advanced`** + **`ADVANCED_KEY_RULES`** — the allow-list.
- **`parse_workflow_share` / `parse_workflow_share_json`** + **`WorkflowShareError`** — the read side.

### Two versions, deliberately not one

`schemaVersion` (integer) is the *contract* version and the **only** thing the parser branches on. `producer.version` is the *build* — `env!("CARGO_PKG_VERSION")`, i.e. the `[workspace.package] version` that `scripts/sync-version.mjs` keeps in lockstep with the web/desktop manifests — and never drives parsing. It is deliberately not derived from `git describe`, a dirty-tree suffix, a CI build number or anything path- or host-derived, because it is the one field the allow-list cannot protect: `0.8.1-dirty-Michael` would walk straight into every shared image. A test asserts strict `MAJOR.MINOR.PATCH` and equality with the root `Cargo.toml`.

### Source is `payload_json`, not `recipe`

The recipe is lossy — `sourceAssetId`, `referenceAssetIds`, `maskAssetId`, `fitMode` and `upscale` are split between `lineage` and untyped `rawAdapterSettings` (`project_store::build_image_sidecar_parts`). The one thing taken from the sidecar is the **seed**: the payload carries the batch base plus the whole `seeds` list, and only the sidecar knows which seed rendered the file being shared. The batch list never travels.

### Allow-list, not deny-list

`ADVANCED_KEY_RULES` classifies all 31 keys `buildImageJobAdvanced` can emit, plus the 2 the API stamps on. The line is **what to make** vs **what this machine can afford**:

- **In:** resolution, sampler, scheduler, schedulerShift, steps, guidanceScale, guidanceMethod, enhancePrompt, usePid, pidTarget, ipAdapterScale, controlnetConditioningScale, trueCfgScale, strength, textStyleGain, viewAngle, poses, faceRestore, controlMode, controlScale, styleId, stylePrompt, phases, structuredPrompt — plus mode, model slug, prompt, negativePrompt, seed, width/height, count, stylePreset, styleId, fitMode, upscale `{enabled, factor, engine, softness}`, and LoRA name + weight + HF repo id.
- **Out:** `flashAttn`, `mlxQuantize`, `mlxQuantizeExplicit`, `convRot`, `quantTier` (hardware budget); `controlImage`, `controlWeights`, `recipePresetId`, `presetMissingLoras` (local ids and the resolved overlay path); every filesystem path; projectId / jobId / assetIds / gensetId / characterId / characterLookId; project and machine names; timestamps; **anything unclassified**.

Allowed values are shape-checked as well as key-checked, which closes two holes a plain key allow-list leaves open: an object cannot be smuggled under a scalar key, and a path-shaped string is dropped even from a key that is otherwise allowed. Authored prose (`prompt`, `negativePrompt`, `stylePrompt`, `intent`, `runtimePrompt`) is exempt from the path guard on purpose — mangling what the user typed would be worse than the leak it prevents, and that exemption is pinned by its own seeded test rather than left implicit.

`is_path_shaped` recognizes absolute **and relative** locations: a backslash anywhere (every Windows path has one — `Users\Michael\x`, `..\..\Users\Michael`, UNC, `%USERPROFILE%\x`), POSIX absolutes, `~` / `~user` expansions, a bare drive prefix with or without a separator (`C:foo` resolves against a per-drive cwd and is still a path), `..` traversal segments, relative POSIX trees of three or more segments, and `file://` including repeatedly percent-decoded forms. It errs toward dropping: a false positive costs one label, a false negative ships the user's home directory — and therefore their name — inside every copy of the image. `acme/mira`, `https://…`, `1024x1024`, `euler` and `dpmpp_2m` are verified not to trip it.

The reduction runs on **parse** as well as build, and at **value** granularity, not just key granularity. Dropping unknown keys says nothing about the strings under the keys we do declare, and an envelope from a stranger's PNG chooses all of them. One `reduce_workflow_share` is what both directions call, so they cannot drift: the path guard on every label (`model`, `mode`, `stylePreset`, `styleId`, `fitMode`, `upscale.engine`, `loras[].name`, `inputs[].controlMode`), `owner/name` validation on `loras[].repo` (the value sc-15952 joins into an HF cache path), the closed four-kind vocabulary on `inputs[].kind`, and a bounded producer block. The type has no `#[serde(flatten)] extra` bucket — a deliberate departure from the sidecar contracts, since forward-compat extras would defeat the allow-list on the way in.

### Input images by shape, not by id

`sourceAssetId` / `referenceAssetId(s)` / `maskAssetId` / `advanced.controlImage` become `inputs: [{ kind, count, controlMode? }]` — "needs 2 reference images", never a dangling local UUID. This is what lets sc-15952 render a missing-inputs panel without leaking ids or base64-bloating the file.

## Acceptance criteria

| AC | Where |
| --- | --- |
| `WorkflowShare` + `build_workflow_share(asset, job_payload)` in `sceneworks-core` | `workflow_share.rs` |
| Producer block: name, canonical repo URL, `CARGO_PKG_VERSION` | `WorkflowProducer::default` |
| `producer.version` is strict semver | `producer_version_is_strict_semver_and_matches_the_workspace` |
| Parser branches on `schemaVersion`, never `producer.version` | `the_parser_branches_on_schema_version_and_never_on_producer_version` |
| Unknown/future `schemaVersion` gives a typed error naming both versions | `WorkflowShareError::UnsupportedSchemaVersion` + two tests |
| Allow-list sanitizer applied on build; unclassified keys dropped | `sanitize_advanced` + `unclassified_advanced_keys_are_dropped` |
| **Coverage lint** over `buildImageJobAdvanced` | `every_advanced_key_the_studio_can_emit_is_classified` |
| Golden fixture + round-trip, matching `contract_roundtrip.rs` | `tests/fixtures/workflow_share/image-workflow-share.json` + 3 tests |
| No value in a built envelope is path-shaped (paths seeded in `advanced`) | `no_value_in_a_built_envelope_is_path_shaped` |
| Source/reference/mask/control ids give shape descriptors, zero id leakage | `input_ids_become_shape_descriptors_with_zero_id_leakage` |
| Descriptive parse errors, no panics, no silent defaults | `WorkflowShareError` + 6 tests |

## The coverage lint

`every_advanced_key_the_studio_can_emit_is_classified` **mechanically parses** `apps/web/src/imageJobAdvanced.js` rather than trusting a hand-maintained list. A small brace-aware scanner, not a regex: the builder's whole shape is conditional spreads, so `...(cond ? { key: value } : {})` contributes a top-level `advanced` key from brace depth two, while `{ controlWeights: { overlayId } }` and a call-argument object like `buildStructuredPromptRecipe({ intent })` do not — a regex cannot tell those apart, and being wrong in the permissive direction would make the lint pass on a key that is never emitted while missing one that is.

It asserts both directions:

- a key the JS can emit that the table does not classify **fails**, with a message telling the author to add `allow(..)` (what to make) or `deny(..)` (what this machine can afford, or anything local) and to write the reason;
- a rule tagged `AdvancedKeySource::StudioBuilder` whose key the JS no longer emits **fails** too, so a knob cannot silently vanish and leave a classification nobody maintains.

It also has a floor (at least 25 keys) plus known anchors, so a refactor that defeats the scanner fails loudly instead of passing with an empty set, and `the_key_extractor_reads_a_representative_builder` pins the scanner itself against every JS shape the builder uses.

It also **refuses shapes it cannot read**. A floor (at least 25 keys) plus known anchors catches a scanner that understands nothing, but that floor is not enough on its own: `...buildFutureKnobs(state),` in the return object contributes no keys while the floor and every anchor still resolve, so a knob would stop travelling with zero signal. A spread of a bare identifier, a call expression, or a parenthesized expression containing no object literal now **panics with instructions** instead of being scanned past — and a parenthesis-less spread no longer leaves a spread open forever, which would have made a later nested object *value* read as an emit scope. Three `#[should_panic]` tests pin the refusals.

**Both directions were verified by hand-mutating the JS** (a new unclassified key, then a removed key) and confirming the lint fails with the intended message — a passing lint proves nothing on its own.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p sceneworks-core --all-targets -- -D warnings` — clean
- `cargo test -p sceneworks-core` — green (719 lib + 15 integration), no pre-existing failures
- `cargo build` — green
- **39 tests** (24 unit + 15 integration), all passing

Each guard is **mutation-verified**, since a passing test proves nothing on its own:

| Mutation | Result |
| --- | --- |
| `is_path_shaped` reverted to the first-character check | 7 tests fail (5 unit + 2 integration) |
| `parse_workflow_share` reverted to re-sanitizing `advanced` only | `parse_reduces_a_hostile_envelope_instead_of_echoing_it` fails |
| `...buildFutureKnobs(state),` added to the real `imageJobAdvanced.js` | the coverage lint fails loudly (previously passed silently) |

## Review fixes

Applied on top of the original push — all defects against this story's own ACs, not follow-ups:

- **The path guard was first-character-only.** `Users\Michael\Desktop\secret.png`, `models\weights\x.safetensors`, `..\..\Users\Michael`, `../../etc/passwd`, `C:foo`, `c:secret\file`, `%USERPROFILE%\x`, `assets/images/x.png`, `~michael/x` and percent-encoded `file://` all travelled verbatim out of any allow-listed key, leaking the OS username into every shared image. Worse, the integration test's *independently written* `looks_like_a_path` was **stricter** than the shipped guard, which defeats the "written independently so a bug can't hide behind itself" design — the property test passed only because its seeds were exactly the subset both agreed on. The guard is strengthened (never the sniffer), the property test is seeded with the relative / traversing / drive-relative cases, and `the_shipped_path_guard_is_never_weaker_than_the_independent_sniffer` now asserts the *relationship*, so a seed corpus can no longer miss the divergence.
- **Parse reduced keys but not values.** A hostile envelope parsed successfully carrying attacker-controlled strings in `loras[].repo` (the build path ran `hf_repo_id`, the parse path did not), `loras[].name`, `model`, `mode`, `upscale.engine`, `fitMode`, `stylePreset`, `styleId`, `inputs[].kind` and the whole producer block. Both paths now run one shared `reduce_workflow_share`. `hf_repo_id` also accepted `../x` — `.` is legal *inside* an HF segment — so a segment must now start with an alphanumeric.
- **Top-level labels had no path check at all** (`model`, `mode`, `stylePreset`, `styleId`, `fitMode`) while `advanced.styleId` — literally the same value — was guarded.
- **The coverage lint could be defeated silently** by a spread it could not parse; it now fails loud.
- **`schemaVersion: "1"` / `-1` / `1.5` reported the field as *missing*.** Present-but-wrong is now `Malformed`, since telling a user a field they can see is missing sends them looking in the wrong place.
- **`AdvancedShape::Poses` dropped `hands` / `face`,** which the worker's `parse_poses` reads and which change the rendered skeleton. Both are pure numeric arrays with nothing identifying in them, so the reduction cost reproduction fidelity for zero privacy gain; they now travel through the same `is_numeric_tree` filter.
- **The `PROSE_KEYS` exemption was untested,** narrowing an "every path without exception" AC by an implicit decision. Behavior is unchanged (prose travels); it is now pinned by `authored_prose_travels_verbatim_even_when_it_names_a_path`, which also asserts the exempt pointers are exactly those five.

## Follow-ups

- `structuredPrompt.caption` (the model-authored structured JSON) is dropped rather than allow-listed key by key — it is free-form and nested. Nothing is lost today: `runtimePrompt` is its serialized form and is what the top-level `prompt` already carries. If sc-15952's rehydrate wants the structured builder repopulated rather than the prose prompt restored, that needs its own classified sub-schema.
- LoRA `source.file` (the file *within* an HF repo) is dropped, so only `repo` travels. A repo with several adapters is ambiguous on replay; the story named "HF repo id" and that is what shipped.
- sc-15957 (A1111 `parameters` chunk) must feed its conventional `Version:` field from `PRODUCER_NAME` / `PRODUCER_VERSION` here, so the two chunks cannot disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

