### PR TITLE
feat(workflow-share): read the embedded workflow on asset import (sc-15949)

### DIFF
--- a/apps/rust-api/src/assets.rs
+++ b/apps/rust-api/src/assets.rs
@@ -165,9 +165,23 @@ pub(crate) async fn import_asset(
                         .await
                         .map_err(|error| ApiError::bad_request(error.to_string()))?;
                     if !value.trim().is_empty() {
-                        provenance = Some(serde_json::from_str(&value).map_err(|error| {
-                            ApiError::bad_request(format!("Invalid provenance JSON: {error}"))
-                        })?);
+                        let parsed: serde_json::Value =
+                            serde_json::from_str(&value).map_err(|error| {
+                                ApiError::bad_request(format!("Invalid provenance JSON: {error}"))
+                            })?;
+                        // `provenance` is written into the sidecar's `extra` OBJECT, so anything
+                        // else is refused here rather than reshaped downstream. Any non-blank JSON
+                        // text used to be accepted, including `42`, `"editor"`, `[1,2]` and `null`,
+                        // and the store then made `extra` that value — which since sc-15949 also
+                        // discards an embedded workflow the import had already read out of the
+                        // file. `ProjectStore::import_asset` refuses the same shape, so neither
+                        // layer depends on the other for it.
+                        if !parsed.is_object() {
+                            return Err(ApiError::bad_request(
+                                "Invalid provenance JSON: provenance must be a JSON object",
+                            ));
+                        }
+                        provenance = Some(parsed);
                     }
                 }
                 _ => {}

--- a/apps/rust-api/src/tests/uploads.rs
+++ b/apps/rust-api/src/tests/uploads.rs
@@ -106,6 +106,77 @@ async fn import_asset_removes_staged_temp_file_when_a_later_field_errors() {
 }
 
 #[tokio::test]
+async fn import_asset_rejects_a_provenance_that_is_not_an_object() {
+    // sc-15949 review: any non-blank JSON text was accepted here, and the store then made the
+    // sidecar's `extra` slot that value verbatim. Once sc-15949 gave `extra` a second writer, that
+    // became a silent-loss path — `provenance=42` (or `null`, or `[1,2]`) discarded a workflow the
+    // import had already read out of the PNG. `extra` is an object in the contract, so anything
+    // else is refused at the boundary, and the staged temp is still cleaned up.
+    for provenance in ["42", "\"editor\"", "[1,2]", "null"] {
+        let temp_dir = tempfile::tempdir().expect("temp dir creates");
+        let settings = test_settings(&temp_dir);
+        let data_dir = settings.data_dir.clone();
+        let app = create_app(settings).expect("app creates");
+
+        let boundary = "SCENEWORKS_SCALAR_PROVENANCE_BOUNDARY";
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"x.png\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+        body.extend_from_slice(b"\x89PNG\r\n\x1a\n payload bytes");
+        body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"provenance\"\r\n\r\n");
+        body.extend_from_slice(provenance.as_bytes());
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+        let (status, _, response) = request_raw(
+            app,
+            "POST",
+            "/api/v1/projects/project-1/assets",
+            body,
+            &[(
+                "content-type",
+                &format!("multipart/form-data; boundary={boundary}"),
+            )],
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "provenance={provenance} must be refused"
+        );
+        let value: Value = serde_json::from_slice(&response).expect("json body parses");
+        // The API's own sentence, matched exactly. `ProjectStore::import_asset` refuses the same
+        // shape with a different one ("Upload provenance must be a JSON object"), and a loose
+        // `contains` would match either — so this test would pass with the boundary check removed
+        // and only the store's belt holding.
+        assert!(
+            value["detail"].as_str().is_some_and(
+                |detail| detail == "Invalid provenance JSON: provenance must be a JSON object"
+            ),
+            "provenance={provenance} produced {:?}",
+            value["detail"]
+        );
+
+        let upload_root = data_dir.join("cache").join("uploads");
+        let leaked: Vec<_> = std::fs::read_dir(&upload_root)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .filter(|entry| entry.file_name().to_string_lossy().starts_with("upload-"))
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            leaked.is_empty(),
+            "staged upload temp file leaked on provenance={provenance}: {leaked:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn import_asset_rejects_duplicate_file_field_and_cleans_first_temp() {
     // sc-8883 (F-081): a second `file` field must be rejected (400), and the first
     // already-staged temp must be cleaned up rather than orphaned until the 24h sweep.

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -50,7 +50,10 @@ const DEFAULT_COUNT: u32 = 4;
 /// The payload-sanity bounds on batch size. NOT a model's limit: that is `limits.count`, which is
 /// still unread (sc-12335 — a menu, and a separate question from this default).
 const MIN_COUNT: u32 = 1;
-const MAX_COUNT: u32 = 8;
+/// `pub(crate)` so `workflow_share`'s pose budget can be derived from it rather than restate it:
+/// a pose set is the pose lane's batch size (one image per pose), so this is the ceiling it is
+/// measured against.
+pub(crate) const MAX_COUNT: u32 = 8;
 
 /// `defaults.count` from a resolved manifest entry, or `None` for the blanket [`DEFAULT_COUNT`].
 ///

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -1865,6 +1865,25 @@ impl ProjectStore {
                 "Uploaded file is empty".to_owned(),
             ));
         }
+        // `extra` is an object in the sidecar contract, and `provenance` is written into it, so a
+        // provenance that is not an object is refused here rather than reshaped or ignored.
+        //
+        // It used to be written through verbatim, which made `extra` a scalar — and once sc-15949
+        // had a second writer of that slot, it became a silent-loss path: a `provenance` of `42`,
+        // `"editor"`, `[1,2]` or `null` would take the whole slot and throw away a workflow the
+        // reader had already found in the file. Rejecting is the only answer that neither loses the
+        // envelope nor quietly rewrites what the caller sent. `apps/rust-api/src/assets.rs` refuses
+        // the same shape at the multipart boundary, so this is the belt to that braces; the API is
+        // the only production caller.
+        if upload
+            .provenance
+            .as_ref()
+            .is_some_and(|provenance| !provenance.is_object())
+        {
+            return Err(ProjectStoreError::BadRequest(
+                "Upload provenance must be a JSON object".to_owned(),
+            ));
+        }
         let (project_path, _project_guard) = self.lock_project(project_id)?;
         let upload_dir = project_path.join("assets").join("uploads");
         fs::create_dir_all(&upload_dir)?;
@@ -1982,35 +2001,34 @@ impl ProjectStore {
         // recipe"; nothing here fabricates a `text_to_image` mode, a seed we did not run, or a
         // generation set that never existed.
         if let Some(object) = asset.as_object_mut() {
-            match &upload.provenance {
-                // A provenance that is not an object stays exactly what it is today: the whole
-                // `extra` value. Merging is not possible, and quietly reshaping a caller's explicit
-                // blob to make room for a field it did not ask for is the wrong trade.
-                Some(provenance) if !provenance.is_object() => {
-                    object.insert("extra".to_owned(), provenance.clone());
-                }
-                _ => {
-                    let mut extra = upload
-                        .provenance
-                        .as_ref()
-                        .and_then(Value::as_object)
-                        .cloned()
-                        .unwrap_or_default();
-                    // Inserted LAST, so `extra.importedWorkflow` is always the envelope this import
-                    // read and sanitized, and never free JSON a caller put under that key in
-                    // `provenance`.
-                    if let Some(workflow) = normalized
-                        .workflow
-                        .as_ref()
-                        .and_then(|share| serde_json::to_value(share).ok())
-                    {
-                        extra.insert(IMPORTED_WORKFLOW_KEY.to_owned(), workflow);
-                    }
-                    // Still nothing to record: leave the key absent, exactly as before.
-                    if !extra.is_empty() {
-                        object.insert("extra".to_owned(), Value::Object(extra));
-                    }
-                }
+            // A non-object provenance was already refused at the top of this function, so this is
+            // the only shape left.
+            let provenance = upload.provenance.as_ref().and_then(Value::as_object);
+            let mut extra = provenance.cloned().unwrap_or_default();
+            // Cleared UNCONDITIONALLY, before the insert below and whether or not there is anything
+            // to insert. `extra.importedWorkflow` is defined as the envelope THIS import read and
+            // sanitized, so the key must be either ours or absent — never free JSON a caller put
+            // under it in `provenance`.
+            //
+            // Inserting ours last is not enough on its own, and that was the bug: when the file
+            // carries no chunk there is nothing to insert, and a caller-supplied
+            // `provenance.importedWorkflow` was written through untouched — an unsanitized `model`,
+            // an `advanced` map the allow-list would have emptied, and a `loras[].repo` of
+            // `../../../../etc/passwd` in the one field sc-15950/sc-15952 turn into a cache path.
+            // The guard has to be a removal, not an ordering.
+            extra.remove(IMPORTED_WORKFLOW_KEY);
+            if let Some(workflow) = normalized
+                .workflow
+                .as_ref()
+                .and_then(|share| serde_json::to_value(share).ok())
+            {
+                extra.insert(IMPORTED_WORKFLOW_KEY.to_owned(), workflow);
+            }
+            // An explicit `provenance` keeps its slot even when it reduces to nothing, because
+            // `provenance: {}` wrote `extra: {}` before this story and "no behaviour change" means
+            // the empty object too. With no provenance and no workflow, `extra` stays absent.
+            if provenance.is_some() || !extra.is_empty() {
+                object.insert("extra".to_owned(), Value::Object(extra));
             }
         }
         let sidecar_path = media_path.with_extension("sceneworks.json");
@@ -9816,6 +9834,130 @@ mod tests {
             serde_json::to_value(&share).expect("serializes"),
             "the import's own sanitized envelope must win over one supplied in provenance"
         );
+
+        // The case that made "inserted last" a false claim: the SAME injected provenance, on a file
+        // with NO chunk. There is nothing to insert, so ordering protects nothing — the key has to
+        // be REMOVED, or a caller's free JSON lands under it untouched. Everything below is what
+        // was reaching the sidecar before the removal: a traversal `loras[].repo` in the one field
+        // sc-15950/sc-15952 turn into a cache path, an unsanitized absolute `model`, and an
+        // `advanced` map the allow-list would have emptied.
+        let plain = temp_dir.path().join("plain.png");
+        std::fs::write(&plain, sceneworks_png(None)).expect("staged upload writes");
+        let injected = json!({
+            "editor": "image_editor",
+            IMPORTED_WORKFLOW_KEY: {
+                "sceneworksWorkflow": "image",
+                "schemaVersion": 1,
+                "model": "C:\\Users\\Victim\\models\\evil",
+                "prompt": "injected",
+                "loras": [{ "repo": "../../../../etc/passwd" }],
+                "advanced": { "anythingAtAll": { "nested": "free JSON" } },
+            },
+        });
+        let asset = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "plain.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: plain,
+                    source_asset_id: None,
+                    provenance: Some(injected),
+                },
+            )
+            .expect("imports");
+        assert_eq!(
+            asset["extra"],
+            json!({ "editor": "image_editor" }),
+            "with no chunk to record, `{IMPORTED_WORKFLOW_KEY}` must be ABSENT — the key is either \
+             the envelope this import parsed or nothing, never a caller's free JSON"
+        );
+        let encoded = serde_json::to_string(&asset["extra"]).expect("serializes");
+        for leak in ["etc/passwd", "Victim", "anythingAtAll", "injected"] {
+            assert!(
+                !encoded.contains(leak),
+                "{leak} was injected through provenance and reached the sidecar: {encoded}"
+            );
+        }
+    }
+
+    #[test]
+    fn import_asset_refuses_a_provenance_that_is_not_an_object() {
+        // `extra` is an object in the sidecar contract, and a scalar `provenance` used to become the
+        // whole slot — which, once sc-15949 gave that slot a second writer, silently discarded a
+        // workflow the reader had already found in the file. `Some(Value::Null)` is reachable from
+        // the API today (any non-blank JSON text was accepted), so this is not hypothetical.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Provenance").expect("project creates");
+
+        let share = workflow_fixture("a lighthouse");
+        let embedded = sceneworks_png(Some(&share));
+        for provenance in [json!(42), json!("editor"), json!([1, 2]), Value::Null] {
+            let source = temp_dir.path().join(format!(
+                "scalar-{}.png",
+                crate::store_util::random_hex(6).expect("hex")
+            ));
+            std::fs::write(&source, &embedded).expect("staged upload writes");
+            let error = store
+                .import_asset(
+                    &project.id,
+                    UploadAsset {
+                        filename: "scalar.png".to_owned(),
+                        content_type: Some("image/png".to_owned()),
+                        source_path: source,
+                        source_asset_id: None,
+                        provenance: Some(provenance.clone()),
+                    },
+                )
+                .expect_err("a non-object provenance must be refused, not silently preferred");
+            assert!(
+                matches!(&error, ProjectStoreError::BadRequest(message)
+                    if message.contains("provenance must be a JSON object")),
+                "{provenance} produced the wrong error: {error}"
+            );
+        }
+
+        // An empty object is not a non-object: it keeps its slot, exactly as it did before this
+        // story, and still makes room for the envelope beside it.
+        let source = temp_dir.path().join("empty-provenance.png");
+        std::fs::write(&source, sceneworks_png(None)).expect("staged upload writes");
+        let plain = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "empty.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: source,
+                    source_asset_id: None,
+                    provenance: Some(json!({})),
+                },
+            )
+            .expect("imports");
+        assert_eq!(
+            plain["extra"],
+            json!({}),
+            "`provenance: {{}}` wrote `extra: {{}}` before sc-15949 and must still"
+        );
+
+        let source = temp_dir.path().join("empty-provenance-with-chunk.png");
+        std::fs::write(&source, &embedded).expect("staged upload writes");
+        let shared = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "shared.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: source,
+                    source_asset_id: None,
+                    provenance: Some(json!({})),
+                },
+            )
+            .expect("imports");
+        assert_eq!(
+            shared["extra"][IMPORTED_WORKFLOW_KEY],
+            serde_json::to_value(&share).expect("serializes")
+        );
     }
 
     #[test]
@@ -9946,6 +10088,28 @@ mod tests {
             corrupt[offset] ^= 0xFF;
             corpus.push((format!("bit flipped at {offset}"), corrupt));
         }
