### PR TITLE
feat(workflow-share): embed the sanitized workflow when generated images are written (sc-15948)

### DIFF
--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -106,6 +106,18 @@ pub(crate) struct UiPreferences {
     /// `MAX_STUDIO_ENTRY_BYTES`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     advanced_studio: Option<BTreeMap<String, serde_json::Value>>,
+    /// Whether a generated PNG carries the sanitized workflow envelope so a shared image reloads
+    /// its recipe on drop (epic 15945, sc-15948). Absent until first set, which every reader takes
+    /// as ON — the feature is pointless off by default, and a user who does not want it should
+    /// have to find the switch once rather than opt in forever.
+    ///
+    /// This is the ONE preference read outside the web app: the WORKER reads it straight off this
+    /// file at its PNG write seam, through `sceneworks_core::app_paths::embed_workflow_in_images`,
+    /// because the desktop hands every process it spawns the same `SCENEWORKS_CONFIG_DIR`. Renaming
+    /// the field or moving the file therefore breaks a consumer the route cannot see.
+    /// sc-15953 owns the Settings toggle and the first-run disclosure that write it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    embed_workflow_in_images: Option<bool>,
 }
 
 /// Retained workspaces in a studio-settings map. The map grows by one entry per workspace the
@@ -323,6 +335,12 @@ pub(crate) async fn set_ui_preferences(
         if let Some(advanced_studio) = payload.advanced_studio {
             prefs.advanced_studio = Some(normalize_studio_settings(advanced_studio));
         }
+        // Same partial-merge rule as `simple_ui`: only touch it when the payload carries it, so an
+        // unrelated PUT can neither turn embedding off nor turn it back on. A plain bool needs no
+        // normalization — an out-of-vocabulary value cannot parse.
+        if let Some(embed_workflow_in_images) = payload.embed_workflow_in_images {
+            prefs.embed_workflow_in_images = Some(embed_workflow_in_images);
+        }
         if let Some(active_view) = normalize_preference_id(payload.active_view.as_deref(), 48) {
             prefs.active_view = Some(active_view);
         }
@@ -458,6 +476,34 @@ mod tests {
             parsed.advanced_studio.unwrap()["project-1"],
             snapshot("advanced side")
         );
+    }
+
+    /// The workflow-embedding toggle has a reader outside this crate: the worker reads it off the
+    /// stored file by name at its PNG write seam (sc-15948). So the wire name and the
+    /// omitted-when-absent behaviour are contract, not detail — an absent field is what the worker
+    /// resolves to ON, and a stored `false` is the only thing that turns embedding off.
+    #[test]
+    fn embed_workflow_in_images_round_trips_under_the_name_the_worker_reads() {
+        let body = serde_json::to_string(&UiPreferences::default()).expect("serialize");
+        assert!(
+            !body.contains("embedWorkflowInImages"),
+            "an untouched install must store nothing, so every reader falls back to ON: {body}"
+        );
+
+        let prefs = UiPreferences {
+            embed_workflow_in_images: Some(false),
+            ..Default::default()
+        };
+        let body = serde_json::to_string(&prefs).expect("serialize");
+        assert!(body.contains("\"embedWorkflowInImages\":false"), "{body}");
+        // The exact shape `sceneworks_core::app_paths::embed_workflow_in_images` parses.
+        assert!(
+            !sceneworks_core::app_paths::embed_workflow_in_images_from_json(&body),
+            "the worker's reader must see the stored opt-out"
+        );
+
+        let parsed: UiPreferences = serde_json::from_str(&body).expect("deserialize");
+        assert_eq!(parsed.embed_workflow_in_images, Some(false));
     }
 
     #[test]

--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -19,7 +19,8 @@ use super::*;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-const PREFERENCES_FILENAME: &str = "ui-preferences.json";
+// The filename lives in `sceneworks_core::app_paths::ui_preferences_file` — see
+// `preferences_path`. A second literal here is what made the cross-crate name drift possible.
 
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -179,8 +180,15 @@ const AUTO_GENERATION_QUALITY: &str = "auto";
 /// with the web `AUTO_GENERATION_QUALITY` default in `normalizeGenerationQuality`.
 const DEFAULT_GENERATION_QUALITY: &str = AUTO_GENERATION_QUALITY;
 
+/// The stored preference file.
+///
+/// Goes through `sceneworks_core::app_paths` rather than joining a local literal, because this file
+/// has a reader in ANOTHER crate: the worker reads `embedWorkflowInImages` off it at its PNG write
+/// seam (sc-15948). Two literals for one cross-crate file is a silent-failure shape — a drift in
+/// either would leave the worker reading a path that does not exist, which its reader resolves to
+/// "embedding ON" with no error and no log, forever.
 fn preferences_path(state: &AppState) -> PathBuf {
-    state.settings.config_dir.join(PREFERENCES_FILENAME)
+    sceneworks_core::app_paths::ui_preferences_file(&state.settings.config_dir)
 }
 
 fn load_preferences(path: &std::path::Path) -> UiPreferences {
@@ -504,6 +512,18 @@ mod tests {
 
         let parsed: UiPreferences = serde_json::from_str(&body).expect("deserialize");
         assert_eq!(parsed.embed_workflow_in_images, Some(false));
+
+        // The FILE, not only the field. This test used to pin the wire name while the two crates
+        // named the file with two separate literals, so a drift in either would have left the
+        // worker opening a path that does not exist — which its reader resolves to "embedding ON",
+        // with no error and no log. `preferences_path` now builds the path from this same helper,
+        // and this pins the name the two crates share.
+        let config = std::path::Path::new("config-dir");
+        assert_eq!(
+            sceneworks_core::app_paths::ui_preferences_file(config),
+            config.join("ui-preferences.json"),
+            "the worker finds this preference by opening this exact filename"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/app_paths.rs
+++ b/crates/sceneworks-core/src/app_paths.rs
@@ -83,22 +83,33 @@ struct WorkerVisiblePreferences {
 
 /// Whether a generated PNG should carry the sanitized workflow envelope (epic 15945, sc-15948).
 ///
-/// **Defaults to `true`**, and every failure mode resolves to the default: no config dir, no file,
-/// a truncated file, a file that is not JSON, or the key absent. A feature whose whole point is
-/// that a shared image reloads its recipe is worthless off by default, and a user who does not want
-/// it should have to find the switch once rather than opt in forever (sc-15953 owns that switch and
-/// the first-run disclosure).
+/// **Defaults to `true` when the preference is ABSENT** — no config dir, no file, valid JSON with
+/// the key missing, or a body that is not JSON at all. A feature whose whole point is that a shared
+/// image reloads its recipe is worthless off by default, and a user who does not want it should have
+/// to find the switch once rather than opt in forever (sc-15953 owns that switch and the first-run
+/// disclosure).
+///
+/// **Fails CLOSED on any other I/O error.** "Absent" and "unreadable" are not the same state, and
+/// collapsing them is how an explicit opt-out silently inverts itself: a user who deliberately
+/// turned embedding off would start embedding again the first time an antivirus scanner held the
+/// file open or an ACL glitched. The envelope is sanitized, but it still carries their prompt, their
+/// model and their LoRA repos — exactly what someone who turned it off was protecting. A transient
+/// read failure costs one image with no chunk; the other direction costs a disclosure they refused.
 ///
 /// Read at the WRITE SEAM rather than cached at worker startup, so flipping the toggle takes effect
 /// on the next image instead of the next launch — the same live-handoff shape as
-/// [`gpu_memory_limit_file`]. The cost is one small file read per encoded image, against tens of
-/// milliseconds of PNG encode.
+/// [`gpu_memory_limit_file`]. The cost is one small file read per JOB: the worker resolves this once
+/// and the answer rides on the image plan (`ImagePlan::workflow_source`), so a 12-image batch reads
+/// it once, against tens of milliseconds of PNG encode per image.
 #[must_use]
 pub fn embed_workflow_in_images(config_dir: &Path) -> bool {
-    std::fs::read_to_string(ui_preferences_file(config_dir))
-        .as_deref()
-        .map(embed_workflow_in_images_from_json)
-        .unwrap_or(true)
+    match std::fs::read_to_string(ui_preferences_file(config_dir)) {
+        Ok(body) => embed_workflow_in_images_from_json(&body),
+        // No preference file (and no config dir — Windows maps a missing parent to `NotFound`
+        // too) is the fresh-install shape: default ON.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    }
 }
 
 /// [`embed_workflow_in_images`] against an already-read preference file body.
@@ -201,12 +212,16 @@ mod tests {
         assert!(paths.cache_dir.is_dir());
     }
 
-    /// Every way the preference file can fail to answer must resolve to ON (sc-15948). A user who
-    /// has never opened Settings, an install whose config dir does not exist yet, and a file
-    /// half-written by a crashed process all have to embed — the alternative is a feature that
-    /// silently does nothing on a fresh install.
+    /// An ABSENT preference defaults ON (sc-15948): a user who has never opened Settings and an
+    /// install whose config dir does not exist yet both have to embed, or the feature silently
+    /// does nothing on a fresh install.
+    ///
+    /// Deliberately separate from [`embedding_fails_closed_when_the_file_cannot_be_read`]. These
+    /// were one test bundling "missing" with "unreadable", and that bundling is precisely what hid
+    /// the distinction that matters: absence is a default, an I/O error is a failure, and they must
+    /// not resolve the same way.
     #[test]
-    fn embedding_defaults_on_through_every_unreadable_case() {
+    fn embedding_defaults_on_when_the_preference_is_absent() {
         let temp = tempfile::tempdir().expect("temp dir");
         let config = temp.path();
 
@@ -219,6 +234,8 @@ mod tests {
             "a missing preference file must default ON"
         );
 
+        // A file that answers nothing — unparseable, or parseable with the key absent or the wrong
+        // type — is also an absent PREFERENCE, not a failure to read. It defaults ON.
         for body in [
             "",
             "{",
@@ -232,6 +249,37 @@ mod tests {
             std::fs::write(ui_preferences_file(config), body).expect("writes");
             assert!(embed_workflow_in_images(config), "{body:?} must default ON");
         }
+    }
+
+    /// An I/O error that is NOT "absent" fails CLOSED (sc-15948).
+    ///
+    /// The real-world causes are an antivirus scanner holding the file open, an ACL change, or a
+    /// half-migrated profile. Whatever the cause, the last thing the user SAID may have been "do not
+    /// embed", and a transient read error must not overturn it — the envelope carries their prompt,
+    /// model and LoRA repos.
+    ///
+    /// A directory where the file belongs is the portable way to force a non-`NotFound` error:
+    /// Windows refuses to open a directory for reading (`PermissionDenied`), and Unix opens it and
+    /// then fails the read (`EISDIR`). Either way it is an `Err` that is not `NotFound`.
+    #[test]
+    fn embedding_fails_closed_when_the_file_cannot_be_read() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config = temp.path();
+        let preference_path = ui_preferences_file(config);
+        std::fs::create_dir_all(&preference_path).expect("creates a directory in the file's place");
+
+        let error = std::fs::read_to_string(&preference_path)
+            .expect_err("reading a directory as a file must fail");
+        assert_ne!(
+            error.kind(),
+            std::io::ErrorKind::NotFound,
+            "this test only means something if the forced error is NOT the absent case: {error}"
+        );
+        assert!(
+            !embed_workflow_in_images(config),
+            "an unreadable preference file must fail CLOSED — a user who turned embedding off must \
+             not start embedding again because of a transient read error"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/app_paths.rs
+++ b/crates/sceneworks-core/src/app_paths.rs
@@ -58,6 +58,63 @@ pub fn gpu_telemetry_file(config_dir: &Path) -> PathBuf {
     config_dir.join("gpu_telemetry.json")
 }
 
+/// Filename (under [`AppPaths::config_dir`]) of the durable UI preference store. Written by the
+/// API's `PUT /api/v1/ui-preferences` (`apps/rust-api/src/preferences.rs`), which owns its shape;
+/// this only names the file so a *reader* outside that module can find it.
+///
+/// Named here for the same reason [`gpu_memory_limit_file`] is: the desktop injects one
+/// `SCENEWORKS_CONFIG_DIR` into every process it spawns, so a preference the API persists is
+/// already sitting in a directory the worker holds. See [`embed_workflow_in_images`].
+pub fn ui_preferences_file(config_dir: &Path) -> PathBuf {
+    config_dir.join("ui-preferences.json")
+}
+
+/// The slice of [`ui_preferences_file`] the WORKER reads.
+///
+/// Deliberately NOT the API's whole `UiPreferences` type: that struct is the route's own contract
+/// and grows with the UI, and a worker that deserialized all of it would fail to read a preference
+/// file written by a newer build. Every field is an `Option` and unknown keys are ignored, so this
+/// stays readable across versions in both directions.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkerVisiblePreferences {
+    embed_workflow_in_images: Option<bool>,
+}
+
+/// Whether a generated PNG should carry the sanitized workflow envelope (epic 15945, sc-15948).
+///
+/// **Defaults to `true`**, and every failure mode resolves to the default: no config dir, no file,
+/// a truncated file, a file that is not JSON, or the key absent. A feature whose whole point is
+/// that a shared image reloads its recipe is worthless off by default, and a user who does not want
+/// it should have to find the switch once rather than opt in forever (sc-15953 owns that switch and
+/// the first-run disclosure).
+///
+/// Read at the WRITE SEAM rather than cached at worker startup, so flipping the toggle takes effect
+/// on the next image instead of the next launch — the same live-handoff shape as
+/// [`gpu_memory_limit_file`]. The cost is one small file read per encoded image, against tens of
+/// milliseconds of PNG encode.
+#[must_use]
+pub fn embed_workflow_in_images(config_dir: &Path) -> bool {
+    std::fs::read_to_string(ui_preferences_file(config_dir))
+        .as_deref()
+        .map(embed_workflow_in_images_from_json)
+        .unwrap_or(true)
+}
+
+/// [`embed_workflow_in_images`] against an already-read preference file body.
+///
+/// Public so the WRITER of that file can assert against the reader directly — the API owns the
+/// route and the field name, this crate owns the parse, and the two are only correct together
+/// (`embed_workflow_in_images_round_trips_under_the_name_the_worker_reads` in
+/// `apps/rust-api/src/preferences.rs`).
+#[must_use]
+pub fn embed_workflow_in_images_from_json(body: &str) -> bool {
+    serde_json::from_str::<WorkerVisiblePreferences>(body)
+        .ok()
+        .and_then(|preferences| preferences.embed_workflow_in_images)
+        .unwrap_or(true)
+}
+
 /// A snapshot of the MLX runtime's process-global memory counters (epic 7819, sc-7825), written by
 /// the worker to [`gpu_telemetry_file`] and read back by the desktop shell for the Settings
 /// display. All values are bytes. `limit_bytes` is the currently-applied soft ceiling (`0` = no
@@ -142,5 +199,58 @@ mod tests {
         assert!(paths.data_dir.is_dir());
         assert!(paths.config_dir.is_dir());
         assert!(paths.cache_dir.is_dir());
+    }
+
+    /// Every way the preference file can fail to answer must resolve to ON (sc-15948). A user who
+    /// has never opened Settings, an install whose config dir does not exist yet, and a file
+    /// half-written by a crashed process all have to embed — the alternative is a feature that
+    /// silently does nothing on a fresh install.
+    #[test]
+    fn embedding_defaults_on_through_every_unreadable_case() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config = temp.path();
+
+        assert!(
+            embed_workflow_in_images(&config.join("does-not-exist")),
+            "a missing config dir must default ON"
+        );
+        assert!(
+            embed_workflow_in_images(config),
+            "a missing preference file must default ON"
+        );
+
+        for body in [
+            "",
+            "{",
+            "not json at all",
+            "[]",
+            "{}",
+            r#"{"theme":"dark"}"#,
+            r#"{"embedWorkflowInImages":null}"#,
+            r#"{"embedWorkflowInImages":"yes"}"#,
+        ] {
+            std::fs::write(ui_preferences_file(config), body).expect("writes");
+            assert!(embed_workflow_in_images(config), "{body:?} must default ON");
+        }
+    }
+
+    #[test]
+    fn embedding_is_off_only_when_the_preference_says_so() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config = temp.path();
+
+        std::fs::write(
+            ui_preferences_file(config),
+            r#"{"theme":"dark","embedWorkflowInImages":false}"#,
+        )
+        .expect("writes");
+        assert!(!embed_workflow_in_images(config));
+
+        std::fs::write(
+            ui_preferences_file(config),
+            r#"{"embedWorkflowInImages":true}"#,
+        )
+        .expect("writes");
+        assert!(embed_workflow_in_images(config));
     }
 }

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -32,11 +32,19 @@
 //! # Allow-list, never a deny-list
 //!
 //! `advanced` (cloned verbatim into an asset's `rawAdapterSettings`) is untyped and grows
-//! whenever someone adds a knob to `apps/web/src/imageJobAdvanced.js`. A deny-list leaks every
-//! future field by default, so [`ADVANCED_KEY_RULES`] classifies every key the builder can emit
-//! and anything unclassified is dropped. `crates/sceneworks-core/tests/workflow_share.rs`
-//! parses that JS file and fails the build when a key is neither allow-listed nor explicitly
-//! denied — a new knob can neither silently leak nor silently vanish.
+//! whenever someone adds a knob to one of the studio's job builders. A deny-list leaks every
+//! future field by default, so [`ADVANCED_KEY_RULES`] classifies every key those builders can
+//! emit and anything unclassified is dropped. `crates/sceneworks-core/tests/workflow_share.rs`
+//! parses each builder named in [`ADVANCED_BUILDERS`] and fails the build when a key is neither
+//! allow-listed nor explicitly denied — a new knob can neither silently leak nor silently vanish.
+//!
+//! sc-15946 shipped that lint against ONE builder on the premise that it was the only one. It was
+//! not: sc-15948 found a second (`buildDetailJobBody`, whose `cnScale` was being dropped) and then
+//! two more (the character lane's `angleSet`, the interleave lane's `systemMessage` /
+//! `imageGuidanceScale`). A lint that is bolted on per discovery closes no class, so
+//! [`ADVANCED_BUILDERS`] is a registry the lint ENUMERATES, and the same test walks
+//! `apps/web/src` for anything that builds an `advanced` map and refuses to pass while one is in
+//! neither the registry nor [`DEFERRED_ADVANCED_BUILDERS`].
 //!
 //! The line between in and out is *what to make* vs *what this machine can afford*:
 //! sampler / steps / guidance / PiD describe the intended output and travel; quant tier,
@@ -289,26 +297,283 @@ pub enum AdvancedDisposition {
     Deny,
 }
 
-/// Where a key comes from, so the coverage lint knows which rules it can hold the JS builder
-/// accountable for.
+/// Which builder a rule is held accountable to, so the coverage lint knows what JS to read.
+///
+/// Every variant except [`Self::Server`] names exactly one entry in [`ADVANCED_BUILDERS`], and
+/// the lint asserts that correspondence in both directions — a variant with no registry entry, or
+/// a registry entry with no variant, fails. That is what makes adding a builder a decision rather
+/// than an omission.
+///
+/// A key MORE THAN ONE builder emits is tagged with its primary builder (the largest,
+/// fastest-moving surface that emits it). The "is every emitted key classified?" half of the lint
+/// runs for every registered builder regardless of tags; only the "is every rule still emitted?"
+/// half is per-tag, and a key needs just one builder holding it honest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AdvancedKeySource {
-    /// Emitted by `buildImageJobAdvanced` in `apps/web/src/imageJobAdvanced.js`. The coverage
-    /// lint asserts these match the JS source exactly, in both directions.
+    /// `buildImageJobAdvanced` — the Image Studio's ~30-knob builder.
     StudioBuilder,
-    /// Emitted by `buildDetailJobBody` in `apps/web/src/imageJobs.js` — the standalone
-    /// `image_detail` pass, whose `advanced` is built by its own two-knob builder rather than by
-    /// the studio's (sc-15948). Held to the same both-directions lint as [`Self::StudioBuilder`],
-    /// against that file.
-    ///
-    /// A key both builders emit belongs under `StudioBuilder`: the lint requires each tagged
-    /// source to still emit its keys, and the studio's is the larger, faster-moving surface.
+    /// `buildEditJobBody` — the Image Editor's prompt-edit body (sc-15948 follow-up: it emits
+    /// `advanced.guidanceScale` and feeds an embedding lane, so it is registered even though
+    /// every key it emits was already classified).
+    EditBuilder,
+    /// `buildDetailJobBody` — the standalone `image_detail` pass's own two-knob builder
+    /// (sc-15948). Before it was registered, `cnScale` was unclassified and silently dropped.
     DetailBuilder,
+    /// `buildAdvanced` in `CharacterAdvancedOptions.jsx` — the character lane's shared tuning
+    /// block, which merges one of the `advancedExtras` maps below into its own knobs.
+    CharacterBuilder,
+    /// `useAngleController`'s `advancedExtras` — the Angle Set form (sc-15948 follow-up).
+    /// `angleSet` is what makes the worker emit one image per view angle, so dropping it made a
+    /// shared angle-set image replay as a single image.
+    CharacterAngleExtras,
+    /// `usePoseController`'s `advancedExtras` — the Pose Library form.
+    CharacterPoseExtras,
+    /// `DocumentStudio.submit` — the interleaved-document lane, which sc-15948 turned INTO an
+    /// embedding lane (`sensenova_jobs.rs` threads `workflow_source` into `ImagePlan`).
+    InterleaveBuilder,
+    /// `buildUpscaleJobBody` — the standalone `image_upscale` job. It emits NO `advanced` map, and
+    /// is registered precisely so that stays true: it feeds an embedding lane (sc-15948 ISSUE 1),
+    /// so the day it grows a knob the lint demands a classification. No rule is tagged with it.
+    UpscaleBuilder,
     /// Stamped onto `advanced` by the API after the request arrives (recipe-preset resolution
     /// in `apps/rust-api/src/generation.rs`). Classified here for the record; the lint does
-    /// not expect to find them in the JS.
+    /// not expect to find them in the JS, and no [`ADVANCED_BUILDERS`] entry claims it.
     Server,
 }
+
+impl AdvancedKeySource {
+    /// Every variant, so the lint can assert the registry covers them all. A new variant that
+    /// nobody registered fails [`ADVANCED_BUILDERS`]'s round-trip test.
+    pub const ALL: &'static [Self] = &[
+        Self::StudioBuilder,
+        Self::EditBuilder,
+        Self::DetailBuilder,
+        Self::CharacterBuilder,
+        Self::CharacterAngleExtras,
+        Self::CharacterPoseExtras,
+        Self::InterleaveBuilder,
+        Self::UpscaleBuilder,
+        Self::Server,
+    ];
+}
+
+/// The JS shape a registered builder writes its `advanced` map in, and therefore which extractor
+/// in `crates/sceneworks-core/tests/workflow_share.rs` can read it.
+///
+/// Named in the registry rather than sniffed, because a wrong guess is the failure mode this whole
+/// lint exists to prevent: an extractor that quietly understands nothing returns an empty key set
+/// and passes. Each extractor panics with instructions when the file stops matching its shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdvancedBuilderShape {
+    /// `return { key, ...(cond ? { key } : {}) }` — the conditional-spread object literal
+    /// `buildImageJobAdvanced` is built from. Needs the brace-aware scanner.
+    ReturnedObject,
+    /// `advanced: { a, b }` — a flat object literal in a returned payload, no spreads, no
+    /// nesting (`buildDetailJobBody`).
+    FlatAdvancedLiteral,
+    /// `const advanced = { … }` followed by `advanced.key = …` assignments. Both halves are
+    /// emits, and a spread in the initializer must be declared in
+    /// [`AdvancedBuilder::spread_of`].
+    AssignedObject,
+    /// `advancedExtras: { … }` — a controller's contribution, merged into a
+    /// [`Self::AssignedObject`] builder's initializer by spread.
+    ExtrasLiteral,
+    /// The builder posts NO `advanced` map at all (`buildUpscaleJobBody`). Registered anyway,
+    /// because it feeds an embedding lane: the lint asserts the function stays empty of
+    /// `advanced`, so the day someone adds a knob there it has to be classified.
+    NoAdvancedMap,
+}
+
+/// One JS builder whose `advanced` keys reach an embedding lane.
+///
+/// The registry the coverage lint enumerates. `path` + `function` are read out of the repo, so a
+/// rename fails loudly rather than silently pointing the lint at nothing.
+#[derive(Debug, Clone, Copy)]
+pub struct AdvancedBuilder {
+    /// The tag rules use to name this builder. Unique across the registry.
+    pub source: AdvancedKeySource,
+    /// Repo-relative path of the file that defines it.
+    pub path: &'static str,
+    /// The JS function whose body the extractor reads.
+    pub function: &'static str,
+    pub shape: AdvancedBuilderShape,
+    /// The embedding lane this builder's payload ends up written by, so a reader can see why the
+    /// keys matter. Prose, asserted only to be non-trivial.
+    pub lane: &'static str,
+    /// Keys the extractor MUST still find. A floor against an extractor that has quietly stopped
+    /// understanding the file — the failure mode that makes a green lint worthless.
+    pub anchors: &'static [&'static str],
+    /// The smallest number of keys the extractor may report before the lint calls itself broken.
+    /// Set well under the real count; it is a floor, not a census.
+    pub minimum_keys: usize,
+    /// Identifiers spread into an [`AdvancedBuilderShape::AssignedObject`] initializer, whose keys
+    /// are accounted for by another registry entry. Declared so a NEW spread of something nobody
+    /// classified fails the lint instead of vanishing into it.
+    pub spread_of: &'static [&'static str],
+}
+
+/// Every builder whose `advanced` keys travel inside a shared image (sc-15948).
+///
+/// The lanes, as of sc-15948: `POST /api/v1/image/jobs` (`text_to_image` / `edit_image` /
+/// `character_image`), `POST /api/v1/image/detail/jobs`, `POST /api/v1/image/interleave/jobs`, and
+/// the standalone `image_upscale` job. All four write their PNG through a seam that embeds.
+///
+/// **Adding a builder here is what turns the lint on for it.** Adding a builder to the WEB and not
+/// to this table fails `every_advanced_builder_in_the_web_app_is_accounted_for`, which walks
+/// `apps/web/src` and refuses any `advanced`-map producer that is in neither this registry nor
+/// [`DEFERRED_ADVANCED_BUILDERS`].
+pub const ADVANCED_BUILDERS: &[AdvancedBuilder] = &[
+    AdvancedBuilder {
+        source: AdvancedKeySource::StudioBuilder,
+        path: "apps/web/src/imageJobAdvanced.js",
+        function: "buildImageJobAdvanced",
+        shape: AdvancedBuilderShape::ReturnedObject,
+        lane:
+            "POST /api/v1/image/jobs — text_to_image, edit_image and character_image, written by \
+               `write_image_asset`",
+        anchors: &["resolution", "sampler", "steps", "styleId", "poses"],
+        minimum_keys: 25,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::EditBuilder,
+        path: "apps/web/src/imageJobs.js",
+        function: "buildEditJobBody",
+        shape: AdvancedBuilderShape::AssignedObject,
+        lane: "POST /api/v1/image/jobs — edit_image from the Image Editor, written by \
+               `write_image_asset`",
+        anchors: &["guidanceScale"],
+        minimum_keys: 1,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::DetailBuilder,
+        path: "apps/web/src/imageJobs.js",
+        function: "buildDetailJobBody",
+        shape: AdvancedBuilderShape::FlatAdvancedLiteral,
+        lane: "POST /api/v1/image/detail/jobs, written by `image_jobs/detail.rs`",
+        anchors: &["strength", "cnScale"],
+        minimum_keys: 2,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::CharacterBuilder,
+        path: "apps/web/src/components/CharacterAdvancedOptions.jsx",
+        function: "buildAdvanced",
+        shape: AdvancedBuilderShape::AssignedObject,
+        lane: "POST /api/v1/image/jobs — character_image, written by `write_image_asset`",
+        anchors: &["ipAdapterScale", "steps", "usePid"],
+        // The angle-set / pose-library controllers' `advancedExtras`, each registered below.
+        minimum_keys: 9,
+        spread_of: &["base"],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::CharacterAngleExtras,
+        path: "apps/web/src/screens/characterPanels.jsx",
+        function: "useAngleController",
+        shape: AdvancedBuilderShape::ExtrasLiteral,
+        lane: "POST /api/v1/image/jobs — character_image (angle set), written by \
+               `write_image_asset`",
+        anchors: &["angleSet"],
+        minimum_keys: 2,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::CharacterPoseExtras,
+        path: "apps/web/src/screens/characterPanels.jsx",
+        function: "usePoseController",
+        shape: AdvancedBuilderShape::ExtrasLiteral,
+        lane: "POST /api/v1/image/jobs — character_image (pose library), written by \
+               `write_image_asset`",
+        anchors: &["poses", "faceRestore"],
+        minimum_keys: 3,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::InterleaveBuilder,
+        path: "apps/web/src/screens/DocumentStudio.jsx",
+        function: "submit",
+        shape: AdvancedBuilderShape::AssignedObject,
+        lane: "POST /api/v1/image/interleave/jobs, written by `sensenova_jobs.rs` through \
+               `write_image_asset`",
+        anchors: &["systemMessage", "imageGuidanceScale"],
+        minimum_keys: 2,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::UpscaleBuilder,
+        path: "apps/web/src/imageJobs.js",
+        function: "buildUpscaleJobBody",
+        shape: AdvancedBuilderShape::NoAdvancedMap,
+        lane: "POST /api/v1/jobs type=image_upscale, written by `single_child_asset.rs`",
+        anchors: &[],
+        minimum_keys: 0,
+        spread_of: &[],
+    },
+];
+
+/// A builder that produces an `advanced` map the lint has SEEN and deliberately does not
+/// classify, because its lane does not embed yet.
+///
+/// This list exists so "unaccounted for" and "accounted for as out of scope" are different
+/// states. Making one of these lanes embed means moving its entry into [`ADVANCED_BUILDERS`] —
+/// at which point every key it emits must be classified, which is the point.
+#[derive(Debug, Clone, Copy)]
+pub struct DeferredAdvancedBuilder {
+    pub path: &'static str,
+    pub function: &'static str,
+    /// Why it is not classified, naming the story that owns turning it on. The lint asserts this
+    /// names a `sc-` story, so a deferral cannot be a shrug.
+    pub reason: &'static str,
+}
+
+/// The VIDEO builders (sc-15956 owns the video envelope and these keys).
+///
+/// `VideoStudio.jsx` alone emits ~15 keys nothing here classifies. That is fine only for as long
+/// as no video write seam embeds: the moment sc-15956 threads a workflow into a video write, its
+/// builder moves up into [`ADVANCED_BUILDERS`] and every one of those keys needs an
+/// `allow`/`deny` decision. Nothing about a video lane can start embedding while its keys sit in
+/// this list — that is what this list is for.
+pub const DEFERRED_ADVANCED_BUILDERS: &[DeferredAdvancedBuilder] = &[
+    DeferredAdvancedBuilder {
+        path: "apps/web/src/screens/VideoStudio.jsx",
+        function: "submit",
+        reason: "The Video Studio's own ~15-knob advanced map. No video write seam embeds a \
+                 workflow yet; sc-15956 owns the video envelope and must classify these keys \
+                 before it does.",
+    },
+    DeferredAdvancedBuilder {
+        path: "apps/web/src/components/editor/useEditorGeneration.js",
+        function: "buildBasePayload",
+        reason: "The timeline editor's shared video payload (queueTimelineVideoJob). Video lane — \
+                 sc-15956 classifies it when video images start embedding.",
+    },
+    DeferredAdvancedBuilder {
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "extendSelectedClip",
+        reason: "Timeline video action: `buildBasePayload`'s advanced plus timelineAction / \
+                 timelineContext. Video lane — sc-15956.",
+    },
+    DeferredAdvancedBuilder {
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "replaceSelectedItem",
+        reason: "Timeline video action: `buildBasePayload`'s advanced plus timelineAction / \
+                 timelineContext. Video lane — sc-15956.",
+    },
+    DeferredAdvancedBuilder {
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "bridgeGap",
+        reason: "Timeline video action: `buildBasePayload`'s advanced plus timelineAction / \
+                 timelineContext. Video lane — sc-15956.",
+    },
+    DeferredAdvancedBuilder {
+        path: "apps/web/src/simple/simpleJobs.js",
+        function: "buildSimpleVideoRequest",
+        reason: "The Simple shell's VIDEO request. Its image sibling \
+                 (`buildSimpleImageRequest`) delegates to `buildImageJobRequest` and so is \
+                 covered by the studio builder; this one is a video lane — sc-15956.",
+    },
+];
 
 /// How an allowed value is reduced. Anything that does not match its shape is dropped rather
 /// than passed through — that is what stops an object (and any path inside it) from being
