### PR TITLE
fix(worker): emit typed geometry refusals (SC-15807)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "candle-audio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "libc",
@@ -461,7 +461,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-acestep"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-audio-acestep",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-audio-chatterbox-ve",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-chatterbox-ve"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-clap"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-kokoro"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -550,7 +550,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-mmaudio"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-sfx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-moss-tts-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-openvoice"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-stable-audio-3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "candle-audio-whisper"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio",
  "candle-nn",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "candle-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-qwen-image",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-anima",
@@ -769,7 +769,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -861,7 +861,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-face",
@@ -874,7 +874,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-llm",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -898,7 +898,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-boogu",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux2",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mage"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -957,7 +957,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-flux",
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "image",
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-pid",
@@ -1031,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "candle-gen-wan",
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1079,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1090,7 +1090,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1102,7 +1102,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1112,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-gen",
  "rand 0.9.4",
@@ -1124,7 +1124,7 @@ dependencies = [
 [[package]]
 name = "candle-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-gen",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.2"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "cudaforge",
 ]
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "candle-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-core",
  "candle-nn",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "core-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "minijinja",
  "minijinja-contrib",
@@ -4025,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "memmap2",
  "pmetal-mlx-rs",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-anima"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-bernini"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4065,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-boogu"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-anima",
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-chroma"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-clip"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-depth"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-face"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-flux2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ideogram"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux2",
@@ -4197,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-instantid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-joycaption"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-kolors"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4244,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-krea-realtime"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-lens"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-ltx"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4279,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mage"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-mochi"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-flux",
@@ -4303,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-pulid"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-face",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-qwen-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sam3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4354,7 +4354,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sana"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-pid",
@@ -4364,7 +4364,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-scail2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-wan",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sd3"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sdxl"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4402,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-seedvr2"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "pmetal-mlx-rs",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-sensenova"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-llm",
@@ -4423,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-svd"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "mlx-gen",
  "mlx-gen-sdxl",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-wan"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "mlx-gen-z-image"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "image",
  "mlx-gen",
@@ -4470,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "mlx-llm"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "core-llm",
  "half",
@@ -6064,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "runtime-catalog"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "core-llm",
  "sceneworks-gen-core",
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "runtime-cuda"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio-catalog",
  "candle-gen-catalog",
@@ -6085,7 +6085,7 @@ dependencies = [
 [[package]]
 name = "runtime-macos"
 version = "0.0.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "candle-audio-catalog",
  "mlx-gen-catalog",
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sceneworks-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/SceneWorks/inference?rev=b9e15fedb7d43b74dda913061fd4ddd7d731e6d6#b9e15fedb7d43b74dda913061fd4ddd7d731e6d6"
+source = "git+https://github.com/SceneWorks/inference?rev=8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe#8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe"
 dependencies = [
  "core-llm",
  "safetensors 0.4.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,4 +98,4 @@ all = "warn"
 # (scripts/bump-inference.mjs rewrites both; crates/sceneworks-worker/tests/
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe" }

--- a/crates/sceneworks-memory-adapter/Cargo.toml
+++ b/crates/sceneworks-memory-adapter/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 serde_json = "1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mlx-gen = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6", optional = true }
+mlx-gen = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe", optional = true }
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0", optional = true }
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6", optional = true }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe", optional = true }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-candle-gen = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6", features = ["cuda", "testkit"], optional = true }
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6", optional = true }
+candle-gen = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe", features = ["cuda", "testkit"], optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe", optional = true }
 
 [features]
 default = []

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -34,7 +34,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rusqlite = { version = "0.32", features = ["bundled"] }
 sceneworks-core = { path = "../sceneworks-core" }
 # Backend-neutral inference contracts; pinned with both platform bundles to one canonical commit.
-sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6" }
+sceneworks-gen-core = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
@@ -89,13 +89,13 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # weights, Metal beat CPU in every paired run for both Speech and Voice Clone, at equal-or-lower
 # peak RSS; the exact ratios are not pinned down because the box was under heavy concurrent load
 # (sc-13501 carries the clean numbers).
-runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6", features = ["audio-metal"] }
+runtime-macos = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe", features = ["audio-metal"] }
 # Retained direct dependency: SceneWorks' native person detector uses MLX tensor primitives.
 mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "932beb4e60db44d378ffa1fe648defea59b5cbd0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # Canonical NVIDIA inference composition; enabled only by `backend-candle`.
-runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "b9e15fedb7d43b74dda913061fd4ddd7d731e6d6", optional = true }
+runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe", optional = true }
 # DWPose whole-body pose detection off-Mac (sc-5496, epic 5482) — the Windows/Linux/CUDA sibling of the
 # macOS `ort`/CoreML path (sc-3487). Same RTMW detector (yolox_m + rtmw-dw-x-l) and the same pure
 # pre/post math in `pose_jobs.rs`; only the execution provider differs (CUDA here, CoreML on Mac), with

--- a/crates/sceneworks-worker/src/error.rs
+++ b/crates/sceneworks-worker/src/error.rs
@@ -79,10 +79,56 @@ pub(crate) fn task_join_error(label: &str, error: tokio::task::JoinError) -> Wor
 /// message text INTACT, rather than burying it in an opaque [`WorkerError::Engine`]. Everything else
 /// stays [`WorkerError::Engine`]. `context` prefixes the message so the origin (load vs generate)
 /// stays legible, matching the existing `format!("{context}: {error}")` seams.