+        // The corpus size, derived and printed rather than described in prose — a claim about it was
+        // wrong by nearly 2x ("~110 imports") because nobody ever multiplied it out.
+        //
+        // NOT asserted as a literal, and that is deliberate: the count is a function of the fixture
+        // PNG's byte length, which is the length of a DEFLATE stream produced by whatever compressor
+        // the `png` crate links. It is 492 bytes here and has been observed at 417, and neither
+        // number is a property of this test. So the derivation is asserted and the count is printed;
+        // a run's own output is the only honest source for it.
+        let truncations = (AFTER_IHDR..good.len()).step_by(11).count();
+        let flips = (8..good.len()).step_by(23).count();
+        assert_eq!(
+            corpus.len(),
+            8 + 2 + truncations + flips,
+            "8 named fixtures + 2 broken-pixel files + one truncation every 11 bytes + one bit flip \
+             every 23 bytes"
+        );
+        println!(
+            "sc-15949: {} imports over the corpus ({} byte fixture: {truncations} truncations, \
+             {flips} bit flips)",
+            corpus.len(),
+            good.len()
+        );
 
         let intact = serde_json::to_value(workflow_fixture("a lighthouse")).expect("serializes");
         for (label, bytes) in corpus {
@@ -10105,6 +10269,221 @@ mod tests {
     }
 
     #[test]
+    fn a_chunk_cannot_amplify_itself_into_the_asset_index() {
+        // The other half of the trust boundary, and the one the path guards said nothing about: not
+        // what the values ARE but how MANY of them there are. Every string in the envelope below is
+        // legitimate; only the counts are hostile.
+        //
+        // sc-15947's 1 MiB cap is on the DECOMPRESSED chunk text, and a repetitive envelope
+        // compresses ~100x — so before the collection bounds, the 8,897-byte PNG built here
+        // produced a 988,271-byte `extra.importedWorkflow`, an equally large sidecar, an equally
+        // large `assets.asset_json` row, and a 989,210-byte `list_assets` response for ONE asset.
+        // Persistent, and in the Library's hottest read path (sc-14797 / sc-14798): 100 of these
+        // 9 kB files, 0.9 MB on disk, made the listing ~100 MB. Reading the chunk is what exposed
+        // it, so it is bounded here.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Amplify").expect("project creates");
+
+        let prose = "z".repeat(20_000);
+        let envelope = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": prose,
+            "negativePrompt": prose,
+            // Identical entries, because that is the shape that maximizes the compression ratio and
+            // so the amplification: the attacker's cost is the COMPRESSED chunk and ours is the
+            // decompressed envelope we then persist forever.
+            "loras": (0..8_000)
+                .map(|_| json!({ "name": "Ghibli watercolor", "repo": "acme/ghibli", "weight": 0.8 }))
+                .collect::<Vec<Value>>(),
+            "inputs": (0..8_000)
+                .map(|_| json!({ "kind": "reference", "count": 1 }))
+                .collect::<Vec<Value>>(),
+            "advanced": {
+                "steps": 8,
+                "stylePrompt": prose,
+                // Smaller counts than the two above only because the whole envelope has to stay
+                // under sc-15947's 1 MiB text cap to reach these bounds at all; 100 is still well
+                // over both caps, and the unit tests in `workflow_share` run the 8,000 case.
+                "poses": (0..100).map(|_| json!({ "keypoints": [[0.1, 0.2]] })).collect::<Vec<Value>>(),
+                "phases": (0..100).map(|_| json!({ "steps": 4, "guidance": 3.5 })).collect::<Vec<Value>>(),
+            },
+        })
+        .to_string();
+        assert!(
+            envelope.len() < crate::workflow_png::MAX_WORKFLOW_TEXT_BYTES,
+            "the fixture must be UNDER the text cap ({} bytes) or the reader refuses it and these \
+             bounds are never reached",
+            envelope.len()
+        );
+        let bytes = splice_after_ihdr(
+            &sceneworks_png(None),
+            &framed_itxt(crate::workflow_png::WORKFLOW_CHUNK_KEYWORD, &envelope, true),
+        );
+        let source = temp_dir.path().join("amplify.png");
+        std::fs::write(&source, &bytes).expect("staged upload writes");
+        let asset = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "amplify.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: source,
+                    source_asset_id: None,
+                    provenance: None,
+                },
+            )
+            .expect("a bounded envelope still imports");
+
+        let recorded = &asset["extra"][IMPORTED_WORKFLOW_KEY];
+        // Measured and PRINTED before anything is asserted, so reverting a bound to check this test
+        // still bites also reports what the amplification was.
+        let recorded_bytes = serde_json::to_string(recorded).expect("serializes").len();
+        let payload_bytes = serde_json::to_string(
+            &store
+                .list_assets(&project.id, false, false, AssetScope::All)
+                .expect("lists"),
+        )
+        .expect("serializes")
+        .len();
+        let asset_json_bytes: String = Connection::open(
+            store
+                .find_project_path(&project.id)
+                .expect("project path")
+                .join("project.db"),
+        )
+        .expect("opens project.db")
+        .query_row(
+            "select asset_json from assets where id = ?1",
+            params![asset["id"].as_str().expect("id")],
+            |row| row.get(0),
+        )
+        .expect("the row is indexed");
+        println!(
+            "sc-15949: {} byte PNG -> {recorded_bytes} byte workflow, {} byte asset_json, \
+             {payload_bytes} byte list_assets payload",
+            bytes.len(),
+            asset_json_bytes.len()
+        );
+
+        // Every unbounded collection is gone; the recipe around them still travels, so this is not
+        // passing by refusing the envelope wholesale.
+        assert!(
+            recorded.get("loras").is_none(),
+            "{:?}",
+            recorded.get("loras")
+        );
+        assert!(recorded.get("inputs").is_none());
+        assert!(recorded["advanced"].get("poses").is_none());
+        assert!(recorded["advanced"].get("phases").is_none());
+        assert_eq!(recorded["advanced"]["steps"], json!(8));
+        assert_eq!(recorded["model"], json!("z_image_turbo"));
+
+        // What is left is the prose allowance, which is the documented ceiling this file already
+        // accepted (`PROSE_MAX_CHARS`: three 20 k fields here). An upper bound rather than an
+        // equality, so this is a REGRESSION guard and not a fixture: what it catches is a new
+        // unbounded collection appearing later. The same fixture with the bounds reverted:
+        // 817,592 bytes recorded, 818,485 in `asset_json`, 818,551 in the `list_assets` payload —
+        // from a 7,389-byte PNG, so 111x.
+        const CEILING: usize = 200 * 1024;
+        assert!(
+            recorded_bytes < CEILING,
+            "the recorded envelope is {recorded_bytes} bytes, over the {CEILING} byte ceiling"
+        );
+        assert!(
+            asset_json_bytes.len() < CEILING,
+            "asset_json is {} bytes",
+            asset_json_bytes.len()
+        );
+        assert!(
+            payload_bytes < CEILING,
+            "the list_assets payload is {payload_bytes} bytes for a single asset"
+        );
+    }
+
+    /// The measurement behind the table in [`the_workflow_scan_reads_chunks_and_never_the_pixels`].
+    ///
+    /// Ignored because it writes hundreds of megabytes and asserts a shape rather than a threshold —
+    /// but it is IN the tree rather than done out of band, because that table has been wrong once
+    /// already. Refresh it with:
+    ///
+    /// ```text
+    /// cargo test -p sceneworks-core --release --lib the_cost_of_the_scan_against_file_size \
+    ///     -- --ignored --nocapture
+    /// ```
+    ///
+    /// Two files per size: one carrying the chunk (the SceneWorks case, answered in pass one) and one
+    /// carrying none (every foreign PNG, which walks the whole file). Incompressible pixels, so the
+    /// bytes on disk are the bytes the scan has to move past — a smooth render compresses away and
+    /// makes the miss look far cheaper than it is on a real photograph.
+    #[test]
+    #[ignore = "measurement: writes >200 MB of PNG; run explicitly to refresh the table"]
+    fn the_cost_of_the_scan_against_file_size() {
+        /// A cheap LCG, so "incompressible" needs no dependency.
+        fn noise(side: u32) -> image::RgbImage {
+            let mut state = 0x2545_F491_4F6C_DD1D_u64;
+            image::RgbImage::from_fn(side, side, |_, _| {
+                let mut channel = || {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    u8::try_from((state >> 33) & 0xFF).expect("masked to a byte")
+                };
+                image::Rgb([channel(), channel(), channel()])
+            })
+        }
+        fn elapsed_micros(mut work: impl FnMut()) -> u128 {
+            // Three passes, best of; the first pays for the page cache.
+            (0..3)
+                .map(|_| {
+                    let start = std::time::Instant::now();
+                    work();
+                    start.elapsed().as_micros()
+                })
+                .min()
+                .expect("three passes")
+        }
+
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let share = workflow_fixture("a lighthouse");
+        println!(
+            "| side | bytes | scan, chunk found | scan, no chunk | plain read | FULL DECODE |"
+        );
+        for side in [1024_u32, 2048, 4096, 6144] {
+            let pixels = noise(side);
+            for (label, embedded) in [("hit", true), ("miss", false)] {
+                let path = temp_dir.path().join(format!("{side}-{label}.png"));
+                crate::workflow_png::write_workflow_chunk(
+                    &pixels,
+                    &path,
+                    embedded.then_some(&share),
+                )
+                .expect("writes");
+                let bytes = std::fs::metadata(&path).expect("metadata").len();
+                let scan = elapsed_micros(|| {
+                    let _ = crate::workflow_png::read_workflow_chunk_file(&path);
+                });
+                let read = elapsed_micros(|| {
+                    let _ = std::fs::read(&path).expect("reads");
+                });
+                let decode = elapsed_micros(|| {
+                    let _ = image::open(&path).expect("decodes");
+                });
+                println!(
+                    "| {side}² {label} | {bytes} | {scan} µs | plain read {read} µs | decode \
+                     {decode} µs | scan/read {:.2}x | scan/decode {:.0}% |",
+                    scan as f64 / read as f64,
+                    100.0 * scan as f64 / decode as f64
+                );
+            }
+        }
+    }
+
+    #[test]
     fn the_workflow_scan_reads_chunks_and_never_the_pixels() {
         // The regression this guards is a quiet one: making the scan work by decoding the image.
         // `normalize_image_upload` exists to store a natively-supported upload WITHOUT a decode,
@@ -10115,19 +10494,34 @@ mod tests {
         // Any decode on this path would fail. The import succeeds and reads the recipe, so nothing
         // decoded.
         //
-        // Measured alongside it, on `soft_render_rgb`-shaped PNGs in release, so the throughput
-        // claim is a number rather than a hope:
+        // Measured alongside it by `the_cost_of_the_scan_against_file_size` below (release,
+        // incompressible pixels so the bytes on disk are bytes the scan must move past — a smooth
+        // render compresses away and flatters the miss):
         //
-        // |          | scan, chunk found | scan, no chunk | plain file read | FULL DECODE |
-        // |----------|-------------------|----------------|-----------------|-------------|
-        // | 1024²    |             81 µs |         144 µs |           36 µs |     4.31 ms |
-        // | 2048²    |             47 µs |         292 µs |          104 µs |    13.36 ms |
+        // |         |    on disk | scan, chunk found | scan, no chunk | plain read | FULL DECODE |
+        // |---------|------------|-------------------|----------------|------------|-------------|
+        // | 1024²   |    3.0 MiB |             44 µs |         870 µs |     681 µs |     1.39 ms |
+        // | 2048²   |   12.0 MiB |             89 µs |        3.99 ms |    2.64 ms |     5.29 ms |
+        // | 4096²   |   48.0 MiB |             96 µs |       17.08 ms |   13.45 ms |    24.77 ms |
+        // | 6144²   |  108.0 MiB |            101 µs |       41.04 ms |   30.53 ms |    57.03 ms |
         //
-        // A SceneWorks image answers in pass one and stops at the first IDAT, so its cost barely
-        // moves with the pixel count. The miss — every foreign PNG — walks the tail framing and CRCs
-        // the bytes on their way past: ~3x a plain read of the same file, and 2-3% of what decoding
-        // it would cost. That is the difference between a metadata walk and the decode-everything
-        // path this test exists to keep us out of.
+        // Two different curves, and only one of them is flat.
+        //
+        // The HIT — a SceneWorks image — answers in pass one and stops at the first IDAT: 44 µs to
+        // 101 µs across a 36x range of file size. That is the structural property this test defends,
+        // and it holds: no pixel inflate, and nothing allocated in proportion to the pixels.
+        //
+        // The MISS — every foreign PNG — is O(file), because sc-15947's reader makes a second pass
+        // over the framing past IDAT to be sure there is no late chunk and no duplicate. It costs
+        // ~1.3x a plain read of the same file and 63-76% of a full decode; at 48 MiB it is 70%.
+        // Roughly 0.36 s per GB imported, and NET-NEW: `move_or_copy_file` renames the upload rather
+        // than reading it, and nothing else on the import path touches the image media, so before
+        // sc-15949 a large foreign PNG was never read end to end at all.
+        //
+        // So the honest claim is narrow: the scan is not a decode and does not scale with pixels on
+        // the SceneWorks path, and on the foreign path it is one sequential pass — cheaper than
+        // decoding, but the same order, not the "2-3%" an earlier version of this comment claimed
+        // from small compressible renders.
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
         let project = store.create_project("NoDecode").expect("project creates");

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -10268,141 +10268,299 @@ mod tests {
         assert_upload_stub_recipe(&asset, "hostile.png");
     }
 
+    /// Every string in these envelopes is legitimate; only the volume is hostile.
+    ///
+    /// sc-15947's 1 MiB cap is on the DECOMPRESSED chunk text, and a repetitive envelope compresses
+    /// ~100x — so what an attacker pays is the compressed chunk and what we pay is the decompressed
+    /// envelope, persisted into the sidecar, the `assets.asset_json` row and every `list_assets`
+    /// response for that asset (sc-14797 / sc-14798) forever.
+    ///
+    /// The history is why this is a table of cases rather than one fixture. The first fix was
+    /// per-collection caps, measured on a fixture whose own size fell with the fix — so the reported
+    /// "111x -> 8x" was an artifact of a shrinking denominator, and the real worst case at that point
+    /// was WORSE than before. Each row below is a vector found after the caps were in place, and each
+    /// is measured in ABSOLUTE bytes at both ends:
+    ///
+    /// | case | PNG | recorded before | recorded after |
+    /// |------|-----|-----------------|----------------|
+    /// | six prose slots of U+1F600 x the cap | 3,633 | 480,321 | 98,654 |
+    /// | 112,128 `null` coordinates over 64 poses | 5,630 | 681,995 | 98,671 |
+    /// | six ASCII prose slots, nothing over any cap | 1,668 | 120,321 | 98,654 |
+    /// | 200,000 empty arrays under one `keypoints` | 4,589 | 720,347 | 98,667 |
+    /// | every bound at once, poses at the slot budget | 3,045 | 221,407 | none recorded |
+    ///
+    /// Measured by running THIS test with the guards reverted one set at a time, not from a separate
+    /// harness, so the "before" column is the same fixture as the "after" one. The `list_assets`
+    /// payload for one asset tracks the recorded envelope within a kilobyte in every row.
+    ///
+    /// The ratio is deliberately not the assertion. The PNG carries the COMPRESSED envelope, so a
+    /// repetitive payload will always have a large ratio; what is bounded is the absolute size of
+    /// what we persist, by `workflow_share::WORKFLOW_SHARE_MAX_BYTES`, and that is what is asserted.
     #[test]
     fn a_chunk_cannot_amplify_itself_into_the_asset_index() {
-        // The other half of the trust boundary, and the one the path guards said nothing about: not
-        // what the values ARE but how MANY of them there are. Every string in the envelope below is
-        // legitimate; only the counts are hostile.
-        //
-        // sc-15947's 1 MiB cap is on the DECOMPRESSED chunk text, and a repetitive envelope
-        // compresses ~100x — so before the collection bounds, the 8,897-byte PNG built here
-        // produced a 988,271-byte `extra.importedWorkflow`, an equally large sidecar, an equally
-        // large `assets.asset_json` row, and a 989,210-byte `list_assets` response for ONE asset.
-        // Persistent, and in the Library's hottest read path (sc-14797 / sc-14798): 100 of these
-        // 9 kB files, 0.9 MB on disk, made the listing ~100 MB. Reading the chunk is what exposed
-        // it, so it is bounded here.
-        let temp_dir = tempfile::tempdir().expect("temp dir");
-        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
-        let project = store.create_project("Amplify").expect("project creates");
+        /// The recorded envelope must stay under this many bytes, in every case below.
+        ///
+        /// `WORKFLOW_SHARE_MAX_BYTES` plus the sidecar's own fields, asserted against the shipped
+        /// constant rather than chosen — a ceiling this test picked for itself would drift away from
+        /// the one the reader enforces. The old form of this assertion was 200 KiB and passed for the
+        /// wrong reason: the fixture used three ASCII prose slots, so the six-slot multi-byte case it
+        /// was meant to cover was 480 kB and never ran.
+        const CEILING: usize = crate::workflow_share::WORKFLOW_SHARE_MAX_BYTES + 4 * 1024;
 
-        let prose = "z".repeat(20_000);
-        let envelope = json!({
-            "sceneworksWorkflow": "image",
-            "schemaVersion": 1,
-            "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
-            "mode": "text_to_image",
-            "model": "z_image_turbo",
-            "prompt": prose,
-            "negativePrompt": prose,
-            // Identical entries, because that is the shape that maximizes the compression ratio and
-            // so the amplification: the attacker's cost is the COMPRESSED chunk and ours is the
-            // decompressed envelope we then persist forever.
-            "loras": (0..8_000)
-                .map(|_| json!({ "name": "Ghibli watercolor", "repo": "acme/ghibli", "weight": 0.8 }))
-                .collect::<Vec<Value>>(),
-            "inputs": (0..8_000)
-                .map(|_| json!({ "kind": "reference", "count": 1 }))
-                .collect::<Vec<Value>>(),
-            "advanced": {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        // 4-byte scalars, so the six prose slots are as wide in BYTES as the bound allows. This is
+        // the case the char-counted bound missed entirely.
+        let emoji = "\u{1F600}".repeat(20_000);
+        let ascii = "z".repeat(20_000);
+        // 1,752 nulls x 64 poses = 112,128 coordinate slots, none of which cost anything against a
+        // budget that counted only `Value::Number`.
+        let nulls: Vec<Value> = (0..1_752).map(|_| Value::Null).collect();
+        let null_poses: Vec<Value> = (0..64)
+            .map(|_| json!({ "keypoints": nulls.clone() }))
+            .collect();
+        // `[]` is vacuously "all coordinates", so it passed the shape check AND cost nothing.
+        let empty_arrays: Vec<Value> = (0..200_000).map(|_| json!([])).collect();
+        // Every bound at once: six prose slots, every allow-listed scalar label at its own cap, a
+        // pose set at the slot budget, a full phase schedule. Each field is individually legal, and
+        // together they are what per-field bounds cannot see.
+        let label = "L".repeat(200);
+        let point = json!([0.123_456_789_012_345_67, 0.987_654_321_098_765_4, 0.55]);
+        let skeleton: Vec<Value> = (0..128).map(|_| point.clone()).collect();
+        let mut maxed = crate::contracts::JsonObject::new();
+        for key in [
+            "resolution",
+            "sampler",
+            "scheduler",
+            "schedulerShift",
+            "steps",
+            "guidanceScale",
+            "guidanceMethod",
+            "enhancePrompt",
+            "usePid",
+            "pidTarget",
+            "ipAdapterScale",
+            "controlnetConditioningScale",
+            "trueCfgScale",
+            "strength",
+            "textStyleGain",
+            "viewAngle",
+            "faceRestore",
+            "controlMode",
+            "controlScale",
+            "styleId",
+            "cnScale",
+            "angleSet",
+            "imageGuidanceScale",
+        ] {
+            maxed.insert(key.to_owned(), json!(label));
+        }
+        maxed.insert(
+            "poses".to_owned(),
+            json!((0..16)
+                .map(|_| json!({ "keypoints": skeleton.clone() }))
+                .collect::<Vec<Value>>()),
+        );
+        maxed.insert(
+            "phases".to_owned(),
+            json!((0..8)
+                .map(|_| json!({
+                    "steps": 4,
+                    "guidance": 3.5,
+                    "loras": (0..5)
+                        .map(|index| json!({ "index": index, "weight": 0.123_456_789 }))
+                        .collect::<Vec<Value>>()
+                }))
+                .collect::<Vec<Value>>()),
+        );
+
+        let cases: Vec<(&str, &String, crate::contracts::JsonObject)> = vec![
+            (
+                "six 4-byte prose slots",
+                &emoji,
+                crate::contracts::JsonObject::new(),
+            ),
+            (
+                "112,128 null coordinates",
+                &ascii,
+                json!({ "poses": null_poses })
+                    .as_object()
+                    .cloned()
+                    .expect("object"),
+            ),
+            (
+                "six ASCII prose slots",
+                &ascii,
+                crate::contracts::JsonObject::new(),
+            ),
+            (
+                "200,000 empty arrays",
+                &ascii,
+                json!({ "poses": [{ "keypoints": empty_arrays }] })
+                    .as_object()
+                    .cloned()
+                    .expect("object"),
+            ),
+            ("every bound at once", &ascii, maxed),
+        ];
+
+        for (label, prose, extra) in cases {
+            // A store per case, so the `list_assets` figure is what ONE asset costs a listing rather
+            // than the running total of every case before it.
+            let store = ProjectStore::new(
+                temp_dir
+                    .path()
+                    .join(crate::store_util::random_hex(6).expect("hex")),
+                "test-version",
+            );
+            let project = store.create_project("Amplify").expect("project creates");
+            let mut advanced = json!({
                 "steps": 8,
                 "stylePrompt": prose,
-                // Smaller counts than the two above only because the whole envelope has to stay
-                // under sc-15947's 1 MiB text cap to reach these bounds at all; 100 is still well
-                // over both caps, and the unit tests in `workflow_share` run the 8,000 case.
-                "poses": (0..100).map(|_| json!({ "keypoints": [[0.1, 0.2]] })).collect::<Vec<Value>>(),
-                "phases": (0..100).map(|_| json!({ "steps": 4, "guidance": 3.5 })).collect::<Vec<Value>>(),
-            },
-        })
-        .to_string();
-        assert!(
-            envelope.len() < crate::workflow_png::MAX_WORKFLOW_TEXT_BYTES,
-            "the fixture must be UNDER the text cap ({} bytes) or the reader refuses it and these \
-             bounds are never reached",
-            envelope.len()
-        );
-        let bytes = splice_after_ihdr(
-            &sceneworks_png(None),
-            &framed_itxt(crate::workflow_png::WORKFLOW_CHUNK_KEYWORD, &envelope, true),
-        );
-        let source = temp_dir.path().join("amplify.png");
-        std::fs::write(&source, &bytes).expect("staged upload writes");
-        let asset = store
-            .import_asset(
-                &project.id,
-                UploadAsset {
-                    filename: "amplify.png".to_owned(),
-                    content_type: Some("image/png".to_owned()),
-                    source_path: source,
-                    source_asset_id: None,
-                    provenance: None,
-                },
+                "systemMessage": prose,
+                "structuredPrompt": { "intent": prose, "runtimePrompt": prose },
+            })
+            .as_object()
+            .cloned()
+            .expect("object");
+            advanced.extend(extra);
+            let envelope = json!({
+                "sceneworksWorkflow": "image",
+                "schemaVersion": 1,
+                "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+                "mode": "text_to_image",
+                "model": "z_image_turbo",
+                "prompt": prose,
+                "negativePrompt": prose,
+                // Identical entries, because that is the shape that maximizes the compression ratio
+                // and so the leverage.
+                // 500 rather than 8,000 only so the widest prose case still fits under sc-15947's
+                // 1 MiB text cap; 500 is 100x `MAX_SHARE_LORAS` and 125x `MAX_SHARE_INPUTS`, and the
+                // unit tests in `workflow_share` run the 8,000 case.
+                "loras": (0..500)
+                    .map(|_| json!({ "name": "Ghibli watercolor", "repo": "acme/ghibli", "weight": 0.8 }))
+                    .collect::<Vec<Value>>(),
+                "inputs": (0..500)
+                    .map(|_| json!({ "kind": "reference", "count": 1 }))
+                    .collect::<Vec<Value>>(),
+                "advanced": advanced,
+            })
+            .to_string();
+            assert!(
+                envelope.len() < crate::workflow_png::MAX_WORKFLOW_TEXT_BYTES,
+                "{label}: the fixture must be UNDER the text cap ({} bytes) or the reader refuses it \
+                 and these bounds are never reached",
+                envelope.len()
+            );
+            let bytes = splice_after_ihdr(
+                &sceneworks_png(None),
+                &framed_itxt(crate::workflow_png::WORKFLOW_CHUNK_KEYWORD, &envelope, true),
+            );
+            let source = temp_dir.path().join(format!(
+                "{}.png",
+                crate::store_util::random_hex(6).expect("hex")
+            ));
+            std::fs::write(&source, &bytes).expect("staged upload writes");
+            let asset = store
+                .import_asset(
+                    &project.id,
+                    UploadAsset {
+                        filename: "amplify.png".to_owned(),
+                        content_type: Some("image/png".to_owned()),
+                        source_path: source,
+                        source_asset_id: None,
+                        provenance: None,
+                    },
+                )
+                .expect("a bounded envelope still imports");
+
+            let recorded = &asset["extra"][IMPORTED_WORKFLOW_KEY];
+            // Measured and PRINTED before anything is asserted, so reverting a bound to check this
+            // test still bites also reports what the amplification was.
+            let recorded_bytes = serde_json::to_string(recorded).expect("serializes").len();
+            let payload_bytes = serde_json::to_string(
+                &store
+                    .list_assets(&project.id, false, false, AssetScope::All)
+                    .expect("lists"),
             )
-            .expect("a bounded envelope still imports");
+            .expect("serializes")
+            .len();
+            let asset_json_bytes: String = Connection::open(
+                store
+                    .find_project_path(&project.id)
+                    .expect("project path")
+                    .join("project.db"),
+            )
+            .expect("opens project.db")
+            .query_row(
+                "select asset_json from assets where id = ?1",
+                params![asset["id"].as_str().expect("id")],
+                |row| row.get(0),
+            )
+            .expect("the row is indexed");
+            println!(
+                "sc-15949 [{label}]: {} byte PNG -> {recorded_bytes} byte workflow, {} byte \
+                 asset_json, {payload_bytes} byte list_assets payload",
+                bytes.len(),
+                asset_json_bytes.len()
+            );
 
-        let recorded = &asset["extra"][IMPORTED_WORKFLOW_KEY];
-        // Measured and PRINTED before anything is asserted, so reverting a bound to check this test
-        // still bites also reports what the amplification was.
-        let recorded_bytes = serde_json::to_string(recorded).expect("serializes").len();
-        let payload_bytes = serde_json::to_string(
-            &store
-                .list_assets(&project.id, false, false, AssetScope::All)
-                .expect("lists"),
-        )
-        .expect("serializes")
-        .len();
-        let asset_json_bytes: String = Connection::open(
-            store
-                .find_project_path(&project.id)
-                .expect("project path")
-                .join("project.db"),
-        )
-        .expect("opens project.db")
-        .query_row(
-            "select asset_json from assets where id = ?1",
-            params![asset["id"].as_str().expect("id")],
-            |row| row.get(0),
-        )
-        .expect("the row is indexed");
-        println!(
-            "sc-15949: {} byte PNG -> {recorded_bytes} byte workflow, {} byte asset_json, \
-             {payload_bytes} byte list_assets payload",
-            bytes.len(),
-            asset_json_bytes.len()
-        );
+            for (what, measured) in [
+                ("the recorded envelope", recorded_bytes),
+                ("asset_json", asset_json_bytes.len()),
+                ("the list_assets payload for one asset", payload_bytes),
+            ] {
+                assert!(
+                    measured < CEILING,
+                    "{label}: {what} is {measured} bytes, over the {CEILING} byte ceiling"
+                );
+            }
 
-        // Every unbounded collection is gone; the recipe around them still travels, so this is not
-        // passing by refusing the envelope wholesale.
-        assert!(
-            recorded.get("loras").is_none(),
-            "{:?}",
-            recorded.get("loras")
-        );
-        assert!(recorded.get("inputs").is_none());
-        assert!(recorded["advanced"].get("poses").is_none());
-        assert!(recorded["advanced"].get("phases").is_none());
-        assert_eq!(recorded["advanced"]["steps"], json!(8));
-        assert_eq!(recorded["model"], json!("z_image_turbo"));
-
-        // What is left is the prose allowance, which is the documented ceiling this file already
-        // accepted (`PROSE_MAX_CHARS`: three 20 k fields here). An upper bound rather than an
-        // equality, so this is a REGRESSION guard and not a fixture: what it catches is a new
-        // unbounded collection appearing later. The same fixture with the bounds reverted:
-        // 817,592 bytes recorded, 818,485 in `asset_json`, 818,551 in the `list_assets` payload —
-        // from a 7,389-byte PNG, so 111x.
-        const CEILING: usize = 200 * 1024;
-        assert!(
-            recorded_bytes < CEILING,
-            "the recorded envelope is {recorded_bytes} bytes, over the {CEILING} byte ceiling"
-        );
-        assert!(
-            asset_json_bytes.len() < CEILING,
-            "asset_json is {} bytes",
-            asset_json_bytes.len()
-        );
-        assert!(
-            payload_bytes < CEILING,
-            "the list_assets payload is {payload_bytes} bytes for a single asset"
-        );
+            if recorded.is_null() {
+                // "Every bound at once" is over `WORKFLOW_SHARE_MAX_BYTES` and degrades to NO
+                // workflow rather than to a partial record, which is the whole point of a ceiling on
+                // the envelope instead of another cap on a field.
+                assert!(
+                    asset["extra"].get(IMPORTED_WORKFLOW_KEY).is_none(),
+                    "an over-ceiling envelope must leave the key absent, not record a fragment"
+                );
+                continue;
+            }
+            // Every unbounded collection is gone; the recipe around them still travels, so this is
+            // not passing by refusing the envelope wholesale.
+            assert!(
+                recorded.get("loras").is_none(),
+                "{label}: {:?}",
+                recorded.get("loras")
+            );
+            assert!(recorded.get("inputs").is_none());
+            // `advanced.poses` is bounded rather than absent, because a pose entry whose coordinates
+            // were refused still occupies its slot as `{}` — the entry count is load-bearing (poses
+            // replace `count` variations). What must not survive is the VOLUME.
+            // `advanced.poses` is bounded rather than absent, because a pose entry whose coordinates
+            // were refused still occupies its slot as `{}` — the entry count is load-bearing (poses
+            // replace `count` variations). What must not survive is the VOLUME.
+            if let Some(poses) = recorded["advanced"].get("poses") {
+                let poses_bytes = serde_json::to_string(poses).expect("serializes").len();
+                assert!(
+                    poses_bytes < 4 * 1024,
+                    "{label}: advanced.poses is {poses_bytes} bytes"
+                );
+            }
+            assert_eq!(recorded["advanced"]["steps"], json!(8));
+            assert_eq!(recorded["model"], json!("z_image_turbo"));
+            // And the drops are LEGIBLE rather than silent: an absent `loras` and a genuinely
+            // LoRA-free recipe serialize identically, so the envelope says which one this is.
+            let omitted: Vec<&str> = recorded["omitted"]
+                .as_array()
+                .expect("the omission marker travels")
+                .iter()
+                .map(|name| name.as_str().expect("a name"))
+                .collect();
+            assert!(
+                omitted.contains(&"loras") && omitted.contains(&"inputs"),
+                "{label}: {omitted:?}"
+            );
+        }
     }
 
     /// The measurement behind the table in [`the_workflow_scan_reads_chunks_and_never_the_pixels`].

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -47,6 +47,15 @@ use crate::training_store::{
     TrainingDatasetCaptionSidecarsInput, TrainingDatasetCreateInput, TrainingDatasetMutationResult,
     TrainingDatasetStore, TrainingDatasetSummary, TrainingDatasetUpdateInput,
 };
+use crate::workflow_share::WorkflowShare;
+
+/// Key inside an imported asset's top-level `extra` that carries the sanitized workflow envelope
+/// the uploaded file had embedded (sc-15949).
+///
+/// Named `imported` on purpose. It says where the recipe came from — a file someone else's install
+/// wrote — and keeps it distinguishable from this asset's own `recipe`, which for an upload is the
+/// `mode: "upload"` stub and stays that way. sc-15952 reads this to offer "Use this recipe".
+pub const IMPORTED_WORKFLOW_KEY: &str = "importedWorkflow";
 
 pub const PROJECT_FOLDERS: &[&str] = &[
     "assets/images",
@@ -858,6 +867,10 @@ impl ProjectStore {
             &content_type,
             &upload.filename,
             &upload_dir,
+            // A dataset item is not an asset: it has no `extra` slot, and no reader offers its
+            // recipe back. So this lane opts out of the sc-15949 chunk scan rather than walking the
+            // metadata of every image in a bulk dataset import for an answer nobody reads.
+            WorkflowScan::Skip,
         )?;
         let content_type = normalized.content_type.clone();
 
@@ -1878,6 +1891,9 @@ impl ProjectStore {
             &content_type,
             &upload.filename,
             &upload_dir,
+            // sc-15949: a shared image may carry the sanitized recipe that made it. Read it from
+            // the bytes the user handed us, before any transcode can strip it.
+            WorkflowScan::Read,
         )?;
         let content_type = normalized.content_type.clone();
 
@@ -1958,9 +1974,43 @@ impl ProjectStore {
         });
         // Provenance (e.g. the Image Editor edit chain) rides the same top-level
         // `extra` slot generated assets use, so the Library/lineage UI can read it.
-        if let Some(provenance) = &upload.provenance {
-            if let Some(object) = asset.as_object_mut() {
-                object.insert("extra".to_owned(), provenance.clone());
+        //
+        // sc-15949 shares that slot: an imported image that carried a workflow chunk records the
+        // parsed, sanitized envelope under `extra.importedWorkflow`. The RECORD stays honest — the
+        // stub recipe above is untouched and `recipe.mode` is still `"upload"`, because this image
+        // WAS uploaded and was not generated here. sc-15952 offers the envelope as "Use this
+        // recipe"; nothing here fabricates a `text_to_image` mode, a seed we did not run, or a
+        // generation set that never existed.
+        if let Some(object) = asset.as_object_mut() {
+            match &upload.provenance {
+                // A provenance that is not an object stays exactly what it is today: the whole
+                // `extra` value. Merging is not possible, and quietly reshaping a caller's explicit
+                // blob to make room for a field it did not ask for is the wrong trade.
+                Some(provenance) if !provenance.is_object() => {
+                    object.insert("extra".to_owned(), provenance.clone());
+                }
+                _ => {
+                    let mut extra = upload
+                        .provenance
+                        .as_ref()
+                        .and_then(Value::as_object)
+                        .cloned()
+                        .unwrap_or_default();
+                    // Inserted LAST, so `extra.importedWorkflow` is always the envelope this import
+                    // read and sanitized, and never free JSON a caller put under that key in
+                    // `provenance`.
+                    if let Some(workflow) = normalized
+                        .workflow
+                        .as_ref()
+                        .and_then(|share| serde_json::to_value(share).ok())
+                    {
+                        extra.insert(IMPORTED_WORKFLOW_KEY.to_owned(), workflow);
+                    }
+                    // Still nothing to record: leave the key absent, exactly as before.
+                    if !extra.is_empty() {
+                        object.insert("extra".to_owned(), Value::Object(extra));
+                    }
+                }
             }
         }
         let sidecar_path = media_path.with_extension("sceneworks.json");
@@ -4943,6 +4993,24 @@ struct NormalizedUpload {
     content_type: String,
     extension: String,
     transcoded_temp: Option<PathBuf>,
+    /// The sanitized workflow envelope the upload carried in a PNG text chunk, when a
+    /// [`WorkflowScan::Read`] caller asked and one was found (sc-15949).
+    ///
+    /// Read from the ORIGINAL upload bytes, so it survives a transcode that re-encodes them.
+    workflow: Option<WorkflowShare>,
+}
+
+/// Whether an upload's metadata is searched for an embedded workflow envelope (sc-15949).
+///
+/// A parameter rather than an unconditional scan, so the cost is paid only where the answer is
+/// used. `import_asset` records what it finds under `extra.importedWorkflow`; the training-dataset
+/// lane has no recipe slot and no reader for one, so it opts out and pays nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkflowScan {
+    /// Look for a `sceneworks:workflow` chunk, before any transcode.
+    Read,
+    /// Do not look.
+    Skip,
 }
 
 /// Normalize a valid-but-unsupported image upload (AVIF/HEIC/HEIF/TIFF/BMP/GIF) to lossless PNG
@@ -4950,17 +5018,23 @@ struct NormalizedUpload {
 /// it can read (sc-6143). The format is sniffed by content, never the extension, so a `.png` that is
 /// really AVIF is still handled. Already-supported formats (png/jpeg/webp) and non-image uploads
 /// pass through untouched — no temp file, no re-encode, no quality loss.
+///
+/// `scan` also makes this the one place an incoming image is searched for an embedded workflow
+/// (sc-15949), because this is the one place that knows what is about to happen to the bytes; see
+/// the comment at the scan itself for why the ordering is load-bearing in both directions.
 fn normalize_image_upload(
     source_path: &Path,
     content_type: &str,
     filename: &str,
     work_dir: &Path,
+    scan: WorkflowScan,
 ) -> ProjectStoreResult<NormalizedUpload> {
     let passthrough = || NormalizedUpload {
         source_path: source_path.to_path_buf(),
         content_type: content_type.to_owned(),
         extension: upload_extension(filename, content_type),
         transcoded_temp: None,
+        workflow: None,
     };
     if !content_type.starts_with("image/") {
         return Ok(passthrough());
@@ -4968,6 +5042,25 @@ fn normalize_image_upload(
     let Some(kind) = crate::media_convert::sniff_image_kind_at(source_path) else {
         // Unrecognized magic (e.g. SVG) — leave it as-is; we can't transcode what we can't sniff.
         return Ok(passthrough());
+    };
+    // sc-15949: the chunk scan goes HERE, and the position is the decision.
+    //
+    // BEFORE the natively-supported branch below, because that branch is a `return`: a PNG — the
+    // one format that carries our chunk — would otherwise never be looked at.
+    //
+    // BEFORE the transcode further down, because `sips`/`ffmpeg` re-encode from pixels and drop
+    // every ancillary chunk by definition. A scan afterwards could only ever report an absence, so
+    // a workflow found here is carried forward on `NormalizedUpload` even though the stored bytes
+    // end up re-encoded.
+    //
+    // And it scans CHUNKS, not pixels. `read_workflow_chunk_file` stops at the first IDAT, and when
+    // that finds nothing it walks the remaining framing with no output buffer, which `png` answers
+    // by consuming the IDAT payload instead of inflating it. So this function's whole point — a
+    // natively-decodable upload is stored byte-for-byte, with no decode anywhere on the path —
+    // still holds.
+    let workflow = match scan {
+        WorkflowScan::Read => read_upload_workflow(source_path),
+        WorkflowScan::Skip => None,
     };
     if kind.is_natively_supported() {
         // Already decodable: keep the bytes (no re-encode) but record the format we actually
@@ -4978,6 +5071,7 @@ fn normalize_image_upload(
             content_type: mime.to_owned(),
             extension: format!(".{extension}"),
             transcoded_temp: None,
+            workflow,
         });
     }
     let temp_png = work_dir.join(format!("upload-transcode-{}.png", random_hex(8)?));
@@ -4993,7 +5087,37 @@ fn normalize_image_upload(
         content_type: "image/png".to_owned(),
         extension: ".png".to_owned(),
         transcoded_temp: Some(temp_png),
+        workflow,
     })
+}
+
+/// Look for a SceneWorks workflow envelope in an upload's PNG metadata, degrading EVERY failure to
+/// "no workflow found" (sc-15949).
+///
+/// This file came from a stranger, and it is the epic's main attack surface. The guards are
+/// [`crate::workflow_png::read_workflow_chunk_file`]'s and are not re-implemented here: a bounded
+/// metadata budget, a 1 MiB cap on the decompressed text so a zip bomb costs a megabyte, a refusal
+/// of duplicate chunks and lying chunk lengths, and — the important one — a single parse path
+/// through the sc-15946 allow-list, so the envelope is reduced at value granularity on the way IN
+/// exactly as it was on the way out. Nothing here deserializes an `ImageJobRequest`, or anything
+/// else, from the file.
+///
+/// Every error becomes `None`, deliberately and with no exception. The user asked to import an
+/// image, and they get their image: a hostile or malformed chunk costs them the recipe field and
+/// nothing else. `NotPng` is not even unusual — it is what every JPEG and WebP upload returns — so
+/// the typed error is logged at debug rather than surfaced.
+fn read_upload_workflow(source_path: &Path) -> Option<WorkflowShare> {
+    match crate::workflow_png::read_workflow_chunk_file(source_path) {
+        Ok(found) => found,
+        Err(error) => {
+            tracing::debug!(
+                path = %source_path.display(),
+                %error,
+                "upload carries no readable workflow chunk; importing it as a plain asset"
+            );
+            None
+        }
+    }
 }
 
 /// Move a (possibly transcoded) upload into place, cleaning up the transcode temp on a move failure
@@ -5658,13 +5782,14 @@ mod tests {
         connect_project_db, ensure_project_db_ready, fail_next_asset_index_db_mutation,
         fail_next_asset_sidecar_remove, find_timeline_file, guess_mime_from_filename,
         index_timeline, install_ensure_ready_before_lock_hook, is_safe_relative_path,
-        is_safe_upload_extension, normalize_asset_tags, read_json, read_registry_payload,
-        sniff_image_format, upload_extension, upscale_lineage_group, write_json,
-        AssetIndexMutation, AssetScope, AssetStatusPatch, CharacterCreateInput, CharacterLookInput,
-        CharacterReferenceInput, ProjectStore, ProjectStoreError, UploadAsset,
-        ASSET_INDEX_DIRTY_MARKER, ASSET_INDEX_VERSION_KEY, GLOBAL_KEYPOINTS_PROJECT_ID,
-        GLOBAL_POSES_PROJECT_ID, MAX_REGISTRY_BYTES, ORPHANED_SIDECAR_DIR, PROJECT_FOLDERS,
-        PROJECT_SCHEMA_VERSION, SAFE_UPLOAD_EXTENSIONS, UPSCALE_LINEAGE_QUERY,
+        is_safe_upload_extension, normalize_asset_tags, normalize_image_upload, read_json,
+        read_registry_payload, sniff_image_format, upload_extension, upscale_lineage_group,
+        write_json, AssetIndexMutation, AssetScope, AssetStatusPatch, CharacterCreateInput,
+        CharacterLookInput, CharacterReferenceInput, ProjectStore, ProjectStoreError, UploadAsset,
+        WorkflowScan, ASSET_INDEX_DIRTY_MARKER, ASSET_INDEX_VERSION_KEY,
+        GLOBAL_KEYPOINTS_PROJECT_ID, GLOBAL_POSES_PROJECT_ID, IMPORTED_WORKFLOW_KEY,
+        MAX_REGISTRY_BYTES, ORPHANED_SIDECAR_DIR, PROJECT_FOLDERS, PROJECT_SCHEMA_VERSION,
+        SAFE_UPLOAD_EXTENSIONS, UPSCALE_LINEAGE_QUERY,
     };
     use rusqlite::{params, Connection, OptionalExtension};
     use serde_json::{json, Value};
@@ -9339,6 +9464,837 @@ mod tests {
             .expect("source still present");
         assert_eq!(source_after["lineage"]["sourceAssetId"], Value::Null);
         assert!(source_after.get("extra").is_none());
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // sc-15949: the embedded workflow on asset import
+    // -----------------------------------------------------------------------------------------
+    //
+    // The reader and its adversarial corpus are sc-15947's and live in `workflow_png`; nothing
+    // below re-tests them. What is under test here is the IMPORT boundary: that a found envelope
+    // lands in `extra.importedWorkflow` without the record pretending the image was generated
+    // here, that an absent chunk changes nothing, that a hostile one costs the user only that
+    // field, and that the scan walks chunks rather than pixels.
+
+    /// A small deterministic image. Nine by seven so the row stride is not a power of two.
+    fn workflow_rgb_fixture() -> image::RgbImage {
+        image::RgbImage::from_fn(9, 7, |x, y| {
+            image::Rgb([
+                u8::try_from(x * 20).expect("fits"),
+                u8::try_from(y * 30).expect("fits"),
+                u8::try_from((x + y) * 10).expect("fits"),
+            ])
+        })
+    }
+
+    /// A sanitized envelope, built through the real parser so the fixture is exactly what the
+    /// contract admits — not a hand-rolled struct that could carry something `parse` would refuse.
+    fn workflow_fixture(prompt: &str) -> crate::workflow_share::WorkflowShare {
+        crate::workflow_share::parse_workflow_share_json(
+            &json!({
+                "sceneworksWorkflow": "image",
+                "schemaVersion": 1,
+                "producer": {
+                    "name": "SceneWorks",
+                    "url": "https://github.com/SceneWorks/SceneWorks",
+                    "version": "0.8.1",
+                },
+                "mode": "text_to_image",
+                "model": "z_image_turbo",
+                "prompt": prompt,
+                "negativePrompt": "text, watermark",
+                "seed": 880_412,
+                "width": 9,
+                "height": 7,
+                "advanced": { "steps": 8, "sampler": "euler" },
+            })
+            .to_string(),
+        )
+        .expect("the fixture envelope parses")
+    }
+
+    /// A PNG as SceneWorks writes one, through the real sc-15947 writer: `Some` embeds the chunk,
+    /// `None` is the byte-identical opt-out.
+    fn sceneworks_png(share: Option<&crate::workflow_share::WorkflowShare>) -> Vec<u8> {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("generated.png");
+        crate::workflow_png::write_workflow_chunk(&workflow_rgb_fixture(), &path, share)
+            .expect("the fixture PNG writes");
+        std::fs::read(&path).expect("the fixture PNG reads back")
+    }
+
+    /// Byte offset one past IHDR: signature + (length + type + 13 bytes + CRC). Where our writer
+    /// puts the chunk, and where the hand-built fixtures below splice theirs.
+    const AFTER_IHDR: usize = 8 + 4 + 4 + 13 + 4;
+
+    /// Bitwise CRC-32, so a hand-framed chunk (or a patched IHDR/IDAT) is well formed rather than
+    /// "passing" because the decoder threw it out on a checksum.
+    fn crc32(bytes: &[u8]) -> u32 {
+        let mut crc = 0xFFFF_FFFF_u32;
+        for byte in bytes {
+            crc ^= u32::from(*byte);
+            for _ in 0..8 {
+                let mask = if crc & 1 == 1 { 0xEDB8_8320 } else { 0 };
+                crc = (crc >> 1) ^ mask;
+            }
+        }
+        !crc
+    }
+
+    /// A framed PNG chunk. `declared_len` overrides the length field so a chunk can lie about how
+    /// much data follows it.
+    fn framed_chunk(kind: &[u8; 4], data: &[u8], declared_len: Option<u32>) -> Vec<u8> {
+        let length = declared_len.unwrap_or_else(|| u32::try_from(data.len()).expect("fits u32"));
+        let mut checked = kind.to_vec();
+        checked.extend_from_slice(data);
+        let mut out = length.to_be_bytes().to_vec();
+        out.extend_from_slice(&checked);
+        out.extend_from_slice(&crc32(&checked).to_be_bytes());
+        out
+    }
+
+    /// The `iTXt` data layout: keyword NUL flag method language NUL translated NUL text.
+    fn itxt_data(keyword: &str, compressed: bool, text: &[u8]) -> Vec<u8> {
+        let mut data = keyword.as_bytes().to_vec();
+        data.push(0);
+        data.push(u8::from(compressed));
+        data.push(0);
+        data.push(0);
+        data.push(0);
+        data.extend_from_slice(text);
+        data
+    }
+
+    /// One `iTXt` chunk framed by `png` itself, under any keyword, compressed or not.
+    fn framed_itxt(keyword: &str, text: &str, compressed: bool) -> Vec<u8> {
+        use png::text_metadata::{EncodableTextChunk, ITXtChunk};
+
+        let mut chunk = ITXtChunk::new(keyword, text);
+        chunk.compressed = compressed;
+        let mut out = Vec::new();
+        chunk.encode(&mut out).expect("the chunk encodes");
+        out
+    }
+
+    fn splice_after_ihdr(png: &[u8], chunk: &[u8]) -> Vec<u8> {
+        let mut out = png[..AFTER_IHDR].to_vec();
+        out.extend_from_slice(chunk);
+        out.extend_from_slice(&png[AFTER_IHDR..]);
+        out
+    }
+
+    /// Offset of a chunk header of type `kind`, found by walking the framing.
+    fn chunk_offset(png: &[u8], kind: &[u8; 4]) -> usize {
+        let mut cursor = 8;
+        loop {
+            assert!(
+                cursor + 8 <= png.len(),
+                "walked off the end looking for kind"
+            );
+            if &png[cursor + 4..cursor + 8] == kind.as_slice() {
+                return cursor;
+            }
+            let length = usize::try_from(u32::from_be_bytes(
+                png[cursor..cursor + 4].try_into().expect("a length field"),
+            ))
+            .expect("a chunk length fits usize");
+            cursor += 12 + length;
+        }
+    }
+
+    /// Replace the first IDAT's payload with bytes that are not a zlib stream, re-framing the CRC
+    /// so the file stays structurally perfect and ONLY the compressed pixel data is unreadable.
+    ///
+    /// The whole point of the no-decode assertion: a file no decoder can get pixels out of, which
+    /// the import must nonetheless read a recipe from and store verbatim.
+    fn break_the_pixel_stream(png: &[u8]) -> Vec<u8> {
+        let idat = chunk_offset(png, b"IDAT");
+        let length = usize::try_from(u32::from_be_bytes(
+            png[idat..idat + 4].try_into().expect("a length field"),
+        ))
+        .expect("fits usize");
+        // 0x00 0x00 fails zlib's header check (CMF/FLG must be divisible by 31), so inflate
+        // refuses immediately rather than allocating anything.
+        let garbage = vec![0_u8; length];
+        let mut out = png[..idat].to_vec();
+        out.extend_from_slice(&framed_chunk(b"IDAT", &garbage, None));
+        out.extend_from_slice(&png[idat + 12 + length..]);
+        out
+    }
+
+    /// Import `bytes` as `name` into `project_id`, staging them the way the API's multipart handler
+    /// does (a temp file the store consumes).
+    fn import_bytes(
+        store: &ProjectStore,
+        project_id: &str,
+        staging: &Path,
+        name: &str,
+        bytes: &[u8],
+    ) -> Result<Value, ProjectStoreError> {
+        let source = staging.join(format!(
+            "{}-{name}",
+            crate::store_util::random_hex(6).expect("hex")
+        ));
+        std::fs::write(&source, bytes).expect("staged upload writes");
+        store.import_asset(
+            project_id,
+            UploadAsset {
+                filename: name.to_owned(),
+                content_type: Some("image/png".to_owned()),
+                source_path: source,
+                source_asset_id: None,
+                provenance: None,
+            },
+        )
+    }
+
+    /// The stub recipe `import_asset` synthesizes for an upload, as it must stay. sc-15949 records
+    /// a found envelope BESIDE this, never inside it.
+    fn assert_upload_stub_recipe(asset: &Value, filename: &str) {
+        assert_eq!(
+            asset["recipe"]["mode"],
+            json!("upload"),
+            "an uploaded image was uploaded, not generated here"
+        );
+        assert_eq!(asset["recipe"]["model"], json!("manual-import"));
+        assert_eq!(asset["recipe"]["adapter"], json!("api-upload"));
+        assert_eq!(asset["recipe"]["prompt"], json!(filename));
+        assert_eq!(asset["recipe"]["negativePrompt"], json!(""));
+        assert_eq!(asset["recipe"]["seed"], json!(0));
+        assert_eq!(asset["recipe"]["loras"], json!([]));
+        assert_eq!(asset["recipe"]["stylePreset"], json!("none"));
+        assert_eq!(asset["recipe"]["normalizedSettings"], json!({}));
+        assert_eq!(asset["origin"], json!("upload"));
+        // No generation set and no job: nothing here ran.
+        assert_eq!(asset["generationSetId"], Value::Null);
+        assert_eq!(asset["lineage"]["jobId"], Value::Null);
+    }
+
+    #[test]
+    fn import_asset_records_an_embedded_workflow_without_faking_a_generation() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Shared").expect("project creates");
+        let staging = temp_dir.path().join("staging");
+        std::fs::create_dir_all(&staging).expect("staging dir");
+
+        let share = workflow_fixture("a lighthouse in heavy fog");
+        let bytes = sceneworks_png(Some(&share));
+        let asset = import_bytes(&store, &project.id, &staging, "shared.png", &bytes)
+            .expect("a SceneWorks PNG imports");
+
+        // The envelope is recorded, whole, exactly as the reader sanitized it.
+        assert_eq!(
+            asset["extra"][IMPORTED_WORKFLOW_KEY],
+            serde_json::to_value(&share).expect("the envelope serializes"),
+            "the parsed envelope must land in extra.importedWorkflow"
+        );
+        // …and the record stays honest. The envelope says `text_to_image`; the ASSET does not.
+        assert_eq!(
+            asset["extra"][IMPORTED_WORKFLOW_KEY]["mode"],
+            json!("text_to_image")
+        );
+        assert_upload_stub_recipe(&asset, "shared.png");
+        // Nothing was hoisted out of the envelope into the asset's own record: not the seed we
+        // never ran, not the model, not the prompt.
+        assert_ne!(asset["recipe"]["seed"], json!(880_412));
+        assert_ne!(asset["recipe"]["model"], json!("z_image_turbo"));
+        assert_ne!(
+            asset["recipe"]["prompt"],
+            json!("a lighthouse in heavy fog")
+        );
+        // The stored bytes are the user's file, untouched (sc-6143's passthrough).
+        let project_path = store.find_project_path(&project.id).expect("project path");
+        let stored = project_path.join(asset["file"]["path"].as_str().expect("path"));
+        assert_eq!(std::fs::read(&stored).expect("read stored"), bytes);
+
+        // `assets.asset_json` is `serde_json::to_string(asset)` over the whole sidecar, so the
+        // field rides the existing envelope blob with no schema migration. Proven through the
+        // index rather than asserted from the source: read the column back.
+        let asset_id = asset["id"].as_str().expect("id").to_owned();
+        let indexed: String = Connection::open(project_path.join("project.db"))
+            .expect("opens project.db")
+            .query_row(
+                "select asset_json from assets where id = ?1",
+                params![asset_id],
+                |row| row.get(0),
+            )
+            .expect("the row is indexed");
+        let indexed: Value = serde_json::from_str(&indexed).expect("asset_json is JSON");
+        assert_eq!(
+            indexed["extra"][IMPORTED_WORKFLOW_KEY], asset["extra"][IMPORTED_WORKFLOW_KEY],
+            "asset_json must round-trip the new field"
+        );
+
+        // And it survives a full index rebuild from disk — the sidecar is the source of truth, so
+        // hydration must not be the thing that was carrying it.
+        store.reindex_project(&project.id).expect("reindex runs");
+        let after = store
+            .get_asset(&project.id, &asset_id)
+            .expect("the asset survives reindex");
+        assert_eq!(
+            after["extra"][IMPORTED_WORKFLOW_KEY], asset["extra"][IMPORTED_WORKFLOW_KEY],
+            "the imported workflow must survive an index rebuild"
+        );
+        assert_eq!(after["recipe"]["mode"], json!("upload"));
+    }
+
+    #[test]
+    fn import_asset_without_a_workflow_chunk_behaves_exactly_as_before() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Plain").expect("project creates");
+        let staging = temp_dir.path().join("staging");
+        std::fs::create_dir_all(&staging).expect("staging dir");
+
+        // The opt-out write path: a real PNG with no chunk at all.
+        let plain = sceneworks_png(None);
+        let asset = import_bytes(&store, &project.id, &staging, "plain.png", &plain)
+            .expect("a plain PNG imports");
+        assert!(
+            asset.get("extra").is_none(),
+            "no chunk must mean no new fields at all, got {:?}",
+            asset.get("extra")
+        );
+        assert_upload_stub_recipe(&asset, "plain.png");
+
+        // And with provenance, `extra` is still the provenance blob and nothing else.
+        let provenance = json!({ "editor": "image_editor", "edits": [{ "op": "crop" }] });
+        let source = staging.join("edited.png");
+        std::fs::write(&source, &plain).expect("staged upload writes");
+        let edited = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "edited.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: source,
+                    source_asset_id: None,
+                    provenance: Some(provenance.clone()),
+                },
+            )
+            .expect("imports");
+        assert_eq!(edited["extra"], provenance);
+        assert!(edited["extra"].get(IMPORTED_WORKFLOW_KEY).is_none());
+    }
+
+    #[test]
+    fn import_asset_merges_a_workflow_beside_the_editor_provenance() {
+        // The two writers of `extra` have to coexist: an Image Editor save of a shared image
+        // carries an edit chain AND a chunk. Neither may evict the other.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Both").expect("project creates");
+
+        let share = workflow_fixture("a lighthouse");
+        let source = temp_dir.path().join("both.png");
+        std::fs::write(&source, sceneworks_png(Some(&share))).expect("staged upload writes");
+        let provenance = json!({
+            "editor": "image_editor",
+            "edits": [{ "op": "crop" }],
+            // A caller-supplied value under OUR key must not win: the field is defined as what the
+            // import parsed and sanitized, so a client cannot inject a recipe through provenance.
+            IMPORTED_WORKFLOW_KEY: { "sceneworksWorkflow": "image", "prompt": "injected" },
+        });
+        let asset = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "both.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: source,
+                    source_asset_id: None,
+                    provenance: Some(provenance),
+                },
+            )
+            .expect("imports");
+
+        assert_eq!(asset["extra"]["editor"], json!("image_editor"));
+        assert_eq!(asset["extra"]["edits"], json!([{ "op": "crop" }]));
+        assert_eq!(
+            asset["extra"][IMPORTED_WORKFLOW_KEY],
+            serde_json::to_value(&share).expect("serializes"),
+            "the import's own sanitized envelope must win over one supplied in provenance"
+        );
+    }
+
+    #[test]
+    fn a_hostile_or_malformed_chunk_still_imports_as_a_plain_asset() {
+        // The corpus is sc-15947's, reframed at this boundary: every one of these is a file a
+        // stranger could hand us, and every one must produce a successful plain import. A bad chunk
+        // costs the user the recipe field and NOTHING else — not the upload, not the bytes.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Hostile").expect("project creates");
+        let staging = temp_dir.path().join("staging");
+        std::fs::create_dir_all(&staging).expect("staging dir");
+
+        let plain = sceneworks_png(None);
+        let good = sceneworks_png(Some(&workflow_fixture("a lighthouse")));
+        let envelope = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "a lighthouse",
+        })
+        .to_string();
+
+        let mut corpus: Vec<(String, Vec<u8>)> = vec![
+            // Two chunks under our keyword: which recipe made the image is ambiguous, so neither.
+            (
+                "duplicate chunks".to_owned(),
+                splice_after_ihdr(
+                    &good,
+                    &framed_itxt(crate::workflow_png::WORKFLOW_CHUNK_KEYWORD, &envelope, true),
+                ),
+            ),
+            // A zip bomb: 8 MiB of NUL in a chunk of a few hundred bytes.
+            (
+                "zip bomb".to_owned(),
+                splice_after_ihdr(
+                    &plain,
+                    &framed_itxt(
+                        crate::workflow_png::WORKFLOW_CHUNK_KEYWORD,
+                        &"\0".repeat(8 * 1024 * 1024),
+                        true,
+                    ),
+                ),
+            ),
+            // Uncompressed text past the 1 MiB cap, so it is the text cap that has to catch it.
+            (
+                "text over the cap".to_owned(),
+                splice_after_ihdr(
+                    &plain,
+                    &framed_itxt(
+                        crate::workflow_png::WORKFLOW_CHUNK_KEYWORD,
+                        &"A".repeat(crate::workflow_png::MAX_WORKFLOW_TEXT_BYTES + 1),
+                        false,
+                    ),
+                ),
+            ),
+            // A chunk header claiming the largest length a PNG may declare, in a small file.
+            (
+                "lying chunk length".to_owned(),
+                splice_after_ihdr(
+                    &plain,
+                    &framed_chunk(
+                        b"iTXt",
+                        &itxt_data(crate::workflow_png::WORKFLOW_CHUNK_KEYWORD, false, b"{}"),
+                        Some(0x7FFF_FFFF),
+                    ),
+                ),
+            ),
+            // Text that decodes fine and is not an envelope.
+            (
+                "not JSON".to_owned(),
+                splice_after_ihdr(
+                    &plain,
+                    &framed_itxt(
+                        crate::workflow_png::WORKFLOW_CHUNK_KEYWORD,
+                        "steps: 28, sampler: euler",
+                        true,
+                    ),
+                ),
+            ),
+            (
+                "JSON of the wrong shape".to_owned(),
+                splice_after_ihdr(
+                    &plain,
+                    &framed_itxt(
+                        crate::workflow_png::WORKFLOW_CHUNK_KEYWORD,
+                        "[1, 2, 3]",
+                        true,
+                    ),
+                ),
+            ),
+            (
+                "a schema version from the future".to_owned(),
+                splice_after_ihdr(
+                    &plain,
+                    &framed_itxt(
+                        crate::workflow_png::WORKFLOW_CHUNK_KEYWORD,
+                        &envelope.replace("\"schemaVersion\":1", "\"schemaVersion\":9999"),
+                        true,
+                    ),
+                ),
+            ),
+            // A ComfyUI / Automatic1111 export: text chunks, none of them ours.
+            (
+                "a foreign writer's chunks".to_owned(),
+                splice_after_ihdr(&plain, &framed_itxt("parameters", "steps: 28", true)),
+            ),
+        ];
+        // A file whose pixels are gone but whose chunk is intact, and the same with no chunk.
+        corpus.push((
+            "broken pixels, good chunk".to_owned(),
+            break_the_pixel_stream(&good),
+        ));
+        corpus.push((
+            "broken pixels, no chunk".to_owned(),
+            break_the_pixel_stream(&plain),
+        ));
+        // Truncations of a file that DOES carry a workflow. A partial chunk must never yield a
+        // partial envelope; a cut past the chunk legitimately still reads it.
+        for cut in (AFTER_IHDR..good.len()).step_by(11) {
+            corpus.push((format!("truncated at {cut}"), good[..cut].to_vec()));
+        }
+        // And a bit flipped in each region of the same file.
+        for offset in (8..good.len()).step_by(23) {
+            let mut corrupt = good.clone();
+            corrupt[offset] ^= 0xFF;
+            corpus.push((format!("bit flipped at {offset}"), corrupt));
+        }
+
+        let intact = serde_json::to_value(workflow_fixture("a lighthouse")).expect("serializes");
+        for (label, bytes) in corpus {
+            let asset = import_bytes(&store, &project.id, &staging, "hostile.png", &bytes)
+                .unwrap_or_else(|error| panic!("{label}: the upload must still succeed ({error})"));
+            // The user got their image, byte for byte.
+            let project_path = store.find_project_path(&project.id).expect("project path");
+            let stored = project_path.join(asset["file"]["path"].as_str().expect("path"));
+            assert_eq!(
+                std::fs::read(&stored).expect("read stored"),
+                bytes,
+                "{label}: the stored bytes must be the file the user handed us"
+            );
+            assert_upload_stub_recipe(&asset, "hostile.png");
+            // And either no workflow at all, or the intact one — never a partial or malformed
+            // envelope pieced out of a damaged file.
+            match asset.get("extra") {
+                None => {}
+                Some(extra) => {
+                    let recorded = &extra[IMPORTED_WORKFLOW_KEY];
+                    assert_eq!(
+                        recorded, &intact,
+                        "{label}: a damaged file produced a workflow that is not the intact one"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn path_shaped_values_in_a_hostile_chunk_do_not_survive_the_import() {
+        // The trust boundary, at this boundary. Every classified string in the envelope below is a
+        // location: absolute POSIX and Windows paths, a UNC share, `file://`, `~/`, and a traversal
+        // dressed up as a Hugging Face repo id. None of them may reach `extra.importedWorkflow` —
+        // sc-15952 turns `loras[].repo` into a cache path and renders the rest.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("Paths").expect("project creates");
+
+        let hostile = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": {
+                "name": "/opt/sceneworks/bin",
+                "url": "file:///D:/Users/Michael/secret.html",
+                "version": "0.8.1-dirty-Michael",
+            },
+            "mode": "/etc/passwd",
+            "model": "C:\\Users\\Michael\\models\\z_image",
+            "prompt": "a lighthouse",
+            "styleId": "file%3A%2F%2FD%3A%2Fsecret",
+            "stylePreset": "\\\\fileserver\\share\\styles\\noir",
+            "fitMode": "~/models/fit",
+            "upscale": { "enabled": true, "engine": "/usr/local/bin/realesrgan" },
+            "loras": [
+                { "name": "D:\\loras\\private.safetensors", "repo": "../../../../etc/passwd" },
+                { "name": "Ghibli watercolor", "repo": "acme/ghibli", "weight": 0.8 },
+            ],
+            "inputs": [
+                { "kind": "source/../../etc", "count": 1 },
+                { "kind": "source", "count": 1, "controlMode": "/dev/null" },
+            ],
+            "advanced": {
+                "sampler": "C:\\Windows\\System32\\euler",
+                "steps": 8,
+            },
+        })
+        .to_string();
+        let bytes = splice_after_ihdr(
+            &sceneworks_png(None),
+            &framed_itxt(crate::workflow_png::WORKFLOW_CHUNK_KEYWORD, &hostile, true),
+        );
+        let source = temp_dir.path().join("hostile.png");
+        std::fs::write(&source, &bytes).expect("staged upload writes");
+        let asset = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "hostile.png".to_owned(),
+                    content_type: Some("image/png".to_owned()),
+                    source_path: source,
+                    source_asset_id: None,
+                    provenance: None,
+                },
+            )
+            .expect("a hostile chunk must not fail the upload");
+        let recorded = &asset["extra"][IMPORTED_WORKFLOW_KEY];
+
+        // Reduced to empty rather than echoed: these are the fields sc-15952 shows as provenance.
+        assert_eq!(recorded["producer"]["name"], json!(""));
+        assert_eq!(recorded["producer"]["url"], json!(""));
+        assert_eq!(recorded["producer"]["version"], json!(""));
+        assert_eq!(recorded["mode"], json!(""));
+        assert_eq!(recorded["model"], json!(""));
+        // Optional labels are dropped outright, key and all.
+        for dropped in ["styleId", "stylePreset", "fitMode"] {
+            assert!(
+                recorded.get(dropped).is_none(),
+                "{dropped} was path-shaped and must not have survived: {:?}",
+                recorded.get(dropped)
+            );
+        }
+        assert_eq!(recorded["upscale"]["enabled"], json!(true));
+        assert!(recorded["upscale"].get("engine").is_none());
+        // The traversal LoRA is dropped entirely (name and repo both refused, nothing left to
+        // say); the legitimate one beside it survives, so this is not passing by dropping all.
+        assert_eq!(
+            recorded["loras"],
+            json!([{ "name": "Ghibli watercolor", "repo": "acme/ghibli", "weight": 0.8 }])
+        );
+        // A kind outside the closed vocabulary is dropped; a path in `controlMode` is stripped.
+        assert_eq!(
+            recorded["inputs"],
+            json!([{ "kind": "source", "count": 1 }])
+        );
+        // The `advanced` allow-list is shape-checked as well as key-checked.
+        assert_eq!(recorded["advanced"], json!({ "steps": 8 }));
+
+        // Nothing path-shaped anywhere in the recorded envelope — asserted over the whole tree
+        // rather than field by field, so a field added later cannot quietly open a hole. The
+        // authored PROSE fields are exempt by the sc-15946 contract (a prompt that names a
+        // directory is the user's own text and mangling it would be the worse failure), so the
+        // sweep skips them by KEY, exactly as the sanitizer does.
+        fn assert_no_locations(value: &Value, path: &str) {
+            match value {
+                Value::String(text) => assert!(
+                    !crate::workflow_share::is_path_shaped(text),
+                    "{path} survived as a location: {text:?}"
+                ),
+                Value::Array(items) => {
+                    for (index, item) in items.iter().enumerate() {
+                        assert_no_locations(item, &format!("{path}[{index}]"));
+                    }
+                }
+                Value::Object(map) => {
+                    for (key, item) in map {
+                        if matches!(
+                            key.as_str(),
+                            "prompt"
+                                | "negativePrompt"
+                                | "stylePrompt"
+                                | "intent"
+                                | "runtimePrompt"
+                                | "systemMessage"
+                        ) {
+                            continue;
+                        }
+                        assert_no_locations(item, &format!("{path}.{key}"));
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert_no_locations(recorded, "importedWorkflow");
+        // The record itself is still an upload.
+        assert_upload_stub_recipe(&asset, "hostile.png");
+    }
+
+    #[test]
+    fn the_workflow_scan_reads_chunks_and_never_the_pixels() {
+        // The regression this guards is a quiet one: making the scan work by decoding the image.
+        // `normalize_image_upload` exists to store a natively-supported upload WITHOUT a decode,
+        // and a chunk walk that inflated the pixel stream would turn every upload into one.
+        //
+        // Proven by contradiction on a file whose pixels CANNOT be decoded: framing and CRCs are
+        // perfect, the workflow chunk is intact, and the IDAT payload is not a zlib stream at all.
+        // Any decode on this path would fail. The import succeeds and reads the recipe, so nothing
+        // decoded.
+        //
+        // Measured alongside it, on `soft_render_rgb`-shaped PNGs in release, so the throughput
+        // claim is a number rather than a hope:
+        //
+        // |          | scan, chunk found | scan, no chunk | plain file read | FULL DECODE |
+        // |----------|-------------------|----------------|-----------------|-------------|
+        // | 1024²    |             81 µs |         144 µs |           36 µs |     4.31 ms |
+        // | 2048²    |             47 µs |         292 µs |          104 µs |    13.36 ms |
+        //
+        // A SceneWorks image answers in pass one and stops at the first IDAT, so its cost barely
+        // moves with the pixel count. The miss — every foreign PNG — walks the tail framing and CRCs
+        // the bytes on their way past: ~3x a plain read of the same file, and 2-3% of what decoding
+        // it would cost. That is the difference between a metadata walk and the decode-everything
+        // path this test exists to keep us out of.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("NoDecode").expect("project creates");
+        let staging = temp_dir.path().join("staging");
+        std::fs::create_dir_all(&staging).expect("staging dir");
+
+        let share = workflow_fixture("a lighthouse");
+        let undecodable = break_the_pixel_stream(&sceneworks_png(Some(&share)));
+
+        // First: the file really is undecodable, so the assertion below has teeth.
+        let probe = staging.join("probe.png");
+        std::fs::write(&probe, &undecodable).expect("writes");
+        assert!(
+            image::open(&probe).is_err(),
+            "the fixture must be undecodable or it proves nothing about decoding"
+        );
+
+        // The scan alone finds the workflow in it.
+        assert_eq!(
+            crate::workflow_png::read_workflow_chunk_file(&probe),
+            Ok(Some(share.clone())),
+            "the chunk walk must not need the pixels"
+        );
+
+        // And so does the import, which stores the bytes verbatim.
+        let asset = import_bytes(
+            &store,
+            &project.id,
+            &staging,
+            "undecodable.png",
+            &undecodable,
+        )
+        .expect("an undecodable-but-well-framed PNG still imports");
+        assert_eq!(
+            asset["extra"][IMPORTED_WORKFLOW_KEY],
+            serde_json::to_value(&share).expect("serializes")
+        );
+        let project_path = store.find_project_path(&project.id).expect("project path");
+        let stored = project_path.join(asset["file"]["path"].as_str().expect("path"));
+        assert_eq!(std::fs::read(&stored).expect("read stored"), undecodable);
+        // Dimensions stay unread, as they are today: nothing opened the image to fill them in.
+        assert_eq!(asset["file"]["width"], Value::Null);
+        assert_eq!(asset["file"]["height"], Value::Null);
+    }
+
+    #[test]
+    fn the_scan_precedes_both_the_passthrough_and_the_transcode() {
+        // The ordering AC, pinned where it is visible. A transcode re-encodes from pixels and drops
+        // every ancillary chunk (the test below proves that on real bytes), so a scan placed after
+        // it could only ever report an absence — and a scan placed after the natively-supported
+        // `return` would never run for a PNG at all. Both are one moved line away, and neither is
+        // observable end to end today: the sc-15947 reader is PNG-only, so no format that TAKES the
+        // transcode branch can carry our chunk in the first place. Source structure is where the
+        // guarantee lives, so that is what this asserts — the same technique
+        // `the_reader_has_exactly_one_parse_path` uses in `tests/workflow_png.rs`.
+        let source = std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src")
+                .join("project_store.rs"),
+        )
+        .expect("reads this module");
+        let body = source
+            .split("fn normalize_image_upload(")
+            .nth(1)
+            .expect("the function is here")
+            .split("\nfn ")
+            .next()
+            .expect("the function ends");
+        let code: String = body
+            .lines()
+            .map(str::trim_start)
+            .filter(|line| !line.starts_with("//"))
+            .collect::<Vec<&str>>()
+            .join("\n");
+
+        let scan = code
+            .find("read_upload_workflow(source_path)")
+            .expect("normalize_image_upload no longer scans the ORIGINAL upload for a workflow");
+        let passthrough = code
+            .find("kind.is_natively_supported()")
+            .expect("the natively-supported branch moved");
+        let transcode = code
+            .find("transcode_to_png(")
+            .expect("the transcode call moved");
+        assert!(
+            scan < passthrough,
+            "the chunk scan must run BEFORE the natively-supported passthrough returns, or a PNG \
+             — the only format that carries our chunk — is never looked at"
+        );
+        assert!(
+            scan < transcode,
+            "the chunk scan must run BEFORE the transcode, which re-encodes from pixels and drops \
+             every ancillary chunk"
+        );
+    }
+
+    #[test]
+    fn a_transcode_destroys_the_chunk_so_only_a_pre_transcode_scan_can_find_it() {
+        // The premise the ordering rests on, measured on real bytes with the real transcoder rather
+        // than asserted from the AVIF/HEIC docs. Skipped where no transcoder is installed (CI
+        // Linux/Windows images do not all carry ffmpeg); macOS always has `sips`.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let share = workflow_fixture("a lighthouse");
+        let embedded = temp_dir.path().join("embedded.png");
+        std::fs::write(&embedded, sceneworks_png(Some(&share))).expect("writes");
+        assert_eq!(
+            crate::workflow_png::read_workflow_chunk_file(&embedded),
+            Ok(Some(share)),
+            "the pre-transcode file carries the workflow"
+        );
+
+        let transcoded = temp_dir.path().join("transcoded.png");
+        if let Err(error) = crate::media_convert::transcode_to_png(&embedded, &transcoded) {
+            println!(
+                "sc-15949: no image transcoder reachable on this host ({error}); skipping the \
+                 metadata-loss assertion"
+            );
+            return;
+        }
+        println!("sc-15949: the real transcoder ran; asserting the chunk did not survive it");
+        assert_eq!(
+            crate::workflow_png::read_workflow_chunk_file(&transcoded),
+            Ok(None),
+            "a transcode re-encodes from pixels, so the chunk cannot survive it — which is why the \
+             scan has to happen first"
+        );
+    }
+
+    #[test]
+    fn the_training_dataset_lane_opts_out_of_the_scan() {
+        // A dataset item has no `extra` and no reader for a recipe, so it must not pay for a
+        // metadata walk per image on a bulk import. Asserted on `normalize_image_upload` directly,
+        // since the opt-out is invisible in the dataset record by definition.
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let source = temp_dir.path().join("embedded.png");
+        std::fs::write(
+            &source,
+            sceneworks_png(Some(&workflow_fixture("a lighthouse"))),
+        )
+        .expect("writes");
+
+        let read = normalize_image_upload(
+            &source,
+            "image/png",
+            "embedded.png",
+            temp_dir.path(),
+            WorkflowScan::Read,
+        )
+        .expect("normalizes");
+        assert!(read.workflow.is_some(), "the reading lane finds the chunk");
+
+        let skipped = normalize_image_upload(
+            &source,
+            "image/png",
+            "embedded.png",
+            temp_dir.path(),
+            WorkflowScan::Skip,
+        )
+        .expect("normalizes");
+        assert!(
+            skipped.workflow.is_none(),
+            "Skip must not scan, even when the file does carry a workflow"
+        );
+        // Both lanes agree on everything else — the scan is the only difference.
+        assert_eq!(read.content_type, skipped.content_type);
+        assert_eq!(read.extension, skipped.extension);
+        assert_eq!(read.source_path, skipped.source_path);
     }
 
     /// sc-13517: the saved-voice id→clip hop end-to-end, cheaply. A saved voice's stored

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -1124,16 +1124,69 @@ const PROSE_MAX_CHARS: usize = 20_000;
 ///
 /// On the BUILD side these strings are the user's own and this is a no-op. On the PARSE side
 /// they are attacker-chosen, which is the epic's trust boundary: the reader (sc-15952) renders
-/// them, so a value carrying ANSI escapes or several megabytes of text must not arrive intact.
-/// Newlines and tabs survive — a multi-line prompt is normal and mangling it would be the very
-/// harm the prose exemption exists to prevent — but every other control character is dropped.
+/// them, so a value carrying ANSI escapes, a bidi override or several megabytes of text must not
+/// arrive intact. Newlines and tabs survive — a multi-line prompt is normal and mangling it would
+/// be the very harm the prose exemption exists to prevent — but every other control character and
+/// every invisible formatting character is dropped.
 fn shareable_prose(value: &str) -> String {
     let stripped: String = value
         .chars()
-        .filter(|character| !character.is_control() || matches!(character, '\n' | '\t'))
+        .filter(|&character| {
+            matches!(character, '\n' | '\t')
+                || !(character.is_control() || is_invisible_formatting(character))
+        })
         .take(PROSE_MAX_CHARS)
         .collect();
     stripped.trim().to_owned()
+}
+
+/// True for a character that takes no width of its own but changes how the text AROUND it reads:
+/// Unicode's `Cf` (format) class plus the `Zl`/`Zp` line and paragraph separators.
+///
+/// [`char::is_control`] is `Cc` and only `Cc`, which is why [`shareable_prose`] cannot stop at it.
+/// `Cc` does catch ANSI escapes (ESC is `Cc`), so this is not terminal injection — it is display
+/// spoofing, and in a feature whose entire pitch is "trust this recipe a stranger sent you" that
+/// is the more relevant one. U+202E RIGHT-TO-LEFT OVERRIDE makes a rendered prompt say something
+/// other than what is stored; U+200B and U+FEFF are the same trick without the reversal, splitting
+/// a word the reader believes is whole. Both survived into a recorded envelope before this guard.
+///
+/// The ranges are the whole `Cf` class (Unicode 15.1) rather than the handful demonstrated,
+/// because a class is what closes a class. Enumerated instead of taken from a crate because `std`
+/// exposes no general-category API and pulling a Unicode table in for one predicate is a poor
+/// trade: `Cf` additions are rare, additive, and — being new invisible formatting characters — are
+/// new display tricks, not new prompt content.
+///
+/// Variation selectors (U+FE00..U+FE0F) are `Mn`, not `Cf`, and are deliberately NOT here: emoji
+/// presentation is prompt content. The tag characters at U+E0020..U+E007F are `Cf` and do go, which
+/// costs subdivision-flag emoji (🏴󠁧󠁢󠁳󠁣󠁴󠁿) in a prompt — the right side of that trade, since the same
+/// range is the standard way to smuggle hidden text through a display.
+fn is_invisible_formatting(character: char) -> bool {
+    matches!(
+        character,
+        '\u{00AD}'
+            | '\u{0600}'..='\u{0605}'
+            | '\u{061C}'
+            | '\u{06DD}'
+            | '\u{070F}'
+            | '\u{0890}'..='\u{0891}'
+            | '\u{08E2}'
+            | '\u{180E}'
+            | '\u{200B}'..='\u{200F}'
+            // Zl / Zp: a line or paragraph separator is not a newline the renderer agreed to.
+            | '\u{2028}'..='\u{2029}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2060}'..='\u{2064}'
+            | '\u{2066}'..='\u{206F}'
+            | '\u{FEFF}'
+            | '\u{FFF9}'..='\u{FFFB}'
+            | '\u{110BD}'
+            | '\u{110CD}'
+            | '\u{13430}'..='\u{1343F}'
+            | '\u{1BCA0}'..='\u{1BCA3}'
+            | '\u{1D173}'..='\u{1D17A}'
+            | '\u{E0001}'
+            | '\u{E0020}'..='\u{E007F}'
+    )
 }
 
 /// A Hugging Face repo id (`owner/name`) and nothing else — never a path, never a URL.
@@ -1423,6 +1476,98 @@ pub const INPUT_KINDS: &[&str] = &[
     INPUT_KIND_CONTROL,
 ];
 
+// ---------------------------------------------------------------------------
+// Collection bounds
+// ---------------------------------------------------------------------------
+//
+// [`LABEL_MAX_CHARS`] and [`PROSE_MAX_CHARS`] bound every individual STRING an envelope can carry.
+// They said nothing about how MANY of them it can carry, and the only remaining ceiling was
+// sc-15947's 1 MiB cap on the decompressed chunk text — which a compressible envelope turns into
+// enormous leverage. Measured before these bounds existed: an 8,897-byte PNG carrying 8,000
+// `inputs` + 8,000 `loras` + three 20 k prose fields produced a 988,271-byte
+// `extra.importedWorkflow`, a 988 kB sidecar, a 988 kB `assets.asset_json` row, and a
+// 989,210-byte `list_assets` response for ONE asset — 111x amplification, persistent, in the
+// Library's hottest read path (sc-14797 / sc-14798). Before sc-15949 nothing wrote a stranger's
+// megabyte into the asset index; reading the chunk is what exposed it.
+//
+// So every collection is bounded, and — like every other guard in this file — bounded in ONE place
+// that both directions run, so the write side cannot drift away from the read side. Each cap below
+// is derived from the contract that already limits the thing, in the same style
+// [`PROSE_MAX_CHARS`] was: a number nothing legitimate can exceed, whose worst case is stated.
+
+/// The most LoRAs an envelope may name — [`crate::lora_family::MAX_JOB_LORAS`] exactly.
+///
+/// Not a chosen number: it is the hard per-job total the generation path REJECTS above
+/// (`apps/rust-api/src/lib.rs`, the worker's `image_jobs` guard) and the recipe-preset
+/// normalizer's own cap ("Recipe presets can include at most 5 LoRAs"). A run that applied more
+/// than this could not have happened here, so an envelope claiming it did not come from us.
+const MAX_SHARE_LORAS: usize = crate::lora_family::MAX_JOB_LORAS;
+
+/// The most input descriptors an envelope may carry — one per kind, and the kinds are a closed
+/// vocabulary.
+///
+/// Exact rather than generous: [`describe_inputs`] emits at most one entry per [`INPUT_KINDS`]
+/// member (a multi-reference run is `{ kind: "reference", count: N }`, one entry with a count, not
+/// N entries). So [`INPUT_KINDS`]`.len()` is not a budget, it is the shape.
+const MAX_SHARE_INPUTS: usize = INPUT_KINDS.len();
+
+/// The most multi-phase phases an envelope may carry.
+///
+/// The worker's `MAX_MULTIPHASE_PHASES` and the web's `MULTIPHASE_MAX_PHASES`, which are the same
+/// 8 and are the values the request is validated against before it ever runs. `sceneworks-worker`
+/// depends on this crate, so the constant cannot be imported; `the_phase_cap_matches_the_worker`
+/// in `crates/sceneworks-core/tests/workflow_share.rs` reads both files and fails if they drift.
+const MAX_SHARE_PHASES: usize = 8;
+
+/// The most pose entries an envelope may carry.
+///
+/// The one collection with no server-side ceiling to inherit: the pose lane renders one image per
+/// pose and nothing clamps how many a user may select. So the derivation is the library they are
+/// selected FROM — `apps/web/public/poses/index.json` ships 46 poses — and 64 clears an
+/// all-of-the-library selection with room for user-created poses on top.
+///
+/// This bounds the ENTRY count only, which on its own would still admit a quarter of a million
+/// empty `{}` poses; [`MAX_SHARE_POSE_NUMBERS`] is what bounds the volume.
+const MAX_SHARE_POSES: usize = 64;
+
+/// The most numbers the whole `advanced.poses` array may carry, across every entry and field.
+///
+/// A budget rather than a per-entry cap, because that is what admits the real cases while still
+/// bounding the worst one. One sanitized pose is at most 18 body keypoints + 42 hand + 68 face =
+/// 128 points (the worker's `normalize_keypoints` / `normalize_hands` / `normalize_face` truncate
+/// to exactly those counts), and a point is `[x, y]` or `[x, y, confidence]` — so 384 numbers,
+/// and this budget is 16 full whole-body skeletons' worth. 16 is also twice
+/// [`crate::image_request::MAX_COUNT`], the payload-sanity ceiling on how many images one image
+/// job may produce, which a pose set is the pose lane's version of.
+///
+/// Checked against the real cases rather than asserted: all 46 built-in poses are body keypoints
+/// only (18 points, no hands, no face), so selecting the entire library spends 46 x 36 = 1,656
+/// numbers — 27% of the budget. What the budget does refuse is a set of dozens of poses each
+/// carrying full hands and face, which is where the worst case lives: 6,144 numbers is ~147 kB of
+/// JSON at the widest a `f64` serializes, the same order as the ~120 kB the six prose fields are
+/// already allowed, so the envelope stays a text chunk rather than a payload.
+const MAX_SHARE_POSE_NUMBERS: usize = 16 * (18 + 42 + 68) * 3;
+
+/// One bounded collection: kept whole, or dropped whole. Never truncated.
+///
+/// The truncate-or-drop question, answered the same way [`shareable_label`] answers it for an
+/// over-long label — by dropping, because a collection's MEMBERSHIP is its identity in exactly the
+/// way a slug's spelling is. "The first 5 of these 8,000 LoRAs" is not the recipe that made the
+/// image, and sc-15952 offers what survives here to the user as "Use this recipe": a plausible
+/// subset is worse than an absence, because a reader cannot tell it is a subset. So an over-cap
+/// collection travels as absent, which the reader renders as "none recorded", and the rest of the
+/// envelope — model, prompt, size, steps — still travels.
+///
+/// [`shareable_prose`] truncates instead, and the difference is the point: prose still means what
+/// it said after its tail is cut, and a list does not.
+fn bounded_collection<T>(values: Vec<T>, max: usize) -> Vec<T> {
+    if values.len() > max {
+        Vec::new()
+    } else {
+        values
+    }
+}
+
 /// Reduce every VALUE in an envelope to what the contract allows.
 ///
 /// The typed struct reduces at KEY granularity only — it drops fields we do not declare, which
@@ -1476,8 +1621,17 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
             engine: upscale.engine.as_deref().and_then(shareable_label),
             softness: upscale.softness.filter(|value| value.is_finite()),
         }),