@@ -360,16 +625,33 @@ const fn deny(key: &'static str, reason: &'static str) -> AdvancedKeyRule {
     }
 }
 
-const fn allow_detail(
+/// `allow`, tagged to a builder other than the studio's.
+const fn allow_from(
     key: &'static str,
     shape: AdvancedShape,
+    source: AdvancedKeySource,
     reason: &'static str,
 ) -> AdvancedKeyRule {
     AdvancedKeyRule {
         key,
         disposition: AdvancedDisposition::Allow,
         shape,
-        source: AdvancedKeySource::DetailBuilder,
+        source,
+        reason,
+    }
+}
+
+/// `deny`, tagged to a builder other than the studio's.
+const fn deny_from(
+    key: &'static str,
+    source: AdvancedKeySource,
+    reason: &'static str,
+) -> AdvancedKeyRule {
+    AdvancedKeyRule {
+        key,
+        disposition: AdvancedDisposition::Deny,
+        shape: AdvancedShape::Scalar,
+        source,
         reason,
     }
 }
@@ -386,9 +668,9 @@ const fn deny_server(key: &'static str, reason: &'static str) -> AdvancedKeyRule
 
 /// Every `advanced` key, classified.
 ///
-/// The load-bearing table. `crates/sceneworks-core/tests/workflow_share.rs` parses
-/// `apps/web/src/imageJobAdvanced.js` and fails when a key the builder can emit is missing
-/// here — so a new knob is a compile-time decision, not a silent leak and not a silent loss.
+/// The load-bearing table. `crates/sceneworks-core/tests/workflow_share.rs` parses every builder
+/// in [`ADVANCED_BUILDERS`] and fails when a key one of them can emit is missing here — so a new
+/// knob is a build-time decision, not a silent leak and not a silent loss.
 ///
 /// The rule of thumb when classifying a new key: does it describe **what to make** (travels)
 /// or **what this machine can afford to make it with** (does not)?
@@ -506,12 +788,44 @@ pub const ADVANCED_KEY_RULES: &[AdvancedKeyRule] = &[
         AdvancedShape::Scalar,
         "The raw pre-style prompt, so a reader sees what was actually typed.",
     ),
-    allow_detail(
+    allow_from(
         "cnScale",
         AdvancedShape::Scalar,
+        AdvancedKeySource::DetailBuilder,
         "Authored tile-ControlNet strength for the Detail pass — one of the two knobs that \
          builder exposes, and the sibling of the allow-listed `strength`. Without it a shared \
          detail-refined image describes half of what produced it (sc-15948).",
+    ),
+    allow_from(
+        "angleSet",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::CharacterAngleExtras,
+        "Authored turnaround request: it makes the worker emit one image per view angle \
+         regardless of `count`, so it decides WHAT IS MADE. Dropping it made a shared angle-set \
+         image replay as a single image (sc-15948).",
+    ),
+    allow_from(
+        "systemMessage",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::InterleaveBuilder,
+        "The interleave system prompt the user typed, and the exact text the model saw — the same \
+         class as `prompt` and `stylePrompt`, so it is PROSE (see `PROSE_KEYS`): bounded and \
+         control-stripped, but never dropped for naming a directory. It is only sent when edited \
+         away from the worker's own default, so it is authored content by construction.",
+    ),
+    allow_from(
+        "imageGuidanceScale",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::InterleaveBuilder,
+        "Authored reference-guidance strength for an interleaved document (engine \
+         `img_cfg_scale`) — the same authored-strength class as `ipAdapterScale` and \
+         `controlScale`, and only emitted when the run actually grounds on reference frames.",
+    ),
+    deny_from(
+        "keypointCollectionId",
+        AdvancedKeySource::CharacterAngleExtras,
+        "A local Key Point Library collection id. It resolves to nothing on another install — the \
+         same class as `recipePresetId` and `controlImage` (sc-15948).",
     ),
     allow(
         "phases",
@@ -1241,7 +1555,16 @@ pub fn sanitize_advanced(advanced: &JsonObject) -> JsonObject {
 ///
 /// Exempt from the PATH check only. They are still bounded and control-stripped by
 /// [`shareable_prose`], because on the parse side they are a stranger's strings.
-const PROSE_KEYS: &[&str] = &["stylePrompt", "intent", "runtimePrompt"];
+const PROSE_KEYS: &[&str] = &[
+    "stylePrompt",
+    "intent",
+    "runtimePrompt",
+    // The interleave system prompt (sc-15948). Prose rather than a label because the user typed
+    // it into a textarea and it is the literal instruction the model received; bounding it as a
+    // slug would silently drop a system message that happened to mention a directory, which is
+    // the exact silent-loss failure this epic's lint exists to prevent.
+    "systemMessage",
+];
 
 fn sanitize_scalar(key: &str, value: &Value) -> Option<Value> {
     match value {
@@ -1877,6 +2200,8 @@ mod tests {
                 "intent": "/home/michael/clients/acme/nda.md",
                 "runtimePrompt": "see ..\\..\\briefs\\acme.json"
             },
+            // The interleave system prompt joined this class in sc-15948 — same reason.
+            "systemMessage": "Ground every panel on ..\\..\\briefs\\acme.json",
             "sampler": "C:\\Users\\Michael\\samplers\\euler.json"
         })
         .as_object()
@@ -1893,9 +2218,16 @@ mod tests {
             recipe["runtimePrompt"],
             json!("see ..\\..\\briefs\\acme.json")
         );
+        assert_eq!(
+            sanitized["systemMessage"],
+            json!("Ground every panel on ..\\..\\briefs\\acme.json")
+        );
         // A NON-prose key next to them is still guarded — the exemption is per key, not global.
         assert!(!sanitized.contains_key("sampler"));
-        assert_eq!(PROSE_KEYS, ["stylePrompt", "intent", "runtimePrompt"]);
+        assert_eq!(
+            PROSE_KEYS,
+            ["stylePrompt", "intent", "runtimePrompt", "systemMessage"]
+        );
     }
 
     /// The prose exemption is from the PATH check and from nothing else. A prompt is

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -296,6 +296,14 @@ pub enum AdvancedKeySource {
     /// Emitted by `buildImageJobAdvanced` in `apps/web/src/imageJobAdvanced.js`. The coverage
     /// lint asserts these match the JS source exactly, in both directions.
     StudioBuilder,
+    /// Emitted by `buildDetailJobBody` in `apps/web/src/imageJobs.js` — the standalone
+    /// `image_detail` pass, whose `advanced` is built by its own two-knob builder rather than by
+    /// the studio's (sc-15948). Held to the same both-directions lint as [`Self::StudioBuilder`],
+    /// against that file.
+    ///
+    /// A key both builders emit belongs under `StudioBuilder`: the lint requires each tagged
+    /// source to still emit its keys, and the studio's is the larger, faster-moving surface.
+    DetailBuilder,
     /// Stamped onto `advanced` by the API after the request arrives (recipe-preset resolution
     /// in `apps/rust-api/src/generation.rs`). Classified here for the record; the lint does
     /// not expect to find them in the JS.
@@ -348,6 +356,20 @@ const fn deny(key: &'static str, reason: &'static str) -> AdvancedKeyRule {
         disposition: AdvancedDisposition::Deny,
         shape: AdvancedShape::Scalar,
         source: AdvancedKeySource::StudioBuilder,
+        reason,
+    }
+}
+
+const fn allow_detail(
+    key: &'static str,
+    shape: AdvancedShape,
+    reason: &'static str,
+) -> AdvancedKeyRule {
+    AdvancedKeyRule {
+        key,
+        disposition: AdvancedDisposition::Allow,
+        shape,
+        source: AdvancedKeySource::DetailBuilder,
         reason,
     }
 }
@@ -483,6 +505,13 @@ pub const ADVANCED_KEY_RULES: &[AdvancedKeyRule] = &[
         "stylePrompt",
         AdvancedShape::Scalar,
         "The raw pre-style prompt, so a reader sees what was actually typed.",
+    ),
+    allow_detail(
+        "cnScale",
+        AdvancedShape::Scalar,
+        "Authored tile-ControlNet strength for the Detail pass — one of the two knobs that \
+         builder exposes, and the sibling of the allow-listed `strength`. Without it a shared \
+         detail-refined image describes half of what produced it (sc-15948).",
     ),
     allow(
         "phases",
@@ -797,6 +826,45 @@ fn hf_repo_id(value: &str) -> Option<String> {
 // Build
 // ---------------------------------------------------------------------------
 
+/// What the envelope takes from the produced IMAGE rather than from the job payload.
+///
+/// Exists because sc-15948 embeds at the worker's write seam, where no [`Asset`] has been built
+/// yet — the worker writes the PNG and reports flat facts, and the API turns those into the
+/// sidecar afterwards. Rather than have the worker fabricate an `Asset` (whose `mode` and
+/// `adapter` are closed enums it would have to guess at), both callers name the same handful of
+/// per-image values and go through the same builder.
+///
+/// Every field here is a FALLBACK for the payload except `seed`, which always wins: the payload
+/// carries the batch's base `seed` and its whole `seeds` list, and only the writer of one file
+/// knows which of those rendered it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowAssetFacts {
+    pub mode: String,
+    pub model: String,
+    pub prompt: String,
+    pub negative_prompt: String,
+    /// The seed of THIS image, never the batch base.
+    pub seed: i64,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+}
+
+impl WorkflowAssetFacts {
+    /// The facts an already-built sidecar carries.
+    #[must_use]
+    pub fn from_asset(asset: &Asset) -> Self {
+        Self {
+            mode: asset.recipe.mode.as_str().to_owned(),
+            model: asset.recipe.model.clone(),
+            prompt: asset.recipe.prompt.clone(),
+            negative_prompt: asset.recipe.negative_prompt.clone(),
+            seed: asset.recipe.seed,
+            width: asset.file.width,
+            height: asset.file.height,
+        }
+    }
+}
+
 /// Build the sanitized envelope for one generated asset.
 ///
 /// `job_payload` is the job row's `payload_json` — the exact `ImageJobRequest` the API stored,
@@ -809,6 +877,21 @@ fn hf_repo_id(value: &str) -> Option<String> {
 /// produced the file being shared.
 #[must_use]
 pub fn build_workflow_share(asset: &Asset, job_payload: &JsonObject) -> WorkflowShare {
+    build_workflow_share_from(&WorkflowAssetFacts::from_asset(asset), job_payload)
+}
+
+/// [`build_workflow_share`] against [`WorkflowAssetFacts`] instead of a built sidecar — the entry
+/// point the worker's write seam uses (sc-15948).
+///
+/// The one implementation both forms share, so the sanitizer, the payload-over-facts precedence
+/// and the allow-list cannot differ between "embedded when the image was written" and "rebuilt
+/// from a sidecar". `build_workflow_share_is_the_facts_builder` in
+/// `crates/sceneworks-core/tests/workflow_share.rs` pins the delegation.
+#[must_use]
+pub fn build_workflow_share_from(
+    facts: &WorkflowAssetFacts,
+    job_payload: &JsonObject,
+) -> WorkflowShare {
     let string_field = |key: &str| {
         job_payload
             .get(key)
@@ -822,17 +905,16 @@ pub fn build_workflow_share(asset: &Asset, job_payload: &JsonObject) -> Workflow
             .and_then(|value| u32::try_from(value).ok())
     };
 
-    let mode = string_field("mode").unwrap_or_else(|| asset.recipe.mode.as_str().to_owned());
-    let model = string_field("model").unwrap_or_else(|| asset.recipe.model.clone());
-    let prompt = string_field("prompt").unwrap_or_else(|| asset.recipe.prompt.clone());
+    let mode = string_field("mode").unwrap_or_else(|| facts.mode.clone());
+    let model = string_field("model").unwrap_or_else(|| facts.model.clone());
+    let prompt = string_field("prompt").unwrap_or_else(|| facts.prompt.clone());
     let negative_prompt =
-        string_field("negativePrompt").unwrap_or_else(|| asset.recipe.negative_prompt.clone());
+        string_field("negativePrompt").unwrap_or_else(|| facts.negative_prompt.clone());
 
-    // The sidecar's seed — not the payload's. `payload.seed` is the batch BASE and
-    // `payload.seeds` is the whole batch; only the sidecar knows which one rendered the file
-    // being shared. The batch list never travels: the other images are not this share's
-    // business. (`Recipe::seed` is a required field, so there is nothing to fall back to.)
-    let seed = Some(asset.recipe.seed);
+    // The produced image's seed — not the payload's. `payload.seed` is the batch BASE and
+    // `payload.seeds` is the whole batch; only whoever wrote one file knows which one rendered
+    // it. The batch list never travels: the other images are not this share's business.
+    let seed = Some(facts.seed);
 
     // Raw on purpose: `reduce_workflow_share` runs `sanitize_advanced`, and sanitizing here as
     // well would be the same pass twice — harmless only for as long as every rule stays
@@ -855,8 +937,8 @@ pub fn build_workflow_share(asset: &Asset, job_payload: &JsonObject) -> Workflow
         prompt,
         negative_prompt,
         seed,
-        width: u32_field("width").or(asset.file.width),
-        height: u32_field("height").or(asset.file.height),
+        width: u32_field("width").or(facts.width),
+        height: u32_field("height").or(facts.height),
         count: u32_field("count"),
         style_preset: string_field("stylePreset"),
         style_id: string_field("styleId"),

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -522,12 +522,27 @@ pub const ADVANCED_BUILDERS: &[AdvancedBuilder] = &[
 pub struct DeferredAdvancedBuilder {
     pub path: &'static str,
     pub function: &'static str,
-    /// Why it is not classified, naming the story that owns turning it on. The lint asserts this
-    /// names a `sc-` story, so a deferral cannot be a shrug.
+    /// Why it is not classified. Two categories, and the lint accepts nothing else, so a deferral
+    /// cannot be a shrug:
+    ///
+    /// * **Awaiting classification** — names the `sc-` story that owns turning its lane on.
+    /// * **Permanently exempt** — starts with [`PERMANENT_EXEMPTION`] and says why no story will
+    ///   ever own it, plus what would have to change for that to stop being true.
     pub reason: &'static str,
 }
 
-/// The VIDEO builders (sc-15956 owns the video envelope and these keys).
+/// The prefix that marks a [`DeferredAdvancedBuilder::reason`] as a PERMANENT exemption rather
+/// than a story-owned deferral.
+///
+/// A deferral normally names the story that will classify its keys. Some `advanced` maps are not
+/// waiting on anybody: they are a different namespace on a lane that embeds nothing, so there is no
+/// story to name and inventing a fake id would be worse than saying so. The lint requires a reason
+/// with this prefix to state what would have to change (an embedding write seam) and to name
+/// [`ADVANCED_BUILDERS`] as where the entry moves if it ever does.
+pub const PERMANENT_EXEMPTION: &str = "PERMANENT EXEMPTION:";
+
+/// The VIDEO builders (sc-15956 owns the video envelope and these keys), plus one permanent
+/// exemption for an `advanced` map that is not an image payload at all.
 ///
 /// `VideoStudio.jsx` alone emits ~15 keys nothing here classifies. That is fine only for as long
 /// as no video write seam embeds: the moment sc-15956 threads a workflow into a video write, its
@@ -572,6 +587,19 @@ pub const DEFERRED_ADVANCED_BUILDERS: &[DeferredAdvancedBuilder] = &[
         reason: "The Simple shell's VIDEO request. Its image sibling \
                  (`buildSimpleImageRequest`) delegates to `buildImageJobRequest` and so is \
                  covered by the studio builder; this one is a video lane — sc-15956.",
+    },
+    DeferredAdvancedBuilder {
+        path: "apps/web/src/training/trainingConfig.js",
+        function: "trainingConfigSnapshot",
+        reason: "PERMANENT EXEMPTION: the Training Studio's `advanced` is a DIFFERENT namespace \
+                 from the image payload's — trainer hyperparameters (networkType, lrScheduler, \
+                 sampleSteps, decomposeFactor) on a training job, not generation intent for an \
+                 image. No training write seam EMBEDS a workflow, nothing sanitizes these keys \
+                 through `ADVANCED_KEY_RULES`, and no story is waiting to classify them: this is \
+                 not a deferral with an owner, it is deliberately outside the allow-list. What \
+                 would have to change is a training write seam that embeds. Then, and only then, \
+                 this entry moves into `ADVANCED_BUILDERS` and every key it emits needs an \
+                 allow/deny decision.",
     },
 ];
 

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -13,8 +13,9 @@ use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
 use sceneworks_core::contracts::{Asset, JsonObject};
 use sceneworks_core::jsonc::strip_jsonc_comments;
 use sceneworks_core::workflow_share::{
-    build_workflow_share, is_path_shaped, parse_workflow_share, AdvancedKeySource, WorkflowShare,
-    ADVANCED_KEY_RULES, PRODUCER_URL, PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
+    build_workflow_share, build_workflow_share_from, is_path_shaped, parse_workflow_share,
+    AdvancedKeySource, WorkflowAssetFacts, WorkflowShare, ADVANCED_KEY_RULES, PRODUCER_URL,
+    PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
 };
 use serde_json::{json, Value};
 
@@ -194,6 +195,60 @@ fn the_builder_reproduces_the_golden_envelope() {
         golden,
         "builder output drifted from the golden fixture.\nActual:\n{}",
         serde_json::to_string_pretty(&encoded).expect("pretty")
+    );
+}
+
+/// The two build entry points are one builder (sc-15948).
+///
+/// sc-15948 embeds at the worker's write seam, where no `Asset` exists yet, so it calls
+/// [`build_workflow_share_from`] with the per-image facts directly. If that were a second
+/// implementation, the allow-list, the path guard and the payload-over-facts precedence could all
+/// drift between "embedded when the file was written" and "rebuilt from a sidecar" — and the
+/// embedded copy is the one that leaves the machine.
+#[test]
+fn build_workflow_share_is_the_facts_builder() {
+    let asset = golden_asset();
+    let payload = golden_payload();
+    let via_asset = build_workflow_share(&asset, &payload);
+    let via_facts = build_workflow_share_from(&WorkflowAssetFacts::from_asset(&asset), &payload);
+    assert_eq!(
+        serde_json::to_value(&via_facts).expect("serializes"),
+        serde_json::to_value(&via_asset).expect("serializes"),
+    );
+
+    // And the facts really are the fallbacks: with an EMPTY payload nothing but them is left, so
+    // each one has to show up in the envelope on its own.
+    let facts = WorkflowAssetFacts {
+        mode: "image_detail".to_owned(),
+        model: "realvisxl".to_owned(),
+        prompt: "ultra detailed, sharp focus".to_owned(),
+        negative_prompt: "blurry, soft".to_owned(),
+        seed: 7,
+        width: Some(1536),
+        height: Some(1024),
+    };
+    let bare = build_workflow_share_from(&facts, &JsonObject::new());
+    assert_eq!(bare.mode, "image_detail");
+    assert_eq!(bare.model, "realvisxl");
+    assert_eq!(bare.prompt, "ultra detailed, sharp focus");
+    assert_eq!(bare.negative_prompt, "blurry, soft");
+    assert_eq!(bare.seed, Some(7));
+    assert_eq!((bare.width, bare.height), (Some(1536), Some(1024)));
+    assert!(bare.advanced.is_empty());
+    assert!(bare.inputs.is_empty());
+
+    // The payload wins over the facts wherever it speaks — except the seed, which is per-image and
+    // is the one thing the payload cannot know.
+    let payload = json!({ "mode": "text_to_image", "seed": 999, "seeds": [999, 1000] })
+        .as_object()
+        .cloned()
+        .expect("object");
+    let overridden = build_workflow_share_from(&facts, &payload);
+    assert_eq!(overridden.mode, "text_to_image");
+    assert_eq!(
+        overridden.seed,
+        Some(7),
+        "the payload's batch base seed must never displace the produced image's own"
     );
 }
 
@@ -399,6 +454,114 @@ fn every_advanced_key_the_studio_can_emit_is_classified() {
             rule.key
         );
     }
+}
+
+const DETAIL_BUILDER_PATH: &str = "apps/web/src/imageJobs.js";
+
+/// The `advanced` keys the standalone Detail pass can emit (sc-15948).
+///
+/// A second, much smaller surface than `buildImageJobAdvanced`: `buildDetailJobBody` returns a
+/// flat shorthand literal (`advanced: { strength, cnScale }`) with no spreads and no nesting, so
+/// this reads that literal directly instead of reusing `emitted_advanced_keys` — which is built
+/// around the studio builder's conditional-spread shape and keyed to that function's name.
+///
+/// Fails loudly rather than returning an empty set if the shape it understands is gone, for the
+/// same reason the studio extractor does: a lint that silently stops looking protects nothing.
+fn emitted_detail_advanced_keys(source: &str) -> BTreeSet<String> {
+    let stripped = strip_comments(source);
+    let function_at = stripped
+        .find("function buildDetailJobBody")
+        .unwrap_or_else(|| {
+            panic!(
+                "`buildDetailJobBody` is gone from {DETAIL_BUILDER_PATH} — this coverage lint \
+                 must be pointed at wherever the `image_detail` payload is built now"
+            )
+        });
+    let advanced_at = stripped[function_at..]
+        .find("advanced:")
+        .map(|offset| function_at + offset + "advanced:".len())
+        .unwrap_or_else(|| {
+            panic!(
+                "`buildDetailJobBody` in {DETAIL_BUILDER_PATH} no longer carries an `advanced:` \
+                 literal, so this lint cannot see which detail knobs travel"
+            )
+        });
+    let open = advanced_at
+        + stripped[advanced_at..]
+            .find('{')
+            .expect("`advanced:` is followed by an object literal");
+    let close = open
+        + stripped[open..]
+            .find('}')
+            .expect("the `advanced` literal is closed");
+    assert!(
+        !stripped[open + 1..close].contains('{'),
+        "`buildDetailJobBody`'s `advanced` literal is no longer flat — teach \
+         `emitted_detail_advanced_keys` the new shape"
+    );
+    stripped[open + 1..close]
+        .split(',')
+        // `key` and `key: value` alike — take the identifier before any colon.
+        .filter_map(|entry| entry.split(':').next())
+        .map(str::trim)
+        .filter(|key| {
+            !key.is_empty()
+                && key
+                    .chars()
+                    .all(|character| character.is_alphanumeric() || character == '_')
+        })
+        .map(str::to_owned)
+        .collect()
+}
+
+/// The Detail pass's own knobs are classified too (sc-15948).
+///
+/// `buildImageJobAdvanced` is not the only builder that fills `advanced`: the standalone
+/// `image_detail` job has its own, and its keys land in the same untyped map and go through the
+/// same allow-list. Before this lint existed, `cnScale` — half of what that UI exposes — was
+/// unclassified and therefore silently dropped from every shared detail-refined image.
+#[test]
+fn every_advanced_key_the_detail_pass_can_emit_is_classified() {
+    let source = read_repo_file(DETAIL_BUILDER_PATH);
+    let emitted = emitted_detail_advanced_keys(&source);
+
+    for anchor in ["strength", "cnScale"] {
+        assert!(
+            emitted.contains(anchor),
+            "the extractor missed the known detail knob `{anchor}` in {DETAIL_BUILDER_PATH}, so \
+             this lint is not protecting anything"
+        );
+    }
+
+    let classified: BTreeSet<String> = ADVANCED_KEY_RULES
+        .iter()
+        .map(|rule| rule.key.to_owned())
+        .collect();
+    let unclassified: Vec<&String> = emitted.difference(&classified).collect();
+    assert!(
+        unclassified.is_empty(),
+        "buildDetailJobBody can emit {unclassified:?}, which `ADVANCED_KEY_RULES` in \
+         crates/sceneworks-core/src/workflow_share.rs does not classify. An unclassified key is \
+         dropped silently, so a shared detail-refined image would describe less of the pass than \
+         the user actually chose."
+    );
+
+    let from_detail: BTreeSet<String> = ADVANCED_KEY_RULES
+        .iter()
+        .filter(|rule| rule.source == AdvancedKeySource::DetailBuilder)
+        .map(|rule| rule.key.to_owned())
+        .collect();
+    assert!(
+        !from_detail.is_empty(),
+        "no rule is tagged `AdvancedKeySource::DetailBuilder`, so nothing holds \
+         {DETAIL_BUILDER_PATH} accountable"
+    );
+    let stale: Vec<&String> = from_detail.difference(&emitted).collect();
+    assert!(
+        stale.is_empty(),
+        "`ADVANCED_KEY_RULES` classifies {stale:?} as coming from buildDetailJobBody, but \
+         {DETAIL_BUILDER_PATH} no longer emits them."
+    );
 }
 
 #[test]

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -1,8 +1,10 @@
 //! Contract tests for the sanitized workflow share envelope (sc-15946, epic 15945).
 //!
-//! The two load-bearing ones are [`every_advanced_key_the_studio_can_emit_is_classified`] —
-//! which parses `apps/web/src/imageJobAdvanced.js` so a new knob cannot silently leak OR
-//! silently vanish — and [`no_value_in_a_built_envelope_is_path_shaped`], which seeds the
+//! Three are load-bearing. [`every_registered_builder_has_its_advanced_keys_classified`] parses
+//! every builder in `ADVANCED_BUILDERS` so a new knob can neither silently leak nor silently
+//! vanish; [`every_advanced_builder_in_the_web_app_is_accounted_for`] walks `apps/web/src` so a
+//! new BUILDER cannot appear unclassified (sc-15946's lint read one file on the premise that it
+//! was the only one — it was not); and [`no_value_in_a_built_envelope_is_path_shaped`] seeds the
 //! request with paths on purpose and asserts none of them reach the file.
 
 use std::collections::BTreeSet;
@@ -13,9 +15,10 @@ use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
 use sceneworks_core::contracts::{Asset, JsonObject};
 use sceneworks_core::jsonc::strip_jsonc_comments;
 use sceneworks_core::workflow_share::{
-    build_workflow_share, build_workflow_share_from, is_path_shaped, parse_workflow_share,
-    AdvancedKeySource, WorkflowAssetFacts, WorkflowShare, ADVANCED_KEY_RULES, PRODUCER_URL,
-    PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
+    advanced_key_rule, build_workflow_share, build_workflow_share_from, is_path_shaped,
+    parse_workflow_share, AdvancedBuilder, AdvancedBuilderShape, AdvancedDisposition,
+    AdvancedKeySource, WorkflowAssetFacts, WorkflowShare, ADVANCED_BUILDERS, ADVANCED_KEY_RULES,
+    DEFERRED_ADVANCED_BUILDERS, PRODUCER_URL, PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
 };
 use serde_json::{json, Value};
 
@@ -385,64 +388,141 @@ fn the_parser_branches_on_schema_version_and_never_on_producer_version() {
 // Coverage lint
 // ---------------------------------------------------------------------------
 
-const ADVANCED_BUILDER_PATH: &str = "apps/web/src/imageJobAdvanced.js";
+/// The registry entry for one source tag, or a failure naming what is missing.
+fn builder_for(source: AdvancedKeySource) -> &'static AdvancedBuilder {
+    ADVANCED_BUILDERS
+        .iter()
+        .find(|builder| builder.source == source)
+        .unwrap_or_else(|| panic!("no `ADVANCED_BUILDERS` entry for {source:?}"))
+}
 
-#[test]
-fn every_advanced_key_the_studio_can_emit_is_classified() {
-    let source = read_repo_file(ADVANCED_BUILDER_PATH);
-    let emitted = emitted_advanced_keys(&source);
+/// Every key `ADVANCED_KEY_RULES` classifies, in either direction.
+fn classified_keys() -> BTreeSet<String> {
+    ADVANCED_KEY_RULES
+        .iter()
+        .map(|rule| rule.key.to_owned())
+        .collect()
+}
 
-    // A sanity floor: if the extractor ever stops understanding the file (a refactor to a
-    // different builder shape, a move), it must fail loudly rather than pass with an empty set.
+/// The whole coverage lint for ONE registered builder, in both directions.
+///
+/// Split out of the per-builder tests so the registry-wide sweep and the two named lints
+/// sc-15946/sc-15948 shipped assert exactly the same thing about their own entries — a builder
+/// cannot be covered by the sweep and not by its own test, or vice versa.
+fn assert_builder_is_fully_classified(builder: &AdvancedBuilder) {
+    let path = builder.path;
+    let function = builder.function;
+    let source = read_repo_file(path);
+    let emitted = emitted_keys(builder, &source);
+
+    // A sanity floor plus named anchors: if an extractor ever stops understanding its file (a
+    // refactor to a different shape, a move), it must fail loudly rather than pass with an empty
+    // set. A lint that has quietly stopped looking protects nothing.
     assert!(
-        emitted.len() >= 25,
-        "only {} keys were extracted from {ADVANCED_BUILDER_PATH} — the extractor no longer \
-         understands that file, so this lint is not protecting anything. Fix \
-         `emitted_advanced_keys` in this test.",
-        emitted.len()
+        emitted.len() >= builder.minimum_keys,
+        "only {} keys were extracted from {function} in {path}, below the registry's declared \
+         floor of {} — the extractor no longer understands that file, so this lint is not \
+         protecting anything. Fix `emitted_keys` in this test.",
+        emitted.len(),
+        builder.minimum_keys
     );
-    for anchor in ["sampler", "steps", "styleId", "poses", "resolution"] {
+    for anchor in builder.anchors {
         assert!(
-            emitted.contains(anchor),
-            "the extractor missed the known key `{anchor}` in {ADVANCED_BUILDER_PATH}"
+            emitted.contains(*anchor),
+            "the extractor missed the known key `{anchor}` in {function} ({path}), so this lint \
+             is not protecting anything"
         );
     }
 
-    let classified: BTreeSet<String> = ADVANCED_KEY_RULES
-        .iter()
-        .map(|rule| rule.key.to_owned())
-        .collect();
-    let from_builder: BTreeSet<String> = ADVANCED_KEY_RULES
-        .iter()
-        .filter(|rule| rule.source == AdvancedKeySource::StudioBuilder)
-        .map(|rule| rule.key.to_owned())
-        .collect();
-
+    let classified = classified_keys();
     let unclassified: Vec<&String> = emitted.difference(&classified).collect();
     assert!(
         unclassified.is_empty(),
-        "buildImageJobAdvanced can emit {unclassified:?}, which `ADVANCED_KEY_RULES` in \
+        "{function} in {path} can emit {unclassified:?}, which `ADVANCED_KEY_RULES` in \
          crates/sceneworks-core/src/workflow_share.rs does not classify.\n\
+         That builder feeds an embedding lane ({lane}), so an unclassified key is dropped \
+         silently from every shared image it writes.\n\
          A new advanced knob must be classified before it ships: add it to the table as \
          `allow(..)` if it describes WHAT TO MAKE (it travels in shared images) or `deny(..)` \
          if it describes WHAT THIS MACHINE CAN AFFORD (tier, kernel, GPU) or names anything \
          local (an id, a path, a preset). Either way write the reason — an unclassified key \
-         is dropped silently today and that is exactly what this lint exists to stop."
+         is dropped silently today and that is exactly what this lint exists to stop.",
+        lane = builder.lane
     );
 
-    let stale: Vec<&String> = from_builder.difference(&emitted).collect();
+    let tagged: BTreeSet<String> = ADVANCED_KEY_RULES
+        .iter()
+        .filter(|rule| rule.source == builder.source)
+        .map(|rule| rule.key.to_owned())
+        .collect();
+    if builder.shape == AdvancedBuilderShape::NoAdvancedMap {
+        assert!(
+            tagged.is_empty(),
+            "{function} in {path} is registered as emitting no `advanced` map, but \
+             `ADVANCED_KEY_RULES` tags {tagged:?} to it. Either it grew a map (change its \
+             registry `shape`) or those rules belong to another builder."
+        );
+        return;
+    }
+
+    // Reverse-direction accountability. A rule's `source` is the builder whose JS the lint reads
+    // to decide whether the rule is stale, so a key that ONLY this builder emits must be tagged to
+    // it — otherwise nothing ever notices the knob being deleted from the UI. Keys several builders
+    // emit are held by whichever one owns them; that builder's own stale check covers them.
+    //
+    // Stricter than the flat "at least one rule names this builder" this generalizes: it is
+    // per-key, so a builder can gain an exclusive knob tagged to the wrong source and still fail.
+    let elsewhere: BTreeSet<String> = ADVANCED_BUILDERS
+        .iter()
+        .filter(|other| other.source != builder.source)
+        .flat_map(|other| emitted_keys(other, &read_repo_file(other.path)))
+        .collect();
+    for key in emitted.difference(&elsewhere) {
+        let rule = advanced_key_rule(key).expect("classified above");
+        assert_eq!(
+            rule.source, builder.source,
+            "`{key}` is emitted ONLY by {function} in {path}, but its rule is tagged \
+             `AdvancedKeySource::{:?}`. The tag is what tells the lint which JS to re-read, so a \
+             key nobody else emits must be tagged to its own builder or nothing will ever notice \
+             it disappearing from the UI.",
+            rule.source
+        );
+    }
+
+    let stale: Vec<&String> = tagged.difference(&emitted).collect();
     assert!(
         stale.is_empty(),
-        "`ADVANCED_KEY_RULES` classifies {stale:?} as coming from buildImageJobAdvanced, but \
-         {ADVANCED_BUILDER_PATH} no longer emits them.\n\
-         Either the knob was removed (drop the rule) or it moved to the server (re-tag the \
-         rule `AdvancedKeySource::Server`). A rule that no longer matches its source is a \
-         classification nobody is maintaining."
+        "`ADVANCED_KEY_RULES` classifies {stale:?} as coming from {function}, but {path} no \
+         longer emits them.\n\
+         Either the knob was removed (drop the rule), it moved to another builder (re-tag the \
+         rule), or it moved to the server (`AdvancedKeySource::Server`). A rule that no longer \
+         matches its source is a classification nobody is maintaining."
     );
+}
+
+/// Every builder in the registry has every key it can emit classified (sc-15948).
+///
+/// The generalized form of the two lints below. sc-15946 shipped one of them on the premise that
+/// `buildImageJobAdvanced` was the only builder filling `advanced`; sc-15948 found three more, one
+/// of which (`cnScale`) was already losing data and two of which (`angleSet`,
+/// `imageGuidanceScale`) were live leaks on lanes that embed. Patching one file per discovery
+/// closes nothing, so this walks the registry instead — and
+/// [`every_advanced_builder_in_the_web_app_is_accounted_for`] is what makes the registry complete.
+#[test]
+fn every_registered_builder_has_its_advanced_keys_classified() {
+    assert!(
+        ADVANCED_BUILDERS.len() >= 8,
+        "the builder registry shrank to {} entries — a lane was removed from the lint rather than \
+         from the product?",
+        ADVANCED_BUILDERS.len()
+    );
+    for builder in ADVANCED_BUILDERS {
+        assert_builder_is_fully_classified(builder);
+    }
 
     // The rules table must not carry a key twice with two dispositions.
     assert_eq!(
-        classified.len(),
+        classified_keys().len(),
         ADVANCED_KEY_RULES.len(),
         "`ADVANCED_KEY_RULES` has duplicate keys"
     );
@@ -456,62 +536,180 @@ fn every_advanced_key_the_studio_can_emit_is_classified() {
     }
 }
 
-const DETAIL_BUILDER_PATH: &str = "apps/web/src/imageJobs.js";
+/// The registry and the source tag are one thing, asserted from both sides.
+///
+/// A `AdvancedKeySource` variant with no registry entry would silently opt its rules out of the
+/// reverse-direction check; a registry entry sharing a tag with another would make the reverse
+/// check read the wrong file.
+#[test]
+fn every_source_tag_names_exactly_one_registered_builder() {
+    for source in AdvancedKeySource::ALL {
+        let entries = ADVANCED_BUILDERS
+            .iter()
+            .filter(|builder| builder.source == *source)
+            .count();
+        let expected = usize::from(*source != AdvancedKeySource::Server);
+        assert_eq!(
+            entries, expected,
+            "`AdvancedKeySource::{source:?}` has {entries} `ADVANCED_BUILDERS` entries, expected \
+             {expected}. Every variant but `Server` names exactly one builder — that pairing is \
+             what lets the lint read the right file for a rule's tag."
+        );
+    }
+    for builder in ADVANCED_BUILDERS {
+        assert!(
+            AdvancedKeySource::ALL.contains(&builder.source),
+            "`AdvancedKeySource::ALL` is missing {:?}, so the check above cannot see it",
+            builder.source
+        );
+        assert!(
+            builder.lane.len() > 20,
+            "the registry entry for {} needs a real `lane` — it is what tells the next author why \
+             those keys matter",
+            builder.function
+        );
+    }
+}
 
-/// The `advanced` keys the standalone Detail pass can emit (sc-15948).
-///
-/// A second, much smaller surface than `buildImageJobAdvanced`: `buildDetailJobBody` returns a
-/// flat shorthand literal (`advanced: { strength, cnScale }`) with no spreads and no nesting, so
-/// this reads that literal directly instead of reusing `emitted_advanced_keys` — which is built
-/// around the studio builder's conditional-spread shape and keyed to that function's name.
-///
-/// Fails loudly rather than returning an empty set if the shape it understands is gone, for the
-/// same reason the studio extractor does: a lint that silently stops looking protects nothing.
-fn emitted_detail_advanced_keys(source: &str) -> BTreeSet<String> {
-    let stripped = strip_comments(source);
-    let function_at = stripped
-        .find("function buildDetailJobBody")
-        .unwrap_or_else(|| {
-            panic!(
-                "`buildDetailJobBody` is gone from {DETAIL_BUILDER_PATH} — this coverage lint \
-                 must be pointed at wherever the `image_detail` payload is built now"
-            )
-        });
-    let advanced_at = stripped[function_at..]
-        .find("advanced:")
-        .map(|offset| function_at + offset + "advanced:".len())
-        .unwrap_or_else(|| {
-            panic!(
-                "`buildDetailJobBody` in {DETAIL_BUILDER_PATH} no longer carries an `advanced:` \
-                 literal, so this lint cannot see which detail knobs travel"
-            )
-        });
-    let open = advanced_at
-        + stripped[advanced_at..]
-            .find('{')
-            .expect("`advanced:` is followed by an object literal");
-    let close = open
-        + stripped[open..]
-            .find('}')
-            .expect("the `advanced` literal is closed");
+/// Every deferral names a story, so "out of scope" cannot be a shrug (sc-15956 owns video).
+#[test]
+fn every_deferred_builder_names_the_story_that_owns_it() {
     assert!(
-        !stripped[open + 1..close].contains('{'),
-        "`buildDetailJobBody`'s `advanced` literal is no longer flat — teach \
-         `emitted_detail_advanced_keys` the new shape"
+        !DEFERRED_ADVANCED_BUILDERS.is_empty(),
+        "the deferral list emptied — if every builder is now classified, the video lanes embed \
+         and their keys must be in `ADVANCED_KEY_RULES`"
     );
-    stripped[open + 1..close]
-        .split(',')
-        // `key` and `key: value` alike — take the identifier before any colon.
-        .filter_map(|entry| entry.split(':').next())
-        .map(str::trim)
-        .filter(|key| {
-            !key.is_empty()
-                && key
-                    .chars()
-                    .all(|character| character.is_alphanumeric() || character == '_')
-        })
-        .map(str::to_owned)
-        .collect()
+    for deferred in DEFERRED_ADVANCED_BUILDERS {
+        assert!(
+            deferred.reason.contains("sc-"),
+            "the deferral for {} in {} must name the story that owns classifying its keys, got \
+             {:?}",
+            deferred.function,
+            deferred.path,
+            deferred.reason
+        );
+        assert!(
+            !ADVANCED_BUILDERS
+                .iter()
+                .any(|builder| builder.path == deferred.path
+                    && builder.function == deferred.function),
+            "{} in {} is both registered and deferred",
+            deferred.function,
+            deferred.path
+        );
+    }
+}
+
+/// The trip-wire that closes the class: NOTHING in the web app builds an `advanced` map without
+/// being either classified or explicitly deferred (sc-15948).
+///
+/// This is the assertion sc-15946 was missing. Its lint read one file, so the second builder
+/// (`buildDetailJobBody`) and then the third and fourth (`CharacterAdvancedOptions.buildAdvanced`
+/// with the `advancedExtras` controllers, and `DocumentStudio.submit`) were each found by hand,
+/// after shipping, one bug at a time. Instead of trusting a premise about how many builders exist,
+/// this walks `apps/web/src` for every place an `advanced` map is built and demands that each one
+/// sit inside a registered builder or a declared deferral.
+///
+/// A NEW builder therefore fails the build the moment it appears — whether it is a new file, a new
+/// function in a file that is already covered, or a new `advancedExtras` on a controller — and the
+/// author has to decide: classify its keys (move it into [`ADVANCED_BUILDERS`]) or state which
+/// story owns it (add it to [`DEFERRED_ADVANCED_BUILDERS`]).
+#[test]
+fn every_advanced_builder_in_the_web_app_is_accounted_for() {
+    // (path, function) → the declared body span, plus whether it is classified or deferred.
+    let mut declared: Vec<(&str, &str, bool)> = ADVANCED_BUILDERS
+        .iter()
+        .map(|builder| (builder.path, builder.function, true))
+        .collect();
+    declared.extend(
+        DEFERRED_ADVANCED_BUILDERS
+            .iter()
+            .map(|deferred| (deferred.path, deferred.function, false)),
+    );
+
+    let files = web_source_files();
+    assert!(
+        files.len() >= 100,
+        "only {} web source files were walked — the discovery scan lost the tree it is supposed \
+         to sweep, so it is not protecting anything",
+        files.len()
+    );
+
+    // Every declared builder must resolve to a real function in a real file. `function_body_span`
+    // panics with instructions when a rename or a move has left the registry pointing at nothing.
+    let mut spans: Vec<(&str, &str, usize, usize)> = Vec::new();
+    for (path, function, _) in &declared {
+        let stripped = scannable(&read_repo_file(path));
+        let (start, end) = function_body_span(&stripped, function, path);
+        spans.push((path, function, start, end));
+    }
+
+    let mut covered_by: Vec<(&str, &str)> = Vec::new();
+    for relative in &files {
+        let stripped = scannable(&read_repo_file(relative));
+        for signal in advanced_map_signals(&stripped) {
+            let owner = spans.iter().find(|(path, _, start, end)| {
+                *path == relative.as_str() && signal.offset >= *start && signal.offset < *end
+            });
+            let (_, function, _, _) = owner.unwrap_or_else(|| {
+                let line = 1 + stripped[..signal.offset].matches('\n').count();
+                panic!(
+                    "{relative}:{line} builds an `advanced` map ({}) inside no builder that \
+                     `ADVANCED_BUILDERS` or `DEFERRED_ADVANCED_BUILDERS` declares.\n\
+                     Every place the web app fills `advanced` must be accounted for, because \
+                     four of those places now feed a lane that embeds the map into the PNG \
+                     (epic 15945). Add the (file, function) pair to `ADVANCED_BUILDERS` in \
+                     crates/sceneworks-core/src/workflow_share.rs and classify every key it can \
+                     emit, or — if its lane does not embed yet — to \
+                     `DEFERRED_ADVANCED_BUILDERS` with the story that owns turning it on.",
+                    signal.kind
+                )
+            });
+            covered_by.push((relative.as_str(), function));
+        }
+    }
+
+    // The other direction: a declared builder that no longer builds an `advanced` map is a stale
+    // entry, and a stale deferral is how a video lane could start embedding unnoticed.
+    //
+    // Two shapes are exempt by construction. `NoAdvancedMap` asserts the absence of a map — that is
+    // its whole point. `ReturnedObject` builds one by RETURNING it (`buildImageJobAdvanced` never
+    // writes the word `advanced`), so there is nothing for a signal scan to find; the floor and
+    // anchors in `assert_builder_is_fully_classified` are what hold that shape honest.
+    for builder in ADVANCED_BUILDERS {
+        if matches!(
+            builder.shape,
+            AdvancedBuilderShape::NoAdvancedMap | AdvancedBuilderShape::ReturnedObject
+        ) {
+            continue;
+        }
+        assert!(
+            covered_by
+                .iter()
+                .any(|(path, function)| *path == builder.path && *function == builder.function),
+            "`ADVANCED_BUILDERS` registers {} in {} but the discovery scan finds no `advanced` map \
+             built there any more",
+            builder.function,
+            builder.path
+        );
+    }
+    for deferred in DEFERRED_ADVANCED_BUILDERS {
+        assert!(
+            covered_by
+                .iter()
+                .any(|(path, function)| *path == deferred.path && *function == deferred.function),
+            "`DEFERRED_ADVANCED_BUILDERS` defers {} in {} but the discovery scan finds no \
+             `advanced` map built there any more — drop the deferral",
+            deferred.function,
+            deferred.path
+        );
+    }
+}
+
+/// The lint sc-15946 shipped, still asserting exactly what it did, now through the registry.
+#[test]
+fn every_advanced_key_the_studio_can_emit_is_classified() {
+    assert_builder_is_fully_classified(builder_for(AdvancedKeySource::StudioBuilder));
 }
 
 /// The Detail pass's own knobs are classified too (sc-15948).
@@ -522,46 +720,68 @@ fn emitted_detail_advanced_keys(source: &str) -> BTreeSet<String> {
 /// unclassified and therefore silently dropped from every shared detail-refined image.
 #[test]
 fn every_advanced_key_the_detail_pass_can_emit_is_classified() {
-    let source = read_repo_file(DETAIL_BUILDER_PATH);
-    let emitted = emitted_detail_advanced_keys(&source);
+    assert_builder_is_fully_classified(builder_for(AdvancedKeySource::DetailBuilder));
+}
 
-    for anchor in ["strength", "cnScale"] {
-        assert!(
-            emitted.contains(anchor),
-            "the extractor missed the known detail knob `{anchor}` in {DETAIL_BUILDER_PATH}, so \
-             this lint is not protecting anything"
+/// The character lane leaked `angleSet` — the knob that decides how many images exist (sc-15948).
+///
+/// `advanced.angleSet` is what makes the worker emit one image per view angle, and
+/// `mode: "character_image"` posts to `/api/v1/image/jobs`, which embeds. Unclassified, it was
+/// dropped, so a shared angle-set image replayed as a SINGLE image. Its neighbour
+/// `keypointCollectionId` is a local id and is denied.
+#[test]
+fn every_advanced_key_the_character_lane_can_emit_is_classified() {
+    for source in [
+        AdvancedKeySource::CharacterBuilder,
+        AdvancedKeySource::CharacterAngleExtras,
+        AdvancedKeySource::CharacterPoseExtras,
+    ] {
+        assert_builder_is_fully_classified(builder_for(source));
+    }
+    assert_eq!(
+        advanced_key_rule("angleSet").map(|rule| rule.disposition),
+        Some(AdvancedDisposition::Allow),
+        "`angleSet` decides how many images the job makes, so it must travel"
+    );
+    assert_eq!(
+        advanced_key_rule("keypointCollectionId").map(|rule| rule.disposition),
+        Some(AdvancedDisposition::Deny),
+        "a Key Point Library collection id resolves to nothing on another install"
+    );
+}
+
+/// The interleave lane BECAME an embedding lane in this story, so its keys are classified here.
+///
+/// `sensenova_jobs.rs` threads `workflow_source` into `ImagePlan`, which reaches
+/// `write_image_asset` — so every shared interleaved document image carries whatever
+/// `DocumentStudio.submit` put in `advanced`, and dropped whatever it did not classify. Making a
+/// lane embed and not classifying its keys is the same bug as the `cnScale` one, on a lane this
+/// story created.
+#[test]
+fn every_advanced_key_the_interleave_lane_can_emit_is_classified() {
+    assert_builder_is_fully_classified(builder_for(AdvancedKeySource::InterleaveBuilder));
+    for (key, disposition) in [
+        ("systemMessage", AdvancedDisposition::Allow),
+        ("imageGuidanceScale", AdvancedDisposition::Allow),
+    ] {
+        assert_eq!(
+            advanced_key_rule(key).map(|rule| rule.disposition),
+            Some(disposition),
+            "`{key}` is authored generation intent on a lane that embeds"
         );
     }
+}
 
-    let classified: BTreeSet<String> = ADVANCED_KEY_RULES
-        .iter()
-        .map(|rule| rule.key.to_owned())
-        .collect();
-    let unclassified: Vec<&String> = emitted.difference(&classified).collect();
-    assert!(
-        unclassified.is_empty(),
-        "buildDetailJobBody can emit {unclassified:?}, which `ADVANCED_KEY_RULES` in \
-         crates/sceneworks-core/src/workflow_share.rs does not classify. An unclassified key is \
-         dropped silently, so a shared detail-refined image would describe less of the pass than \
-         the user actually chose."
-    );
-
-    let from_detail: BTreeSet<String> = ADVANCED_KEY_RULES
-        .iter()
-        .filter(|rule| rule.source == AdvancedKeySource::DetailBuilder)
-        .map(|rule| rule.key.to_owned())
-        .collect();
-    assert!(
-        !from_detail.is_empty(),
-        "no rule is tagged `AdvancedKeySource::DetailBuilder`, so nothing holds \
-         {DETAIL_BUILDER_PATH} accountable"
-    );
-    let stale: Vec<&String> = from_detail.difference(&emitted).collect();
-    assert!(
-        stale.is_empty(),
-        "`ADVANCED_KEY_RULES` classifies {stale:?} as coming from buildDetailJobBody, but \
-         {DETAIL_BUILDER_PATH} no longer emits them."
-    );
+/// The standalone upscale job posts NO `advanced` map — and that is now asserted, not assumed.
+///
+/// sc-15948 made that job embed (ISSUE 1), which puts `buildUpscaleJobBody` on the same footing as
+/// the other three builders: the day it grows a knob, the lint demands a classification instead of
+/// dropping it silently.
+#[test]
+fn the_standalone_upscale_builder_still_posts_no_advanced_map() {
+    let builder = builder_for(AdvancedKeySource::UpscaleBuilder);
+    assert_eq!(builder.shape, AdvancedBuilderShape::NoAdvancedMap);
+    assert_builder_is_fully_classified(builder);
 }
 
 #[test]
@@ -953,6 +1173,52 @@ fn the_shipped_path_guard_is_never_weaker_than_the_independent_sniffer() {
     }
 }
 
+/// The two live leaks sc-15948's review found, asserted as BEHAVIOUR rather than as coverage.
+///
+/// The lint tests above would have caught these at build time; this catches them at the seam, so
+/// the fix cannot regress by someone re-tagging a rule while leaving it denied. Both lanes post to
+/// endpoints that embed, so each of these keys either travels inside a shared PNG or is lost:
+///
+/// * `angleSet` is what makes the worker emit one image per view angle. Dropped, a shared angle-set
+///   image replays as a SINGLE image.
+/// * `imageGuidanceScale` is the authored reference-guidance strength for an interleaved document,
+///   and `systemMessage` is the system prompt the user typed. Dropped, a shared interleaved image
+///   loses both.
+/// * `keypointCollectionId` is a local Key Point Library id and must NOT travel.
+#[test]
+fn the_character_and_interleave_lane_knobs_survive_the_allow_list() {
+    let mut payload = golden_payload();
+    let advanced = payload
+        .get_mut("advanced")
+        .and_then(Value::as_object_mut)
+        .expect("advanced object");
+    advanced.insert("angleSet".to_owned(), json!(true));
+    advanced.insert("keypointCollectionId".to_owned(), json!("kpc_7f31"));
+    advanced.insert("imageGuidanceScale".to_owned(), json!(1.8));
+    advanced.insert(
+        "systemMessage".to_owned(),
+        json!("Keep every panel on the same character."),
+    );
+
+    let share = build_workflow_share(&golden_asset(), &payload);
+    assert_eq!(share.advanced.get("angleSet"), Some(&json!(true)));
+    assert_eq!(share.advanced.get("imageGuidanceScale"), Some(&json!(1.8)));
+    assert_eq!(
+        share.advanced.get("systemMessage"),
+        Some(&json!("Keep every panel on the same character."))
+    );
+    assert!(
+        !share.advanced.contains_key("keypointCollectionId"),
+        "a local Key Point Library id must not travel"
+    );
+    assert!(
+        !serde_json::to_string(&share)
+            .expect("serializes")
+            .contains("kpc_7f31"),
+        "the collection id leaked into the envelope"
+    );
+}
+
 #[test]
 fn input_ids_become_shape_descriptors_with_zero_id_leakage() {
     let mut payload = golden_payload();
@@ -1096,16 +1362,377 @@ fn looks_like_a_path(value: &str) -> bool {
 // The JS key extractor
 // ---------------------------------------------------------------------------
 
-/// Every key `buildImageJobAdvanced` can put into the `advanced` payload.
+/// Comments removed and every non-ASCII character replaced by a space.
 ///
-/// A small brace-aware scanner rather than a regex, because the builder's whole shape is
+/// The ASCII normalization is not cosmetic: the discovery scan compares byte offsets of `advanced`
+/// signals against byte offsets of function-body spans, and every builder file carries em-dashes in
+/// its comments and prose in its string literals. Normalizing first makes byte offsets and
+/// character offsets the same number, so a `&str` slice can never land mid-codepoint and the two
+/// halves of the scan cannot silently disagree. Identifiers are ASCII, so nothing the extractors
+/// read is affected.
+fn scannable(source: &str) -> String {
+    strip_comments(source)
+        .chars()
+        .map(|character| if character.is_ascii() { character } else { ' ' })
+        .collect()
+}
+
+/// Every web source file the discovery scan reads, repo-relative with forward slashes.
+///
+/// Test scaffolding is excluded by name: `main.testSupport.jsx` builds request bodies with
+/// `advanced` maps on purpose (they are fixtures for the tests, not payloads a user can send), and
+/// `*.test.js(x)` do the same.
+fn web_source_files() -> Vec<String> {
+    let root = repo_root().join("apps").join("web").join("src");
+    let mut out = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        let entries = fs::read_dir(&dir)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", dir.display()));
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_owned();
+            if !(name.ends_with(".js") || name.ends_with(".jsx"))
+                || name.contains(".test.")
+                || name.contains(".testSupport.")
+            {
+                continue;
+            }
+            let relative = path
+                .strip_prefix(repo_root())
+                .expect("under the repo root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.push(relative);
+        }
+    }
+    out.sort_unstable();
+    out
+}
+
+/// One place a web file builds an `advanced` map.
+struct AdvancedSignal {
+    /// Offset into the [`scannable`] text of the `advanced` / `advancedExtras` identifier.
+    offset: usize,
+    /// What was matched, for the failure message.
+    kind: &'static str,
+}
+
+/// Every place `stripped` builds an `advanced` map.
+///
+/// Four shapes, which between them cover every builder in the tree today:
+///
+/// * `advanced: { … }` — a map written inline into a request body.
+/// * `advancedExtras: { … }` — a character-lane controller's contribution.
+/// * `advanced = { … }` — the initializer half of an assignment-style builder.
+/// * `advanced.key = …` — the assignment half.
+///
+/// Deliberately NOT matched: `advanced: buildImageJobAdvanced({ … })` and
+/// `advanced: advanced.buildAdvanced(extras)`, which are CALL SITES of a builder that is itself
+/// registered. Matching those would demand a registry entry for every screen that submits a job,
+/// which says nothing about which keys exist.
+///
+/// A computed write (`advanced["key"] = …`) or an `Object.assign(advanced, …)` would be invisible
+/// here, so [`emitted_keys`] refuses them inside a registered builder rather than reading past them.
+fn advanced_map_signals(stripped: &str) -> Vec<AdvancedSignal> {
+    let bytes = stripped.as_bytes();
+    let mut out = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            byte if is_identifier_start(byte as char) => {
+                let start = index;
+                while index < bytes.len() && is_identifier_char(bytes[index] as char) {
+                    index += 1;
+                }
+                let word = &stripped[start..index];
+                if word != "advanced" && word != "advancedExtras" {
+                    continue;
+                }
+                let mut lookahead = skip_ascii_whitespace(bytes, index);
+                let kind = match bytes.get(lookahead) {
+                    // `advanced: {` / `advancedExtras: {`
+                    Some(b':') => {
+                        lookahead = skip_ascii_whitespace(bytes, lookahead + 1);
+                        (bytes.get(lookahead) == Some(&b'{')).then_some("an inline object literal")
+                    }
+                    // `advanced = {`, but never `advanced == …`.
+                    Some(b'=') if bytes.get(lookahead + 1) != Some(&b'=') => {
+                        lookahead = skip_ascii_whitespace(bytes, lookahead + 1);
+                        (bytes.get(lookahead) == Some(&b'{'))
+                            .then_some("an assigned object literal")
+                    }
+                    // `advanced.key = …`, but never `advanced.key ==` or `advanced.key(…)`.
+                    Some(b'.') if word == "advanced" => {
+                        let key_start = lookahead + 1;
+                        let mut key_end = key_start;
+                        while key_end < bytes.len() && is_identifier_char(bytes[key_end] as char) {
+                            key_end += 1;
+                        }
+                        let after = skip_ascii_whitespace(bytes, key_end);
+                        (key_end > key_start
+                            && bytes.get(after) == Some(&b'=')
+                            && bytes.get(after + 1) != Some(&b'=')
+                            && bytes.get(after + 1) != Some(&b'>'))
+                        .then_some("a property assignment")
+                    }
+                    _ => None,
+                };
+                if let Some(kind) = kind {
+                    out.push(AdvancedSignal {
+                        offset: start,
+                        kind,
+                    });
+                }
+            }
+            _ => index += 1,
+        }
+    }
+    out
+}
+
+/// The offsets of `function <name>`'s body in `stripped` — the text BETWEEN its braces.
+///
+/// Panics with instructions rather than returning nothing when the function is gone: a registry
+/// entry pointing at a renamed function must fail the lint, not quietly stop covering it.
+fn function_body_span(stripped: &str, function: &str, path: &str) -> (usize, usize) {
+    let needle = format!("function {function}");
+    let occurrences = stripped.matches(needle.as_str()).count();
+    assert_eq!(
+        occurrences, 1,
+        "`{needle}` appears {occurrences} times in {path}; this coverage lint needs exactly one so \
+         it reads an unambiguous body. Either the function was renamed or moved — point the \
+         `ADVANCED_BUILDERS` entry at wherever that `advanced` map is built now — or a second \
+         function shares the name, in which case rename one."
+    );
+    let at = stripped.find(needle.as_str()).expect("just counted one");
+    let bytes = stripped.as_bytes();
+
+    // Walk the parameter list first: a default value carries braces of its own
+    // (`buildAdvanced(base = {})`), so the body's `{` is not simply the next one.
+    let mut index = at + needle.len();
+    while index < bytes.len() && bytes[index] != b'(' {
+        index += 1;
+    }
+    assert!(
+        index < bytes.len(),
+        "`{needle}` in {path} has no parameter list"
+    );
+    let mut depth = 0_usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    index += 1;
+                    break;
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    while index < bytes.len() && bytes[index] != b'{' {
+        index += 1;
+    }
+    assert!(
+        index < bytes.len(),
+        "`{needle}` in {path} has no body — an arrow-bodied function is a shape this lint cannot \
+         read"
+    );
+    let open = index;
+    let mut depth = 0_usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return (open + 1, index);
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    panic!("`{needle}` in {path} has an unbalanced body");
+}
+
+/// The balanced text inside the first `{` at or after `from`.
+fn object_literal_body(text: &str, from: usize, what: &str) -> String {
+    let bytes = text.as_bytes();
+    let open = from
+        + text[from..]
+            .find('{')
+            .unwrap_or_else(|| panic!("{what} is not followed by an object literal"));
+    let mut depth = 0_usize;
+    let mut index = open;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return text[open + 1..index].to_owned();
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    panic!("{what}'s object literal is unbalanced");
+}
+
+/// Every `advanced` key one registered builder can emit, read out of its own JS shape.
+///
+/// The dispatch the registry's [`AdvancedBuilderShape`] exists for. Each arm fails loudly when the
+/// file stops matching the shape it claims, because a green lint that has quietly stopped reading
+/// anything is worse than no lint — it is the exact failure that let `cnScale` ship unclassified.
+fn emitted_keys(builder: &AdvancedBuilder, source: &str) -> BTreeSet<String> {
+    let stripped = scannable(source);
+    let (start, end) = function_body_span(&stripped, builder.function, builder.path);
+    let body = &stripped[start..end];
+    let what = format!("`{}` in {}", builder.function, builder.path);
+
+    match builder.shape {
+        AdvancedBuilderShape::ReturnedObject => {
+            let return_at = body
+                .find("return {")
+                .unwrap_or_else(|| panic!("{what} no longer returns an object literal"))
+                + "return ".len();
+            let literal = object_literal_body(body, return_at, &what);
+            scan_object_literal(&literal, &what, false).0
+        }
+        AdvancedBuilderShape::ExtrasLiteral => {
+            let at = body.find("advancedExtras:").unwrap_or_else(|| {
+                panic!(
+                    "{what} no longer carries an `advancedExtras:` literal, so this lint cannot \
+                     see which knobs that form contributes"
+                )
+            }) + "advancedExtras:".len();
+            let literal = object_literal_body(body, at, &what);
+            scan_object_literal(&literal, &what, false).0
+        }
+        AdvancedBuilderShape::FlatAdvancedLiteral => {
+            let at = body
+                .find("advanced:")
+                .unwrap_or_else(|| panic!("{what} no longer carries an `advanced:` literal"))
+                + "advanced:".len();
+            let literal = object_literal_body(body, at, &what);
+            assert!(
+                !literal.contains('{') && !literal.contains("..."),
+                "{what}'s `advanced` literal is no longer flat — re-tag its registry `shape` (the \
+                 conditional-spread scanner reads that shape) rather than letting this arm \
+                 misread it"
+            );
+            literal
+                .split(',')
+                // `key` and `key: value` alike — take the identifier before any colon.
+                .filter_map(|entry| entry.split(':').next())
+                .map(str::trim)
+                .filter(|key| !key.is_empty() && key.chars().all(is_identifier_char))
+                .map(str::to_owned)
+                .collect()
+        }
+        AdvancedBuilderShape::AssignedObject => {
+            refuse_invisible_advanced_writes(body, &what);
+            let at = body
+                .find("advanced =")
+                .unwrap_or_else(|| panic!("{what} no longer initializes an `advanced` object"));
+            let literal = object_literal_body(body, at + "advanced =".len(), &what);
+            let (mut keys, spreads) = scan_object_literal(&literal, &what, true);
+            let declared: BTreeSet<String> = builder
+                .spread_of
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect();
+            assert_eq!(
+                spreads, declared,
+                "{what} spreads {spreads:?} into its `advanced` initializer, but its registry \
+                 entry declares `spread_of: {declared:?}`. A spread nobody declared is a whole \
+                 set of keys this lint cannot see — either point `spread_of` at it and register \
+                 the builder that produces those keys, or stop spreading it."
+            );
+            keys.extend(assigned_advanced_keys(body));
+            keys
+        }
+        AdvancedBuilderShape::NoAdvancedMap => {
+            assert!(
+                !body.contains("advanced"),
+                "{what} is registered as posting NO `advanced` map, but its body now mentions \
+                 `advanced`. It feeds a lane that embeds the map into every PNG it writes, so \
+                 give it a real registry `shape` and classify every key it can emit."
+            );
+            BTreeSet::new()
+        }
+    }
+}
+
+/// A write this lint cannot follow must fail rather than be scanned past.
+fn refuse_invisible_advanced_writes(body: &str, what: &str) {
+    for invisible in ["advanced[", "Object.assign(advanced", "advanced.push("] {
+        assert!(
+            !body.contains(invisible),
+            "{what} writes `advanced` through `{invisible}…`, which this coverage lint cannot \
+             read — the keys it sets would be invisible here and silently dropped from every \
+             shared image. Write them as plain `advanced.key = …` assignments."
+        );
+    }
+}
+
+/// Every `advanced.key = …` assignment in one function body.
+fn assigned_advanced_keys(body: &str) -> BTreeSet<String> {
+    advanced_map_signals(body)
+        .into_iter()
+        .filter(|signal| signal.kind == "a property assignment")
+        .map(|signal| {
+            let after_dot = signal.offset + "advanced.".len();
+            let bytes = body.as_bytes();
+            let mut end = after_dot;
+            while end < bytes.len() && is_identifier_char(bytes[end] as char) {
+                end += 1;
+            }
+            body[after_dot..end].to_owned()
+        })
+        .collect()
+}
+
+/// Every key an object literal built from conditional spreads can contribute, plus the bare
+/// identifiers it spreads.
+///
+/// A small brace-aware scanner rather than a regex, because the studio builder's whole shape is
 /// conditional spreads: `...(cond ? { key: value } : {})` contributes a TOP-LEVEL advanced
 /// key from brace depth two, while `{ controlWeights: { overlayId } }` and a call argument
 /// object like `buildStructuredPromptRecipe({ intent })` do not. A regex cannot tell those
 /// apart, and getting it wrong in the permissive direction would make this lint pass on a key
 /// that is never emitted while missing one that is.
 ///
-/// Rule: a brace is an "emit scope" when it is the return object itself, or when it is an
+/// Rule: a brace is an "emit scope" when it is the literal itself, or when it is an
 /// object literal at the top level of a spread expression (`...( … )`) written inside another
 /// emit scope — which covers BOTH branches of the `cond ? { a } : { b }` the builder uses.
 /// Only identifiers in key position inside an emit scope count.
@@ -1114,16 +1741,24 @@ fn looks_like_a_path(value: &str) -> bool {
 ///
 /// The scanner understands ONE shape, and a lint that silently understands nothing is worse
 /// than no lint: `...buildFutureKnobs(state)` in the return object would contribute no keys, the
-/// `>= 25` floor and every anchor would still resolve, and a brand-new knob would stop
-/// travelling with zero signal. So a spread this scanner cannot follow — a bare identifier
-/// (`...defaults,`), a call expression, or a parenthesized expression with no object literal in
-/// it — PANICS with instructions instead of scanning past it. Fail-safe on the privacy axis
-/// (the key is dropped, not leaked) is only half of what this lint is for; the other half is
-/// noticing that a knob went missing.
-fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
-    let body = builder_return_body(source);
+/// key floor and every anchor would still resolve, and a brand-new knob would stop
+/// travelling with zero signal. So a spread this scanner cannot follow — a call expression, or a
+/// parenthesized expression with no object literal in it — PANICS with instructions instead of
+/// scanning past it. Fail-safe on the privacy axis (the key is dropped, not leaked) is only half
+/// of what this lint is for; the other half is noticing that a knob went missing.
+///
+/// `allow_identifier_spreads` is the one exception, for `{ ...base, key }`: an
+/// [`AdvancedBuilderShape::AssignedObject`] builder merges another registered builder's map in by
+/// name. Those identifiers are RETURNED rather than ignored, so the caller can assert they are
+/// exactly the ones the registry declares.
+fn scan_object_literal(
+    body: &str,
+    what: &str,
+    allow_identifier_spreads: bool,
+) -> (BTreeSet<String>, BTreeSet<String>) {
     let chars: Vec<char> = body.chars().collect();
     let mut keys = BTreeSet::new();
+    let mut identifier_spreads = BTreeSet::new();
     // (is_emit_scope, expecting_a_key)
     let mut scopes: Vec<(bool, bool)> = vec![(true, true)];
     // Open spread expressions, as (open scope count, paren depth at the `...`, produced an
@@ -1175,11 +1810,10 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
                     }
                     assert!(
                         produced,
-                        "a spread in buildImageJobAdvanced's return object contains no object \
-                         literal, so `emitted_advanced_keys` in this test scanned past it and \
-                         contributed nothing. Every key inside it is invisible to this lint. \
-                         Write the spread as `...(cond ? {{ key }} : {{}})`, or teach the \
-                         scanner the new shape."
+                        "a spread in {what} contains no object literal, so `scan_object_literal` \
+                         in this test scanned past it and contributed nothing. Every key inside \
+                         it is invisible to this lint. Write the spread as \
+                         `...(cond ? {{ key }} : {{}})`, or teach the scanner the new shape."
                     );
                     spreads.pop();
                 }
@@ -1197,20 +1831,55 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
             '.' => {
                 if index + 2 < chars.len() && chars[index + 1] == '.' && chars[index + 2] == '.' {
                     if scopes.last().is_some_and(|(emit, _)| *emit) {
-                        // The scanner follows `...( … )` and nothing else. A bare identifier or
-                        // a call would leave a spread open forever — the next nested object
-                        // VALUE would then read as an emit scope — so refuse rather than guess.
+                        // The scanner follows `...( … )`, plus a bare identifier where the caller
+                        // has declared one. Anything else — a call, a member expression — would
+                        // leave a spread open forever, so the next nested object VALUE would read
+                        // as an emit scope: refuse rather than guess.
                         let mut lookahead = index + 3;
                         while lookahead < chars.len() && chars[lookahead].is_whitespace() {
                             lookahead += 1;
                         }
+                        let identifier_spread = allow_identifier_spreads
+                            && chars
+                                .get(lookahead)
+                                .copied()
+                                .is_some_and(is_identifier_start);
+                        if identifier_spread {
+                            let start = lookahead;
+                            while lookahead < chars.len() && is_identifier_char(chars[lookahead]) {
+                                lookahead += 1;
+                            }
+                            let mut after = lookahead;
+                            while after < chars.len() && chars[after].is_whitespace() {
+                                after += 1;
+                            }
+                            assert!(
+                                matches!(chars.get(after), Some(',') | Some('}') | None),
+                                "{what} spreads something this coverage lint cannot read: a \
+                                 member or call expression (`...{}`). Every key it contributes is \
+                                 invisible to this lint, so a new knob would silently stop \
+                                 travelling.",
+                                chars[start..]
+                                    .iter()
+                                    .take(24)
+                                    .collect::<String>()
+                                    .trim_end()
+                            );
+                            identifier_spreads
+                                .insert(chars[start..lookahead].iter().collect::<String>());
+                            index = lookahead;
+                            if let Some(scope) = scopes.last_mut() {
+                                scope.1 = false;
+                            }
+                            continue;
+                        }
                         assert!(
                             chars.get(lookahead) == Some(&'('),
-                            "buildImageJobAdvanced spreads something `emitted_advanced_keys` in \
-                             this test cannot read: a bare identifier or a call expression \
-                             (`...{}`). Every key it contributes is invisible to this lint, so a \
-                             new knob would silently stop travelling. Write it as \
-                             `...(cond ? {{ key }} : {{}})`, or teach the scanner the new shape.",
+                            "{what} spreads something this coverage lint cannot read: a bare \
+                             identifier or a call expression (`...{}`). Every key it contributes \
+                             is invisible to this lint, so a new knob would silently stop \
+                             travelling. Write it as `...(cond ? {{ key }} : {{}})`, or teach the \
+                             scanner the new shape.",
                             chars[lookahead..]
                                 .iter()
                                 .take(24)
@@ -1244,7 +1913,10 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
                     while lookahead < chars.len() && chars[lookahead].is_whitespace() {
                         lookahead += 1;
                     }
-                    if lookahead < chars.len() && matches!(chars[lookahead], ':' | ',' | '}') {
+                    // End of the literal counts as a terminator: the caller passes the text
+                    // INSIDE the braces, so a final entry with no trailing comma
+                    // (`{ ...base, ipAdapterScale }`) ends at the slice's end rather than at `}`.
+                    if lookahead >= chars.len() || matches!(chars[lookahead], ':' | ',' | '}') {
                         keys.insert(chars[start..index].iter().collect::<String>());
                     }
                 }
@@ -1262,53 +1934,23 @@ fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
     }
     assert!(
         spreads.is_empty(),
-        "a spread in buildImageJobAdvanced's return object never closed, so \
-         `emitted_advanced_keys` in this test lost track of the builder's shape. Fix the \
-         scanner rather than letting it scan a shape it does not understand."
+        "a spread in {what} never closed, so `scan_object_literal` in this test lost track of the \
+         literal's shape. Fix the scanner rather than letting it scan a shape it does not \
+         understand."
     );
-    keys
+    (keys, identifier_spreads)
 }
 
-/// The text inside `buildImageJobAdvanced`'s `return { … }`, comments removed.
-fn builder_return_body(source: &str) -> String {
-    let stripped = strip_comments(source);
-    let function_at = stripped
-        .find("function buildImageJobAdvanced")
-        .unwrap_or_else(|| {
-            panic!(
-                "`buildImageJobAdvanced` is gone from {ADVANCED_BUILDER_PATH} — this coverage \
-                 lint must be pointed at wherever the advanced payload is built now"
-            )
-        });
-    let return_at = stripped[function_at..]
-        .find("return {")
-        .map(|offset| function_at + offset + "return ".len())
-        .expect("buildImageJobAdvanced returns an object literal");
-
-    let chars: Vec<char> = stripped[return_at..].chars().collect();
-    let mut depth = 0_usize;
-    let mut index = 0;
-    let mut end = None;
-    while index < chars.len() {
-        match chars[index] {
-            '"' | '\'' | '`' => {
-                index = skip_string(&chars, index);
-                continue;
-            }
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    end = Some(index);
-                    break;
-                }
-            }
-            _ => {}
-        }
-        index += 1;
-    }
-    let end = end.expect("the returned object literal is balanced");
-    chars[1..end].iter().collect()
+/// Every key `buildImageJobAdvanced` can put into the `advanced` payload — the studio builder's
+/// extractor, exposed on its own so the scanner's own unit tests can feed it a synthetic builder.
+fn emitted_advanced_keys(source: &str) -> BTreeSet<String> {
+    emitted_keys(
+        ADVANCED_BUILDERS
+            .iter()
+            .find(|builder| builder.source == AdvancedKeySource::StudioBuilder)
+            .expect("the studio builder is registered"),
+        source,
+    )
 }
 
 /// Blank out `//` and `/* */` comments without disturbing string literals.
@@ -1358,6 +2000,29 @@ fn skip_string(chars: &[char], start: usize) -> usize {
         }
     }
     chars.len()
+}
+
+/// [`skip_string`] over the ASCII-normalized text the offset-based scanners work on.
+fn skip_string_ascii(bytes: &[u8], start: usize) -> usize {
+    let quote = bytes[start];
+    let mut index = start + 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index += 2,
+            byte if byte == quote => return index + 1,
+            _ => index += 1,
+        }
+    }
+    bytes.len()
+}
+
+/// The first non-whitespace offset at or after `from`.
+fn skip_ascii_whitespace(bytes: &[u8], from: usize) -> usize {
+    let mut index = from;
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    index
 }
 
 fn is_identifier_start(character: char) -> bool {

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -18,7 +18,8 @@ use sceneworks_core::workflow_share::{
     advanced_key_rule, build_workflow_share, build_workflow_share_from, is_path_shaped,
     parse_workflow_share, AdvancedBuilder, AdvancedBuilderShape, AdvancedDisposition,
     AdvancedKeySource, WorkflowAssetFacts, WorkflowShare, ADVANCED_BUILDERS, ADVANCED_KEY_RULES,
-    DEFERRED_ADVANCED_BUILDERS, PRODUCER_URL, PRODUCER_VERSION, WORKFLOW_SHARE_SCHEMA_VERSION,
+    DEFERRED_ADVANCED_BUILDERS, PERMANENT_EXEMPTION, PRODUCER_URL, PRODUCER_VERSION,
+    WORKFLOW_SHARE_SCHEMA_VERSION,
 };
 use serde_json::{json, Value};
 
@@ -571,7 +572,15 @@ fn every_source_tag_names_exactly_one_registered_builder() {
     }
 }
 
-/// Every deferral names a story, so "out of scope" cannot be a shrug (sc-15956 owns video).
+/// Every deferral either names a story or is an explicit permanent exemption, so "out of scope"
+/// cannot be a shrug (sc-15956 owns video; the training namespace is exempt).
+///
+/// The permanent category exists because the alternative is worse. `trainingConfigSnapshot` builds
+/// a ~20-key `advanced` map that no story will ever classify — it is trainer hyperparameters on a
+/// lane that embeds nothing, a different namespace that shares a name — and a deferral list that
+/// only accepts `sc-` ids would have forced either a fake story id or leaving the biggest
+/// unaccounted builder in the tree unaccounted. So a permanent reason must say what would have to
+/// change (an embedding write seam) and where the entry moves when it does.
 #[test]
 fn every_deferred_builder_names_the_story_that_owns_it() {
     assert!(
@@ -580,14 +589,30 @@ fn every_deferred_builder_names_the_story_that_owns_it() {
          and their keys must be in `ADVANCED_KEY_RULES`"
     );
     for deferred in DEFERRED_ADVANCED_BUILDERS {
+        let permanent = deferred.reason.starts_with(PERMANENT_EXEMPTION);
         assert!(
-            deferred.reason.contains("sc-"),
-            "the deferral for {} in {} must name the story that owns classifying its keys, got \
-             {:?}",
+            permanent || deferred.reason.contains("sc-"),
+            "the deferral for {} in {} must name the story that owns classifying its keys, or \
+             start with `{PERMANENT_EXEMPTION}` and say why no story ever will, got {:?}",
             deferred.function,
             deferred.path,
             deferred.reason
         );
+        if permanent {
+            // A permanent exemption is the one shape nobody will revisit on a story's schedule,
+            // so the reason has to carry the escape route itself.
+            assert!(
+                deferred.reason.contains("embed")
+                    && deferred.reason.contains("ADVANCED_BUILDERS")
+                    && deferred.reason.len() > 200,
+                "the permanent exemption for {} in {} must state what would have to change (a \
+                 write seam that EMBEDS) and that the entry then moves into `ADVANCED_BUILDERS`, \
+                 got {:?}",
+                deferred.function,
+                deferred.path,
+                deferred.reason
+            );
+        }
         assert!(
             !ADVANCED_BUILDERS
                 .iter()
@@ -600,8 +625,70 @@ fn every_deferred_builder_names_the_story_that_owns_it() {
     }
 }
 
-/// The trip-wire that closes the class: NOTHING in the web app builds an `advanced` map without
-/// being either classified or explicitly deferred (sc-15948).
+/// What to do about an `advanced` map nothing accounts for.
+///
+/// Three branches, and the third is not a formality. This sweep reads the NAME `advanced`, and
+/// nothing in the text separates a UI-state local called `advanced` from a payload map — a JSX prop
+/// and a parameter default can be recognized by their shape and are skipped, a plain local cannot
+/// be. Telling that author to "classify every key it can emit" would be wrong advice on a
+/// build-blocking failure, which is how a lint gets deleted instead of diagnosed. Renaming the local
+/// is the honest fix, and it is offered here rather than left to be guessed.
+const UNACCOUNTED_ADVANCED_ADVICE: &str = "\
+    Every place the web app fills `advanced` must be accounted for, because four of those places \
+    now feed a lane that embeds the map into the PNG (epic 15945). So either:\n\
+    * add the (file, function) pair to `ADVANCED_BUILDERS` in \
+    crates/sceneworks-core/src/workflow_share.rs and classify every key it can emit; or\n\
+    * if its lane does not embed yet, add it to `DEFERRED_ADVANCED_BUILDERS` with the story that \
+    owns turning it on; or\n\
+    * if this is not a job payload at all, RENAME THE LOCAL. This lint reads the name `advanced`, \
+    and a non-payload map that carries that name is indistinguishable from one that ships.";
+
+/// Call heads an indirect `advanced` expression may name WITHOUT being a declared builder.
+///
+/// (file, call head, why). One entry, and it is not a builder: `useCharacterAdvancedOptions` is the
+/// hook that returns the character panel's advanced-options CONTROLLER — the thing whose
+/// `buildAdvanced` is registered as [`AdvancedKeySource::CharacterBuilder`] and is called at
+/// `advanced.buildAdvanced(controller.advancedExtras)`. So `const advanced =
+/// useCharacterAdvancedOptions(…)` names a controller, not a map: there are no keys behind it for
+/// this lint to classify, and the keys that do exist are already covered by the entry for
+/// `buildAdvanced`.
+///
+/// Path-scoped on purpose. The same helper name called from another screen is a NEW indirection and
+/// has to be looked at rather than inherited.
+const ADVANCED_INDIRECTION_CALL_HEADS: &[(&str, &str, &str)] = &[(
+    "apps/web/src/screens/characterPanels.jsx",
+    "useCharacterAdvancedOptions",
+    "The hook that returns the CharacterAdvancedOptions controller. Its `buildAdvanced` is the \
+     registered builder; the local this initializes is the controller itself.",
+)];
+
+/// An exemption that no longer describes the tree is how a lint loses a subject quietly.
+///
+/// The same staleness check the registry and the deferral list get: if the hook call moves or is
+/// renamed, the entry must go rather than sit there excusing something that is not there.
+#[test]
+fn every_indirection_exemption_still_describes_the_tree() {
+    for (path, head, reason) in ADVANCED_INDIRECTION_CALL_HEADS {
+        assert!(
+            reason.len() > 40,
+            "the indirection exemption for `{head}` in {path} needs a real reason — it is the only \
+             thing telling the next author why an unreadable expression is allowed"
+        );
+        let stripped = scannable(&read_repo_file(path));
+        let found = advanced_map_signals(&stripped).into_iter().any(|signal| {
+            signal.kind == AdvancedSignalKind::Indirect && signal.called.as_deref() == Some(*head)
+        });
+        assert!(
+            found,
+            "`ADVANCED_INDIRECTION_CALL_HEADS` exempts `{head}` in {path}, but no `advanced` \
+             expression there comes from it any more — drop the exemption instead of leaving a \
+             hole open for whatever gets called `{head}` next"
+        );
+    }
+}
+
+/// The trip-wire that closes the class: every place `apps/web/src` builds an `advanced` map — or
+/// hands one in from a helper — is classified, deferred, or exempt by name (sc-15948).
 ///
 /// This is the assertion sc-15946 was missing. Its lint read one file, so the second builder
 /// (`buildDetailJobBody`) and then the third and fourth (`CharacterAdvancedOptions.buildAdvanced`
@@ -610,10 +697,42 @@ fn every_deferred_builder_names_the_story_that_owns_it() {
 /// this walks `apps/web/src` for every place an `advanced` map is built and demands that each one
 /// sit inside a registered builder or a declared deferral.
 ///
-/// A NEW builder therefore fails the build the moment it appears — whether it is a new file, a new
-/// function in a file that is already covered, or a new `advancedExtras` on a controller — and the
-/// author has to decide: classify its keys (move it into [`ADVANCED_BUILDERS`]) or state which
-/// story owns it (add it to [`DEFERRED_ADVANCED_BUILDERS`]).
+/// # Exactly what it proves
+///
+/// In every non-test `.js`/`.jsx` file under `apps/web/src`, each of these fails the build unless
+/// it falls inside the body of a function [`ADVANCED_BUILDERS`] or [`DEFERRED_ADVANCED_BUILDERS`]
+/// declares:
+///
+/// * an inline literal — `advanced: { … }`, `advancedExtras: { … }`;
+/// * an assigned literal — `advanced = { … }`;
+/// * a property assignment — `advanced.key = …`;
+/// * INDIRECTION — `advanced: buildFoo(state)`, `advanced: someVar`, `advanced =
+///   compactObject({ … })`. The map is assembled somewhere this scan cannot read, so the call has
+///   to name a declared builder (that builder's own entry accounts for the keys) or the signal
+///   stands. This is the hole the first cut of this sweep had: it matched only a literal `{`, so
+///   `trainingConfigSnapshot` built a ~20-key map through `compactObject` and the lint stayed
+///   green — a live counterexample to the "we found all the builders" premise sc-15946 died of.
+///
+/// Plus, in every file it reads and not merely inside a declared builder, a write it could not
+/// follow at all: `advanced["k"] = v`, `Object.assign(x.advanced, …)`, `advanced.push(…)`.
+///
+/// # What it does NOT prove
+///
+/// * That a declared builder's keys are classified. That is
+///   [`every_registered_builder_has_its_advanced_keys_classified`], which also refuses a SECOND,
+///   unread `advanced` map inside a declared span — a nested helper inside `DocumentStudio.submit`
+///   is not accounted for by `submit`'s entry, because the extractor never reads it.
+/// * That indirection is caught in assignment position when the right-hand side is not a call.
+///   `const advanced = defaults.advanced ?? {}` is a READ of someone else's map, not a build, and
+///   flagging member reads made this sweep fire on the training config's draft reader. Key
+///   position (`advanced:`) is strict about every non-brace expression; assignment position needs
+///   a call.
+/// * Anything about `advanced` maps assembled outside `apps/web/src`.
+///
+/// A NEW builder therefore fails the build the moment it appears — a new file, a new function in a
+/// file that is already covered, a new `advancedExtras` on a controller, or a new helper a payload
+/// calls — and the author has to decide: classify its keys (move it into [`ADVANCED_BUILDERS`]) or
+/// state which story owns it (add it to [`DEFERRED_ADVANCED_BUILDERS`]).
 #[test]
 fn every_advanced_builder_in_the_web_app_is_accounted_for() {
     // (path, function) → the declared body span, plus whether it is classified or deferred.
@@ -644,25 +763,35 @@ fn every_advanced_builder_in_the_web_app_is_accounted_for() {
         spans.push((path, function, start, end));
     }
 
+    let declared_functions = declared_builder_functions();
+
     let mut covered_by: Vec<(&str, &str)> = Vec::new();
     for relative in &files {
         let stripped = scannable(&read_repo_file(relative));
+        // Not only inside a declared builder: a write this lint cannot follow is invisible
+        // wherever it is, and `body.payload.advanced["k"] = v` in a brand-new file was green
+        // before this call moved out of the `AssignedObject` arm.
+        refuse_invisible_advanced_writes(&stripped, relative);
         for signal in advanced_map_signals(&stripped) {
-            let owner = spans.iter().find(|(path, _, start, end)| {
-                *path == relative.as_str() && signal.offset >= *start && signal.offset < *end
-            });
+            if signal.calls_a_declared_builder(relative, &declared_functions) {
+                continue;
+            }
+            // The INNERMOST declared span wins, so a nested helper that has been given its own
+            // registry entry is credited to that entry rather than to the function around it.
+            let owner = spans
+                .iter()
+                .filter(|(path, _, start, end)| {
+                    *path == relative.as_str() && signal.offset >= *start && signal.offset < *end
+                })
+                .min_by_key(|(_, _, start, end)| end - start);
             let (_, function, _, _) = owner.unwrap_or_else(|| {
                 let line = 1 + stripped[..signal.offset].matches('\n').count();
                 panic!(
                     "{relative}:{line} builds an `advanced` map ({}) inside no builder that \
-                     `ADVANCED_BUILDERS` or `DEFERRED_ADVANCED_BUILDERS` declares.\n\
-                     Every place the web app fills `advanced` must be accounted for, because \
-                     four of those places now feed a lane that embeds the map into the PNG \
-                     (epic 15945). Add the (file, function) pair to `ADVANCED_BUILDERS` in \
-                     crates/sceneworks-core/src/workflow_share.rs and classify every key it can \
-                     emit, or — if its lane does not embed yet — to \
-                     `DEFERRED_ADVANCED_BUILDERS` with the story that owns turning it on.",
-                    signal.kind
+                     `ADVANCED_BUILDERS` or `DEFERRED_ADVANCED_BUILDERS` declares.{}\n{}",
+                    signal.kind.describe(),
+                    signal.indirection_advice(),
+                    UNACCOUNTED_ADVANCED_ADVICE,
                 )
             });
             covered_by.push((relative.as_str(), function));
@@ -865,6 +994,261 @@ fn the_key_extractor_refuses_a_spread_with_no_object_literal_in_it() {
     emitted_advanced_keys(&builder_with_return_body(
         "    resolution,\n    ...(buildFutureKnobs(state)),",
     ));
+}
+
+// ---------------------------------------------------------------------------
+// The discovery scan's own unit tests: what it sees, and what it must not
+// ---------------------------------------------------------------------------
+
+/// Every signal `advanced_map_signals` reports for one snippet, as (kind, callee).
+fn signal_shapes(source: &str) -> Vec<(AdvancedSignalKind, Option<String>)> {
+    advanced_map_signals(&scannable(source))
+        .into_iter()
+        .map(|signal| (signal.kind, signal.called))
+        .collect()
+}
+
+/// Indirection is a signal, not silence — the hole that let `trainingConfigSnapshot` stay green.
+///
+/// The first cut of this sweep only ever matched a literal `{` after `advanced:`, so every one of
+/// these was invisible: the map was assembled in a helper, a variable or a ternary, and a ~20-key
+/// builder sat in neither the registry nor the deferral list with the lint reporting 27/27.
+#[test]
+fn the_discovery_scan_sees_a_map_handed_in_from_somewhere_else() {
+    for (source, called) in [
+        (
+            "const body = { advanced: probeExtrasMap(opts) };",
+            Some("probeExtrasMap"),
+        ),
+        ("const body = { advanced: someVar };", None),
+        (
+            "const body = { advanced: cond ? { a: 1 } : { b: 2 } };",
+            None,
+        ),
+        (
+            "const advanced = compactObject({ probeKnob: 1 });",
+            Some("compactObject"),
+        ),
+        ("const advanced = helpers.build(opts);", Some("build")),
+    ] {
+        assert_eq!(
+            signal_shapes(source),
+            vec![(AdvancedSignalKind::Indirect, called.map(str::to_owned))],
+            "indirection went unreported for {source:?}, which is how a builder stays invisible"
+        );
+    }
+}
+
+/// A call site of a REGISTERED builder stays exempt, or every screen would need an entry.
+#[test]
+fn the_discovery_scan_lets_a_declared_builders_call_site_through() {
+    let declared = declared_builder_functions();
+    for source in [
+        "const body = { advanced: buildImageJobAdvanced({ prompt }) };",
+        "const body = { advanced: advanced.buildAdvanced(controller.advancedExtras) };",
+    ] {
+        let signals = advanced_map_signals(&scannable(source));
+        assert_eq!(signals.len(), 1, "expected one signal for {source:?}");
+        assert!(
+            signals[0].calls_a_declared_builder("apps/web/src/imageJobRequest.js", &declared),
+            "{source:?} calls a registered builder, so demanding a registry entry for the SCREEN \
+             would say nothing about which keys exist"
+        );
+    }
+    // ... and an unregistered helper of the same shape is NOT exempt.
+    let signals = advanced_map_signals(&scannable("const b = { advanced: probeMap(o) };"));
+    assert!(
+        !signals[0].calls_a_declared_builder("apps/web/src/imageJobRequest.js", &declared),
+        "an indirection through an unregistered helper must stand as a signal"
+    );
+}
+
+/// A member READ is not a build, and flagging it fired on the training config's draft reader.
+#[test]
+fn the_discovery_scan_ignores_a_read_of_somebody_elses_advanced() {
+    assert!(
+        signal_shapes("const advanced = defaults.advanced ?? {};").is_empty(),
+        "`defaults.advanced ?? {{}}` reads a saved config; the sweep must not demand a registry \
+         entry for every screen that inspects one"
+    );
+}
+
+/// A JSX prop is not a payload, and a build-blocking lint that says otherwise gets deleted.
+///
+/// `advanced` appears in 59 non-test files under `apps/web/src`. Failing the BUILD on
+/// `<Child advanced={state.opts} />` with "classify every key it can emit" is advice that cannot be
+/// followed, on work that has nothing to do with sharing.
+#[test]
+fn the_discovery_scan_ignores_a_jsx_prop() {
+    for source in [
+        "const row = <Child advanced={state.opts} />;",
+        "const row = <Child title=\"a > b; not a tag\" advanced={{ open: false }} />;",
+        "const row = <ProbeRow advanced = {renamed} label=\"spaced\" />;",
+        "const row = <Outer>{items.map((item) => <Child advanced={item.opts} />)}</Outer>;",
+    ] {
+        assert!(
+            signal_shapes(source).is_empty(),
+            "{source:?} is a JSX prop, not a map this app builds"
+        );
+    }
+}
+
+/// A binding is not a build: a parameter default, and a destructuring rename.
+#[test]
+fn the_discovery_scan_ignores_a_binding_pattern() {
+    for source in [
+        "function Row({ advanced = {} }) { return advanced; }",
+        "function Row({ advanced = {} }, ref) { return ref ?? advanced; }",
+        "const Row = ({ advanced = {} }) => advanced;",
+        "const { advanced = {} } = props;",
+        "const { advanced: renamed } = props;",
+    ] {
+        assert!(
+            signal_shapes(source).is_empty(),
+            "{source:?} BINDS `advanced`, it does not build one"
+        );
+    }
+}
+
+/// A ternary's middle arm wears the same colon and builds nothing.
+#[test]
+fn the_discovery_scan_ignores_a_colon_that_is_not_a_key() {
+    assert!(
+        signal_shapes("const map = useSaved ? advanced : fallback;").is_empty(),
+        "`cond ? advanced : fallback` is not an object key"
+    );
+}
+
+/// Handing on a map that was already built is not building a second one.
+///
+/// `{ advanced: advanced }` is the long spelling of the `{ advanced }` shorthand three registered
+/// builders use. Reporting it would fail the build on a rewrite that changes nothing, and it can
+/// hide nothing: the map still has to be created somewhere, and creation is what this scan reads.
+#[test]
+fn the_discovery_scan_ignores_a_hand_on_of_the_same_map() {
+    for source in [
+        "const body = { mode, advanced: advanced };",
+        "return { advancedExtras: advancedExtras };",
+    ] {
+        assert!(
+            signal_shapes(source).is_empty(),
+            "{source:?} hands on a map this scan already saw being built"
+        );
+    }
+    // But a member read or a call on it is still indirection.
+    assert_eq!(
+        signal_shapes("const body = { advanced: advanced.buildAdvanced(extras) };"),
+        vec![(
+            AdvancedSignalKind::Indirect,
+            Some("buildAdvanced".to_owned())
+        )]
+    );
+}
+
+/// The one shape nothing in the text can settle, so the failure has to offer the rename.
+///
+/// A plain local named `advanced` holding UI state is indistinguishable from a payload map — the
+/// same `const advanced = { … }` that `buildEditJobBody` and `DocumentStudio.submit` use. Narrowing
+/// the signal to "locals that visibly flow into a request" would let `const advanced = { probeKnob:
+/// 1 }; body.advanced = advanced;` back through, so the signal stands and the message carries the
+/// third branch instead.
+#[test]
+fn a_plain_local_still_signals_and_the_advice_offers_the_rename() {
+    assert_eq!(
+        signal_shapes("const advanced = { open: false };"),
+        vec![(AdvancedSignalKind::AssignedLiteral, None)],
+    );
+    assert!(
+        UNACCOUNTED_ADVANCED_ADVICE.contains("RENAME THE LOCAL"),
+        "a local this lint cannot classify must be told the one fix that applies to it, or the \
+         next author deletes the lint rather than diagnosing it"
+    );
+}
+
+/// The literal shapes the sweep has always caught, pinned so a rewrite cannot drop one.
+#[test]
+fn the_discovery_scan_still_sees_every_literal_shape() {
+    assert_eq!(
+        signal_shapes("const body = { advanced: { steps: 4 } };"),
+        vec![(AdvancedSignalKind::InlineLiteral, None)]
+    );
+    assert_eq!(
+        signal_shapes("return { advancedExtras: { angleSet } };"),
+        vec![(AdvancedSignalKind::ExtrasLiteral, None)]
+    );
+    assert_eq!(
+        signal_shapes("const advanced = {};\nadvanced.steps = 4;"),
+        vec![
+            (AdvancedSignalKind::AssignedLiteral, None),
+            (AdvancedSignalKind::PropertyAssignment, None)
+        ]
+    );
+    // Never an equality test, and never a method call on the map.
+    assert!(signal_shapes("if (advanced == null) return;").is_empty());
+    assert!(signal_shapes("const n = advanced.steps;").is_empty());
+}
+
+#[test]
+#[should_panic(expected = "a computed key")]
+fn an_invisible_write_is_refused_through_any_object_path() {
+    refuse_invisible_advanced_writes(
+        &scannable("body.payload.advanced[\"probeKnob\"] = value;"),
+        "a probe",
+    );
+}
+
+#[test]
+#[should_panic(expected = "Object.assign(body.payload.advanced, …)")]
+fn an_object_assign_onto_a_nested_advanced_is_refused() {
+    // `Object.assign(advanced` as a literal substring missed this: the target was nested.
+    refuse_invisible_advanced_writes(
+        &scannable("Object.assign(body.payload.advanced, { probeKnob: 1 });"),
+        "a probe",
+    );
+}
+
+#[test]
+#[should_panic(expected = "`advanced.push(…)`")]
+fn an_array_mutator_on_advanced_is_refused() {
+    refuse_invisible_advanced_writes(&scannable("advanced.push(knob);"), "a probe");
+}
+
+/// The refusal must not fire on an `Object.assign` that has nothing to do with `advanced`.
+#[test]
+fn an_unrelated_object_assign_is_not_an_invisible_advanced_write() {
+    for source in [
+        "Object.assign(target, { a: 1 });",
+        "const merged = Object.assign({}, base, extra);",
+        "Object.assign(state.advancedOpen, { a: 1 });",
+    ] {
+        assert!(
+            invisible_advanced_writes(&scannable(source)).is_empty(),
+            "{source:?} does not write an `advanced` map"
+        );
+    }
+}
+
+/// A nested helper inside a declared span is not accounted for by that declaration.
+#[test]
+#[should_panic(expected = "builds a SECOND `advanced` map")]
+fn a_second_map_inside_a_declared_builder_is_refused() {
+    // Shaped like `DocumentStudio.submit`: the registered `AssignedObject` initializer, plus a
+    // nested helper with its own literal that the arm never reads. Verified against the real lint:
+    // inserting this into the real `submit` left 27/27 green before this refusal existed.
+    emitted_keys(
+        builder_for(AdvancedKeySource::InterleaveBuilder),
+        r#"
+async function submit(event) {
+  const advanced = {};
+  advanced.systemMessage = trimmedSystem;
+  advanced.imageGuidanceScale = referenceGuidance;
+  function probeNestedBody(probeKnob, probeSecret) {
+    return { advanced: { probeKnob, probeSecret } };
+  }
+  return probeNestedBody(1, 2);
+}
+"#,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1418,32 +1802,110 @@ fn web_source_files() -> Vec<String> {
     out
 }
 
+/// What a web file did with the name `advanced`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AdvancedSignalKind {
+    /// `advanced: { … }` — a map written inline into a request body.
+    InlineLiteral,
+    /// `advancedExtras: { … }` — a character-lane controller's contribution.
+    ExtrasLiteral,
+    /// `advanced = { … }` — the initializer half of an assignment-style builder.
+    AssignedLiteral,
+    /// `advanced.key = …` — the assignment half.
+    PropertyAssignment,
+    /// `advanced: buildFoo(state)`, `advanced: someVar`, `advanced = compactObject({ … })` — the
+    /// map exists but is assembled somewhere this scan cannot read.
+    Indirect,
+}
+
+impl AdvancedSignalKind {
+    fn describe(self) -> &'static str {
+        match self {
+            Self::InlineLiteral => "an inline object literal",
+            Self::ExtrasLiteral => "an inline `advancedExtras` object literal",
+            Self::AssignedLiteral => "an assigned object literal",
+            Self::PropertyAssignment => "a property assignment",
+            Self::Indirect => "an expression this lint cannot read",
+        }
+    }
+}
+
 /// One place a web file builds an `advanced` map.
 struct AdvancedSignal {
     /// Offset into the [`scannable`] text of the `advanced` / `advancedExtras` identifier.
     offset: usize,
     /// What was matched, for the failure message.
-    kind: &'static str,
+    kind: AdvancedSignalKind,
+    /// For [`AdvancedSignalKind::Indirect`], the callee the map comes from:
+    /// `advanced: buildImageJobAdvanced({ … })` → `buildImageJobAdvanced`,
+    /// `advanced: advanced.buildAdvanced(extras)` → `buildAdvanced`. `None` when the expression is
+    /// not a call at all (`advanced: someVar`), which can never be a builder call site.
+    called: Option<String>,
 }
 
-/// Every place `stripped` builds an `advanced` map.
+impl AdvancedSignal {
+    /// True when this is indirection through a builder the registry already accounts for.
+    ///
+    /// `advanced: buildImageJobAdvanced({ … })` and `advanced: advanced.buildAdvanced(extras)` are
+    /// CALL SITES of a registered builder: demanding a registry entry for every screen that
+    /// submits a job would say nothing about which keys exist. The difference from before is that
+    /// the callee now has to be NAMED somewhere — an indirection through an unregistered helper is
+    /// a signal, not silence.
+    fn calls_a_declared_builder(&self, path: &str, declared: &BTreeSet<&str>) -> bool {
+        let Some(called) = self.called.as_deref() else {
+            return false;
+        };
+        declared.contains(called)
+            || ADVANCED_INDIRECTION_CALL_HEADS
+                .iter()
+                .any(|(exempt_path, head, _)| *exempt_path == path && *head == called)
+    }
+
+    /// The indirection-specific half of the failure message.
+    fn indirection_advice(&self) -> String {
+        if self.kind != AdvancedSignalKind::Indirect {
+            return String::new();
+        }
+        match self.called.as_deref() {
+            Some(called) => format!(
+                "\nThe map comes from `{called}(…)`, so its keys are assembled where this scan \
+                 never looks. Either build it inline (`advanced: {{ … }}`) inside a builder that \
+                 is declared, or declare `{called}` itself."
+            ),
+            None => "\nThe map comes from a bare expression (a variable, a member read, a \
+                     ternary), so its keys are assembled where this scan never looks. Build it \
+                     inline (`advanced: { … }`) inside a builder that is declared, or move the \
+                     assembly into a function and declare that."
+                .to_owned(),
+        }
+    }
+}
+
+/// Every place `stripped` builds an `advanced` map, or takes one from somewhere unreadable.
 ///
-/// Four shapes, which between them cover every builder in the tree today:
+/// Five shapes; see [`AdvancedSignalKind`]. The first four are literal writes. The fifth,
+/// [`AdvancedSignalKind::Indirect`], is what makes the sweep a class-closer rather than a
+/// pattern-matcher: any indirection is enough to hide a map, and this scan reports it so the
+/// caller can insist the callee be named.
 ///
-/// * `advanced: { … }` — a map written inline into a request body.
-/// * `advancedExtras: { … }` — a character-lane controller's contribution.
-/// * `advanced = { … }` — the initializer half of an assignment-style builder.
-/// * `advanced.key = …` — the assignment half.
+/// # Not every `advanced` is a payload
 ///
-/// Deliberately NOT matched: `advanced: buildImageJobAdvanced({ … })` and
-/// `advanced: advanced.buildAdvanced(extras)`, which are CALL SITES of a builder that is itself
-/// registered. Matching those would demand a registry entry for every screen that submits a job,
-/// which says nothing about which keys exist.
+/// Three ordinary React shapes carry the name and build nothing, and a build-blocking lint that
+/// misfires on them gets deleted rather than diagnosed:
 ///
-/// A computed write (`advanced["key"] = …`) or an `Object.assign(advanced, …)` would be invisible
-/// here, so [`emitted_keys`] refuses them inside a registered builder rather than reading past them.
+/// * a JSX prop — `<Child advanced={state.opts} />`;
+/// * a destructuring default or rename — `function Row({ advanced = {} })`,
+///   `const { advanced: opts } = props`;
+/// * (not suppressible) a plain local named `advanced` that holds something else. Nothing in the
+///   text distinguishes it from a payload map, so it still fails, and the failure message offers
+///   the only honest fix: rename the local.
+///
+/// A computed write (`advanced["key"] = …`) or an `Object.assign(x.advanced, …)` is invisible here
+/// no matter where it sits, so [`refuse_invisible_advanced_writes`] refuses those over every file
+/// the sweep reads rather than reading past them.
 fn advanced_map_signals(stripped: &str) -> Vec<AdvancedSignal> {
     let bytes = stripped.as_bytes();
+    let mask = string_literal_mask(bytes);
     let mut out = Vec::new();
     let mut index = 0;
     while index < bytes.len() {
@@ -1461,18 +1923,47 @@ fn advanced_map_signals(stripped: &str) -> Vec<AdvancedSignal> {
                 if word != "advanced" && word != "advancedExtras" {
                     continue;
                 }
-                let mut lookahead = skip_ascii_whitespace(bytes, index);
+                let extras = word == "advancedExtras";
+                let lookahead = skip_ascii_whitespace(bytes, index);
+                let mut called = None;
                 let kind = match bytes.get(lookahead) {
-                    // `advanced: {` / `advancedExtras: {`
-                    Some(b':') => {
-                        lookahead = skip_ascii_whitespace(bytes, lookahead + 1);
-                        (bytes.get(lookahead) == Some(&b'{')).then_some("an inline object literal")
+                    // `advanced: {` / `advancedExtras: {`, or `advanced: <expression>`. Only in KEY
+                    // position: `cond ? advanced : fallback` wears the same colon and builds
+                    // nothing, and `const { advanced: opts } = props` is a rename, not a build.
+                    Some(b':')
+                        if is_object_key_position(bytes, &mask, start)
+                            && !is_binding_pattern_position(bytes, &mask, start) =>
+                    {
+                        let after = skip_ascii_whitespace(bytes, lookahead + 1);
+                        if bytes.get(after) == Some(&b'{') {
+                            Some(if extras {
+                                AdvancedSignalKind::ExtrasLiteral
+                            } else {
+                                AdvancedSignalKind::InlineLiteral
+                            })
+                        } else {
+                            called = call_head(bytes, stripped, after);
+                            (called.is_some() || !is_pass_through(bytes, stripped, after))
+                                .then_some(AdvancedSignalKind::Indirect)
+                        }
                     }
-                    // `advanced = {`, but never `advanced == …`.
-                    Some(b'=') if bytes.get(lookahead + 1) != Some(&b'=') => {
-                        lookahead = skip_ascii_whitespace(bytes, lookahead + 1);
-                        (bytes.get(lookahead) == Some(&b'{'))
-                            .then_some("an assigned object literal")
+                    // `advanced = {` or `advanced = someBuilder(…)`, but never `advanced == …`, a
+                    // JSX prop, or a parameter default.
+                    Some(b'=')
+                        if bytes.get(lookahead + 1) != Some(&b'=')
+                            && !is_jsx_attribute_position(bytes, &mask, start)
+                            && !is_binding_pattern_position(bytes, &mask, start) =>
+                    {
+                        let after = skip_ascii_whitespace(bytes, lookahead + 1);
+                        if bytes.get(after) == Some(&b'{') {
+                            Some(AdvancedSignalKind::AssignedLiteral)
+                        } else {
+                            // A CALL can build a map; `defaults.advanced ?? {}` and friends are
+                            // reads of someone else's, and flagging those fires on every screen
+                            // that merely inspects a saved config.
+                            called = call_head(bytes, stripped, after);
+                            called.is_some().then_some(AdvancedSignalKind::Indirect)
+                        }
                     }
                     // `advanced.key = …`, but never `advanced.key ==` or `advanced.key(…)`.
                     Some(b'.') if word == "advanced" => {
@@ -1486,7 +1977,7 @@ fn advanced_map_signals(stripped: &str) -> Vec<AdvancedSignal> {
                             && bytes.get(after) == Some(&b'=')
                             && bytes.get(after + 1) != Some(&b'=')
                             && bytes.get(after + 1) != Some(&b'>'))
-                        .then_some("a property assignment")
+                        .then_some(AdvancedSignalKind::PropertyAssignment)
                     }
                     _ => None,
                 };
@@ -1494,6 +1985,7 @@ fn advanced_map_signals(stripped: &str) -> Vec<AdvancedSignal> {
                     out.push(AdvancedSignal {
                         offset: start,
                         kind,
+                        called,
                     });
                 }
             }
@@ -1503,21 +1995,275 @@ fn advanced_map_signals(stripped: &str) -> Vec<AdvancedSignal> {
     out
 }
 
+/// True when the expression at `from` is just the tracked name again: `advanced: advanced`.
+///
+/// The long spelling of the `{ advanced }` shorthand every builder already uses. It hands on a map
+/// that had to be BUILT somewhere first — and building it is what this scan catches — so reporting
+/// the hand-on adds nothing and would fail the build on rewriting `advanced,` as `advanced:
+/// advanced` inside a builder that is already registered.
+fn is_pass_through(bytes: &[u8], text: &str, from: usize) -> bool {
+    let (name, end) = identifier_at(bytes, text, from);
+    if name != "advanced" && name != "advancedExtras" {
+        return false;
+    }
+    // `advanced: advanced.buildAdvanced(x)` and `advanced: advanced[key]` are not hand-ons.
+    !matches!(
+        bytes.get(skip_ascii_whitespace(bytes, end)),
+        Some(b'.') | Some(b'(') | Some(b'[') | Some(b'?')
+    )
+}
+
+/// The callee of a call expression starting at `from`: `buildFoo(x)` → `buildFoo`,
+/// `advanced.buildAdvanced(x)` → `buildAdvanced`. `None` when this is not a plain call.
+fn call_head(bytes: &[u8], text: &str, from: usize) -> Option<String> {
+    let mut index = from;
+    loop {
+        if index >= bytes.len() || !is_identifier_start(bytes[index] as char) {
+            return None;
+        }
+        let start = index;
+        while index < bytes.len() && is_identifier_char(bytes[index] as char) {
+            index += 1;
+        }
+        let next = skip_ascii_whitespace(bytes, index);
+        match bytes.get(next) {
+            // `Object.keys(x)` → keep walking, the callee is the LAST name in the chain.
+            Some(b'.') => index = skip_ascii_whitespace(bytes, next + 1),
+            Some(b'(') => return Some(text[start..index].to_owned()),
+            _ => return None,
+        }
+    }
+}
+
+/// Every position inside a string literal, so a BACKWARD scan can skip them.
+///
+/// The forward scanners skip strings by jumping over them; the context checks below walk backwards
+/// and cannot, so a `<` or a `;` inside a string would otherwise decide whether a signal fires.
+fn string_literal_mask(bytes: &[u8]) -> Vec<bool> {
+    let mut mask = vec![false; bytes.len()];
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                let end = skip_string_ascii(bytes, index).min(bytes.len());
+                for slot in mask[index..end].iter_mut() {
+                    *slot = true;
+                }
+                index = end.max(index + 1);
+            }
+            _ => index += 1,
+        }
+    }
+    mask
+}
+
+/// The nearest significant character before `at`, skipping whitespace and string bodies.
+fn previous_significant(bytes: &[u8], mask: &[bool], at: usize) -> Option<u8> {
+    let mut index = at;
+    while index > 0 {
+        index -= 1;
+        if mask[index] {
+            return Some(bytes[index]);
+        }
+        if !bytes[index].is_ascii_whitespace() {
+            return Some(bytes[index]);
+        }
+    }
+    None
+}
+
+/// True when the identifier at `at` starts an object-literal entry (`{ advanced:`, `, advanced:`).
+///
+/// The discriminator against a ternary's middle arm (`cond ? advanced : fallback`) and against a
+/// labelled statement, both of which put a colon after the name and build nothing.
+fn is_object_key_position(bytes: &[u8], mask: &[bool], at: usize) -> bool {
+    match previous_significant(bytes, mask, at) {
+        Some(b'{') | Some(b',') => true,
+        // A body slice can begin mid-literal, so "nothing before it" stays permissive.
+        None => true,
+        _ => false,
+    }
+}
+
+/// True when the identifier at `at` sits in JSX attribute position: `<Child advanced={…} />`.
+///
+/// Walks back to the tag that would own the attribute. Anything that cannot appear between a tag
+/// name and one of its attributes — a statement end, an open brace or paren at this level — means
+/// this is ordinary JS.
+fn is_jsx_attribute_position(bytes: &[u8], mask: &[bool], at: usize) -> bool {
+    let mut depth = 0_usize;
+    let mut index = at;
+    while index > 0 {
+        index -= 1;
+        if mask[index] {
+            continue;
+        }
+        match bytes[index] {
+            b'}' => depth += 1,
+            b'{' => {
+                if depth == 0 {
+                    return false;
+                }
+                depth -= 1;
+            }
+            b'(' | b')' | b';' | b',' if depth == 0 => return false,
+            // `=>` is an arrow, not a tag that just closed.
+            b'>' if depth == 0 && bytes.get(index.wrapping_sub(1)) != Some(&b'=') => return false,
+            b'<' if depth == 0 => {
+                return bytes
+                    .get(index + 1)
+                    .is_some_and(|next| is_identifier_start(*next as char));
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// True when the identifier at `at` is being BOUND rather than built: a parameter destructuring
+/// default (`function Row({ advanced = {} })`, `({ advanced = {} }) => …`) or a destructuring
+/// declaration (`const { advanced = {} } = props`, `const { advanced: opts } = props`).
+///
+/// Decided by what follows the pattern, because what PRECEDES it cannot tell a parameter list from
+/// a call argument: `foo({ advanced: 1 })` and `function foo({ advanced = {} })` both put a `(`
+/// before the brace. A pattern's closing brace is followed by `=` (a binding), or by the `)` of a
+/// parameter list that a body or an `=>` follows.
+fn is_binding_pattern_position(bytes: &[u8], mask: &[bool], at: usize) -> bool {
+    let Some(open) = enclosing_open_brace(bytes, mask, at) else {
+        return false;
+    };
+    let Some(close) = matching_close_brace(bytes, open) else {
+        return false;
+    };
+    let after = skip_ascii_whitespace(bytes, close + 1);
+    match bytes.get(after) {
+        // `const { advanced = {} } = props`
+        Some(b'=') => bytes.get(after + 1) != Some(&b'=') && bytes.get(after + 1) != Some(&b'>'),
+        // `function Row({ advanced = {} }) {` / `({ advanced = {} }) => …`
+        Some(b')') => opens_a_function_body(bytes, after + 1),
+        // `function Row({ advanced = {} }, ref) {` — a non-final parameter.
+        Some(b',') => enclosing_close_paren(bytes, after + 1)
+            .is_some_and(|paren| opens_a_function_body(bytes, paren + 1)),
+        _ => false,
+    }
+}
+
+/// True when a function body (`{`) or an arrow (`=>`) starts at or after `from`.
+fn opens_a_function_body(bytes: &[u8], from: usize) -> bool {
+    let at = skip_ascii_whitespace(bytes, from);
+    match bytes.get(at) {
+        Some(b'{') => true,
+        Some(b'=') => bytes.get(at + 1) == Some(&b'>'),
+        _ => false,
+    }
+}
+
+/// The innermost `{` still open at `at`.
+fn enclosing_open_brace(bytes: &[u8], mask: &[bool], at: usize) -> Option<usize> {
+    let mut depth = 0_usize;
+    let mut index = at;
+    while index > 0 {
+        index -= 1;
+        if mask[index] {
+            continue;
+        }
+        match bytes[index] {
+            b'}' => depth += 1,
+            b'{' => {
+                if depth == 0 {
+                    return Some(index);
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The `}` that closes the `{` at `open`.
+fn matching_close_brace(bytes: &[u8], open: usize) -> Option<usize> {
+    let mut depth = 0_usize;
+    let mut index = open;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+/// The `)` that closes the parenthesis `from` is already inside.
+fn enclosing_close_paren(bytes: &[u8], from: usize) -> Option<usize> {
+    let mut depth = 0_usize;
+    let mut index = from;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            b'(' | b'[' | b'{' => depth += 1,
+            b']' | b'}' => {
+                if depth == 0 {
+                    return None;
+                }
+                depth -= 1;
+            }
+            b')' => {
+                if depth == 0 {
+                    return Some(index);
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
 /// The offsets of `function <name>`'s body in `stripped` — the text BETWEEN its braces.
 ///
 /// Panics with instructions rather than returning nothing when the function is gone: a registry
 /// entry pointing at a renamed function must fail the lint, not quietly stop covering it.
 fn function_body_span(stripped: &str, function: &str, path: &str) -> (usize, usize) {
     let needle = format!("function {function}");
-    let occurrences = stripped.matches(needle.as_str()).count();
+    // On a NAME boundary, not a prefix: `function buildDetailJobBody` matches inside
+    // `function buildDetailJobBodyV2`, so a rename could leave the registry pointing at a
+    // different function while the lint reported one clean match.
+    let occurrences: Vec<usize> = stripped
+        .match_indices(needle.as_str())
+        .filter(
+            |(at, _)| match stripped[at + needle.len()..].chars().next() {
+                Some(next) => !is_identifier_char(next),
+                None => true,
+            },
+        )
+        .map(|(at, _)| at)
+        .collect();
     assert_eq!(
-        occurrences, 1,
-        "`{needle}` appears {occurrences} times in {path}; this coverage lint needs exactly one so \
-         it reads an unambiguous body. Either the function was renamed or moved — point the \
+        occurrences.len(),
+        1,
+        "`{needle}` appears {} times in {path}; this coverage lint needs exactly one so it reads an \
+         unambiguous body. Either the function was renamed or moved — point the \
          `ADVANCED_BUILDERS` entry at wherever that `advanced` map is built now — or a second \
-         function shares the name, in which case rename one."
+         function shares the name, in which case rename one.",
+        occurrences.len()
     );
-    let at = stripped.find(needle.as_str()).expect("just counted one");
+    let at = occurrences[0];
     let bytes = stripped.as_bytes();
 
     // Walk the parameter list first: a default value carries braces of its own
@@ -1619,14 +2365,21 @@ fn emitted_keys(builder: &AdvancedBuilder, source: &str) -> BTreeSet<String> {
     let body = &stripped[start..end];
     let what = format!("`{}` in {}", builder.function, builder.path);
 
-    match builder.shape {
+    // Every shape, not just `AssignedObject`: a `FlatAdvancedLiteral` builder can grow a computed
+    // write too, and reading past one is how a knob goes missing with the lint still green.
+    refuse_invisible_advanced_writes(body, &what);
+
+    // Which signals each arm actually READ. Anything left over is a second map the registry entry
+    // does not account for, refused below.
+    let signals = advanced_map_signals(body);
+    let (keys, consumed): (BTreeSet<String>, Vec<usize>) = match builder.shape {
         AdvancedBuilderShape::ReturnedObject => {
             let return_at = body
                 .find("return {")
                 .unwrap_or_else(|| panic!("{what} no longer returns an object literal"))
                 + "return ".len();
             let literal = object_literal_body(body, return_at, &what);
-            scan_object_literal(&literal, &what, false).0
+            (scan_object_literal(&literal, &what, false).0, Vec::new())
         }
         AdvancedBuilderShape::ExtrasLiteral => {
             let at = body.find("advancedExtras:").unwrap_or_else(|| {
@@ -1634,33 +2387,32 @@ fn emitted_keys(builder: &AdvancedBuilder, source: &str) -> BTreeSet<String> {
                     "{what} no longer carries an `advancedExtras:` literal, so this lint cannot \
                      see which knobs that form contributes"
                 )
-            }) + "advancedExtras:".len();
-            let literal = object_literal_body(body, at, &what);
-            scan_object_literal(&literal, &what, false).0
+            });
+            let literal = object_literal_body(body, at + "advancedExtras:".len(), &what);
+            (scan_object_literal(&literal, &what, false).0, vec![at])
         }
         AdvancedBuilderShape::FlatAdvancedLiteral => {
             let at = body
                 .find("advanced:")
-                .unwrap_or_else(|| panic!("{what} no longer carries an `advanced:` literal"))
-                + "advanced:".len();
-            let literal = object_literal_body(body, at, &what);
+                .unwrap_or_else(|| panic!("{what} no longer carries an `advanced:` literal"));
+            let literal = object_literal_body(body, at + "advanced:".len(), &what);
             assert!(
                 !literal.contains('{') && !literal.contains("..."),
                 "{what}'s `advanced` literal is no longer flat — re-tag its registry `shape` (the \
                  conditional-spread scanner reads that shape) rather than letting this arm \
                  misread it"
             );
-            literal
+            let keys = literal
                 .split(',')
                 // `key` and `key: value` alike — take the identifier before any colon.
                 .filter_map(|entry| entry.split(':').next())
                 .map(str::trim)
                 .filter(|key| !key.is_empty() && key.chars().all(is_identifier_char))
                 .map(str::to_owned)
-                .collect()
+                .collect();
+            (keys, vec![at])
         }
         AdvancedBuilderShape::AssignedObject => {
-            refuse_invisible_advanced_writes(body, &what);
             let at = body
                 .find("advanced =")
                 .unwrap_or_else(|| panic!("{what} no longer initializes an `advanced` object"));
@@ -1678,8 +2430,10 @@ fn emitted_keys(builder: &AdvancedBuilder, source: &str) -> BTreeSet<String> {
                  set of keys this lint cannot see — either point `spread_of` at it and register \
                  the builder that produces those keys, or stop spreading it."
             );
-            keys.extend(assigned_advanced_keys(body));
-            keys
+            let (assigned, mut consumed) = assigned_advanced_keys(body, &signals);
+            keys.extend(assigned);
+            consumed.push(at);
+            (keys, consumed)
         }
         AdvancedBuilderShape::NoAdvancedMap => {
             assert!(
@@ -1688,38 +2442,204 @@ fn emitted_keys(builder: &AdvancedBuilder, source: &str) -> BTreeSet<String> {
                  `advanced`. It feeds a lane that embeds the map into every PNG it writes, so \
                  give it a real registry `shape` and classify every key it can emit."
             );
-            BTreeSet::new()
+            (BTreeSet::new(), Vec::new())
         }
-    }
+    };
+    refuse_unread_advanced_signals(body, &what, builder, &signals, &consumed);
+    keys
 }
 
-/// A write this lint cannot follow must fail rather than be scanned past.
-fn refuse_invisible_advanced_writes(body: &str, what: &str) {
-    for invisible in ["advanced[", "Object.assign(advanced", "advanced.push("] {
-        assert!(
-            !body.contains(invisible),
-            "{what} writes `advanced` through `{invisible}…`, which this coverage lint cannot \
-             read — the keys it sets would be invisible here and silently dropped from every \
-             shared image. Write them as plain `advanced.key = …` assignments."
+/// A second `advanced` map inside a declared builder is NOT accounted for by that declaration.
+///
+/// [`every_advanced_builder_in_the_web_app_is_accounted_for`] credits every signal inside a declared
+/// function's body span to that function, but the extractors above read exactly one shape each — the
+/// one the registry names. So a nested helper declared inside `DocumentStudio.submit`, with its own
+/// `advanced: { probeKnob, probeSecret }`, counted as accounted for while its keys were never
+/// classified and the sweep stayed green. This is the refusal
+/// [`refuse_invisible_advanced_writes`] makes for a write it cannot follow, applied to a map the arm
+/// can see and did not read.
+fn refuse_unread_advanced_signals(
+    body: &str,
+    what: &str,
+    builder: &AdvancedBuilder,
+    signals: &[AdvancedSignal],
+    consumed: &[usize],
+) {
+    let declared = declared_builder_functions();
+    for signal in signals {
+        if consumed.contains(&signal.offset)
+            || signal.calls_a_declared_builder(builder.path, &declared)
+        {
+            continue;
+        }
+        let line = 1 + body[..signal.offset].matches('\n').count();
+        panic!(
+            "{what} builds a SECOND `advanced` map at line {line} of its body ({}), which the \
+             `{:?}` arm of this extractor never reads. Its keys are invisible here, so they would \
+             be dropped from every shared image exactly as if the builder were unregistered. A \
+             nested helper is not accounted for by the entry around it: fold those keys into the \
+             map this arm does read, or give the helper its own `ADVANCED_BUILDERS` entry — the \
+             innermost declared span wins, so a nested entry is credited to itself.",
+            signal.kind.describe(),
+            builder.shape,
         );
     }
 }
 
-/// Every `advanced.key = …` assignment in one function body.
-fn assigned_advanced_keys(body: &str) -> BTreeSet<String> {
-    advanced_map_signals(body)
-        .into_iter()
-        .filter(|signal| signal.kind == "a property assignment")
-        .map(|signal| {
-            let after_dot = signal.offset + "advanced.".len();
-            let bytes = body.as_bytes();
-            let mut end = after_dot;
-            while end < bytes.len() && is_identifier_char(bytes[end] as char) {
-                end += 1;
-            }
-            body[after_dot..end].to_owned()
-        })
+/// Every function name the registry declares, registered or deferred.
+fn declared_builder_functions() -> BTreeSet<&'static str> {
+    ADVANCED_BUILDERS
+        .iter()
+        .map(|builder| builder.function)
+        .chain(
+            DEFERRED_ADVANCED_BUILDERS
+                .iter()
+                .map(|deferred| deferred.function),
+        )
         .collect()
+}
+
+/// A write this lint cannot follow must fail rather than be scanned past.
+///
+/// Three shapes set keys without ever naming one: a computed key (`advanced["k"] = v`),
+/// `Object.assign(x.advanced, { … })`, and an array mutator. Called over EVERY file the sweep
+/// reads, not only inside an `AssignedObject` body: while this ran in that one arm,
+/// `body.payload.advanced["probeKnob"] = v` was green both in a brand-new file and inside
+/// `buildDetailJobBody`.
+///
+/// The `Object.assign` check reads the first ARGUMENT instead of matching the text
+/// `Object.assign(advanced`, which `Object.assign(body.payload.advanced, { … })` walked straight
+/// past.
+fn refuse_invisible_advanced_writes(text: &str, what: &str) {
+    if let Some((offset, how)) = invisible_advanced_writes(text).into_iter().next() {
+        let line = 1 + text[..offset].matches('\n').count();
+        panic!(
+            "{what} writes `advanced` through {how} at line {line}, which this coverage lint \
+             cannot read — the keys it sets are invisible here and would be silently dropped from \
+             every shared image. Write them as plain `advanced.key = …` assignments, or as an \
+             `advanced: {{ … }}` literal, inside a builder `ADVANCED_BUILDERS` declares."
+        );
+    }
+}
+
+/// Mutators that reshape a map/array without naming a key.
+const INVISIBLE_ADVANCED_MUTATORS: &[&str] = &["push", "unshift", "splice"];
+
+/// Every `advanced` write in `text` that this lint cannot follow, as (offset, how).
+fn invisible_advanced_writes(text: &str) -> Vec<(usize, String)> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            byte if is_identifier_start(byte as char) => {
+                let start = index;
+                while index < bytes.len() && is_identifier_char(bytes[index] as char) {
+                    index += 1;
+                }
+                let word = &text[start..index];
+                let after = skip_ascii_whitespace(bytes, index);
+                match word {
+                    "advanced" | "advancedExtras" => match bytes.get(after) {
+                        Some(b'[') => out.push((start, format!("a computed key (`{word}[…]`)"))),
+                        Some(b'.') => {
+                            let (method, method_end) = identifier_at(bytes, text, after + 1);
+                            if INVISIBLE_ADVANCED_MUTATORS.contains(&method)
+                                && bytes.get(skip_ascii_whitespace(bytes, method_end))
+                                    == Some(&b'(')
+                            {
+                                out.push((start, format!("`{word}.{method}(…)`")));
+                            }
+                        }
+                        _ => {}
+                    },
+                    "Object" => {
+                        if bytes.get(after) != Some(&b'.') {
+                            continue;
+                        }
+                        let (method, method_end) = identifier_at(bytes, text, after + 1);
+                        let open = skip_ascii_whitespace(bytes, method_end);
+                        if method != "assign" || bytes.get(open) != Some(&b'(') {
+                            continue;
+                        }
+                        let Some(target) = first_argument(bytes, text, open + 1) else {
+                            continue;
+                        };
+                        let target = target.trim();
+                        if ["advanced", "advancedExtras"].contains(&target)
+                            || target.ends_with(".advanced")
+                            || target.ends_with(".advancedExtras")
+                        {
+                            out.push((start, format!("`Object.assign({target}, …)`")));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => index += 1,
+        }
+    }
+    out
+}
+
+/// The identifier starting at or after `from`, plus the offset just past it.
+fn identifier_at<'text>(bytes: &[u8], text: &'text str, from: usize) -> (&'text str, usize) {
+    let start = skip_ascii_whitespace(bytes, from);
+    let mut end = start;
+    while end < bytes.len() && is_identifier_char(bytes[end] as char) {
+        end += 1;
+    }
+    (&text[start..end], end)
+}
+
+/// The text of the first argument of a call whose `(` ends just before `from`.
+fn first_argument(bytes: &[u8], text: &str, from: usize) -> Option<String> {
+    let mut depth = 0_usize;
+    let mut index = from;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string_ascii(bytes, index);
+                continue;
+            }
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' | b',' if depth == 0 => {
+                return (bytes[index] != b']' && bytes[index] != b'}')
+                    .then(|| text[from..index].to_owned());
+            }
+            b')' | b']' | b'}' => depth -= 1,
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Every `advanced.key = …` assignment in one function body, with the signal offsets it read.
+fn assigned_advanced_keys(
+    body: &str,
+    signals: &[AdvancedSignal],
+) -> (BTreeSet<String>, Vec<usize>) {
+    let mut keys = BTreeSet::new();
+    let mut consumed = Vec::new();
+    for signal in signals
+        .iter()
+        .filter(|signal| signal.kind == AdvancedSignalKind::PropertyAssignment)
+    {
+        let after_dot = signal.offset + "advanced.".len();
+        let bytes = body.as_bytes();
+        let mut end = after_dot;
+        while end < bytes.len() && is_identifier_char(bytes[end] as char) {
+            end += 1;
+        }
+        keys.insert(body[after_dot..end].to_owned());
+        consumed.push(signal.offset);
+    }
+    (keys, consumed)
 }
 
 /// Every key an object literal built from conditional spreads can contribute, plus the bare

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -24,6 +24,9 @@ use super::*;
 ))]
 use sceneworks_core::contracts::GenerationMetrics;
 use sceneworks_core::image_request::ImageRequest;
+use sceneworks_core::workflow_png::write_workflow_chunk;
+use sceneworks_core::workflow_share::{build_workflow_share_from, WorkflowAssetFacts};
+use std::sync::Arc;
 
 // Backend-neutral contract types come from the canonical inference release. The selected runtime
 // bundle explicitly owns its provider catalog; this product module names only contract types and
@@ -243,11 +246,18 @@ pub(crate) async fn run_image_generate_job(
     // the gallery.
     #[cfg(target_os = "macos")]
     let route = resolve_image_route(&request, settings);
+    // Whether — and from what — every image this job writes embeds its sanitized workflow
+    // (sc-15948). Resolved once here so the base write and the inline-upscale write share one
+    // answer, and read live off the config dir so flipping the Settings toggle takes effect on the
+    // next job rather than the next launch.
+    let workflow_source = workflow_source(settings, &job.payload);
+
     #[cfg(target_os = "macos")]
     let plan = ImagePlan::with_count_and_adapter(
         &request,
         route.map_or(request.count, |route| route.image_count(&request, settings)) * upscale_mult,
         route.map_or(STUB_ADAPTER, |route| route.adapter_label(&request)),
+        workflow_source,
     );
     // Windows/CUDA candle lane: resolve the candle dispatch branch once and bake THAT branch's real
     // total into the plan, exactly as the macOS arm does with `resolve_image_route`. An InstantID
@@ -263,12 +273,13 @@ pub(crate) async fn run_image_generate_job(
         &request,
         route.map_or(request.count, |route| route.image_count(&request, settings)) * upscale_mult,
         route.map_or(STUB_ADAPTER, |route| route.adapter_label(&request)),
+        workflow_source,
     );
     #[cfg(all(
         not(target_os = "macos"),
         not(all(not(target_os = "macos"), feature = "backend-candle"))
     ))]
-    let plan = ImagePlan::with_count(&request, request.count * upscale_mult);
+    let plan = ImagePlan::with_count(&request, request.count * upscale_mult, workflow_source);
 
     // Pre-flight LoRA family-compat guardrail (sc-3027): reject an incompatible LoRA
     // (e.g. a Flux LoRA on an SDXL model, or a Wan 5B LoRA on the 14B base) before any
@@ -1212,20 +1223,153 @@ pub(crate) struct ImagePlan {
     /// `count`/`expectedCount` reflect this so the gallery streams against the real
     /// total, not the requested `count`.
     image_count: u32,
+    /// The job's raw `payload_json`, or `None` when nothing should be embedded (epic 15945,
+    /// sc-15948). One field for both halves of the decision, resolved ONCE per job by
+    /// [`workflow_source`], so the two write seams that read it cannot disagree about whether the
+    /// user opted out — and a `None` here means both take the byte-identical `save_with_format`
+    /// path.
+    ///
+    /// The RAW payload rather than a re-serialization of [`ImageRequest`]: the envelope's
+    /// allow-list is defined against the payload's own keys (`sceneworks_core::workflow_share`),
+    /// and the epic's decision is to source from `jobs.payload_json` because the recipe is lossy.
+    /// `Arc` because every per-image asset writer clones the plan into a `spawn_blocking` encode
+    /// task and a payload carries the resolved model manifest.
+    pub(crate) workflow_source: Option<Arc<JsonObject>>,
+}
+
+/// The workflow-envelope source for one job, or `None` for "write the file exactly as today"
+/// (sc-15948).
+///
+/// Two independent reasons to embed nothing, deliberately collapsed into one `Option` at the top
+/// of the job rather than re-decided at each write:
+///
+/// * the user turned `embedWorkflowInImages` off (read live off the config dir — see
+///   `sceneworks_core::app_paths::embed_workflow_in_images`);
+/// * there is no payload to describe. A stub or dry-run write with an empty payload has nothing to
+///   say about how the image was made, and an envelope of bare fallbacks is worse than no chunk —
+///   so absence is an absence, never an error.
+pub(crate) fn workflow_source(
+    settings: &Settings,
+    job_payload: &JsonObject,
+) -> Option<Arc<JsonObject>> {
+    if job_payload.is_empty() {
+        return None;
+    }
+    if !sceneworks_core::app_paths::embed_workflow_in_images(&settings.config_dir) {
+        return None;
+    }
+    Some(Arc::new(job_payload.clone()))
+}
+
+/// The workflow envelope for an inline-upscaled variant (sc-15948): the generation's own payload
+/// with the APPLIED pass overlaid.
+///
+/// The inline upscale is a sub-step of the generate job, not a job of its own, so there is no second
+/// payload to build from — but the base generation's envelope alone would describe an image that was
+/// never written. The overlay is what makes the difference honest, and it is the *applied* record
+/// rather than the requested one: `write_upscaled_asset`'s caller normalizes the engine id (anything
+/// unknown, including the dropped `aura-sr`, becomes `real-esrgan`) and clamps the factor to 2 or 4,
+/// and it is that pass the file came out of. It is the same `Value` the fact's
+/// `rawAdapterSettings.upscale` records, so a shared image and its sidecar cannot disagree.
+///
+/// Geometry deliberately stays the GENERATION geometry rather than the upscaled file's. The envelope
+/// is a recipe: "render 1024² then upscale 2x" replays to this image, where "render 2048² then
+/// upscale 2x" would replay to something twice the size.
+///
+/// Compiled under `test` on every platform (unlike `write_upscaled_asset`, which needs an upscaler
+/// backend) so the lineage contract is tested on every build, not only where candle or MLX compiles.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle"),
+    test
+))]
+pub(crate) fn upscaled_workflow_share(
+    request: &ImageRequest,
+    base_fact: &JsonObject,
+    job_payload: &JsonObject,
+    upscale_record: &Value,
+) -> sceneworks_core::workflow_share::WorkflowShare {
+    let base_u32 = |key: &str| {
+        base_fact
+            .get(key)
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+    };
+    let mut overlay = job_payload.clone();
+    overlay.insert("upscale".to_owned(), upscale_record.clone());
+    // `upscale` is the ONLY key overlaid. Everything else — the payload's own `width`/`height`
+    // included — is left exactly as the base image's own envelope reads it, so two envelopes
+    // describing one generation cannot disagree about the render that produced it. The base fact
+    // supplies the geometry fallback for a payload that omitted it, which is the actual written
+    // size of the image this variant was upscaled FROM.
+    build_workflow_share_from(
+        &WorkflowAssetFacts {
+            mode: request.mode.clone(),
+            model: request.model.clone(),
+            prompt: request.prompt.clone(),
+            negative_prompt: request.negative_prompt.clone(),
+            seed: base_fact.get("seed").and_then(Value::as_i64).unwrap_or(0),
+            width: base_u32("width"),
+            height: base_u32("height"),
+        },
+        &overlay,
+    )
+}
+
+/// The workflow envelope for the standalone detail pass (sc-15948).
+///
+/// Unlike the inline upscale, `image_detail` IS its own job with its own payload, so nothing here is
+/// inherited from the generation that produced the source image — there is no base-generation
+/// envelope in play at all. What the payload cannot supply, the resolved pass does: the mode, the
+/// SDXL backbone that actually ran, the detail prompt/negative (which live under `advanced` and are
+/// what the model saw, not the payload's absent top-level prompt), the seed and the output geometry.
+/// `advanced.strength` and `advanced.cnScale` — the two knobs the Detail UI exposes — travel through
+/// the sc-15946 allow-list, and the source image rides as an input SHAPE rather than as the local
+/// asset id `sourceAssetId` names.
+///
+/// Compiled under `test` everywhere for the same reason as [`upscaled_workflow_share`]:
+/// `image_jobs/detail.rs` compiles on macOS only, and the lineage contract should not go untested on
+/// every other platform.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn detail_workflow_share(
+    job_payload: &JsonObject,
+    model: &str,
+    prompt: &str,
+    negative_prompt: &str,
+    seed: i64,
+    width: u32,
+    height: u32,
+) -> sceneworks_core::workflow_share::WorkflowShare {
+    build_workflow_share_from(
+        &WorkflowAssetFacts {
+            mode: "image_detail".to_owned(),
+            model: model.to_owned(),
+            prompt: prompt.to_owned(),
+            negative_prompt: negative_prompt.to_owned(),
+            seed,
+            width: Some(width),
+            height: Some(height),
+        },
+        job_payload,
+    )
 }
 
 impl ImagePlan {
-    /// Test-only convenience: a plan whose image count is the request count. Production
-    /// always goes through [`ImagePlan::with_count`] (the FLUX.2 angle/pose sets need an
+    /// Test-only convenience: a plan whose image count is the request count, embedding nothing.
+    /// Production always goes through [`ImagePlan::with_count`] (the FLUX.2 angle/pose sets need an
     /// effective count that differs from `request.count`).
     #[cfg(test)]
     fn new(request: &ImageRequest) -> Self {
-        Self::with_count_and_adapter(request, request.count, adapter_id(request))
+        Self::with_count_and_adapter(request, request.count, adapter_id(request), None)
     }
 
     /// Build a plan whose generation set reports `image_count` images (see the field).
-    pub(crate) fn with_count(request: &ImageRequest, image_count: u32) -> Self {
-        Self::with_count_and_adapter(request, image_count, adapter_id(request))
+    pub(crate) fn with_count(
+        request: &ImageRequest,
+        image_count: u32,
+        workflow_source: Option<Arc<JsonObject>>,
+    ) -> Self {
+        Self::with_count_and_adapter(request, image_count, adapter_id(request), workflow_source)
     }
 
     /// Build a plan with the count and adapter label selected by the already-resolved route.
@@ -1233,6 +1377,7 @@ impl ImagePlan {
         request: &ImageRequest,
         image_count: u32,
         adapter: &'static str,
+        workflow_source: Option<Arc<JsonObject>>,
     ) -> Self {
         let genset_id = format!("genset_{}", Uuid::new_v4().simple());
         let created_at = now_rfc3339();
@@ -1256,6 +1401,7 @@ impl ImagePlan {
             generation_set,
             adapter,
             image_count,
+            workflow_source,
         }
     }
 }
@@ -1298,8 +1444,25 @@ pub(crate) fn write_image_asset(
         std::fs::create_dir_all(parent)?;
     }
     let temp_path = media_path.with_extension("tmp.png");
-    rgb_image
-        .save_with_format(&temp_path, image::ImageFormat::Png)
+    // The one funnel every generated image goes through, and therefore the one place the sanitized
+    // workflow needs embedding (epic 15945, sc-15948). `None` — embedding off, or no payload to
+    // describe — routes through the same `save_with_format` call this used to make, byte for byte.
+    let share = plan.workflow_source.as_deref().map(|payload| {
+        build_workflow_share_from(
+            &WorkflowAssetFacts {
+                mode: request.mode.clone(),
+                model: request.model.clone(),
+                prompt: request.prompt.clone(),
+                negative_prompt: request.negative_prompt.clone(),
+                // THIS image's seed, not the batch base the payload carries.
+                seed,
+                width: Some(width),
+                height: Some(height),
+            },
+            payload,
+        )
+    });
+    write_workflow_chunk(&rgb_image, &temp_path, share.as_ref())
         .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
     std::fs::rename(&temp_path, &media_path).inspect_err(|_| {
         let _ = std::fs::remove_file(&temp_path);
@@ -1529,9 +1692,23 @@ fn write_upscaled_asset(
     if let Some(parent) = media_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    // The APPLIED pass, not the requested one. Hoisted above the write because two things now read
+    // it: the embedded workflow (sc-15948) and the `rawAdapterSettings.upscale` record below, and a
+    // shared image must not describe a different pass from the one the sidecar records.
+    let upscale_record = if engine_id == "seedvr2" {
+        json!({ "enabled": true, "engine": engine_id, "factor": factor, "softness": softness })
+    } else {
+        json!({ "enabled": true, "engine": engine_id, "factor": factor })
+    };
+
     let temp_path = media_path.with_extension("tmp.png");
-    upscaled
-        .save_with_format(&temp_path, image::ImageFormat::Png)
+    // The upscaled variant is the asset users share most, so it carries the workflow that produced
+    // IT rather than a stale base-generation envelope (sc-15948) — see `upscaled_workflow_share`.
+    let share = plan
+        .workflow_source
+        .as_deref()
+        .map(|payload| upscaled_workflow_share(request, base_fact, payload, &upscale_record));
+    write_workflow_chunk(upscaled, &temp_path, share.as_ref())
         .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
     std::fs::rename(&temp_path, &media_path).inspect_err(|_| {
         let _ = std::fs::remove_file(&temp_path);
@@ -1550,11 +1727,6 @@ fn write_upscaled_asset(
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
-    let upscale_record = if engine_id == "seedvr2" {
-        json!({ "enabled": true, "engine": engine_id, "factor": factor, "softness": softness })
-    } else {
-        json!({ "enabled": true, "engine": engine_id, "factor": factor })
-    };
     raw_settings.insert("upscale".to_owned(), upscale_record);
 
     let mut fact = base_fact.clone();

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1248,16 +1248,34 @@ pub(crate) struct ImagePlan {
 /// * there is no payload to describe. A stub or dry-run write with an empty payload has nothing to
 ///   say about how the image was made, and an envelope of bare fallbacks is worse than no chunk —
 ///   so absence is an absence, never an error.
+///
+/// Each branch logs its reason at `debug`. Collapsing the two into one `Option` is right for the
+/// callers — both mean "write the file exactly as today" — but it leaves "there is no chunk in this
+/// PNG" with two indistinguishable causes, and a user asking why an image has no recipe needs to
+/// know whether they turned it off or the payload was empty. One line each is the whole diagnostic.
 pub(crate) fn workflow_source(
     settings: &Settings,
     job_payload: &JsonObject,
 ) -> Option<Arc<JsonObject>> {
     if job_payload.is_empty() {
+        tracing::debug!(
+            reason = "empty_job_payload",
+            "not embedding a workflow: the job carries no payload to describe"
+        );
         return None;
     }
     if !sceneworks_core::app_paths::embed_workflow_in_images(&settings.config_dir) {
+        tracing::debug!(
+            reason = "preference_off",
+            config_dir = %settings.config_dir.display(),
+            "not embedding a workflow: `embedWorkflowInImages` did not resolve to true"
+        );
         return None;
     }
+    tracing::debug!(
+        keys = job_payload.len(),
+        "embedding the sanitized workflow in every image this job writes"
+    );
     Some(Arc::new(job_payload.clone()))
 }
 
@@ -1351,6 +1369,71 @@ pub(crate) fn detail_workflow_share(
             height: Some(height),
         },
         job_payload,
+    )
+}
+
+/// The workflow envelope for the STANDALONE `image_upscale` job (sc-15948).
+///
+/// The fourth write seam, and the one carrying the asset class users share most: `single_child_asset.rs`
+/// wrote this PNG with a bare `save_with_format` and no chunk at all, so an upscaled image — the
+/// version people actually post — was the one image in the app with no recipe inside it. The story's
+/// rule for a derived pass is "where the pass is a distinct job, use that job's payload", and this is
+/// exactly that: its own `JobType::ImageUpscale` row with its own payload.
+///
+/// So, like [`detail_workflow_share`] and unlike [`upscaled_workflow_share`], nothing is inherited
+/// from whatever generated the source image. There is no prompt and no model in an upscale — the
+/// "model" IS the engine that ran — and `sourceAssetId` rides as an input SHAPE rather than as a
+/// local id.
+///
+/// The pass is the APPLIED one: `engine_id` has already been canonicalized and validated by the
+/// caller (`real-esrgan` / `seedvr2`; the dropped `aura-sr` is rejected outright) and `factor` has
+/// already been through `resolve_image_upscale_factor`, so what lands here cannot name an engine that
+/// does not exist or a factor nobody offers. `softness` is SeedVR2's knob and is `None` for
+/// Real-ESRGAN, which ignores it — recording `softness: 0.0` on an engine that has no such control
+/// would be inventing a fact.
+///
+/// Geometry is the SOURCE image's, matching [`upscaled_workflow_share`]: the envelope is a recipe, so
+/// "this 1024² image, upscaled 2x" is what reproduces the file, where the written 2048² would read as
+/// an instruction to upscale something already upscaled.
+///
+/// Compiled under `test` on every platform (unlike `upscale_jobs.rs`, which needs an upscaler
+/// backend) so the contract is tested on every build rather than only where candle or MLX compiles.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle"),
+    test
+))]
+pub(crate) fn standalone_upscale_workflow_share(
+    job_payload: &JsonObject,
+    engine_id: &str,
+    factor: u8,
+    softness: Option<f32>,
+    seed: i64,
+    source_width: u32,
+    source_height: u32,
+) -> sceneworks_core::workflow_share::WorkflowShare {
+    let mut upscale = json!({ "enabled": true, "engine": engine_id, "factor": factor });
+    if let Some(softness) = softness {
+        upscale["softness"] = json!(softness);
+    }
+    // `upscale` is the only key overlaid: the job payload's own `factor` / `engine` are the
+    // REQUESTED values and are not envelope fields, so the record built here is the only thing that
+    // describes the pass.
+    let mut overlay = job_payload.clone();
+    overlay.insert("upscale".to_owned(), upscale);
+    build_workflow_share_from(
+        &WorkflowAssetFacts {
+            mode: "image_upscale".to_owned(),
+            // The engine IS the model for this pass. The payload carries no `model` key (see
+            // `buildUpscaleJobBody`), so this is what travels.
+            model: engine_id.to_owned(),
+            prompt: String::new(),
+            negative_prompt: String::new(),
+            seed,
+            width: Some(source_width),
+            height: Some(source_height),
+        },
+        &overlay,
     )
 }
 
@@ -1448,7 +1531,7 @@ pub(crate) fn write_image_asset(
     // workflow needs embedding (epic 15945, sc-15948). `None` — embedding off, or no payload to
     // describe — routes through the same `save_with_format` call this used to make, byte for byte.
     let share = plan.workflow_source.as_deref().map(|payload| {
-        build_workflow_share_from(
+        let mut share = build_workflow_share_from(
             &WorkflowAssetFacts {
                 mode: request.mode.clone(),
                 model: request.model.clone(),
@@ -1460,7 +1543,17 @@ pub(crate) fn write_image_asset(
                 height: Some(height),
             },
             payload,
-        )
+        );
+        // This function only ever writes a BASE render. The inline-upscale post-pass writes its
+        // output through `write_upscaled_asset` and keeps the base as its own retained asset, so a
+        // `upscale.enabled: true` from the request would describe, on this file, a pass this file
+        // never received — and describe it in the REQUESTED terms, which `apply_inline_upscale`
+        // then clamps (factor to 2/4) and normalizes (a dropped engine to `real-esrgan`). Naming a
+        // dropped engine at an unoffered factor is worse than saying nothing: sc-15952 prefills the
+        // studio from this. The variant's own envelope carries the pass that actually ran, which is
+        // the same reasoning `upscaled_workflow_share` applies from the other side.
+        share.upscale = None;
+        share
     });
     write_workflow_chunk(&rgb_image, &temp_path, share.as_ref())
         .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;

--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -580,12 +580,25 @@ pub(crate) async fn run_image_detail_job(
     let (out_w, out_h) = (refined.width(), refined.height());
     let media_path = project_path.join(&media_rel);
     let temp_path = media_path.with_extension("tmp.png");
+    // This pass is its own job with its own payload, so the embedded workflow describes the REFINE
+    // (its own prompt, backbone, seed, strength and cnScale) and inherits nothing from the
+    // generation that produced the source image — see `detail_workflow_share` (sc-15948).
+    let share = workflow_source(settings, &job.payload).map(|payload| {
+        detail_workflow_share(
+            &payload,
+            &model,
+            &params.prompt,
+            &params.negative,
+            params.seed,
+            out_w,
+            out_h,
+        )
+    });
     // Encode + atomically promote the refined PNG off the async runtime thread (sc-8909 / F-107).
     let encode_tmp = temp_path.clone();
     let encode_final = media_path.clone();
     tokio::task::spawn_blocking(move || {
-        refined
-            .save_with_format(&encode_tmp, image::ImageFormat::Png)
+        write_workflow_chunk(&refined, &encode_tmp, share.as_ref())
             .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
         std::fs::rename(&encode_tmp, &encode_final).inspect_err(|_| {
             let _ = std::fs::remove_file(&encode_tmp);

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -352,10 +352,9 @@ fn a_generated_png_carries_the_sanitized_workflow_of_its_own_render() {
     assert_eq!((share.width, share.height), (Some(320), Some(256)));
     assert_eq!(share.style_preset.as_deref(), Some("cinematic"));
     assert_eq!(share.fit_mode.as_deref(), Some("pad"));
-    assert_eq!(
-        share.upscale.as_ref().map(|upscale| upscale.enabled),
-        Some(true)
-    );
+    // The payload asked for an inline upscale, but THIS file is the base render — see
+    // `the_base_image_of_an_inline_upscale_describes_no_upscale_pass`.
+    assert_eq!(share.upscale, None);
     assert_eq!(
         share.loras.first().and_then(|lora| lora.repo.as_deref()),
         Some("acme/film-grain")
@@ -549,6 +548,72 @@ fn the_upscaled_variant_describes_the_pass_that_actually_ran() {
     geometry_less.remove("height");
     let share = upscaled_workflow_share(&req, &base_fact, &geometry_less, &applied);
     assert_eq!((share.width, share.height), (Some(320), Some(256)));
+}
+
+/// The BASE image of an inline-upscale generation must not describe a pass it never received
+/// (sc-15948).
+///
+/// `apply_inline_upscale` keeps the base render as its own retained asset and appends the upscaled
+/// variant beside it, so an inline-upscale generation ships TWO files. `write_image_asset` embeds the
+/// raw request payload, which means the base file used to claim `upscale.enabled: true` — and claim
+/// it in the REQUESTED terms, which the pass then clamps (`factor` to 2 or 4) and normalizes (the
+/// dropped `aura-sr` to `real-esrgan`). The hostile request below asks for `aura-sr` at 3x: neither
+/// exists, and the base image was never upscaled at all, so a base envelope echoing them named a
+/// dropped engine at an unoffered factor on a file that received no pass. sc-15952 prefills the
+/// studio from this.
+///
+/// The two halves are asserted together on one generation, because "drop it from the base" is only
+/// right if the variant still carries it — otherwise the pass would go unrecorded everywhere.
+#[test]
+fn the_base_image_of_an_inline_upscale_describes_no_upscale_pass() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let config_dir = dir.path().join("config");
+    let settings = settings_with_config_dir(&config_dir);
+
+    let mut payload = embed_payload();
+    payload.insert(
+        "upscale".to_owned(),
+        json!({ "enabled": true, "engine": "aura-sr", "factor": 3 }),
+    );
+    let req = ImageRequest::from_payload(&payload);
+    let plan = ImagePlan::with_count(&req, req.count, workflow_source(&settings, &payload));
+    let base_fact = write_one(&plan, &req, resolve_seed(&req, 0), &project_path);
+
+    let media = project_path.join(base_fact["mediaPath"].as_str().unwrap());
+    let base = sceneworks_core::workflow_png::read_workflow_chunk_file(&media)
+        .expect("the written PNG is readable")
+        .expect("the base image still carries its own workflow");
+    assert_eq!(
+        base.upscale, None,
+        "the base render received no upscale pass, so its envelope must not describe one"
+    );
+    // Not merely absent from the typed field — absent from the FILE. A serialized `"upscale"` key
+    // would still reach sc-15952's prefill.
+    let text = serde_json::to_string(&base).unwrap();
+    for fragment in ["upscale", "aura-sr"] {
+        assert!(
+            !text.contains(fragment),
+            "{fragment:?} must not appear in the base image's envelope: {text}"
+        );
+    }
+    // Everything else about the base render is untouched.
+    assert_eq!(base.prompt, "Mist over hills");
+    assert_eq!(base.seed, Some(100));
+    assert_eq!((base.width, base.height), (Some(320), Some(256)));
+
+    // The derived variant is where the pass lives, in APPLIED terms: `apply_inline_upscale` clamps
+    // 3 to 2 and normalizes `aura-sr` to `real-esrgan` before upscaling.
+    let applied = json!({ "enabled": true, "engine": "real-esrgan", "factor": 2 });
+    let variant = upscaled_workflow_share(&req, &base_fact, &payload, &applied);
+    let upscale = variant
+        .upscale
+        .as_ref()
+        .expect("the variant records the pass");
+    assert!(upscale.enabled);
+    assert_eq!(upscale.engine.as_deref(), Some("real-esrgan"));
+    assert_eq!(upscale.factor, Some(2));
 }
 
 /// The detail pass has its OWN job payload, so its envelope describes the refine — not the

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -239,6 +239,426 @@ fn write_image_asset_confines_malicious_model_id() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Embedded workflow (epic 15945, sc-15948)
+// ---------------------------------------------------------------------------
+
+/// Worker settings pointed at a scratch config dir, so the embed toggle can be written and read
+/// without touching the real install's `ui-preferences.json`.
+fn settings_with_config_dir(config_dir: &Path) -> Settings {
+    let mut settings = Settings::from_env();
+    settings.config_dir = config_dir.to_path_buf();
+    settings
+}
+
+fn write_embed_preference(config_dir: &Path, enabled: bool) {
+    std::fs::create_dir_all(config_dir).unwrap();
+    std::fs::write(
+        sceneworks_core::app_paths::ui_preferences_file(config_dir),
+        format!(r#"{{"theme":"dark","embedWorkflowInImages":{enabled}}}"#),
+    )
+    .unwrap();
+}
+
+/// A representative Image Studio payload: an edit with a reference and a mask, LoRAs, a style, an
+/// upscale pass, and `advanced` carrying both allow-listed knobs and denied ones.
+fn embed_payload() -> JsonObject {
+    json!({
+        "projectId": "p",
+        "mode": "edit_image",
+        "model": "krea_2_turbo",
+        "prompt": "Mist over hills",
+        "negativePrompt": "text, watermark",
+        "count": 2,
+        "width": 320,
+        "height": 256,
+        "seed": 100,
+        "seeds": [100, 101],
+        "stylePreset": "cinematic",
+        "styleId": "style_noir",
+        "fitMode": "pad",
+        "sourceAssetId": "asset_source_1",
+        "referenceAssetIds": ["asset_ref_1", "asset_ref_2"],
+        "maskAssetId": "asset_mask_1",
+        "upscale": { "enabled": true, "engine": "real-esrgan", "factor": 2 },
+        "loras": [{
+            "name": "Film Grain",
+            "weight": 0.6,
+            "source": { "provider": "huggingface", "repo": "acme/film-grain", "file": "grain.safetensors" }
+        }],
+        "modelManifestEntry": { "family": "krea" },
+        "advanced": {
+            "steps": 8,
+            "sampler": "euler",
+            "guidanceScale": 3.5,
+            "mlxQuantize": 4,
+            "flashAttn": true,
+            "controlImage": "asset_control_1"
+        }
+    })
+    .as_object()
+    .cloned()
+    .unwrap()
+}
+
+fn write_one(plan: &ImagePlan, req: &ImageRequest, seed: i64, project_path: &Path) -> JsonObject {
+    let pixels = stub_rgb8(req.width, req.height, seed);
+    write_image_asset(
+        plan,
+        0,
+        seed,
+        req.width,
+        req.height,
+        pixels,
+        STUB_ADAPTER,
+        stub_raw_settings(req),
+        project_path,
+    )
+    .unwrap()
+}
+
+/// The main funnel embeds the sanitized envelope, and the envelope describes THIS image.
+///
+/// `write_image_asset` is the one place every generated image is written, which is why sc-15948
+/// embeds here rather than at the four egress paths (`std::fs::copy`, the API's `ReaderStream`, the
+/// browser's `<a download>`, the MCP base64) — all of which are byte-exact and therefore carry
+/// whatever this wrote, including a PNG dragged straight out of Explorer.
+#[test]
+fn a_generated_png_carries_the_sanitized_workflow_of_its_own_render() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let config_dir = dir.path().join("config");
+    let settings = settings_with_config_dir(&config_dir);
+
+    let payload = embed_payload();
+    let req = ImageRequest::from_payload(&payload);
+    // No preference file at all — embedding is ON by default, which is the shape a fresh install has.
+    let plan = ImagePlan::with_count(&req, req.count, workflow_source(&settings, &payload));
+    // Image index 0 of a two-image batch whose base seed is 100 — so the seed that lands in the
+    // envelope has to be this image's, not the batch's `seeds` list.
+    let fact = write_one(&plan, &req, resolve_seed(&req, 0), &project_path);
+
+    let media = project_path.join(fact["mediaPath"].as_str().unwrap());
+    let share = sceneworks_core::workflow_png::read_workflow_chunk_file(&media)
+        .expect("the written PNG is readable")
+        .expect("it carries a workflow");
+
+    assert_eq!(share.mode, "edit_image");
+    assert_eq!(share.model, "krea_2_turbo");
+    assert_eq!(share.prompt, "Mist over hills");
+    assert_eq!(share.negative_prompt, "text, watermark");
+    assert_eq!(share.seed, Some(100));
+    assert_eq!((share.width, share.height), (Some(320), Some(256)));
+    assert_eq!(share.style_preset.as_deref(), Some("cinematic"));
+    assert_eq!(share.fit_mode.as_deref(), Some("pad"));
+    assert_eq!(
+        share.upscale.as_ref().map(|upscale| upscale.enabled),
+        Some(true)
+    );
+    assert_eq!(
+        share.loras.first().and_then(|lora| lora.repo.as_deref()),
+        Some("acme/film-grain")
+    );
+
+    // Input images by SHAPE, never by id: source + two references + mask + the control map.
+    let mut kinds: Vec<(&str, u32)> = share
+        .inputs
+        .iter()
+        .map(|input| (input.kind.as_str(), input.count))
+        .collect();
+    kinds.sort_unstable();
+    assert_eq!(
+        kinds,
+        vec![("control", 1), ("mask", 1), ("reference", 2), ("source", 1)]
+    );
+
+    // The allow-list ran on the way out, in the file that actually leaves the machine.
+    let advanced = &share.advanced;
+    assert_eq!(advanced.get("steps"), Some(&json!(8)));
+    assert_eq!(advanced.get("sampler"), Some(&json!("euler")));
+    for denied in ["mlxQuantize", "flashAttn", "controlImage"] {
+        assert!(
+            !advanced.contains_key(denied),
+            "`{denied}` must not travel inside a shared image"
+        );
+    }
+    let text = serde_json::to_string(&share).unwrap();
+    for local_id in [
+        "asset_source_1",
+        "asset_ref_1",
+        "asset_mask_1",
+        "asset_control_1",
+        "\"projectId\"",
+    ] {
+        assert!(!text.contains(local_id), "{local_id} leaked: {text}");
+    }
+
+    // And it is still an ordinary PNG: the chunk is ancillary, so every decoder must ignore it.
+    let decoded = image::open(&media).unwrap();
+    assert_eq!((decoded.width(), decoded.height()), (320, 256));
+}
+
+/// Turning the setting off writes the file SceneWorks writes today, to the byte.
+///
+/// Proven by comparison against a real `save_with_format` write of the same pixel buffer rather
+/// than by reading the implementation — the `None` arm of `write_workflow_chunk` guarantees this
+/// (`the_none_path_is_byte_identical_to_save_with_format`, sc-15947) and this is the seam actually
+/// taking it.
+#[test]
+fn embedding_off_writes_the_bytes_sceneworks_writes_today() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let config_dir = dir.path().join("config");
+    write_embed_preference(&config_dir, false);
+    let settings = settings_with_config_dir(&config_dir);
+
+    let payload = embed_payload();
+    let req = ImageRequest::from_payload(&payload);
+    let source = workflow_source(&settings, &payload);
+    assert!(
+        source.is_none(),
+        "a stored `embedWorkflowInImages: false` must leave nothing to embed"
+    );
+
+    let seed = resolve_seed(&req, 0);
+    let plan = ImagePlan::with_count(&req, req.count, source);
+    let fact = write_one(&plan, &req, seed, &project_path);
+    let written = std::fs::read(project_path.join(fact["mediaPath"].as_str().unwrap())).unwrap();
+
+    // The same pixels through the encoder this seam used before sc-15948.
+    let reference_path = dir.path().join("reference.png");
+    image::RgbImage::from_raw(
+        req.width,
+        req.height,
+        stub_rgb8(req.width, req.height, seed),
+    )
+    .unwrap()
+    .save_with_format(&reference_path, image::ImageFormat::Png)
+    .unwrap();
+    let reference = std::fs::read(&reference_path).unwrap();
+
+    assert_eq!(
+        written.len(),
+        reference.len(),
+        "opting out changed the encoded size by {} bytes",
+        written.len().abs_diff(reference.len())
+    );
+    assert!(
+        written == reference,
+        "opting out did not produce the bytes `save_with_format` produces"
+    );
+
+    // Stated the other way round too, so this cannot pass because the reader is broken.
+    let embedded_plan = ImagePlan::with_count(&req, req.count, Some(Arc::new(payload)));
+    let embedded = write_one(&embedded_plan, &req, seed, &project_path);
+    let embedded_bytes =
+        std::fs::read(project_path.join(embedded["mediaPath"].as_str().unwrap())).unwrap();
+    assert!(embedded_bytes.len() > reference.len());
+}
+
+/// A write with no job payload behind it must produce a plain PNG, not an error and not an envelope
+/// of bare fallbacks. The stub and dry-run paths go through this funnel too.
+#[test]
+fn a_write_with_no_payload_embeds_nothing_and_still_succeeds() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let config_dir = dir.path().join("config");
+    let settings = settings_with_config_dir(&config_dir);
+
+    assert!(
+        workflow_source(&settings, &JsonObject::new()).is_none(),
+        "an empty payload has nothing to describe, so it must embed nothing"
+    );
+
+    let req =
+        request(json!({ "projectId": "p", "model": "z_image_turbo", "width": 256, "height": 256 }));
+    let plan = ImagePlan::new(&req);
+    let fact = write_one(&plan, &req, 1, &project_path);
+    let media = project_path.join(fact["mediaPath"].as_str().unwrap());
+    assert_eq!(
+        sceneworks_core::workflow_png::read_workflow_chunk_file(&media).unwrap(),
+        None,
+        "an absent payload is an absence, never an error"
+    );
+    assert!(image::open(&media).is_ok());
+}
+
+/// The toggle is read live off the config dir, so a user who flips it does not have to restart the
+/// worker — the same live-handoff shape as the GPU-memory-limit file (epic 7819).
+#[test]
+fn the_embed_toggle_is_read_from_the_config_dir_each_job() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_dir = dir.path().to_path_buf();
+    let settings = settings_with_config_dir(&config_dir);
+    let payload = embed_payload();
+
+    assert!(
+        workflow_source(&settings, &payload).is_some(),
+        "no preference file means ON"
+    );
+    write_embed_preference(&config_dir, false);
+    assert!(workflow_source(&settings, &payload).is_none());
+    write_embed_preference(&config_dir, true);
+    assert!(workflow_source(&settings, &payload).is_some());
+}
+
+/// The inline-upscaled variant carries the pass that produced IT, and specifically the pass that
+/// RAN rather than the one that was requested (sc-15948).
+///
+/// The request here asks for `aura-sr` at 3x — an engine that no longer exists and a factor the
+/// worker does not offer. `apply_inline_upscale` normalizes both before upscaling, so a shared
+/// upscaled image that echoed the request would describe a pass nobody can reproduce.
+#[test]
+fn the_upscaled_variant_describes_the_pass_that_actually_ran() {
+    let mut payload = embed_payload();
+    payload.insert(
+        "upscale".to_owned(),
+        json!({ "enabled": true, "engine": "aura-sr", "factor": 3 }),
+    );
+    let req = ImageRequest::from_payload(&payload);
+    let base_fact = json!({
+        "assetId": "asset_base", "seed": 101, "width": 320, "height": 256, "index": 0
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    let applied = json!({ "enabled": true, "engine": "seedvr2", "factor": 2, "softness": 0.25 });
+
+    let share = upscaled_workflow_share(&req, &base_fact, &payload, &applied);
+    let upscale = share.upscale.as_ref().expect("the pass is recorded");
+    assert!(upscale.enabled);
+    assert_eq!(upscale.engine.as_deref(), Some("seedvr2"));
+    assert_eq!(upscale.factor, Some(2));
+    assert_eq!(upscale.softness, Some(0.25));
+
+    // The base generation still travels — the upscaled file is base + pass, not pass alone — and the
+    // seed is the BASE image's, because that is the render this variant came out of.
+    assert_eq!(share.prompt, "Mist over hills");
+    assert_eq!(share.model, "krea_2_turbo");
+    assert_eq!(share.seed, Some(101));
+    // Generation geometry, not the upscaled file's: the envelope is a recipe, and "render 320x256
+    // then upscale 2x" is what reproduces this image.
+    assert_eq!((share.width, share.height), (Some(320), Some(256)));
+
+    // A payload that omitted geometry falls back to the BASE fact's, never to the upscaled file's.
+    let mut geometry_less = payload.clone();
+    geometry_less.remove("width");
+    geometry_less.remove("height");
+    let share = upscaled_workflow_share(&req, &base_fact, &geometry_less, &applied);
+    assert_eq!((share.width, share.height), (Some(320), Some(256)));
+}
+
+/// The detail pass has its OWN job payload, so its envelope describes the refine — not the
+/// generation that produced the image it refined (sc-15948).
+#[test]
+fn the_detail_pass_describes_itself_and_not_the_source_generation() {
+    // The payload `buildDetailJobBody` sends: a source asset, a backbone, and two knobs.
+    let payload = json!({
+        "projectId": "p",
+        "sourceAssetId": "asset_source_1",
+        "model": "realvisxl",
+        "displayName": "Mist over hills",
+        "advanced": { "strength": 0.55, "cnScale": 0.7 }
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let share = detail_workflow_share(
+        &payload,
+        "realvisxl",
+        "ultra detailed, sharp focus, fine texture, high quality",
+        "blurry, soft, lowres, smooth, plastic",
+        7,
+        1536,
+        1024,
+    );
+
+    assert_eq!(share.mode, "image_detail");
+    assert_eq!(share.model, "realvisxl");
+    assert_eq!(
+        share.prompt, "ultra detailed, sharp focus, fine texture, high quality",
+        "the prompt the model saw lives in `advanced`, not at the payload's top level"
+    );
+    assert_eq!(
+        share.negative_prompt,
+        "blurry, soft, lowres, smooth, plastic"
+    );
+    assert_eq!(share.seed, Some(7));
+    assert_eq!((share.width, share.height), (Some(1536), Some(1024)));
+
+    // Both knobs the Detail UI exposes travel. `cnScale` was unclassified — and therefore silently
+    // dropped — until sc-15948 added it to `ADVANCED_KEY_RULES`.
+    assert_eq!(share.advanced.get("strength"), Some(&json!(0.55)));
+    assert_eq!(share.advanced.get("cnScale"), Some(&json!(0.7)));
+
+    // The source image is a SHAPE, never the local id.
+    assert_eq!(share.inputs.len(), 1);
+    assert_eq!(share.inputs[0].kind, "source");
+    let text = serde_json::to_string(&share).unwrap();
+    assert!(!text.contains("asset_source_1"), "{text}");
+}
+
+/// The measured per-image cost, recorded on sc-15948.
+///
+/// A batch at the sizes the Image Studio actually renders, so "the chunk and nothing else" is a
+/// number rather than a claim. The bound is deliberately loose in one direction only: what would be
+/// a regression is the *encoder* drifting (a compression-level or row-filter change would move the
+/// delta by kilobytes on the pixels, not by tens of bytes on the text), which is what the sc-15947
+/// invariant test pins and what this would notice second.
+#[test]
+fn the_embedded_chunk_costs_only_the_chunk_on_a_representative_batch() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let config_dir = dir.path().join("config");
+    let settings = settings_with_config_dir(&config_dir);
+
+    let mut deltas = Vec::new();
+    for (width, height) in [(512, 512), (768, 512), (1024, 1024), (1280, 720)] {
+        let mut payload = embed_payload();
+        payload.insert("width".to_owned(), json!(width));
+        payload.insert("height".to_owned(), json!(height));
+        let req = ImageRequest::from_payload(&payload);
+        let seed = resolve_seed(&req, 0);
+
+        let embedded = ImagePlan::with_count(&req, 1, workflow_source(&settings, &payload));
+        let plain = ImagePlan::with_count(&req, 1, None);
+        let with = write_one(&embedded, &req, seed, &project_path);
+        let without = write_one(&plain, &req, seed, &project_path);
+
+        let with_bytes = std::fs::metadata(project_path.join(with["mediaPath"].as_str().unwrap()))
+            .unwrap()
+            .len();
+        let without_bytes =
+            std::fs::metadata(project_path.join(without["mediaPath"].as_str().unwrap()))
+                .unwrap()
+                .len();
+        let delta = with_bytes as i64 - without_bytes as i64;
+        println!("{width}x{height}: {without_bytes} -> {with_bytes} (+{delta} bytes)");
+        deltas.push(delta);
+    }
+
+    // Effectively one number regardless of the pixels: the only thing that moves is the deflated
+    // length of the envelope's own `width`/`height` digits, which is single-digit bytes. Measured on
+    // this batch: 446 / 449 / 448 / 446 bytes.
+    let (low, high) = (
+        *deltas.iter().min().expect("a batch"),
+        *deltas.iter().max().expect("a batch"),
+    );
+    assert!(
+        high - low <= 32,
+        "the per-image cost must be flat across image sizes, measured {deltas:?}"
+    );
+    assert!(
+        (200..2048).contains(&low) && (200..2048).contains(&high),
+        "a representative envelope should cost a few hundred bytes, measured {deltas:?}"
+    );
+}
+
 #[test]
 fn resolve_seed_matches_python_precedence() {
     // base seed wins (seed + index), even over an explicit seeds list.

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -75,10 +75,13 @@ mod asset_media;
 mod image_sampling;
 // Shared one-child PNG persistence for upscale (Mac + candle) and smart-select (Mac).
 // Keep the include site on the callers' superset so the neither-backend lane does not
-// compile an otherwise dead helper.
+// compile an otherwise dead helper — plus `test`, because this seam is where the standalone
+// upscale's embedded workflow is written (sc-15948) and that contract should be asserted on every
+// lane rather than only where an upscaler backend compiles. The non-test build is unchanged.
 #[cfg(any(
     target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
+    all(not(target_os = "macos"), feature = "backend-candle"),
+    test
 ))]
 mod single_child_asset;
 // Lazy, on-demand download-credential pull from the macOS desktop credential socket

--- a/crates/sceneworks-worker/src/segment_jobs.rs
+++ b/crates/sceneworks-worker/src/segment_jobs.rs
@@ -337,6 +337,13 @@ pub(crate) async fn run_image_segment_job(
             model: "sam3",
             adapter: "sam3",
             encode_label: "smart-select mask encode task",
+            // Deliberately NO workflow (epic 15945, sc-15948). This asset is not a generated image:
+            // it is a binary selection mask derived from a box prompt plus a concept string, and it
+            // has no generation recipe to replay — sc-15952 would prefill the Image Studio with a
+            // "recipe" that produces nothing. It is also grayscale (`ImageLuma8`), and the chunk
+            // writer encodes RGB8, so embedding would triple a mask's size and change its colour
+            // type, which `writes_one_png_and_builds_the_shared_result_envelope` pins.
+            workflow: None,
         },
         |write| {
             json!({

--- a/crates/sceneworks-worker/src/sensenova_jobs.rs
+++ b/crates/sceneworks-worker/src/sensenova_jobs.rs
@@ -626,10 +626,12 @@ pub(crate) async fn run_interleave_job(
     // no loop worth interrupting, and aborting a half-written document asset mid-rename is worse
     // than letting the seconds-long write finish.
     let job_owned = job.clone();
+    let workflow_source = crate::image_jobs::workflow_source(settings, &job.payload);
     let write_task = tokio::task::spawn_blocking(move || {
         write_interleaved_document(
             request,
             job_owned,
+            workflow_source,
             project_path,
             prompt,
             model_id,
@@ -848,6 +850,9 @@ pub(crate) async fn run_interleave_job(
 fn write_interleaved_document(
     request: ImageRequest,
     job: JobSnapshot,
+    // Resolved by the async caller (sc-15948): the embed toggle lives in the config dir, and this
+    // runs on the blocking pool with no `Settings` in hand.
+    workflow_source: Option<std::sync::Arc<JsonObject>>,
     project_path: PathBuf,
     prompt: String,
     model_id: String,
@@ -880,7 +885,7 @@ fn write_interleaved_document(
 
     // Generated images persist as ordinary image assets — the worker saves the PNG + reports facts,
     // and the Rust API builds + indexes their sidecars. The document references them in order.
-    let plan = ImagePlan::with_count(&request, images.len() as u32);
+    let plan = ImagePlan::with_count(&request, images.len() as u32, workflow_source);
     let mut image_raw_settings = raw_settings.clone();
     image_raw_settings.insert("interleaved".to_owned(), Value::Bool(true));
     let mut image_writes: Vec<Value> = Vec::with_capacity(images.len());

--- a/crates/sceneworks-worker/src/single_child_asset.rs
+++ b/crates/sceneworks-worker/src/single_child_asset.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
 use image::DynamicImage;
+use sceneworks_core::workflow_png::write_workflow_chunk;
+use sceneworks_core::workflow_share::WorkflowShare;
 use serde_json::{json, Value};
 
 use crate::{fresh_asset_id, now_rfc3339, task_join_error, JsonObject, WorkerError, WorkerResult};
@@ -18,6 +20,14 @@ pub(crate) struct SingleChildAssetSpec<'a> {
     pub model: &'a str,
     pub adapter: &'a str,
     pub encode_label: &'a str,
+    /// The sanitized workflow to embed in the written PNG, or `None` to write the file exactly as
+    /// this seam always has (epic 15945, sc-15948).
+    ///
+    /// Not defaulted, and deliberately not `Default`-derived: this is the FOURTH place the worker
+    /// writes a generated PNG, and the reason the standalone upscale shipped with no chunk is that
+    /// nobody had to decide. A new caller of this seam now has to say which it is, and to say why in
+    /// the `None` case.
+    pub workflow: Option<WorkflowShare>,
 }
 
 /// Persist one PNG child and build the common one-asset generation result. Upscale and smart-select
@@ -26,7 +36,7 @@ pub(crate) struct SingleChildAssetSpec<'a> {
 pub(crate) async fn write_single_child_asset<F>(
     project_path: &Path,
     image: DynamicImage,
-    spec: SingleChildAssetSpec<'_>,
+    mut spec: SingleChildAssetSpec<'_>,
     build_fact: F,
 ) -> WorkerResult<JsonObject>
 where
@@ -45,10 +55,16 @@ where
     }
     let tmp_path = absolute_path.with_extension("tmp.png");
     let encode_tmp = tmp_path.clone();
-    tokio::task::spawn_blocking(move || {
-        image
+    let workflow = spec.workflow.take();
+    tokio::task::spawn_blocking(move || match workflow {
+        // The embed lane (sc-15948). `write_workflow_chunk` encodes RGB8, which is what the upscale
+        // lane already hands in (`DynamicImage::ImageRgb8`), so this is a move rather than a
+        // conversion. The grayscale mask lane passes `None` and keeps its L8 encoding untouched.
+        Some(share) => write_workflow_chunk(&image.into_rgb8(), &encode_tmp, Some(&share))
+            .map_err(|error| WorkerError::Io(std::io::Error::other(error))),
+        None => image
             .save_with_format(&encode_tmp, image::ImageFormat::Png)
-            .map_err(|error| WorkerError::Io(std::io::Error::other(error)))
+            .map_err(|error| WorkerError::Io(std::io::Error::other(error))),
     })
     .await
     .map_err(|error| task_join_error(spec.encode_label, error))??;
@@ -107,6 +123,7 @@ mod tests {
                 model: "sam3",
                 adapter: "sam3",
                 encode_label: "test encode",
+                workflow: None,
             },
             |write| {
                 json!({
@@ -135,6 +152,123 @@ mod tests {
                 .color(),
             image::ColorType::L8,
             "mask encoding remains grayscale"
+        );
+        assert_eq!(
+            sceneworks_core::workflow_png::read_workflow_chunk_file(&dir.path().join(relative))
+                .expect("the mask PNG is readable"),
+            None,
+            "a segmentation mask carries no generation recipe — see the `workflow: None` at the \
+             smart-select call site"
+        );
+    }
+
+    /// The FOURTH write seam embeds too (sc-15948).
+    ///
+    /// `write_single_child_asset` is where the standalone `image_upscale` job's PNG is written, and
+    /// it wrote a bare `save_with_format` with no chunk — so the most-shared asset class in the app
+    /// was the one with no recipe inside it. This drives the real seam and reads the envelope back
+    /// out of the file on disk, because the AC is about what is IN the written PNG.
+    #[tokio::test]
+    async fn an_upscaled_png_carries_the_workflow_of_the_pass_that_produced_it() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        // The payload `buildUpscaleJobBody` posts, plus the geometry the pass resolved.
+        let payload = json!({
+            "projectId": "project_7a10",
+            "sourceAssetId": "asset_source_1",
+            "factor": 2,
+            "engine": "seedvr2",
+            "displayName": "Lighthouse in fog",
+            "softness": 0.25
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let share = crate::image_jobs::standalone_upscale_workflow_share(
+            &payload,
+            "seedvr2",
+            2,
+            Some(0.25),
+            4242,
+            320,
+            256,
+        );
+
+        let image =
+            DynamicImage::ImageRgb8(image::RgbImage::from_pixel(8, 8, image::Rgb([12, 34, 56])));
+        let result = write_single_child_asset(
+            dir.path(),
+            image,
+            SingleChildAssetSpec {
+                filename_stem: "upscaled_x2",
+                mode: "image_upscale",
+                model: "seedvr2",
+                adapter: "seedvr2",
+                encode_label: "test encode",
+                workflow: Some(share),
+            },
+            |write| json!({ "mediaPath": write.media_path }),
+        )
+        .await
+        .expect("child writes");
+
+        let media = dir.path().join(
+            result["assetWrites"][0]["mediaPath"]
+                .as_str()
+                .expect("path"),
+        );
+        let embedded = sceneworks_core::workflow_png::read_workflow_chunk_file(&media)
+            .expect("the written PNG is readable")
+            .expect("the standalone upscale must embed its own workflow");
+
+        assert_eq!(embedded.mode, "image_upscale");
+        assert_eq!(
+            embedded.model, "seedvr2",
+            "the engine IS the model of this pass"
+        );
+        assert_eq!(embedded.seed, Some(4242));
+        // Source geometry, not the written file's: the envelope is a recipe, and "this 320x256
+        // image, upscaled 2x" is what reproduces it.
+        assert_eq!((embedded.width, embedded.height), (Some(320), Some(256)));
+        let upscale = embedded.upscale.as_ref().expect("the pass is recorded");
+        assert!(upscale.enabled);
+        assert_eq!(upscale.engine.as_deref(), Some("seedvr2"));
+        assert_eq!(upscale.factor, Some(2));
+        assert_eq!(upscale.softness, Some(0.25));
+        // The source image rides as a SHAPE, never as the local asset id.
+        assert_eq!(embedded.inputs.len(), 1);
+        assert_eq!(embedded.inputs[0].kind, "source");
+        let text = serde_json::to_string(&embedded).expect("serializes");
+        for local in ["asset_source_1", "project_7a10", "Lighthouse in fog"] {
+            assert!(!text.contains(local), "{local} leaked: {text}");
+        }
+
+        // And it is still an ordinary PNG that every decoder reads.
+        let decoded = image::open(&media).expect("decodes");
+        assert_eq!((decoded.width(), decoded.height()), (8, 8));
+    }
+
+    /// Real-ESRGAN has no softness control, so the envelope must not invent one.
+    #[test]
+    fn a_softness_less_engine_records_no_softness() {
+        let payload = json!({ "sourceAssetId": "asset_source_1", "factor": 4 })
+            .as_object()
+            .cloned()
+            .expect("object");
+        let share = crate::image_jobs::standalone_upscale_workflow_share(
+            &payload,
+            "real-esrgan",
+            4,
+            None,
+            0,
+            512,
+            512,
+        );
+        let upscale = share.upscale.as_ref().expect("the pass is recorded");
+        assert_eq!(upscale.engine.as_deref(), Some("real-esrgan"));
+        assert_eq!(upscale.factor, Some(4));
+        assert_eq!(
+            upscale.softness, None,
+            "recording a softness on an engine with no such knob would be inventing a fact"
         );
     }
 }

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -1107,6 +1107,22 @@ pub(crate) async fn run_image_upscale_job(
         // upscale result reveals whether the hardware EP ran or it fell back to CPU (sc-8923).
         upscale_settings["device"] = json!(device);
     }
+    // The sanitized workflow this PNG carries (epic 15945, sc-15948). This is a DISTINCT job with
+    // its own payload, so — per the story's rule for a derived pass — the envelope describes THIS
+    // pass and inherits nothing from whatever generated the source image. `engine_id` and `factor`
+    // are the APPLIED values (canonicalized and validated above), not the requested ones, and
+    // `softness` only travels for the engine that has the knob.
+    let workflow = crate::image_jobs::workflow_source(settings, &job.payload).map(|payload| {
+        crate::image_jobs::standalone_upscale_workflow_share(
+            &payload,
+            engine_id,
+            factor,
+            (engine_id == "seedvr2").then_some(softness),
+            seed as i64,
+            src_w,
+            src_h,
+        )
+    });
     let result = write_single_child_asset(
         &project_path,
         image::DynamicImage::ImageRgb8(upscaled),
@@ -1116,6 +1132,7 @@ pub(crate) async fn run_image_upscale_job(
             model: engine_id,
             adapter: engine_id,
             encode_label: "upscale encode task",
+            workflow,
         },
         |write| {
             json!({


### PR DESCRIPTION
Wires sc-15946 (the sanitized envelope) and sc-15947 (the PNG `iTXt` codec) into the three places the worker writes a generated PNG. Closes sc-15948.

## What changed

**The three write seams** — all three previously called `save_with_format(.., ImageFormat::Png)` and now call `sceneworks_core::workflow_png::write_workflow_chunk`:

| seam | file | envelope it carries |
|---|---|---|
| every generated image | `crates/sceneworks-worker/src/image_jobs.rs` — `write_image_asset` | the job's payload + **this** image's seed and geometry |
| inline upscale post-pass | `crates/sceneworks-worker/src/image_jobs.rs` — `write_upscaled_asset` | base recipe + the **applied** upscale pass |
| standalone detail refine | `crates/sceneworks-worker/src/image_jobs/detail.rs` | its **own** job payload + the resolved refine |

**Envelope building from a write seam.** `build_workflow_share` needed an `Asset`, and no sidecar exists yet when the worker writes the PNG. Split into `build_workflow_share_from(&WorkflowAssetFacts, &JsonObject)`, with `build_workflow_share` delegating — one implementation, so the allow-list, path guard and payload-over-facts precedence cannot drift between "embedded when the file was written" and "rebuilt from a sidecar". Pinned by `build_workflow_share_is_the_facts_builder`.

**The setting.** `embedWorkflowInImages`, default **on**, read at the write seam through the new `sceneworks_core::app_paths::embed_workflow_in_images(config_dir)`. It lives in the existing `ui-preferences.json` that `PUT /api/v1/ui-preferences` already persists into the config dir the desktop injects as `SCENEWORKS_CONFIG_DIR` — so no new channel, and reading it live (rather than caching at worker startup) means flipping the toggle takes effect on the next job, the same live-handoff shape as `gpu_memory_limit_file` (epic 7819). `UiPreferences` gains the field so a PUT round-trips it; sc-15953 still owns the toggle UI and the first-run disclosure.

**`cnScale` was being dropped.** `ADVANCED_KEY_RULES` classified only what `buildImageJobAdvanced` emits, but the standalone Detail pass has its own builder (`buildDetailJobBody` in `apps/web/src/imageJobs.js`) and exposes exactly two knobs: `strength` (allow-listed) and `cnScale` (unclassified, so silently dropped). Added as `allow_detail`, with a new `AdvancedKeySource::DetailBuilder` and a second coverage lint (`every_advanced_key_the_detail_pass_can_emit_is_classified`) holding that builder to the same both-directions rule. Without it a shared detail-refined image would describe half of what produced it.

**Encoder settings untouched.** No change to `encode_png_with_text` — `Compression::Fast` + `Filter::Adaptive` stay mirrored from `image`, and `the_some_path_is_the_none_path_plus_the_chunk` still passes over both DEFLATE regimes.

## Scope vs each acceptance criterion

- **All FOUR call sites embed when the setting is on** (review round two: there were four write seams, not three -- the standalone `image_upscale` job wrote through `single_child_asset.rs` with no chunk at all, and smart-select shares that seam with a documented `None`) — done; `a_generated_png_carries_the_sanitized_workflow_of_its_own_render` covers the funnel end to end (chunk read back off the written file, allow-list applied, no ids, no project name), and the two derived passes have their own tests.
- **Setting off produces byte-identical output to today** — `embedding_off_writes_the_bytes_sceneworks_writes_today` writes through the seam with the preference stored `false` and compares the resulting file **byte for byte** against a real `save_with_format` write of the same pixel buffer, then asserts the embedded variant differs (so it cannot pass because the writer is inert).
- **Generated PNG still decodes in a non-Rust reader** — verified against Python 3.14: an independent stdlib chunk walker (CRC-validated every chunk; order `IHDR iTXt(440) IDAT IEND`) and **PIL 12.2.0**, which decodes the pixels and surfaces the chunk under `Image.text["sceneworks:workflow"]` parsing to the same JSON. Output below.
- **Upscaled and detail outputs carry the pass that produced them** — the upscale overlay is the **applied** record, not the requested one (`aura-sr` / `3x` normalizes to `real-esrgan` / `2x` before running, so echoing the request would describe a pass nobody can reproduce), and it is the same `Value` the fact's `rawAdapterSettings.upscale` records so file and sidecar cannot disagree. The detail pass builds from its own payload with its own `mode`, backbone, prompt/negative (which live in `advanced`, not at the payload's top level), seed and output geometry — nothing base-generation is inherited.
- **Stub/dry-run paths do not crash with no payload** — `workflow_source` returns `None` for an empty payload, which takes the `save_with_format` path. `a_write_with_no_payload_embeds_nothing_and_still_succeeds` asserts absence, not error.
- **File-size delta measured on a representative batch** — **+446 / +449 / +448 / +446 bytes** at 512x512, 768x512, 1024x1024, 1280x720 (framed chunk 452 bytes on the richer example: 597 bytes of JSON deflating to 440). `the_embedded_chunk_costs_only_the_chunk_on_a_representative_batch` keeps it flat in the pixels and inside a band, so an encoder drift would show up as a kilobyte-scale move.

## Deliberate choices worth reviewing

- **Geometry on the upscaled variant stays the GENERATION geometry.** The envelope is a recipe: "render 1024 square then upscale 2x" replays to this image; "render 2048 square then upscale 2x" replays to something twice the size. `upscale` is the only key overlaid.
- **The base image's envelope DROPS `upscale`** (changed in review round two). It was reporting the request's pass, un-normalized: a 320x256 base PNG read `factor: 3, engine: "aura-sr"` -- a factor the worker does not offer and an engine that was dropped -- for a pass that file never received (`apply_inline_upscale` clamps and normalizes; `sanitize_upscale` does neither). The base render is not upscaled, so it says nothing about an upscale; the derived variant carries the pass, in applied terms.
- **The raw payload, not a re-serialized `ImageRequest`,** is what `ImagePlan` carries (`Option<Arc<JsonObject>>`) — the epic's decision, and it keeps the allow-list defined against the payload's own keys instead of a lossy round trip. `Arc` because the per-image writers clone the plan into `spawn_blocking`.
- **`upscaled_workflow_share` / `detail_workflow_share` are compiled under `test` on every platform** even though their callers are macOS/candle-gated, so the lineage contract is tested everywhere rather than only where an upscaler backend compiles.

## Tests

Added **24** (the first push added 12, not the 11 this section originally claimed; review round two added 12 more).

First round -- 12: 6 worker (`crates/sceneworks-worker/src/image_jobs/tests.rs`), 3 core `app_paths` unit, 2 core integration (`crates/sceneworks-core/tests/workflow_share.rs`), 1 rust-api (`preferences.rs`, which also asserts the API's stored field against the worker's reader directly).

Review round two -- 12:
- 8 core integration: the registry-driven coverage lint (`every_registered_builder_has_its_advanced_keys_classified`, `every_source_tag_names_exactly_one_registered_builder`, `every_deferred_builder_names_the_story_that_owns_it`, `every_advanced_builder_in_the_web_app_is_accounted_for`), the two newly-covered lanes (`every_advanced_key_the_character_lane_can_emit_is_classified`, `every_advanced_key_the_interleave_lane_can_emit_is_classified`), `the_standalone_upscale_builder_still_posts_no_advanced_map`, and `the_character_and_interleave_lane_knobs_survive_the_allow_list` (behaviour, not coverage).
- 2 worker `single_child_asset`: `an_upscaled_png_carries_the_workflow_of_the_pass_that_produced_it` (drives the real seam and reads the envelope back off the written file) and `a_softness_less_engine_records_no_softness`.
- 1 worker `image_jobs`: `the_base_image_of_an_inline_upscale_describes_no_upscale_pass` (asserts base and variant together on one generation).
- 1 core `app_paths`: `embedding_fails_closed_when_the_file_cannot_be_read`, split out of the bundled "every unreadable case" test so absence and I/O failure cannot be re-collapsed.

Each of the four functional review findings was mutation-proved: reverting the fix fails the named test, restoring it passes. The new-builder trip-wire was proved the same way, by adding an unregistered `advanced: { ... }` builder to a file the registry already covers.

- `cargo fmt --all -- --check` clean.
- `cargo clippy --all-targets -- -D warnings` clean (on a non-macOS host this is also the parity "neither" lane).
- `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` clean, so `write_upscaled_asset` is compile-verified on the lane that actually builds it (MSVC 14.44 + `CUDA_COMPUTE_CAP=120`).
- `cargo build --workspace` clean.
- `cargo test --workspace --no-fail-fast`: **23 failures, all pre-existing** — the rustls `No provider set` set in `sceneworks-mcp` (21) and `sceneworks-rust-api tests::mcp` (2), tracked as sc-15337. The count did not grow.
- `image_jobs/detail.rs` is `#[cfg(target_os = "macos")]` and cannot be compiled on this box; its change is a swap of the encode call plus a call into the ungated, tested envelope builder, reviewed by hand against the same pattern the candle lane compiles. It is untouched by review round two.
- `segment_jobs.rs` is also macOS-only; its one-line `workflow: None` was type-checked by temporarily flipping its module gate to `#[cfg(all())]` (plus `asset_media` / `single_child_asset`) and stubbing the MLX-only `person_segment_sam3` import -- **zero errors**, only dead-code warnings from the artificial gate. Reverted; the tree is clean.
- `npm run rust:check:candle` clean, which is what type-checks `upscale_jobs.rs`'s new envelope call on the lane that compiles it.

## Coverage lint, restructured (review round two)

`ADVANCED_BUILDERS` in `crates/sceneworks-core/src/workflow_share.rs` is a checked-in registry of every `(file, function, shape, lane)` that fills `advanced` for a lane that embeds; `DEFERRED_ADVANCED_BUILDERS` holds the ones whose lane does not embed yet, each naming sc-15956. `every_advanced_builder_in_the_web_app_is_accounted_for` walks `apps/web/src`, finds every `advanced: { }` / `advancedExtras: { }` / `advanced = { }` / `advanced.key =` and requires each to fall inside a declared function's body span -- so a new builder fails the build whether it is a new file, a new function in a covered file, or a new `advancedExtras` on a controller. Five builders were unlinted before this: `buildEditJobBody`, `CharacterAdvancedOptions.buildAdvanced`, both `advancedExtras` controllers, and `DocumentStudio.submit`. `buildUpscaleJobBody` is registered as `NoAdvancedMap` so the day it grows a knob it must be classified rather than dropped.

Newly classified: `angleSet` **allow** (it decides how many images exist -- a shared angle-set image was replaying as ONE image), `keypointCollectionId` **deny** (a local Key Point Library id), `systemMessage` **allow/PROSE** (authored text the model saw, same class as `stylePrompt`; bounding it as a slug would silently drop a system message that mentions a directory) and `imageGuidanceScale` **allow** on the interleave lane this story turned into an embedding lane.

## External decoder output

```
file bytes: 164594
chunks: IHDR(13) iTXt(440) IDAT(164085) IEND(0)
iTXt keyword: sceneworks:workflow | compressed: 1 | method: 0
decompressed text bytes: 597
PIL: PNG RGB (640, 480)
PIL pixels [0,0] / [639,479]: (0, 0, 0) (213, 239, 23)
PIL .text keys: ['sceneworks:workflow']
OK
```

The envelope it read back carried the CJK + emoji prompt intact, `advanced` reduced to `steps` / `sampler` / `guidanceScale` (with `mlxQuantize` and `flashAttn` gone), the source image as `inputs: [{kind: "source", count: 1}]`, and no local asset id anywhere.

## Follow-ups (not in this story)

- `crates/sceneworks-worker/src/upscale_jobs.rs` and `single_child_asset.rs` (the **standalone** upscale job and smart-select) write PNGs through a shared child-asset helper and embed nothing. They are transformations of an existing asset rather than generations, and the story names three seams — worth deciding deliberately rather than by omission.
- A hand-crafted `image_detail` payload can override `advanced.tile` / `advanced.overlap` / `advanced.tileControlNetRepo`, which stay unclassified and therefore do not travel. `tile` / `overlap` are tile geometry — a VRAM accommodation, so dropping them looks right — but no rule says so out loud. Not reachable from the UI today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