+fn geometry_refusal_event(
+    context: &str,
+    reason: &str,
+    requested_width: u32,
+    requested_height: u32,
+    alternative: Option<(u32, u32)>,
+) -> Value {
+    json!({
+        "event": "generation_geometry_refused",
+        "context": context,
+        "refusalReason": reason,
+        "requestedGeometry": {
+            "width": requested_width,
+            "height": requested_height,
+        },
+        "verifiedAlternative": alternative
+            .map(|(width, height)| json!({ "width": width, "height": height })),
+    })
+}
+
 pub(crate) fn classify_engine_error(context: &str, error: gen_core::Error) -> WorkerError {
     match error {
         gen_core::Error::Unsupported(_) => {
             WorkerError::InvalidPayload(format!("{context}: {error}"))
+        }
+        gen_core::Error::GeometryRefused {
+            reason,
+            requested_width,
+            requested_height,
+            alternative,
+        } => {
+            emit_event_value(
+                Level::WARN,
+                geometry_refusal_event(
+                    context,
+                    &reason,
+                    requested_width,
+                    requested_height,
+                    alternative,
+                ),
+            );
+            let verified_alternative = alternative.map_or_else(
+                || "none available".to_owned(),
+                |(width, height)| format!("{width}x{height}"),
+            );
+            WorkerError::InvalidPayload(format!(
+                "{context}: geometry refused: {reason}; requested \
+                 {requested_width}x{requested_height}; verified alternative: \
+                 {verified_alternative}"
+            ))
         }
         other => WorkerError::Engine(format!("{context}: {other}")),
     }
@@ -93,6 +139,40 @@ pub type WorkerResult<T> = Result<T, WorkerError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing::{Event, Subscriber};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::Layer;
+
+    #[derive(Default)]
+    struct PayloadVisitor {
+        payload: Option<Value>,
+    }
+
+    impl Visit for PayloadVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            if field.name() == "sw_payload" {
+                self.payload = serde_json::from_str(&format!("{value:?}")).ok();
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct EventCapture(Arc<Mutex<Vec<(Level, Value)>>>);
+
+    impl<S: Subscriber> Layer<S> for EventCapture {
+        fn on_event(&self, event: &Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = PayloadVisitor::default();
+            event.record(&mut visitor);
+            if let Some(payload) = visitor.payload {
+                self.0
+                    .lock()
+                    .expect("event capture lock")
+                    .push((*event.metadata().level(), payload));
+            }
+        }
+    }
 
     // sc-10051 / epic 10043: at the new mlx-gen rev, the Wan load path rejects a LoHa adapter on a
     // packed (quantized) base with a typed `gen_core::Error::Unsupported` carrying an actionable
@@ -140,5 +220,39 @@ mod tests {
             matches!(classified, WorkerError::Engine(_)),
             "a generic engine failure must stay WorkerError::Engine, got {classified:?}"
         );
+    }
+
+    #[test]
+    fn geometry_refusal_emits_current_none_alternative_and_preserves_user_fields() {
+        let captured = EventCapture::default();
+        let observed = captured.0.clone();
+        let subscriber = tracing_subscriber::registry().with(captured);
+        let classified = tracing::subscriber::with_default(subscriber, || {
+            classify_engine_error(
+                "Krea control generation failed",
+                gen_core::Error::GeometryRefused {
+                    reason: "measured infeasible".to_owned(),
+                    requested_width: 1536,
+                    requested_height: 1024,
+                    alternative: None,
+                },
+            )
+        });
+
+        let events = observed.lock().expect("event capture lock");
+        assert_eq!(events.len(), 1, "the refusal must emit exactly one event");
+        let (level, event) = &events[0];
+        assert_eq!(*level, Level::WARN);
+        assert_eq!(event["event"], "generation_geometry_refused");
+        assert_eq!(event["refusalReason"], "measured infeasible");
+        assert_eq!(event["requestedGeometry"]["width"], 1536);
+        assert_eq!(event["requestedGeometry"]["height"], 1024);
+        assert_eq!(event["verifiedAlternative"], Value::Null);
+
+        let WorkerError::InvalidPayload(message) = classified else {
+            panic!("typed geometry refusal must be user-facing: {classified:?}");
+        };
+        assert!(message.contains("requested 1536x1024"));
+        assert!(message.contains("verified alternative: none available"));
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/krea_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control.rs
@@ -344,7 +344,9 @@ fn krea_control_generate_one(
     };
     let output = generator
         .generate(&request, on_progress)
-        .map_err(|error| WorkerError::Engine(format!("Krea control generation failed: {error}")))?;
+        .map_err(|error| {
+            crate::classify_engine_error("Krea control generation failed", error)
+        })?;
     match output {
         GenerationOutput::Images(mut images) => {
             let image = images.pop().ok_or_else(|| {

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -638,15 +638,31 @@ pub(super) async fn generate_candle_krea_control_stream(
             needed_gb,
             available_gb,
         } => {
-            return Err(WorkerError::InvalidPayload(format!(
-                "Krea 2 pose-ControlNet at the {tier} base tier needs ~{needed} GB of VRAM (with \
-                 headroom, sequential residency + tiled VAE decode + attention chunking) but \
-                 GPU {gpu} has ~{available} GB available. Lower the output resolution or run on a card \
-                 with more VRAM.",
-                needed = needed_gb.round() as i64,
-                available = available_gb.round() as i64,
-                gpu = settings.gpu_id,
-            )));
+            // There is no current exact-geometry alternative record for this control lane (SC-16013
+            // owns remeasurement after the branch repack), so do not turn peak arithmetic into a
+            // claimed alternative. The typed refusal and its structured fields are the worker/API
+            // telemetry surface SC-15613 can consume.
+            let refusal =
+                crate::krea_control_fit::geometry_refusal(request.width, request.height, None);
+            crate::emit_event_value(
+                tracing::Level::WARN,
+                json!({
+                    "event": "krea_control_geometry_refused",
+                    "refusalReason": refusal.reason,
+                    "requestedGeometry": {
+                        "width": refusal.requested_width,
+                        "height": refusal.requested_height,
+                    },
+                    "verifiedAlternative": refusal
+                        .verified_alternative
+                        .map(|(width, height)| json!({ "width": width, "height": height })),
+                    "neededGb": needed_gb,
+                    "availableGb": available_gb,
+                    "gpuId": settings.gpu_id,
+                    "tier": tier,
+                }),
+            );
+            return Err(WorkerError::InvalidPayload(refusal.to_string()));
         }
     };
     // sc-13960: record the admitted control peak so a repeated control render (or a following

--- a/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_control_candle.rs
@@ -638,31 +638,14 @@ pub(super) async fn generate_candle_krea_control_stream(
             needed_gb,
             available_gb,
         } => {
-            // There is no current exact-geometry alternative record for this control lane (SC-16013
-            // owns remeasurement after the branch repack), so do not turn peak arithmetic into a
-            // claimed alternative. The typed refusal and its structured fields are the worker/API
-            // telemetry surface SC-15613 can consume.
-            let refusal =
-                crate::krea_control_fit::geometry_refusal(request.width, request.height, None);
-            crate::emit_event_value(
-                tracing::Level::WARN,
-                json!({
-                    "event": "krea_control_geometry_refused",
-                    "refusalReason": refusal.reason,
-                    "requestedGeometry": {
-                        "width": refusal.requested_width,
-                        "height": refusal.requested_height,
-                    },
-                    "verifiedAlternative": refusal
-                        .verified_alternative
-                        .map(|(width, height)| json!({ "width": width, "height": height })),
-                    "neededGb": needed_gb,
-                    "availableGb": available_gb,
-                    "gpuId": settings.gpu_id,
-                    "tier": tier,
-                }),
-            );
-            return Err(WorkerError::InvalidPayload(refusal.to_string()));
+            return Err(WorkerError::InvalidPayload(format!(
+                "Krea 2 pose-ControlNet at the {tier} base tier needs ~{needed} GB of VRAM (with \
+                 headroom, sequential residency + tiled VAE decode + attention chunking) but \
+                 GPU {gpu} has ~{available} GB available. Run on a card with more VRAM.",
+                needed = needed_gb.round() as i64,
+                available = available_gb.round() as i64,
+                gpu = settings.gpu_id,
+            )));
         }
     };
     // sc-13960: record the admitted control peak so a repeated control render (or a following

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1,23 +1,16 @@
 use super::*;
 
 #[test]
-fn krea_control_geometry_refusal_is_structured_and_never_suggests_an_unverified_size() {
-    let fit = include_str!("../krea_control_fit.rs");
-    let worker = include_str!("krea_control_candle.rs");
-    assert!(fit.contains("pub(crate) struct KreaGeometryRefusal"));
-    assert!(fit.contains("requested_width"));
-    assert!(fit.contains("requested_height"));
-    assert!(fit.contains("verified_alternative"));
-    assert!(worker.contains("\"event\": \"krea_control_geometry_refused\""));
-    assert!(worker.contains("\"refusalReason\": refusal.reason"));
-    assert!(worker.contains("\"requestedGeometry\""));
-    assert!(worker.contains("\"width\": refusal.requested_width"));
-    assert!(worker.contains("\"height\": refusal.requested_height"));
-    assert!(worker.contains("\"verifiedAlternative\": refusal"));
+fn krea_control_refusal_paths_preserve_provider_fields_and_never_invent_geometry_advice() {
+    let mlx = include_str!("krea_control.rs");
+    assert!(mlx.contains("crate::classify_engine_error(\"Krea control generation failed\", error)"));
+
+    let candle = include_str!("krea_control_candle.rs");
     assert!(
-        !worker.contains("Lower the output resolution"),
-        "control refusal must not name a geometry or strategy without a current verified record"
+        !candle.contains("Lower the output resolution"),
+        "tier-only Candle fit evidence must not be relabeled as geometry evidence"
     );
+    assert!(!candle.contains("krea_control_geometry_refused"));
 }
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use super::{

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -1,4 +1,24 @@
 use super::*;
+
+#[test]
+fn krea_control_geometry_refusal_is_structured_and_never_suggests_an_unverified_size() {
+    let fit = include_str!("../krea_control_fit.rs");
+    let worker = include_str!("krea_control_candle.rs");
+    assert!(fit.contains("pub(crate) struct KreaGeometryRefusal"));
+    assert!(fit.contains("requested_width"));
+    assert!(fit.contains("requested_height"));
+    assert!(fit.contains("verified_alternative"));
+    assert!(worker.contains("\"event\": \"krea_control_geometry_refused\""));
+    assert!(worker.contains("\"refusalReason\": refusal.reason"));
+    assert!(worker.contains("\"requestedGeometry\""));
+    assert!(worker.contains("\"width\": refusal.requested_width"));
+    assert!(worker.contains("\"height\": refusal.requested_height"));
+    assert!(worker.contains("\"verifiedAlternative\": refusal"));
+    assert!(
+        !worker.contains("Lower the output resolution"),
+        "control refusal must not name a geometry or strategy without a current verified record"
+    );
+}
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use super::{
     flux1_control_candle::*, flux2_comfyui_candle::*, flux2_control_candle::*,

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -112,11 +112,75 @@
 use super::*;
 use gen_core::{OffloadPolicy, Quant};
 use serde_json::Value;
+use std::fmt;
 
 /// Fixed transient/runtime headroom (GB) added on top of the control-lane peak
 /// ([`predicted_control_peak_gb`]), mirroring [`crate::vram_gate`]'s `HEADROOM_GB` — covers allocator
 /// slack + activation spikes not captured by the steady peak.
 const HEADROOM_GB: f64 = 2.0;
+
+/// Typed pre-render refusal for an output geometry. An alternative may be attached only after the
+/// caller has validated a current, exact evidence record; absence is truthful and preferable to
+/// inventing a geometry from a peak estimate.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct KreaGeometryRefusal {
+    pub(crate) reason: &'static str,
+    pub(crate) requested_width: u32,
+    pub(crate) requested_height: u32,
+    pub(crate) verified_alternative: Option<(u32, u32)>,
+}
+
+impl fmt::Display for KreaGeometryRefusal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "Krea 2 pose-ControlNet cannot render the requested {}x{} geometry: {}.",
+            self.requested_width, self.requested_height, self.reason
+        )?;
+        match self.verified_alternative {
+            Some((width, height)) => write!(
+                formatter,
+                " A current measurement verifies {}x{} as an alternative.",
+                width, height
+            ),
+            None => formatter.write_str(
+                " No current verified alternative geometry is available; choose a geometry the UI \
+                 marks verified or use hardware with a verified fit.",
+            ),
+        }
+    }
+}
+
+pub(crate) fn geometry_refusal(
+    requested_width: u32,
+    requested_height: u32,
+    verified_alternative: Option<(u32, u32)>,
+) -> KreaGeometryRefusal {
+    KreaGeometryRefusal {
+        reason: "the current measured feasibility gate rejects it before render",
+        requested_width,
+        requested_height,
+        verified_alternative,
+    }
+}
+
+#[cfg(test)]
+mod geometry_refusal_tests {
+    use super::*;
+
+    #[test]
+    fn refusal_telemetry_preserves_request_and_never_invents_an_alternative() {
+        let refusal = geometry_refusal(1536, 1024, None);
+        assert_eq!(
+            (refusal.requested_width, refusal.requested_height),
+            (1536, 1024)
+        );
+        assert_eq!(refusal.verified_alternative, None);
+        let message = refusal.to_string();
+        assert!(message.contains("1536x1024"));
+        assert!(message.contains("No current verified alternative geometry"));
+    }
+}
 
 /// The outcome of walking the Krea control fit ladder. `Unknown` = no signal (no `candle.control` block,
 /// or a non-NVIDIA host) ⇒ never block — exactly like [`crate::vram_gate::FitDecision::Unknown`].

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -112,75 +112,11 @@
 use super::*;
 use gen_core::{OffloadPolicy, Quant};
 use serde_json::Value;
-use std::fmt;
 
 /// Fixed transient/runtime headroom (GB) added on top of the control-lane peak
 /// ([`predicted_control_peak_gb`]), mirroring [`crate::vram_gate`]'s `HEADROOM_GB` — covers allocator
 /// slack + activation spikes not captured by the steady peak.
 const HEADROOM_GB: f64 = 2.0;
-
-/// Typed pre-render refusal for an output geometry. An alternative may be attached only after the
-/// caller has validated a current, exact evidence record; absence is truthful and preferable to
-/// inventing a geometry from a peak estimate.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct KreaGeometryRefusal {
-    pub(crate) reason: &'static str,
-    pub(crate) requested_width: u32,
-    pub(crate) requested_height: u32,
-    pub(crate) verified_alternative: Option<(u32, u32)>,
-}
-
-impl fmt::Display for KreaGeometryRefusal {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "Krea 2 pose-ControlNet cannot render the requested {}x{} geometry: {}.",
-            self.requested_width, self.requested_height, self.reason
-        )?;
-        match self.verified_alternative {
-            Some((width, height)) => write!(
-                formatter,
-                " A current measurement verifies {}x{} as an alternative.",
-                width, height
-            ),
-            None => formatter.write_str(
-                " No current verified alternative geometry is available; choose a geometry the UI \
-                 marks verified or use hardware with a verified fit.",
-            ),
-        }
-    }
-}
-
-pub(crate) fn geometry_refusal(
-    requested_width: u32,
-    requested_height: u32,
-    verified_alternative: Option<(u32, u32)>,
-) -> KreaGeometryRefusal {
-    KreaGeometryRefusal {
-        reason: "the current measured feasibility gate rejects it before render",
-        requested_width,
-        requested_height,
-        verified_alternative,
-    }
-}
-
-#[cfg(test)]
-mod geometry_refusal_tests {
-    use super::*;
-
-    #[test]
-    fn refusal_telemetry_preserves_request_and_never_invents_an_alternative() {
-        let refusal = geometry_refusal(1536, 1024, None);
-        assert_eq!(
-            (refusal.requested_width, refusal.requested_height),
-            (1536, 1024)
-        );
-        assert_eq!(refusal.verified_alternative, None);
-        let message = refusal.to_string();
-        assert!(message.contains("1536x1024"));
-        assert!(message.contains("No current verified alternative geometry"));
-    }
-}
 
 /// The outcome of walking the Krea control fit ladder. `Unknown` = no signal (no `candle.control` block,
 /// or a non-NVIDIA host) ⇒ never block — exactly like [`crate::vram_gate::FitDecision::Unknown`].