-        loras: loras.into_iter().filter_map(reduce_lora).collect(),
-        inputs: inputs.into_iter().filter_map(reduce_input).collect(),
+        // Bounded BEFORE reduction, not after: an envelope that declares 8,000 LoRAs is
+        // disqualified by declaring them, and capping the survivors instead would let 7,995 junk
+        // entries carry 5 real ones through.
+        loras: bounded_collection(loras, MAX_SHARE_LORAS)
+            .into_iter()
+            .filter_map(reduce_lora)
+            .collect(),
+        inputs: bounded_collection(inputs, MAX_SHARE_INPUTS)
+            .into_iter()
+            .filter_map(reduce_input)
+            .collect(),
         advanced: sanitize_advanced(&advanced),
     }
 }
@@ -1643,7 +1797,7 @@ fn sanitize_structured_prompt(value: &Value) -> Option<Value> {
 const POSE_FIELDS: &[&str] = &["keypoints", "hands", "face"];
 
 fn sanitize_poses(value: &Value) -> Option<Value> {
-    let poses = value.as_array()?;
+    let poses = bounded_collection(value.as_array()?.clone(), MAX_SHARE_POSES);
     // The entry count is load-bearing (poses replace `count` variations), so an entry whose
     // coordinates are missing or malformed still occupies its slot as an empty object.
     let sanitized: Vec<Value> = poses
@@ -1660,6 +1814,14 @@ fn sanitize_poses(value: &Value) -> Option<Value> {
             Value::Object(out)
         })
         .collect();
+    // Entry count is not volume: a numeric tree is otherwise unbounded in both length and depth, so
+    // 64 poses of a million coordinates each would walk straight through the cap above. Budgeted
+    // across the WHOLE array (see `MAX_SHARE_POSE_NUMBERS`) rather than per entry, so a large set
+    // of plain body skeletons — which is what the shipped library is — still travels whole.
+    let numbers: usize = sanitized.iter().map(count_numbers).sum();
+    if numbers > MAX_SHARE_POSE_NUMBERS {
+        return None;
+    }
     (!sanitized.is_empty()).then_some(Value::Array(sanitized))
 }
 
