### PR TITLE
fix(web): pin the Logs filter panel and add per-entry copy (#1966)

### DIFF
--- a/apps/web/src/screens/LogsScreen.jsx
+++ b/apps/web/src/screens/LogsScreen.jsx
@@ -4,6 +4,7 @@ import { apiFetch } from "../api.js";
 import { useAppStatic } from "../context/AppContext.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
+import { writeClipboardText } from "../clipboard.js";
 
 // In-app Logs viewer (sc-3452). Shows the current session's activity — most
 // importantly the GPU routing decisions (`gpu_route_decision`) and claim
@@ -52,6 +53,45 @@ const SEARCH_DEBOUNCE_MS = 250;
 // Events that answer the routing question get visual emphasis.
 const HIGHLIGHT_EVENTS = new Set(["gpu_route_decision", "claim_lock_contention"]);
 
+// How long the copy button reads "Copied" before reverting (#1966).
+const COPY_FEEDBACK_MS = 1500;
+// Sticky-offset fallback for the filter panel when the topbar can't be measured
+// (jsdom, or a shell that renders the Logs screen without the app chrome).
+// Roughly the topbar's natural height: 12px padding × 2 + a two-line title.
+const TOPBAR_FALLBACK_PX = 64;
+
+// What the per-entry copy button puts on the clipboard (#1966). The structured
+// event is what people actually paste into a bug report, so prefer its
+// pretty-printed form and fall back to the raw log line for entries the parser
+// didn't turn into an event.
+export function logEntryClipboardText(entry) {
+  if (!entry) return "";
+  if (entry.event) return JSON.stringify(entry.event, null, 2);
+  return entry.raw ?? entry.message ?? "";
+}
+
+// The filter panel pins below the global topbar rather than at the top of the
+// scroll box: `.workspace` is the scrolling ancestor and `.topbar` is already
+// sticky at its top edge, so a `top: 0` panel would slide underneath it. The
+// topbar's height is content-driven (its status pills wrap on narrow windows),
+// so measure it instead of hardcoding an offset.
+function useTopbarHeight() {
+  const [height, setHeight] = useState(TOPBAR_FALLBACK_PX);
+  useEffect(() => {
+    const topbar = globalThis.document?.querySelector(".topbar");
+    if (!topbar) return undefined;
+    const measure = () => {
+      setHeight(topbar.getBoundingClientRect().height || TOPBAR_FALLBACK_PX);
+    };
+    measure();
+    if (typeof ResizeObserver !== "function") return undefined;
+    const observer = new ResizeObserver(measure);
+    observer.observe(topbar);
+    return () => observer.disconnect();
+  }, []);
+  return height;
+}
+
 // Note: text `search` is intentionally NOT a fetch parameter. Source/level are
 // cheap, coarse toggles that legitimately change what the server returns, but
 // the full snapshot is already held in memory, so free-text search filters
@@ -87,11 +127,27 @@ export function LogsScreen() {
   const [paused, setPaused] = useState(false);
   const [error, setError] = useState("");
   const [expanded, setExpanded] = useState(null);
+  // seq of the entry whose copy button just fired, plus whether it succeeded.
+  const [copied, setCopied] = useState(null);
 
   const lastSeqRef = useRef(undefined);
   const bottomRef = useRef(null);
+  const copyTimerRef = useRef(null);
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
+
+  const topbarHeight = useTopbarHeight();
+
+  // Clear the transient "Copied" flag on unmount so a late timer can't set
+  // state on a torn-down tree.
+  useEffect(() => () => clearTimeout(copyTimerRef.current), []);
+
+  const copyEntry = useCallback(async (entry) => {
+    const ok = await writeClipboardText(logEntryClipboardText(entry));
+    setCopied({ seq: entry.seq, ok });
+    clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = setTimeout(() => setCopied(null), COPY_FEEDBACK_MS);
+  }, []);
 
   // Full (re)load: source/level filters changed, or first mount. Text search is
   // deliberately absent from the deps so typing doesn't refetch (sc-8849).
@@ -219,7 +275,13 @@ export function LogsScreen() {
 
   return (
     <section className="page-frame logs-screen">
-      <WorkPanel eyebrow="Filter the stream">
+      {/* Pinned so the filters/pause control stay reachable while the tail
+          scrolls (#1966); `--logs-sticky-top` is the measured topbar height. */}
+      <WorkPanel
+        eyebrow="Filter the stream"
+        className="logs-panel"
+        style={{ "--logs-sticky-top": `${topbarHeight}px` }}
+      >
         <div className="logs-toolbar" role="toolbar" aria-label="Log filters">
         <div className="segmented-control" role="group" aria-label="Source">
           <button
@@ -307,8 +369,30 @@ export function LogsScreen() {
               <span className={`logs-chip source-${entry.source}`}>{entry.source}</span>
               <span className={`logs-chip level-${entry.level}`}>{entry.level}</span>
               <span className="logs-message">{entry.message}</span>
-              {isOpen && entry.event ? (
-                <pre className="logs-detail">{JSON.stringify(entry.event, null, 2)}</pre>
+              {isOpen ? (
+                <div className="logs-detail-panel">
+                  {/* Copying the expanded entry used to mean hand-selecting the
+                      JSON out of a live-tailing list (#1966). `stopPropagation`
+                      keeps the click off the row's expand/collapse toggle. */}
+                  <button
+                    type="button"
+                    className="logs-copy"
+                    aria-label="Copy log entry to clipboard"
+                    onClick={(clickEvent) => {
+                      clickEvent.stopPropagation();
+                      copyEntry(entry);
+                    }}
+                  >
+                    {copied?.seq === entry.seq
+                      ? copied.ok
+                        ? "Copied"
+                        : "Couldn’t copy"
+                      : "Copy"}
+                  </button>
+                  {entry.event ? (
+                    <pre className="logs-detail">{JSON.stringify(entry.event, null, 2)}</pre>
+                  ) : null}
+                </div>
               ) : null}
             </div>
           );

--- a/apps/web/src/screens/LogsScreen.test.jsx
+++ b/apps/web/src/screens/LogsScreen.test.jsx
@@ -22,7 +22,7 @@ vi.mock("../api.js", async (importOriginal) => {
 });
 
 import { apiFetch } from "../api.js";
-import { LogsScreen } from "./LogsScreen.jsx";
+import { LogsScreen, logEntryClipboardText } from "./LogsScreen.jsx";
 import { AppContext } from "../context/AppContext.js";
 
 function row(seq, source, level, message, event) {
@@ -312,6 +312,114 @@ describe("LogsScreen", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // ---- Log viewer ergonomics (#1966) ----------------------------------------
+
+  it("pins the filter panel below the topbar instead of letting it scroll away (#1966)", async () => {
+    // The real shell puts a sticky `.topbar` above the screen inside the
+    // scrolling `.workspace`, so the panel's sticky offset must clear it.
+    const topbar = document.createElement("header");
+    topbar.className = "topbar";
+    topbar.getBoundingClientRect = () => ({ height: 72 });
+    document.body.appendChild(topbar);
+    try {
+      await render();
+      const panel = container.querySelector(".logs-panel");
+      expect(panel).toBeTruthy();
+      // The stylesheet isn't loaded in jsdom, so assert the contract the CSS
+      // consumes: the measured topbar height, published as the offset var.
+      expect(panel.style.getPropertyValue("--logs-sticky-top")).toBe("72px");
+    } finally {
+      topbar.remove();
+    }
+  });
+
+  it("copies the expanded entry's event JSON to the clipboard (#1966)", async () => {
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    try {
+      await render();
+      // Expand the error row, then hit its copy button.
+      const errorRow = [...container.querySelectorAll(".logs-row")].find((r) =>
+        r.textContent.includes("image_inference_failed"),
+      );
+      await act(async () => errorRow.click());
+      const copyButton = errorRow.querySelector(".logs-copy");
+      expect(copyButton).toBeTruthy();
+      await act(async () => copyButton.click());
+
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText).toHaveBeenCalledWith(
+        JSON.stringify({ event: "image_inference_failed", error: "boom" }, null, 2),
+      );
+      // The button confirms the copy rather than silently succeeding.
+      expect(errorRow.querySelector(".logs-copy").textContent).toBe("Copied");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps the row expanded when the copy button is clicked (#1966)", async () => {
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText: vi.fn(async () => {}) } });
+    try {
+      await render();
+      const errorRow = [...container.querySelectorAll(".logs-row")].find((r) =>
+        r.textContent.includes("image_inference_failed"),
+      );
+      await act(async () => errorRow.click());
+      await act(async () => errorRow.querySelector(".logs-copy").click());
+      // The click must not bubble to the row's expand/collapse toggle, or the
+      // detail — and the button itself — would vanish out from under the click.
+      expect(errorRow.querySelector(".logs-detail")).toBeTruthy();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("reports a failed clipboard write instead of claiming success (#1966)", async () => {
+    // Both paths unavailable: no navigator.clipboard, and execCommand refuses.
+    vi.stubGlobal("navigator", { ...navigator, clipboard: undefined });
+    const execCommand = vi.fn(() => false);
+    document.execCommand = execCommand;
+    try {
+      await render();
+      const errorRow = [...container.querySelectorAll(".logs-row")].find((r) =>
+        r.textContent.includes("image_inference_failed"),
+      );
+      await act(async () => errorRow.click());
+      await act(async () => errorRow.querySelector(".logs-copy").click());
+      expect(errorRow.querySelector(".logs-copy").textContent).toContain("Couldn");
+    } finally {
+      delete document.execCommand;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("offers a copy button for entries with no parsed event, using the raw line (#1966)", async () => {
+    logRows = [{ seq: 7, source: "api", level: "info", timestamp: "2026-06-07T01:02:07Z", message: "plain line", raw: "plain line" }];
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    try {
+      await render();
+      const row = container.querySelector(".logs-row");
+      await act(async () => row.click());
+      const copyButton = row.querySelector(".logs-copy");
+      expect(copyButton).toBeTruthy();
+      await act(async () => copyButton.click());
+      expect(writeText).toHaveBeenCalledWith("plain line");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("prefers the structured event over the raw line when building clipboard text (#1966)", () => {
+    expect(logEntryClipboardText({ event: { event: "tick" }, raw: "tick raw" })).toBe(
+      JSON.stringify({ event: "tick" }, null, 2),
+    );
+    expect(logEntryClipboardText({ raw: "tick raw", message: "tick" })).toBe("tick raw");
+    expect(logEntryClipboardText({ message: "only message" })).toBe("only message");
+    expect(logEntryClipboardText(null)).toBe("");
   });
 
   it("backs off the poll after consecutive failures and resets to 2s cadence on success (sc-11224)", async () => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15235,6 +15235,17 @@ details[open] > summary.lora-scope-group-heading::before,
   gap: 12px;
   min-height: 0;
 }
+/* The filter panel pins under the global topbar instead of scrolling away with
+   the tail (#1966). `.workspace` is the scroll container and `.topbar` is
+   already sticky at its top edge (z-index 5), so this sits just below it in
+   both offset and stacking order. `--logs-sticky-top` is set inline by
+   LogsScreen from the measured topbar height — the literal here is only the
+   fallback for a shell rendered without the app chrome. */
+.logs-screen > .logs-panel {
+  position: sticky;
+  top: var(--logs-sticky-top, 64px);
+  z-index: 4;
+}
 .logs-toolbar {
   display: flex;
   flex-wrap: wrap;
@@ -15330,9 +15341,35 @@ details[open] > summary.lora-scope-group-heading::before,
   white-space: pre-wrap;
   word-break: break-word;
 }
-.logs-detail {
+/* Expanded entry: a copy affordance above the structured event (#1966). Rows
+   without a parsed event still expand to the button so the raw line is
+   copyable. */
+.logs-detail-panel {
   flex: 1 1 100%;
-  margin: 6px 0 2px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+.logs-copy {
+  align-self: flex-end;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  padding: 3px 10px;
+  font-family: var(--font-ui);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.logs-copy:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+.logs-detail {
+  align-self: stretch;
+  margin: 0 0 2px;
   padding: 8px 10px;
   background: var(--bg);
   border: 1px solid var(--border);


### PR DESCRIPTION
## What does this PR do?

Fixes the two Logs-tab ergonomics problems reported in #1966.

**1. The filter/pause toolbar scrolled out of reach.**

`.workspace` is the scroll container, and `.workspace > *` is `flex: 0 0 auto`. The Logs page therefore grows to its full content height instead of being bounded by the viewport, so `.logs-list`'s own `overflow-y: auto` never engages — the whole workspace scrolls and the panel above the list leaves the viewport. (The existing `min-height: 0` / `flex: 1 1 auto` on `.logs-screen` / `.logs-list` were written expecting a bounded height that the workspace rule defeats.)

The panel is now `position: sticky`. The global `.topbar` is itself sticky at the top edge of that same scroll box, so a `top: 0` panel would slide underneath it — this pins one rung below the topbar in both offset and stacking order. The topbar's height is content-driven (its status pills wrap on narrow windows), so `LogsScreen` measures it via `ResizeObserver` and publishes the offset as `--logs-sticky-top` rather than hardcoding a magic number; the literal in the stylesheet is only a fallback for a shell rendered without the app chrome.

**2. No way to copy an expanded log entry.**

Copying meant hand-selecting JSON out of a list that re-renders every 2s. Expanding a row now reveals a **Copy** button that puts the pretty-printed event on the clipboard. Notes:

- Falls back to the raw log line for entries with no parsed event — those rows previously expanded to nothing at all, so this also gives them a reason to expand.
- Reuses the existing `writeClipboardText` helper, so the WebKitGTK `execCommand` fallback applies.
- Reports a refused write ("Couldn't copy") instead of silently claiming success.
- `stopPropagation` on the click keeps it off the row's expand/collapse toggle, which would otherwise collapse the detail out from under the button.

**Not addressed here:** the `CUDA_ERROR_SYSTEM_DRIVER_MISMATCH` load failure that opens #1966. That is a host-environment problem — the loaded kernel NVIDIA module and the CUDA userspace driver are out of step, which is a common state on an immutable distro (Bazzite, in the report) after an image update but before a reboot onto the matching module. There is no code-side fix for the mismatch itself. A separate, arguably worthwhile change would be to map that driver error to actionable guidance in `classify_engine_error` instead of surfacing the raw `DriverError(...)` string, but that reclassification has queue/retry semantics worth deciding deliberately, so it is left out of this PR.

## Related issue

Partially addresses #1966 — the two UI items in the report. Leaving the issue open for the CUDA driver-mismatch half described above.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

Six new cases in `LogsScreen.test.jsx` (18 in the file, all passing):

- The panel publishes the *measured* topbar height as `--logs-sticky-top` (asserted against a stubbed 72px topbar) — the stylesheet isn't loaded under jsdom, so the test pins the contract the CSS consumes.
- Copy puts the pretty-printed event JSON on the clipboard and the button confirms with "Copied".
- Clicking Copy leaves the row expanded (guards the `stopPropagation`).
- A refused clipboard write — no `navigator.clipboard` *and* `execCommand` returning false — surfaces "Couldn't copy" rather than a false success.
- An entry with no parsed event still gets a Copy button, and it copies the raw line.
- `logEntryClipboardText` unit cases: event preferred over raw, raw over message, null-safe.

Full web suite: 214 files / 3112 tests passing. Sticky-offset and z-index behavior against the live topbar is CSS-only and was reasoned about rather than exercised in a browser.

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed — n/a, no Rust touched
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app) — all three clean
- [x] I ran `npm run check` (scaffold checks) — 104/104 passing
- [ ] I updated documentation where relevant — no doc surface for this
- [ ] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md) — **not signed off; needs a maintainer amend or a sign-off push before merge**
- [x] My PR is focused on a single logical change

---
_Generated by [Claude Code](https://claude.ai/code/session_01S44HRJ8ugAMjiRwU7fNqzi)_