### PR TITLE
feat(workflow-share): cross-install resolution report + POST /api/v1/workflows/inspect (sc-15950)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -122,6 +122,8 @@ use assets::{
     move_asset_to_library, purge_asset, sweep_stale_asset_uploads, update_asset_status,
     update_asset_tags, write_upload_field_to_dir, write_upload_field_to_temp_file,
 };
+mod workflows;
+use workflows::inspect_workflow;
 // Test-only crate-root imports: the `tests` module reaches these helpers via
 // `super::` (either `use super::{...}` or a fully-qualified `super::fn(...)` call).
 // Gating them keeps the non-test build warning-free — they have no non-test
@@ -350,6 +352,10 @@ const MAX_ADVANCED_JSON_BYTES: usize = 64 * 1024;
 #[cfg(test)]
 thread_local! {
     static TEST_MAX_LORA_UPLOAD_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    // sc-15950: same override, same reasoning, for `POST /api/v1/workflows/inspect`. The real cap
+    // is `MAX_UPLOAD_BYTES` (2 GiB), which no test can send, so the oversized-body branch is only
+    // reachable through a lowered cap.
+    static TEST_MAX_WORKFLOW_INSPECT_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 #[cfg(test)]
 static TEST_MAX_MODEL_UPLOAD_BYTES: std::sync::atomic::AtomicUsize =
@@ -1395,6 +1401,15 @@ fn create_app_with_state_mode(
                 // limit; re-attach it per-route since the router default is now the
                 // small JSON cap. GET has no body, so this is harmless for listing.
                 .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES)),
+        )
+        // sc-15950: read a shared image's embedded workflow WITHOUT creating an asset. Registered
+        // beside the asset routes because it shares their multipart shape and staging area, but it
+        // is deliberately not project-scoped — it mutates nothing, so there is nothing to scope.
+        // Same auth posture as the upload route above; the large per-route limit is re-attached
+        // for the same reason (the router default is the small JSON cap).
+        .route(
+            "/api/v1/workflows/inspect",
+            post(inspect_workflow).layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES)),
         )
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id",

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -123,7 +123,7 @@ use assets::{
     update_asset_tags, write_upload_field_to_dir, write_upload_field_to_temp_file,
 };
 mod workflows;
-use workflows::inspect_workflow;
+use workflows::{inspect_workflow, max_inspect_multipart_body_bytes};
 // Test-only crate-root imports: the `tests` module reaches these helpers via
 // `super::` (either `use super::{...}` or a fully-qualified `super::fn(...)` call).
 // Gating them keeps the non-test build warning-free — they have no non-test
@@ -333,6 +333,33 @@ const MAX_UPLOAD_BYTES: usize = 2 * 1024 * 1024 * 1024;
 const MAX_MODEL_UPLOAD_BYTES: usize = 256 * 1024 * 1024 * 1024;
 const MAX_LORA_MULTIPART_BODY_BYTES: usize = MAX_UPLOAD_BYTES + 16 * 1024 * 1024;
 const MAX_MODEL_MULTIPART_BODY_BYTES: usize = MAX_MODEL_UPLOAD_BYTES + 16 * 1024 * 1024;
+// sc-15950: `POST /api/v1/workflows/inspect` deliberately does NOT get `MAX_UPLOAD_BYTES`.
+//
+// The asset upload route pays 2 GiB because the bytes BECOME the asset — the write is the point.
+// Inspect streams the body to `cache/uploads` before any PNG check, throws it away, and returns a
+// small JSON report, so a 2 GiB body buys 2 GiB of transient disk and one blocking thread for a
+// result measured in kilobytes. There is no rate limit, concurrency limit or timeout layer in this
+// app (tower-http is compression + cors only) and the desktop sets `SCENEWORKS_TRUST_LOOPBACK`, so
+// any local process can drive N of those concurrently without a token.
+//
+// 512 MiB is sized against what users actually drop, not against a round number. The largest PNG
+// SceneWorks itself can write is a 4096² generation (`image_request::MAX_DIMENSION`) through a 4×
+// upscale = 16384², 8-bit RGB (`workflow_png::write_workflow_chunk` takes an `RgbImage`) = 805 MB
+// raw, which PNG's filtered deflate puts well under 512 MiB on rendered content; an ordinary 4096²
+// share is ~50 MB, and a phone photo is single-digit MB. So the cap rejects nothing a user would
+// plausibly drop while cutting the transient-disk exposure 4×.
+const MAX_WORKFLOW_INSPECT_BYTES: usize = 512 * 1024 * 1024;
+// The route limit must sit ABOVE the per-field cap, not equal to it: a body exactly at the cap
+// plus multipart framing (boundaries, headers, the trailing CRLF) exceeds an equal router limit,
+// so axum's own limit trips first and `field.chunk()` surfaces it as a plain 400 — the typed 413
+// would then be unreachable at the only boundary that matters. Same headroom, for the same reason,
+// as `MAX_LORA_MULTIPART_BODY_BYTES`. The route reads it through
+// `workflows::max_inspect_multipart_body_bytes`, which derives it from the live per-field cap so
+// the two cannot drift back into equality and so a test can exercise the real boundary at a
+// sendable size.
+const MULTIPART_FRAMING_HEADROOM_BYTES: usize = 16 * 1024 * 1024;
+const MAX_WORKFLOW_INSPECT_MULTIPART_BODY_BYTES: usize =
+    MAX_WORKFLOW_INSPECT_BYTES + MULTIPART_FRAMING_HEADROOM_BYTES;
 // sc-8885 (F-083): the shared max age for every `cache/*-uploads` staging area (asset,
 // lora, model, pose, keypoint) before the startup sweep reclaims it. Named for uploads
 // in general — the old `STALE_LORA_UPLOAD_SECONDS` misleadingly implied LoRA-only.
