### PR TITLE
fix(docker): copy the embedded calibration evidence into the Rust build context (sc-16080)

### DIFF
--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -79,6 +79,20 @@ COPY apps/desktop/build.rs ./apps/desktop/build.rs
 # so the API can seed an empty config dir, which means they must exist in the
 # build context (not just the runtime bind mount) or the compile can't read them.
 COPY config ./config
+# Same constraint, second source (sc-16080): `sceneworks-core::memory_calibration`
+# embeds the generated calibration evidence via `include_str!`, and that embed is NOT
+# test-gated, so a release build of the API cannot compile without it.
+#
+# Deliberately the single embedded FILE rather than `docs/generated`: that directory
+# also holds `memory-matrix.json`, which is regenerated and re-hashed by any change to
+# the selector's source, so copying the directory would invalidate this layer and
+# rebuild the whole Rust graph on edits the image does not depend on.
+#
+# Every `include_str!`/`include_bytes!` that reaches outside its crate needs a line
+# here, or the Docker build breaks while `cargo build` on a checkout stays green — the
+# two see different trees. Embeds inside `mod tests` are exempt: this stage builds
+# `--release` without tests.
+COPY docs/generated/memory-calibration-evidence.json ./docs/generated/
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
**`main` is red and has been for three commits.** The parity lane's *Smoke default Rust API Docker runtime* step has failed on every push since `6647be62` ([#1971](https://github.com/SceneWorks/SceneWorks/pull/1971), sc-16080); `f5c05c0e` before it was the last green one.

```
error: couldn't read `crates/sceneworks-core/src/../../../docs/generated/memory-calibration-evidence.json`:
       No such file or directory (os error 2)
  --> crates/sceneworks-core/src/memory_calibration.rs:23
```

`sceneworks-core::memory_calibration` embeds that file via `include_str!`, and `docker/rust.Dockerfile` copies `crates`, `apps` and `config` — but not `docs`. So the API image cannot compile.

This is the second instance of a class the Dockerfile already handles once: `COPY config ./config` carries a comment explaining that `sceneworks-core` embeds the builtin manifests and they must exist in the *build context*, not just the runtime bind mount. This adds the sibling line and extends that comment to state the general rule.

## Why this was invisible until it hit main

A checkout build and the Docker build see different trees. `cargo build`, `cargo clippy` and every test lane compile against the full repo, where the file is present — so none of them can observe this. Only the Docker smoke can. PR runs that don't trigger that step pass cleanly and merge, and main goes red on push.

## Scope: one file, not a directory — both halves verified

`sceneworks-core` has two other out-of-crate embeds, `documents/ideogram-style-injection.fixtures.json` and `documents/style-composer.fixtures.json`. Both sit inside `mod tests`, and this stage builds `--release` without tests, so neither is needed. Checked rather than assumed — otherwise the safe-looking move is to copy several directories that are never read.

And deliberately the single **file** rather than `docs/generated`: that directory also holds `memory-matrix.json`, which is regenerated and re-hashed by *any* change to the selector's source. Copying the directory would invalidate this layer and rebuild the whole Rust dependency graph on edits the image doesn't depend on.

## Verification

**Not verified locally** — the Docker build requires the `inference_token` build secret, which is CI-only. CI is the verification here, and I'd rather say that than imply a green I didn't get. The failure mode is unambiguous (a missing path in the build context) and the fix mirrors an existing, working line four lines above it.

## Provenance

Found while landing the sc-16090 inference pin bump ([#1976](https://github.com/SceneWorks/SceneWorks/pull/1976)), which inherited the failure. Fixed here rather than inside that PR: main is broken for everyone, and a one-line build-context fix shouldn't be buried in a dependency bump. #1976 rebases onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)