@@ -1673,8 +1835,20 @@ fn is_numeric_tree(value: &Value) -> bool {
     }
 }
 
+/// How many numbers a value's tree holds, at any depth. The unit [`MAX_SHARE_POSE_NUMBERS`] is
+/// spent in — a coordinate is a number whether it arrived as `[[x, y]]` or `[[[x, y]]]`, and both
+/// forms are legal for `hands`.
+fn count_numbers(value: &Value) -> usize {
+    match value {
+        Value::Number(_) => 1,
+        Value::Array(values) => values.iter().map(count_numbers).sum(),
+        Value::Object(map) => map.values().map(count_numbers).sum(),
+        _ => 0,
+    }
+}
+
 fn sanitize_phases(value: &Value) -> Option<Value> {
-    let phases = value.as_array()?;
+    let phases = bounded_collection(value.as_array()?.clone(), MAX_SHARE_PHASES);
     let sanitized: Vec<Value> = phases
         .iter()
         .filter_map(Value::as_object)
@@ -1686,9 +1860,11 @@ fn sanitize_phases(value: &Value) -> Option<Value> {
                 }
             }
             // Phase LoRA references are indices into THIS request's own `loras` list, so they
-            // carry no id and stay meaningful next to the sanitized `loras` above.
+            // carry no id and stay meaningful next to the sanitized `loras` above — and they take
+            // the same bound, for the same reason: a phase cannot reference more LoRAs than a job
+            // is allowed to have.
             if let Some(loras) = phase.get("loras").and_then(Value::as_array) {
-                let entries: Vec<Value> = loras
+                let entries: Vec<Value> = bounded_collection(loras.clone(), MAX_SHARE_LORAS)
                     .iter()
                     .filter_map(Value::as_object)
                     .filter_map(|lora| {
@@ -2702,5 +2878,238 @@ mod tests {
                 "a present-but-wrong version must not be reported as missing: {message}"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Collection bounds
+    // -----------------------------------------------------------------------------------------
+
+    /// Every cap, against the contract it is derived from. The numbers are load-bearing, so a
+    /// change to either side has to be a decision rather than a drift.
+    #[test]
+    fn every_collection_cap_is_the_contract_it_came_from() {
+        assert_eq!(MAX_SHARE_LORAS, crate::lora_family::MAX_JOB_LORAS);
+        assert_eq!(MAX_SHARE_LORAS, 5);
+        assert_eq!(MAX_SHARE_INPUTS, INPUT_KINDS.len());
+        assert_eq!(MAX_SHARE_INPUTS, 4);
+        // The worker's `MAX_MULTIPHASE_PHASES`; pinned against its source by
+        // `the_phase_cap_matches_the_multi_phase_validators` in tests/workflow_share.rs, which can
+        // read the file this crate cannot import.
+        assert_eq!(MAX_SHARE_PHASES, 8);
+        // The pose budget is 16 whole-body skeletons, and 16 is twice the payload-sanity ceiling on
+        // images per job — the thing a pose set is the pose lane's version of. If that ceiling
+        // moves, the budget is a decision to re-make, not a number to follow.
+        assert_eq!(MAX_SHARE_POSE_NUMBERS, 6_144);
+        assert_eq!(
+            MAX_SHARE_POSE_NUMBERS,
+            2 * crate::image_request::MAX_COUNT as usize * (18 + 42 + 68) * 3
+        );
+    }
+
+    /// The bound that did not exist: an envelope with 8,000 entries in a collection. Asserted in
+    /// BOTH directions from the same fixture, because a bound only one direction runs is how the
+    /// write and read sides drift apart.
+    #[test]
+    fn an_over_cap_collection_is_dropped_in_both_directions() {
+        let many_loras: Vec<Value> = (0..8_000)
+            .map(|index| json!({ "name": format!("lora {index}"), "weight": 0.5 }))
+            .collect();
+        let many_inputs: Vec<Value> = (0..8_000)
+            .map(|_| json!({ "kind": "reference", "count": 1 }))
+            .collect();
+
+        // Parse: a file from a stranger.
+        let parsed = parse_workflow_share(&json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "a lighthouse",
+            "loras": many_loras.clone(),
+            "inputs": many_inputs.clone(),
+            "advanced": {
+                "steps": 8,
+                "poses": (0..8_000).map(|_| json!({})).collect::<Vec<Value>>(),
+                "phases": (0..8_000).map(|_| json!({ "steps": 4 })).collect::<Vec<Value>>(),
+            }
+        }))
+        .expect("a bounded envelope still parses — the recipe is not the collections");
+        assert!(parsed.loras.is_empty(), "{:?}", parsed.loras);
+        assert!(parsed.inputs.is_empty(), "{:?}", parsed.inputs);
+        assert!(parsed.advanced.get("poses").is_none());
+        assert!(parsed.advanced.get("phases").is_none());
+        // Dropped, not truncated: a subset would be offered to the user as the recipe that made
+        // the image, and they could not tell it was a subset.
+        assert_eq!(parsed.advanced["steps"], json!(8), "the rest still travels");
+        assert_eq!(parsed.prompt, "a lighthouse");
+
+        // Build: the same collections arriving on a job payload.
+        let mut payload = payload_fixture();
+        payload.insert("loras".to_owned(), Value::Array(many_loras));
+        payload.insert(
+            "advanced".to_owned(),
+            json!({
+                "steps": 8,
+                "poses": (0..8_000).map(|_| json!({ "keypoints": [[0.1, 0.2]] })).collect::<Vec<Value>>(),
+                "phases": (0..8_000).map(|_| json!({ "steps": 4 })).collect::<Vec<Value>>(),
+            }),
+        );
+        let built = build_workflow_share(&asset_fixture(), &payload);
+        assert!(built.loras.is_empty(), "{:?}", built.loras);
+        assert!(built.advanced.get("poses").is_none());
+        assert!(built.advanced.get("phases").is_none());
+        assert_eq!(built.advanced["steps"], json!(8));
+    }
+
+    /// The other half of every bound: exactly at the cap must survive, whole, both ways. This is
+    /// the assertion that would fail if a cap were set below anything legitimate.
+    #[test]
+    fn a_collection_exactly_at_its_cap_survives_both_directions() {
+        let loras: Vec<Value> = (0..MAX_SHARE_LORAS)
+            .map(|index| json!({ "name": format!("Lora {index}"), "weight": 0.5, "source": { "repo": format!("acme/lora-{index}") } }))
+            .collect();
+        let phases: Vec<Value> = (0..MAX_SHARE_PHASES)
+            .map(|index| json!({ "steps": index + 1, "guidance": 3.5, "loras": [{ "index": 0, "weight": 0.4 }] }))
+            .collect();
+        // 16 full whole-body skeletons is the pose budget exactly: 18 + 42 + 68 points of [x, y].
+        let skeleton = |points: usize| -> Value {
+            Value::Array(
+                (0..points)
+                    .map(|point| json!([point as f64 / 100.0, 0.5]))
+                    .collect(),
+            )
+        };
+        let poses: Vec<Value> = (0..16)
+            .map(|_| {
+                json!({
+                    "keypoints": skeleton(18),
+                    "hands": [skeleton(21), skeleton(21)],
+                    "face": skeleton(68),
+                })
+            })
+            .collect();
+
+        let mut payload = payload_fixture();
+        payload.insert("loras".to_owned(), Value::Array(loras));
+        payload.insert("sourceAssetId".to_owned(), json!("asset_source"));
+        payload.insert(
+            "referenceAssetIds".to_owned(),
+            json!(["asset_a", "asset_b", "asset_c"]),
+        );
+        payload.insert("maskAssetId".to_owned(), json!("asset_mask"));
+        payload.insert(
+            "advanced".to_owned(),
+            json!({
+                "steps": 8,
+                "controlImage": "asset_control",
+                "controlMode": "canny",
+                "poses": poses,
+                "phases": phases,
+            }),
+        );
+
+        let built = build_workflow_share(&asset_fixture(), &payload);
+        assert_eq!(built.loras.len(), MAX_SHARE_LORAS);
+        // One entry per kind, all four kinds — the widest `inputs` the builder can emit.
+        assert_eq!(built.inputs.len(), MAX_SHARE_INPUTS);
+        assert_eq!(
+            built.advanced["phases"].as_array().expect("phases").len(),
+            MAX_SHARE_PHASES
+        );
+        let built_poses = built.advanced["poses"].as_array().expect("poses");
+        assert_eq!(built_poses.len(), 16);
+        assert_eq!(
+            built_poses.iter().map(count_numbers).sum::<usize>(),
+            MAX_SHARE_POSE_NUMBERS * 2 / 3,
+            "16 skeletons of [x, y] pairs is two thirds of a budget sized for [x, y, confidence]"
+        );
+
+        // And back in through the reader, unchanged.
+        let envelope = serde_json::to_value(&built).expect("serializes");
+        let parsed = parse_workflow_share(&envelope).expect("parses");
+        assert_eq!(parsed, built);
+    }
+
+    /// The entry cap is not a volume cap. 64 poses is under [`MAX_SHARE_POSES`], so only the
+    /// numeric budget can catch a pose carrying a million coordinates — and it is the whole reason
+    /// the budget exists as well as the count.
+    #[test]
+    fn a_pose_that_is_a_payload_rather_than_a_skeleton_is_dropped() {
+        let flood: Vec<Value> = (0..4_000).map(|index| json!([index, 0.5])).collect();
+        let advanced = json!({ "steps": 8, "poses": [{ "keypoints": flood }] })
+            .as_object()
+            .cloned()
+            .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        assert!(
+            sanitized.get("poses").is_none(),
+            "one pose held {} numbers, over the {MAX_SHARE_POSE_NUMBERS} budget",
+            8_000
+        );
+        assert_eq!(sanitized["steps"], json!(8));
+
+        // The realistic large case is NOT refused: every one of the 46 built-in poses
+        // (`apps/web/public/poses/index.json`) is 18 body keypoints with no hands and no face, so
+        // selecting the whole library spends 1,656 of the 6,144 numbers.
+        let library: Vec<Value> = (0..46)
+            .map(|_| {
+                json!({ "keypoints": (0..18).map(|point| json!([f64::from(point) / 20.0, 0.5])).collect::<Vec<Value>>() })
+            })
+            .collect();
+        let advanced = json!({ "poses": library })
+            .as_object()
+            .cloned()
+            .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        let poses = sanitized["poses"]
+            .as_array()
+            .expect("the whole library travels");
+        assert_eq!(poses.len(), 46);
+        assert_eq!(poses.iter().map(count_numbers).sum::<usize>(), 46 * 36);
+    }
+
+    /// sc-15949 review: `char::is_control` is `Cc` only, so a bidi override and the zero-width
+    /// family were surviving into a recorded envelope — where sc-15952 renders them.
+    #[test]
+    fn prose_strips_invisible_formatting_as_well_as_control_characters() {
+        // U+202E RIGHT-TO-LEFT OVERRIDE / U+202D LEFT-TO-RIGHT OVERRIDE reverse how the rest of
+        // the line reads; U+200B and U+FEFF split a word invisibly; U+2028 / U+2029 are line and
+        // paragraph separators the renderer never agreed to.
+        let hostile = "a light\u{202e}house\u{202d} in\u{200b} fo\u{feff}g\u{2028}second\u{2029}third\u{200f}\u{00ad}\u{2060}";
+        let cleaned = shareable_prose(hostile);
+        assert_eq!(cleaned, "a lighthouse in fogsecondthird");
+        for smuggled in [
+            '\u{202e}', '\u{202d}', '\u{200b}', '\u{feff}', '\u{2028}', '\u{2029}', '\u{200f}',
+            '\u{00ad}', '\u{2060}',
+        ] {
+            assert!(
+                !cleaned.contains(smuggled),
+                "U+{:04X} survived: {cleaned:?}",
+                smuggled as u32
+            );
+        }
+
+        // Through the real parse path, in the field a stranger's file actually fills.
+        let share = parse_workflow_share(&json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": hostile,
+            "advanced": { "systemMessage": hostile }
+        }))
+        .expect("parses");
+        assert_eq!(share.prompt, "a lighthouse in fogsecondthird");
+        assert_eq!(
+            share.advanced["systemMessage"],
+            json!("a lighthouse in fogsecondthird")
+        );
+
+        // What must NOT change: the newlines and tabs a multi-line prompt is made of, and the
+        // emoji variation selectors that are prompt content rather than a display trick.
+        let real = "a lighthouse\n\tshot on 35mm \u{2764}\u{fe0f}, rain \u{1f327}\u{fe0f}";
+        assert_eq!(shareable_prose(real), real);
     }
 }

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -217,6 +217,75 @@ pub struct WorkflowShare {
     /// The allow-listed subset of the request's `advanced` map. See [`ADVANCED_KEY_RULES`].
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub advanced: JsonObject,
+    /// The collections this envelope declared but could not record whole. See [`OMITTED_FIELDS`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub omitted: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// The omission marker
+// ---------------------------------------------------------------------------
+
+/// `loras`, dropped or thinned.
+pub const OMITTED_LORAS: &str = "loras";
+/// `inputs`, dropped or thinned.
+pub const OMITTED_INPUTS: &str = "inputs";
+/// `advanced.poses`, dropped.
+pub const OMITTED_POSES: &str = "advanced.poses";
+/// `advanced.phases`, dropped.
+pub const OMITTED_PHASES: &str = "advanced.phases";
+/// A phase's own `loras` schedule, dropped.
+pub const OMITTED_PHASE_LORAS: &str = "advanced.phases[].loras";
+
+/// Every name [`WorkflowShare::omitted`] may hold, and nothing else.
+///
+/// The marker exists because the drop-vs-truncate doctrine [`over_cap`] documents rested
+/// on a premise that is empirically false. It argued a reader "cannot tell a plausible subset from
+/// the real thing but can tell an absence" — and an absence is exactly what it cannot tell:
+/// `loras` carries `skip_serializing_if = "Vec::is_empty"`, so a 6-LoRA envelope whose LoRAs were
+/// dropped over the cap and a genuinely LoRA-free one serialize BYTE-IDENTICALLY. Same for
+/// `advanced.poses` and `advanced.phases`, which are simply absent keys. sc-15952 would render "no
+/// LoRAs" and offer one-click "Use this recipe" for a recipe that had five.
+///
+/// Dropping is still right (truncating fabricates a specific membership, which is worse), so the
+/// fix is to make the drop SELF-DESCRIBING rather than to stop dropping. With this field the reader
+/// can say "this file declared more LoRAs than a job can have; they were not recorded" and withhold
+/// the replay.
+///
+/// A closed vocabulary of FIELD NAMES rather than free text, deliberately: it adds no new attack
+/// surface — the parse side keeps only members of this list, so the worst an envelope can put here
+/// is a subset of five short constants — and it is bounded by construction rather than by another
+/// cap that would have to compose with the rest.
+///
+/// Emitted in BOTH directions. On the build side it is the difference between a silently lost
+/// 70-pose selection ([`MAX_SHARE_POSES`]) and a visible one, which is the only thing standing
+/// between our own writer and the silent-loss failure this epic exists to prevent.
+///
+/// Scoped to collections, and to entries that had something shareable to say. A `loras` entry
+/// carrying only a local `id` is not an omission — the id was never going to travel and the entry
+/// declared nothing else — where an entry count over [`MAX_SHARE_LORAS`] is, because the recipe
+/// named LoRAs and the envelope records none of them.
+pub const OMITTED_FIELDS: &[&str] = &[
+    OMITTED_LORAS,
+    OMITTED_INPUTS,
+    OMITTED_POSES,
+    OMITTED_PHASES,
+    OMITTED_PHASE_LORAS,
+];
+
+/// The marker, reduced to the closed vocabulary: unknown names dropped, duplicates collapsed,
+/// sorted so the field is a SET rather than an order an envelope could carry information in.
+///
+/// Sanitized on parse like everything else. Sorting also makes it deterministic across the two
+/// `serde_json` map-ordering configurations the workspace builds under.
+fn reduce_omitted(names: Vec<String>) -> Vec<String> {
+    let mut kept: Vec<String> = names
+        .into_iter()
+        .filter(|name| OMITTED_FIELDS.contains(&name.as_str()))
+        .collect();
+    kept.sort_unstable();
+    kept.dedup();
+    kept
 }
 
 // ---------------------------------------------------------------------------
@@ -246,6 +315,11 @@ pub enum WorkflowShareError {
     UnsupportedSchemaVersion { file: u32, supported: u32 },
     /// A declared field is present but the wrong shape.
     Malformed { field: String, detail: String },
+    /// The envelope is bigger than this reader records (see [`WORKFLOW_SHARE_MAX_BYTES`]).
+    ///
+    /// Measured on the SANITIZED envelope, after every per-field bound has already run — because
+    /// per-field bounds are what did not compose. `bytes` is what it reduced to, not what arrived.
+    TooLarge { bytes: usize, limit: usize },
 }
 
 impl fmt::Display for WorkflowShareError {
@@ -277,6 +351,10 @@ impl fmt::Display for WorkflowShareError {
             Self::Malformed { field, detail } => write!(
                 f,
                 "This SceneWorks workflow is malformed: `{field}` {detail}."
+            ),
+            Self::TooLarge { bytes, limit } => write!(
+                f,
+                "This SceneWorks workflow is {bytes} bytes of settings, over the {limit} bytes {PRODUCER_NAME} records, so no recipe was read from it."
             ),
         }
     }
@@ -1106,17 +1184,29 @@ fn shareable_label(value: &str) -> Option<String> {
     Some(trimmed.to_owned())
 }
 
-/// The longest an authored prose field may be — `prompt`, `negativePrompt`, `stylePrompt` and
-/// the structured prompt's `intent` / `runtimePrompt`.
+/// The longest an authored prose field may be, **in bytes** — `prompt`, `negativePrompt`,
+/// `stylePrompt`, `systemMessage` and the structured prompt's `intent` / `runtimePrompt`.
 ///
-/// Distinct from and 100× [`LABEL_MAX_CHARS`] on purpose: a label is a slug and prose is
-/// paragraphs. 20,000 characters is roughly 3,000 words. The longest thing this field class
-/// legitimately holds is `runtimePrompt`, the serialized structured-prompt recipe, which runs to
-/// a few kilobytes at its most verbose; a hand-typed prompt is two orders of magnitude shorter.
-/// So the cap cannot truncate anything real, while still bounding what an envelope from a
-/// stranger can hand sc-15952 to render: five prose fields × 20 k is ~100 kB worst case, which
-/// keeps a PNG text chunk a text chunk rather than a payload.
-const PROSE_MAX_CHARS: usize = 20_000;
+/// Bytes, not characters, and that is the whole point of the number. The bound used to be 20,000
+/// CHARACTERS, which is 20 kB of English and 80 kB of any 4-byte scalar — so six prose slots of
+/// U+1F600 were 480 kB of prose in one envelope, four times the "~120 kB worst case" the old
+/// comment claimed and enough on its own to make a 3 kB PNG a 480 kB row in the asset index. A
+/// character count cannot bound a serialized size, and a serialized size is what
+/// [`WORKFLOW_SHARE_MAX_BYTES`] has to compose out of.
+///
+/// 16 KiB is the widest UTF-8 encoding of the API's own ceiling on this field class:
+/// `MAX_PROMPT_CHARS` in `apps/rust-api/src/lib.rs` rejects a `prompt` or `negativePrompt` over
+/// 4,000 characters, and 4,000 characters is at most 16,000 bytes. So a prompt this app accepted
+/// cannot be truncated here, in any script — but a non-Latin prompt does get fewer CHARACTERS than a
+/// Latin one out of the same allowance (5,461 for 3-byte CJK, 4,096 for 4-byte scalars), which is
+/// the cost of bounding the thing that is actually persisted. All four are above the API's own
+/// 4,000, so the bound the user can hit is still the API's, not this one.
+///
+/// The four `advanced` slots have no per-field validator of their own — they are bounded only by
+/// `MAX_ADVANCED_JSON_BYTES`, the API's 64 KiB ceiling on the whole serialized `advanced` map — so
+/// they take the same 16 KiB. `runtimePrompt`, the longest of them, is a serialized structured
+/// prompt running to a few kilobytes at its most verbose.
+const PROSE_MAX_BYTES: usize = 16 * 1024;
 
 /// Authored prose, reduced. Unlike [`shareable_label`] this keeps what the user typed —
 /// including a path, which is the deliberate exemption [`is_path_shaped`] documents — and only
@@ -1128,15 +1218,22 @@ const PROSE_MAX_CHARS: usize = 20_000;
 /// arrive intact. Newlines and tabs survive — a multi-line prompt is normal and mangling it would
 /// be the very harm the prose exemption exists to prevent — but every other control character and
 /// every invisible formatting character is dropped.
+///
+/// Truncation is per CHARACTER against a BYTE budget, so the result can never be split UTF-8: a
+/// character is pushed only if it fits whole, and the loop stops at the first that does not. A
+/// `String` cannot hold invalid UTF-8 anyway — what this avoids is the byte-slicing form of the
+/// same bound, which panics on a multi-byte boundary rather than producing invalid output.
 fn shareable_prose(value: &str) -> String {
-    let stripped: String = value
-        .chars()
-        .filter(|&character| {
-            matches!(character, '\n' | '\t')
-                || !(character.is_control() || is_invisible_formatting(character))
-        })
-        .take(PROSE_MAX_CHARS)
-        .collect();
+    let mut stripped = String::new();
+    for character in value.chars().filter(|&character| {
+        matches!(character, '\n' | '\t')
+            || !(character.is_control() || is_invisible_formatting(character))
+    }) {
+        if stripped.len() + character.len_utf8() > PROSE_MAX_BYTES {
+            break;
+        }
+        stripped.push(character);
+    }
     stripped.trim().to_owned()
 }
 
@@ -1150,7 +1247,8 @@ fn shareable_prose(value: &str) -> String {
 /// other than what is stored; U+200B and U+FEFF are the same trick without the reversal, splitting
 /// a word the reader believes is whole. Both survived into a recorded envelope before this guard.
 ///
-/// The ranges are the whole `Cf` class (Unicode 15.1) rather than the handful demonstrated,
+/// The ranges are the whole `Cf` class (Unicode 16.0 — 16.0 added no `Cf`, so the list is exact for
+/// 15.1 as well) rather than the handful demonstrated,
 /// because a class is what closes a class. Enumerated instead of taken from a crate because `std`
 /// exposes no general-category API and pulling a Unicode table in for one predicate is a poor
 /// trade: `Cf` additions are rare, additive, and — being new invisible formatting characters — are
@@ -1160,6 +1258,12 @@ fn shareable_prose(value: &str) -> String {
 /// presentation is prompt content. The tag characters at U+E0020..U+E007F are `Cf` and do go, which
 /// costs subdivision-flag emoji (🏴󠁧󠁢󠁳󠁣󠁴󠁿) in a prompt — the right side of that trade, since the same
 /// range is the standard way to smuggle hidden text through a display.
+///
+/// FOLLOW-UP (not this story): `Cf` is not the whole display-spoof class. U+3164 HANGUL FILLER,
+/// U+115F / U+1160 (the jamo fillers), U+2800 BRAILLE PATTERN BLANK and U+FFA0 HALFWIDTH HANGUL
+/// FILLER all render blank and are `Lo` / `So`, so they survive this guard. Same trick, different
+/// general category — a separate decision from "close the `Cf` class", because `Lo` is where real
+/// prompt content lives and a range list there needs its own justification.
 fn is_invisible_formatting(character: char) -> bool {
     matches!(
         character,
@@ -1342,7 +1446,33 @@ pub fn build_workflow_share_from(
         loras: sanitize_loras(job_payload.get("loras")),
         inputs: describe_inputs(job_payload),
         advanced,
+        // Nothing to carry in: the marker is derived by `reduce_workflow_share` from what the
+        // sanitizer actually dropped, in this direction exactly as in the other.
+        omitted: Vec::new(),
     })
+}
+
+/// The envelope to EMBED for one generated image, or `None` when there is none to embed.
+///
+/// The write seam's entry point, and the only one that runs the recording gate — so a writer cannot
+/// produce a file its own reader would refuse with [`WorkflowShareError::TooLarge`]. `None` means
+/// "write the file exactly as today", which is a shape the seams already have: the worker's
+/// `workflow_source` already collapses "the user opted out" and "there is no payload to describe"
+/// into the same `Option`, and this is a third reason with the same handling.
+///
+/// Unreachable for a request that came through the API, and that is the intent rather than an
+/// accident: `MAX_PROMPT_CHARS` and `MAX_ADVANCED_JSON_BYTES` bound the payload well under
+/// [`WORKFLOW_SHARE_MAX_BYTES`] (see the derivation there), and
+/// `no_real_request_is_truncated_by_the_collection_bounds` in
+/// `crates/sceneworks-core/tests/workflow_share.rs` measures the widest real requests against it.
+/// It is here so that the ceiling is a property of the envelope rather than of the reader.
+#[must_use]
+pub fn embeddable_workflow_share(
+    facts: &WorkflowAssetFacts,
+    job_payload: &JsonObject,
+) -> Option<WorkflowShare> {
+    let share = build_workflow_share_from(facts, job_payload);
+    within_recording_ceiling(&share).ok().map(|()| share)
 }
 
 /// Input images by shape. Reads the ids only to count them; no id ever reaches the envelope.
@@ -1477,23 +1607,35 @@ pub const INPUT_KINDS: &[&str] = &[
 ];
 
 // ---------------------------------------------------------------------------
-// Collection bounds
+// Collection bounds and the recording ceiling
 // ---------------------------------------------------------------------------
 //
-// [`LABEL_MAX_CHARS`] and [`PROSE_MAX_CHARS`] bound every individual STRING an envelope can carry.
-// They said nothing about how MANY of them it can carry, and the only remaining ceiling was
-// sc-15947's 1 MiB cap on the decompressed chunk text — which a compressible envelope turns into
-// enormous leverage. Measured before these bounds existed: an 8,897-byte PNG carrying 8,000
-// `inputs` + 8,000 `loras` + three 20 k prose fields produced a 988,271-byte
-// `extra.importedWorkflow`, a 988 kB sidecar, a 988 kB `assets.asset_json` row, and a
-// 989,210-byte `list_assets` response for ONE asset — 111x amplification, persistent, in the
-// Library's hottest read path (sc-14797 / sc-14798). Before sc-15949 nothing wrote a stranger's
-// megabyte into the asset index; reading the chunk is what exposed it.
+// [`LABEL_MAX_CHARS`] and [`PROSE_MAX_BYTES`] bound every individual STRING an envelope can carry
+// and the caps below bound how MANY of them it can carry. The only ceiling before either existed
+// was sc-15947's 1 MiB cap on the decompressed chunk text, which a compressible envelope turns
+// into enormous leverage: what an attacker pays for is the COMPRESSED chunk and what we pay is the
+// decompressed envelope, persisted into the sidecar, the `assets.asset_json` row and every
+// `list_assets` response for that asset (sc-14797 / sc-14798) forever.
 //
-// So every collection is bounded, and — like every other guard in this file — bounded in ONE place
-// that both directions run, so the write side cannot drift away from the read side. Each cap below
-// is derived from the contract that already limits the thing, in the same style
-// [`PROSE_MAX_CHARS`] was: a number nothing legitimate can exceed, whose worst case is stated.
+// PER-FIELD BOUNDS DO NOT COMPOSE, and that is the lesson this section was rewritten around. The
+// first attempt was per-collection caps, and each new measurement found a new way to spend what the
+// caps left: 200,000 `null` coordinates cost nothing against a budget that counted only numbers;
+// 200,000 empty arrays cost nothing against either; six prose slots of a 4-byte scalar were 480 kB
+// under a bound written in characters. Measured at that point, from a real import: a 3,070-byte PNG
+// became a 480,321-byte `extra.importedWorkflow`, and a 4,043-byte PNG became 720,347 bytes — worse
+// than the 111x the caps were introduced to remove.
+//
+// So there are two kinds of bound here, and the second is the one that closes the class:
+//
+// * the per-collection caps, each derived from the validator that already limits the thing, so an
+//   envelope claiming more did not come from a run here; and
+// * [`WORKFLOW_SHARE_MAX_BYTES`], ONE ceiling on the serialized envelope, checked after every
+//   per-field rule has run. It composes by construction — it is a bound on the thing we actually
+//   persist — so a new field or a new leak inside an existing one cannot walk around it the way
+//   each new vector walked around the caps.
+//
+// Everything here runs in ONE place both directions share, so the write side cannot drift from the
+// read side.
 
 /// The most LoRAs an envelope may name — [`crate::lora_family::MAX_JOB_LORAS`] exactly.
 ///
@@ -1521,32 +1663,99 @@ const MAX_SHARE_PHASES: usize = 8;
 
 /// The most pose entries an envelope may carry.
 ///
-/// The one collection with no server-side ceiling to inherit: the pose lane renders one image per
-/// pose and nothing clamps how many a user may select. So the derivation is the library they are
+/// The one collection with NO upstream validator to inherit, and the review that added it said so:
+/// the pose lane renders one image per pose and nothing in the worker's `pose_entries` or in
+/// `apps/web/src` clamps how many a user may select. So the derivation is the library they are
 /// selected FROM — `apps/web/public/poses/index.json` ships 46 poses — and 64 clears an
-/// all-of-the-library selection with room for user-created poses on top.
+/// all-of-the-library selection with room for user-created Key Point Library entries on top.
 ///
-/// This bounds the ENTRY count only, which on its own would still admit a quarter of a million
-/// empty `{}` poses; [`MAX_SHARE_POSE_NUMBERS`] is what bounds the volume.
+/// Because there is no upstream ceiling, this cap can fire on OUR OWN WRITE SIDE: a user who
+/// selects 65 poses gets an envelope with no `advanced.poses` in it. That is why
+/// [`OMITTED_FIELDS`] exists and is emitted on the build side too — a 70-pose selection that is
+/// not recorded says so, instead of arriving as an absence indistinguishable from "no poses".
+/// Clamping the selection at the source is the better fix and is not this story's to make.
+///
+/// This bounds the ENTRY count only; [`MAX_SHARE_POSE_SLOTS`] is what bounds the volume.
 const MAX_SHARE_POSES: usize = 64;
 
-/// The most numbers the whole `advanced.poses` array may carry, across every entry and field.
+/// The most coordinate SLOTS the whole `advanced.poses` array may carry, across every entry and
+/// field: a number, or a `null` standing in for one.
+///
+/// Slots rather than numbers, and that distinction is a fixed bug rather than a nicety. The budget
+/// counted `Value::Number` only, while [`is_coordinate_tree`] accepted `Value::Null` as a
+/// coordinate — so 200,000 nulls under one `keypoints` key cost nothing against a 6,144-number
+/// budget and serialized to 1,000,027 bytes. Nulls are counted because they ARE coordinate slots
+/// (the worker's `normalize_points` fills a missing one), not because they are hostile. Empty
+/// arrays were the same hole from the other side and are refused outright by
+/// [`is_coordinate_tree`]: an array with nothing in it is not a point.
 ///
 /// A budget rather than a per-entry cap, because that is what admits the real cases while still
 /// bounding the worst one. One sanitized pose is at most 18 body keypoints + 42 hand + 68 face =
 /// 128 points (the worker's `normalize_keypoints` / `normalize_hands` / `normalize_face` truncate
-/// to exactly those counts), and a point is `[x, y]` or `[x, y, confidence]` — so 384 numbers,
-/// and this budget is 16 full whole-body skeletons' worth. 16 is also twice
+/// to exactly those counts), and a point is `[x, y]` or `[x, y, confidence]` — so 384 slots, and
+/// this budget is 16 full whole-body skeletons' worth. 16 is also twice
 /// [`crate::image_request::MAX_COUNT`], the payload-sanity ceiling on how many images one image
 /// job may produce, which a pose set is the pose lane's version of.
 ///
 /// Checked against the real cases rather than asserted: all 46 built-in poses are body keypoints
 /// only (18 points, no hands, no face), so selecting the entire library spends 46 x 36 = 1,656
-/// numbers — 27% of the budget. What the budget does refuse is a set of dozens of poses each
-/// carrying full hands and face, which is where the worst case lives: 6,144 numbers is ~147 kB of
-/// JSON at the widest a `f64` serializes, the same order as the ~120 kB the six prose fields are
-/// already allowed, so the envelope stays a text chunk rather than a payload.
-const MAX_SHARE_POSE_NUMBERS: usize = 16 * (18 + 42 + 68) * 3;
+/// slots — 27% of the budget. What it refuses is dozens of poses each carrying full hands and face,
+/// and what backstops IT — because 6,144 slots is ~147 kB of JSON at the widest an `f64` serializes,
+/// which is over the whole envelope's allowance — is [`WORKFLOW_SHARE_MAX_BYTES`].
+const MAX_SHARE_POSE_SLOTS: usize = 16 * (18 + 42 + 68) * 3;
+
+/// The ceiling on the SERIALIZED envelope — the one bound that composes, and the reason the
+/// per-collection caps above are no longer the last line.
+///
+/// Derived from the widest envelope this app can legitimately produce, which is an arithmetic sum
+/// of validators rather than an estimate. Every term is a hard ceiling something else already
+/// enforces:
+///
+/// | term | bytes | where it comes from |
+/// |------|-------|---------------------|
+/// | `prompt` + `negativePrompt` | 32,000 | `MAX_PROMPT_CHARS` (4,000) x 4 bytes, twice |
+/// | `advanced` | 65,536 | `MAX_ADVANCED_JSON_BYTES`, the API's ceiling on the serialized map |
+/// | `loras` | 8,250 | [`MAX_SHARE_LORAS`] x (name + repo at [`LABEL_MAX_CHARS`] x 4 + weight) |
+/// | labels + `upscale` + `producer` + scalars | ~15,000 | [`LABEL_MAX_CHARS`] x 4, per field |
+/// | | **~113,900** | |
+///
+/// 160 KiB leaves 44% headroom over that, which the measured real cases make look enormous: the
+/// golden fixture is 1,239 bytes, a Krea multi-phase recipe at the validators' own ceiling is
+/// ~2 kB, and a long CJK prompt is ~2 kB — all two orders of magnitude under. What the ceiling
+/// refuses is the composition the caps could not: the sanitizer's own per-field bounds still admit
+/// ~400 kB in total (six 16 KiB prose slots, ~40 allow-listed scalar labels, and a 6,144-slot pose
+/// budget), and this is what stops that from being persisted.
+///
+/// Over the ceiling degrades to NO WORKFLOW — [`WorkflowShareError::TooLarge`] on the read side, a
+/// `None` from [`embeddable_workflow_share`] on the write side — rather than to a partial record.
+/// Shedding the biggest field instead would mean recording a recipe missing exactly the part that
+/// made it too large, and the reader has no way to know which one that was.
+pub const WORKFLOW_SHARE_MAX_BYTES: usize = 160 * 1024;
+
+/// How many bytes an envelope serializes to: the unit [`WORKFLOW_SHARE_MAX_BYTES`] is spent in, and
+/// the same measurement the sidecar row and the `list_assets` payload will pay.
+fn workflow_share_bytes(share: &WorkflowShare) -> usize {
+    // A serialization failure is not reachable for this type (no map with non-string keys, no
+    // non-finite float — `reduce_workflow_share` filters those). Treating it as "over the ceiling"
+    // is still the right fallback: an envelope we cannot serialize is one we cannot record.
+    serde_json::to_string(share).map_or(usize::MAX, |text| text.len())
+}
+
+/// The recording gate, run by BOTH directions.
+///
+/// One function rather than a check at each end, for the same reason every other guard in this file
+/// is one function: a ceiling the reader enforces and the writer does not is a writer that produces
+/// files its own reader refuses.
+fn within_recording_ceiling(share: &WorkflowShare) -> Result<(), WorkflowShareError> {
+    let bytes = workflow_share_bytes(share);
+    if bytes > WORKFLOW_SHARE_MAX_BYTES {
+        return Err(WorkflowShareError::TooLarge {
+            bytes,
+            limit: WORKFLOW_SHARE_MAX_BYTES,
+        });
+    }
+    Ok(())
+}
 
 /// One bounded collection: kept whole, or dropped whole. Never truncated.
 ///
@@ -1554,18 +1763,18 @@ const MAX_SHARE_POSE_NUMBERS: usize = 16 * (18 + 42 + 68) * 3;
 /// over-long label — by dropping, because a collection's MEMBERSHIP is its identity in exactly the
 /// way a slug's spelling is. "The first 5 of these 8,000 LoRAs" is not the recipe that made the
 /// image, and sc-15952 offers what survives here to the user as "Use this recipe": a plausible
-/// subset is worse than an absence, because a reader cannot tell it is a subset. So an over-cap
-/// collection travels as absent, which the reader renders as "none recorded", and the rest of the
-/// envelope — model, prompt, size, steps — still travels.
+/// subset is worse than a stated absence, because a reader cannot tell it is a subset.
+///
+/// A stated absence, now: the original form of this argument claimed a reader "can tell an
+/// absence", and it cannot — see [`OMITTED_FIELDS`], which is what makes the drop legible.
 ///
 /// [`shareable_prose`] truncates instead, and the difference is the point: prose still means what
 /// it said after its tail is cut, and a list does not.
-fn bounded_collection<T>(values: Vec<T>, max: usize) -> Vec<T> {
-    if values.len() > max {
-        Vec::new()
-    } else {
-        values
-    }
+///
+/// Takes the length rather than the values, so an over-cap array is refused without being cloned
+/// first — the 8,000-entry case allocated 8,000 `Value`s to decide it wanted none of them.
+fn over_cap(len: usize, max: usize) -> bool {
+    len > max
 }
 
 /// Reduce every VALUE in an envelope to what the contract allows.
@@ -1596,7 +1805,39 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
         loras,
         inputs,
         advanced,
+        omitted,
     } = share;
+
+    // Every collection's loss is derived by COMPARING what came in with what the sanitizer let out,
+    // rather than reported by the rules themselves. One derivation instead of a marker push at every
+    // `return None`, and it cannot go stale against a rule it does not know about: a new reason to
+    // drop `advanced.poses` is a new reason this records it.
+    let declared_loras = loras.len();
+    let declared_inputs = inputs.len();
+    let loras: Vec<WorkflowLora> = if over_cap(declared_loras, MAX_SHARE_LORAS) {
+        // Bounded BEFORE reduction, not after: an envelope that declares 8,000 LoRAs is
+        // disqualified by declaring them, and capping the survivors instead would let 7,995 junk
+        // entries carry 5 real ones through.
+        Vec::new()
+    } else {
+        loras.into_iter().filter_map(reduce_lora).collect()
+    };
+    let inputs: Vec<WorkflowInput> = if over_cap(declared_inputs, MAX_SHARE_INPUTS) {
+        Vec::new()
+    } else {
+        inputs.into_iter().filter_map(reduce_input).collect()
+    };
+    let sanitized_advanced = sanitize_advanced(&advanced);
+
+    let mut lost: Vec<String> = reduce_omitted(omitted);
+    if loras.len() < declared_loras {
+        lost.push(OMITTED_LORAS.to_owned());
+    }
+    if inputs.len() < declared_inputs {
+        lost.push(OMITTED_INPUTS.to_owned());
+    }
+    lost.extend(advanced_omissions(&advanced, &sanitized_advanced));
+
     WorkflowShare {
         kind,
         schema_version,
@@ -1621,19 +1862,55 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
             engine: upscale.engine.as_deref().and_then(shareable_label),
             softness: upscale.softness.filter(|value| value.is_finite()),
         }),
-        // Bounded BEFORE reduction, not after: an envelope that declares 8,000 LoRAs is
-        // disqualified by declaring them, and capping the survivors instead would let 7,995 junk
-        // entries carry 5 real ones through.
-        loras: bounded_collection(loras, MAX_SHARE_LORAS)
-            .into_iter()
-            .filter_map(reduce_lora)
-            .collect(),
-        inputs: bounded_collection(inputs, MAX_SHARE_INPUTS)
-            .into_iter()
-            .filter_map(reduce_input)
-            .collect(),
-        advanced: sanitize_advanced(&advanced),
+        loras,
+        inputs,
+        advanced: sanitized_advanced,
+        omitted: reduce_omitted(lost),
     }
+}
+
+/// Which `advanced` collections went missing between the raw map and the sanitized one.
+///
+/// Read off the two maps rather than pushed by the rules, so it stays true when a rule changes: a
+/// non-empty array that the allow-list, the entry cap, the slot budget or a shape check reduced to
+/// nothing is a loss whatever caused it, and an input that was already empty is an absence rather
+/// than an omission.
+fn advanced_omissions(raw: &JsonObject, sanitized: &JsonObject) -> Vec<String> {
+    let mut lost = Vec::new();
+    let declared = |key: &str| {
+        raw.get(key)
+            .and_then(Value::as_array)
+            .is_some_and(|values| !values.is_empty())
+    };
+    for (key, name) in [("poses", OMITTED_POSES), ("phases", OMITTED_PHASES)] {
+        if declared(key) && !sanitized.contains_key(key) {
+            lost.push(name.to_owned());
+        }
+    }
+    // Phase LoRA schedules are the substance of a Krea multi-phase recipe, and a phase's `loras`
+    // going missing is invisible in exactly the way the whole marker exists for: over the cap the
+    // key is omitted, so the phase reads as "applies no LoRAs". Counted rather than index-matched
+    // because a malformed phase does not occupy a slot in the output the way a malformed pose does.
+    let with_loras = |map: &JsonObject| -> usize {
+        map.get("phases")
+            .and_then(Value::as_array)
+            .map(|phases| {
+                phases
+                    .iter()
+                    .filter(|phase| {
+                        phase
+                            .get("loras")
+                            .and_then(Value::as_array)
+                            .is_some_and(|loras| !loras.is_empty())
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
+    };
+    if sanitized.contains_key("phases") && with_loras(sanitized) < with_loras(raw) {
+        lost.push(OMITTED_PHASE_LORAS.to_owned());
+    }
+    lost
 }
 
 /// One LoRA reference, reduced. An entry left with nothing to say is dropped entirely.
@@ -1797,7 +2074,13 @@ fn sanitize_structured_prompt(value: &Value) -> Option<Value> {
 const POSE_FIELDS: &[&str] = &["keypoints", "hands", "face"];
 
 fn sanitize_poses(value: &Value) -> Option<Value> {
-    let poses = bounded_collection(value.as_array()?.clone(), MAX_SHARE_POSES);
+    let poses = value.as_array()?;
+    // Checked against the length before anything is cloned: the 8,000-entry case used to allocate
+    // 8,000 `Value`s to decide it wanted none of them, which is work done precisely in the case the
+    // guard exists to make cheap.
+    if over_cap(poses.len(), MAX_SHARE_POSES) {
+        return None;
+    }
     // The entry count is load-bearing (poses replace `count` variations), so an entry whose
     // coordinates are missing or malformed still occupies its slot as an empty object.
     let sanitized: Vec<Value> = poses
@@ -1806,49 +2089,65 @@ fn sanitize_poses(value: &Value) -> Option<Value> {
             let mut out = JsonObject::new();
             if let Some(pose) = pose.as_object() {
                 for field in POSE_FIELDS {
-                    if let Some(numbers) = pose.get(*field).filter(|value| is_numeric_tree(value)) {
-                        out.insert((*field).to_owned(), numbers.clone());
+                    // An array, and a coordinate tree: a bare number or a bare `null` under
+                    // `keypoints` is not a skeleton, and letting one through would record a
+                    // positive claim about a pose nobody made.
+                    if let Some(points) = pose
+                        .get(*field)
+                        .filter(|value| value.is_array() && is_coordinate_tree(value))
+                    {
+                        out.insert((*field).to_owned(), points.clone());
                     }
                 }
             }
             Value::Object(out)
         })
         .collect();
-    // Entry count is not volume: a numeric tree is otherwise unbounded in both length and depth, so
-    // 64 poses of a million coordinates each would walk straight through the cap above. Budgeted
-    // across the WHOLE array (see `MAX_SHARE_POSE_NUMBERS`) rather than per entry, so a large set
-    // of plain body skeletons — which is what the shipped library is — still travels whole.
-    let numbers: usize = sanitized.iter().map(count_numbers).sum();
-    if numbers > MAX_SHARE_POSE_NUMBERS {
+    // Entry count is not volume: a coordinate tree is otherwise unbounded in both length and depth,
+    // so 64 poses of a million coordinates each would walk straight through the cap above. Budgeted
+    // across the WHOLE array (see `MAX_SHARE_POSE_SLOTS`) rather than per entry, so a large set of
+    // plain body skeletons — which is what the shipped library is — still travels whole.
+    let slots: usize = sanitized.iter().map(count_coordinate_slots).sum();
+    if slots > MAX_SHARE_POSE_SLOTS {
         return None;
     }
     (!sanitized.is_empty()).then_some(Value::Array(sanitized))
 }
 
-/// True when `value` is made only of numbers, nulls and arrays of them — the shape pose
-/// keypoints have. Anything with a string in it is not keypoints and does not travel.
-fn is_numeric_tree(value: &Value) -> bool {
+/// True when `value` is made only of coordinate slots — numbers, `null`s standing in for a missing
+/// one, and NON-EMPTY arrays of them. Anything with a string in it is not keypoints and does not
+/// travel.
+///
+/// The emptiness rule is a closed hole rather than pedantry: `[]` is vacuously "all coordinates",
+/// so 200,000 empty arrays under one `keypoints` key passed this check and cost nothing against the
+/// slot budget, serializing to 600,027 bytes. An array with nothing in it is not a point, so it is
+/// not a coordinate tree.
+fn is_coordinate_tree(value: &Value) -> bool {
     match value {
         Value::Number(_) | Value::Null => true,
-        Value::Array(values) => values.iter().all(is_numeric_tree),
+        Value::Array(values) => !values.is_empty() && values.iter().all(is_coordinate_tree),
         _ => false,
     }
 }
 
-/// How many numbers a value's tree holds, at any depth. The unit [`MAX_SHARE_POSE_NUMBERS`] is
-/// spent in — a coordinate is a number whether it arrived as `[[x, y]]` or `[[[x, y]]]`, and both
-/// forms are legal for `hands`.
-fn count_numbers(value: &Value) -> usize {
+/// How many coordinate slots a value's tree holds, at any depth. The unit
+/// [`MAX_SHARE_POSE_SLOTS`] is spent in — a coordinate is one slot whether it arrived as
+/// `[[x, y]]` or `[[[x, y]]]` (both forms are legal for `hands`), and a `null` is a slot too,
+/// because it is a coordinate the worker's `normalize_points` fills in.
+fn count_coordinate_slots(value: &Value) -> usize {
     match value {
-        Value::Number(_) => 1,
-        Value::Array(values) => values.iter().map(count_numbers).sum(),
-        Value::Object(map) => map.values().map(count_numbers).sum(),
+        Value::Number(_) | Value::Null => 1,
+        Value::Array(values) => values.iter().map(count_coordinate_slots).sum(),
+        Value::Object(map) => map.values().map(count_coordinate_slots).sum(),
         _ => 0,
     }
 }
 
 fn sanitize_phases(value: &Value) -> Option<Value> {
-    let phases = bounded_collection(value.as_array()?.clone(), MAX_SHARE_PHASES);
+    let phases = value.as_array()?;
+    if over_cap(phases.len(), MAX_SHARE_PHASES) {
+        return None;
+    }
     let sanitized: Vec<Value> = phases
         .iter()
         .filter_map(Value::as_object)
@@ -1863,22 +2162,32 @@ fn sanitize_phases(value: &Value) -> Option<Value> {
             // carry no id and stay meaningful next to the sanitized `loras` above — and they take
             // the same bound, for the same reason: a phase cannot reference more LoRAs than a job
             // is allowed to have.
+            //
+            // The key is written only when there is a schedule to write. An unconditional insert
+            // turned an over-cap schedule into `"loras": []`, which is not an absence — it is the
+            // positive claim "this phase applies no LoRAs", the exact plausible-and-unfalsifiable
+            // record the drop doctrine above exists to refuse. `advanced_omissions` names it.
             if let Some(loras) = phase.get("loras").and_then(Value::as_array) {
-                let entries: Vec<Value> = bounded_collection(loras.clone(), MAX_SHARE_LORAS)
-                    .iter()
-                    .filter_map(Value::as_object)
-                    .filter_map(|lora| {
-                        let mut entry = JsonObject::new();
-                        for field in ["index", "weight"] {
-                            if let Some(number) = lora.get(field).filter(|value| value.is_number())
-                            {
-                                entry.insert(field.to_owned(), number.clone());
+                if !over_cap(loras.len(), MAX_SHARE_LORAS) {
+                    let entries: Vec<Value> = loras
+                        .iter()
+                        .filter_map(Value::as_object)
+                        .filter_map(|lora| {
+                            let mut entry = JsonObject::new();
+                            for field in ["index", "weight"] {
+                                if let Some(number) =
+                                    lora.get(field).filter(|value| value.is_number())
+                                {
+                                    entry.insert(field.to_owned(), number.clone());
+                                }
                             }
-                        }
-                        entry.contains_key("index").then_some(Value::Object(entry))
-                    })
-                    .collect();
-                out.insert("loras".to_owned(), Value::Array(entries));
+                            entry.contains_key("index").then_some(Value::Object(entry))
+                        })
+                        .collect();
+                    if !entries.is_empty() {
+                        out.insert("loras".to_owned(), Value::Array(entries));
+                    }
+                }
             }
             Value::Object(out)
         })
@@ -1959,7 +2268,13 @@ pub fn parse_workflow_share(value: &Value) -> Result<WorkflowShare, WorkflowShar
     // An envelope that arrived from outside is reduced on the way IN by the same function that
     // reduced ours on the way OUT — at VALUE granularity, not only key granularity. Dropping
     // the keys we do not declare says nothing about the strings under the keys we do.
-    Ok(reduce_workflow_share(share))
+    let reduced = reduce_workflow_share(share);
+    // Last, on the reduced envelope, and refusing the WHOLE thing rather than shedding a field:
+    // what gets persisted is this value, and an envelope over the ceiling is one whose recipe we
+    // cannot record without also recording the payload attached to it. See
+    // `WORKFLOW_SHARE_MAX_BYTES` — this is the bound the per-field caps could not compose into.
+    within_recording_ceiling(&reduced)?;
+    Ok(reduced)
 }
 
 /// Best-effort field name out of a serde error, so the message names something the user can
@@ -2170,7 +2485,16 @@ mod tests {
         let phases = sanitized["phases"].as_array().expect("array");
         assert_eq!(phases[0]["loras"][0]["index"], json!(0));
         assert!(phases[0].get("note").is_none());
-        assert_eq!(phases[1]["loras"].as_array().expect("array").len(), 0);
+        // The second phase named a LoRA by local id and nothing else, so there is no schedule left
+        // to record — and the key is ABSENT rather than `[]`. sc-15949 review: an empty array is not
+        // an absence, it is the positive claim "this phase applies no LoRAs", which for a Krea
+        // multi-phase recipe is the substance of the thing. `advanced_omissions` names the loss;
+        // `an_over_cap_phase_lora_schedule_is_omitted_not_emptied` covers that half.
+        assert!(
+            phases[1].get("loras").is_none(),
+            "{:?}",
+            phases[1].get("loras")
+        );
         let encoded = serde_json::to_string(&sanitized).expect("serializes");
         assert!(!encoded.contains("lora_local_uuid"));
     }
@@ -2495,12 +2819,45 @@ mod tests {
         let absurd = "x".repeat(4 * 1024 * 1024);
         let share = parse_workflow_share(&hostile(&absurd)).expect("parses");
         for value in prose_fields(&share) {
-            assert_eq!(value.chars().count(), PROSE_MAX_CHARS);
+            assert_eq!(value.len(), PROSE_MAX_BYTES);
         }
 
-        // The bound is prose-sized, not label-sized: the two must never be conflated.
-        assert_eq!(PROSE_MAX_CHARS, 20_000);
-        assert_eq!(PROSE_MAX_CHARS, LABEL_MAX_CHARS * 100);
+        // The same field in BYTES, which is the review's finding: a character count bounds nothing
+        // that is measured in bytes, and every persisted copy of this envelope is. Four megabytes of
+        // a 4-byte scalar used to come back as 20,000 characters — 80 kB, four times what the old
+        // comment claimed the whole envelope's prose could be.
+        let absurd = "\u{1F600}".repeat(1024 * 1024);
+        let share = parse_workflow_share(&hostile(&absurd)).expect("parses");
+        for value in prose_fields(&share) {
+            assert!(
+                value.len() <= PROSE_MAX_BYTES,
+                "{} bytes, over the {PROSE_MAX_BYTES} byte bound",
+                value.len()
+            );
+            // Truncated on a CHARACTER boundary: 16,384 is a multiple of 4, so this lands exactly,
+            // and every scalar is intact. `String` cannot hold a split sequence, so the assertion
+            // that matters is that no character was lost to a partial one.
+            assert_eq!(value.chars().count(), PROSE_MAX_BYTES / 4);
+            assert!(value.chars().all(|character| character == '\u{1F600}'));
+        }
+
+        // A 3-byte script does not divide the budget evenly, which is the case that would split a
+        // sequence if the bound were applied to bytes rather than to whole characters.
+        let cjk = "霧".repeat(100_000);
+        let share = parse_workflow_share(&hostile(&cjk)).expect("parses");
+        for value in prose_fields(&share) {
+            assert_eq!(value.chars().count(), PROSE_MAX_BYTES / 3);
+            assert_eq!(value.len(), (PROSE_MAX_BYTES / 3) * 3);
+            assert!(value.chars().all(|character| character == '霧'));
+        }
+
+        // The number itself: 16 KiB is the widest UTF-8 encoding of the API's own 4,000-character
+        // ceiling on this field class (`MAX_PROMPT_CHARS` in `apps/rust-api/src/lib.rs`), so a
+        // prompt this app accepted cannot be truncated here in ANY script.
+        assert_eq!(PROSE_MAX_BYTES, 16 * 1024);
+        const _: () = assert!(PROSE_MAX_BYTES >= 4_000 * 4);
+        // And prose-sized rather than label-sized: the two must never be conflated.
+        const _: () = assert!(PROSE_MAX_BYTES > LABEL_MAX_CHARS * 4);
     }
 
     /// The other half: a bound this blunt must not touch anything real. A prompt far longer than
@@ -2513,7 +2870,7 @@ mod tests {
             "a lighthouse in heavy fog, cinematic, rain on the lens, ".repeat(30)
         );
         assert!(prompt.chars().count() > 1_500, "the fixture must be long");
-        assert!(prompt.chars().count() < PROSE_MAX_CHARS);
+        assert!(prompt.len() < PROSE_MAX_BYTES);
 
         let mut payload = payload_fixture();
         payload.insert("prompt".to_owned(), json!(prompt));
@@ -2899,9 +3256,9 @@ mod tests {
         // The pose budget is 16 whole-body skeletons, and 16 is twice the payload-sanity ceiling on
         // images per job — the thing a pose set is the pose lane's version of. If that ceiling
         // moves, the budget is a decision to re-make, not a number to follow.
-        assert_eq!(MAX_SHARE_POSE_NUMBERS, 6_144);
+        assert_eq!(MAX_SHARE_POSE_SLOTS, 6_144);
         assert_eq!(
-            MAX_SHARE_POSE_NUMBERS,
+            MAX_SHARE_POSE_SLOTS,
             2 * crate::image_request::MAX_COUNT as usize * (18 + 42 + 68) * 3
         );
     }
@@ -3020,8 +3377,11 @@ mod tests {
         let built_poses = built.advanced["poses"].as_array().expect("poses");
         assert_eq!(built_poses.len(), 16);
         assert_eq!(
-            built_poses.iter().map(count_numbers).sum::<usize>(),
-            MAX_SHARE_POSE_NUMBERS * 2 / 3,
+            built_poses
+                .iter()
+                .map(count_coordinate_slots)
+                .sum::<usize>(),
+            MAX_SHARE_POSE_SLOTS * 2 / 3,
             "16 skeletons of [x, y] pairs is two thirds of a budget sized for [x, y, confidence]"
         );
 
@@ -3044,7 +3404,7 @@ mod tests {
         let sanitized = sanitize_advanced(&advanced);
         assert!(
             sanitized.get("poses").is_none(),
-            "one pose held {} numbers, over the {MAX_SHARE_POSE_NUMBERS} budget",
+            "one pose held {} numbers, over the {MAX_SHARE_POSE_SLOTS} budget",
             8_000
         );
         assert_eq!(sanitized["steps"], json!(8));
@@ -3066,7 +3426,402 @@ mod tests {
             .as_array()
             .expect("the whole library travels");
         assert_eq!(poses.len(), 46);
-        assert_eq!(poses.iter().map(count_numbers).sum::<usize>(), 46 * 36);
+        assert_eq!(
+            poses.iter().map(count_coordinate_slots).sum::<usize>(),
+            46 * 36
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Volume that is not a number (sc-15949 review)
+    // -----------------------------------------------------------------------------------------
+
+    /// A `null` is a coordinate SLOT and costs one, and an empty array is not a coordinate at all.
+    ///
+    /// The budget counted `Value::Number` while the shape check accepted `Value::Null`, so the two
+    /// disagreed about what a coordinate is and the gap between them was free volume: 200,000 nulls
+    /// under one `keypoints` key survived and serialized to a megabyte. Empty arrays were the same
+    /// hole from the other side — `[]` is vacuously "all coordinates" — at 600 kB.
+    #[test]
+    fn a_null_costs_a_slot_and_an_empty_array_is_not_a_coordinate() {
+        // 1. Nulls, over the budget: the field is dropped, and the size the envelope would have
+        //    carried is asserted rather than described.
+        let nulls: Vec<Value> = (0..200_000).map(|_| Value::Null).collect();
+        let unbounded = serde_json::to_string(&json!([{ "keypoints": nulls.clone() }]))
+            .expect("serializes")
+            .len();
+        assert!(
+            unbounded > 900_000,
+            "the fixture must be a payload to be worth guarding: {unbounded} bytes"
+        );
+        let advanced = json!({ "steps": 8, "poses": [{ "keypoints": nulls }] })
+            .as_object()
+            .cloned()
+            .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        assert!(sanitized.get("poses").is_none(), "{:?}", sanitized);
+        assert_eq!(sanitized["steps"], json!(8), "the rest still travels");
+
+        // 2. Empty arrays: refused by the shape check, so the field never occupies the budget at all.
+        let empties: Vec<Value> = (0..200_000).map(|_| json!([])).collect();
+        let advanced = json!({ "steps": 8, "poses": [{ "keypoints": empties }] })
+            .as_object()
+            .cloned()
+            .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        let poses = sanitized["poses"].as_array().expect("the slot is kept");
+        assert_eq!(poses.len(), 1, "a pose entry still occupies its slot");
+        assert!(
+            poses[0].as_object().expect("object").is_empty(),
+            "an array with nothing in it is not a point: {:?}",
+            poses[0]
+        );
+        assert!(!is_coordinate_tree(&json!([])));
+        assert!(!is_coordinate_tree(&json!([[0.1, 0.2], []])));
+
+        // 3. Nulls WITHIN the budget still travel: they are the missing-coordinate form the worker's
+        //    `normalize_points` fills in, so counting them is a bound and not a ban.
+        let advanced = json!({ "poses": [{ "keypoints": [[0.1, null], [null, null]] }] })
+            .as_object()
+            .cloned()
+            .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        assert_eq!(
+            sanitized["poses"][0]["keypoints"],
+            json!([[0.1, null], [null, null]])
+        );
+        assert_eq!(count_coordinate_slots(&sanitized["poses"]), 4);
+
+        // 4. And a bare scalar under a pose field is not a skeleton: `keypoints: 5` used to pass the
+        //    shape check and record a positive claim about a pose nobody made.
+        for shape in [json!(5), Value::Null, json!("keypoints")] {
+            let advanced = json!({ "poses": [{ "keypoints": shape }] })
+                .as_object()
+                .cloned()
+                .expect("object");
+            let sanitized = sanitize_advanced(&advanced);
+            assert!(
+                sanitized["poses"][0]
+                    .as_object()
+                    .expect("object")
+                    .is_empty(),
+                "{:?} travelled as a keypoint set",
+                sanitized["poses"][0]
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // The recording ceiling (sc-15949 review)
+    // -----------------------------------------------------------------------------------------
+
+    /// The bound that composes: per-field bounds, all satisfied, adding up to an envelope nobody
+    /// would record.
+    ///
+    /// Every value here is legal on its own — six prose slots inside [`PROSE_MAX_BYTES`], every
+    /// allow-listed scalar inside [`LABEL_MAX_CHARS`], a pose set exactly at
+    /// [`MAX_SHARE_POSE_SLOTS`] — and their sum is ~220 kB. That is the shape each round of
+    /// per-field caps kept missing, and the ceiling is what closes it rather than another cap.
+    #[test]
+    fn an_envelope_over_the_recording_ceiling_is_no_workflow_at_all() {
+        let prose = "z".repeat(PROSE_MAX_BYTES);
+        let label = "L".repeat(LABEL_MAX_CHARS);
+        let point = json!([0.123_456_789_012_345_67, 0.987_654_321_098_765_4, 0.55]);
+        let skeleton: Vec<Value> = (0..(18 + 42 + 68)).map(|_| point.clone()).collect();
+        let mut advanced = JsonObject::new();
+        for key in [
+            "sampler",
+            "scheduler",
+            "guidanceMethod",
+            "pidTarget",
+            "controlMode",
+            "styleId",
+            "angleSet",
+            "resolution",
+        ] {
+            advanced.insert(key.to_owned(), json!(label));
+        }
+        advanced.insert("stylePrompt".to_owned(), json!(prose));
+        advanced.insert("systemMessage".to_owned(), json!(prose));
+        advanced.insert(
+            "structuredPrompt".to_owned(),
+            json!({ "intent": prose, "runtimePrompt": prose }),
+        );
+        advanced.insert(
+            "poses".to_owned(),
+            json!((0..16)
+                .map(|_| json!({ "keypoints": skeleton.clone() }))
+                .collect::<Vec<Value>>()),
+        );
+        let envelope = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": prose,
+            "negativePrompt": prose,
+            "advanced": Value::Object(advanced),
+        });
+
+        let error = parse_workflow_share(&envelope)
+            .expect_err("an envelope over the recording ceiling must not be recorded");
+        let WorkflowShareError::TooLarge { bytes, limit } = error else {
+            panic!("wrong error: {error}");
+        };
+        assert_eq!(limit, WORKFLOW_SHARE_MAX_BYTES);
+        assert!(
+            bytes > WORKFLOW_SHARE_MAX_BYTES,
+            "{bytes} is not over {WORKFLOW_SHARE_MAX_BYTES}"
+        );
+        // Every per-field bound held: this is a composition failure, not a field failure.
+        assert!(
+            bytes < 4 * WORKFLOW_SHARE_MAX_BYTES,
+            "{bytes} — the per-field bounds should have kept this to a few hundred kB"
+        );
+        // NO workflow, not a partial one. Shedding the biggest field would record a recipe missing
+        // exactly the part that made it too large, and nothing in the file would say which.
+        let message = WorkflowShareError::TooLarge { bytes, limit }.to_string();
+        assert!(message.contains("no recipe was read"), "{message}");
+
+        // The same envelope minus the poses is under the ceiling and travels whole, so the ceiling is
+        // a bound on the sum and not a refusal of prose.
+        let mut smaller = envelope.clone();
+        smaller["advanced"]
+            .as_object_mut()
+            .expect("object")
+            .remove("poses");
+        let share = parse_workflow_share(&smaller).expect("under the ceiling");
+        assert_eq!(share.prompt.len(), PROSE_MAX_BYTES);
+        assert!(
+            workflow_share_bytes(&share) <= WORKFLOW_SHARE_MAX_BYTES,
+            "{}",
+            workflow_share_bytes(&share)
+        );
+    }
+
+    /// The ceiling's figure, against the validators it is derived from.
+    #[test]
+    fn the_recording_ceiling_clears_every_upstream_validator() {
+        assert_eq!(WORKFLOW_SHARE_MAX_BYTES, 160 * 1024);
+        // The arithmetic maximum a legitimate envelope can reach: two prompt fields at the API's
+        // 4,000-character cap in the widest encoding, the API's own ceiling on the serialized
+        // `advanced` map, and the bounded labels/LoRAs around them. See the constant's own table.
+        const LEGITIMATE_MAX: usize = 2 * 4_000 * 4 + 64 * 1024 + 8_250 + 15_000;
+        const _: () = assert!(LEGITIMATE_MAX < WORKFLOW_SHARE_MAX_BYTES);
+        // With real headroom, rather than a number that only just clears the sum.
+        const _: () = assert!(LEGITIMATE_MAX * 4 / 3 < WORKFLOW_SHARE_MAX_BYTES);
+        // And the write side runs the same gate as the read side, so a writer cannot produce a file
+        // its own reader refuses.
+        let payload = payload_fixture();
+        let facts = WorkflowAssetFacts::from_asset(&asset_fixture());
+        let embedded = embeddable_workflow_share(&facts, &payload).expect("a real envelope embeds");
+        assert_eq!(embedded, build_workflow_share_from(&facts, &payload));
+        assert!(workflow_share_bytes(&embedded) < 4 * 1024, "{embedded:?}");
+    }
+
+    /// The write side's half: an envelope the ceiling refuses is not embedded, rather than embedded
+    /// for our own reader to refuse on the way back in.
+    #[test]
+    fn the_write_side_refuses_what_the_read_side_would() {
+        let prose = "z".repeat(PROSE_MAX_BYTES);
+        let point = json!([0.123_456_789_012_345_67, 0.987_654_321_098_765_4, 0.55]);
+        let skeleton: Vec<Value> = (0..(18 + 42 + 68)).map(|_| point.clone()).collect();
+        let mut payload = payload_fixture();
+        payload.insert("prompt".to_owned(), json!(prose));
+        payload.insert("negativePrompt".to_owned(), json!(prose));
+        payload.insert(
+            "advanced".to_owned(),
+            json!({
+                "stylePrompt": prose,
+                "systemMessage": prose,
+                "structuredPrompt": { "intent": prose, "runtimePrompt": prose },
+                "poses": (0..16).map(|_| json!({ "keypoints": skeleton.clone() })).collect::<Vec<Value>>(),
+            }),
+        );
+        let facts = WorkflowAssetFacts::from_asset(&asset_fixture());
+        assert!(
+            embeddable_workflow_share(&facts, &payload).is_none(),
+            "the write seam must embed nothing rather than a file our own reader refuses"
+        );
+        // And the reader agrees about the same envelope, which is the property one shared gate buys.
+        let built = build_workflow_share_from(&facts, &payload);
+        let envelope = serde_json::to_value(&built).expect("serializes");
+        assert!(matches!(
+            parse_workflow_share(&envelope),
+            Err(WorkflowShareError::TooLarge { .. })
+        ));
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // The omission marker (sc-15949 review)
+    // -----------------------------------------------------------------------------------------
+
+    /// A dropped collection says so, in both directions.
+    ///
+    /// The premise the drop doctrine rested on — "a reader can tell an absence" — is false: `loras`
+    /// carries `skip_serializing_if = "Vec::is_empty"`, so this test starts by proving that a 6-LoRA
+    /// envelope whose LoRAs were dropped and a genuinely LoRA-free one would otherwise be BYTE
+    /// IDENTICAL, and then that the marker is what tells them apart.
+    #[test]
+    fn a_dropped_collection_is_self_describing_in_both_directions() {
+        let with_loras = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "a lighthouse",
+            "loras": (0..6).map(|index| json!({ "name": format!("Lora {index}"), "weight": 0.5 })).collect::<Vec<Value>>(),
+        });
+        let mut without_loras = with_loras.clone();
+        without_loras
+            .as_object_mut()
+            .expect("object")
+            .remove("loras");
+
+        let dropped = parse_workflow_share(&with_loras).expect("parses");
+        let never_had_any = parse_workflow_share(&without_loras).expect("parses");
+        assert!(dropped.loras.is_empty());
+        assert!(never_had_any.loras.is_empty());
+        assert_eq!(dropped.omitted, vec![OMITTED_LORAS.to_owned()]);
+        assert!(never_had_any.omitted.is_empty());
+        assert_ne!(
+            serde_json::to_string(&dropped).expect("serializes"),
+            serde_json::to_string(&never_had_any).expect("serializes"),
+            "without the marker these two serialize identically, which is the whole finding"
+        );
+
+        // The BUILD side too, which is where it matters most: `MAX_SHARE_POSES` has no upstream
+        // validator, so our own writer can drop a 70-pose selection — and this is what makes that
+        // visible instead of silent.
+        let mut payload = payload_fixture();
+        payload.insert(
+            "advanced".to_owned(),
+            json!({
+                "steps": 8,
+                "poses": (0..70).map(|_| json!({ "keypoints": [[0.1, 0.2]] })).collect::<Vec<Value>>(),
+            }),
+        );
+        let built = build_workflow_share(&asset_fixture(), &payload);
+        assert!(built.advanced.get("poses").is_none());
+        assert_eq!(built.omitted, vec![OMITTED_POSES.to_owned()]);
+        assert_eq!(built.advanced["steps"], json!(8));
+
+        // And it survives its own round trip, so a shared file carries the knowledge onward.
+        let envelope = serde_json::to_value(&built).expect("serializes");
+        assert_eq!(parse_workflow_share(&envelope).expect("parses"), built);
+    }
+
+    /// The marker is a closed vocabulary, so it adds no surface of its own.
+    #[test]
+    fn the_omission_marker_admits_only_field_names_it_defined() {
+        let hostile = json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "a lighthouse",
+            "omitted": [
+                "loras",
+                "loras",
+                "advanced.poses",
+                "C:\\Users\\Victim\\secrets.txt",
+                "../../etc/passwd",
+                "\u{1b}[31mred",
+                "x".repeat(100_000),
+                "everything",
+            ],
+        });
+        let share = parse_workflow_share(&hostile).expect("parses");
+        // Sorted, deduplicated, and nothing that is not a name this contract defined.
+        assert_eq!(
+            share.omitted,
+            vec![OMITTED_POSES.to_owned(), OMITTED_LORAS.to_owned()]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<String>>()
+                .into_iter()
+                .collect::<Vec<String>>()
+        );
+        for name in &share.omitted {
+            assert!(
+                OMITTED_FIELDS.contains(&name.as_str()),
+                "`{name}` is not in the vocabulary"
+            );
+        }
+        // Bounded by construction: the vocabulary IS the bound, so no cap has to compose with it.
+        assert!(share.omitted.len() <= OMITTED_FIELDS.len());
+        assert!(
+            serde_json::to_string(&share.omitted)
+                .expect("serializes")
+                .len()
+                < 200
+        );
+        // Every name is a plain field path — nothing here can be a label, a path or free text.
+        for name in OMITTED_FIELDS {
+            assert!(
+                name.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '[' | ']')),
+                "{name}"
+            );
+        }
+    }
+
+    /// An over-cap phase LoRA schedule omits the KEY, and says so.
+    ///
+    /// `"loras": []` is not an absence: it is the positive claim "this phase applies no LoRAs", and
+    /// the phase schedule is the substance of a Krea multi-phase recipe. This is the same
+    /// plausible-and-unfalsifiable record the drop doctrine refuses everywhere else.
+    #[test]
+    fn an_over_cap_phase_lora_schedule_is_omitted_not_emptied() {
+        let advanced = json!({
+            "phases": [
+                { "steps": 4, "loras": (0..6).map(|index| json!({ "index": index, "weight": 0.5 })).collect::<Vec<Value>>() },
+                { "steps": 6, "loras": [{ "index": 0, "weight": 0.4 }] },
+            ]
+        })
+        .as_object()
+        .cloned()
+        .expect("object");
+        let sanitized = sanitize_advanced(&advanced);
+        let phases = sanitized["phases"].as_array().expect("phases");
+        assert!(
+            phases[0].get("loras").is_none(),
+            "an over-cap schedule became {:?}, which reads as `applies no LoRAs`",
+            phases[0].get("loras")
+        );
+        assert_eq!(
+            phases[0]["steps"],
+            json!(4),
+            "the phase itself still travels"
+        );
+        assert_eq!(
+            phases[1]["loras"].as_array().expect("array").len(),
+            1,
+            "the phase that was within the cap keeps its schedule"
+        );
+        assert_eq!(
+            advanced_omissions(&advanced, &sanitized),
+            vec![OMITTED_PHASE_LORAS.to_owned()]
+        );
+
+        // Through the reducer, in both directions, so the marker is on the envelope and not only in
+        // a helper's return value.
+        let mut payload = payload_fixture();
+        payload.insert("advanced".to_owned(), Value::Object(advanced));
+        let built = build_workflow_share(&asset_fixture(), &payload);
+        assert_eq!(built.omitted, vec![OMITTED_PHASE_LORAS.to_owned()]);
+        let envelope = serde_json::to_value(&built).expect("serializes");
+        assert_eq!(parse_workflow_share(&envelope).expect("parses"), built);
+
+        // A phase that declared NO schedule is an absence rather than an omission, so the marker
+        // stays quiet — it has to mean something when it does appear.
+        let quiet = json!({ "phases": [{ "steps": 4 }, { "steps": 6, "loras": [] }] })
+            .as_object()
+            .cloned()
+            .expect("object");
+        assert!(advanced_omissions(&quiet, &sanitize_advanced(&quiet)).is_empty());
     }
 
     /// sc-15949 review: `char::is_control` is `Cc` only, so a bidi override and the zero-width

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -1700,6 +1700,122 @@ fn denied_top_level_request_fields_never_travel() {
 }
 
 // ---------------------------------------------------------------------------
+// Collection bounds (sc-15949 review)
+// ---------------------------------------------------------------------------
+
+/// `workflow_share::MAX_SHARE_PHASES` against the two validators it claims to be.
+///
+/// `sceneworks-worker` depends on `sceneworks-core`, so the constant cannot be imported and the
+/// derivation would otherwise be a comment nobody checks. Read from source instead, the same
+/// technique the `ADVANCED_BUILDERS` lint uses on `apps/web/src`: if either validator's cap moves,
+/// this fails and the envelope's cap becomes a decision rather than a stale copy.
+#[test]
+fn the_phase_cap_matches_the_multi_phase_validators() {
+    let worker = read_repo_file("crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs");
+    assert!(
+        worker.contains("const MAX_MULTIPHASE_PHASES: usize = 8;"),
+        "the worker's multi-phase cap moved; `workflow_share::MAX_SHARE_PHASES` (8) has to move \
+         with it or the envelope will drop a phase set the worker would have run"
+    );
+    let web = read_repo_file("apps/web/src/imageMultiPhase.js");
+    assert!(
+        web.contains("export const MULTIPHASE_MAX_PHASES = 8;"),
+        "the web's multi-phase cap moved; see `workflow_share::MAX_SHARE_PHASES`"
+    );
+}
+
+/// The bounds against REAL requests, not fixtures written to pass them.
+///
+/// A cap is only correct if nothing legitimate touches it, and the failure mode of getting that
+/// wrong is silent: the envelope simply arrives without its LoRAs. So the three widest shapes the
+/// studio actually submits are run through the builder and every collection is asserted to have
+/// survived whole.
+#[test]
+fn no_real_request_is_truncated_by_the_collection_bounds() {
+    // 1. The golden fixture — an edit with a source, two references, a mask, a control map and a
+    //    LoRA, i.e. all four input kinds at once.
+    let golden = build_workflow_share(&golden_asset(), &golden_payload());
+    assert_eq!(golden.loras.len(), 1, "{:?}", golden.loras);
+    assert_eq!(golden.inputs.len(), 4, "{:?}", golden.inputs);
+    // And the fixture ON DISK, which is what a reader will actually be handed.
+    let parsed = parse_workflow_share(&load_golden_fixture()).expect("the golden fixture parses");
+    assert_eq!(parsed.loras.len(), 1);
+    assert_eq!(parsed.inputs.len(), 4);
+
+    // 2. A Krea multi-phase recipe at the validators' own ceiling: 8 phases, each naming phase
+    //    LoRAs by index into a full 5-LoRA stack.
+    let mut krea = golden_payload();
+    krea.insert("model".to_owned(), json!("krea_2_turbo"));
+    krea.insert(
+        "loras".to_owned(),
+        json!((0..5)
+            .map(|index| json!({
+                "id": format!("lora_{index}"),
+                "name": format!("Foggy Coast {index}"),
+                "weight": 0.6,
+                "source": { "provider": "huggingface", "repo": format!("acme/foggy-{index}") }
+            }))
+            .collect::<Vec<Value>>()),
+    );
+    krea.insert(
+        "advanced".to_owned(),
+        json!({
+            "steps": 28,
+            "phases": (0..8)
+                .map(|index| json!({
+                    "steps": index + 2,
+                    "guidance": 3.5,
+                    "loras": (0..5).map(|lora| json!({ "index": lora, "weight": 0.5 })).collect::<Vec<Value>>()
+                }))
+                .collect::<Vec<Value>>(),
+        }),
+    );
+    let krea_share = build_workflow_share(&golden_asset(), &krea);
+    assert_eq!(krea_share.loras.len(), 5, "{:?}", krea_share.loras);
+    let phases = krea_share.advanced["phases"].as_array().expect("phases");
+    assert_eq!(phases.len(), 8);
+    for phase in phases {
+        assert_eq!(
+            phase["loras"].as_array().expect("phase loras").len(),
+            5,
+            "a phase's LoRA indices point into the job's own 5-LoRA stack and must all survive"
+        );
+    }
+
+    // 3. A multi-reference FLUX.2 request: many reference images, which the builder records as ONE
+    //    input entry with a count — the reason `MAX_SHARE_INPUTS` can be the number of kinds.
+    let mut flux = golden_payload();
+    flux.insert("model".to_owned(), json!("flux2_dev"));
+    flux.insert("mode".to_owned(), json!("edit_image"));
+    flux.remove("maskAssetId");
+    flux.insert(
+        "referenceAssetIds".to_owned(),
+        json!((0..10)
+            .map(|index| json!(format!("asset_ref_{index}")))
+            .collect::<Vec<Value>>()),
+    );
+    let flux_share = build_workflow_share(&golden_asset(), &flux);
+    let references = flux_share
+        .inputs
+        .iter()
+        .find(|input| input.kind == "reference")
+        .expect("the reference inputs travel");
+    assert_eq!(references.count, 10, "the COUNT carries the breadth");
+    assert!(flux_share.inputs.len() <= 4, "{:?}", flux_share.inputs);
+
+    // Every one of the three round-trips through the reader unchanged, so the bounds cannot be
+    // asymmetric between the direction that wrote the file and the direction that reads it.
+    for share in [golden, krea_share, flux_share] {
+        let envelope = serde_json::to_value(&share).expect("serializes");
+        assert_eq!(
+            parse_workflow_share(&envelope).expect("parses"),
+            share,
+            "a real envelope must survive its own reader"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -19,7 +19,7 @@ use sceneworks_core::workflow_share::{
     parse_workflow_share, AdvancedBuilder, AdvancedBuilderShape, AdvancedDisposition,
     AdvancedKeySource, WorkflowAssetFacts, WorkflowShare, ADVANCED_BUILDERS, ADVANCED_KEY_RULES,
     DEFERRED_ADVANCED_BUILDERS, PERMANENT_EXEMPTION, PRODUCER_URL, PRODUCER_VERSION,
-    WORKFLOW_SHARE_SCHEMA_VERSION,
+    WORKFLOW_SHARE_MAX_BYTES, WORKFLOW_SHARE_SCHEMA_VERSION,
 };
 use serde_json::{json, Value};
 
@@ -1813,6 +1813,173 @@ fn no_real_request_is_truncated_by_the_collection_bounds() {
             "a real envelope must survive its own reader"
         );
     }
+}
+
+/// Nothing legitimate is anywhere near the recording ceiling.
+///
+/// A ceiling is only correct if no real envelope reaches it, and getting that wrong is silent in the
+/// worst way: the image simply arrives with no recipe. So the four widest real shapes are measured
+/// against it in ABSOLUTE bytes, and the margin is printed rather than described.
+#[test]
+fn no_legitimate_envelope_comes_close_to_the_recording_ceiling() {
+    let mut widest = 0;
+    let mut measure = |label: &str, share: &WorkflowShare| {
+        let bytes = serde_json::to_string(share).expect("serializes").len();
+        println!(
+            "sc-15949: {label} is {bytes} bytes, {:.0}x under the {WORKFLOW_SHARE_MAX_BYTES} byte \
+             ceiling",
+            WORKFLOW_SHARE_MAX_BYTES as f64 / bytes as f64
+        );
+        assert!(
+            bytes * 4 < WORKFLOW_SHARE_MAX_BYTES,
+            "{label} is {bytes} bytes, within 4x of the {WORKFLOW_SHARE_MAX_BYTES} byte ceiling — \
+             the ceiling has stopped having real headroom over what this app produces"
+        );
+        assert!(
+            share.omitted.is_empty(),
+            "{label} lost something: {share:?}"
+        );
+        widest = widest.max(bytes);
+    };
+
+    // 1. The golden fixture, both as the builder makes it and as it sits on disk.
+    measure(
+        "the golden envelope",
+        &build_workflow_share(&golden_asset(), &golden_payload()),
+    );
+    let parsed = parse_workflow_share(&load_golden_fixture()).expect("the golden fixture parses");
+    measure("the golden fixture on disk", &parsed);
+
+    // 2. A Krea multi-phase recipe at the validators' own ceiling: 8 phases, a full 5-LoRA stack,
+    //    every phase naming every LoRA.
+    let mut krea = golden_payload();
+    krea.insert("model".to_owned(), json!("krea_2_turbo"));
+    krea.insert(
+        "loras".to_owned(),
+        json!((0..5)
+            .map(|index| json!({
+                "id": format!("lora_{index}"),
+                "name": format!("Foggy Coast {index}"),
+                "weight": 0.6,
+                "source": { "provider": "huggingface", "repo": format!("acme/foggy-{index}") }
+            }))
+            .collect::<Vec<Value>>()),
+    );
+    krea.insert(
+        "advanced".to_owned(),
+        json!({
+            "steps": 28,
+            "guidanceScale": 3.5,
+            "sampler": "euler",
+            "scheduler": "beta",
+            "phases": (0..8)
+                .map(|index| json!({
+                    "steps": index + 2,
+                    "guidance": 3.5,
+                    "loras": (0..5).map(|lora| json!({ "index": lora, "weight": 0.5 })).collect::<Vec<Value>>()
+                }))
+                .collect::<Vec<Value>>(),
+        }),
+    );
+    measure(
+        "a Krea multi-phase recipe at the validators' ceiling",
+        &build_workflow_share(&golden_asset(), &krea),
+    );
+
+    // 3. A multi-reference FLUX.2 request: ten reference images, all four input kinds in play.
+    let mut flux = golden_payload();
+    flux.insert("model".to_owned(), json!("flux2_dev"));
+    flux.insert(
+        "referenceAssetIds".to_owned(),
+        json!((0..10)
+            .map(|index| json!(format!("asset_ref_{index}")))
+            .collect::<Vec<Value>>()),
+    );
+    measure(
+        "a multi-reference FLUX.2 request",
+        &build_workflow_share(&golden_asset(), &flux),
+    );
+
+    // 4. A realistic long non-Latin prompt — the case a BYTE bound on prose could have truncated
+    //    where a character bound would not. 3 bytes per character, at a length people really type.
+    let cjk = "霧の中の灯台、シネマティック、レンズに雨、35mmフィルムで撮影、\
+               ボリューメトリックライト、夜明けの海岸線、遠くの汽笛、"
+        .repeat(12);
+    assert!(
+        cjk.chars().count() > 700 && cjk.len() > 2_000,
+        "the fixture must be a long non-Latin prompt: {} chars, {} bytes",
+        cjk.chars().count(),
+        cjk.len()
+    );
+    let mut japanese = golden_payload();
+    japanese.insert("prompt".to_owned(), json!(cjk.clone()));
+    japanese.insert("negativePrompt".to_owned(), json!(cjk.clone()));
+    let advanced = japanese
+        .get_mut("advanced")
+        .and_then(Value::as_object_mut)
+        .expect("advanced object");
+    advanced.insert("stylePrompt".to_owned(), json!(cjk.clone()));
+    advanced.insert("systemMessage".to_owned(), json!(cjk.clone()));
+    let japanese_share = build_workflow_share(&golden_asset(), &japanese);
+    measure("a long CJK prompt in every prose slot", &japanese_share);
+    // Character for character, not "roughly the same length": a byte bound must not have cut it.
+    assert_eq!(japanese_share.prompt, cjk);
+    assert_eq!(japanese_share.negative_prompt, cjk);
+    assert_eq!(japanese_share.advanced["stylePrompt"], json!(cjk));
+    assert_eq!(japanese_share.advanced["systemMessage"], json!(cjk));
+
+    // Every one of them round-trips through the reader unchanged, so the ceiling and the marker are
+    // not asymmetric between the direction that wrote the file and the direction that reads it.
+    for share in [
+        build_workflow_share(&golden_asset(), &golden_payload()),
+        build_workflow_share(&golden_asset(), &krea),
+        build_workflow_share(&golden_asset(), &flux),
+        japanese_share,
+    ] {
+        let envelope = serde_json::to_value(&share).expect("serializes");
+        assert_eq!(
+            parse_workflow_share(&envelope).expect("a real envelope survives its own reader"),
+            share
+        );
+    }
+    println!("sc-15949: the widest legitimate envelope measured here is {widest} bytes");
+}
+
+/// Every write seam goes through the GATED builder.
+///
+/// `build_workflow_share_from` does not run the recording ceiling — `embeddable_workflow_share` is
+/// the form that does, and it is the one the worker must call. A seam that called the ungated builder
+/// would embed a chunk our own reader then refuses with `TooLarge`, which is the writer-and-reader
+/// drift every guard in `workflow_share.rs` is arranged to prevent. Pinned as source structure
+/// because `sceneworks-worker` depends on this crate and cannot be inspected any other way.
+#[test]
+fn every_write_seam_embeds_through_the_gated_builder() {
+    for relative in [
+        "crates/sceneworks-worker/src/image_jobs.rs",
+        "crates/sceneworks-worker/src/image_jobs/detail.rs",
+        "crates/sceneworks-worker/src/upscale_jobs.rs",
+        "crates/sceneworks-worker/src/single_child_asset.rs",
+    ] {
+        let source = read_repo_file(relative);
+        // Only the code: the prose in these files names the function it does not call.
+        let code: String = source
+            .lines()
+            .map(str::trim_start)
+            .filter(|line| !line.starts_with("//") && !line.starts_with("///"))
+            .collect::<Vec<&str>>()
+            .join("\n");
+        assert!(
+            !code.contains("build_workflow_share_from("),
+            "{relative} builds an embedded envelope with `build_workflow_share_from`, which does \
+             not run the recording ceiling. Call `embeddable_workflow_share` and treat `None` as \
+             `write the file exactly as today`."
+        );
+    }
+    let worker = read_repo_file("crates/sceneworks-worker/src/image_jobs.rs");
+    assert!(
+        worker.contains("embeddable_workflow_share("),
+        "the worker stopped building envelopes through the gated builder"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -25,7 +25,7 @@ use super::*;
 use sceneworks_core::contracts::GenerationMetrics;
 use sceneworks_core::image_request::ImageRequest;
 use sceneworks_core::workflow_png::write_workflow_chunk;
-use sceneworks_core::workflow_share::{build_workflow_share_from, WorkflowAssetFacts};
+use sceneworks_core::workflow_share::{embeddable_workflow_share, WorkflowAssetFacts};
 use std::sync::Arc;
 
 // Backend-neutral contract types come from the canonical inference release. The selected runtime
@@ -1306,7 +1306,7 @@ pub(crate) fn upscaled_workflow_share(
     base_fact: &JsonObject,
     job_payload: &JsonObject,
     upscale_record: &Value,
-) -> sceneworks_core::workflow_share::WorkflowShare {
+) -> Option<sceneworks_core::workflow_share::WorkflowShare> {
     let base_u32 = |key: &str| {
         base_fact
             .get(key)
@@ -1320,7 +1320,7 @@ pub(crate) fn upscaled_workflow_share(
     // describing one generation cannot disagree about the render that produced it. The base fact
     // supplies the geometry fallback for a payload that omitted it, which is the actual written
     // size of the image this variant was upscaled FROM.
-    build_workflow_share_from(
+    embeddable_workflow_share(
         &WorkflowAssetFacts {
             mode: request.mode.clone(),
             model: request.model.clone(),
@@ -1357,8 +1357,8 @@ pub(crate) fn detail_workflow_share(
     seed: i64,
     width: u32,
     height: u32,
-) -> sceneworks_core::workflow_share::WorkflowShare {
-    build_workflow_share_from(
+) -> Option<sceneworks_core::workflow_share::WorkflowShare> {
+    embeddable_workflow_share(
         &WorkflowAssetFacts {
             mode: "image_detail".to_owned(),
             model: model.to_owned(),
@@ -1411,7 +1411,7 @@ pub(crate) fn standalone_upscale_workflow_share(
     seed: i64,
     source_width: u32,
     source_height: u32,
-) -> sceneworks_core::workflow_share::WorkflowShare {
+) -> Option<sceneworks_core::workflow_share::WorkflowShare> {
     let mut upscale = json!({ "enabled": true, "engine": engine_id, "factor": factor });
     if let Some(softness) = softness {
         upscale["softness"] = json!(softness);
@@ -1421,7 +1421,7 @@ pub(crate) fn standalone_upscale_workflow_share(
     // describes the pass.
     let mut overlay = job_payload.clone();
     overlay.insert("upscale".to_owned(), upscale);
-    build_workflow_share_from(
+    embeddable_workflow_share(
         &WorkflowAssetFacts {
             mode: "image_upscale".to_owned(),
             // The engine IS the model for this pass. The payload carries no `model` key (see
@@ -1530,8 +1530,8 @@ pub(crate) fn write_image_asset(
     // The one funnel every generated image goes through, and therefore the one place the sanitized
     // workflow needs embedding (epic 15945, sc-15948). `None` — embedding off, or no payload to
     // describe — routes through the same `save_with_format` call this used to make, byte for byte.
-    let share = plan.workflow_source.as_deref().map(|payload| {
-        let mut share = build_workflow_share_from(
+    let share = plan.workflow_source.as_deref().and_then(|payload| {
+        let mut share = embeddable_workflow_share(
             &WorkflowAssetFacts {
                 mode: request.mode.clone(),
                 model: request.model.clone(),
@@ -1543,7 +1543,7 @@ pub(crate) fn write_image_asset(
                 height: Some(height),
             },
             payload,
-        );
+        )?;
         // This function only ever writes a BASE render. The inline-upscale post-pass writes its
         // output through `write_upscaled_asset` and keeps the base as its own retained asset, so a
         // `upscale.enabled: true` from the request would describe, on this file, a pass this file
@@ -1553,7 +1553,7 @@ pub(crate) fn write_image_asset(
         // studio from this. The variant's own envelope carries the pass that actually ran, which is
         // the same reasoning `upscaled_workflow_share` applies from the other side.
         share.upscale = None;
-        share
+        Some(share)
     });
     write_workflow_chunk(&rgb_image, &temp_path, share.as_ref())
         .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
@@ -1800,7 +1800,7 @@ fn write_upscaled_asset(
     let share = plan
         .workflow_source
         .as_deref()
-        .map(|payload| upscaled_workflow_share(request, base_fact, payload, &upscale_record));
+        .and_then(|payload| upscaled_workflow_share(request, base_fact, payload, &upscale_record));
     write_workflow_chunk(upscaled, &temp_path, share.as_ref())
         .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
     std::fs::rename(&temp_path, &media_path).inspect_err(|_| {

--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -583,7 +583,7 @@ pub(crate) async fn run_image_detail_job(
     // This pass is its own job with its own payload, so the embedded workflow describes the REFINE
     // (its own prompt, backbone, seed, strength and cnScale) and inherits nothing from the
     // generation that produced the source image — see `detail_workflow_share` (sc-15948).
-    let share = workflow_source(settings, &job.payload).map(|payload| {
+    let share = workflow_source(settings, &job.payload).and_then(|payload| {
         detail_workflow_share(
             &payload,
             &model,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -526,7 +526,8 @@ fn the_upscaled_variant_describes_the_pass_that_actually_ran() {
     .unwrap();
     let applied = json!({ "enabled": true, "engine": "seedvr2", "factor": 2, "softness": 0.25 });
 
-    let share = upscaled_workflow_share(&req, &base_fact, &payload, &applied);
+    let share = upscaled_workflow_share(&req, &base_fact, &payload, &applied)
+        .expect("a fixture envelope is far under the recording ceiling");
     let upscale = share.upscale.as_ref().expect("the pass is recorded");
     assert!(upscale.enabled);
     assert_eq!(upscale.engine.as_deref(), Some("seedvr2"));
@@ -546,7 +547,8 @@ fn the_upscaled_variant_describes_the_pass_that_actually_ran() {
     let mut geometry_less = payload.clone();
     geometry_less.remove("width");
     geometry_less.remove("height");
-    let share = upscaled_workflow_share(&req, &base_fact, &geometry_less, &applied);
+    let share = upscaled_workflow_share(&req, &base_fact, &geometry_less, &applied)
+        .expect("a fixture envelope is far under the recording ceiling");
     assert_eq!((share.width, share.height), (Some(320), Some(256)));
 }
 
@@ -606,7 +608,8 @@ fn the_base_image_of_an_inline_upscale_describes_no_upscale_pass() {
     // The derived variant is where the pass lives, in APPLIED terms: `apply_inline_upscale` clamps
     // 3 to 2 and normalizes `aura-sr` to `real-esrgan` before upscaling.
     let applied = json!({ "enabled": true, "engine": "real-esrgan", "factor": 2 });
-    let variant = upscaled_workflow_share(&req, &base_fact, &payload, &applied);
+    let variant = upscaled_workflow_share(&req, &base_fact, &payload, &applied)
+        .expect("a fixture envelope is far under the recording ceiling");
     let upscale = variant
         .upscale
         .as_ref()
@@ -640,7 +643,8 @@ fn the_detail_pass_describes_itself_and_not_the_source_generation() {
         7,
         1536,
         1024,
-    );
+    )
+    .expect("a fixture envelope is far under the recording ceiling");
 
     assert_eq!(share.mode, "image_detail");
     assert_eq!(share.model, "realvisxl");

--- a/crates/sceneworks-worker/src/single_child_asset.rs
+++ b/crates/sceneworks-worker/src/single_child_asset.rs
@@ -191,7 +191,8 @@ mod tests {
             4242,
             320,
             256,
-        );
+        )
+        .expect("a fixture envelope is far under the recording ceiling");
 
         let image =
             DynamicImage::ImageRgb8(image::RgbImage::from_pixel(8, 8, image::Rgb([12, 34, 56])));
@@ -262,7 +263,8 @@ mod tests {
             0,
             512,
             512,
-        );
+        )
+        .expect("a fixture envelope is far under the recording ceiling");
         let upscale = share.upscale.as_ref().expect("the pass is recorded");
         assert_eq!(upscale.engine.as_deref(), Some("real-esrgan"));
         assert_eq!(upscale.factor, Some(4));

--- a/crates/sceneworks-worker/src/upscale_jobs.rs
+++ b/crates/sceneworks-worker/src/upscale_jobs.rs
@@ -1112,7 +1112,7 @@ pub(crate) async fn run_image_upscale_job(
     // pass and inherits nothing from whatever generated the source image. `engine_id` and `factor`
     // are the APPLIED values (canonicalized and validated above), not the requested ones, and
     // `softness` only travels for the engine that has the knob.
-    let workflow = crate::image_jobs::workflow_source(settings, &job.payload).map(|payload| {
+    let workflow = crate::image_jobs::workflow_source(settings, &job.payload).and_then(|payload| {
         crate::image_jobs::standalone_upscale_workflow_share(
             &payload,
             engine_id,


### PR DESCRIPTION
Detect and record an embedded workflow when a shared image is imported.

Builds on sc-15946 (envelope + allow-list sanitizer), sc-15947 (`read_workflow_chunk_file`) and sc-15948 (the write side) — all merged. **No new reader, no second parse path.**

Story: [sc-15949](https://app.shortcut.com/sceneworks/story/15949)

## What changed

* `normalize_image_upload` takes a `WorkflowScan` parameter and returns the envelope it found on `NormalizedUpload.workflow`. The scan is a new private `read_upload_workflow`, a thin wrapper over `crate::workflow_png::read_workflow_chunk_file` that degrades **every** error to `None`.
* `import_asset` passes `WorkflowScan::Read` and merges what it finds into the asset's top-level `extra` as `importedWorkflow`.
* `upload_training_dataset_item` passes `WorkflowScan::Skip` — a dataset item has no `extra` slot and no reader for a recipe, so it does not pay for a metadata walk per image on a bulk import.
* New `pub const IMPORTED_WORKFLOW_KEY = "importedWorkflow"`.

Plus the five review fixes in the second commit, described under **Review round 1** below. Those touch `workflow_share.rs` (collection bounds + the prose filter), `assets.rs` (the `provenance` shape check) and one line of `image_request.rs` (`MAX_COUNT` becomes `pub(crate)` so the pose budget can be derived from it rather than restate it).

### Where the scan sits, and why

Right after the format sniff, **before** the natively-supported passthrough `return` and **before** the transcode:

* Before the passthrough, because that branch is a `return` — a PNG, the only format that carries our chunk, would otherwise never be looked at.
* Before the transcode, because `sips`/`ffmpeg` re-encode from pixels and drop every ancillary chunk. A scan afterwards could only ever report an absence.

### Keeping the record honest

`recipe.mode` stays `"upload"`, the synthesized stub recipe is exactly what it was, `generationSetId` and `lineage.jobId` stay `null`. Nothing is hoisted out of the envelope into the asset's own record — asserted explicitly (`assert_ne!` on the envelope's seed, model and prompt against the recipe's). sc-15952 offers the envelope as "Use this recipe"; this story does not fabricate a generation.

### Trust boundary

* Validated against the sc-15946 allow-list **on the way in**, because the only route in is `parse_workflow_share_json` inside sc-15947's reader — which also runs `reduce_workflow_share` at value granularity, not just key granularity. Nothing anywhere deserializes an `ImageJobRequest`, or anything else, out of the file.
* sc-15947's `the_reader_has_exactly_one_parse_path` structural test still passes; no second parse path was added.
* Every reader error becomes "no workflow found" and a successful plain import. The typed error is logged at `debug` (`NotPng` is what every JPEG and WebP upload returns).
* `extra.importedWorkflow` is either the envelope this import parsed and sanitized, or absent. The key is `remove`d from a caller-supplied `provenance` unconditionally, before ours is inserted. (**Round 1 correction** — the original claim here was "our sanitized envelope is inserted last, so a caller cannot inject a recipe through `provenance`", and that was **false** whenever the file carried no chunk. See finding 1.)
* Path-shaped values are stripped by sc-15946's `shareable_label` / `hf_repo_id` / `INPUT_KINDS` guards; a hand-crafted hostile chunk is asserted field by field *and* swept over the whole recorded tree with `is_path_shaped`.
* Every collection in the envelope is length-bounded, in the one shared reducer both directions run.

## Review round 1

Five findings, all against this story's own trust-boundary AC. Each fix carries a test proved by mutation (revert the fix → the test fails → restore).

### 1. MAJOR — the provenance-injection guard only worked half the time

`extra` was seeded from `upload.provenance` and ours was inserted only `if let Some(workflow)`. With **no chunk in the file there is nothing to insert**, so ordering protects nothing and a caller-supplied `provenance.importedWorkflow` was written through byte for byte — a `loras[].repo` of `../../../../etc/passwd` in the one field sc-15950/sc-15952 turn into a cache path, an unsanitized absolute `model`, and a free-form `advanced` map the allow-list would have emptied.

**Fix:** `extra.remove(IMPORTED_WORKFLOW_KEY)` unconditionally, before the conditional insert. The guard has to be a removal, not an ordering. The no-chunk + injected-key case is now asserted inside `import_asset_merges_a_workflow_beside_the_editor_provenance`, which previously passed only because its fixture DID carry a chunk.

### 2. MAJOR — no collection bound: ~111x amplification into the Library's hottest read path

`reduce_workflow_share` bounded every individual string (`LABEL_MAX_CHARS`, `PROSE_MAX_CHARS`) and no collection length, so sc-15947's 1 MiB cap on the decompressed chunk text was the only ceiling — and a compressible envelope turns that into enormous leverage.

> [!WARNING]
> **The measurement in this section was wrong, and round 2 replaces it.** It reported "817,592 B before / 60,250 B after, 111x -> 8x" from the same fixture — but that fixture's own size *fell with the fix*: the 8,000-entry collections the caps drop were most of the PNG, so shrinking the payload shrank the denominator and the ratio came back. Re-measured with fixtures that do not change size, the worst case at that commit was **worse** than before the caps: 480,321 B recorded from a 3,633-byte PNG. See **Review round 2**, which has the honest figures and the bound that actually composes. The caps below are correct and are kept; they were just not the last line of defence.

`list_assets` is a known sore spot (sc-14797 / sc-14798), and before this story nothing wrote a stranger's megabyte into the asset index.

**Fix:** caps in `reduce_workflow_share` / `sanitize_advanced`, so both directions run them and the write side cannot drift from the read side. Each derived from the contract that already limits the thing:

| collection | cap | derivation |
|---|---|---|
| `loras` | 5 | `lora_family::MAX_JOB_LORAS` — the hard per-job total the generation path rejects above, and the recipe-preset normalizer's own cap |
| `inputs` | 4 | `INPUT_KINDS.len()`, exact: `describe_inputs` emits at most one entry per kind (a multi-reference run is one entry with a `count`) |
| `advanced.phases` | 8 | the worker's `MAX_MULTIPHASE_PHASES` and the web's `MULTIPHASE_MAX_PHASES`; `sceneworks-worker` depends on this crate so the constant cannot be imported, and `the_phase_cap_matches_the_multi_phase_validators` reads both files instead |
| `advanced.phases[].loras` | 5 | indices into the job's own `loras` list, so the same cap |
| `advanced.poses` | 64 entries | the library they are chosen from — `apps/web/public/poses/index.json` ships 46 — with headroom for user poses |
| `advanced.poses` numbers | 6,144 total | 16 whole-body skeletons: `normalize_keypoints`/`normalize_hands`/`normalize_face` truncate to 18 + 42 + 68 points and a point is `[x, y]` or `[x, y, conf]`. 16 is also 2x `image_request::MAX_COUNT`. ~147 kB worst case, the same order as the prose allowance |

An entry cap alone would still admit 64 poses of a million coordinates each, which is why poses get both.

**Over the cap the collection is DROPPED, never truncated** — the same answer `shareable_label` gives an over-long slug, and for the same reason: a collection's membership is its identity, "the first 5 of these 8,000 LoRAs" is not the recipe that made the image, and sc-15952 would offer it to the user as one. A reader cannot tell a plausible subset from the real thing; it can tell an absence. The rest of the envelope — model, prompt, size, steps — still travels. (`shareable_prose` still truncates, because prose still means what it said after its tail is cut and a list does not.)

`no_real_request_is_truncated_by_the_collection_bounds` runs the three widest real shapes through the builder and asserts nothing is lost: the golden fixture (1 LoRA, all four input kinds), a Krea multi-phase recipe at the validators' own ceiling (8 phases × 5 phase-LoRAs over a 5-LoRA stack), and a multi-reference FLUX.2 request (10 references → one `reference` entry with `count: 10`). All three round-trip through the reader unchanged.

### 3. MINOR — a non-object provenance silently discarded a real workflow

`provenance` of `42`, `"editor"`, `[1,2]` or `null` took the verbatim arm and became the whole `extra` value, throwing away a workflow the reader had already found. `Some(Value::Null)` was reachable from the API, which accepted any non-blank JSON text. And `provenance: {}` had started yielding `extra` absent where it used to be `{}`.

**Fix:** refused at the multipart boundary (`assets.rs`) with `Invalid provenance JSON: provenance must be a JSON object`, and again in `import_asset` with its own sentence, so neither layer depends on the other. `provenance: {}` writes `extra: {}` again. The API test matches its message exactly, so it cannot pass on the store's belt alone.

### 4. MINOR — the documented perf margin was wrong for large files

The old table was measured on small, smooth, compressible renders and claimed the scan miss costs "~3x a plain read and 2-3% of what decoding would cost". On incompressible pixels (release, this box, `the_cost_of_the_scan_against_file_size`):

| | on disk | scan, chunk found | scan, no chunk | plain read | full decode |
|---|---|---|---|---|---|
| 1024² | 3.0 MiB | 44 µs | 870 µs | 681 µs | 1.39 ms |
| 2048² | 12.0 MiB | 89 µs | 3.99 ms | 2.64 ms | 5.29 ms |
| 4096² | 48.0 MiB | 96 µs | 17.08 ms | 13.45 ms | 24.77 ms |
| 6144² | 108.0 MiB | 101 µs | 41.04 ms | 30.53 ms | 57.03 ms |

Two curves, and only one of them is flat. The **hit** is the structural property the test defends and it holds: 44 → 101 µs across a 36x range of file size, no pixel inflate, nothing allocated in proportion to the pixels. The **miss** is O(file) — sc-15947's reader makes a second pass over the framing past IDAT to rule out a late or duplicate chunk — costing ~1.3x a plain read and 63-76% of a full decode (70% at 48 MiB), roughly **0.36 s per GB imported**, and **net-new**: `move_or_copy_file` renames the upload and nothing else on the import path reads the image media, so a large foreign PNG was never read end to end before.

The comment now says exactly that, the "2-3%" claim is gone, and the measurement lives in the tree as an `#[ignore]`d harness rather than being done out of band.

**Corpus count:** the adversarial sweep is 8 named fixtures + 2 broken-pixel files + one truncation every 11 bytes + one bit flip every 23 — **74 imports here**, not the "~110" this PR body claimed. It is a function of the fixture PNG's DEFLATE length (492 bytes here, 417 elsewhere), so the test asserts the derivation and prints the count instead of writing a number down.

### 5. MINOR — prose stripped Cc but not Cf

`shareable_prose` filtered `char::is_control()`, which is Unicode **Cc only**. ANSI escapes were caught (ESC is Cc), so this was display spoofing rather than terminal injection — but U+202E (RLO), U+202D, U+200B, U+FEFF, U+2028 and U+2029 all survived into a recorded envelope, in a feature whose pitch is "trust this recipe a stranger sent you".

**Fix:** `is_invisible_formatting` drops the whole **Cf** class (Unicode 15.1, enumerated — `std` exposes no general-category API and a Unicode table crate is a poor trade for one predicate) plus **Zl**/**Zp**. Newlines and tabs still survive, and emoji variation selectors (U+FE00..U+FE0F, category Mn) are deliberately kept as prompt content.

### Settled and deliberately unchanged

The prose exemption from the path check stands. sc-15946's decision is respected and `authored_prose_travels_verbatim_even_when_it_names_a_path` still passes: prose renders as a React text child (no `dangerouslySetInnerHTML` on host data), reaches disk only through `slugify`, and sc-15952's only path-forming value is `loras[].repo`, which goes through the strict `hf_repo_id`. The leak is the sender's own path, committed at the write seam where the exemption is correct, so a read-side strip could not un-leak anything and would break the write/read symmetry the same AC demands.

## Scope vs each acceptance criterion

| AC | Status |
|----|--------|
| Importing a SceneWorks-generated PNG populates `extra.importedWorkflow` | `import_asset_records_an_embedded_workflow_without_faking_a_generation` — real writer, real reader, whole envelope compared |
| `recipe.mode` is `"upload"` and the stub recipe is unchanged | `assert_upload_stub_recipe` asserts all ten stub fields plus origin and the null generation set / job id, applied in every new import test |
| A PNG with no chunk behaves exactly as today | `import_asset_without_a_workflow_chunk_behaves_exactly_as_before` (`extra` absent), plus `provenance: {}` → `extra: {}` in `import_asset_refuses_a_provenance_that_is_not_an_object` |
| Adversarial corpus imports cleanly, no partial `importedWorkflow` | `a_hostile_or_malformed_chunk_still_imports_as_a_plain_asset` — 8 named hostile fixtures + broken-pixel cases + a truncation sweep + a bit-flip sweep (74 imports here, derived and printed). Each: import succeeds, stored bytes are the user's file byte-for-byte, stub recipe intact, any recorded workflow equals the intact envelope |
| Path-shaped values stripped or envelope rejected | `path_shaped_values_in_a_hostile_chunk_do_not_survive_the_import` |
| Validated against the allow-list on the way in | one parse path through `parse_workflow_share_json`; value-granular reduction, the collection bounds and the Cf/bidi strip all live in the shared reducer |
| The passthrough still avoids a full decode | `the_workflow_scan_reads_chunks_and_never_the_pixels` (by contradiction on an undecodable file) + `the_cost_of_the_scan_against_file_size` (by measurement) |
| `assets.asset_json` round-trips the field | Same test reads the `asset_json` column back, then reruns `reindex_project` and re-reads |

## How verified

* `cargo fmt --all -- --check` — clean (exit 0).
* `cargo clippy --all-targets -- -D warnings` — clean (exit 0).
* `cargo test -p sceneworks-core` — 1,040 passed, 0 failed (769 lib + 271 across the integration targets), 4 ignored.
* `cargo test --workspace --no-fail-fast` — 23 failures, every one in `sceneworks-mcp` / `sceneworks-rust-api`'s MCP tests and every one the pre-existing rustls `No provider set` set (sc-15337). The set did not grow; each of those targets passes on its own. Nothing in `sceneworks-core` fails.
* `npm run rust:check` — exit 0, zero failing targets.
* `crates/sceneworks-core/src/workflow_png.rs` and `crates/sceneworks-core/tests/workflow_png.rs` are 0-line diffs.
* Every review fix proved by mutation: revert the guard, watch the new test fail, restore.

### No-decode evidence

**By contradiction.** `break_the_pixel_stream` rebuilds a PNG whose framing and CRCs are perfect, whose workflow chunk is intact, and whose IDAT payload is not a zlib stream (`0x00 0x00` fails zlib's header check). The test first asserts `image::open` **fails** on it, so the fixture has teeth — then asserts the import succeeds, reads the recipe, and stores the bytes verbatim. A decode-everything path could not do that.

**By measurement.** The table under finding 4.

### Transcode ordering

`a_transcode_destroys_the_chunk_so_only_a_pre_transcode_scan_can_find_it` runs the **real** transcoder (`ffmpeg` here, `sips` on macOS) over a PNG carrying a chunk and asserts the output reads back as `Ok(None)` — the premise, on real bytes rather than from the AVIF/HEIC docs. It skips with a printed note where no transcoder is reachable.

A *positive* end-to-end "an AVIF carrying a workflow imports with the field" test is not constructible today, and not because of this box: sc-15947's reader is PNG-only, so no format that takes the transcode branch can carry the chunk in the first place. The ordering is therefore pinned as source structure by `the_scan_precedes_both_the_passthrough_and_the_transcode`, using the same technique as sc-15947's `the_reader_has_exactly_one_parse_path`.

### `asset_json`

**No migration needed.** `upsert_asset_row` stores `serde_json::to_string(asset)` over the whole sidecar `Value`, and `hydrate_asset` mutates that `Value` in place without a typed round trip — so a new key under `extra` rides the existing blob. Confirmed rather than assumed: the test reads the `asset_json` column back, then runs `reindex_project` (which rebuilds the tables from the sidecars on disk) and re-reads through `get_asset`.

## Review round 2

Six findings. Round 1's per-collection caps were correct but were *the whole defence*, and per-field
bounds do not compose — each re-measurement found a new way to spend what the caps left. So this
round stops patching vectors and adds the bound that composes.

Honest re-measurement at `c599d37d`, with fixtures whose size does **not** change with the fix
(measured by reverting the guards one set at a time inside the same test, so before and after are the
same bytes):

| case | PNG | recorded before | recorded after |
|---|---|---|---|
| six prose slots of U+1F600 x the cap | 3,633 B | 480,321 B | **98,654 B** |
| 112,128 `null` coordinates over 64 poses | 5,630 B | 681,995 B | **98,671 B** |
| six ASCII prose slots, nothing over any cap | 1,668 B | 120,321 B | **98,654 B** |
| 200,000 empty arrays under one `keypoints` | 4,589 B | 720,347 B | **98,667 B** |
| every per-field bound spent at once | 3,045 B | 221,407 B | **not recorded at all** |

The ratio against the PNG is deliberately not the headline: the PNG carries the *compressed*
envelope, so a repetitive payload will always have a large ratio no matter what we do. What is
bounded is the absolute size of what we persist. The widest envelope that can still be recorded is
**152,479 B** (measured, from a 2,050-byte PNG) against a hard ceiling of 163,840 B — down from
1,043,211 B at `c599d37d`.

### 1. BLOCKER — `null` was free volume against the pose budget

`is_numeric_tree` accepted `Value::Null` as a coordinate while `count_numbers` fell through to
`_ => 0`, so the two disagreed about what a coordinate is and the gap was free: **200,000 nulls
under one `keypoints` key survived and serialized to 1,000,027 B.** Empty arrays were the same hole
from the other side — `[]` is vacuously "all coordinates" — at 600,027 B.

**Fix, both halves.** A `null` now costs one slot, because it *is* a coordinate slot (the worker's
`normalize_points` fills a missing one) — so counting it is a bound and not a ban, and nulls within
the budget still travel verbatim. An empty array is refused outright by `is_coordinate_tree`: an
array with nothing in it is not a point. `count_numbers` / `is_numeric_tree` /
`MAX_SHARE_POSE_NUMBERS` are renamed to `count_coordinate_slots` / `is_coordinate_tree` /
`MAX_SHARE_POSE_SLOTS` so the unit and the shape check name the same thing. A bare scalar or `null`
directly under a pose field is also now refused, where it used to travel as a recorded claim about a
pose nobody made.

### 2. MAJOR — prose was bounded in chars, and nothing bounded the envelope in bytes

**(a)** `PROSE_MAX_CHARS = 20_000` is 20 kB of English and **80 kB of any 4-byte scalar**, so the six
prose slots were 480 kB — four times the "~120 kB worst case" the constant's own comment claimed. A
character count cannot bound a serialized size, and every persisted copy of this envelope is measured
in bytes.

`PROSE_MAX_BYTES = 16 KiB` replaces it. Derived, not chosen: the API's `MAX_PROMPT_CHARS` rejects a
`prompt` or `negativePrompt` over 4,000 characters, and 4,000 characters is at most 16,000 bytes — so
**no prompt this app accepted can be truncated here, in any script.** The four `advanced` prose slots
have no per-field validator of their own (only `MAX_ADVANCED_JSON_BYTES`, the 64 KiB ceiling on the
whole serialized map) and take the same bound. Truncation is per whole character against the byte
budget, so a sequence can never be split; documented cost is that a non-Latin prompt gets fewer
*characters* out of the same allowance (5,461 for 3-byte CJK, 4,096 for 4-byte scalars), all still
above the API's own 4,000.

**(b)** `WORKFLOW_SHARE_MAX_BYTES = 160 KiB` — one ceiling on the **serialized envelope**, checked in
the path both directions run, after every per-field rule. Derived from the arithmetic maximum a
legitimate envelope can reach, every term a hard ceiling something else already enforces:

| term | bytes | source |
|---|---|---|
| `prompt` + `negativePrompt` | 32,000 | `MAX_PROMPT_CHARS` (4,000) x 4 bytes, twice |
| `advanced` | 65,536 | `MAX_ADVANCED_JSON_BYTES`, the API's ceiling on the serialized map |
| `loras` | 8,250 | `MAX_SHARE_LORAS` x (name + repo at `LABEL_MAX_CHARS` x 4 + weight) |
| labels + `upscale` + `producer` + scalars | ~15,000 | `LABEL_MAX_CHARS` x 4, per field |
| | **~113,900** | |

160 KiB is 44% headroom over a hard sum, and the measured real cases make that look enormous: the
golden fixture is **960 B**, a Krea multi-phase recipe at the validators' own ceiling **2,258 B**, a
multi-reference FLUX.2 request **958 B**, and a long CJK prompt in every prose slot **9,159 B** — 18x
under, the closest of the four. What the ceiling refuses is the composition the caps could not: the
per-field bounds still admit ~400 kB in total (six 16 KiB prose slots, ~28 allow-listed scalar
labels, a 6,144-slot pose budget).

**Over the ceiling degrades to NO workflow, not to a partial record** —
`WorkflowShareError::TooLarge` on the read side, and `None` from a new `embeddable_workflow_share` on
the write side, which is a shape the write seams already had (`workflow_source` already collapses
"the user opted out" and "no payload to describe" into the same `Option`). Shedding the biggest field
instead would record a recipe missing exactly the part that made it too large, with nothing in the
file to say which. One shared gate, so **a writer cannot produce a file its own reader refuses** —
pinned by `every_write_seam_embeds_through_the_gated_builder`, which reads the worker's sources and
fails if a seam calls the ungated builder.

### 3. MINOR — an over-cap `phases[].loras` became `[]`, a positive claim

The insert was unconditional once the key existed, so an over-cap schedule serialized as
`"loras": []` — not an absence but the claim *"this phase applies no LoRAs"*, and a phase LoRA
schedule is the substance of a Krea multi-phase recipe. The key is now written only when there is a
schedule to write, and the loss is named in `omitted`.

### 4. MINOR — deep-clone before discarding

`bounded_collection(value.as_array()?.clone(), …)` cloned the whole array before deciding to discard
it — 8,000 `Value`s allocated to return none of them, work done precisely in the case the guard exists
to make cheap. Replaced by `over_cap(len, max)`, checked against the length before anything is cloned.

### 5. MINOR — `MAX_SHARE_POSES = 64` has no upstream contract

Correct: every other cap derives from a validator, and this one cannot, because nothing in the
worker's `pose_entries` or in `apps/web/src` clamps how many poses a user may select. So this cap can
fire **on our own write side** — 65+ poses, and `advanced.poses` is simply absent.

Clamping the selection at the source is the better fix and is genuinely a different story (it changes
what the studio submits, and the API would start rejecting payloads it accepts today). **So it is
covered by the marker instead, explicitly**: a 70-pose selection that is not recorded now says so on
the build side, which is asserted in
`a_dropped_collection_is_self_describing_in_both_directions`. Filed as a follow-up below.

### 6. ACCEPTED — a dropped collection is now self-describing

The drop-vs-truncate doctrine rested on "a reader can't tell a plausible subset from the real thing
but can tell an absence", and **the second half is empirically false**: `loras` carries
`skip_serializing_if = "Vec::is_empty"`, so a 6-LoRA envelope whose LoRAs were dropped over the cap
and a genuinely LoRA-free one serialize **byte-identically**. Same for `advanced.poses` and
`advanced.phases`, which are just absent keys. sc-15952 would render "no LoRAs" and offer one-click
"Use this recipe" for a recipe that had five.

Dropping stays (truncating fabricates a specific membership, which is worse; refusing the whole
envelope would throw away model/prompt/seed). What is added is a top-level `omitted` field over a
**closed vocabulary of five field names** — `loras`, `inputs`, `advanced.poses`, `advanced.phases`,
`advanced.phases[].loras` — so it adds no attack surface and is bounded by construction rather than by
another cap that would have to compose. On parse, unknown names are dropped, duplicates collapsed and
the list sorted, so it is a set rather than an order that could carry information. Emitted in **both**
directions, and the derivation is read off the sanitizer's actual input and output rather than pushed
by each rule, so a new reason to drop a collection is a new reason it gets recorded. `omitted` is
skipped when empty, so every existing envelope — including the golden fixture on disk — is
byte-unchanged.

sc-15952 can now say "this file declared more LoRAs than a job can have; they were not recorded" and
withhold the one-click replay.

### Also

`is_invisible_formatting`'s doc said "Unicode 15.1"; the list is exact for **16.0** (16.0 added no
`Cf`), and the label is corrected.

### Verification

* Every fix proved by mutation: revert the guard, watch a named test fail, restore. Round 2's five
  mutations each fail a targeted test (`a_null_costs_a_slot_and_an_empty_array_is_not_a_coordinate`,
  `prose_from_outside_is_control_stripped_and_bounded`,
  `an_envelope_over_the_recording_ceiling_is_no_workflow_at_all` +
  `the_write_side_refuses_what_the_read_side_would`,
  `an_over_cap_phase_lora_schedule_is_omitted_not_emptied`,
  `a_dropped_collection_is_self_describing_in_both_directions`).
* `no_legitimate_envelope_comes_close_to_the_recording_ceiling` measures the golden fixture, a Krea
  multi-phase recipe at the validators' ceiling, a multi-reference FLUX.2 request and a long CJK
  prompt in every prose slot: none is dropped, none is truncated (the CJK prompt is asserted character
  for character), none is within 4x of the ceiling, and all four round-trip through the reader.
* `workflow_png.rs` and `tests/workflow_png.rs` are 0-line diffs;
  `the_reader_has_exactly_one_parse_path` and
  `authored_prose_travels_verbatim_even_when_it_names_a_path` still pass.
* `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test -p sceneworks-core` (1,049 tests), `npm run rust:check` — all clean.
  `cargo test --workspace --no-fail-fast`: 23 failures, byte-identical to the same run on the
  unmodified tree (the pre-existing rustls set, sc-15337).

## Follow-ups (not done here, deliberately)

* Non-UTF-8 chunk text is not re-tested at this boundary — it needs the hand-framed zlib-stored fixture that lives in `workflow_png`'s own module tests, and every reader error is handled identically here.
* **Clamp pose selection at the source.** `MAX_SHARE_POSES = 64` is the one cap with no upstream validator to inherit, so it can fire on our own write side (round 2, finding 5). It is now a *visible* loss — the `omitted` marker names it — but the right fix is a ceiling where the poses are chosen, in `apps/web/src` and the API's `validate_image_payload`, which would both give the cap a real derivation and stop the envelope from being where a user discovers the limit. Out of scope here: it changes what the studio may submit.
* **`Cf` is not the whole display-spoof class.** U+3164 HANGUL FILLER, U+115F / U+1160, U+2800 BRAILLE PATTERN BLANK and U+FFA0 all render blank and are `Lo` / `So`, so they survive `is_invisible_formatting`. Same trick, different general category — and a separate decision, because `Lo` is where real prompt content lives and a range list there needs its own justification. Noted in the function's doc.
* **`workflow_png.rs`'s doc references `PROSE_MAX_CHARS`,** which round 2 replaced with `PROSE_MAX_BYTES`. It is prose in a code span (not an intra-doc link, so nothing breaks) in a file this round had to keep as a 0-line diff. Worth a one-line correction in the next story that touches it — the derivation it describes still clears the 1 MiB text cap by a wider margin than before, since the prose allowance shrank from ~400 kB to 96 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