@@ -1405,11 +1432,13 @@ fn create_app_with_state_mode(
         // sc-15950: read a shared image's embedded workflow WITHOUT creating an asset. Registered
         // beside the asset routes because it shares their multipart shape and staging area, but it
         // is deliberately not project-scoped — it mutates nothing, so there is nothing to scope.
-        // Same auth posture as the upload route above; the large per-route limit is re-attached
-        // for the same reason (the router default is the small JSON cap).
+        // Same auth posture as the upload route above; a larger-than-JSON per-route limit is
+        // re-attached for the same reason (the router default is the small JSON cap), but it is
+        // this route's OWN cap plus framing headroom rather than the 2 GiB asset ceiling — see
+        // `MAX_WORKFLOW_INSPECT_BYTES` for why both numbers are what they are.
         .route(
             "/api/v1/workflows/inspect",
-            post(inspect_workflow).layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES)),
+            post(inspect_workflow).layer(DefaultBodyLimit::max(max_inspect_multipart_body_bytes())),
         )
         .route(
             "/api/v1/projects/:project_id/assets/:asset_id",

--- a/apps/rust-api/src/tests/mod.rs
+++ b/apps/rust-api/src/tests/mod.rs
@@ -21,3 +21,4 @@ mod startup;
 pub(crate) mod support;
 mod training;
 mod uploads;
+mod workflows;

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -25,6 +25,7 @@ pub(crate) use crate::{
     sweep_stale_lora_uploads_before, sweep_stale_uploads, validate_model_id, Settings,
     WorkerCapability, WorkerSnapshot, WorkerStatus, API_MANAGED_MANIFEST_HEADER, DEFAULT_API_HOST,
     EVENT_BUFFER_SIZE, HEARTBEAT_SSE_DATA, HEARTBEAT_SSE_WIRE, TEST_MAX_LORA_UPLOAD_BYTES,
+    TEST_MAX_WORKFLOW_INSPECT_BYTES,
 };
 
 pub(crate) use axum::body::{to_bytes, Body};

--- a/apps/rust-api/src/tests/workflows.rs
+++ b/apps/rust-api/src/tests/workflows.rs
@@ -1,0 +1,589 @@
+//! `POST /api/v1/workflows/inspect` (sc-15950, epic 15945).
+//!
+//! Three of these are load-bearing: [`inspect_creates_no_asset_no_job_and_no_project_mutation`]
+//! (the endpoint's whole reason for existing is that sc-15951 can prefill from a file the user may
+//! never import), [`inspect_reports_a_plain_png_as_no_workflow_not_as_a_failure`] (a foreign PNG
+//! with no chunk is the COMMON case), and
+//! [`inspect_reports_a_catalog_known_but_absent_model_as_installable`] (the actionable middle case,
+//! proven through the real model catalog rather than a hand-built lookup).
+
+use super::support::*;
+
+use sceneworks_core::workflow_share::WorkflowShare;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const INSPECT_ROUTE: &str = "/api/v1/workflows/inspect";
+
+fn rgb_fixture() -> image::RgbImage {
+    image::RgbImage::from_fn(8, 8, |x, y| image::Rgb([(x * 8) as u8, (y * 8) as u8, 128]))
+}
+
+/// An envelope in the shape a real generated image carries. Built through the parser, so it is
+/// reduced by exactly the rules a stranger's file is.
+fn image_envelope(model: &str, prompt: &str) -> WorkflowShare {
+    sceneworks_core::workflow_share::parse_workflow_share_json(&format!(
+        r#"{{
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": {{ "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" }},
+            "mode": "text_to_image",
+            "model": "{model}",
+            "prompt": "{prompt}",
+            "stylePreset": "cinematic",
+            "loras": [{{ "name": "Aurora Portrait v3", "weight": 0.8 }}]
+        }}"#
+    ))
+    .expect("the fixture envelope parses")
+}
+
+/// PNG bytes carrying `share` in a `sceneworks:workflow` iTXt chunk (or none at all), written
+/// through the ONE writer (sc-15947) rather than a hand-rolled chunk.
+fn sceneworks_png(temp_dir: &tempfile::TempDir, share: Option<&WorkflowShare>) -> Vec<u8> {
+    let path = temp_dir
+        .path()
+        .join(format!("fixture-{}.png", uuid::Uuid::new_v4().simple()));
+    sceneworks_core::workflow_png::write_workflow_chunk(&rgb_fixture(), &path, share)
+        .expect("the fixture PNG writes");
+    std::fs::read(&path).expect("the fixture PNG reads")
+}
+
+/// POST a multipart body to the inspect route with the given `file` bytes and optional fields.
+async fn inspect(
+    app: axum::Router,
+    filename: &str,
+    bytes: &[u8],
+    fields: &[(&str, &str)],
+) -> (StatusCode, Value) {
+    let boundary = "SCENEWORKS_INSPECT_BOUNDARY";
+    let mut body = Vec::new();
+    for (name, value) in fields {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+        );
+        body.extend_from_slice(value.as_bytes());
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!("Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n")
+            .as_bytes(),
+    );
+    body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+    body.extend_from_slice(bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    let (status, _, response) = request_raw(
+        app,
+        "POST",
+        INSPECT_ROUTE,
+        body,
+        &[(
+            "content-type",
+            &format!("multipart/form-data; boundary={boundary}"),
+        )],
+    )
+    .await;
+    let value = serde_json::from_slice(&response).expect("json body parses");
+    (status, value)
+}
+
+/// Every `upload-*` left under `cache/uploads`. Must always be empty: inspect stages the image
+/// there and owns removing it on every path.
+fn staged_uploads(data_dir: &std::path::Path) -> Vec<String> {
+    std::fs::read_dir(data_dir.join("cache").join("uploads"))
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                .filter(|name| name.starts_with("upload-"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// The happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn inspect_returns_the_workflow_and_its_resolution_report() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+    let share = image_envelope("krea_2_turbo", "a lighthouse in heavy fog");
+
+    let (status, body) = inspect(
+        app,
+        "shared.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["status"], json!("workflow"));
+    assert_eq!(
+        body["workflow"]["prompt"],
+        json!("a lighthouse in heavy fog")
+    );
+    assert_eq!(body["workflow"]["model"], json!("krea_2_turbo"));
+    // The report is present and classifies every class the envelope carried.
+    assert!(body["resolution"].is_object(), "body: {body}");
+    assert_eq!(body["resolution"]["model"]["slug"], json!("krea_2_turbo"));
+    assert_eq!(
+        body["resolution"]["loras"][0]["name"],
+        json!("Aurora Portrait v3")
+    );
+    assert!(body["resolution"]["replayable"].is_boolean());
+    // `stylePreset: "cinematic"` is the inert wire default EVERY generated image carries, so it is
+    // not a style requirement — otherwise every shared image would report an unresolved style.
+    assert_eq!(body["resolution"]["styles"], json!([]));
+    assert!(body.get("detail").is_none(), "success carries no detail");
+    assert!(
+        staged_uploads(&data_dir).is_empty(),
+        "the staged temp is removed"
+    );
+}
+
+#[tokio::test]
+async fn inspect_creates_no_asset_no_job_and_no_project_mutation() {
+    // The endpoint's reason for existing. A test that only reads the response body would pass with
+    // an asset quietly created behind it, so this reads the STORES: the project's asset list, the
+    // job queue, and a recursive listing of the project directory.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    let (status, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Inspect Purity" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(project["path"].as_str().expect("project path"));
+
+    let before_assets = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/assets"),
+        Value::Null,
+    )
+    .await
+    .1;
+    let before_jobs = request(app.clone(), "GET", "/api/v1/jobs", Value::Null)
+        .await
+        .1;
+    let before_tree = directory_tree(&project_path);
+    assert_eq!(before_assets, json!([]), "the project starts empty");
+
+    let share = image_envelope("krea_2_turbo", "a lighthouse");
+    // `projectId` is passed on purpose: it widens the LoRA/preset lookups to the project scope,
+    // which is the only branch that touches the project store at all.
+    let (status, body) = inspect(
+        app.clone(),
+        "shared.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[("projectId", &project_id)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["status"], json!("workflow"));
+    // No asset id anywhere in the response — there is no asset.
+    assert!(body.get("id").is_none());
+    assert!(body.get("asset").is_none());
+
+    let after_assets = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/assets"),
+        Value::Null,
+    )
+    .await
+    .1;
+    let after_jobs = request(app.clone(), "GET", "/api/v1/jobs", Value::Null)
+        .await
+        .1;
+    assert_eq!(after_assets, json!([]), "inspect created no asset");
+    assert_eq!(after_jobs, before_jobs, "inspect created no job");
+    assert_eq!(
+        directory_tree(&project_path),
+        before_tree,
+        "inspect wrote nothing into the project"
+    );
+    assert!(
+        staged_uploads(&data_dir).is_empty(),
+        "no staged temp survives"
+    );
+}
+
+/// A sorted recursive listing of `root`, relative, so a project directory can be compared
+/// before/after. Content is not hashed — a mutation this endpoint could plausibly make (a sidecar,
+/// an index marker, a media file) shows up as a new path.
+fn directory_tree(root: &std::path::Path) -> Vec<String> {
+    fn walk(base: &std::path::Path, dir: &std::path::Path, out: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if let Ok(relative) = path.strip_prefix(base) {
+                out.push(relative.to_string_lossy().replace('\\', "/"));
+            }
+            if path.is_dir() {
+                walk(base, &path, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out.sort();
+    out
+}
+
+// ---------------------------------------------------------------------------
+// The "no workflow" branch — distinct, and NOT an error
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn inspect_reports_a_plain_png_as_no_workflow_not_as_a_failure() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    let (status, body) = inspect(app, "foreign.png", &sceneworks_png(&temp_dir, None), &[]).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a PNG from anywhere else in the world is the COMMON case, not a failure: {body}"
+    );
+    assert_eq!(body["status"], json!("no_workflow"));
+    // Both contract keys are PRESENT and null, so sc-15951 never has to tell absent from null.
+    assert_eq!(body["workflow"], Value::Null);
+    assert_eq!(body["resolution"], Value::Null);
+    assert!(body.get("workflow").is_some() && body.get("resolution").is_some());
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("no SceneWorks workflow")));
+    assert!(staged_uploads(&data_dir).is_empty());
+}
+
+#[tokio::test]
+async fn inspect_uses_a_real_32x32_png_from_the_repo_as_the_foreign_case() {
+    // A PNG this project did not write at all (the desktop icon), so the no-workflow answer is not
+    // an artifact of the fixture writer.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, body) = inspect(app, "32x32.png", PNG_32X32, &[]).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["status"], json!("no_workflow"));
+}
+
+// ---------------------------------------------------------------------------
+// Typed errors — never a 500
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn inspect_rejects_a_non_image_with_a_typed_400() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    let (status, body) = inspect(app, "notes.txt", b"this is not a PNG at all", &[]).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    assert_eq!(body["code"], json!("workflow_inspect_not_png"));
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("not a PNG")));
+    assert!(staged_uploads(&data_dir).is_empty());
+}
+
+#[tokio::test]
+async fn inspect_rejects_a_png_whose_workflow_this_build_will_not_read_with_a_typed_422() {
+    // A VIDEO envelope handed to the image reader (sc-15956's half of the marker key). The chunk is
+    // there and well-formed, so this is neither "no workflow" nor "not a PNG" — it is a file whose
+    // recipe we refuse to guess at, and the reader's own sentence says which.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+    let mut share = image_envelope("krea_2_turbo", "a lighthouse");
+    share.kind = "video".to_owned();
+
+    let (status, body) = inspect(
+        app,
+        "video.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
+    assert_eq!(body["code"], json!("workflow_inspect_unreadable"));
+    assert!(body["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("video")));
+    assert!(staged_uploads(&data_dir).is_empty());
+}
+
+#[tokio::test]
+async fn inspect_rejects_an_oversized_body_with_413_and_leaves_no_temp() {
+    // The real cap is `MAX_UPLOAD_BYTES` (2 GiB), which no test can send, so the branch is reached
+    // through the same lowered-cap override the LoRA import uses.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+    let bytes = sceneworks_png(
+        &temp_dir,
+        Some(&image_envelope("krea_2_turbo", "a lighthouse")),
+    );
+
+    TEST_MAX_WORKFLOW_INSPECT_BYTES.with(|cap| cap.set(8));
+    let (status, body) = inspect(app, "huge.png", &bytes, &[]).await;
+    TEST_MAX_WORKFLOW_INSPECT_BYTES.with(|cap| cap.set(0));
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "body: {body}");
+    assert_eq!(body["detail"], json!("Uploaded image is too large"));
+    assert!(staged_uploads(&data_dir).is_empty());
+}
+
+#[tokio::test]
+async fn inspect_requires_a_file_field() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let boundary = "SCENEWORKS_INSPECT_EMPTY";
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(b"Content-Disposition: form-data; name=\"projectId\"\r\n\r\n");
+    body.extend_from_slice(b"project-1");
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    let (status, _, response) = request_raw(
+        app,
+        "POST",
+        INSPECT_ROUTE,
+        body,
+        &[(
+            "content-type",
+            &format!("multipart/form-data; boundary={boundary}"),
+        )],
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let value: Value = serde_json::from_slice(&response).expect("json body parses");
+    assert_eq!(value["detail"], json!("Upload file field is required"));
+}
+
+#[tokio::test]
+async fn inspect_rejects_a_duplicate_file_field_and_cleans_the_first_temp() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+    let bytes = sceneworks_png(&temp_dir, None);
+
+    let boundary = "SCENEWORKS_INSPECT_DUPE";
+    let mut body = Vec::new();
+    for _ in 0..2 {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"a.png\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+        body.extend_from_slice(&bytes);
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    let (status, _, response) = request_raw(
+        app,
+        "POST",
+        INSPECT_ROUTE,
+        body,
+        &[(
+            "content-type",
+            &format!("multipart/form-data; boundary={boundary}"),
+        )],
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let value: Value = serde_json::from_slice(&response).expect("json body parses");
+    assert_eq!(value["detail"], json!("Only one file field is allowed"));
+    assert!(
+        staged_uploads(&data_dir).is_empty(),
+        "the first staged temp must not be orphaned"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The report, through the REAL catalogs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn inspect_reports_a_catalog_known_but_absent_model_as_installable() {
+    // The actionable middle case, end to end: the seeded manifest knows `fixture_model`, nothing is
+    // on disk for it, and the report must point at the Model Manager's own download flow rather
+    // than call it missing.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let config_dir = settings.config_dir.join("manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    single_model_manifest(&config_dir, "fixture_model", "acme/fixture-model");
+    let app = create_app(settings).expect("app creates");
+    let _env = isolate_hf_cache();
+    let share = image_envelope("fixture_model", "a lighthouse");
+
+    let (status, body) = inspect(
+        app,
+        "shared.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let model = &body["resolution"]["model"];
+    assert_eq!(model["state"], json!("installable"), "model: {model}");
+    assert_eq!(model["catalogId"], json!("fixture_model"));
+    assert_eq!(
+        model["install"],
+        json!({ "method": "POST", "path": "/api/v1/models/fixture_model/download" }),
+        "the middle case must name the existing Model Manager flow"
+    );
+    assert_eq!(body["resolution"]["replayable"], json!(false));
+    // The user-trained LoRA the envelope names resolves to nothing here, and is LISTED.
+    assert_eq!(body["resolution"]["loras"][0]["state"], json!("missing"));
+    assert!(staged_uploads(&data_dir).is_empty());
+}
+
+#[tokio::test]
+async fn inspect_reports_a_model_this_install_never_heard_of_as_missing() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let config_dir = settings.config_dir.join("manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    single_model_manifest(&config_dir, "fixture_model", "acme/fixture-model");
+    let app = create_app(settings).expect("app creates");
+    let _env = isolate_hf_cache();
+    let share = image_envelope("a_model_from_their_install", "a lighthouse");
+
+    let (status, body) = inspect(
+        app,
+        "shared.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let model = &body["resolution"]["model"];
+    assert_eq!(model["state"], json!("missing"));
+    assert_eq!(model["slug"], json!("a_model_from_their_install"));
+    assert!(model.get("catalogId").is_none(), "nothing matched");
+    assert!(
+        model.get("install").is_none(),
+        "there is nothing to offer to install"
+    );
+    // Never substituted: the one model this install DOES know is not reached for.
+    assert!(!model["detail"]
+        .as_str()
+        .expect("detail")
+        .contains("fixture_model"));
+}
+
+#[tokio::test]
+async fn inspect_reports_an_input_image_the_recipe_needs_by_shape() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let share = sceneworks_core::workflow_share::parse_workflow_share_json(
+        r#"{
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+            "mode": "edit_image",
+            "model": "krea_2_turbo",
+            "prompt": "make it night",
+            "inputs": [{ "kind": "source", "count": 1 }, { "kind": "reference", "count": 2 }]
+        }"#,
+    )
+    .expect("the envelope parses");
+
+    let (status, body) = inspect(
+        app,
+        "edit.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let inputs = body["resolution"]["inputs"]
+        .as_array()
+        .expect("inputs is an array");
+    assert_eq!(inputs.len(), 2);
+    assert_eq!(inputs[0]["state"], json!("userSupplied"));
+    assert_eq!(inputs[0]["detail"], json!("Needs a source image."));
+    assert_eq!(inputs[1]["detail"], json!("Needs 2 reference images."));
+    assert_eq!(body["resolution"]["replayable"], json!(false));
+}
+
+#[tokio::test]
+async fn inspect_surfaces_a_dropped_collection_so_replay_can_be_withheld() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let share = sceneworks_core::workflow_share::parse_workflow_share_json(
+        r#"{
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "krea_2_turbo",
+            "prompt": "a lighthouse",
+            "omitted": ["loras"]
+        }"#,
+    )
+    .expect("the envelope parses");
+
+    let (status, body) = inspect(
+        app,
+        "dropped.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["resolution"]["loras"], json!([]));
+    assert_eq!(body["resolution"]["omitted"][0]["field"], json!("loras"));
+    assert!(body["resolution"]["omitted"][0]["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.contains("NOT a LoRA-free recipe")));
+    assert_eq!(
+        body["resolution"]["replayable"],
+        json!(false),
+        "an omitted collection withholds one-click replay"
+    );
+}
+
+#[tokio::test]
+async fn inspect_requires_a_token_when_one_is_configured() {
+    // Same posture as the upload route: no auth change, so the shared `access_control` middleware
+    // guards it like every other `/api/v1` route.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let (status, _) = inspect(app, "shared.png", &sceneworks_png(&temp_dir, None), &[]).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}

--- a/apps/rust-api/src/tests/workflows.rs
+++ b/apps/rust-api/src/tests/workflows.rs
@@ -138,7 +138,8 @@ async fn inspect_returns_the_workflow_and_its_resolution_report() {
         body["resolution"]["loras"][0]["name"],
         json!("Aurora Portrait v3")
     );
-    assert!(body["resolution"]["replayable"].is_boolean());
+    assert!(body["resolution"]["runnable"].is_boolean());
+    assert!(body["resolution"]["inputImagesRequired"].is_u64());
     // `stylePreset: "cinematic"` is the inert wire default EVERY generated image carries, so it is
     // not a style requirement — otherwise every shared image would report an unresolved style.
     assert_eq!(body["resolution"]["styles"], json!([]));
@@ -339,8 +340,8 @@ async fn inspect_rejects_a_png_whose_workflow_this_build_will_not_read_with_a_ty
 
 #[tokio::test]
 async fn inspect_rejects_an_oversized_body_with_413_and_leaves_no_temp() {
-    // The real cap is `MAX_UPLOAD_BYTES` (2 GiB), which no test can send, so the branch is reached
-    // through the same lowered-cap override the LoRA import uses.
+    // The real cap is `MAX_WORKFLOW_INSPECT_BYTES` (512 MiB), which no test wants to send, so the
+    // branch is reached through the same lowered-cap override the LoRA import uses.
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);
     let data_dir = settings.data_dir.clone();
@@ -356,7 +357,104 @@ async fn inspect_rejects_an_oversized_body_with_413_and_leaves_no_temp() {
 
     assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "body: {body}");
     assert_eq!(body["detail"], json!("Uploaded image is too large"));
+    assert_eq!(body["code"], json!("workflow_inspect_too_large"));
     assert!(staged_uploads(&data_dir).is_empty());
+}
+
+#[tokio::test]
+async fn the_typed_413_wins_at_the_real_cap_boundary_not_just_far_under_it() {
+    // The test above lowers the field cap to 8 bytes — far under the ROUTER limit, so it proves
+    // nothing about the boundary that actually matters. With `DefaultBodyLimit` equal to the field
+    // cap, a body AT the cap plus its multipart framing (boundaries, part headers, the trailing
+    // CRLF — ~200 bytes here) exceeds the router limit, axum rejects the body first, and
+    // `field.chunk()` surfaces it as a plain 400 with no typed code at all.
+    //
+    // `max_inspect_multipart_body_bytes` derives the router limit from the live per-field cap, so
+    // lowering the cap BEFORE `create_app` scales the router limit with it and the same
+    // cap-plus-framing relationship is exercised at a sendable size.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let png = sceneworks_png(
+        &temp_dir,
+        Some(&image_envelope("krea_2_turbo", "a lighthouse")),
+    );
+    // The cap is set to the PNG's exact length, so the file field lands precisely ON it and the
+    // framing is the only thing that could push the request over a router limit.
+    let cap = png.len();
+
+    TEST_MAX_WORKFLOW_INSPECT_BYTES.with(|limit| limit.set(cap));
+    let app = create_app(settings).expect("app creates");
+    let (at_cap, at_cap_body) = inspect(app.clone(), "exact.png", &png, &[]).await;
+    // One byte over: the field cap is the thing that must reject it, with the typed 413.
+    let mut over = png.clone();
+    over.push(0);
+    let (over_cap, over_cap_body) = inspect(app, "over.png", &over, &[]).await;
+    TEST_MAX_WORKFLOW_INSPECT_BYTES.with(|limit| limit.set(0));
+
+    assert_eq!(
+        at_cap,
+        StatusCode::OK,
+        "a body exactly at the cap must reach the handler, framing and all: {at_cap_body}"
+    );
+    assert_eq!(at_cap_body["status"], json!("workflow"));
+    assert_eq!(
+        over_cap,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "one byte over the cap is the typed 413, not axum's plain 400: {over_cap_body}"
+    );
+    assert_eq!(over_cap_body["code"], json!("workflow_inspect_too_large"));
+    assert!(staged_uploads(&data_dir).is_empty());
+}
+
+#[tokio::test]
+async fn a_malformed_multipart_request_still_carries_a_machine_readable_code() {
+    // The extractor rejects these before the handler body runs. Left to axum the response is a
+    // PLAIN-TEXT body — so sc-15951, which branches on `code`, would be handed something it cannot
+    // parse as JSON at all. Every shape that fails at the extractor is covered here.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    for (label, content_type, body) in [
+        (
+            "an empty body",
+            "multipart/form-data; boundary=B",
+            Vec::new(),
+        ),
+        (
+            "a JSON body",
+            "application/json",
+            br#"{"file":"nope"}"#.to_vec(),
+        ),
+        (
+            "a boundary-less content type",
+            "multipart/form-data",
+            b"--B\r\n\r\n--B--\r\n".to_vec(),
+        ),
+    ] {
+        let (status, _, response) = request_raw(
+            app.clone(),
+            "POST",
+            INSPECT_ROUTE,
+            body,
+            &[("content-type", content_type)],
+        )
+        .await;
+        assert!(
+            status.is_client_error(),
+            "{label} must be a typed 4xx, got {status}"
+        );
+        let value: Value = serde_json::from_slice(&response)
+            .unwrap_or_else(|error| panic!("{label} must render a JSON envelope: {error}"));
+        assert_eq!(
+            value["code"],
+            json!("workflow_inspect_bad_multipart"),
+            "{label}: {value}"
+        );
+        assert!(
+            value["detail"].as_str().is_some_and(|d| !d.is_empty()),
+            "{label} needs a sentence: {value}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -383,6 +481,7 @@ async fn inspect_requires_a_file_field() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let value: Value = serde_json::from_slice(&response).expect("json body parses");
     assert_eq!(value["detail"], json!("Upload file field is required"));
+    assert_eq!(value["code"], json!("workflow_inspect_bad_multipart"));
 }
 
 #[tokio::test]
@@ -419,6 +518,7 @@ async fn inspect_rejects_a_duplicate_file_field_and_cleans_the_first_temp() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let value: Value = serde_json::from_slice(&response).expect("json body parses");
     assert_eq!(value["detail"], json!("Only one file field is allowed"));
+    assert_eq!(value["code"], json!("workflow_inspect_bad_multipart"));
     assert!(
         staged_uploads(&data_dir).is_empty(),
         "the first staged temp must not be orphaned"
@@ -461,7 +561,7 @@ async fn inspect_reports_a_catalog_known_but_absent_model_as_installable() {
         json!({ "method": "POST", "path": "/api/v1/models/fixture_model/download" }),
         "the middle case must name the existing Model Manager flow"
     );
-    assert_eq!(body["resolution"]["replayable"], json!(false));
+    assert_eq!(body["resolution"]["runnable"], json!(false));
     // The user-trained LoRA the envelope names resolves to nothing here, and is LISTED.
     assert_eq!(body["resolution"]["loras"][0]["state"], json!("missing"));
     assert!(staged_uploads(&data_dir).is_empty());
@@ -535,7 +635,10 @@ async fn inspect_reports_an_input_image_the_recipe_needs_by_shape() {
     assert_eq!(inputs[0]["state"], json!("userSupplied"));
     assert_eq!(inputs[0]["detail"], json!("Needs a source image."));
     assert_eq!(inputs[1]["detail"], json!("Needs 2 reference images."));
-    assert_eq!(body["resolution"]["replayable"], json!(false));
+    // The two answers, separately: this install cannot RUN it (the model is unknown here) and it
+    // would additionally need three images from the user.
+    assert_eq!(body["resolution"]["runnable"], json!(false));
+    assert_eq!(body["resolution"]["inputImagesRequired"], json!(3));
 }
 
 #[tokio::test]
@@ -570,10 +673,71 @@ async fn inspect_surfaces_a_dropped_collection_so_replay_can_be_withheld() {
         .as_str()
         .is_some_and(|detail| detail.contains("NOT a LoRA-free recipe")));
     assert_eq!(
-        body["resolution"]["replayable"],
+        body["resolution"]["runnable"],
         json!(false),
         "an omitted collection withholds one-click replay"
     );
+}
+
+#[tokio::test]
+async fn inspect_never_matches_a_scrubbed_model_to_a_catalog_row_that_has_no_id() {
+    // `workflow_share` scrubs a path-shaped `model` to `""` (it is unshareable), and a manifest may
+    // omit `id` entirely — `load_manifest_entries` validates nothing and `apply_model_catalog_entry`
+    // defaults it. Reduced to `id: ""`, the row matched an envelope that named NO model, and the
+    // report said a model the file never mentioned was on this machine.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let config_dir = settings.config_dir.join("manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    write_empty_sibling_manifests(&config_dir);
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [{
+            "name": "Some Other Model", "type": "image", "family": "test",
+            "downloads": [{ "provider": "huggingface", "repo": "acme/some-other-model" }]
+        }] }"#,
+    )
+    .expect("id-less models manifest writes");
+    let app = create_app(settings).expect("app creates");
+    let _env = isolate_hf_cache();
+
+    let share = sceneworks_core::workflow_share::parse_workflow_share_json(
+        r#"{
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "C:\\models\\theirs\\weights.safetensors",
+            "prompt": "a lighthouse"
+        }"#,
+    )
+    .expect("the envelope parses");
+    assert_eq!(share.model, "", "the parser scrubbed the path-shaped model");
+
+    let (status, body) = inspect(
+        app,
+        "scrubbed.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let model = &body["resolution"]["model"];
+    assert_eq!(model["state"], json!("missing"), "model: {model}");
+    assert!(
+        model.get("catalogId").is_none(),
+        "a blank slug matched a row: {model}"
+    );
+    assert!(model.get("install").is_none(), "model: {model}");
+    assert!(
+        !model["detail"]
+            .as_str()
+            .expect("detail")
+            .contains("Some Other Model"),
+        "the sentence names a model the envelope never did: {model}"
+    );
+    assert_eq!(body["resolution"]["runnable"], json!(false));
 }
 
 #[tokio::test]

--- a/apps/rust-api/src/workflows.rs
+++ b/apps/rust-api/src/workflows.rs
@@ -14,7 +14,20 @@
 //!   workflow: null, resolution: null, detail }`. **This is the common case** (any foreign PNG) and
 //!   it must not look like a failure; sc-15951 branches on `status`.
 //! * The file is not a PNG at all, or claims a workflow this build refuses to guess at → a typed
-//!   4xx carrying a machine-readable `code` and the reader's own sentence. Never a 500.
+//!   4xx carrying a machine-readable `code` and a sentence fit to show the user.
+//!
+//! # Every failure carries a `code`
+//!
+//! Including the ones that never reach the handler body: a malformed multipart request (an empty
+//! body, a JSON body, a `Content-Type` with no `boundary`) is rejected by the extractor before the
+//! handler runs, and axum's own rejection is a PLAIN-TEXT body with no `code` at all. So the
+//! handler takes `Result<Multipart, MultipartRejection>` and maps it itself
+//! ([`INSPECT_CODE_BAD_MULTIPART`]) rather than letting sc-15951 parse a body that is not JSON.
+//!
+//! One failure is deliberately a 5xx: [`WorkflowChunkError::Io`] fires when OUR OWN staged temp
+//! cannot be opened or read — the caller's bytes were written successfully by then, so an AV
+//! sharing violation on `cache/uploads` or a disk fault is a server fault. Reporting it as "this
+//! file is not a PNG" would be exactly the mislabeling this epic exists to stop.
 //!
 //! The resolution report itself is `sceneworks_core::workflow_resolution` — shared with the import
 //! path (sc-15949) and the web (sc-15951 / sc-15952) rather than owned here. This module's whole
@@ -45,6 +58,65 @@ pub(crate) const INSPECT_CODE_NOT_PNG: &str = "workflow_inspect_not_png";
 /// two workflow chunks, a zip bomb, a newer schema version, a video envelope).
 pub(crate) const INSPECT_CODE_UNREADABLE: &str = "workflow_inspect_unreadable";
 
+/// `code` on the 500 for a SERVER-side read failure of our own staged temp.
+///
+/// Split out of [`INSPECT_CODE_NOT_PNG`] because the two are not the same fact and the user-facing
+/// consequence of confusing them is a lie: `Io` is raised after the caller's bytes were written to
+/// `cache/uploads` successfully, so it says nothing about the file. On Windows an antivirus
+/// sharing violation on the staging directory is the likely cause, and telling the user their PNG
+/// is malformed sends them to fix a file that is fine.
+pub(crate) const INSPECT_CODE_READ_FAILED: &str = "workflow_inspect_read_failed";
+
+/// `code` on the 4xx for a request that is not a usable multipart with exactly one `file` field —
+/// an empty body, a JSON body, a missing `boundary`, a missing or duplicated `file`.
+///
+/// A `boundary` failure is rejected by the EXTRACTOR, before the handler body runs, and axum's own
+/// rejection is plain text with no `code` at all — unparseable by a reader that branches on one.
+pub(crate) const INSPECT_CODE_BAD_MULTIPART: &str = "workflow_inspect_bad_multipart";
+
+/// `code` on the typed 413 for a body over [`MAX_WORKFLOW_INSPECT_BYTES`].
+pub(crate) const INSPECT_CODE_TOO_LARGE: &str = "workflow_inspect_too_large";
+
+/// `code` on the 5xx for a failure to WRITE the upload into `cache/uploads`.
+pub(crate) const INSPECT_CODE_STAGE_FAILED: &str = "workflow_inspect_stage_failed";
+
+/// `code` on the 5xx for a failure to read this install's catalogs, which the report is built
+/// against. Distinct from the file-side codes: the caller's image was fine.
+pub(crate) const INSPECT_CODE_CATALOG_FAILED: &str = "workflow_inspect_catalog_failed";
+
+/// Stamp a machine-readable `code` on an error produced by a shared helper that has no per-route
+/// vocabulary — the multipart machinery, `stream_multipart_field_to_file`, the catalog readers.
+///
+/// Every failure this route returns has to carry one, or sc-15951's `code` branch is handed an
+/// envelope it cannot classify. A 413 is recognized by status wherever it comes from, since
+/// "too large" is the same fact whichever layer noticed it. An error that already carries a code
+/// keeps it.
+fn coded(mut error: ApiError, fallback: &'static str) -> ApiError {
+    if error.code.is_none() {
+        error.code = Some(if error.status == StatusCode::PAYLOAD_TOO_LARGE {
+            INSPECT_CODE_TOO_LARGE
+        } else {
+            fallback
+        });
+    }
+    error
+}
+
+/// A `multer` failure surfaced by `next_field`/`Field::text`, given this route's vocabulary.
+///
+/// The status is the one `multer` chose (a field over an inner limit is a 413, malformed framing a
+/// 400) rather than a flattened 400, so the caller is told which it was.
+fn multipart_error(error: &axum::extract::multipart::MultipartError) -> ApiError {
+    coded(
+        ApiError {
+            status: error.status(),
+            detail: error.body_text(),
+            code: None,
+        },
+        INSPECT_CODE_BAD_MULTIPART,
+    )
+}
+
 /// The `{ workflow, resolution }` contract, plus the `status` discriminator.
 ///
 /// `workflow` and `resolution` are always PRESENT — `null` in the no-workflow case — so a reader
@@ -68,22 +140,33 @@ pub(crate) struct WorkflowInspectResponse {
 /// project's `loras/manifest.jsonc`, and neither is created if absent.
 pub(crate) async fn inspect_workflow(
     State(state): State<AppState>,
-    mut multipart: Multipart,
+    multipart: Result<Multipart, axum::extract::multipart::MultipartRejection>,
 ) -> Result<Json<WorkflowInspectResponse>, ApiError> {
+    // Taken as a `Result` so the EXTRACTOR's failure is mapped here too. Left to axum it renders a
+    // plain-text body with no `code`, which is the one shape sc-15951 cannot parse.
+    let mut multipart = multipart.map_err(|rejection| ApiError {
+        status: rejection.status(),
+        detail: rejection.body_text(),
+        code: Some(INSPECT_CODE_BAD_MULTIPART),
+    })?;
     let mut file: Option<PathBuf> = None;
     let mut project_id: Option<String> = None;
     // Same shape as `assets::import_asset`: the `file` field is staged before a later field can
     // error, so collection happens inside a fallible block whose error path removes the temp.
     let collect_result = async {
-        while let Some(field) = multipart
-            .next_field()
-            .await
-            .map_err(|error| ApiError::bad_request(error.to_string()))?
-        {
+        while let Some(field) = multipart.next_field().await.map_err(|error| {
+            // An EMPTY body reaches here rather than the extractor — `Multipart` is lazy, so it is
+            // the first `next_field` that discovers there is no framing to read.
+            multipart_error(&error)
+        })? {
             match field.name() {
                 Some("file") => {
                     if file.is_some() {
-                        return Err(ApiError::bad_request("Only one file field is allowed"));
+                        return Err(ApiError {
+                            status: StatusCode::BAD_REQUEST,
+                            detail: "Only one file field is allowed".to_owned(),
+                            code: Some(INSPECT_CODE_BAD_MULTIPART),
+                        });
                     }
                     file = Some(stage_inspect_upload(&state, field).await?);
                 }
@@ -91,7 +174,7 @@ pub(crate) async fn inspect_workflow(
                     let value = field
                         .text()
                         .await
-                        .map_err(|error| ApiError::bad_request(error.to_string()))?;
+                        .map_err(|error| multipart_error(&error))?;
                     let value = value.trim();
                     if !value.is_empty() {
                         project_id = Some(value.to_owned());
@@ -110,19 +193,28 @@ pub(crate) async fn inspect_workflow(
         return Err(error);
     }
 
-    let temp_path = file.ok_or_else(|| ApiError::bad_request("Upload file field is required"))?;
+    let temp_path = file.ok_or_else(|| ApiError {
+        status: StatusCode::BAD_REQUEST,
+        detail: "Upload file field is required".to_owned(),
+        code: Some(INSPECT_CODE_BAD_MULTIPART),
+    })?;
     // The chunk read is bounded but synchronous (`workflow_png` walks chunk headers off the
     // executor's thread otherwise). The temp file is removed whether it succeeded, failed, or the
     // task itself panicked — nothing about the outcome may leave an upload behind.
     let read_path = temp_path.clone();
     let read = tokio::task::spawn_blocking(move || read_workflow_chunk_file(&read_path)).await;
     let _ = tokio::fs::remove_file(&temp_path).await;
-    let read =
-        read.map_err(|error| ApiError::internal(format!("Workflow chunk read failed: {error}")))?;
+    let read = read.map_err(|error| ApiError {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        detail: format!("Workflow chunk read failed: {error}"),
+        code: Some(INSPECT_CODE_READ_FAILED),
+    })?;
 
     match read {
         Ok(Some(share)) => {
-            let catalogs = inspect_catalogs(&state, project_id.as_deref()).await?;
+            let catalogs = inspect_catalogs(&state, project_id.as_deref())
+                .await
+                .map_err(|error| coded(error, INSPECT_CODE_CATALOG_FAILED))?;
             let resolution = build_resolution_report(&share, &catalogs);
             Ok(Json(WorkflowInspectResponse {
                 status: INSPECT_STATUS_WORKFLOW,
@@ -144,8 +236,9 @@ pub(crate) async fn inspect_workflow(
     }
 }
 
-/// The per-field upload cap. `MAX_UPLOAD_BYTES` in production; overridable in tests, because the
-/// real cap is 2 GiB and no test can send that (the `max_lora_upload_bytes` pattern).
+/// The per-field upload cap. [`MAX_WORKFLOW_INSPECT_BYTES`] in production; overridable in tests,
+/// because even the reduced cap is 512 MiB and no test wants to send that (the
+/// `max_lora_upload_bytes` pattern).
 fn max_inspect_upload_bytes() -> usize {
     #[cfg(test)]
     {
@@ -154,7 +247,23 @@ fn max_inspect_upload_bytes() -> usize {
             return limit;
         }
     }
-    MAX_UPLOAD_BYTES
+    MAX_WORKFLOW_INSPECT_BYTES
+}
+
+/// The route's `DefaultBodyLimit` — the per-field cap PLUS multipart framing headroom.
+///
+/// Derived rather than fixed for two reasons. It cannot drift back into equality with the field
+/// cap, which is the bug: with the two equal, a body AT the cap plus its boundaries and part
+/// headers exceeds the router limit, so axum rejects it before `stage_inspect_upload` ever counts
+/// a byte and the caller sees a plain 400 from `field.chunk()` instead of the typed 413. And it
+/// tracks the test override, so the real boundary — a body one byte over the cap, framing included
+/// — is reachable at a size a test can actually send.
+pub(crate) fn max_inspect_multipart_body_bytes() -> usize {
+    let cap = max_inspect_upload_bytes();
+    if cap == MAX_WORKFLOW_INSPECT_BYTES {
+        return MAX_WORKFLOW_INSPECT_MULTIPART_BODY_BYTES;
+    }
+    cap.saturating_add(MULTIPART_FRAMING_HEADROOM_BYTES)
 }
 
 /// Stream the uploaded image into the SAME `cache/uploads` staging area asset import uses, so the
@@ -168,7 +277,12 @@ async fn stage_inspect_upload(
     let upload_dir = state.settings.data_dir.join("cache").join("uploads");
     tokio::fs::create_dir_all(&upload_dir)
         .await
-        .map_err(|error| ApiError::internal(error.to_string()))?;
+        .map_err(|error| {
+            coded(
+                ApiError::internal(error.to_string()),
+                INSPECT_CODE_STAGE_FAILED,
+            )
+        })?;
     let temp_path = upload_dir.join(format!("upload-{}.tmp", Uuid::new_v4().simple()));
     stream_multipart_field_to_file(
         field,
@@ -179,13 +293,36 @@ async fn stage_inspect_upload(
             let _ = tokio::fs::remove_file(&temp_path).await;
         },
     )
-    .await?;
+    .await
+    // The shared streamer has no per-route vocabulary, so the `code` is stamped here. `coded`
+    // recognizes the 413 by status; everything else it can return is a failure to WRITE the temp.
+    .map_err(|error| coded(error, INSPECT_CODE_STAGE_FAILED))?;
     Ok(temp_path)
 }
 
-/// Map a reader failure onto a typed 4xx. Never a 500: every variant here is a fact about the
-/// bytes the caller sent, and each carries the reader's own user-facing sentence.
+/// Map a reader failure onto a typed status, a machine-readable `code`, and a sentence fit to show
+/// a person.
+///
+/// Two rules the naive `error.to_string()` broke:
+///
+/// * **Whose fault is it?** Every variant but [`WorkflowChunkError::Io`] is a fact about the bytes
+///   the caller sent, so it is a 4xx. `Io` is raised when our OWN staged temp cannot be opened or
+///   read — the upload already succeeded by then — so it is a 5xx, with its own code. Calling a
+///   disk fault "this file is not a PNG" is the mislabeling epic 15945 exists to stop.
+/// * **Is the sentence showable?** The variants that carry an upstream `detail` inline it into
+///   their `Display`, and for a garbage chunk that upstream text is the `png` crate's `Debug`
+///   output (`ChunkType { type: ageg, critical: false, … }`). That is diagnostic, not a sentence.
+///   Those variants get a human one here and the raw text goes to the LOG, which is where a
+///   developer reading a bug report will look for it.
 fn inspect_error(error: &WorkflowChunkError) -> ApiError {
+    // The full Display — upstream detail and all — always lands here, so nothing is lost by
+    // showing the user a cleaner sentence. `Io` is the server's problem, hence the higher level.
+    match error {
+        WorkflowChunkError::Io { .. } => {
+            tracing::error!(event = "workflow_inspect_read_failed", error = %error);
+        }
+        _ => tracing::debug!(event = "workflow_inspect_rejected", error = %error),
+    }
     match error {
         // Not an image we can carry a workflow in. Distinct from "no workflow" on purpose: a JPEG
         // could never have one, where a PNG might.
@@ -194,24 +331,48 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
             detail: error.to_string(),
             code: Some(INSPECT_CODE_NOT_PNG),
         },
-        // Reading the FILE failed (unreadable temp). The caller's bytes did not describe an
-        // openable file, so it is still their request that is at fault — and 500 would hide it.
+        // OUR staged temp could not be opened or read. The caller's bytes were written
+        // successfully before this point, so nothing is known to be wrong with their file and the
+        // sentence must not imply otherwise.
         WorkflowChunkError::Io { .. } => ApiError {
-            status: StatusCode::BAD_REQUEST,
-            detail: error.to_string(),
-            code: Some(INSPECT_CODE_NOT_PNG),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: "SceneWorks could not read the uploaded image back off disk, so its workflow \
+                     could not be checked. Nothing is known to be wrong with the file — try again."
+                .to_owned(),
+            code: Some(INSPECT_CODE_READ_FAILED),
         },
-        // A PNG that claims a workflow we will not guess at: truncated framing, two workflow
-        // chunks, oversized metadata, a zip bomb, a newer schema version, a video envelope.
-        WorkflowChunkError::Png { .. }
-        | WorkflowChunkError::DuplicateChunk { .. }
+        // A PNG whose framing never got as far as our keyword. The upstream `detail` is `png`'s
+        // Debug output; it goes to the log above, not to the user.
+        WorkflowChunkError::Png { .. } => ApiError {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "This PNG could not be read far enough to look for a workflow, so it may be \
+                     truncated or damaged."
+                .to_owned(),
+            code: Some(INSPECT_CODE_UNREADABLE),
+        },
+        // Same treatment, same reason: a corrupt zlib stream's message is not a sentence.
+        WorkflowChunkError::UnreadableChunk { limit, .. } => ApiError {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: format!(
+                "This PNG's workflow text could not be read as text within {limit} bytes, so the \
+                 recipe it claims cannot be shown."
+            ),
+            code: Some(INSPECT_CODE_UNREADABLE),
+        },
+        // `Encode` is unreachable on a read; given a sentence rather than left to a catch-all so a
+        // new variant has to be classified here instead of silently inheriting one.
+        WorkflowChunkError::Encode { .. } => ApiError {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "This image's workflow could not be processed.".to_owned(),
+            code: Some(INSPECT_CODE_UNREADABLE),
+        },
+        // The remaining variants' own sentences are already written FOR a person and name a
+        // concrete number the user can act on (two chunks, N bytes over the limit, an envelope
+        // this build will not read) — no upstream text is inlined into any of them.
+        WorkflowChunkError::DuplicateChunk { .. }
         | WorkflowChunkError::MetadataTooLarge { .. }
         | WorkflowChunkError::TextTooLarge { .. }
-        | WorkflowChunkError::UnreadableChunk { .. }
-        | WorkflowChunkError::Envelope(_)
-        // `Encode` is unreachable on a read; folded in rather than left to a catch-all so a new
-        // variant has to be classified here instead of silently becoming a 422.
-        | WorkflowChunkError::Encode { .. } => ApiError {
+        | WorkflowChunkError::Envelope(_) => ApiError {
             status: StatusCode::UNPROCESSABLE_ENTITY,
             detail: error.to_string(),
             code: Some(INSPECT_CODE_UNREADABLE),
@@ -224,18 +385,31 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
 /// Every read here is one the existing endpoints already do, and all four are read-only:
 /// `model_catalog` is the shared install-state snapshot behind `GET /models`, `lora_catalog` is the
 /// builtin → global → external → project merge, `styles_catalog` reads `builtin.styles.jsonc`, and
-/// `recipe_preset_catalog` is the three-scope preset merge.
+/// `recipe_preset_catalog_with` is the three-scope preset merge.
+///
+/// ONE [`JobCatalogSnapshot`] is threaded through both model readers (sc-8819). The preset merge
+/// needs the model catalog too, so without the snapshot this request read it twice — two full deep
+/// clones of the cached value, and two values that could DISAGREE if a model write landed between
+/// them, leaving the report's `model` row classified against a different catalog than the presets.
 async fn inspect_catalogs(
     state: &AppState,
     project_id: Option<&str>,
 ) -> Result<StaticCatalogs, ApiError> {
-    let models = crate::models::model_catalog(state).await?;
-    let loras = crate::loras::lora_catalog(state, project_id).await?;
+    let snapshot = crate::generation::JobCatalogSnapshot::default();
+    let models = snapshot.models(state).await?;
+    let loras = snapshot.loras(state, project_id).await?;
     let styles = crate::styles::styles_catalog(state).await?;
-    let presets = crate::recipe_presets::recipe_preset_catalog(state, project_id).await?;
+    let presets =
+        crate::recipe_presets::recipe_preset_catalog_with(state, project_id, Some(&snapshot))
+            .await?;
     Ok(StaticCatalogs {
-        models: models.iter().map(model_catalog_entry).collect(),
-        loras: loras.iter().map(lora_catalog_entry).collect(),
+        // `filter_map`, not `map`: a row with no usable `id` is DROPPED rather than reduced to a
+        // matchable `id: ""`. A manifest may omit `id` entirely (`load_manifest_entries` validates
+        // nothing and `apply_model_catalog_entry` never inserts one), and a blank id used to match
+        // an envelope whose `model` had been scrubbed to `""` — reporting a model the file never
+        // named as installed. Same rule the styles/presets already followed through `named_entry`.
+        models: models.iter().filter_map(model_catalog_entry).collect(),
+        loras: loras.iter().filter_map(lora_catalog_entry).collect(),
         styles: style_catalog_entries(&styles),
         recipe_presets: presets.iter().filter_map(named_entry).collect(),
     })
@@ -266,27 +440,29 @@ fn named_entry(entry: &Value) -> Option<CatalogEntry> {
     })
 }
 
-/// One model catalog row.
+/// One model catalog row, or `None` for a row with no usable `id`.
 ///
 /// `installed` is the `installState` the shared snapshot computed — the whole point of the
 /// distinction the report draws, since a cache-only resolver never auto-downloads. The install
 /// action is offered only when the row is `downloadable`, which is the same predicate
 /// `create_model_download_job` needs to find a Hugging Face download to enqueue.
-fn model_catalog_entry(entry: &Value) -> CatalogEntry {
-    let id = entry_str(entry, "id").unwrap_or_default();
+fn model_catalog_entry(entry: &Value) -> Option<CatalogEntry> {
+    // An id-less row is unmatchable and unactionable — the download route is keyed by id — so it
+    // is dropped rather than carried as `id: ""`. See `inspect_catalogs`.
+    let id = entry_str(entry, "id")?;
     let installed = is_installed(entry);
     let downloadable = entry.get("downloadable").and_then(Value::as_bool) == Some(true);
-    let install = (!installed && downloadable && !id.is_empty()).then(|| InstallAction {
+    let install = (!installed && downloadable).then(|| InstallAction {
         method: "POST".to_owned(),
         path: format!("/api/v1/models/{id}/download"),
     });
-    CatalogEntry {
+    Some(CatalogEntry {
         id,
         name: entry_str(entry, "name"),
         repo: None,
         installed,
         install,
-    }
+    })
 }
 
 /// One LoRA catalog row.
@@ -295,8 +471,10 @@ fn model_catalog_entry(entry: &Value) -> CatalogEntry {
 /// `create_lora_download_job` refuses a row with no `huggingface` provider, and it looks the row up
 /// with `lora_catalog(.., None)` — so a PROJECT-scoped row can never be fetched through it and is
 /// deliberately left without an action rather than pointed at a route that would 404.
-fn lora_catalog_entry(entry: &Value) -> CatalogEntry {
-    let id = entry_str(entry, "id").unwrap_or_default();
+fn lora_catalog_entry(entry: &Value) -> Option<CatalogEntry> {
+    // Same drop as `model_catalog_entry`: an id-less row could only ever be matched by a blank
+    // label, and nothing this report is asked about is blank on purpose.
+    let id = entry_str(entry, "id")?;
     let source = entry.get("source").and_then(Value::as_object);
     let is_huggingface = source
         .and_then(|source| source.get("provider"))
@@ -313,18 +491,17 @@ fn lora_catalog_entry(entry: &Value) -> CatalogEntry {
         .map(str::to_owned);
     let installed = is_installed(entry);
     let fetchable = entry.get("scope").and_then(Value::as_str) != Some("project");
-    let install =
-        (!installed && repo.is_some() && fetchable && !id.is_empty()).then(|| InstallAction {
-            method: "POST".to_owned(),
-            path: format!("/api/v1/loras/{id}/download"),
-        });
-    CatalogEntry {
+    let install = (!installed && repo.is_some() && fetchable).then(|| InstallAction {
+        method: "POST".to_owned(),
+        path: format!("/api/v1/loras/{id}/download"),
+    });
+    Some(CatalogEntry {
         id,
         name: entry_str(entry, "name"),
         repo,
         installed,
         install,
-    }
+    })
 }
 
 /// Flatten the Style catalog into its one id-space: every group id and every sub-style id, which is
@@ -357,7 +534,8 @@ mod tests {
             "name": "Krea 2 Turbo",
             "installState": "missing",
             "downloadable": true
-        }));
+        }))
+        .expect("a row with an id survives");
         assert!(!entry.installed);
         assert_eq!(
             entry.install.as_ref().map(|action| action.path.as_str()),
@@ -370,7 +548,8 @@ mod tests {
     fn an_installed_model_row_publishes_no_download() {
         let entry = model_catalog_entry(&json!({
             "id": "krea_2_turbo", "installState": "installed", "downloadable": true
-        }));
+        }))
+        .expect("a row with an id survives");
         assert!(entry.installed);
         assert!(entry.install.is_none());
     }
@@ -381,7 +560,8 @@ mod tests {
         // rather than offer a button `create_model_download_job` would refuse.
         let entry = model_catalog_entry(&json!({
             "id": "external_base_x", "installState": "missing", "downloadable": false
-        }));
+        }))
+        .expect("a row with an id survives");
         assert!(entry.install.is_none());
     }
 
@@ -393,7 +573,8 @@ mod tests {
             "scope": "builtin",
             "installState": "missing",
             "source": { "provider": "huggingface", "repo": "acme/film-grain", "file": "x.safetensors" }
-        }));
+        }))
+        .expect("a row with an id survives");
         assert_eq!(entry.repo.as_deref(), Some("acme/film-grain"));
         assert_eq!(
             entry.install.as_ref().map(|action| action.path.as_str()),
@@ -409,7 +590,8 @@ mod tests {
             "scope": "global",
             "installState": "installed",
             "source": { "provider": "local", "path": "loras/aurora_v3" }
-        }));
+        }))
+        .expect("a row with an id survives");
         assert!(entry.repo.is_none());
         assert!(entry.install.is_none());
         assert!(entry.installed);
@@ -424,7 +606,8 @@ mod tests {
             "scope": "project",
             "installState": "missing",
             "source": { "provider": "huggingface", "repo": "acme/x" }
-        }));
+        }))
+        .expect("a row with an id survives");
         assert_eq!(entry.repo.as_deref(), Some("acme/x"));
         assert!(entry.install.is_none());
     }