### PR DESCRIPTION
## Summary
- pin all inference dependencies to paired PR head `8a5aeb2ef0f54804f88d6a61a0c9abbd6c6a3dbe`
- route MLX Krea control generation errors through the typed worker classifier
- emit `generation_geometry_refused` at WARN with refusal reason, requested geometry, and `verifiedAlternative`
- preserve the current truthful `alternative: None` as telemetry `null` and user-facing `none available`
- keep the Candle tier-only VRAM fit rejection ordinary; it does not claim geometry evidence and no longer suggests unverified lower resolution

## Blocking acceptance gap
**Draft / not ready to merge.** SC-15807 requires a refusal to name an alternative with current VERIFIED evidence. The shipped Krea control evidence is superseded (`candle.control.measured == false`), SC-16013 owns remeasurement, and no current exact-geometry Verified record exists. Keep this PR draft until authoritative evidence supplies a verified alternative.

## Validation
- `cargo test --locked -p sceneworks-worker error::tests --lib` (3 passed)
- `cargo test --locked -p sceneworks-worker krea_control_refusal_paths_preserve_provider_fields_and_never_invent_geometry_advice --lib` (passed)
- `cargo clippy --locked -p sceneworks-worker --all-targets -- -D warnings`
- `npm run rust:check:candle` (off-Mac candle worker clippy and rust-api check green)
- mutation proof: bypassing `emit_event_value` makes the focused telemetry-capture test fail with zero observed events; restored and green

Paired inference draft: https://github.com/SceneWorks/inference/pull/333
Shortcut: SC-15807