@@ -460,11 +643,9 @@ mod tests {
         let duplicate = inspect_error(&WorkflowChunkError::DuplicateChunk { count: 2 });
         assert_eq!(duplicate.status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(duplicate.code, Some(INSPECT_CODE_UNREADABLE));
-        // Never a 500, whatever the variant.
+        // Every variant that IS a fact about the caller's bytes is a typed 4xx. `Io` is not one of
+        // them — see `a_server_side_read_failure_is_not_reported_as_a_bad_file`.
         for error in [
-            WorkflowChunkError::Io {
-                detail: "x".to_owned(),
-            },
             WorkflowChunkError::Png {
                 detail: "x".to_owned(),
             },
@@ -488,6 +669,114 @@ mod tests {
                 mapped.status
             );
             assert!(!mapped.detail.is_empty(), "{error:?} needs a sentence");
+            assert!(mapped.code.is_some(), "{error:?} needs a machine code");
         }
+    }
+
+    #[test]
+    fn a_server_side_read_failure_is_not_reported_as_a_bad_file() {
+        // `WorkflowChunkError::Io` fires when OUR staged temp cannot be opened or read — the
+        // caller's bytes were written successfully before that point. On Windows an antivirus
+        // sharing violation on `cache/uploads` is the plausible cause. Calling that "not a PNG"
+        // sends the user to fix a file that is fine.
+        let mapped = inspect_error(&WorkflowChunkError::Io {
+            detail: "The process cannot access the file because it is being used by another \
+                     process. (os error 32)"
+                .to_owned(),
+        });
+        assert_eq!(mapped.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(mapped.code, Some(INSPECT_CODE_READ_FAILED));
+        assert_ne!(mapped.code, Some(INSPECT_CODE_NOT_PNG));
+        assert!(
+            !mapped.detail.contains("not a PNG"),
+            "detail: {}",
+            mapped.detail
+        );
+        // The OS message is diagnostic, not a sentence — it goes to the log, not the response.
+        assert!(
+            !mapped.detail.contains("os error"),
+            "detail: {}",
+            mapped.detail
+        );
+    }
+
+    #[test]
+    fn a_garbage_chunks_sentence_does_not_leak_the_png_crates_debug_output() {
+        // The first time sc-15947's reader failure is shown to a person. `Png`/`UnreadableChunk`
+        // inline the upstream text into their `Display`, and for a corrupt chunk that text is a
+        // `Debug` dump of a `ChunkType` struct.
+        let leaky = "ChunkType { type: ageg, critical: false, private: true, reserved: true, \
+                     safecopy: true }";
+        for error in [
+            WorkflowChunkError::Png {
+                detail: leaky.to_owned(),
+            },
+            WorkflowChunkError::UnreadableChunk {
+                limit: 262_144,
+                detail: leaky.to_owned(),
+            },
+        ] {
+            let mapped = inspect_error(&error);
+            assert_eq!(mapped.status, StatusCode::UNPROCESSABLE_ENTITY);
+            assert_eq!(mapped.code, Some(INSPECT_CODE_UNREADABLE));
+            assert!(
+                !mapped.detail.contains("ChunkType") && !mapped.detail.contains("safecopy"),
+                "{error:?} leaked its upstream debug text: {}",
+                mapped.detail
+            );
+            assert!(
+                mapped.detail.ends_with('.'),
+                "{error:?} must read as a sentence: {}",
+                mapped.detail
+            );
+        }
+    }
+
+    #[test]
+    fn a_catalog_row_with_no_usable_id_is_dropped_rather_than_carried_as_a_blank() {
+        // A manifest may omit `id` entirely — `load_manifest_entries` validates nothing and
+        // `apply_model_catalog_entry` defaults it. A blank id used to be matchable, and
+        // `workflow_share` scrubs an unshareable `model` to exactly that.
+        for row in [
+            json!({ "name": "Some Other Model", "installState": "installed" }),
+            json!({ "id": "", "name": "Some Other Model", "installState": "installed" }),
+            json!({ "id": "   ", "name": "Some Other Model", "installState": "installed" }),
+        ] {
+            assert!(model_catalog_entry(&row).is_none(), "row: {row}");
+            assert!(lora_catalog_entry(&row).is_none(), "row: {row}");
+        }
+        // A row that DOES have one still survives, so the guard drops only the unmatchable.
+        assert!(model_catalog_entry(&json!({ "id": "krea_2_turbo" })).is_some());
+        assert!(lora_catalog_entry(&json!({ "id": "film_grain" })).is_some());
+    }
+
+    #[test]
+    fn the_route_body_limit_sits_above_the_per_field_cap() {
+        // Issue 4: with the two EQUAL, a body at the cap plus multipart framing trips axum's own
+        // limit first and surfaces as a plain 400 from `field.chunk()`, so the typed 413 is
+        // unreachable at the only boundary that matters. Same headroom as the LoRA route.
+        const {
+            assert!(
+                MAX_WORKFLOW_INSPECT_MULTIPART_BODY_BYTES > MAX_WORKFLOW_INSPECT_BYTES,
+                "the router limit must leave room for boundaries and part headers"
+            );
+            assert!(
+                MAX_WORKFLOW_INSPECT_MULTIPART_BODY_BYTES - MAX_WORKFLOW_INSPECT_BYTES
+                    == MULTIPART_FRAMING_HEADROOM_BYTES
+            );
+            // Issue 8: inspect stages the body, throws it away and returns a small JSON report, so
+            // it does not buy the asset route's 2 GiB. The cap must still clear any PNG a user
+            // would plausibly drop.
+            assert!(MAX_WORKFLOW_INSPECT_BYTES < MAX_UPLOAD_BYTES);
+            assert!(
+                MAX_WORKFLOW_INSPECT_BYTES >= 512 * 1024 * 1024,
+                "a 16384² 8-bit RGB PNG (4096² through a 4x upscale) has to fit"
+            );
+        }
+        // The production value the derived accessor yields, with no test override in force.
+        assert_eq!(
+            max_inspect_multipart_body_bytes(),
+            MAX_WORKFLOW_INSPECT_MULTIPART_BODY_BYTES
+        );
     }
 }

--- a/apps/rust-api/src/workflows.rs
+++ b/apps/rust-api/src/workflows.rs
@@ -1,0 +1,493 @@
+//! `POST /api/v1/workflows/inspect` — read a shared image's embedded workflow and say whether this
+//! machine can run it (sc-15950, epic 15945).
+//!
+//! Read-only by construction. It creates **no asset, no job and no project mutation**: the upload
+//! is streamed to the same swept `cache/uploads` staging area asset import uses, the PNG's text
+//! chunk is read out of it, and the temp file is removed on every path. That matters because
+//! sc-15951 prefills the studio from a dropped file the user may never import — asking them to
+//! commit an asset in order to find out what a file contains would be exactly backwards.
+//!
+//! # Three outcomes, and only one of them is an error
+//!
+//! * The file carries an envelope → `200 { status: "workflow", workflow, resolution }`.
+//! * The file is a PNG with no `sceneworks:workflow` chunk → `200 { status: "no_workflow",
+//!   workflow: null, resolution: null, detail }`. **This is the common case** (any foreign PNG) and
+//!   it must not look like a failure; sc-15951 branches on `status`.
+//! * The file is not a PNG at all, or claims a workflow this build refuses to guess at → a typed
+//!   4xx carrying a machine-readable `code` and the reader's own sentence. Never a 500.
+//!
+//! The resolution report itself is `sceneworks_core::workflow_resolution` — shared with the import
+//! path (sc-15949) and the web (sc-15951 / sc-15952) rather than owned here. This module's whole
+//! job is to bridge it to the catalogs, which live in this crate.
+
+use super::*;
+
+use sceneworks_core::workflow_png::{read_workflow_chunk_file, WorkflowChunkError};
+use sceneworks_core::workflow_resolution::{
+    build_resolution_report, CatalogEntry, InstallAction, ResolutionReport, StaticCatalogs,
+};
+use sceneworks_core::workflow_share::WorkflowShare;
+
+/// `status` when the file carried a readable envelope.
+pub(crate) const INSPECT_STATUS_WORKFLOW: &str = "workflow";
+
+/// `status` when the file is a readable image that simply has no workflow in it.
+///
+/// The distinct, unambiguous branch sc-15951 keys off. Deliberately a 200 with its own status
+/// rather than a 404/422: a PNG from anywhere else in the world has no chunk, and calling that a
+/// failure would make the normal case look broken.
+pub(crate) const INSPECT_STATUS_NO_WORKFLOW: &str = "no_workflow";
+
+/// `code` on the 400 for bytes that are not a PNG.
+pub(crate) const INSPECT_CODE_NOT_PNG: &str = "workflow_inspect_not_png";
+
+/// `code` on the 422 for a file that claims a workflow this build will not read (a truncated PNG,
+/// two workflow chunks, a zip bomb, a newer schema version, a video envelope).
+pub(crate) const INSPECT_CODE_UNREADABLE: &str = "workflow_inspect_unreadable";
+
+/// The `{ workflow, resolution }` contract, plus the `status` discriminator.
+///
+/// `workflow` and `resolution` are always PRESENT — `null` in the no-workflow case — so a reader
+/// never has to tell an absent key from a null one.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkflowInspectResponse {
+    pub(crate) status: &'static str,
+    pub(crate) workflow: Option<WorkflowShare>,
+    pub(crate) resolution: Option<ResolutionReport>,
+    /// A sentence for the no-workflow case. Absent on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) detail: Option<String>,
+}
+
+/// `POST /api/v1/workflows/inspect` — multipart `file` (required) plus an optional `projectId`.
+///
+/// `projectId` widens the LoRA and recipe-preset lookups to that project's scope (the same
+/// builtin → global → project merge the generation path uses); without it only the install-wide
+/// scopes are consulted. It is read-only either way — `get_project` reads `project.json` and the
+/// project's `loras/manifest.jsonc`, and neither is created if absent.
+pub(crate) async fn inspect_workflow(
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Result<Json<WorkflowInspectResponse>, ApiError> {
+    let mut file: Option<PathBuf> = None;
+    let mut project_id: Option<String> = None;
+    // Same shape as `assets::import_asset`: the `file` field is staged before a later field can
+    // error, so collection happens inside a fallible block whose error path removes the temp.
+    let collect_result = async {
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()))?
+        {
+            match field.name() {
+                Some("file") => {
+                    if file.is_some() {
+                        return Err(ApiError::bad_request("Only one file field is allowed"));
+                    }
+                    file = Some(stage_inspect_upload(&state, field).await?);
+                }
+                Some("projectId") => {
+                    let value = field
+                        .text()
+                        .await
+                        .map_err(|error| ApiError::bad_request(error.to_string()))?;
+                    let value = value.trim();
+                    if !value.is_empty() {
+                        project_id = Some(value.to_owned());
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok::<(), ApiError>(())
+    }
+    .await;
+    if let Err(error) = collect_result {
+        if let Some(path) = file.as_ref() {
+            let _ = tokio::fs::remove_file(path).await;
+        }
+        return Err(error);
+    }
+
+    let temp_path = file.ok_or_else(|| ApiError::bad_request("Upload file field is required"))?;
+    // The chunk read is bounded but synchronous (`workflow_png` walks chunk headers off the
+    // executor's thread otherwise). The temp file is removed whether it succeeded, failed, or the
+    // task itself panicked — nothing about the outcome may leave an upload behind.
+    let read_path = temp_path.clone();
+    let read = tokio::task::spawn_blocking(move || read_workflow_chunk_file(&read_path)).await;
+    let _ = tokio::fs::remove_file(&temp_path).await;
+    let read =
+        read.map_err(|error| ApiError::internal(format!("Workflow chunk read failed: {error}")))?;
+
+    match read {
+        Ok(Some(share)) => {
+            let catalogs = inspect_catalogs(&state, project_id.as_deref()).await?;
+            let resolution = build_resolution_report(&share, &catalogs);
+            Ok(Json(WorkflowInspectResponse {
+                status: INSPECT_STATUS_WORKFLOW,
+                workflow: Some(share),
+                resolution: Some(resolution),
+                detail: None,
+            }))
+        }
+        Ok(None) => Ok(Json(WorkflowInspectResponse {
+            status: INSPECT_STATUS_NO_WORKFLOW,
+            workflow: None,
+            resolution: None,
+            detail: Some(
+                "This image carries no SceneWorks workflow, so there is no recipe to read from it."
+                    .to_owned(),
+            ),
+        })),
+        Err(error) => Err(inspect_error(&error)),
+    }
+}
+
+/// The per-field upload cap. `MAX_UPLOAD_BYTES` in production; overridable in tests, because the
+/// real cap is 2 GiB and no test can send that (the `max_lora_upload_bytes` pattern).
+fn max_inspect_upload_bytes() -> usize {
+    #[cfg(test)]
+    {
+        let limit = TEST_MAX_WORKFLOW_INSPECT_BYTES.with(std::cell::Cell::get);
+        if limit > 0 {
+            return limit;
+        }
+    }
+    MAX_UPLOAD_BYTES
+}
+
+/// Stream the uploaded image into the SAME `cache/uploads` staging area asset import uses, so the
+/// existing `sweep_stale_asset_uploads` startup backstop already covers anything an aborted
+/// inspect leaves behind. A near-twin of `assets::write_upload_field_to_temp_file`, split out only
+/// so the cap can be lowered in tests.
+async fn stage_inspect_upload(
+    state: &AppState,
+    field: axum::extract::multipart::Field<'_>,
+) -> Result<PathBuf, ApiError> {
+    let upload_dir = state.settings.data_dir.join("cache").join("uploads");
+    tokio::fs::create_dir_all(&upload_dir)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let temp_path = upload_dir.join(format!("upload-{}.tmp", Uuid::new_v4().simple()));
+    stream_multipart_field_to_file(
+        field,
+        &temp_path,
+        max_inspect_upload_bytes(),
+        || "Uploaded image is too large".to_owned(),
+        || async {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+        },
+    )
+    .await?;
+    Ok(temp_path)
+}
+
+/// Map a reader failure onto a typed 4xx. Never a 500: every variant here is a fact about the
+/// bytes the caller sent, and each carries the reader's own user-facing sentence.
+fn inspect_error(error: &WorkflowChunkError) -> ApiError {
+    match error {
+        // Not an image we can carry a workflow in. Distinct from "no workflow" on purpose: a JPEG
+        // could never have one, where a PNG might.
+        WorkflowChunkError::NotPng => ApiError {
+            status: StatusCode::BAD_REQUEST,
+            detail: error.to_string(),
+            code: Some(INSPECT_CODE_NOT_PNG),
+        },
+        // Reading the FILE failed (unreadable temp). The caller's bytes did not describe an
+        // openable file, so it is still their request that is at fault — and 500 would hide it.
+        WorkflowChunkError::Io { .. } => ApiError {
+            status: StatusCode::BAD_REQUEST,
+            detail: error.to_string(),
+            code: Some(INSPECT_CODE_NOT_PNG),
+        },
+        // A PNG that claims a workflow we will not guess at: truncated framing, two workflow
+        // chunks, oversized metadata, a zip bomb, a newer schema version, a video envelope.
+        WorkflowChunkError::Png { .. }
+        | WorkflowChunkError::DuplicateChunk { .. }
+        | WorkflowChunkError::MetadataTooLarge { .. }
+        | WorkflowChunkError::TextTooLarge { .. }
+        | WorkflowChunkError::UnreadableChunk { .. }
+        | WorkflowChunkError::Envelope(_)
+        // `Encode` is unreachable on a read; folded in rather than left to a catch-all so a new
+        // variant has to be classified here instead of silently becoming a 422.
+        | WorkflowChunkError::Encode { .. } => ApiError {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: error.to_string(),
+            code: Some(INSPECT_CODE_UNREADABLE),
+        },
+    }
+}
+
+/// Build the injected catalog lookup from this install's real catalogs.
+///
+/// Every read here is one the existing endpoints already do, and all four are read-only:
+/// `model_catalog` is the shared install-state snapshot behind `GET /models`, `lora_catalog` is the
+/// builtin → global → external → project merge, `styles_catalog` reads `builtin.styles.jsonc`, and
+/// `recipe_preset_catalog` is the three-scope preset merge.
+async fn inspect_catalogs(
+    state: &AppState,
+    project_id: Option<&str>,
+) -> Result<StaticCatalogs, ApiError> {
+    let models = crate::models::model_catalog(state).await?;
+    let loras = crate::loras::lora_catalog(state, project_id).await?;
+    let styles = crate::styles::styles_catalog(state).await?;
+    let presets = crate::recipe_presets::recipe_preset_catalog(state, project_id).await?;
+    Ok(StaticCatalogs {
+        models: models.iter().map(model_catalog_entry).collect(),
+        loras: loras.iter().map(lora_catalog_entry).collect(),
+        styles: style_catalog_entries(&styles),
+        recipe_presets: presets.iter().filter_map(named_entry).collect(),
+    })
+}
+
+fn entry_str(entry: &Value, key: &str) -> Option<String> {
+    entry
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn is_installed(entry: &Value) -> bool {
+    entry.get("installState").and_then(Value::as_str) == Some("installed")
+}
+
+/// A catalog row reduced to `{ id, name }` — for the catalogs where "on disk" is not a question
+/// (styles, recipe presets). Rows with no usable id are dropped; they could never be matched.
+fn named_entry(entry: &Value) -> Option<CatalogEntry> {
+    Some(CatalogEntry {
+        id: entry_str(entry, "id")?,
+        name: entry_str(entry, "name"),
+        repo: None,
+        installed: false,
+        install: None,
+    })
+}
+
+/// One model catalog row.
+///
+/// `installed` is the `installState` the shared snapshot computed — the whole point of the
+/// distinction the report draws, since a cache-only resolver never auto-downloads. The install
+/// action is offered only when the row is `downloadable`, which is the same predicate
+/// `create_model_download_job` needs to find a Hugging Face download to enqueue.
+fn model_catalog_entry(entry: &Value) -> CatalogEntry {
+    let id = entry_str(entry, "id").unwrap_or_default();
+    let installed = is_installed(entry);
+    let downloadable = entry.get("downloadable").and_then(Value::as_bool) == Some(true);
+    let install = (!installed && downloadable && !id.is_empty()).then(|| InstallAction {
+        method: "POST".to_owned(),
+        path: format!("/api/v1/models/{id}/download"),
+    });
+    CatalogEntry {
+        id,
+        name: entry_str(entry, "name"),
+        repo: None,
+        installed,
+        install,
+    }
+}
+
+/// One LoRA catalog row.
+///
+/// `repo` is the Hugging Face source id, which is also the gate on the install action:
+/// `create_lora_download_job` refuses a row with no `huggingface` provider, and it looks the row up
+/// with `lora_catalog(.., None)` — so a PROJECT-scoped row can never be fetched through it and is
+/// deliberately left without an action rather than pointed at a route that would 404.
+fn lora_catalog_entry(entry: &Value) -> CatalogEntry {
+    let id = entry_str(entry, "id").unwrap_or_default();
+    let source = entry.get("source").and_then(Value::as_object);
+    let is_huggingface = source
+        .and_then(|source| source.get("provider"))
+        .or_else(|| entry.get("provider"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        == Some("huggingface");
+    let repo = source
+        .and_then(|source| source.get("repo"))
+        .or_else(|| entry.get("repo"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && is_huggingface)
+        .map(str::to_owned);
+    let installed = is_installed(entry);
+    let fetchable = entry.get("scope").and_then(Value::as_str) != Some("project");
+    let install =
+        (!installed && repo.is_some() && fetchable && !id.is_empty()).then(|| InstallAction {
+            method: "POST".to_owned(),
+            path: format!("/api/v1/loras/{id}/download"),
+        });
+    CatalogEntry {
+        id,
+        name: entry_str(entry, "name"),
+        repo,
+        installed,
+        install,
+    }
+}
+
+/// Flatten the Style catalog into its one id-space: every group id and every sub-style id, which is
+/// exactly what `styles::style_text_for_id` resolves against.
+fn style_catalog_entries(catalog: &Value) -> Vec<CatalogEntry> {
+    let Some(groups) = catalog.get("groups").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    for group in groups {
+        if let Some(entry) = named_entry(group) {
+            entries.push(entry);
+        }
+        let Some(styles) = group.get("styles").and_then(Value::as_array) else {
+            continue;
+        };
+        entries.extend(styles.iter().filter_map(named_entry));
+    }
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_model_row_that_is_known_but_absent_gets_the_model_manager_download() {
+        let entry = model_catalog_entry(&json!({
+            "id": "krea_2_turbo",
+            "name": "Krea 2 Turbo",
+            "installState": "missing",
+            "downloadable": true
+        }));
+        assert!(!entry.installed);
+        assert_eq!(
+            entry.install.as_ref().map(|action| action.path.as_str()),
+            Some("/api/v1/models/krea_2_turbo/download")
+        );
+        assert_eq!(entry.name.as_deref(), Some("Krea 2 Turbo"));
+    }
+
+    #[test]
+    fn an_installed_model_row_publishes_no_download() {
+        let entry = model_catalog_entry(&json!({
+            "id": "krea_2_turbo", "installState": "installed", "downloadable": true
+        }));
+        assert!(entry.installed);
+        assert!(entry.install.is_none());
+    }
+
+    #[test]
+    fn a_non_downloadable_model_row_gets_no_action() {
+        // An external ComfyUI base or a `downloadable: false` row: the report must call it missing
+        // rather than offer a button `create_model_download_job` would refuse.
+        let entry = model_catalog_entry(&json!({
+            "id": "external_base_x", "installState": "missing", "downloadable": false
+        }));
+        assert!(entry.install.is_none());
+    }
+
+    #[test]
+    fn a_lora_row_carries_its_hugging_face_repo_and_download() {
+        let entry = lora_catalog_entry(&json!({
+            "id": "film_grain",
+            "name": "Film Grain",
+            "scope": "builtin",
+            "installState": "missing",
+            "source": { "provider": "huggingface", "repo": "acme/film-grain", "file": "x.safetensors" }
+        }));
+        assert_eq!(entry.repo.as_deref(), Some("acme/film-grain"));
+        assert_eq!(
+            entry.install.as_ref().map(|action| action.path.as_str()),
+            Some("/api/v1/loras/film_grain/download")
+        );
+    }
+
+    #[test]
+    fn a_local_lora_row_has_no_repo_and_no_download() {
+        let entry = lora_catalog_entry(&json!({
+            "id": "aurora_v3",
+            "name": "Aurora v3",
+            "scope": "global",
+            "installState": "installed",
+            "source": { "provider": "local", "path": "loras/aurora_v3" }
+        }));
+        assert!(entry.repo.is_none());
+        assert!(entry.install.is_none());
+        assert!(entry.installed);
+    }
+
+    #[test]
+    fn a_project_scoped_lora_row_is_never_pointed_at_the_install_route() {
+        // `create_lora_download_job` looks the row up with `lora_catalog(.., None)`, so a
+        // project-scoped id 404s there — an action would be a button that cannot work.
+        let entry = lora_catalog_entry(&json!({
+            "id": "proj_lora",
+            "scope": "project",
+            "installState": "missing",
+            "source": { "provider": "huggingface", "repo": "acme/x" }
+        }));
+        assert_eq!(entry.repo.as_deref(), Some("acme/x"));
+        assert!(entry.install.is_none());
+    }
+
+    #[test]
+    fn the_style_catalog_flattens_groups_and_sub_styles_into_one_id_space() {
+        let entries = style_catalog_entries(&json!({
+            "groups": [{
+                "id": "anime-style",
+                "name": "Anime Style",
+                "styles": [
+                    { "id": "ghibli-style", "name": "Ghibli Style" },
+                    { "id": "70s-anime", "name": "70s Anime" }
+                ]
+            }]
+        }));
+        let ids: Vec<&str> = entries.iter().map(|entry| entry.id.as_str()).collect();
+        assert_eq!(ids, vec!["anime-style", "ghibli-style", "70s-anime"]);
+        assert!(entries.iter().all(|entry| entry.install.is_none()));
+    }
+
+    #[test]
+    fn an_empty_style_catalog_flattens_to_nothing() {
+        assert!(style_catalog_entries(&json!({ "schemaVersion": 1, "groups": [] })).is_empty());
+        assert!(style_catalog_entries(&json!({})).is_empty());
+    }
+
+    #[test]
+    fn not_a_png_is_a_typed_400_and_a_bad_chunk_is_a_typed_422() {
+        let not_png = inspect_error(&WorkflowChunkError::NotPng);
+        assert_eq!(not_png.status, StatusCode::BAD_REQUEST);
+        assert_eq!(not_png.code, Some(INSPECT_CODE_NOT_PNG));
+        let duplicate = inspect_error(&WorkflowChunkError::DuplicateChunk { count: 2 });
+        assert_eq!(duplicate.status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(duplicate.code, Some(INSPECT_CODE_UNREADABLE));
+        // Never a 500, whatever the variant.
+        for error in [
+            WorkflowChunkError::Io {
+                detail: "x".to_owned(),
+            },
+            WorkflowChunkError::Png {
+                detail: "x".to_owned(),
+            },
+            WorkflowChunkError::MetadataTooLarge { limit: 1 },
+            WorkflowChunkError::TextTooLarge { bytes: 2, limit: 1 },
+            WorkflowChunkError::UnreadableChunk {
+                limit: 1,
+                detail: "x".to_owned(),
+            },
+            WorkflowChunkError::Envelope(
+                sceneworks_core::workflow_share::WorkflowShareError::MissingMarker,
+            ),
+            WorkflowChunkError::Encode {
+                detail: "x".to_owned(),
+            },
+        ] {
+            let mapped = inspect_error(&error);
+            assert!(
+                mapped.status.is_client_error(),
+                "{error:?} must be a typed 4xx, got {}",
+                mapped.status
+            );
+            assert!(!mapped.detail.is_empty(), "{error:?} needs a sentence");
+        }
+    }
+}

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -33,7 +33,15 @@ use crate::payload_util::{
 /// Default model when the payload omits one (matches the Python worker).
 const DEFAULT_MODEL: &str = "z_image_turbo";
 const DEFAULT_MODE: &str = "text_to_image";
-const DEFAULT_STYLE_PRESET: &str = "cinematic";
+/// Default `stylePreset` when the payload omits one (matches the Python worker, and the
+/// rust-api DTO's `default_style_preset`).
+///
+/// Public because it is the value that means "no preset ran": the API overwrites this field with a
+/// recipe-preset id when one does, so anything still holding this literal names nothing.
+/// [`crate::workflow_resolution::INERT_STYLE_PRESETS`] reads it from here rather than repeating the
+/// literal, because every generated envelope carries it — misreading it as an unresolved preset
+/// would mark every shared image unreplayable.
+pub const DEFAULT_STYLE_PRESET: &str = "cinematic";
 /// Default fit mode (epic 2551): never distort, cover the frame. Shared with the
 /// video request (sc-6139) so image- and video-conditioned sources normalize identically.
 pub(crate) const DEFAULT_FIT_MODE: &str = "crop";

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod training_store;
 pub mod video_request;
 pub mod voice_store;
 pub mod workflow_png;
+pub mod workflow_resolution;
 pub mod workflow_share;
 
 pub const API_PREFIX: &str = "/api/v1";

--- a/crates/sceneworks-core/src/workflow_resolution.rs
+++ b/crates/sceneworks-core/src/workflow_resolution.rs
@@ -29,8 +29,10 @@
 //!
 //! What stays in core is everything that must not drift between callers: the matching ORDER (a
 //! Hugging Face repo id before a display name, because a repo id is unambiguous and a name is
-//! not), the name normalization ([`normalized_label`]), the mapping from
-//! (known, installed, fetchable) to a state, and the sentences.
+//! not; then the display name before the catalog id, because the envelope's `name` IS a display
+//! name), the rule that an ambiguous pass resolves to NOTHING (see [`unique_match`]), the name
+//! normalization ([`normalized_label`]), the mapping from (known, installed, fetchable) to a
+//! state, and the sentences.
 //!
 //! # "In the catalog" and "on disk" are different answers
 //!
@@ -200,8 +202,9 @@ pub trait WorkflowCatalogs {
 /// A [`WorkflowCatalogs`] over plain lists, for a caller that already holds its rows in memory
 /// (the API's cached catalog snapshots) and for tests.
 ///
-/// Name matching goes through [`normalized_label`] against both `name` and `id`, so a LoRA a
-/// sender displayed as `"Film Grain"` matches a local row whose id is `film_grain`.
+/// Name matching goes through [`normalized_label`] in TWO passes — display name first, catalog id
+/// only if no row matched by name — and a pass that matches more than one row resolves to nothing.
+/// See [`unique_match`] for why.
 #[derive(Debug, Clone, Default)]
 pub struct StaticCatalogs {
     pub models: Vec<CatalogEntry>,
@@ -210,8 +213,66 @@ pub struct StaticCatalogs {
     pub recipe_presets: Vec<CatalogEntry>,
 }
 
+/// The outcome of one matching pass over a catalog.
+///
+/// Three answers, not two, because "nothing matched" and "several matched" must lead to different
+/// places: the first may fall through to the next, weaker pass, the second must not — a weaker key
+/// cannot disambiguate what a stronger one already found ambiguous.
+enum Match<'a> {
+    None,
+    One(&'a CatalogEntry),
+    /// More than one row matched. Resolves to nothing: see [`unique_match`].
+    Ambiguous,
+}
+
+/// The single row matching `predicate`, or nothing when zero or MORE THAN ONE row does.
+///
+/// The "more than one" half is the doctrine, not a nicety. `Iterator::find` returns the first row
+/// in catalog order, which is an accident of manifest merge order — so with two rows a sender's
+/// label could plausibly mean, picking one is a coin flip presented to the user as a fact, and
+/// sc-15952 would offer one-click replay with an adapter the file never named. There is no honest
+/// way to choose, so the entry is reported [`RequirementState::Missing`] and NAMED instead. Import
+/// what resolves, name what does not, never silently substitute.
+fn unique_match<'a>(
+    entries: &'a [CatalogEntry],
+    mut predicate: impl FnMut(&CatalogEntry) -> bool,
+) -> Match<'a> {
+    let mut found: Option<&CatalogEntry> = None;
+    for entry in entries {
+        if !predicate(entry) {
+            continue;
+        }
+        if found.is_some() {
+            return Match::Ambiguous;
+        }
+        found = Some(entry);
+    }
+    found.map_or(Match::None, Match::One)
+}
+
+/// An exact-id lookup, with a blank id matching NOTHING.
+///
+/// The blank guard is load-bearing: `workflow_share` scrubs an unshareable (path-shaped) `model`
+/// to the empty string, and a catalog row whose manifest omitted `id` used to read as `id: ""` —
+/// so an envelope that named no model at all matched a row the file never mentioned and was
+/// reported "installed on this machine". Both ends are now closed; this is the reader's half.
+///
+/// Deliberately first-match rather than [`unique_match`]: `id` is the catalogs' primary key
+/// (`merge_entries_by_id`), and the live resolvers this report describes — `style_text_for_id`,
+/// the preset lookup in `apply_recipe_preset_to_image_payload` — also take the first row. Being
+/// STRICTER than the resolver would report a style as missing that the app would in fact apply,
+/// which is its own kind of lie.
 fn find_by_id(entries: &[CatalogEntry], id: &str) -> Option<CatalogEntry> {
-    entries.iter().find(|entry| entry.id == id).cloned()
+    // The guard is here rather than only at the two call sites so a THIRD id-keyed lookup cannot be
+    // added without it. A row is dropped upstream when its manifest carried no id, so a blank here
+    // can only come from a scrubbed envelope field — a question with no answer, not a key.
+    if id.trim().is_empty() {
+        return None;
+    }
+    entries
+        .iter()
+        .find(|entry| !entry.id.trim().is_empty() && entry.id == id)
+        .cloned()
 }
 
 impl WorkflowCatalogs for StaticCatalogs {
@@ -221,15 +282,20 @@ impl WorkflowCatalogs for StaticCatalogs {
 
     fn lora_by_repo(&self, repo: &str) -> Option<CatalogEntry> {
         let wanted = repo.trim().to_ascii_lowercase();
-        self.loras
-            .iter()
-            .find(|entry| {
-                entry
-                    .repo
-                    .as_deref()
-                    .is_some_and(|candidate| candidate.trim().to_ascii_lowercase() == wanted)
-            })
-            .cloned()
+        if wanted.is_empty() {
+            return None;
+        }
+        match unique_match(&self.loras, |entry| {
+            entry
+                .repo
+                .as_deref()
+                .is_some_and(|candidate| candidate.trim().to_ascii_lowercase() == wanted)
+        }) {
+            Match::One(entry) => Some(entry.clone()),
+            // Two rows off one repo (two adapter FILES from the same Hugging Face repo) are two
+            // different adapters. The repo id no longer identifies one, so it identifies none.
+            Match::None | Match::Ambiguous => None,
+        }
     }
 
     fn lora_by_name(&self, name: &str) -> Option<CatalogEntry> {
@@ -237,16 +303,27 @@ impl WorkflowCatalogs for StaticCatalogs {
         if wanted.is_empty() {
             return None;
         }
-        self.loras
-            .iter()
-            .find(|entry| {
-                entry
-                    .name
-                    .as_deref()
-                    .is_some_and(|candidate| normalized_label(candidate) == wanted)
-                    || normalized_label(&entry.id) == wanted
-            })
-            .cloned()
+        // Pass 1: the DISPLAY NAME, which is what the envelope's `name` actually is. A single
+        // predicate over `name || id` let a row whose id happened to equal the sender's name win
+        // over the row actually CALLED that, purely because it came first in the catalog.
+        match unique_match(&self.loras, |entry| {
+            entry
+                .name
+                .as_deref()
+                .is_some_and(|candidate| normalized_label(candidate) == wanted)
+        }) {
+            Match::One(entry) => return Some(entry.clone()),
+            // An ambiguous name pass stops here rather than falling through: an id match is the
+            // WEAKER key, so it cannot break a tie the stronger one could not.
+            Match::Ambiguous => return None,
+            Match::None => {}
+        }
+        // Pass 2: the catalog id, so a name slugged on one install (`film_grain`) still matches a
+        // row that carries no display name. Only reached when NOTHING is called `wanted`.
+        match unique_match(&self.loras, |entry| normalized_label(&entry.id) == wanted) {
+            Match::One(entry) => Some(entry.clone()),
+            Match::None | Match::Ambiguous => None,
+        }
     }
 
     fn style(&self, id: &str) -> Option<CatalogEntry> {
@@ -414,16 +491,36 @@ pub struct ResolutionReport {
     pub inputs: Vec<InputRequirement>,
     /// Collections the envelope declared but did not record.
     pub omitted: Vec<OmittedCollection>,
-    /// Whether a one-click "use this recipe" may be offered: every classified requirement
-    /// [`RequirementState::Resolved`], no input image outstanding, and nothing omitted.
+    /// **Nothing is missing or omitted — this install can run it.** Every requirement this report
+    /// had to look UP ([`model`](Self::model), [`loras`](Self::loras), [`styles`](Self::styles)) is
+    /// [`RequirementState::Resolved`], and no collection was dropped on the way into the envelope.
     ///
-    /// Deliberately strict. Every `false` here is a case where replaying would quietly produce
-    /// something other than what the file describes, which is the one thing this report exists to
-    /// prevent.
-    pub replayable: bool,
+    /// Deliberately says nothing about input images. They are not a resolution failure — nothing
+    /// on this machine could ever have supplied them — so folding them in here would report every
+    /// `edit_image` share as unrunnable even when the model and every LoRA are installed and the
+    /// user has the source image open. Ask [`input_images_required`](Self::input_images_required)
+    /// for that, and [`one_click_replayable`](Self::one_click_replayable) for both at once.
+    pub runnable: bool,
+    /// **How many images the user must supply before this can run**, summed over
+    /// [`inputs`](Self::inputs). `0` for a text-to-image recipe.
+    ///
+    /// The other half of the old conflated `replayable`: a share this install can run but that
+    /// needs one more click is a different answer from one it cannot reproduce at all, and a
+    /// single boolean could not tell sc-15952 which it was holding.
+    pub input_images_required: u32,
 }
 
 impl ResolutionReport {
+    /// Both flags at once: this install can run it AND there is nothing left for the user to
+    /// supply. The condition under which sc-15952 may offer a true one-click "use this recipe".
+    ///
+    /// Provided so the composition lives here rather than being re-derived (and eventually
+    /// re-derived DIFFERENTLY) by each reader.
+    #[must_use]
+    pub const fn one_click_replayable(&self) -> bool {
+        self.runnable && self.input_images_required == 0
+    }
+
     /// Every requirement that is not [`RequirementState::Resolved`], as sentences — the "name what
     /// does not resolve" half of the doctrine, in the order a reader would present them.
     #[must_use]
@@ -521,11 +618,18 @@ pub fn build_resolution_report(
         })
         .collect::<Vec<_>>();
 
-    let replayable = !model.state.blocks_replay()
+    // "This install can run it" — the LOOKED-UP requirements only. Input images are counted
+    // separately rather than folded in; see `ResolutionReport::runnable`.
+    let runnable = !model.state.blocks_replay()
         && loras.iter().all(|lora| !lora.state.blocks_replay())
         && styles.iter().all(|style| !style.state.blocks_replay())
-        && inputs.is_empty()
         && omitted.is_empty();
+    // `classify_input` floors a zero/absent count at 1, and the same floor is used here so the
+    // total never says "0 images" for an input the report is simultaneously describing.
+    let input_images_required = inputs
+        .iter()
+        .map(|input| input.count.max(1))
+        .fold(0u32, u32::saturating_add);
 
     ResolutionReport {
         model,
@@ -533,7 +637,8 @@ pub fn build_resolution_report(
         styles,
         inputs,
         omitted,
-        replayable,
+        runnable,
+        input_images_required,
     }
 }
 
@@ -559,7 +664,15 @@ fn install_for(entry: Option<&CatalogEntry>, state: RequirementState) -> Option<
 }
 
 fn classify_model(slug: &str, catalogs: &dyn WorkflowCatalogs) -> ModelRequirement {
-    let entry = catalogs.model(slug);
+    // A blank slug names nothing, so it must MATCH nothing. `workflow_share` scrubs a path-shaped
+    // `model` to the empty string, and consulting the catalog with it once resolved against an
+    // id-less catalog row — reporting a model the envelope never named as "installed on this
+    // machine". The catalog is not asked at all rather than being asked a question with no answer.
+    let entry = if slug.trim().is_empty() {
+        None
+    } else {
+        catalogs.model(slug)
+    };
     let state = state_for(entry.as_ref());
     let install = install_for(entry.as_ref(), state);
     let label = entry
@@ -837,6 +950,133 @@ mod tests {
             let serialized = serde_json::to_string(&state).expect("state serializes");
             assert_eq!(serialized, format!("\"{}\"", state.as_str()));
         }
+    }
+
+    /// The reviewer's exact collision: row A's ID is row B's NAME. `Iterator::find` over
+    /// `name || id` returned row A — the wrong adapter, reported as installed, with a one-click
+    /// replay offered on top of it.
+    fn colliding_loras() -> Vec<CatalogEntry> {
+        vec![
+            CatalogEntry::new("film_grain")
+                .with_name("Vintage Filmstock")
+                .installed(),
+            CatalogEntry::new("vintage_1")
+                .with_name("Film Grain")
+                .installed(),
+        ]
+    }
+
+    #[test]
+    fn the_display_name_pass_runs_before_the_id_pass() {
+        let catalogs = StaticCatalogs {
+            loras: colliding_loras(),
+            ..StaticCatalogs::default()
+        };
+        // `film_grain` is one row's ID and another row's NAME. The row actually CALLED "Film
+        // Grain" wins, whatever order the catalog merged them in.
+        let matched = catalogs
+            .lora_by_name("Film Grain")
+            .expect("one row matches");
+        assert_eq!(matched.id, "vintage_1");
+        assert_eq!(matched.name.as_deref(), Some("Film Grain"));
+        // Reversing the catalog order must not change the answer — that is the whole bug.
+        let reversed = StaticCatalogs {
+            loras: colliding_loras().into_iter().rev().collect(),
+            ..StaticCatalogs::default()
+        };
+        assert_eq!(
+            reversed.lora_by_name("Film Grain").map(|entry| entry.id),
+            Some("vintage_1".to_owned()),
+            "the winner must not be an accident of catalog order"
+        );
+    }
+
+    #[test]
+    fn a_name_matched_by_two_rows_resolves_to_nothing() {
+        let catalogs = StaticCatalogs {
+            loras: vec![
+                CatalogEntry::new("film_grain_a")
+                    .with_name("Film Grain")
+                    .installed(),
+                CatalogEntry::new("film_grain_b")
+                    .with_name("film-grain")
+                    .installed(),
+            ],
+            ..StaticCatalogs::default()
+        };
+        assert!(
+            catalogs.lora_by_name("Film Grain").is_none(),
+            "two rows share the name, so neither may be presented as the answer"
+        );
+    }
+
+    #[test]
+    fn an_ambiguous_name_pass_does_not_fall_through_to_the_id_pass() {
+        // Two rows are CALLED "Film Grain" and a third has it as an id. The weaker key cannot
+        // break a tie the stronger one could not, so nothing resolves.
+        let catalogs = StaticCatalogs {
+            loras: vec![
+                CatalogEntry::new("a").with_name("Film Grain").installed(),
+                CatalogEntry::new("b").with_name("Film Grain").installed(),
+                CatalogEntry::new("film_grain").installed(),
+            ],
+            ..StaticCatalogs::default()
+        };
+        assert!(catalogs.lora_by_name("film grain").is_none());
+    }
+
+    #[test]
+    fn two_rows_off_one_repo_resolve_to_nothing() {
+        let catalogs = StaticCatalogs {
+            loras: vec![
+                CatalogEntry::new("union")
+                    .with_repo("acme/pack")
+                    .installed(),
+                CatalogEntry::new("hdr").with_repo("Acme/Pack").installed(),
+            ],
+            ..StaticCatalogs::default()
+        };
+        assert!(
+            catalogs.lora_by_repo("acme/pack").is_none(),
+            "two adapter files from one repo are two adapters"
+        );
+    }
+
+    #[test]
+    fn a_blank_id_matches_nothing_even_when_a_catalog_row_carries_one() {
+        // The scrubbed-`model` case: an id-less catalog row used to read as `id: ""` and match an
+        // envelope that named no model at all.
+        let entries = vec![CatalogEntry::new("")
+            .with_name("Some Other Model")
+            .installed()];
+        assert!(find_by_id(&entries, "").is_none());
+        assert!(find_by_id(&entries, "   ").is_none());
+    }
+
+    #[test]
+    fn a_blank_model_slug_never_consults_the_catalog() {
+        struct Exploding;
+        impl WorkflowCatalogs for Exploding {
+            fn model(&self, _: &str) -> Option<CatalogEntry> {
+                panic!("a blank slug must not reach the catalog");
+            }
+            fn lora_by_repo(&self, _: &str) -> Option<CatalogEntry> {
+                None
+            }
+            fn lora_by_name(&self, _: &str) -> Option<CatalogEntry> {
+                None
+            }
+            fn style(&self, _: &str) -> Option<CatalogEntry> {
+                None
+            }
+            fn recipe_preset(&self, _: &str) -> Option<CatalogEntry> {
+                None
+            }
+        }
+        let requirement = classify_model("", &Exploding);
+        assert_eq!(requirement.state, RequirementState::Missing);
+        assert!(requirement.catalog_id.is_none());
+        assert!(requirement.name.is_none());
     }
 
     #[test]

--- a/crates/sceneworks-core/src/workflow_resolution.rs
+++ b/crates/sceneworks-core/src/workflow_resolution.rs
@@ -668,10 +668,11 @@ fn classify_model(slug: &str, catalogs: &dyn WorkflowCatalogs) -> ModelRequireme
     // `model` to the empty string, and consulting the catalog with it once resolved against an
     // id-less catalog row — reporting a model the envelope never named as "installed on this
     // machine". The catalog is not asked at all rather than being asked a question with no answer.
-    let entry = if slug.trim().is_empty() {
-        None
-    } else {
+    let names_a_model = !slug.trim().is_empty();
+    let entry = if names_a_model {
         catalogs.model(slug)
+    } else {
+        None
     };
     let state = state_for(entry.as_ref());
     let install = install_for(entry.as_ref(), state);
@@ -689,6 +690,16 @@ fn classify_model(slug: &str, catalogs: &dyn WorkflowCatalogs) -> ModelRequireme
             "{label} is in the model catalog but this install has no way to fetch it, so this \
              workflow cannot be reproduced here."
         ),
+        // The envelope named no model AT ALL. `workflow_share` reduces an unshareable value — a
+        // local file path, an over-long label — to the empty string, so there is no slug to have
+        // missed with. "No model matching ``" would report a catalog miss for something that was
+        // never a catalog key, and it reads to a user like a bug in the reader.
+        RequirementState::Missing | RequirementState::UserSupplied if !names_a_model => {
+            "This image does not name a model. The sender's model was a local file path or was \
+             otherwise not shareable, so it was left out of the file and the recipe cannot be \
+             reproduced here."
+                .to_owned()
+        }
         RequirementState::Missing | RequirementState::UserSupplied => format!(
             "No model matching `{slug}` is in this install's catalog, so this workflow cannot be \
              reproduced here."

--- a/crates/sceneworks-core/src/workflow_resolution.rs
+++ b/crates/sceneworks-core/src/workflow_resolution.rs
@@ -1,0 +1,848 @@
+//! "Can this machine actually run this workflow?" — the cross-install resolution report
+//! (sc-15950, epic 15945).
+//!
+//! A shared workflow references things that exist on the sender's install and may not exist here.
+//! This module answers, per requirement, which of those three it is: **resolved** (usable right
+//! now), **installable** (this install knows it and can fetch it), or **missing** (nothing here
+//! matches). Input images are a fourth answer — [`RequirementState::UserSupplied`] — because they
+//! are never auto-resolved.
+//!
+//! The doctrine, and the reason this is a report rather than a resolver: **import what resolves,
+//! name what does not, never silently substitute.** Nothing here falls back to a default model, a
+//! similar LoRA or a nearest resolution. A requirement that does not resolve is reported as not
+//! resolved, and an entry that matches nothing stays in the list rather than being dropped —
+//! dropping it would make the report claim a recipe that is not the one in the file, which is the
+//! silent-loss failure epic 15945 exists to prevent.
+//!
+//! # Why the catalogs are injected
+//!
+//! The catalogs live behind `apps/rust-api`: the model catalog is the merged
+//! `builtin.models.jsonc` + `user.models.jsonc` with a filesystem install-state sweep stapled on
+//! (`models::model_catalog`), the LoRA catalog additionally merges the user's external ComfyUI
+//! tree and a project manifest (`loras::lora_catalog`), the Style catalog is
+//! `builtin.styles.jsonc` (`styles::styles_catalog`) and the recipe presets are the three-scope
+//! merge in `recipe_presets::recipe_preset_catalog`. None of that is reachable from core, and
+//! moving the report into the API crate would put it out of reach of import (sc-15949) and of the
+//! web contract (sc-15951 / sc-15952). So the lookup is a trait — [`WorkflowCatalogs`] — and the
+//! API injects it. [`StaticCatalogs`] is the ready-made implementation for a caller that already
+//! has its rows in memory, which the API does.
+//!
+//! What stays in core is everything that must not drift between callers: the matching ORDER (a
+//! Hugging Face repo id before a display name, because a repo id is unambiguous and a name is
+//! not), the name normalization ([`normalized_label`]), the mapping from
+//! (known, installed, fetchable) to a state, and the sentences.
+//!
+//! # "In the catalog" and "on disk" are different answers
+//!
+//! A cache-only resolver never auto-downloads, so a model the catalog knows perfectly well can
+//! still be absent from this machine. That middle case is the difference between the feature
+//! working and the feature being a tease, so it is [`RequirementState::Installable`] and it
+//! carries the [`InstallAction`] that fetches it — never [`RequirementState::Missing`]. The
+//! inverse guard matters too: a catalog row this install has no way to fetch is `Missing`, because
+//! offering an action that cannot run is its own kind of lie.
+//!
+//! # The report is computed, never stored
+//!
+//! Deliberately not persisted beside the envelope sc-15949 writes to `extra.importedWorkflow`.
+//! The envelope is a fact about the file and never changes; the report is a fact about THIS
+//! machine at THIS moment and stops being true the instant the user installs the model. So it is
+//! rebuilt on read, from the stored envelope, every time.
+
+use serde::{Deserialize, Serialize};
+
+use crate::image_request::DEFAULT_STYLE_PRESET;
+use crate::workflow_share::{
+    WorkflowInput, WorkflowLora, WorkflowShare, INPUT_KIND_CONTROL, INPUT_KIND_MASK,
+    INPUT_KIND_REFERENCE, INPUT_KIND_SOURCE, OMITTED_INPUTS, OMITTED_LORAS, OMITTED_PHASES,
+    OMITTED_PHASE_LORAS, OMITTED_POSES,
+};
+
+// ---------------------------------------------------------------------------
+// States
+// ---------------------------------------------------------------------------
+
+/// What this install can do about one requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RequirementState {
+    /// Present and usable right now.
+    Resolved,
+    /// This install's catalog knows it, it is not on disk, and there is a flow that fetches it.
+    /// The actionable middle case — see the module docs on why it is not [`Self::Missing`].
+    Installable,
+    /// Nothing here matches, or nothing here can fetch what does. Named, never substituted.
+    Missing,
+    /// The user supplies it and nothing resolves it — the input images. Not a failure; a
+    /// prerequisite.
+    UserSupplied,
+}
+
+impl RequirementState {
+    /// The wire value, so a caller comparing against a string does not re-derive the mapping.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Resolved => "resolved",
+            Self::Installable => "installable",
+            Self::Missing => "missing",
+            Self::UserSupplied => "userSupplied",
+        }
+    }
+
+    /// Whether this state stops a one-click replay. Everything except [`Self::Resolved`] does:
+    /// an installable requirement needs a download first, a missing one cannot be run at all, and
+    /// a user-supplied image is by definition not one click.
+    #[must_use]
+    pub const fn blocks_replay(self) -> bool {
+        !matches!(self, Self::Resolved)
+    }
+}
+
+/// The existing flow that fetches a catalog-known but absent requirement.
+///
+/// Supplied by the injected [`WorkflowCatalogs`] rather than built here, so core hardcodes no HTTP
+/// route and the report points at the Model Manager's real endpoints
+/// (`POST /api/v1/models/:model_id/download`, `POST /api/v1/loras/:lora_id/download`) instead of
+/// inventing a mechanism.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallAction {
+    pub method: String,
+    pub path: String,
+}
+
+// ---------------------------------------------------------------------------
+// The injected catalog lookup
+// ---------------------------------------------------------------------------
+
+/// One catalog row, reduced to what the report needs.
+///
+/// Not a mirror of any manifest: the catalogs are untyped `serde_json::Value` everywhere in the
+/// API, and the report only ever asks four questions of a row — what is it called, does it name a
+/// Hugging Face repo, is it on disk, and can we fetch it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CatalogEntry {
+    /// The local catalog id, so a caller can act on the match (select the model, apply the LoRA).
+    pub id: String,
+    /// Display name, when the row has one.
+    pub name: Option<String>,
+    /// `owner/name` on Hugging Face, when the row names one. Read by [`StaticCatalogs`]'s repo
+    /// match; a lazier implementation may leave it unset and answer
+    /// [`WorkflowCatalogs::lora_by_repo`] however it likes.
+    pub repo: Option<String>,
+    /// Whether it is usable RIGHT NOW — not merely known. See the module docs.
+    pub installed: bool,
+    /// The flow that fetches it when `installed` is false. `None` means this install has no way
+    /// to get it, which makes the requirement [`RequirementState::Missing`].
+    pub install: Option<InstallAction>,
+}
+
+impl CatalogEntry {
+    /// A row keyed by `id`, not installed, with nothing else known.
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Mark the row as present on disk.
+    #[must_use]
+    pub fn installed(mut self) -> Self {
+        self.installed = true;
+        self
+    }
+
+    #[must_use]
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_repo(mut self, repo: impl Into<String>) -> Self {
+        self.repo = Some(repo.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_install(mut self, install: InstallAction) -> Self {
+        self.install = Some(install);
+        self
+    }
+}
+
+/// What this install's catalogs know. Implemented by the caller that can actually read them.
+///
+/// Deliberately lookups rather than whole lists: the matching rules (order, normalization) belong
+/// in core so import, the `POST /api/v1/workflows/inspect` endpoint and the web all agree, while
+/// the catalog READS stay where the catalogs are.
+pub trait WorkflowCatalogs {
+    /// The model catalog's row for an envelope's `model` slug.
+    fn model(&self, slug: &str) -> Option<CatalogEntry>;
+
+    /// The LoRA catalog row whose Hugging Face repo id is `repo`. Tried FIRST, because a repo id
+    /// identifies one adapter and a display name does not.
+    fn lora_by_repo(&self, repo: &str) -> Option<CatalogEntry>;
+
+    /// The LoRA catalog row whose display name (or catalog id) matches `name`. Compare with
+    /// [`normalized_label`] so both sides fold case and separators identically.
+    fn lora_by_name(&self, name: &str) -> Option<CatalogEntry>;
+
+    /// The Style catalog row for a `styleId` — a group id or a sub-style id, one flat id-space.
+    fn style(&self, id: &str) -> Option<CatalogEntry>;
+
+    /// The merged builtin/global/project recipe-preset row for a `stylePreset` id.
+    fn recipe_preset(&self, id: &str) -> Option<CatalogEntry>;
+}
+
+/// A [`WorkflowCatalogs`] over plain lists, for a caller that already holds its rows in memory
+/// (the API's cached catalog snapshots) and for tests.
+///
+/// Name matching goes through [`normalized_label`] against both `name` and `id`, so a LoRA a
+/// sender displayed as `"Film Grain"` matches a local row whose id is `film_grain`.
+#[derive(Debug, Clone, Default)]
+pub struct StaticCatalogs {
+    pub models: Vec<CatalogEntry>,
+    pub loras: Vec<CatalogEntry>,
+    pub styles: Vec<CatalogEntry>,
+    pub recipe_presets: Vec<CatalogEntry>,
+}
+
+fn find_by_id(entries: &[CatalogEntry], id: &str) -> Option<CatalogEntry> {
+    entries.iter().find(|entry| entry.id == id).cloned()
+}
+
+impl WorkflowCatalogs for StaticCatalogs {
+    fn model(&self, slug: &str) -> Option<CatalogEntry> {
+        find_by_id(&self.models, slug)
+    }
+
+    fn lora_by_repo(&self, repo: &str) -> Option<CatalogEntry> {
+        let wanted = repo.trim().to_ascii_lowercase();
+        self.loras
+            .iter()
+            .find(|entry| {
+                entry
+                    .repo
+                    .as_deref()
+                    .is_some_and(|candidate| candidate.trim().to_ascii_lowercase() == wanted)
+            })
+            .cloned()
+    }
+
+    fn lora_by_name(&self, name: &str) -> Option<CatalogEntry> {
+        let wanted = normalized_label(name);
+        if wanted.is_empty() {
+            return None;
+        }
+        self.loras
+            .iter()
+            .find(|entry| {
+                entry
+                    .name
+                    .as_deref()
+                    .is_some_and(|candidate| normalized_label(candidate) == wanted)
+                    || normalized_label(&entry.id) == wanted
+            })
+            .cloned()
+    }
+
+    fn style(&self, id: &str) -> Option<CatalogEntry> {
+        find_by_id(&self.styles, id)
+    }
+
+    fn recipe_preset(&self, id: &str) -> Option<CatalogEntry> {
+        find_by_id(&self.recipe_presets, id)
+    }
+}
+
+/// The comparison key for a free label: case-folded, with every run of non-alphanumeric
+/// characters collapsed to one space, trimmed.
+///
+/// So `"Film Grain"`, `"film-grain"`, `"film_grain"` and `"FILM  GRAIN"` are one name. That
+/// forgiveness is deliberate and bounded: a display name typed on one install and a catalog id
+/// slugged on another are routinely the same adapter, and refusing to see it would report a
+/// perfectly resolvable LoRA as user-trained. It never crosses a word boundary, so
+/// `"film grain heavy"` still does not match `"film grain"`.
+#[must_use]
+pub fn normalized_label(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut pending_space = false;
+    for character in value.chars() {
+        if character.is_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.extend(character.to_lowercase());
+        } else {
+            pending_space = true;
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Requirements
+// ---------------------------------------------------------------------------
+
+/// The model the envelope names, classified.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelRequirement {
+    /// The envelope's `model` — a catalog slug, never a resolved weights location. Preserved
+    /// verbatim whatever the state, so an unresolved model is still nameable.
+    pub slug: String,
+    pub state: RequirementState,
+    /// The local catalog id that matched. `None` when nothing did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Set only for [`RequirementState::Installable`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install: Option<InstallAction>,
+    /// A sentence fit to show the user.
+    pub detail: String,
+}
+
+/// Which envelope field a LoRA resolved through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LoraMatchedBy {
+    /// The Hugging Face repo id. Unambiguous, so it is tried first.
+    Repo,
+    /// The display name, normalized by [`normalized_label`].
+    Name,
+}
+
+/// One LoRA the envelope named, classified. Never dropped, whatever the state.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoraRequirement {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
+    pub state: RequirementState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matched_by: Option<LoraMatchedBy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install: Option<InstallAction>,
+    pub detail: String,
+}
+
+/// Which style axis a [`StyleRequirement`] came from.
+///
+/// Two fields, two catalogs, and they are not interchangeable: `styleId` is the live Style-catalog
+/// axis (`builtin.styles.jsonc`, one flat id-space of groups and sub-styles) while `stylePreset`
+/// holds a RECIPE PRESET id whenever a preset ran (the API stamps it in
+/// `apply_recipe_preset_to_image_payload`) and the inert wire default otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StyleField {
+    StyleId,
+    StylePreset,
+}
+
+/// A style axis the envelope carried, classified.
+///
+/// A style is never [`RequirementState::Installable`]: there is nothing to fetch. Either this
+/// install's catalog has the id or it does not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StyleRequirement {
+    pub field: StyleField,
+    pub id: String,
+    pub state: RequirementState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Always `None`. Declared for symmetry with the other classes so a reader's
+    /// "is there an action?" branch does not need a special case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install: Option<InstallAction>,
+    pub detail: String,
+}
+
+/// An input image the recipe needs, by shape. Always [`RequirementState::UserSupplied`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InputRequirement {
+    /// One of the `workflow_share::INPUT_KIND_*` constants.
+    pub kind: String,
+    pub count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_mode: Option<String>,
+    pub state: RequirementState,
+    /// "Needs a source image." / "Needs 2 reference images." / "Needs a mask."
+    pub detail: String,
+}
+
+/// A collection the envelope declared but could not record.
+///
+/// The reason this is a first-class part of the report rather than a footnote: `loras` carries
+/// `skip_serializing_if = "Vec::is_empty"`, so a six-LoRA envelope whose LoRAs were dropped over
+/// the cap and a genuinely LoRA-free one serialize byte-identically. Without the marker sc-15952
+/// would render "no LoRAs" and offer one-click replay for a recipe that had five.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OmittedCollection {
+    /// A member of `workflow_share::OMITTED_FIELDS`.
+    pub field: String,
+    /// What the absence does, and does NOT, mean.
+    pub detail: String,
+}
+
+/// Everything one shared workflow needs, and what this install can do about each of it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionReport {
+    pub model: ModelRequirement,
+    /// Every LoRA the envelope named, in envelope order. Unresolvable entries are listed, not
+    /// dropped.
+    pub loras: Vec<LoraRequirement>,
+    /// The style axes the envelope carried, live axis (`styleId`) first. Empty when it carried
+    /// neither, or only the inert `stylePreset` default (see [`INERT_STYLE_PRESETS`]).
+    pub styles: Vec<StyleRequirement>,
+    /// The input images the user must supply, by shape.
+    pub inputs: Vec<InputRequirement>,
+    /// Collections the envelope declared but did not record.
+    pub omitted: Vec<OmittedCollection>,
+    /// Whether a one-click "use this recipe" may be offered: every classified requirement
+    /// [`RequirementState::Resolved`], no input image outstanding, and nothing omitted.
+    ///
+    /// Deliberately strict. Every `false` here is a case where replaying would quietly produce
+    /// something other than what the file describes, which is the one thing this report exists to
+    /// prevent.
+    pub replayable: bool,
+}
+
+impl ResolutionReport {
+    /// Every requirement that is not [`RequirementState::Resolved`], as sentences — the "name what
+    /// does not resolve" half of the doctrine, in the order a reader would present them.
+    #[must_use]
+    pub fn unresolved(&self) -> Vec<&str> {
+        let mut out = Vec::new();
+        if self.model.state.blocks_replay() {
+            out.push(self.model.detail.as_str());
+        }
+        out.extend(
+            self.loras
+                .iter()
+                .filter(|lora| lora.state.blocks_replay())
+                .map(|lora| lora.detail.as_str()),
+        );
+        out.extend(
+            self.styles
+                .iter()
+                .filter(|style| style.state.blocks_replay())
+                .map(|style| style.detail.as_str()),
+        );
+        out.extend(self.inputs.iter().map(|input| input.detail.as_str()));
+        out.extend(self.omitted.iter().map(|entry| entry.detail.as_str()));
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The inert `stylePreset` values
+// ---------------------------------------------------------------------------
+
+/// The `stylePreset` values that name NOTHING and are therefore not requirements.
+///
+/// `stylePreset` is only a recipe-preset id when a preset actually ran — the API overwrites the
+/// field with the preset id in `apply_recipe_preset_to_image_payload`. With no preset it keeps the
+/// wire default [`DEFAULT_STYLE_PRESET`] that `ImageRequest::from_payload` fills in, which means
+/// EVERY generated envelope carries it (`crates/sceneworks-worker/src/image_jobs.rs` writes
+/// `request.style_preset` into the asset facts the builder reads). Older sidecars wrote the
+/// literal `"none"` for the same "no preset" state.
+///
+/// Looking either up in the preset catalog would fail for every shared image and mark all of them
+/// unreplayable, which is not an honest answer — the field names no preset, so there is nothing to
+/// resolve and nothing to report.
+pub const INERT_STYLE_PRESETS: &[&str] = &[DEFAULT_STYLE_PRESET, "none"];
+
+/// Whether a `stylePreset` value names a preset at all.
+fn names_a_preset(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && !INERT_STYLE_PRESETS
+            .iter()
+            .any(|inert| trimmed.eq_ignore_ascii_case(inert))
+}
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+
+/// Classify everything `share` needs against `catalogs`.
+///
+/// Total and infallible: there is no input for which the right answer is an error. A workflow
+/// naming nothing this install has is a perfectly readable report that says so.
+#[must_use]
+pub fn build_resolution_report(
+    share: &WorkflowShare,
+    catalogs: &dyn WorkflowCatalogs,
+) -> ResolutionReport {
+    let model = classify_model(&share.model, catalogs);
+    let loras = share
+        .loras
+        .iter()
+        .map(|lora| classify_lora(lora, catalogs))
+        .collect::<Vec<_>>();
+    let mut styles = Vec::new();
+    if let Some(id) = share.style_id.as_deref().map(str::trim) {
+        if !id.is_empty() {
+            styles.push(classify_style(StyleField::StyleId, id, catalogs));
+        }
+    }
+    if let Some(preset) = share.style_preset.as_deref() {
+        if names_a_preset(preset) {
+            styles.push(classify_style(
+                StyleField::StylePreset,
+                preset.trim(),
+                catalogs,
+            ));
+        }
+    }
+    let inputs = share.inputs.iter().map(classify_input).collect::<Vec<_>>();
+    let omitted = share
+        .omitted
+        .iter()
+        .map(|field| OmittedCollection {
+            field: field.clone(),
+            detail: omission_detail(field),
+        })
+        .collect::<Vec<_>>();
+
+    let replayable = !model.state.blocks_replay()
+        && loras.iter().all(|lora| !lora.state.blocks_replay())
+        && styles.iter().all(|style| !style.state.blocks_replay())
+        && inputs.is_empty()
+        && omitted.is_empty();
+
+    ResolutionReport {
+        model,
+        loras,
+        styles,
+        inputs,
+        omitted,
+        replayable,
+    }
+}
+
+/// The state a catalog match implies. The one place (known, installed, fetchable) becomes a state,
+/// so the model and LoRA classes cannot drift apart.
+fn state_for(entry: Option<&CatalogEntry>) -> RequirementState {
+    match entry {
+        Some(entry) if entry.installed => RequirementState::Resolved,
+        // Known but absent, and there is a flow. The actionable middle case.
+        Some(entry) if entry.install.is_some() => RequirementState::Installable,
+        // Known, absent, and unfetchable — an action here would be a button that cannot work.
+        Some(_) | None => RequirementState::Missing,
+    }
+}
+
+/// The install action to publish: only for [`RequirementState::Installable`], so a resolved
+/// requirement never carries a download the caller might offer anyway.
+fn install_for(entry: Option<&CatalogEntry>, state: RequirementState) -> Option<InstallAction> {
+    match state {
+        RequirementState::Installable => entry.and_then(|entry| entry.install.clone()),
+        _ => None,
+    }
+}
+
+fn classify_model(slug: &str, catalogs: &dyn WorkflowCatalogs) -> ModelRequirement {
+    let entry = catalogs.model(slug);
+    let state = state_for(entry.as_ref());
+    let install = install_for(entry.as_ref(), state);
+    let label = entry
+        .as_ref()
+        .and_then(|entry| entry.name.clone())
+        .unwrap_or_else(|| format!("`{slug}`"));
+    let detail = match state {
+        RequirementState::Resolved => format!("{label} is installed on this machine."),
+        RequirementState::Installable => format!(
+            "{label} is in the model catalog but is not downloaded on this machine; the Model \
+             Manager can fetch it."
+        ),
+        RequirementState::Missing if entry.is_some() => format!(
+            "{label} is in the model catalog but this install has no way to fetch it, so this \
+             workflow cannot be reproduced here."
+        ),
+        RequirementState::Missing | RequirementState::UserSupplied => format!(
+            "No model matching `{slug}` is in this install's catalog, so this workflow cannot be \
+             reproduced here."
+        ),
+    };
+    ModelRequirement {
+        slug: slug.to_owned(),
+        state,
+        catalog_id: entry.as_ref().map(|entry| entry.id.clone()),
+        name: entry.and_then(|entry| entry.name),
+        install,
+        detail,
+    }
+}
+
+fn classify_lora(lora: &WorkflowLora, catalogs: &dyn WorkflowCatalogs) -> LoraRequirement {
+    // Repo before name: `owner/name` identifies one adapter, a display name is whatever the
+    // sender's install called it.
+    let matched = lora
+        .repo
+        .as_deref()
+        .map(str::trim)
+        .filter(|repo| !repo.is_empty())
+        .and_then(|repo| catalogs.lora_by_repo(repo))
+        .map(|entry| (LoraMatchedBy::Repo, entry))
+        .or_else(|| {
+            lora.name
+                .as_deref()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .and_then(|name| catalogs.lora_by_name(name))
+                .map(|entry| (LoraMatchedBy::Name, entry))
+        });
+    let entry = matched.as_ref().map(|(_, entry)| entry);
+    let state = state_for(entry);
+    let install = install_for(entry, state);
+    let identity = match (lora.name.as_deref(), lora.repo.as_deref()) {
+        (Some(name), _) => format!("`{name}`"),
+        (None, Some(repo)) => format!("Hugging Face repo `{repo}`"),
+        (None, None) => "an unnamed LoRA".to_owned(),
+    };
+    let label = entry
+        .and_then(|entry| entry.name.clone())
+        .unwrap_or_else(|| identity.clone());
+    let detail = match state {
+        RequirementState::Resolved => format!("{label} is installed."),
+        RequirementState::Installable => format!(
+            "{label} is in the LoRA catalog but is not downloaded; the Model Manager can fetch it."
+        ),
+        RequirementState::Missing if entry.is_some() => {
+            format!("{label} is in the LoRA catalog but this install has no way to fetch it.")
+        }
+        RequirementState::Missing | RequirementState::UserSupplied => format!(
+            "No LoRA on this install matches {identity}; it was most likely trained by whoever \
+             shared the image."
+        ),
+    };
+    LoraRequirement {
+        name: lora.name.clone(),
+        repo: lora.repo.clone(),
+        weight: lora.weight,
+        state,
+        matched_by: matched.as_ref().map(|(how, _)| *how),
+        catalog_id: entry.map(|entry| entry.id.clone()),
+        install,
+        detail,
+    }
+}
+
+fn classify_style(
+    field: StyleField,
+    id: &str,
+    catalogs: &dyn WorkflowCatalogs,
+) -> StyleRequirement {
+    let entry = match field {
+        StyleField::StyleId => catalogs.style(id),
+        StyleField::StylePreset => catalogs.recipe_preset(id),
+    };
+    // A style/preset is either in the catalog or it is not — there is nothing to download, so
+    // `installed` never enters into it and `Installable` is unreachable by construction.
+    let state = if entry.is_some() {
+        RequirementState::Resolved
+    } else {
+        RequirementState::Missing
+    };
+    let detail = match (field, state) {
+        (StyleField::StyleId, RequirementState::Resolved) => {
+            format!("Style `{id}` is in this install's Style catalog.")
+        }
+        (StyleField::StyleId, _) => format!(
+            "Style `{id}` is not in this install's Style catalog, so the style it applied cannot \
+             be reproduced here."
+        ),
+        (StyleField::StylePreset, RequirementState::Resolved) => {
+            format!("Recipe preset `{id}` is on this install.")
+        }
+        (StyleField::StylePreset, _) => format!(
+            "Recipe preset `{id}` is not on this install, so the prompt wrapping and LoRAs it \
+             contributed cannot be reproduced here."
+        ),
+    };
+    StyleRequirement {
+        field,
+        id: id.to_owned(),
+        state,
+        name: entry.and_then(|entry| entry.name),
+        install: None,
+        detail,
+    }
+}
+
+fn classify_input(input: &WorkflowInput) -> InputRequirement {
+    let count = input.count.max(1);
+    let label = input_label(input);
+    let detail = if count == 1 {
+        format!("Needs {} {label}.", article(&label))
+    } else {
+        format!("Needs {count} {label}s.")
+    };
+    InputRequirement {
+        kind: input.kind.clone(),
+        count: input.count,
+        control_mode: input.control_mode.clone(),
+        state: RequirementState::UserSupplied,
+        detail,
+    }
+}
+
+/// The noun for one input shape, singular. A control map names its conditioning when the original
+/// run named one (`canny`, `depth`, …), which is what makes the descriptor actionable rather than
+/// merely true.
+fn input_label(input: &WorkflowInput) -> String {
+    match input.kind.as_str() {
+        INPUT_KIND_SOURCE => "source image".to_owned(),
+        INPUT_KIND_REFERENCE => "reference image".to_owned(),
+        INPUT_KIND_MASK => "mask".to_owned(),
+        INPUT_KIND_CONTROL => match input.control_mode.as_deref().map(str::trim) {
+            Some(mode) if !mode.is_empty() => format!("{mode} control image"),
+            _ => "control image".to_owned(),
+        },
+        // `reduce_input` drops anything outside `INPUT_KINDS` on parse, so this is only reachable
+        // from a hand-built envelope. Still answered rather than panicked on.
+        other => format!("{other} image"),
+    }
+}
+
+/// `a` / `an` for a label, so a `depth` control image does not read as "a edge control image".
+fn article(label: &str) -> &'static str {
+    match label.chars().next().map(|first| first.to_ascii_lowercase()) {
+        Some('a' | 'e' | 'i' | 'o' | 'u') => "an",
+        _ => "a",
+    }
+}
+
+/// What a dropped collection means. One sentence per member of
+/// `workflow_share::OMITTED_FIELDS`, each saying what the absence does NOT mean — which is the
+/// whole point of the marker.
+fn omission_detail(field: &str) -> String {
+    match field {
+        OMITTED_LORAS => "This workflow named more LoRAs than a job can carry, so none of them \
+                          were recorded. This is NOT a LoRA-free recipe."
+            .to_owned(),
+        OMITTED_INPUTS => "This workflow named more input images than the envelope records, so \
+                           none of them were recorded. This is NOT a recipe with no input images."
+            .to_owned(),
+        OMITTED_POSES => "This workflow carried a pose selection too large to record, so no poses \
+                          were recorded. This is NOT a pose-free recipe."
+            .to_owned(),
+        OMITTED_PHASES => "This workflow carried a multi-phase denoise schedule too large to \
+                           record, so no phases were recorded. This is NOT a single-phase recipe."
+            .to_owned(),
+        OMITTED_PHASE_LORAS => {
+            "A denoise phase's own LoRA schedule was too large to record and was dropped. The \
+             phases that remain are NOT the whole schedule."
+                .to_owned()
+        }
+        // The parse side keeps only members of the closed vocabulary, so this is unreachable from
+        // a file. Answered anyway rather than showing the user a bare field name.
+        other => format!("The `{other}` collection was declared but not recorded."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalized_label_folds_case_and_separators_but_not_words() {
+        assert_eq!(normalized_label("Film  Grain"), "film grain");
+        assert_eq!(normalized_label("film-grain"), "film grain");
+        assert_eq!(normalized_label("FILM_GRAIN"), "film grain");
+        assert_eq!(normalized_label("  film / grain  "), "film grain");
+        assert_ne!(normalized_label("film grain heavy"), "film grain");
+        assert_eq!(normalized_label("---"), "");
+    }
+
+    #[test]
+    fn state_for_separates_known_absent_from_unknown() {
+        assert_eq!(state_for(None), RequirementState::Missing);
+        assert_eq!(
+            state_for(Some(&CatalogEntry::new("x").installed())),
+            RequirementState::Resolved
+        );
+        assert_eq!(
+            state_for(Some(&CatalogEntry::new("x").with_install(InstallAction {
+                method: "POST".to_owned(),
+                path: "/x".to_owned(),
+            }))),
+            RequirementState::Installable
+        );
+        assert_eq!(
+            state_for(Some(&CatalogEntry::new("x"))),
+            RequirementState::Missing,
+            "known but unfetchable is missing, not falsely actionable"
+        );
+    }
+
+    #[test]
+    fn only_the_installable_state_publishes_an_action() {
+        let entry = CatalogEntry::new("x")
+            .installed()
+            .with_install(InstallAction {
+                method: "POST".to_owned(),
+                path: "/x".to_owned(),
+            });
+        assert!(install_for(Some(&entry), RequirementState::Resolved).is_none());
+        assert!(install_for(Some(&entry), RequirementState::Missing).is_none());
+        assert!(install_for(Some(&entry), RequirementState::Installable).is_some());
+    }
+
+    #[test]
+    fn the_inert_style_presets_name_no_preset() {
+        assert!(!names_a_preset(DEFAULT_STYLE_PRESET));
+        assert!(!names_a_preset("None"));
+        assert!(!names_a_preset("   "));
+        assert!(names_a_preset("preset_noir"));
+    }
+
+    #[test]
+    fn every_state_but_resolved_blocks_replay() {
+        assert!(!RequirementState::Resolved.blocks_replay());
+        for state in [
+            RequirementState::Installable,
+            RequirementState::Missing,
+            RequirementState::UserSupplied,
+        ] {
+            assert!(state.blocks_replay(), "{state:?} must block replay");
+        }
+    }
+
+    #[test]
+    fn the_wire_value_matches_what_serde_emits() {
+        for state in [
+            RequirementState::Resolved,
+            RequirementState::Installable,
+            RequirementState::Missing,
+            RequirementState::UserSupplied,
+        ] {
+            let serialized = serde_json::to_string(&state).expect("state serializes");
+            assert_eq!(serialized, format!("\"{}\"", state.as_str()));
+        }
+    }
+
+    #[test]
+    fn article_reads_correctly_for_a_vowel_initial_control_mode() {
+        assert_eq!(article("source image"), "a");
+        assert_eq!(article("edge control image"), "an");
+        assert_eq!(article("Openpose control image"), "an");
+    }
+}

--- a/crates/sceneworks-core/tests/workflow_resolution.rs
+++ b/crates/sceneworks-core/tests/workflow_resolution.rs
@@ -72,7 +72,12 @@ fn an_installed_catalog_model_resolves() {
     assert_eq!(report.model.catalog_id.as_deref(), Some("krea_2_turbo"));
     assert_eq!(report.model.name.as_deref(), Some("Krea 2 Turbo"));
     assert!(report.model.install.is_none(), "nothing to install");
-    assert!(report.replayable, "a resolved, input-free recipe replays");
+    assert!(report.runnable, "a fully resolved recipe runs here");
+    assert_eq!(report.input_images_required, 0);
+    assert!(
+        report.one_click_replayable(),
+        "a resolved, input-free recipe replays in one click"
+    );
 }
 
 #[test]
@@ -102,9 +107,10 @@ fn a_catalog_known_but_absent_model_is_installable_not_missing() {
         "the actionable middle case must name the flow that fetches it"
     );
     assert!(
-        !report.replayable,
-        "a model that is not on disk cannot be replayed in one click"
+        !report.runnable,
+        "a model that is not on disk cannot be run here"
     );
+    assert!(!report.one_click_replayable());
 }
 
 #[test]
@@ -168,7 +174,7 @@ fn nothing_is_ever_substituted() {
     assert!(report.loras[0].matched_by.is_none());
     assert_eq!(report.styles.len(), 1);
     assert_eq!(report.styles[0].state, RequirementState::Missing);
-    assert!(!report.replayable);
+    assert!(!report.runnable);
 }
 
 // ---------------------------------------------------------------------------
@@ -193,7 +199,7 @@ fn a_lora_matches_by_hugging_face_repo_id() {
     assert_eq!(report.loras[0].matched_by, Some(LoraMatchedBy::Repo));
     assert_eq!(report.loras[0].catalog_id.as_deref(), Some("film_grain"));
     assert_eq!(report.loras[0].weight, Some(0.6));
-    assert!(report.replayable);
+    assert!(report.runnable);
 }
 
 #[test]
@@ -298,7 +304,7 @@ fn an_unresolvable_lora_is_listed_rather_than_dropped() {
         "a repo-only entry is named by its repo: {}",
         report.loras[1].detail
     );
-    assert!(!report.replayable);
+    assert!(!report.runnable);
 }
 
 #[test]
@@ -323,6 +329,212 @@ fn a_catalog_known_but_uninstalled_lora_is_installable() {
 }
 
 // ---------------------------------------------------------------------------
+// Ambiguity resolves to NOTHING
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_name_that_is_another_rows_id_resolves_to_the_row_actually_called_that() {
+    // The reviewer's reproduction, verbatim. Row A's ID is row B's NAME, both installed. A single
+    // `name || id` predicate evaluated by `Iterator::find` returned row A — so an envelope naming
+    // "Film Grain" resolved to `film_grain`/"Vintage Filmstock", reported it as installed, and
+    // offered a one-click replay with an adapter the file never named.
+    let catalogs = StaticCatalogs {
+        loras: vec![
+            CatalogEntry::new("film_grain")
+                .with_name("Vintage Filmstock")
+                .installed(),
+            CatalogEntry::new("vintage_1")
+                .with_name("Film Grain")
+                .installed(),
+        ],
+        ..model_installed()
+    };
+    let report = build_resolution_report(
+        &envelope(json!({ "loras": [{ "name": "Film Grain" }] })),
+        &catalogs,
+    );
+    assert_eq!(report.loras[0].state, RequirementState::Resolved);
+    assert_eq!(
+        report.loras[0].catalog_id.as_deref(),
+        Some("vintage_1"),
+        "the display-name pass runs first, so the row CALLED `Film Grain` wins"
+    );
+    assert!(
+        !report.loras[0].detail.contains("Vintage Filmstock"),
+        "the sentence must not name an adapter the envelope never did: {}",
+        report.loras[0].detail
+    );
+}
+
+#[test]
+fn a_name_two_installed_rows_both_claim_is_reported_missing_rather_than_guessed() {
+    // Two rows are genuinely called the same thing. There is no honest way to pick one, so the
+    // entry is NAMED as unresolved instead of resolved to a coin flip.
+    let catalogs = StaticCatalogs {
+        loras: vec![
+            CatalogEntry::new("film_grain_v1")
+                .with_name("Film Grain")
+                .installed(),
+            CatalogEntry::new("film_grain_v2")
+                .with_name("film-grain")
+                .installed(),
+        ],
+        ..model_installed()
+    };
+    let report = build_resolution_report(
+        &envelope(json!({ "loras": [{ "name": "Film Grain", "weight": 0.7 }] })),
+        &catalogs,
+    );
+    assert_eq!(report.loras.len(), 1, "the entry is listed, never dropped");
+    assert_eq!(report.loras[0].state, RequirementState::Missing);
+    assert!(report.loras[0].catalog_id.is_none());
+    assert!(report.loras[0].matched_by.is_none());
+    assert_eq!(
+        report.loras[0].weight,
+        Some(0.7),
+        "the entry keeps its facts"
+    );
+    assert!(
+        report.loras[0].detail.contains("Film Grain"),
+        "the sentence names what did not resolve: {}",
+        report.loras[0].detail
+    );
+    assert!(!report.runnable);
+}
+
+#[test]
+fn an_ambiguous_name_does_not_fall_through_to_a_row_whose_id_matches() {
+    // Two rows CALLED "Film Grain" plus a third whose ID is `film_grain`. Falling through to the
+    // id pass would let the weaker key break a tie the stronger one could not.
+    let catalogs = StaticCatalogs {
+        loras: vec![
+            CatalogEntry::new("a").with_name("Film Grain").installed(),
+            CatalogEntry::new("b").with_name("Film Grain").installed(),
+            CatalogEntry::new("film_grain").installed(),
+        ],
+        ..model_installed()
+    };
+    let report = build_resolution_report(
+        &envelope(json!({ "loras": [{ "name": "film grain" }] })),
+        &catalogs,
+    );
+    assert_eq!(report.loras[0].state, RequirementState::Missing);
+    assert!(report.loras[0].catalog_id.is_none());
+}
+
+#[test]
+fn a_blank_model_slug_never_matches_a_catalog_row_that_lost_its_id() {
+    // `workflow_share` scrubs a path-shaped `model` to `""`, and an id-less catalog row used to be
+    // carried as `id: ""`. The two matched, and the report said a model the envelope never named
+    // was "installed on this machine".
+    let catalogs = StaticCatalogs {
+        models: vec![CatalogEntry::new("")
+            .with_name("Some Other Model")
+            .installed()],
+        ..StaticCatalogs::default()
+    };
+    let share = envelope(json!({ "model": "C:\\models\\secret\\weights.safetensors" }));
+    assert_eq!(share.model, "", "the parser scrubs a path-shaped model");
+    let report = build_resolution_report(&share, &catalogs);
+    assert_eq!(report.model.state, RequirementState::Missing);
+    assert!(report.model.catalog_id.is_none());
+    assert!(report.model.name.is_none());
+    assert!(
+        !report.model.detail.contains("Some Other Model"),
+        "detail: {}",
+        report.model.detail
+    );
+    assert!(!report.runnable);
+}
+
+#[test]
+fn a_blank_lora_label_matches_nothing() {
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("").with_name("").installed()],
+        ..model_installed()
+    };
+    // A name of only separators normalizes to the empty label; a blank repo is filtered before the
+    // lookup. Neither may reach for the id-less row.
+    let report = build_resolution_report(
+        &envelope(json!({ "loras": [{ "name": "---" }, { "repo": "   " }] })),
+        &catalogs,
+    );
+    assert!(report
+        .loras
+        .iter()
+        .all(|lora| lora.state == RequirementState::Missing && lora.catalog_id.is_none()));
+}
+
+#[test]
+fn nothing_resolves_to_something_the_envelope_did_not_name() {
+    // The substitution sweep, in one place: every near-miss shape that could plausibly tempt a
+    // match. A resolved requirement must carry a `catalogId` the envelope's own label maps to,
+    // and never one belonging to a neighbouring row.
+    let catalogs = StaticCatalogs {
+        models: vec![
+            CatalogEntry::new("krea_2_turbo")
+                .with_name("Krea 2 Turbo")
+                .installed(),
+            CatalogEntry::new("").with_name("Id-less Model").installed(),
+        ],
+        loras: vec![
+            CatalogEntry::new("film_grain")
+                .with_name("Vintage Filmstock")
+                .installed(),
+            CatalogEntry::new("vintage_1")
+                .with_name("Film Grain")
+                .with_repo("acme/vintage")
+                .installed(),
+        ],
+        styles: vec![CatalogEntry::new("ghibli-style").with_name("Ghibli Style")],
+        recipe_presets: vec![CatalogEntry::new("preset_noir").with_name("Ghibli Style")],
+    };
+
+    // A model slug differing only in case or separator is a DIFFERENT slug: the catalogs are
+    // keyed by exact id, and folding them here would resolve `Krea-2-Turbo` to a row the sender
+    // may not have meant.
+    for slug in ["KREA_2_TURBO", "krea-2-turbo", "krea 2 turbo", ""] {
+        let report = build_resolution_report(&envelope(json!({ "model": slug })), &catalogs);
+        assert_eq!(
+            report.model.state,
+            RequirementState::Missing,
+            "`{slug}` must not resolve to `krea_2_turbo`"
+        );
+        assert!(report.model.catalog_id.is_none(), "slug: {slug}");
+    }
+
+    // A LoRA whose NAME matches one row while a DIFFERENT row matches by repo: the repo wins (it
+    // is the unambiguous key), and the name row is not reached for.
+    let by_repo = build_resolution_report(
+        &envelope(json!({ "loras": [{ "name": "Vintage Filmstock", "repo": "acme/vintage" }] })),
+        &catalogs,
+    );
+    assert_eq!(by_repo.loras[0].catalog_id.as_deref(), Some("vintage_1"));
+    assert_eq!(by_repo.loras[0].matched_by, Some(LoraMatchedBy::Repo));
+
+    // A style id that is a PRESET's display name resolves against neither: `styleId` is only ever
+    // looked up in the Style catalog, and a preset's name is not an id in it.
+    let crossed = build_resolution_report(
+        &envelope(json!({ "styleId": "Ghibli Style", "stylePreset": "Ghibli Style" })),
+        &catalogs,
+    );
+    assert!(crossed
+        .styles
+        .iter()
+        .all(|style| style.state == RequirementState::Missing));
+
+    // And the two axes never borrow each other's catalog.
+    let swapped = build_resolution_report(
+        &envelope(json!({ "styleId": "preset_noir", "stylePreset": "ghibli-style" })),
+        &catalogs,
+    );
+    assert!(swapped
+        .styles
+        .iter()
+        .all(|style| style.state == RequirementState::Missing));
+}
+
+// ---------------------------------------------------------------------------
 // Style
 // ---------------------------------------------------------------------------
 
@@ -338,7 +550,7 @@ fn a_style_id_resolves_against_the_style_catalog() {
     assert_eq!(report.styles[0].field, StyleField::StyleId);
     assert_eq!(report.styles[0].state, RequirementState::Resolved);
     assert_eq!(report.styles[0].name.as_deref(), Some("Ghibli Style"));
-    assert!(report.replayable);
+    assert!(report.runnable);
 
     let unknown =
         build_resolution_report(&envelope(json!({ "styleId": "not-a-style" })), &catalogs);
@@ -347,7 +559,7 @@ fn a_style_id_resolves_against_the_style_catalog() {
         unknown.styles[0].install.is_none(),
         "a style is not something this install can fetch"
     );
-    assert!(!unknown.replayable);
+    assert!(!unknown.runnable);
 }
 
 #[test]
@@ -363,14 +575,14 @@ fn a_style_preset_resolves_against_the_merged_recipe_preset_catalog() {
     assert_eq!(report.styles.len(), 1);
     assert_eq!(report.styles[0].field, StyleField::StylePreset);
     assert_eq!(report.styles[0].state, RequirementState::Resolved);
-    assert!(report.replayable);
+    assert!(report.runnable);
 
     let unknown = build_resolution_report(
         &envelope(json!({ "stylePreset": "preset_from_their_install" })),
         &catalogs,
     );
     assert_eq!(unknown.styles[0].state, RequirementState::Missing);
-    assert!(!unknown.replayable);
+    assert!(!unknown.runnable);
 }
 
 #[test]
@@ -387,7 +599,7 @@ fn the_inert_style_preset_defaults_are_not_requirements() {
             report.styles.is_empty(),
             "`{inert}` names no preset, so it is not a requirement"
         );
-        assert!(report.replayable, "`{inert}` must not block replay");
+        assert!(report.runnable, "`{inert}` must not block replay");
     }
 }
 
@@ -438,10 +650,80 @@ fn input_images_are_user_supplied_and_named_by_shape() {
         .inputs
         .iter()
         .all(|input| input.state == RequirementState::UserSupplied));
+    // Issue 7: an `edit_image` share whose model IS installed is RUNNABLE — the user simply has
+    // to hand it the images first. The old single boolean called this identical to "cannot
+    // reproduce this at all", which is the conflation these two fields exist to undo.
     assert!(
-        !report.replayable,
+        report.runnable,
+        "the model resolved and nothing was omitted, so this install can run it"
+    );
+    assert_eq!(
+        report.input_images_required, 5,
+        "1 source + 2 reference + 1 mask + 1 control"
+    );
+    assert!(
+        !report.one_click_replayable(),
         "an input image the user must pick is not a one-click replay"
     );
+}
+
+#[test]
+fn an_edit_share_this_install_can_run_says_so_and_counts_the_images_separately() {
+    // Issue 7. `inputs` is never empty for an `edit_image`/img2img share, so a single boolean that
+    // folded them in was permanently false for EVERY such share — reading identically to "the
+    // model is missing" even with the model and every LoRA installed and the source image in hand.
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("film_grain")
+            .with_name("Film Grain")
+            .installed()],
+        ..model_installed()
+    };
+    let share = envelope(json!({
+        "mode": "edit_image",
+        "loras": [{ "name": "Film Grain", "weight": 0.5 }],
+        "inputs": [{ "kind": "source", "count": 1 }],
+    }));
+    let report = build_resolution_report(&share, &catalogs);
+    assert!(
+        report.runnable,
+        "every requirement resolved and nothing was omitted"
+    );
+    assert_eq!(report.input_images_required, 1);
+    assert!(
+        !report.one_click_replayable(),
+        "one image still has to be supplied"
+    );
+
+    // The contrast that used to be invisible: the SAME share against an install that does not have
+    // the model. Both were `replayable: false`; only one of them is unreproducible.
+    let elsewhere = build_resolution_report(&share, &StaticCatalogs::default());
+    assert!(!elsewhere.runnable);
+    assert_eq!(elsewhere.input_images_required, 1);
+    assert_ne!(
+        (report.runnable, report.input_images_required),
+        (elsewhere.runnable, elsewhere.input_images_required),
+        "the two answers must be distinguishable"
+    );
+}
+
+#[test]
+fn the_image_count_is_the_sum_over_every_input_shape() {
+    let share = envelope(json!({
+        "inputs": [
+            { "kind": "reference", "count": 3 },
+            { "kind": "control", "count": 2, "controlMode": "depth" },
+        ],
+    }));
+    let report = build_resolution_report(&share, &model_installed());
+    assert_eq!(report.input_images_required, 5);
+    // A zero/absent count is floored at one by `classify_input`'s own sentence ("Needs a … ."), so
+    // the total agrees with what the reader is being shown rather than claiming zero images.
+    let floored = build_resolution_report(
+        &envelope(json!({ "inputs": [{ "kind": "source", "count": 0 }] })),
+        &model_installed(),
+    );
+    assert_eq!(floored.inputs[0].detail, "Needs a source image.");
+    assert_eq!(floored.input_images_required, 1);
 }
 
 #[test]
@@ -521,7 +803,7 @@ fn an_omitted_collection_withholds_one_click_replay() {
         "the LoRA omission has to say what the absence does not mean"
     );
     assert!(
-        !report.replayable,
+        !report.runnable,
         "an omitted collection withholds one-click replay"
     );
 }
@@ -530,7 +812,7 @@ fn an_omitted_collection_withholds_one_click_replay() {
 fn an_envelope_with_nothing_omitted_reports_no_omissions() {
     let report = build_resolution_report(&envelope(json!({})), &model_installed());
     assert!(report.omitted.is_empty());
-    assert!(report.replayable);
+    assert!(report.runnable);
 }
 
 // ---------------------------------------------------------------------------
@@ -557,7 +839,7 @@ fn the_report_reads_an_imported_assets_stored_envelope() {
     };
     let report = build_resolution_report(&round_tripped, &catalogs);
     assert_eq!(report.loras[0].state, RequirementState::Resolved);
-    assert!(report.replayable);
+    assert!(report.runnable);
 }
 
 #[test]
@@ -575,7 +857,10 @@ fn the_report_serializes_as_camel_case_json_for_the_web() {
     assert_eq!(value["model"]["install"]["method"], json!("POST"));
     assert_eq!(value["inputs"][0]["state"], json!("userSupplied"));
     assert_eq!(value["inputs"][0]["kind"], json!("source"));
-    assert_eq!(value["replayable"], json!(false));
+    // The model is `installable` — known but not on disk — so this install cannot run it yet, and
+    // the recipe additionally needs one image from the user. Two facts, two fields.
+    assert_eq!(value["runnable"], json!(false), "value: {value}");
+    assert_eq!(value["inputImagesRequired"], json!(1));
     // Every declared key is present even when empty, so a reader never has to distinguish
     // "absent" from "none".
     for key in [
@@ -584,7 +869,8 @@ fn the_report_serializes_as_camel_case_json_for_the_web() {
         "styles",
         "inputs",
         "omitted",
-        "replayable",
+        "runnable",
+        "inputImagesRequired",
     ] {
         assert!(value.get(key).is_some(), "`{key}` must be serialized");
     }

--- a/crates/sceneworks-core/tests/workflow_resolution.rs
+++ b/crates/sceneworks-core/tests/workflow_resolution.rs
@@ -466,6 +466,45 @@ fn a_blank_lora_label_matches_nothing() {
 }
 
 #[test]
+fn an_envelope_that_names_no_model_says_so_rather_than_quoting_an_empty_slug() {
+    // The user-facing half of the blank-slug guard. There is no slug to have missed with, so the
+    // generic sentence would render "No model matching `` is in this install's catalog" — which
+    // reads to a person as a bug in the reader rather than as a fact about the file.
+    let report = build_resolution_report(
+        &envelope(json!({ "model": "C:\\models\\theirs\\weights.safetensors" })),
+        &StaticCatalogs::default(),
+    );
+    assert_eq!(
+        report.model.slug, "",
+        "the parser scrubs a path-shaped model"
+    );
+    assert_eq!(report.model.state, RequirementState::Missing);
+    assert!(
+        !report.model.detail.contains("``"),
+        "an empty slug must not be quoted back at the user: {}",
+        report.model.detail
+    );
+    assert!(
+        report
+            .model
+            .detail
+            .starts_with("This image does not name a model."),
+        "detail: {}",
+        report.model.detail
+    );
+    // A slug that IS present keeps the sentence that names it.
+    let named = build_resolution_report(
+        &envelope(json!({ "model": "krea_2_turbo" })),
+        &StaticCatalogs::default(),
+    );
+    assert!(
+        named.model.detail.contains("`krea_2_turbo`"),
+        "detail: {}",
+        named.model.detail
+    );
+}
+
+#[test]
 fn nothing_resolves_to_something_the_envelope_did_not_name() {
     // The substitution sweep, in one place: every near-miss shape that could plausibly tempt a
     // match. A resolved requirement must carry a `catalogId` the envelope's own label maps to,

--- a/crates/sceneworks-core/tests/workflow_resolution.rs
+++ b/crates/sceneworks-core/tests/workflow_resolution.rs
@@ -1,0 +1,641 @@
+//! Contract tests for the cross-install resolution report (sc-15950, epic 15945).
+//!
+//! The load-bearing ones are [`a_catalog_known_but_absent_model_is_installable_not_missing`]
+//! (the actionable middle case the story is built around), [`nothing_is_ever_substituted`] (a
+//! requirement that does not resolve is NEVER swapped for something that does), and
+//! [`an_omitted_collection_withholds_one_click_replay`] (a recipe whose `loras` were dropped is
+//! not a recipe with no LoRAs).
+
+use sceneworks_core::project_store::IMPORTED_WORKFLOW_KEY;
+use sceneworks_core::workflow_resolution::{
+    build_resolution_report, CatalogEntry, InstallAction, LoraMatchedBy, RequirementState,
+    StaticCatalogs, StyleField, INERT_STYLE_PRESETS,
+};
+use sceneworks_core::workflow_share::{
+    parse_workflow_share, parse_workflow_share_json, WorkflowShare, OMITTED_LORAS, OMITTED_POSES,
+};
+use serde_json::{json, Value};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// A parsed envelope built from `overrides` merged onto a minimal valid body, so every test
+/// exercises the SAME reduction the reader applies to a stranger's PNG rather than a hand-built
+/// struct the parser would have rejected.
+fn envelope(overrides: Value) -> WorkflowShare {
+    let mut body = json!({
+        "sceneworksWorkflow": "image",
+        "schemaVersion": 1,
+        "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+        "mode": "text_to_image",
+        "model": "krea_2_turbo",
+        "prompt": "a lighthouse in heavy fog",
+    });
+    let object = body.as_object_mut().expect("fixture body is an object");
+    for (key, value) in overrides
+        .as_object()
+        .expect("overrides is an object")
+        .clone()
+    {
+        object.insert(key, value);
+    }
+    parse_workflow_share(&body).expect("the fixture envelope parses")
+}
+
+/// A catalog in which the fixture model is installed and nothing else is known.
+fn model_installed() -> StaticCatalogs {
+    StaticCatalogs {
+        models: vec![CatalogEntry::new("krea_2_turbo")
+            .with_name("Krea 2 Turbo")
+            .installed()],
+        ..StaticCatalogs::default()
+    }
+}
+
+fn download_action(path: &str) -> InstallAction {
+    InstallAction {
+        method: "POST".to_owned(),
+        path: path.to_owned(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_installed_catalog_model_resolves() {
+    let report = build_resolution_report(&envelope(json!({})), &model_installed());
+    assert_eq!(report.model.state, RequirementState::Resolved);
+    assert_eq!(report.model.slug, "krea_2_turbo");
+    assert_eq!(report.model.catalog_id.as_deref(), Some("krea_2_turbo"));
+    assert_eq!(report.model.name.as_deref(), Some("Krea 2 Turbo"));
+    assert!(report.model.install.is_none(), "nothing to install");
+    assert!(report.replayable, "a resolved, input-free recipe replays");
+}
+
+#[test]
+fn a_catalog_known_but_absent_model_is_installable_not_missing() {
+    // The middle case the story is built around: a cache-only resolver never auto-downloads, so
+    // "in the catalog" and "on disk" are different answers — and the middle one must be ACTIONABLE.
+    let catalogs = StaticCatalogs {
+        models: vec![CatalogEntry::new("krea_2_turbo")
+            .with_name("Krea 2 Turbo")
+            .with_install(download_action("/api/v1/models/krea_2_turbo/download"))],
+        ..StaticCatalogs::default()
+    };
+    let report = build_resolution_report(&envelope(json!({})), &catalogs);
+    assert_eq!(report.model.state, RequirementState::Installable);
+    assert_ne!(
+        report.model.state,
+        RequirementState::Missing,
+        "a model the catalog knows is not missing"
+    );
+    assert_eq!(
+        report
+            .model
+            .install
+            .as_ref()
+            .map(|action| action.path.as_str()),
+        Some("/api/v1/models/krea_2_turbo/download"),
+        "the actionable middle case must name the flow that fetches it"
+    );
+    assert!(
+        !report.replayable,
+        "a model that is not on disk cannot be replayed in one click"
+    );
+}
+
+#[test]
+fn a_model_the_catalog_does_not_know_is_missing_and_names_the_slug() {
+    let report = build_resolution_report(&envelope(json!({})), &StaticCatalogs::default());
+    assert_eq!(report.model.state, RequirementState::Missing);
+    assert_eq!(report.model.slug, "krea_2_turbo");
+    assert!(report.model.catalog_id.is_none());
+    assert!(report.model.install.is_none());
+    assert!(
+        report.model.detail.contains("krea_2_turbo"),
+        "the sentence must name what could not be resolved: {}",
+        report.model.detail
+    );
+}
+
+#[test]
+fn a_catalog_known_model_with_no_install_flow_is_missing_rather_than_falsely_actionable() {
+    // An entry the catalog knows but cannot fetch (a `downloadable: false` row, an external
+    // ComfyUI base that vanished). Reporting it as installable would offer a button that
+    // cannot work, which is its own kind of silent substitution.
+    let catalogs = StaticCatalogs {
+        models: vec![CatalogEntry::new("krea_2_turbo").with_name("Krea 2 Turbo")],
+        ..StaticCatalogs::default()
+    };
+    let report = build_resolution_report(&envelope(json!({})), &catalogs);
+    assert_eq!(report.model.state, RequirementState::Missing);
+    assert!(report.model.install.is_none());
+    assert_eq!(
+        report.model.catalog_id.as_deref(),
+        Some("krea_2_turbo"),
+        "the catalog match is still reported, only the action is not"
+    );
+}
+
+#[test]
+fn nothing_is_ever_substituted() {
+    // One model in the catalog, installed, and it is NOT the one the envelope names. The report
+    // must not reach for it — no default model, no nearest match, no quiet success.
+    let catalogs = StaticCatalogs {
+        models: vec![CatalogEntry::new("z_image_turbo")
+            .with_name("Z-Image Turbo")
+            .installed()],
+        loras: vec![CatalogEntry::new("film_grain")
+            .with_name("Film Grain")
+            .installed()],
+        styles: vec![CatalogEntry::new("ghibli-style")],
+        ..StaticCatalogs::default()
+    };
+    let share = envelope(json!({
+        "loras": [{ "name": "Aurora Portrait", "weight": 0.8 }],
+        "styleId": "akira-style",
+    }));
+    let report = build_resolution_report(&share, &catalogs);
+    assert_eq!(report.model.state, RequirementState::Missing);
+    assert_eq!(report.model.slug, "krea_2_turbo");
+    assert!(report.model.catalog_id.is_none());
+    assert_eq!(report.loras.len(), 1);
+    assert_eq!(report.loras[0].state, RequirementState::Missing);
+    assert!(report.loras[0].catalog_id.is_none());
+    assert!(report.loras[0].matched_by.is_none());
+    assert_eq!(report.styles.len(), 1);
+    assert_eq!(report.styles[0].state, RequirementState::Missing);
+    assert!(!report.replayable);
+}
+
+// ---------------------------------------------------------------------------
+// LoRAs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_lora_matches_by_hugging_face_repo_id() {
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("film_grain")
+            .with_name("Film Grain (local rename)")
+            .with_repo("acme/film-grain")
+            .installed()],
+        ..model_installed()
+    };
+    let share = envelope(json!({
+        "loras": [{ "name": "Whatever the sender called it", "repo": "acme/film-grain", "weight": 0.6 }],
+    }));
+    let report = build_resolution_report(&share, &catalogs);
+    assert_eq!(report.loras.len(), 1);
+    assert_eq!(report.loras[0].state, RequirementState::Resolved);
+    assert_eq!(report.loras[0].matched_by, Some(LoraMatchedBy::Repo));
+    assert_eq!(report.loras[0].catalog_id.as_deref(), Some("film_grain"));
+    assert_eq!(report.loras[0].weight, Some(0.6));
+    assert!(report.replayable);
+}
+
+#[test]
+fn a_lora_matches_by_name_when_the_envelope_carried_no_repo() {
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("film_grain")
+            .with_name("Film Grain")
+            .installed()],
+        ..model_installed()
+    };
+    let share = envelope(json!({ "loras": [{ "name": "Film Grain" }] }));
+    let report = build_resolution_report(&share, &catalogs);
+    assert_eq!(report.loras[0].state, RequirementState::Resolved);
+    assert_eq!(report.loras[0].matched_by, Some(LoraMatchedBy::Name));
+    assert_eq!(report.loras[0].catalog_id.as_deref(), Some("film_grain"));
+}
+
+#[test]
+fn a_name_match_ignores_case_and_separators() {
+    // "Film Grain" / "film-grain" / "film_grain" are one name — a display name typed on one
+    // install and a catalog id slugged on another are the same LoRA, and refusing to see that
+    // would report a resolvable LoRA as user-trained.
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("film_grain")
+            .with_name("Film  Grain")
+            .installed()],
+        ..model_installed()
+    };
+    for sent in ["film-grain", "FILM GRAIN", "Film_Grain", "film grain"] {
+        let share = envelope(json!({ "loras": [{ "name": sent }] }));
+        let report = build_resolution_report(&share, &catalogs);
+        assert_eq!(
+            report.loras[0].state,
+            RequirementState::Resolved,
+            "`{sent}` must match the catalog name"
+        );
+    }
+}
+
+#[test]
+fn a_name_match_also_accepts_the_catalog_id() {
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("film_grain").installed()],
+        ..model_installed()
+    };
+    let share = envelope(json!({ "loras": [{ "name": "film_grain" }] }));
+    let report = build_resolution_report(&share, &catalogs);
+    assert_eq!(report.loras[0].state, RequirementState::Resolved);
+    assert_eq!(report.loras[0].matched_by, Some(LoraMatchedBy::Name));
+}
+
+#[test]
+fn a_repo_match_wins_over_a_name_match() {
+    // A repo id is unambiguous and a display name is not, so the repo is tried first.
+    let catalogs = StaticCatalogs {
+        loras: vec![
+            CatalogEntry::new("by_name")
+                .with_name("Film Grain")
+                .installed(),
+            CatalogEntry::new("by_repo")
+                .with_name("Something else entirely")
+                .with_repo("acme/film-grain")
+                .installed(),
+        ],
+        ..model_installed()
+    };
+    let share = envelope(json!({
+        "loras": [{ "name": "Film Grain", "repo": "acme/film-grain" }],
+    }));
+    let report = build_resolution_report(&share, &catalogs);
+    assert_eq!(report.loras[0].catalog_id.as_deref(), Some("by_repo"));
+    assert_eq!(report.loras[0].matched_by, Some(LoraMatchedBy::Repo));
+}
+
+#[test]
+fn an_unresolvable_lora_is_listed_rather_than_dropped() {
+    // A user-trained LoRA is the EXPECTED unresolvable case. Dropping the entry would make the
+    // report claim a recipe with no LoRAs, which is the silent-loss failure this epic exists for.
+    let share = envelope(json!({
+        "loras": [
+            { "name": "Aurora Portrait v3", "weight": 0.9 },
+            { "repo": "someone/private-style" },
+        ],
+    }));
+    let report = build_resolution_report(&share, &model_installed());
+    assert_eq!(
+        report.loras.len(),
+        2,
+        "both entries survive into the report"
+    );
+    assert!(report
+        .loras
+        .iter()
+        .all(|lora| lora.state == RequirementState::Missing));
+    assert!(
+        report.loras[0].detail.contains("Aurora Portrait v3"),
+        "the sentence names the LoRA: {}",
+        report.loras[0].detail
+    );
+    assert!(
+        report.loras[1].detail.contains("someone/private-style"),
+        "a repo-only entry is named by its repo: {}",
+        report.loras[1].detail
+    );
+    assert!(!report.replayable);
+}
+
+#[test]
+fn a_catalog_known_but_uninstalled_lora_is_installable() {
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("film_grain")
+            .with_name("Film Grain")
+            .with_repo("acme/film-grain")
+            .with_install(download_action("/api/v1/loras/film_grain/download"))],
+        ..model_installed()
+    };
+    let share = envelope(json!({ "loras": [{ "repo": "acme/film-grain" }] }));
+    let report = build_resolution_report(&share, &catalogs);
+    assert_eq!(report.loras[0].state, RequirementState::Installable);
+    assert_eq!(
+        report.loras[0]
+            .install
+            .as_ref()
+            .map(|action| action.path.as_str()),
+        Some("/api/v1/loras/film_grain/download")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Style
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_style_id_resolves_against_the_style_catalog() {
+    let catalogs = StaticCatalogs {
+        styles: vec![CatalogEntry::new("ghibli-style").with_name("Ghibli Style")],
+        ..model_installed()
+    };
+    let report =
+        build_resolution_report(&envelope(json!({ "styleId": "ghibli-style" })), &catalogs);
+    assert_eq!(report.styles.len(), 1);
+    assert_eq!(report.styles[0].field, StyleField::StyleId);
+    assert_eq!(report.styles[0].state, RequirementState::Resolved);
+    assert_eq!(report.styles[0].name.as_deref(), Some("Ghibli Style"));
+    assert!(report.replayable);
+
+    let unknown =
+        build_resolution_report(&envelope(json!({ "styleId": "not-a-style" })), &catalogs);
+    assert_eq!(unknown.styles[0].state, RequirementState::Missing);
+    assert!(
+        unknown.styles[0].install.is_none(),
+        "a style is not something this install can fetch"
+    );
+    assert!(!unknown.replayable);
+}
+
+#[test]
+fn a_style_preset_resolves_against_the_merged_recipe_preset_catalog() {
+    let catalogs = StaticCatalogs {
+        recipe_presets: vec![CatalogEntry::new("preset_noir").with_name("Noir")],
+        ..model_installed()
+    };
+    let report = build_resolution_report(
+        &envelope(json!({ "stylePreset": "preset_noir" })),
+        &catalogs,
+    );
+    assert_eq!(report.styles.len(), 1);
+    assert_eq!(report.styles[0].field, StyleField::StylePreset);
+    assert_eq!(report.styles[0].state, RequirementState::Resolved);
+    assert!(report.replayable);
+
+    let unknown = build_resolution_report(
+        &envelope(json!({ "stylePreset": "preset_from_their_install" })),
+        &catalogs,
+    );
+    assert_eq!(unknown.styles[0].state, RequirementState::Missing);
+    assert!(!unknown.replayable);
+}
+
+#[test]
+fn the_inert_style_preset_defaults_are_not_requirements() {
+    // `stylePreset` is only a preset id when a recipe preset actually ran; otherwise it is the
+    // wire default that `ImageRequest::from_payload` fills in, which EVERY generated envelope
+    // carries. Treating that as an unresolved preset would mark every shared image unreplayable.
+    for inert in INERT_STYLE_PRESETS {
+        let report = build_resolution_report(
+            &envelope(json!({ "stylePreset": inert })),
+            &model_installed(),
+        );
+        assert!(
+            report.styles.is_empty(),
+            "`{inert}` names no preset, so it is not a requirement"
+        );
+        assert!(report.replayable, "`{inert}` must not block replay");
+    }
+}
+
+#[test]
+fn both_style_axes_are_reported_with_the_live_one_first() {
+    let catalogs = StaticCatalogs {
+        styles: vec![CatalogEntry::new("ghibli-style")],
+        recipe_presets: vec![CatalogEntry::new("preset_noir")],
+        ..model_installed()
+    };
+    let share = envelope(json!({ "styleId": "ghibli-style", "stylePreset": "preset_noir" }));
+    let report = build_resolution_report(&share, &catalogs);
+    let fields: Vec<StyleField> = report.styles.iter().map(|style| style.field).collect();
+    assert_eq!(fields, vec![StyleField::StyleId, StyleField::StylePreset]);
+}
+
+// ---------------------------------------------------------------------------
+// Input images
+// ---------------------------------------------------------------------------
+
+#[test]
+fn input_images_are_user_supplied_and_named_by_shape() {
+    let share = envelope(json!({
+        "mode": "edit_image",
+        "inputs": [
+            { "kind": "source", "count": 1 },
+            { "kind": "reference", "count": 2 },
+            { "kind": "mask", "count": 1 },
+            { "kind": "control", "count": 1, "controlMode": "canny" },
+        ],
+    }));
+    let report = build_resolution_report(&share, &model_installed());
+    let details: Vec<&str> = report
+        .inputs
+        .iter()
+        .map(|input| input.detail.as_str())
+        .collect();
+    assert_eq!(
+        details,
+        vec![
+            "Needs a source image.",
+            "Needs 2 reference images.",
+            "Needs a mask.",
+            "Needs a canny control image.",
+        ]
+    );
+    assert!(report
+        .inputs
+        .iter()
+        .all(|input| input.state == RequirementState::UserSupplied));
+    assert!(
+        !report.replayable,
+        "an input image the user must pick is not a one-click replay"
+    );
+}
+
+#[test]
+fn a_control_input_without_a_mode_still_reads_as_a_control_image() {
+    let share = envelope(json!({ "inputs": [{ "kind": "control", "count": 1 }] }));
+    let report = build_resolution_report(&share, &model_installed());
+    assert_eq!(report.inputs[0].detail, "Needs a control image.");
+    assert!(report.inputs[0].control_mode.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// The "name what does not resolve" roll-up
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unresolved_collects_every_sentence_a_reader_has_to_show() {
+    let share = envelope(json!({
+        "loras": [{ "name": "Aurora Portrait" }],
+        "styleId": "not-a-style",
+        "inputs": [{ "kind": "source", "count": 1 }],
+        "omitted": [OMITTED_POSES],
+    }));
+    // Model resolved, everything else not: the roll-up must carry four sentences and not the
+    // model's.
+    let report = build_resolution_report(&share, &model_installed());
+    let unresolved = report.unresolved();
+    assert_eq!(unresolved.len(), 4, "got {unresolved:?}");
+    assert!(unresolved
+        .iter()
+        .any(|line| line.contains("Aurora Portrait")));
+    assert!(unresolved.iter().any(|line| line.contains("not-a-style")));
+    assert!(unresolved.contains(&"Needs a source image."));
+    assert!(unresolved.iter().any(|line| line.contains("pose-free")));
+    assert!(!unresolved
+        .iter()
+        .any(|line| line.contains("krea_2_turbo") || line.contains("Krea 2 Turbo")));
+}
+
+#[test]
+fn a_fully_resolved_report_has_nothing_to_name() {
+    assert!(
+        build_resolution_report(&envelope(json!({})), &model_installed())
+            .unresolved()
+            .is_empty()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Omitted collections
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_omitted_collection_withholds_one_click_replay() {
+    // A recipe whose `loras` were omitted is NOT a recipe with no LoRAs — the envelope says so
+    // and the report has to pass that on, or sc-15952 offers a replay that silently drops five
+    // LoRAs.
+    let share = envelope(json!({ "omitted": [OMITTED_LORAS, OMITTED_POSES] }));
+    let report = build_resolution_report(&share, &model_installed());
+    assert!(report.loras.is_empty(), "there were none to classify");
+    let fields: Vec<&str> = report
+        .omitted
+        .iter()
+        .map(|entry| entry.field.as_str())
+        .collect();
+    // The envelope's `omitted` is a sorted SET (`reduce_omitted`), so the report preserves that
+    // order rather than inventing one.
+    assert_eq!(fields, vec![OMITTED_POSES, OMITTED_LORAS]);
+    assert!(
+        report.omitted.iter().all(|entry| !entry.detail.is_empty()),
+        "each omission carries a sentence"
+    );
+    assert!(
+        report
+            .omitted
+            .iter()
+            .any(|entry| entry.field == OMITTED_LORAS && entry.detail.contains("NOT")),
+        "the LoRA omission has to say what the absence does not mean"
+    );
+    assert!(
+        !report.replayable,
+        "an omitted collection withholds one-click replay"
+    );
+}
+
+#[test]
+fn an_envelope_with_nothing_omitted_reports_no_omissions() {
+    let report = build_resolution_report(&envelope(json!({})), &model_installed());
+    assert!(report.omitted.is_empty());
+    assert!(report.replayable);
+}
+
+// ---------------------------------------------------------------------------
+// The whole report
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_report_reads_an_imported_assets_stored_envelope() {
+    // sc-15949 stores the envelope at `extra.importedWorkflow`. The report must work on THAT
+    // value, not only on one freshly read out of a PNG, because sc-15951/sc-15952 read the
+    // asset row.
+    let share = envelope(json!({ "loras": [{ "repo": "acme/film-grain" }] }));
+    let stored =
+        json!({ "extra": { IMPORTED_WORKFLOW_KEY: serde_json::to_value(&share).unwrap() } });
+    let round_tripped = parse_workflow_share(&stored["extra"][IMPORTED_WORKFLOW_KEY])
+        .expect("the stored envelope re-parses");
+    assert_eq!(round_tripped, share);
+
+    let catalogs = StaticCatalogs {
+        loras: vec![CatalogEntry::new("film_grain")
+            .with_repo("acme/film-grain")
+            .installed()],
+        ..model_installed()
+    };
+    let report = build_resolution_report(&round_tripped, &catalogs);
+    assert_eq!(report.loras[0].state, RequirementState::Resolved);
+    assert!(report.replayable);
+}
+
+#[test]
+fn the_report_serializes_as_camel_case_json_for_the_web() {
+    let catalogs = StaticCatalogs {
+        models: vec![CatalogEntry::new("krea_2_turbo")
+            .with_install(download_action("/api/v1/models/krea_2_turbo/download"))],
+        ..StaticCatalogs::default()
+    };
+    let share = envelope(json!({ "inputs": [{ "kind": "source", "count": 1 }] }));
+    let report = build_resolution_report(&share, &catalogs);
+    let value = serde_json::to_value(&report).expect("the report serializes");
+    assert_eq!(value["model"]["state"], json!("installable"));
+    assert_eq!(value["model"]["slug"], json!("krea_2_turbo"));
+    assert_eq!(value["model"]["install"]["method"], json!("POST"));
+    assert_eq!(value["inputs"][0]["state"], json!("userSupplied"));
+    assert_eq!(value["inputs"][0]["kind"], json!("source"));
+    assert_eq!(value["replayable"], json!(false));
+    // Every declared key is present even when empty, so a reader never has to distinguish
+    // "absent" from "none".
+    for key in [
+        "model",
+        "loras",
+        "styles",
+        "inputs",
+        "omitted",
+        "replayable",
+    ] {
+        assert!(value.get(key).is_some(), "`{key}` must be serialized");
+    }
+}
+
+#[test]
+fn a_report_round_trips_through_json() {
+    let report = build_resolution_report(
+        &envelope(json!({ "loras": [{ "name": "Aurora" }], "styleId": "ghibli-style" })),
+        &model_installed(),
+    );
+    let text = serde_json::to_string(&report).expect("serializes");
+    let parsed: sceneworks_core::workflow_resolution::ResolutionReport =
+        serde_json::from_str(&text).expect("deserializes");
+    assert_eq!(parsed, report);
+}
+
+#[test]
+fn every_omitted_field_the_envelope_can_carry_has_a_sentence() {
+    // The closed vocabulary is `workflow_share::OMITTED_FIELDS`; a member with no sentence here
+    // would reach the user as a bare field name.
+    for field in sceneworks_core::workflow_share::OMITTED_FIELDS {
+        let share = envelope(json!({ "omitted": [field] }));
+        let report = build_resolution_report(&share, &model_installed());
+        assert_eq!(report.omitted.len(), 1, "`{field}` survives the parse");
+        let detail = &report.omitted[0].detail;
+        assert!(
+            !detail.is_empty() && !detail.contains("was declared but not recorded"),
+            "`{field}` needs its own sentence, got: {detail}"
+        );
+    }
+}
+
+#[test]
+fn a_share_read_out_of_json_text_is_reportable_end_to_end() {
+    // The shape sc-15951 hands us: a chunk's text straight off a dropped file.
+    let share = parse_workflow_share_json(
+        r#"{
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": { "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "a fox in the snow",
+            "loras": [{ "name": "Aurora Portrait", "weight": 0.7 }]
+        }"#,
+    )
+    .expect("the envelope parses");
+    let report = build_resolution_report(&share, &StaticCatalogs::default());
+    assert_eq!(report.model.slug, "z_image_turbo");
+    assert_eq!(report.model.state, RequirementState::Missing);
+    assert_eq!(report.loras.len(), 1);
+    assert_eq!(report.loras[0].name.as_deref(), Some("Aurora Portrait"));
+}


### PR DESCRIPTION
Closes [sc-15950](https://app.shortcut.com/sceneworks/story/15950). Epic 15945 (embedded workflow share). Builds on sc-15946 / sc-15947 / sc-15948 / sc-15949, all merged.

## What changed

### `crates/sceneworks-core/src/workflow_resolution.rs` (new)

`build_resolution_report(&WorkflowShare, &dyn WorkflowCatalogs) -> ResolutionReport` — the shared "can this machine run it?" capability, in core so that the endpoint below and the web readers to come (sc-15951 / sc-15952) consume one implementation rather than each growing their own.

Four requirement classes, four states:

| state | meaning |
|---|---|
| `resolved` | present and usable right now |
| `installable` | the catalog knows it, it is not on disk, **and there is a flow that fetches it** |
| `missing` | nothing matches, or nothing here can fetch what does |
| `userSupplied` | the input images — never auto-resolved |

The doctrine is the story's and it is load-bearing: **never silently substitute.** No default model, no similar LoRA, no nearest resolution. `nothing_is_ever_substituted` seeds a catalog holding exactly one installed model / LoRA / style — none of them the ones the envelope names — and asserts the report reaches for none of them.

The inverse guard matters too and is tested: a catalog row this install has **no way to fetch** is `missing`, not `installable`, because offering a button that cannot work is its own kind of lie.

### Matching is two passes, and ambiguity resolves to NOTHING

Review found the doctrine had a hole in it. A LoRA was matched with one `Iterator::find` over a `name matches OR id matches` predicate, so the **first row in catalog order won regardless of match quality** — and catalog order is an accident of manifest merge order. With `[{ id: "film_grain", name: "Vintage Filmstock" }, { id: "vintage_1", name: "Film Grain" }]` both installed, an envelope naming `"Film Grain"` resolved to `film_grain`, was reported as *"Vintage Filmstock is installed."*, and carried `replayable: true`. That is the exact silent substitution this report exists to prevent, dressed up as a fact and with a one-click replay on top of it.

The rule is now:

1. **Display name first** — the envelope's `name` *is* a display name, so the row actually called that wins over a row whose id merely happens to equal it.
2. **Catalog id second**, and only if nothing matched by name (so a name slugged on the sender's install still matches a row carrying no display name here).
3. **More than one row matching the winning pass resolves to nothing.** The entry is reported `missing` and NAMED. There is no honest way to pick one, and an ambiguous name pass does **not** fall through to the id pass — the weaker key cannot break a tie the stronger one could not.

The same rule applies to `lora_by_repo`: two adapter files off one Hugging Face repo are two adapters, so the repo id identifies none of them.

`unique_match` is the one place the rule lives. `the_display_name_pass_runs_before_the_id_pass` asserts the answer does not change when the catalog is reversed, which is the whole bug.

### A blank id matches nothing, at both ends

`workflow_share` scrubs an unshareable (path-shaped) `model` to `""`. A catalog row whose manifest omitted `id` was reduced to `id: ""` by `entry_str(..).unwrap_or_default()`. The two matched — so an envelope that named **no model at all** resolved against a row the file never mentioned and reported it "installed on this machine", with `catalogId: ""`.

Both halves are closed. `model_catalog_entry` / `lora_catalog_entry` return `Option<CatalogEntry>` and **drop** an id-less row (the same rule `named_entry` already followed for styles and presets), and `find_by_id` / `classify_model` refuse a blank slug rather than asking the catalog a question with no answer.

The sentence that case produces is its own third half: with no slug to have missed with, the generic wording rendered *"No model matching `` is in this install's catalog"*, which reads to a person as a bug in the reader. It now says the file does not name a model and why (`an_envelope_that_names_no_model_says_so_rather_than_quoting_an_empty_slug`), while a slug that *is* present still gets quoted back.

### `replayable` split into two fields

The old boolean conflated two different answers, and one of them was permanently wrong. It was false whenever any input image was outstanding — but `inputs` is never empty for an `edit_image` / img2img share, so **every such share reported `replayable: false` forever**, regardless of what was installed. "The model is missing" and "you need to pick a source image" read identically.

| field | meaning |
|---|---|
| `runnable` | nothing is missing or omitted — **this install can run it**. Every looked-up requirement (`model`, `loras`, `styles`) is `resolved`, and no collection was dropped on the way into the envelope. Says nothing about input images: nothing on this machine could ever have supplied them. |
| `inputImagesRequired` | **how many images the user must supply**, summed over `inputs`. `0` for a text-to-image recipe. |

`ResolutionReport::one_click_replayable()` composes the two, so the condition sc-15952 needs lives in one place rather than being re-derived (and eventually re-derived *differently*) by each reader.

### `apps/rust-api/src/workflows.rs` (new) — `POST /api/v1/workflows/inspect`

Multipart `file` (required) plus an optional `projectId` (widens the LoRA/preset lookups to the project scope). Returns `{ status, workflow, resolution }` and creates nothing. Registered beside the asset routes in `lib.rs`, reusing the `import_asset` multipart pattern (including its duplicate-`file` rejection and its staged-temp cleanup on every error path). No auth change — the shared `access_control` middleware guards it like every other `/api/v1` route.

**The body cap is 512 MiB, not the asset route's 2 GiB.** The asset route pays 2 GiB because the bytes *become* the asset; the write is the point. Inspect streams the body to `cache/uploads` **before any PNG check**, throws it away, and returns a small JSON report — so 2 GiB bought 2 GiB of transient disk and one blocking thread for a result measured in kilobytes, with no rate limit, concurrency limit or timeout layer anywhere in the app (tower-http here is compression + cors only) and `SCENEWORKS_TRUST_LOOPBACK` letting any local process drive N of them untokened. 512 MiB is sized against what users actually drop, not against a round number: the largest PNG SceneWorks itself can write is a 4096² generation through a 4× upscale = 16384², 8-bit RGB = 805 MB raw, well under 512 MiB once PNG's filtered deflate is applied to rendered content; an ordinary 4096² share is ~50 MB and a phone photo is single-digit MB. Nothing a user would plausibly drop is rejected, and the transient-disk exposure drops 4×.

**The route's `DefaultBodyLimit` sits above the per-field cap**, at cap + 16 MiB of multipart framing headroom — the same relationship, for the same reason, as `MAX_LORA_MULTIPART_BODY_BYTES`. With the two *equal* (as they were), a body exactly at the cap plus its boundaries and part headers exceeded the router limit, so axum rejected it before `stage_inspect_upload` counted a byte and the typed 413 was unreachable at the only boundary that matters. `max_inspect_multipart_body_bytes` derives the router limit from the live per-field cap so the two cannot drift back into equality, and so `the_typed_413_wins_at_the_real_cap_boundary_not_just_far_under_it` can exercise the real relationship at a sendable size.

**One catalog snapshot per request.** `inspect_catalogs` threads a single `JobCatalogSnapshot` (sc-8819) through both model reads. Without it the request read `model_catalog(state)` twice — the preset merge needs it too — which is two full deep clones and, worse, two values that can *disagree* if a model write lands between them, leaving the report's `model` row classified against a different catalog than its presets.

### Every failure carries a machine-readable `code` — including the ones that never reach the handler

The module doc claims it, so it has to be true of the extractor rejections too. A malformed multipart request (empty body, JSON body, `Content-Type` with no `boundary`) is rejected *before* the handler body runs, and axum's own rejection is a **plain-text** body with no `code` at all — the one shape a reader branching on `code` cannot parse. The handler takes `Result<Multipart, MultipartRejection>` and maps it itself.

| code | status | when |
|---|---|---|
| `workflow_inspect_not_png` | 400 | the bytes are not a PNG |
| `workflow_inspect_unreadable` | 422 | a PNG claiming a workflow this build will not read |
| `workflow_inspect_too_large` | 413 | body over the cap |
| `workflow_inspect_bad_multipart` | 4xx | not a usable multipart with exactly one `file` field |
| `workflow_inspect_stage_failed` | 5xx | the upload could not be written to `cache/uploads` |
| `workflow_inspect_catalog_failed` | 5xx | this install's catalogs could not be read |
| `workflow_inspect_read_failed` | **500** | our own staged temp could not be opened or read |

**One failure is deliberately a 5xx.** `WorkflowChunkError::Io` fires when *our* staged temp cannot be read — the caller's bytes were written successfully by then, so it says nothing about their file. On Windows an antivirus sharing violation on the staging directory is the likely cause. It was previously mapped to 400 `workflow_inspect_not_png`, which sends the user to fix a file that is fine — exactly the mislabeling epic 15945 exists to stop.

**And the 422 sentences no longer leak `png`-crate `Debug` output.** `Png` and `UnreadableChunk` inline their upstream `detail` into their `Display`, and for a garbage chunk that upstream text is a `Debug` dump: `ChunkType { type: ageg, critical: false, private: true, reserved: true, safecopy: true }`. That was going to users verbatim. Those two variants now get a written sentence and the raw text goes to the **log**, where a developer reading a bug report will look for it. The variants whose own sentences were already written for a person (two chunks, N bytes over the limit, a video envelope) keep them.

## Scope vs each acceptance criterion

| AC | Where |
|---|---|
| `build_resolution_report(&WorkflowShare) -> ResolutionReport` in core, four requirement classes | `workflow_resolution.rs`. The signature takes the injected `&dyn WorkflowCatalogs` as a second argument — required by the story's own "define a trait/closure boundary in core and inject the lookup" guidance. |
| Model: catalog-known-and-installed vs catalog-known-but-absent vs unknown; the middle case actionable | `classify_model` + `state_for`. `a_catalog_known_but_absent_model_is_installable_not_missing` (core) and `inspect_reports_a_catalog_known_but_absent_model_as_installable` (end to end, through the real catalog). |
| LoRA matching by name and by repo id, unresolvable entries listed not dropped | `classify_lora`. Repo first (unambiguous), then display name, then catalog id — see the two-pass section. `an_unresolvable_lora_is_listed_rather_than_dropped`, `a_repo_match_wins_over_a_name_match`, `a_name_two_installed_rows_both_claim_is_reported_missing_rather_than_guessed`. |
| Style preset / style id present in the merged catalog | `classify_style`, two axes (see the note below). |
| Input images by shape, always user-supplied | `classify_input` — `"Needs a source image."` / `"Needs 2 reference images."` / `"Needs a mask."` / `"Needs a canny control image."` |
| Endpoint returns the report for a valid image; typed error (not 500) for a non-image / oversized body | 400 `workflow_inspect_not_png`, 413 `workflow_inspect_too_large`. `inspect_error` matches every `WorkflowChunkError` variant exhaustively, so a new variant has to be classified rather than falling into a catch-all. The one 500 is `Io` — a *server*-side read failure of our own temp, not a fact about the caller's bytes; see above. |
| An image with no embedded workflow returns a distinct, unambiguous "no workflow" response | 200 `{ status: "no_workflow", workflow: null, resolution: null, detail }`. |
| Endpoint creates no asset, no job, no project mutation — asserted by test | `inspect_creates_no_asset_no_job_and_no_project_mutation`. |

## Notes on three judgement calls

**1. "No workflow" is a 200, not a typed error.** The first AC lists it among the typed-error cases and the next AC says it must be distinct and unambiguous; the story's guidance settles it — "a foreign PNG with no chunk is the COMMON case — it must not look like a failure". So: PNG-without-chunk is `200 { status: "no_workflow" }`, and only **not-a-PNG** is the typed 400. Both `workflow` and `resolution` keys are always **present** (null in that branch) so sc-15951 never has to tell absent from null. A file whose chunk exists but this build refuses to read (truncated PNG, two workflow chunks, a zip bomb, a newer schema version, a **video** envelope) is a typed 422 `workflow_inspect_unreadable`.

**2. `stylePreset` is a second style axis, and its wire default is inert.** `styleId` resolves against the Style catalog; `stylePreset` holds a **recipe-preset id** whenever a preset ran (the API stamps it in `apply_recipe_preset_to_image_payload`), so it resolves against the merged builtin/global/project preset catalog — that is the "merged builtin/global/project catalog" the story names.

But with no preset the field keeps the wire default `"cinematic"` that `ImageRequest::from_payload` fills in, and the worker writes `request.style_preset` into the facts the envelope builder reads — so **every generated image carries it** (pinned today by `image_jobs/tests.rs`). Resolving that against the preset catalog would report an unresolved style on every shared image and mark all of them unrunnable. `INERT_STYLE_PRESETS` (reading `DEFAULT_STYLE_PRESET` from `image_request`, now `pub`, rather than repeating the literal) excludes it, and `the_inert_style_preset_defaults_are_not_requirements` pins that.

Correction to the story's premise: the **Style** catalog has no global/project scope — `builtin.styles.jsonc` is the only source, verified.

**3. `omitted` becomes a first-class part of the report.** `ResolutionReport.omitted` carries one entry per envelope omission, each with a sentence saying what the absence does **not** mean ("This workflow named more LoRAs than a job can carry, so none of them were recorded. This is NOT a LoRA-free recipe."), and `runnable` is false whenever anything was omitted. `every_omitted_field_the_envelope_can_carry_has_a_sentence` walks the closed `OMITTED_FIELDS` vocabulary so a member with no sentence fails the build rather than reaching the user as a bare field name.

`runnable` is deliberately strict: true only when the model, every LoRA and every style are `resolved` and nothing was omitted. Every `false` is a case where replaying would quietly produce something other than what the file describes.

## Endpoint purity — how it was proved

A test that only checks the response body would pass with an asset created behind it, so `inspect_creates_no_asset_no_job_and_no_project_mutation` reads the **stores**: it creates a project, snapshots `GET /projects/{id}/assets`, `GET /jobs` and a recursive listing of the project directory, POSTs the shared PNG **with `projectId` set** (the only branch that touches the project store at all), then re-asserts all three are unchanged. Every inspect test additionally asserts `cache/uploads` holds no `upload-*` leftovers, including the 400 / 413 / duplicate-field paths.

The report is computed on read and deliberately **never persisted** beside the envelope sc-15949 stores at `extra.importedWorkflow`: the envelope is a fact about the file, the report is a fact about this machine right now and stops being true the moment the user installs the model.

## Substitution sweep

The near-miss shapes that could plausibly tempt a wrong match, each asserted to resolve to nothing rather than to a neighbour (`nothing_resolves_to_something_the_envelope_did_not_name` plus the named tests beside it):

| case | result |
|---|---|
| model slug differing only in case (`KREA_2_TURBO`) | `missing` — the catalogs are keyed by exact id |
| model slug differing only in separator (`krea-2-turbo`, `krea 2 turbo`) | `missing` |
| blank model slug against a catalog row that lost its id | `missing`, no `catalogId`, and the id-less row is dropped upstream anyway |
| LoRA name matching row A while row B matches by repo | resolves to **B**, `matchedBy: repo` — the unambiguous key wins and A is never reached for |
| two installed rows sharing a normalized name | `missing`, named, weight preserved |
| two rows named X plus a third whose *id* is X | `missing` — an ambiguous name pass does not fall through |
| two rows off one Hugging Face repo | `missing` |
| a `styleId` that is a preset's display name (and the mirror case) | `missing` on both axes — neither borrows the other's catalog |

The reviewer's reproduction is shipped verbatim, twice: as `colliding_loras()` in the unit tests and as `a_name_that_is_another_rows_id_resolves_to_the_row_actually_called_that` end to end. It now resolves to `vintage_1` — the row *actually called* "Film Grain" — with a sentence that does not contain the string "Vintage Filmstock", and the assertion is repeated against a reversed catalog so the answer cannot be an accident of merge order. (It resolves rather than reporting `missing` because exactly one row matches the winning pass: `"Film Grain"` is an exact display-name match on one row only. The `missing` answer is for genuine ambiguity, covered by the three rows above it in the table.)

## Tests

- **`crates/sceneworks-core/tests/workflow_resolution.rs` — 36**, every fixture built through `parse_workflow_share` so it is reduced by the same rules a stranger's PNG is.
- **`crates/sceneworks-core/src/workflow_resolution.rs` — 13 unit tests** (label normalization, the state mapping, action publication, serde wire values, the two-pass rule, the blank-id guards).
- **`apps/rust-api/src/tests/workflows.rs` — 17**, driving the real router: happy path, purity, no-workflow (both a fixture PNG and the repo's own `32x32.png`), typed 400 / 422 / 413, the 413 at the *real* cap boundary, malformed multipart, missing and duplicate `file`, installable-vs-missing through the real model catalog, a scrubbed model against an id-less manifest row, input shapes, omitted collections, and the auth posture.
- **`apps/rust-api/src/workflows.rs` — 13 unit tests** for the catalog-row adapters and the error mapping (install action only when downloadable; a project-scoped LoRA is never pointed at a route that would 404 it; style flattening; an id-less row is dropped; `Io` is not reported as a bad file; no `Debug` output in a 422 sentence; the router limit sits above the field cap).

Each fix above was **mutation-proved**: the fix was reverted, a named test was confirmed to fail, and the fix restored. Two-pass order → `the_display_name_pass_runs_before_the_id_pass`; the ambiguity rule → `a_name_two_installed_rows_both_claim_is_reported_missing_rather_than_guessed`; the blank-id guard → `a_blank_id_matches_nothing_even_when_a_catalog_row_carries_one`; the id-less drop → `a_catalog_row_with_no_usable_id_is_dropped_rather_than_carried_as_a_blank`; the `Io` status → `a_server_side_read_failure_is_not_reported_as_a_bad_file`; the body-limit headroom → `the_typed_413_wins_at_the_real_cap_boundary_not_just_far_under_it`; the `runnable` split → `an_edit_share_this_install_can_run_says_so_and_counts_the_images_separately`.

The 413 branch is reached through a lowered per-field cap (`TEST_MAX_WORKFLOW_INSPECT_BYTES`), the same thread-local override the LoRA import already uses — the real cap is 512 MiB, which no test wants to send.

`workflow_png.rs` and `tests/workflow_png.rs` are **0-line diffs**; the reader is used as-is and no second parse path was introduced (`the_reader_has_exactly_one_parse_path` still passes).

## How verified

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --workspace --no-fail-fast` — **23 failures, exactly the pre-existing set** (rustls `No provider set` in `sceneworks-mcp` / `sceneworks-rust-api`, sc-15337). The set did not grow; `-p sceneworks-rust-api --lib` is 510 passed / 2 failed, both of them that pre-existing pair.
- `npm run rust:check` — fmt, lint, test, build

## Follow-ups

- **`build_resolution_report` has exactly one production call site today: this endpoint.** Nothing yet reads the envelope sc-15949 stores at `extra.importedWorkflow` back into a report — `the_report_reads_an_imported_assets_stored_envelope` proves the shape round-trips, but it is a test, not a caller. Wiring the import path to the report is **deferred**, not delivered here. The core placement is what makes that wiring a call rather than a reimplementation.
- **sc-15951 / sc-15952** consume this endpoint: the `status` discriminator and `resolution.runnable` / `resolution.inputImagesRequired` / `resolution.omitted` are the contract they branch on, and `ResolutionReport::one_click_replayable()` is the composed condition for the one-click offer.
- `tests/fixtures/rust_migration_contracts/api_surface.json` lists the API surface but has **no automated reader** in either the Rust or Python suites — it is a stale Python-to-Rust migration snapshot, so the new route was not added to it. Worth deciding separately whether it should become a live drift guard or be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
