### PR TITLE
feat(workflow-share): drop a shared image anywhere → "Workflow found" → prefill Image Studio (sc-15951)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -29,6 +29,8 @@ import { usePersonTracks } from "./hooks/usePersonTracks.js";
 import { useTimelines } from "./hooks/useTimelines.js";
 import { useAccessGate } from "./hooks/useAccessGate.js";
 import { useDropNavigationGuard } from "./hooks/useDropNavigationGuard.js";
+import { useWorkflowDrop } from "./hooks/useWorkflowDrop.js";
+import { WorkflowDropPanel } from "./components/WorkflowDropPanel.jsx";
 import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { ScreenActiveContext } from "./context/ScreenActiveContext.js";
@@ -683,9 +685,9 @@ export function App() {
     saveToken,
     lockRemote,
   } = useAccessGate({ setError, pushNotice, dismissNoticeKind });
-  // Stop a file dropped outside a real dropzone from navigating the webview to
-  // the image and replacing the whole UI (issue #1308).
-  useDropNavigationGuard();
+  // The drop guard that stops a stray file from navigating the webview (issue #1308) is
+  // installed further down, next to `useWorkflowDrop` — it now hands the unclaimed file to
+  // the workflow inspector (sc-15951), which needs the active project and `importAsset`.
   const [theme, setTheme] = useState(readStoredTheme);
   // Apply a theme and persist it through the API. localStorage gives an instant
   // initial paint, but on the desktop shell the UI runs at the API's per-launch
@@ -2393,6 +2395,41 @@ export function App() {
     return asset?.generationSet?.recipe ?? asset?.recipe ?? null;
   }
 
+  // THE prefill path into Image Studio (sc-15951). Every caller that wants the studio's form
+  // populated from a recorded recipe goes through here — the viewer's "Use this recipe" below,
+  // and the dropped-image "Use this workflow" — so there is one launch shape, one hydration
+  // race guard, and one injection effect on the other side (`screens/ImageStudio.jsx`). A second
+  // parallel prefill would drift from this one the first time the recipe shape changed.
+  //
+  // `assetId` / `sourceAssetId` are null for a launch with no asset behind it, which is exactly
+  // the dropped-file case: the studio's edit branch then leaves its source picker empty rather
+  // than pointing at an image this install does not have.
+  async function launchImageRecipe({
+    recipe,
+    replaySeed = null,
+    assetId = null,
+    sourceAssetId = null,
+  }) {
+    if (!recipe) {
+      return false;
+    }
+    const projectId = activeProjectRef.current?.id;
+    setActiveView("Image");
+    const hydration = await stableHydrateLaunchDomains("Image", projectId);
+    if (hydration?.ok !== true || activeProjectRef.current?.id !== projectId) {
+      return false;
+    }
+    setStudioLaunch({
+      id: crypto.randomUUID(),
+      view: "Image",
+      assetId,
+      sourceAssetId,
+      recipe,
+      replaySeed,
+    });
+    return true;
+  }
+
   async function sendAssetRecipeToImage(asset, options = {}) {
     const recipe = recipeForAsset(asset);
     if (!asset || !recipe) {
@@ -2404,21 +2441,13 @@ export function App() {
     // Null → Image Studio leaves the seed random (a close variation), the default.
     const seed = assetSeed(asset);
     const replaySeed = options.keepSeed && seed != null && seed !== "" ? seed : null;
-    const projectId = activeProjectRef.current?.id;
     setSelectedAssetId(asset.id);
     closePreview();
-    setActiveView("Image");
-    const hydration = await stableHydrateLaunchDomains("Image", projectId);
-    if (hydration?.ok !== true || activeProjectRef.current?.id !== projectId) {
-      return;
-    }
-    setStudioLaunch({
-      id: crypto.randomUUID(),
-      view: "Image",
-      assetId: asset.id,
-      sourceAssetId: asset.lineage?.sourceAssetId ?? null,
+    await launchImageRecipe({
       recipe,
       replaySeed,
+      assetId: asset.id,
+      sourceAssetId: asset.lineage?.sourceAssetId ?? null,
     });
   }
 
@@ -2748,6 +2777,41 @@ export function App() {
       }
     },
     [activeProject, setError, token],
+  );
+
+  // Drop a shared image anywhere → "Workflow found" → prefill Image Studio (sc-15951).
+  //
+  // The guard below is the unchanged issue-#1308 fallback: it swallows any drag no in-app
+  // dropzone claimed so the webview cannot navigate to the file. The only addition is that an
+  // unclaimed drop of exactly one file is now also offered to the inspector, on that SAME
+  // "nothing else claimed it" branch — the five real dropzones (AssetPicker, the Image Editor
+  // canvas, DatasetAddDialog, DocumentStudio, PoseLibraryScreen) each preventDefault() as the
+  // event bubbles through them, so their drops never reach either behaviour.
+  //
+  // `launchRecipe` is `launchImageRecipe`, the same seam the viewer's "Use this recipe" uses.
+  // `importAsset` is the ordinary upload path, which is what records `extra.importedWorkflow`
+  // on the asset (sc-15949).
+  const workflowDrop = useWorkflowDrop({
+    // Inspecting needs a live, authenticated API. Before the gate opens every request 401s, and
+    // a drop on the login screen has nothing to prefill anyway.
+    enabled: gateStatus === "open",
+    projectId: activeProject?.id ?? null,
+    token,
+    importAsset,
+    launchRecipe: launchImageRecipe,
+  });
+  useDropNavigationGuard({ onUnclaimedFileDrop: workflowDrop.handleDroppedFile });
+  // Rendered from a single place even though the app has two shells: `Modal` portals to
+  // <body>, so this element does not have to sit inside whichever shell is on screen.
+  const workflowDropPanel = (
+    <WorkflowDropPanel
+      canImport={Boolean(activeProject)}
+      importState={workflowDrop.importState}
+      offer={workflowDrop.offer}
+      onDismiss={workflowDrop.dismiss}
+      onImport={workflowDrop.importImage}
+      onUse={workflowDrop.useWorkflow}
+    />
   );
 
   const jobAction = useCallback(
@@ -3175,6 +3239,11 @@ export function App() {
             preferencesHydrated={navigationHydrated}
             simpleDefault={simpleUiDefault}
           />
+          {/* The dropped-workflow offer (sc-15951). The drop guard is installed at App level
+              and therefore runs in BOTH shells, so the panel it opens has to render in both
+              too — otherwise a Simple-UI user's drop would be inspected and then answered by
+              nothing. It portals to <body>, so it does not disturb this shell's layout. */}
+          {workflowDropPanel}
         </AppLiveContext.Provider>
       </AppStaticContext.Provider>
     );
@@ -3457,6 +3526,11 @@ export function App() {
           navTo — resolve through a real React dialog instead of window.confirm (which
           silently no-ops in the Tauri WebView). Renders nothing until a confirm is asked. */}
       <ConfirmHost />
+
+      {/* "Workflow found" (sc-15951) — opened by a drop no in-app dropzone claimed, and only
+          after the file turned out to carry a recipe. Renders nothing otherwise, which is the
+          common case for every image that did not come from SceneWorks. */}
+      {workflowDropPanel}
     </main>
     </AppLiveContext.Provider>
     </AppStaticContext.Provider>

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2404,6 +2404,11 @@ export function App() {
   // `assetId` / `sourceAssetId` are null for a launch with no asset behind it, which is exactly
   // the dropped-file case: the studio's edit branch then leaves its source picker empty rather
   // than pointing at an image this install does not have.
+  //
+  // Returns `{ ok }`, plus a `reason` when it refused, because "the launch went nowhere" and "the
+  // launch cannot go anywhere from here" need different answers on the other side: the first is a
+  // race the caller should close its panel over, the second is a control the caller must not
+  // pretend worked.
   async function launchImageRecipe({
     recipe,
     replaySeed = null,
@@ -2411,13 +2416,29 @@ export function App() {
     sourceAssetId = null,
   }) {
     if (!recipe) {
-      return false;
+      return { ok: false, reason: "no-recipe" };
+    }
+    // The Simple shell renders its OWN studios and consumes no `studioLaunch`, so from in there
+    // `setActiveView("Image")` alone points the workspace at a screen nobody is looking at: the
+    // panel dismisses, nothing visible happens, and the launch sits queued to fire unprompted the
+    // next time the user opens the Advanced studio. Flip the shell the way `SimpleShell`'s own
+    // `openInAdvanced` does — and refuse for the same reason it does when the viewport has Simple
+    // locked on, because there is no Advanced workspace to land in at that width.
+    if (uiMode === SIMPLE_MODE) {
+      if (uiModeLocked) {
+        return {
+          ok: false,
+          reason: "locked",
+          detail: "That opens in the Advanced workspace — switch on a larger screen.",
+        };
+      }
+      setUiModeOverride(ADVANCED_MODE);
     }
     const projectId = activeProjectRef.current?.id;
     setActiveView("Image");
     const hydration = await stableHydrateLaunchDomains("Image", projectId);
     if (hydration?.ok !== true || activeProjectRef.current?.id !== projectId) {
-      return false;
+      return { ok: false, reason: "raced" };
     }
     setStudioLaunch({
       id: crypto.randomUUID(),
@@ -2427,7 +2448,7 @@ export function App() {
       recipe,
       replaySeed,
     });
-    return true;
+    return { ok: true };
   }
 
   async function sendAssetRecipeToImage(asset, options = {}) {

--- a/apps/web/src/App.workflowDropLaunch.test.jsx
+++ b/apps/web/src/App.workflowDropLaunch.test.jsx
@@ -1,0 +1,181 @@
+// "Use this workflow" has to LAND somewhere, from either shell (sc-15951, epic 15945).
+//
+// The drop guard is installed at App level and therefore runs in BOTH shells, which is why the
+// offer panel renders in both. But `SimpleShell` renders its own studios and consumes no
+// `studioLaunch`, so pointing the workspace at "Image" from in there is invisible: the panel
+// dismissed, nothing happened, and the launch sat queued to fire unprompted the next time the user
+// opened the Advanced studio. This suite pins the two halves of the fix — the shell flip, and the
+// refusal on a viewport that has Simple locked on, where there is no Advanced workspace to reach.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./main.jsx";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+import { resetStartupTimingForTests } from "./startupTiming.js";
+
+const PNG_HEAD = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+const MODEL = {
+  id: "krea_2_turbo",
+  name: "Krea 2 Turbo",
+  type: "image",
+  family: "krea2",
+  capabilities: ["text_to_image"],
+  installState: "installed",
+  defaults: { resolution: "1024x1024" },
+  limits: { resolutions: ["1024x1024"] },
+  loraCompatibility: {},
+  ui: {},
+};
+
+const INSPECT_BODY = {
+  status: "workflow",
+  workflow: {
+    sceneworksWorkflow: "image",
+    schemaVersion: 1,
+    producer: { name: "SceneWorks", url: "https://example.invalid", version: "0.8.1" },
+    mode: "text_to_image",
+    model: "krea_2_turbo",
+    prompt: "a lighthouse in heavy fog, cinematic",
+    negativePrompt: "",
+    seed: 880412,
+    width: 1024,
+    height: 1024,
+    count: 1,
+    advanced: { steps: 28 },
+  },
+  resolution: {
+    model: {
+      slug: "krea_2_turbo",
+      state: "resolved",
+      catalogId: "krea_2_turbo",
+      name: "Krea 2 Turbo",
+      detail: "Krea 2 Turbo is installed on this machine.",
+    },
+    loras: [],
+    styles: [],
+    inputs: [],
+    omitted: [],
+    runnable: true,
+    inputImagesRequired: 0,
+  },
+};
+
+function pngFile() {
+  return new File([new Uint8Array([...PNG_HEAD, 1, 2, 3, 4])], "shared.png", { type: "image/png" });
+}
+
+describe("App — a dropped workflow launches from either shell", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    // Open in the Simple shell, the way a user who ticked "Use Simple UI by default" does.
+    window.localStorage.setItem("sceneworks-simple-ui-default", "true");
+    window.innerWidth = 1440;
+    global.fetch = vi.fn((url) => {
+      const path = new URL(url, "http://localhost").pathname;
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) {
+        return Promise.resolve(response({ authRequired: false }));
+      }
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
+      if (path.endsWith("/ui-preferences")) {
+        return Promise.resolve(response({}));
+      }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([MODEL]));
+      }
+      if (path.endsWith("/workflows/inspect")) {
+        return Promise.resolve(response(INSPECT_BODY));
+      }
+      return Promise.resolve(response([]));
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container.remove();
+    resetStartupTimingForTests();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function renderApp() {
+    root = createRoot(container);
+    await act(async () => root.render(<App />));
+    await settle();
+  }
+
+  // A drop nothing in the tree claims — the same window-level branch the issue-#1308 guard has
+  // always used.
+  async function dropOnNeutralChrome() {
+    const event = new Event("drop", { bubbles: true, cancelable: true });
+    event.dataTransfer = { dropEffect: "copy", files: [pngFile()], types: ["Files"] };
+    await act(async () => {
+      document.body.dispatchEvent(event);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    await settle();
+  }
+
+  const buttonByLabel = (label) =>
+    [...document.body.querySelectorAll("button")].find(
+      (node) => node.textContent.trim() === label,
+    );
+  const click = async (node) => {
+    await act(async () => node.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    await settle();
+  };
+
+  it("flips the Simple shell to the Advanced workspace and applies the recipe there", async () => {
+    await renderApp();
+    expect(container.querySelector(".su-root")).toBeTruthy();
+
+    await dropOnNeutralChrome();
+    const use = buttonByLabel("Use this workflow");
+    expect(use).toBeTruthy();
+
+    await click(use);
+
+    // The Simple shell is gone and the full workspace is on screen — without the flip this stayed
+    // on Simple and the launch sat queued for whenever the user next opened Advanced.
+    expect(container.querySelector(".su-root")).toBeNull();
+    expect(container.querySelector("main.app")).toBeTruthy();
+    // …and the recipe actually landed: the studio's prompt box holds the shared prompt.
+    const prompt = [...container.querySelectorAll("textarea")].find((node) =>
+      node.value.includes("a lighthouse in heavy fog"),
+    );
+    expect(prompt).toBeTruthy();
+    expect(document.body.querySelector(".workflow-drop-modal")).toBeNull();
+  });
+
+  it("refuses, and says why, on a viewport that has Simple locked on", async () => {
+    // A phone has no Advanced workspace to land in (the full workspace is unusable at that width),
+    // so the honest answer is a refusal with a reason — not a dismissed panel over a button that
+    // did nothing, and not a launch queued to fire unprompted somewhere else.
+    window.innerWidth = 375;
+    await renderApp();
+    await dropOnNeutralChrome();
+
+    await click(buttonByLabel("Use this workflow"));
+
+    expect(document.body.querySelector(".workflow-drop-modal")).toBeTruthy();
+    expect(document.body.textContent).toContain("switch on a larger screen");
+    expect(container.querySelector(".su-root")).toBeTruthy();
+  });
+});

--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -172,3 +172,25 @@ export function withMediaTicket(url) {
   }
   return `${url}${url.includes("?") ? "&" : "?"}ticket=${encodeURIComponent(mediaTicket)}`;
 }
+
+// ---- Workflow inspect (sc-15950 / sc-15951) -------------------------------------
+// Read a file's embedded workflow WITHOUT importing it: no asset, no job, no project
+// mutation. `projectId` is optional and only widens the LoRA/preset lookups the
+// resolution report is built against.
+//
+// Resolves to `{ status, workflow, resolution, detail }` — branch on `status`, since
+// `workflow`/`resolution` are always present and are `null` for `no_workflow`, which is
+// the common case for any image that did not come from SceneWorks.
+//
+// Failures arrive as the usual `ApiError`. A malformed multipart is rejected by axum
+// with a PLAIN-TEXT body and no `code`; `apiFetch` already degrades a non-JSON body to
+// `payload = null`, so such a rejection surfaces as a status with `code === undefined`
+// rather than throwing inside the parse.
+export async function inspectWorkflowFile(file, { projectId, token, signal } = {}) {
+  const body = new FormData();
+  body.append("file", file);
+  if (projectId) {
+    body.append("projectId", projectId);
+  }
+  return apiFetch("/api/v1/workflows/inspect", token, { method: "POST", body, signal });
+}

--- a/apps/web/src/components/WorkflowDropPanel.jsx
+++ b/apps/web/src/components/WorkflowDropPanel.jsx
@@ -1,0 +1,155 @@
+import React from "react";
+
+import { Modal } from "./Modal.jsx";
+import { WorkflowResolutionReport } from "./WorkflowResolutionReport.jsx";
+import {
+  workflowModeLabel,
+  workflowResolutionLabel,
+  workflowSettingRows,
+} from "../workflowShare.js";
+
+// "Workflow found" — the offer an unclaimed image drop opens when the file turned out to carry a
+// SceneWorks recipe (sc-15951, epic 15945).
+//
+// Shows what is actually in the file, then what this install can do with it
+// (`WorkflowResolutionReport`, which sc-15952 reuses), then three actions. It is opened only
+// after a workflow has been read, so there is no loading state here by design: an image with no
+// workflow — every foreign PNG — never reaches this component at all.
+
+function Field({ label, children }) {
+  return (
+    <div className="workflow-drop-field">
+      <span className="workflow-drop-field-label">{label}</span>
+      <span className="workflow-drop-field-value">{children}</span>
+    </div>
+  );
+}
+
+export function WorkflowDropPanel({
+  offer,
+  importState,
+  canImport,
+  onUse,
+  onImport,
+  onDismiss,
+}) {
+  if (!offer) {
+    return null;
+  }
+  const { share, report, error } = offer;
+  if (error) {
+    return (
+      <Modal
+        className="workflow-drop-modal"
+        labelledBy="workflow-drop-title"
+        onClose={onDismiss}
+      >
+        <h2 className="workflow-drop-title" id="workflow-drop-title">
+          That image could not be read
+        </h2>
+        <p className="workflow-drop-error">{error}</p>
+        <div className="workflow-drop-actions">
+          <button className="btn" onClick={onDismiss} type="button">
+            Close
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
+  const resolutionLabel = workflowResolutionLabel(share);
+  const settings = workflowSettingRows(share);
+  const batchCount = Number(share.count);
+  const producer = share.producer ?? {};
+  // A model this install cannot resolve is NOT prefilled — the studio keeps the model it is
+  // already on. Saying so is the whole difference between "we could not reproduce this" and a
+  // prompt quietly rendered by somebody else's model.
+  const modelUnresolved = report?.model ? report.model.state !== "resolved" : true;
+
+  return (
+    <Modal className="workflow-drop-modal" labelledBy="workflow-drop-title" onClose={onDismiss}>
+      <h2 className="workflow-drop-title" id="workflow-drop-title">
+        Workflow found
+      </h2>
+      <p className="workflow-drop-lede">
+        This image carries the recipe that made it
+        {producer.name ? ` (written by ${producer.name}${producer.version ? ` ${producer.version}` : ""})` : ""}.
+      </p>
+
+      <div className="workflow-drop-summary">
+        <Field label="Mode">{workflowModeLabel(share)}</Field>
+        <Field label="Model">{report?.model?.name ?? share.model ?? "Not named"}</Field>
+        {resolutionLabel ? <Field label="Resolution">{resolutionLabel}</Field> : null}
+        {share.seed === null || share.seed === undefined ? null : (
+          <Field label="Seed">{String(share.seed)}</Field>
+        )}
+      </div>
+
+      <div className="workflow-drop-prompt">
+        <span className="workflow-drop-field-label">Prompt</span>
+        <p>{share.prompt || <em>No prompt recorded.</em>}</p>
+      </div>
+      {share.negativePrompt ? (
+        <div className="workflow-drop-prompt">
+          <span className="workflow-drop-field-label">Negative prompt</span>
+          <p>{share.negativePrompt}</p>
+        </div>
+      ) : null}
+
+      {settings.length ? (
+        <div className="workflow-drop-settings">
+          <span className="workflow-drop-field-label">Settings</span>
+          <ul>
+            {settings.map((row) => (
+              <li key={row.key}>
+                <span>{row.label}</span>
+                <strong>{row.value}</strong>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <WorkflowResolutionReport report={report} />
+
+      {/* The count note. The envelope's seed is THIS image's; `count` is what the run asked for,
+          so a naive replay would make the shared image the first of an N-image batch. Prefill
+          asks for one and says so rather than quietly reproducing the batch. */}
+      {Number.isFinite(batchCount) && batchCount > 1 ? (
+        <p className="workflow-drop-note">
+          This image was one of a batch of {batchCount}. Only its own seed travelled, so the studio
+          is set to make a single image.
+        </p>
+      ) : null}
+      {modelUnresolved ? (
+        <p className="workflow-drop-note warn">
+          The model is not prefilled, so Image Studio keeps the model it is already on. Nothing
+          here substitutes one for the model this image names.
+        </p>
+      ) : null}
+
+      {importState.done ? (
+        <p className="workflow-drop-note">The image was imported into this project.</p>
+      ) : null}
+      {importState.error ? <p className="workflow-drop-error">{importState.error}</p> : null}
+
+      <div className="workflow-drop-actions">
+        <button className="btn" onClick={onDismiss} type="button">
+          Cancel
+        </button>
+        <button
+          className="btn"
+          disabled={!canImport || importState.busy || importState.done}
+          onClick={onImport}
+          title={canImport ? undefined : "Open a project to import this image."}
+          type="button"
+        >
+          {importState.busy ? "Importing…" : "Import the image too"}
+        </button>
+        <button className="btn primary" onClick={onUse} type="button">
+          Use this workflow
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/WorkflowDropPanel.jsx
+++ b/apps/web/src/components/WorkflowDropPanel.jsx
@@ -36,7 +36,7 @@ export function WorkflowDropPanel({
   if (!offer) {
     return null;
   }
-  const { share, report, error } = offer;
+  const { share, report, error, launchError } = offer;
   if (error) {
     return (
       <Modal
@@ -58,7 +58,7 @@ export function WorkflowDropPanel({
   }
 
   const resolutionLabel = workflowResolutionLabel(share);
-  const settings = workflowSettingRows(share);
+  const settings = workflowSettingRows(share, report);
   const batchCount = Number(share.count);
   const producer = share.producer ?? {};
   // A model this install cannot resolve is NOT prefilled — the studio keeps the model it is
@@ -100,17 +100,26 @@ export function WorkflowDropPanel({
         <div className="workflow-drop-settings">
           <span className="workflow-drop-field-label">Settings</span>
           <ul>
+            {/* Each row says whether "Use this workflow" will actually apply it. A grid where
+                "PiD decoder — On" and "Steps — 28" look identical, when only one of them reaches a
+                control, tells the user a recipe replayed faithfully when it did not — so the mark
+                is a state on the row, not a footnote under the list. */}
             {settings.map((row) => (
-              <li key={row.key}>
+              <li className={row.restored ? undefined : "not-restored"} key={row.key}>
                 <span>{row.label}</span>
                 <strong>{row.value}</strong>
+                {row.restored ? null : (
+                  <em className="workflow-drop-setting-mark" title={row.detail}>
+                    not restored
+                  </em>
+                )}
               </li>
             ))}
           </ul>
         </div>
       ) : null}
 
-      <WorkflowResolutionReport report={report} />
+      <WorkflowResolutionReport report={report} share={share} />
 
       {/* The count note. The envelope's seed is THIS image's; `count` is what the run asked for,
           so a naive replay would make the shared image the first of an N-image batch. Prefill
@@ -132,6 +141,11 @@ export function WorkflowDropPanel({
         <p className="workflow-drop-note">The image was imported into this project.</p>
       ) : null}
       {importState.error ? <p className="workflow-drop-error">{importState.error}</p> : null}
+      {/* "Use this workflow" refused, and the panel stays open saying why. The one case today is a
+          viewport locked to the Simple UI: Image Studio's prefill lands in the Advanced workspace,
+          which cannot be opened at that width, and closing the panel over a launch that went
+          nowhere is the inert-control failure this whole path exists to avoid. */}
+      {launchError ? <p className="workflow-drop-error">{launchError}</p> : null}
 
       <div className="workflow-drop-actions">
         <button className="btn" onClick={onDismiss} type="button">

--- a/apps/web/src/components/WorkflowDropPanel.test.jsx
+++ b/apps/web/src/components/WorkflowDropPanel.test.jsx
@@ -1,0 +1,234 @@
+// "Workflow found" (sc-15951, epic 15945).
+//
+// The panel's whole job is to be honest about a file that came from a stranger's install, so the
+// tests below are almost all about what it REFUSES to imply: that a missing model is fine, that a
+// recipe whose LoRAs were omitted had none, or that a batch of four replays as a batch of four.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WorkflowDropPanel } from "./WorkflowDropPanel.jsx";
+
+function share(overrides = {}) {
+  return {
+    sceneworksWorkflow: "image",
+    schemaVersion: 1,
+    producer: { name: "SceneWorks", url: "https://example.invalid", version: "0.8.1" },
+    mode: "text_to_image",
+    model: "krea_2_turbo",
+    prompt: "a lighthouse in heavy fog, cinematic",
+    negativePrompt: "text, watermark",
+    seed: 880412,
+    width: 1024,
+    height: 1024,
+    count: 1,
+    advanced: { steps: 28, guidanceScale: 3.5 },
+    ...overrides,
+  };
+}
+
+function report(overrides = {}) {
+  return {
+    model: {
+      slug: "krea_2_turbo",
+      state: "resolved",
+      catalogId: "krea_2_turbo",
+      name: "Krea 2 Turbo",
+      detail: "Krea 2 Turbo is installed on this machine.",
+    },
+    loras: [],
+    styles: [],
+    inputs: [],
+    omitted: [],
+    runnable: true,
+    inputImagesRequired: 0,
+    ...overrides,
+  };
+}
+
+const idleImport = { busy: false, done: false, error: "" };
+
+describe("WorkflowDropPanel", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  // The Modal portals to <body>, so assertions read the document rather than the container.
+  const text = () => document.body.textContent;
+  const buttonByLabel = (label) =>
+    [...document.querySelectorAll("button")].find((node) => node.textContent.trim() === label);
+
+  const render = async (props) =>
+    act(async () =>
+      root.render(
+        <WorkflowDropPanel
+          canImport
+          importState={idleImport}
+          offer={null}
+          onDismiss={() => {}}
+          onImport={() => {}}
+          onUse={() => {}}
+          {...props}
+        />,
+      ),
+    );
+
+  it("renders nothing without an offer", async () => {
+    await render({});
+    expect(document.querySelector(".workflow-drop-modal")).toBeNull();
+  });
+
+  it("shows the recipe that came with the file", async () => {
+    await render({ offer: { share: share(), report: report(), error: "" } });
+    expect(text()).toContain("Workflow found");
+    expect(text()).toContain("a lighthouse in heavy fog, cinematic");
+    expect(text()).toContain("text, watermark");
+    expect(text()).toContain("880412");
+    expect(text()).toContain("1024 × 1024");
+    expect(text()).toContain("Krea 2 Turbo");
+    expect(text()).toContain("Steps");
+    expect(text()).toContain("Everything this recipe names is installed here.");
+    // No "model not prefilled" warning when the model resolved.
+    expect(text()).not.toContain("keeps the model it is already on");
+  });
+
+  it("names a missing model instead of quietly running the studio's own", async () => {
+    await render({
+      offer: {
+        share: share({ model: "someones_private_model" }),
+        report: report({
+          model: {
+            slug: "someones_private_model",
+            state: "missing",
+            detail:
+              "No model matching `someones_private_model` is in this install's catalog, so this " +
+              "workflow cannot be reproduced here.",
+          },
+          runnable: false,
+        }),
+        error: "",
+      },
+    });
+    expect(text()).toContain("No model matching `someones_private_model`");
+    expect(text()).toContain("Missing");
+    expect(text()).toContain("keeps the model it is already on");
+    // "Use this workflow" is still offered — the prompt, seed and knobs are real and the
+    // panel has said exactly what will not come with them.
+    expect(buttonByLabel("Use this workflow")).toBeTruthy();
+  });
+
+  it("does not present an omitted LoRA list as a LoRA-free recipe", async () => {
+    // A 6-LoRA envelope whose LoRAs were dropped over the cap and a genuinely LoRA-free one
+    // serialize identically; `omitted` is the only thing that tells them apart.
+    await render({
+      offer: {
+        share: share({ omitted: ["loras"] }),
+        report: report({
+          omitted: [
+            {
+              field: "loras",
+              detail:
+                "This image's LoRA list was declared but not recorded, so this recipe is not a " +
+                "LoRA-free one.",
+            },
+          ],
+          runnable: false,
+        }),
+        error: "",
+      },
+    });
+    expect(text()).toContain("Not recorded — loras");
+    expect(text()).toContain("not a LoRA-free one");
+    expect(text()).toContain("cannot be reproduced on this install");
+  });
+
+  it("says a shared edit still needs its source image", async () => {
+    await render({
+      offer: {
+        share: share({ mode: "edit_image" }),
+        report: report({
+          inputs: [
+            {
+              kind: "source",
+              count: 1,
+              state: "userSupplied",
+              detail: "Needs a source image.",
+            },
+          ],
+          inputImagesRequired: 1,
+        }),
+        error: "",
+      },
+    });
+    expect(text()).toContain("Edit image");
+    expect(text()).toContain("Needs a source image.");
+    expect(text()).toContain("still needs 1 image from you");
+  });
+
+  it("reports the batch it came out of, and that replay makes one image", async () => {
+    await render({ offer: { share: share({ count: 4 }), report: report(), error: "" } });
+    expect(text()).toContain("one of a batch of 4");
+    expect(text()).toContain("single image");
+  });
+
+  it("wires the three actions", async () => {
+    const onUse = vi.fn();
+    const onImport = vi.fn();
+    const onDismiss = vi.fn();
+    await render({
+      offer: { share: share(), report: report(), error: "" },
+      onUse,
+      onImport,
+      onDismiss,
+    });
+    for (const [label, spy] of [
+      ["Use this workflow", onUse],
+      ["Import the image too", onImport],
+      ["Cancel", onDismiss],
+    ]) {
+      const button = buttonByLabel(label);
+      expect(button, label).toBeTruthy();
+      await act(async () => button.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+      expect(spy, label).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("disables the import when there is no project to import into", async () => {
+    await render({ canImport: false, offer: { share: share(), report: report(), error: "" } });
+    expect(buttonByLabel("Import the image too").disabled).toBe(true);
+  });
+
+  it("confirms an import and keeps the workflow available", async () => {
+    await render({
+      importState: { busy: false, done: true, error: "" },
+      offer: { share: share(), report: report(), error: "" },
+    });
+    expect(text()).toContain("imported into this project");
+    expect(buttonByLabel("Use this workflow")).toBeTruthy();
+  });
+
+  it("shows a read failure as its own sentence with nothing to act on", async () => {
+    await render({
+      offer: {
+        share: null,
+        report: null,
+        error: "This PNG could not be read far enough to look for a workflow.",
+      },
+    });
+    expect(text()).toContain("could not be read far enough");
+    expect(buttonByLabel("Use this workflow")).toBeFalsy();
+    expect(buttonByLabel("Close")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/WorkflowDropPanel.test.jsx
+++ b/apps/web/src/components/WorkflowDropPanel.test.jsx
@@ -232,3 +232,147 @@ describe("WorkflowDropPanel", () => {
     expect(buttonByLabel("Close")).toBeTruthy();
   });
 });
+
+// The mark, and the verdict that counts it (sc-15951 review). A settings grid where
+// "PiD decoder — On" and "Steps — 28" look identical, when only one of them reaches a control,
+// tells the user a recipe replayed faithfully when it did not.
+describe("WorkflowDropPanel — what will not be restored", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const render = async (props) =>
+    act(async () =>
+      root.render(
+        <WorkflowDropPanel
+          canImport
+          importState={idleImport}
+          onDismiss={() => {}}
+          onImport={() => {}}
+          onUse={() => {}}
+          {...props}
+        />,
+      ),
+    );
+
+  const settingRow = (label) =>
+    [...document.querySelectorAll(".workflow-drop-settings li")].find((node) =>
+      node.textContent.startsWith(label),
+    );
+
+  it("marks the rows that reach no control, and leaves the applied ones unmarked", async () => {
+    await render({
+      offer: {
+        share: share({
+          advanced: {
+            steps: 28,
+            usePid: true,
+            cnScale: 0.4,
+            poses: [{ keypoints: [] }, { keypoints: [] }, { keypoints: [] }],
+          },
+        }),
+        report: report(),
+        error: "",
+      },
+    });
+
+    expect(settingRow("Steps").querySelector(".workflow-drop-setting-mark")).toBeNull();
+    expect(settingRow("PiD decoder").querySelector(".workflow-drop-setting-mark")).toBeNull();
+    expect(settingRow("Tile ControlNet").textContent).toContain("not restored");
+    expect(settingRow("Poses").textContent).toContain("3 poses");
+    expect(settingRow("Poses").textContent).toContain("not restored");
+  });
+
+  it("folds them into the verdict, so a fully installed recipe still reads as lossy", async () => {
+    await render({
+      offer: {
+        share: share({ advanced: { steps: 28, poses: [{ keypoints: [] }] } }),
+        report: report(),
+        error: "",
+      },
+    });
+
+    // The report itself is clean — the model is installed and nothing was omitted — so without
+    // this clause the panel would say "Everything this recipe names is installed here." over a
+    // pose selection that is about to be dropped on the floor.
+    expect(document.body.textContent).toContain("1 setting will not be restored");
+    expect(document.querySelector(".workflow-req-verdict.ok")).toBeNull();
+    expect(document.body.textContent).toContain("Poses — 1 pose");
+  });
+
+  it("says nothing extra when every setting in the file lands somewhere", async () => {
+    await render({
+      offer: { share: share({ advanced: { steps: 28, usePid: true } }), report: report(), error: "" },
+    });
+
+    expect(document.body.textContent).toContain("Everything this recipe names is installed here.");
+    expect(document.body.textContent).not.toContain("will not be restored");
+    expect(document.querySelector(".workflow-req-verdict.ok")).toBeTruthy();
+  });
+
+  it("does not count an input image the user supplies as something that cannot be reproduced", async () => {
+    await render({
+      offer: {
+        share: share({ mode: "edit_image" }),
+        report: report({
+          inputs: [
+            { kind: "source", count: 1, state: "userSupplied", detail: "Needs a source image." },
+          ],
+          inputImagesRequired: 1,
+          runnable: true,
+        }),
+        error: "",
+      },
+    });
+
+    expect(document.body.textContent).toContain("It still needs 1 image from you.");
+    expect(document.body.textContent).not.toContain("cannot be reproduced");
+    // The row is still rendered — only the verdict's arithmetic excludes it.
+    expect(document.body.textContent).toContain("Input image — source");
+  });
+
+  it("marks an installed style preset, which reaches no control on this replay path", async () => {
+    await render({
+      offer: {
+        share: share(),
+        report: report({
+          styles: [
+            { field: "stylePreset", id: "cine", name: "Cinematic", state: "resolved", detail: "ok" },
+          ],
+        }),
+        error: "",
+      },
+    });
+
+    expect(document.body.textContent).toContain("Style preset — Cinematic");
+    expect(document.body.textContent).toContain("Not restored");
+    // …and NOT as a "Ready" style row, which claimed an axis the studio never receives.
+    expect(document.body.textContent).not.toContain("Style — Cinematic");
+  });
+
+  it("says why the launch refused rather than closing over a button that did nothing", async () => {
+    await render({
+      offer: {
+        share: share(),
+        report: report(),
+        error: "",
+        launchError: "That opens in the Advanced workspace — switch on a larger screen.",
+      },
+    });
+
+    expect(document.body.textContent).toContain("switch on a larger screen");
+    expect(document.querySelector(".workflow-drop-modal")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/WorkflowResolutionReport.jsx
+++ b/apps/web/src/components/WorkflowResolutionReport.jsx
@@ -1,0 +1,125 @@
+import React from "react";
+
+import { workflowUnresolved } from "../workflowShare.js";
+
+// "Can this machine actually run this workflow?", rendered (sc-15951, epic 15945).
+//
+// The presentation half of `crates/sceneworks-core/src/workflow_resolution.rs`. Deliberately a
+// component of its own and not part of the drop panel: sc-15952 offers the same recipe from an
+// ALREADY-IMPORTED asset and has to say the same things about it, and two surfaces that describe
+// the same report differently is exactly how "the model is missing" turns into "the model is
+// fine" on one of them.
+//
+// It states, and never repairs. Every sentence rendered here is one the report already wrote —
+// nothing is reworded, nothing is summarized away, and no requirement is dropped for being
+// inconvenient. Two of them carry weight beyond their text:
+//
+// * **A missing model.** The recipe cannot be reproduced here, and the studio will keep whatever
+//   model it is already on — which the panel has to SAY, because a prefilled prompt over someone
+//   else's model looks like a successful replay.
+// * **`omitted`.** A collection the envelope declared but could not record. A recipe whose LoRAs
+//   were omitted is not a LoRA-free recipe, and it is indistinguishable from one in the JSON, so
+//   this marker is the only thing standing between the user and a confidently wrong replay.
+
+const STATE_LABELS = {
+  resolved: "Ready",
+  installable: "Not downloaded",
+  missing: "Missing",
+  userSupplied: "You supply it",
+};
+
+const STATE_CLASSES = {
+  resolved: "workflow-req-ok",
+  installable: "workflow-req-warn",
+  missing: "workflow-req-bad",
+  userSupplied: "workflow-req-warn",
+};
+
+function StateChip({ state }) {
+  return (
+    <span className={`workflow-req-chip ${STATE_CLASSES[state] ?? "workflow-req-warn"}`}>
+      {STATE_LABELS[state] ?? state}
+    </span>
+  );
+}
+
+function Row({ title, state, detail }) {
+  return (
+    <li className="workflow-req-row">
+      <span className="workflow-req-head">
+        <strong>{title}</strong>
+        <StateChip state={state} />
+      </span>
+      <span className="workflow-req-detail">{detail}</span>
+    </li>
+  );
+}
+
+export function WorkflowResolutionReport({ report }) {
+  if (!report) {
+    return (
+      <p className="workflow-req-empty">
+        This install could not be checked against the recipe, so nothing here says whether it can
+        be reproduced.
+      </p>
+    );
+  }
+  const unresolved = workflowUnresolved(report);
+  const model = report.model ?? null;
+  const loras = report.loras ?? [];
+  const styles = report.styles ?? [];
+  const inputs = report.inputs ?? [];
+  const omitted = report.omitted ?? [];
+  return (
+    <div className="workflow-req">
+      <p className={report.runnable ? "workflow-req-verdict ok" : "workflow-req-verdict warn"}>
+        {report.runnable
+          ? report.inputImagesRequired > 0
+            ? `Everything this recipe names is installed here. It still needs ${report.inputImagesRequired} image${report.inputImagesRequired === 1 ? "" : "s"} from you.`
+            : "Everything this recipe names is installed here."
+          : `${unresolved.length} thing${unresolved.length === 1 ? "" : "s"} in this recipe cannot be reproduced on this install.`}
+      </p>
+      <ul className="workflow-req-list">
+        {model ? (
+          <Row
+            detail={model.detail}
+            state={model.state}
+            title={model.name ?? model.slug ?? "Model"}
+          />
+        ) : null}
+        {loras.map((lora, index) => (
+          <Row
+            detail={lora.detail}
+            key={`lora-${lora.catalogId ?? lora.repo ?? lora.name ?? index}`}
+            state={lora.state}
+            title={`LoRA — ${lora.name ?? lora.repo ?? "unnamed"}`}
+          />
+        ))}
+        {styles.map((style, index) => (
+          <Row
+            detail={style.detail}
+            key={`style-${style.field}-${style.id}-${index}`}
+            state={style.state}
+            title={`Style — ${style.name ?? style.id}`}
+          />
+        ))}
+        {inputs.map((input, index) => (
+          <Row
+            detail={input.detail}
+            key={`input-${input.kind}-${index}`}
+            state={input.state}
+            title={`Input image — ${input.kind}`}
+          />
+        ))}
+        {omitted.map((entry) => (
+          <Row
+            detail={entry.detail}
+            key={`omitted-${entry.field}`}
+            state="missing"
+            title={`Not recorded — ${entry.field}`}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkflowResolutionReport.jsx
+++ b/apps/web/src/components/WorkflowResolutionReport.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { workflowUnresolved } from "../workflowShare.js";
+import { workflowNotRestored, workflowUnresolved } from "../workflowShare.js";
 
 // "Can this machine actually run this workflow?", rendered (sc-15951, epic 15945).
 //
@@ -20,12 +20,19 @@ import { workflowUnresolved } from "../workflowShare.js";
 // * **`omitted`.** A collection the envelope declared but could not record. A recipe whose LoRAs
 //   were omitted is not a LoRA-free recipe, and it is indistinguishable from one in the JSON, so
 //   this marker is the only thing standing between the user and a confidently wrong replay.
+// * **`notRestored`.** A setting that travelled INTACT and still will not be applied, because this
+//   studio has no control for it (`workflowNotRestored`). It is the mirror image of `omitted` and
+//   exists for the same reason: without it, a recipe whose poses were dropped over the writer's cap
+//   is reported honestly while one whose poses arrived perfectly is not — successful transport
+//   punished, silent loss rewarded. `share` is optional only so a caller with a report and no
+//   envelope still renders; every real caller passes both.
 
 const STATE_LABELS = {
   resolved: "Ready",
   installable: "Not downloaded",
   missing: "Missing",
   userSupplied: "You supply it",
+  notRestored: "Not restored",
 };
 
 const STATE_CLASSES = {
@@ -33,6 +40,7 @@ const STATE_CLASSES = {
   installable: "workflow-req-warn",
   missing: "workflow-req-bad",
   userSupplied: "workflow-req-warn",
+  notRestored: "workflow-req-warn",
 };
 
 function StateChip({ state }) {
@@ -55,7 +63,25 @@ function Row({ title, state, detail }) {
   );
 }
 
-export function WorkflowResolutionReport({ report }) {
+// The verdict sentence. Two independent axes, so three sentences rather than a boolean: what this
+// install cannot RESOLVE, and what this studio cannot APPLY. A recipe can fail either alone.
+function verdictText({ report, blocking, notRestored }) {
+  const lost = `${notRestored.length} setting${notRestored.length === 1 ? "" : "s"} will not be restored`;
+  if (!report.runnable) {
+    const blocked = `${blocking.length} thing${blocking.length === 1 ? "" : "s"} in this recipe cannot be reproduced on this install.`;
+    return notRestored.length ? `${blocked} ${lost[0].toUpperCase()}${lost.slice(1)}.` : blocked;
+  }
+  const inputClause =
+    report.inputImagesRequired > 0
+      ? ` It still needs ${report.inputImagesRequired} image${report.inputImagesRequired === 1 ? "" : "s"} from you.`
+      : "";
+  if (notRestored.length) {
+    return `Everything this recipe names is installed here, but ${lost}.${inputClause}`;
+  }
+  return `Everything this recipe names is installed here.${inputClause}`;
+}
+
+export function WorkflowResolutionReport({ report, share = null }) {
   if (!report) {
     return (
       <p className="workflow-req-empty">
@@ -64,20 +90,22 @@ export function WorkflowResolutionReport({ report }) {
       </p>
     );
   }
-  const unresolved = workflowUnresolved(report);
+  const blocking = workflowUnresolved(report);
+  const notRestored = workflowNotRestored(share, report);
   const model = report.model ?? null;
   const loras = report.loras ?? [];
-  const styles = report.styles ?? [];
+  // A resolved `stylePreset` is rendered by the not-restored list below instead — "Ready" would be
+  // a true statement about the catalog and a false one about this replay.
+  const styles = (report.styles ?? []).filter(
+    (style) => !(style.field === "stylePreset" && style.state === "resolved"),
+  );
   const inputs = report.inputs ?? [];
   const omitted = report.omitted ?? [];
+  const clean = report.runnable && notRestored.length === 0;
   return (
     <div className="workflow-req">
-      <p className={report.runnable ? "workflow-req-verdict ok" : "workflow-req-verdict warn"}>
-        {report.runnable
-          ? report.inputImagesRequired > 0
-            ? `Everything this recipe names is installed here. It still needs ${report.inputImagesRequired} image${report.inputImagesRequired === 1 ? "" : "s"} from you.`
-            : "Everything this recipe names is installed here."
-          : `${unresolved.length} thing${unresolved.length === 1 ? "" : "s"} in this recipe cannot be reproduced on this install.`}
+      <p className={clean ? "workflow-req-verdict ok" : "workflow-req-verdict warn"}>
+        {verdictText({ report, blocking, notRestored })}
       </p>
       <ul className="workflow-req-list">
         {model ? (
@@ -117,6 +145,14 @@ export function WorkflowResolutionReport({ report }) {
             key={`omitted-${entry.field}`}
             state="missing"
             title={`Not recorded — ${entry.field}`}
+          />
+        ))}
+        {notRestored.map((entry) => (
+          <Row
+            detail={entry.detail}
+            key={`not-restored-${entry.kind}-${entry.key}`}
+            state="notRestored"
+            title={entry.title}
           />
         ))}
       </ul>

--- a/apps/web/src/hooks/useDropNavigationGuard.js
+++ b/apps/web/src/hooks/useDropNavigationGuard.js
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-// Swallows file drops that no in-app dropzone claimed (issue #1308).
+// Swallows file drops that no in-app dropzone claimed (issue #1308), and — since
+// sc-15951 — hands that unclaimed file to an optional inspector first.
 //
 // The desktop shell runs the webview with Tauri's `dragDropEnabled: false`
 // (apps/desktop/tauri.conf.json) so the real dropzones — AssetPicker, the
@@ -17,7 +18,25 @@ import { useEffect } from "react";
 // the guard bows out. It only acts on drags nothing else claimed, where it
 // prevents the default navigation and marks the drop as "not allowed" so the
 // cursor reads as a rejection rather than a copy affordance.
-export function useDropNavigationGuard() {
+//
+// `onUnclaimedFileDrop` (sc-15951) rides on exactly that "nothing else claimed it"
+// branch — the same `defaultPrevented` test, unchanged, is what decides whether it is
+// called at all, so a drop one of the five real targets handles can never reach it.
+// It is invoked only for a drop carrying EXACTLY one file: a bare-text or URL drag
+// carries none, and a multi-file drag is a bulk gesture no single-recipe offer could
+// answer honestly. Both keep today's silent swallow. Whatever the handler does is
+// asynchronous and cannot affect the swallow, which has already happened by the time it
+// runs — so a slow or throwing inspector can never let the webview navigate.
+export function useDropNavigationGuard({ onUnclaimedFileDrop } = {}) {
+  // Held in a ref, refreshed post-commit, so the window listeners below subscribe once
+  // for the app's lifetime rather than tearing down and re-attaching on every render of
+  // the component that owns the handler. A drag in flight across such a re-subscribe
+  // would otherwise land on no listener at all and navigate.
+  const handlerRef = useRef(null);
+  useEffect(() => {
+    handlerRef.current = typeof onUnclaimedFileDrop === "function" ? onUnclaimedFileDrop : null;
+  });
+
   useEffect(() => {
     if (typeof window === "undefined") {
       return undefined;
@@ -33,6 +52,15 @@ export function useDropNavigationGuard() {
       event.preventDefault();
       if (event.dataTransfer) {
         event.dataTransfer.dropEffect = "none";
+      }
+      if (event.type !== "drop") {
+        return;
+      }
+      // Read synchronously: a `DataTransfer` is neutered once the handler returns, so the
+      // `File` has to be taken out of it here even though the inspector is async.
+      const files = event.dataTransfer?.files;
+      if (files?.length === 1) {
+        handlerRef.current?.(files[0]);
       }
     };
     window.addEventListener("dragover", swallowStrayDrag);

--- a/apps/web/src/hooks/useDropNavigationGuard.test.jsx
+++ b/apps/web/src/hooks/useDropNavigationGuard.test.jsx
@@ -1,27 +1,35 @@
 // Issue #1308: a file dropped outside a real dropzone must not navigate the
 // webview to the image (replacing the whole UI). The guard installs a
 // window-level fallback that swallows any drag no in-app dropzone claimed.
+//
+// sc-15951 rides on the same "nothing else claimed it" branch: an unclaimed drop of one file is
+// handed to a workflow inspector. The tests below pin BOTH halves of that — that the handler
+// fires for a stray drop, and that it cannot fire for a drop a real dropzone handled.
 import React from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useDropNavigationGuard } from "./useDropNavigationGuard.js";
 
-function Harness() {
-  useDropNavigationGuard();
+function Harness({ onUnclaimedFileDrop }) {
+  useDropNavigationGuard({ onUnclaimedFileDrop });
   return null;
 }
 
 // jsdom's Event has no dataTransfer; attach a minimal writable stand-in so we
 // can observe the dropEffect the guard sets.
-function dragEvent(type, { defaultPrevented = false } = {}) {
+function dragEvent(type, { defaultPrevented = false, files = [] } = {}) {
   const event = new Event(type, { bubbles: true, cancelable: true });
-  event.dataTransfer = { dropEffect: "copy" };
+  event.dataTransfer = { dropEffect: "copy", files };
   if (defaultPrevented) {
     event.preventDefault();
   }
   return event;
+}
+
+function pngFile(name = "shared.png") {
+  return new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], name, { type: "image/png" });
 }
 
 describe("useDropNavigationGuard", () => {
@@ -82,5 +90,69 @@ describe("useDropNavigationGuard", () => {
       root = createRoot(container);
       root.render(<Harness />);
     });
+  });
+
+  // ---- The workflow inspector hand-off (sc-15951) --------------------------------------
+
+  it("hands an unclaimed single-file drop to the inspector, still swallowing it", () => {
+    const onUnclaimedFileDrop = vi.fn();
+    act(() => root.render(<Harness onUnclaimedFileDrop={onUnclaimedFileDrop} />));
+    const file = pngFile();
+    const event = dragEvent("drop", { files: [file] });
+    window.dispatchEvent(event);
+    expect(onUnclaimedFileDrop).toHaveBeenCalledWith(file);
+    // The swallow is unconditional and already done by the time the handler runs, so a slow or
+    // throwing inspector can never let the webview navigate.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("never offers a drop a real dropzone claimed", () => {
+    // The regression that would silently steal AssetPicker's and the Image Editor's uploads:
+    // the inspector must sit strictly inside the `!defaultPrevented` branch.
+    const onUnclaimedFileDrop = vi.fn();
+    act(() => root.render(<Harness onUnclaimedFileDrop={onUnclaimedFileDrop} />));
+    window.dispatchEvent(dragEvent("drop", { defaultPrevented: true, files: [pngFile()] }));
+    expect(onUnclaimedFileDrop).not.toHaveBeenCalled();
+  });
+
+  it("never offers a dragover, only a drop", () => {
+    const onUnclaimedFileDrop = vi.fn();
+    act(() => root.render(<Harness onUnclaimedFileDrop={onUnclaimedFileDrop} />));
+    window.dispatchEvent(dragEvent("dragover", { files: [pngFile()] }));
+    expect(onUnclaimedFileDrop).not.toHaveBeenCalled();
+  });
+
+  it("never offers a drag carrying no files, or more than one", () => {
+    // A text or URL drag carries no files; a multi-file drag is a bulk gesture no single-recipe
+    // offer could answer honestly. Both keep the pre-sc-15951 silent swallow.
+    const onUnclaimedFileDrop = vi.fn();
+    act(() => root.render(<Harness onUnclaimedFileDrop={onUnclaimedFileDrop} />));
+    window.dispatchEvent(dragEvent("drop", { files: [] }));
+    window.dispatchEvent(dragEvent("drop", { files: [pngFile("a.png"), pngFile("b.png")] }));
+    expect(onUnclaimedFileDrop).not.toHaveBeenCalled();
+  });
+
+  it("keeps its listeners across a handler change rather than re-subscribing", () => {
+    // The handler lives in a ref for exactly this: a drag in flight across a listener teardown
+    // would land on nothing at all and navigate.
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const first = vi.fn();
+    const second = vi.fn();
+    act(() => root.render(<Harness onUnclaimedFileDrop={first} />));
+    const addsAfterFirst = addSpy.mock.calls.length;
+    act(() => root.render(<Harness onUnclaimedFileDrop={second} />));
+    expect(addSpy.mock.calls.length).toBe(addsAfterFirst);
+    window.dispatchEvent(dragEvent("drop", { files: [pngFile()] }));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    addSpy.mockRestore();
+  });
+
+  it("swallows a stray drop unchanged when no inspector is wired at all", () => {
+    act(() => root.render(<Harness />));
+    const event = dragEvent("drop", { files: [pngFile()] });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.dataTransfer.dropEffect).toBe("none");
   });
 });

--- a/apps/web/src/hooks/useWorkflowDrop.js
+++ b/apps/web/src/hooks/useWorkflowDrop.js
@@ -1,0 +1,153 @@
+import { useCallback, useRef, useState } from "react";
+
+import { inspectWorkflowFile } from "../api.js";
+import {
+  looksLikeWorkflowCandidate,
+  recipeFromWorkflowShare,
+  workflowReplaySeed,
+  WORKFLOW_STATUS_WORKFLOW,
+} from "../workflowShare.js";
+
+// "Someone sent you an image, you drag it onto SceneWorks, you are in Image Studio with their
+// settings loaded" (sc-15951, epic 15945).
+//
+// Owns the state behind the offer panel: the inspect round trip for a file no in-app dropzone
+// claimed, the panel it opens when a workflow is found, and the two things the panel can do with
+// it. The drop ROUTING is `useDropNavigationGuard`; the prefill is App's `launchImageRecipe`,
+// which is the same seam "Use this recipe" goes through.
+//
+// # Nothing happens for an image with no workflow
+//
+// That is the common case — every foreign PNG in the world — and it must stay indistinguishable
+// from the swallow that was there before this hook existed. So the panel is opened only AFTER a
+// workflow has actually been read: no optimistic open, no spinner, no error band. A
+// `no_workflow` response, a file that never passed the client prescreen, and a failure that says
+// nothing about the file all leave the app exactly as it was.
+
+// The `code`s worth showing a person. Everything else — a `no_workflow` body, a `not_png` (the
+// prescreen already refused those, so one here means the file lied and today's swallow is the
+// right answer), a malformed multipart (our bug, not their file), a network failure, an abort —
+// resolves to silence.
+//
+// `too_large` is on the list even though the prescreen bounds the size: the client mirrors the
+// server's cap rather than reading it, so an install whose server cap is LOWER than this build's
+// constant would otherwise fail silently on a file the user watched disappear.
+const SHOWABLE_INSPECT_CODES = new Set([
+  "workflow_inspect_unreadable",
+  "workflow_inspect_read_failed",
+  "workflow_inspect_stage_failed",
+  "workflow_inspect_catalog_failed",
+  "workflow_inspect_too_large",
+]);
+
+// The sentence to show for a failed inspect, or null to stay silent.
+export function inspectFailureMessage(error) {
+  if (!error || !SHOWABLE_INSPECT_CODES.has(error.code)) {
+    return null;
+  }
+  const message = typeof error.message === "string" ? error.message.trim() : "";
+  return message || null;
+}
+
+export function useWorkflowDrop({
+  enabled = true,
+  projectId = null,
+  token = "",
+  importAsset = null,
+  launchRecipe = null,
+} = {}) {
+  // `null` while there is nothing to offer — which is almost always. When set it is either a read
+  // workflow (`share` + `report`) or a failure worth naming (`error`), never both.
+  const [offer, setOffer] = useState(null);
+  const [importState, setImportState] = useState({ busy: false, done: false, error: "" });
+  // Monotonic ticket: a second drop supersedes the first, so a slow inspect cannot open a panel
+  // for a file the user has already replaced.
+  const ticketRef = useRef(0);
+
+  const dismiss = useCallback(() => {
+    ticketRef.current += 1;
+    setOffer(null);
+    setImportState({ busy: false, done: false, error: "" });
+  }, []);
+
+  const handleDroppedFile = useCallback(
+    async (file) => {
+      if (!enabled) {
+        return;
+      }
+      // The ticket is taken BEFORE the prescreen, not after it. The prescreen is itself
+      // asynchronous (a range read off the file), so a ticket taken after it would leave a
+      // window in which `dismiss` — or a newer drop — could not supersede this one.
+      ticketRef.current += 1;
+      const ticket = ticketRef.current;
+      if (!(await looksLikeWorkflowCandidate(file))) {
+        return;
+      }
+      if (ticket !== ticketRef.current) {
+        return;
+      }
+      let response = null;
+      try {
+        response = await inspectWorkflowFile(file, { projectId, token });
+      } catch (error) {
+        if (ticket !== ticketRef.current) {
+          return;
+        }
+        const detail = inspectFailureMessage(error);
+        if (detail) {
+          setImportState({ busy: false, done: false, error: "" });
+          setOffer({ file, share: null, report: null, error: detail });
+        }
+        return;
+      }
+      if (ticket !== ticketRef.current) {
+        return;
+      }
+      // The no-workflow branch, and the only one that has to be invisible.
+      if (response?.status !== WORKFLOW_STATUS_WORKFLOW || !response.workflow) {
+        return;
+      }
+      setImportState({ busy: false, done: false, error: "" });
+      setOffer({
+        file,
+        share: response.workflow,
+        report: response.resolution ?? null,
+        error: "",
+      });
+    },
+    [enabled, projectId, token],
+  );
+
+  // "Use this workflow" — build the recipe and hand it to the SAME launch the viewer's
+  // "Use this recipe" uses. The panel closes either way: a launch that bailed (a project switch
+  // raced the hydration) has already navigated to the studio, and leaving the panel over it would
+  // be worse than closing.
+  const useWorkflow = useCallback(async () => {
+    const current = offer;
+    if (!current?.share || typeof launchRecipe !== "function") {
+      return;
+    }
+    const recipe = recipeFromWorkflowShare(current.share, current.report);
+    dismiss();
+    await launchRecipe({ recipe, replaySeed: workflowReplaySeed(current.share) });
+  }, [offer, launchRecipe, dismiss]);
+
+  // "Import the image too" — the ordinary upload path, which is what records
+  // `extra.importedWorkflow` on the asset (sc-15949). The panel stays open on success so the
+  // user can still take the workflow into the studio; "too" is not "instead".
+  const importImage = useCallback(async () => {
+    const current = offer;
+    if (!current?.file || typeof importAsset !== "function" || importState.busy) {
+      return;
+    }
+    setImportState({ busy: true, done: false, error: "" });
+    try {
+      await importAsset(current.file, { throwOnError: true });
+      setImportState({ busy: false, done: true, error: "" });
+    } catch (error) {
+      setImportState({ busy: false, done: false, error: error?.message ?? "Import failed." });
+    }
+  }, [offer, importAsset, importState.busy]);
+
+  return { offer, importState, handleDroppedFile, dismiss, useWorkflow, importImage };
+}

--- a/apps/web/src/hooks/useWorkflowDrop.js
+++ b/apps/web/src/hooks/useWorkflowDrop.js
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { inspectWorkflowFile } from "../api.js";
 import {
@@ -63,11 +63,32 @@ export function useWorkflowDrop({
   // Monotonic ticket: a second drop supersedes the first, so a slow inspect cannot open a panel
   // for a file the user has already replaced.
   const ticketRef = useRef(0);
+  // The in-flight inspect's controller, so superseding a ticket actually STOPS the upload rather
+  // than only ignoring its answer. The endpoint accepts up to 512 MiB and stages the whole body
+  // before it reads a byte, so an ignored request is a multi-hundred-megabyte upload still running
+  // — on a LAN deployment that is real bandwidth, and on unmount it is a leak.
+  const inFlightRef = useRef(null);
+
+  // Abandon whatever inspect is running and take the next ticket. Every supersede goes through
+  // here so there is one place that can forget to abort.
+  const supersede = useCallback(() => {
+    inFlightRef.current?.abort();
+    inFlightRef.current = null;
+    ticketRef.current += 1;
+    return ticketRef.current;
+  }, []);
 
   const dismiss = useCallback(() => {
-    ticketRef.current += 1;
+    supersede();
     setOffer(null);
     setImportState({ busy: false, done: false, error: "" });
+  }, [supersede]);
+
+  // Unmount is a supersede with nobody left to tell. Without this the request outlives the tree
+  // that started it.
+  useEffect(() => () => {
+    inFlightRef.current?.abort();
+    inFlightRef.current = null;
   }, []);
 
   const handleDroppedFile = useCallback(
@@ -78,21 +99,27 @@ export function useWorkflowDrop({
       // The ticket is taken BEFORE the prescreen, not after it. The prescreen is itself
       // asynchronous (a range read off the file), so a ticket taken after it would leave a
       // window in which `dismiss` — or a newer drop — could not supersede this one.
-      ticketRef.current += 1;
-      const ticket = ticketRef.current;
+      const ticket = supersede();
       if (!(await looksLikeWorkflowCandidate(file))) {
         return;
       }
       if (ticket !== ticketRef.current) {
         return;
       }
+      const controller = typeof AbortController === "function" ? new AbortController() : null;
+      inFlightRef.current = controller;
       let response = null;
       try {
-        response = await inspectWorkflowFile(file, { projectId, token });
+        response = await inspectWorkflowFile(file, {
+          projectId,
+          token,
+          signal: controller?.signal,
+        });
       } catch (error) {
         if (ticket !== ticketRef.current) {
           return;
         }
+        inFlightRef.current = null;
         const detail = inspectFailureMessage(error);
         if (detail) {
           setImportState({ busy: false, done: false, error: "" });
@@ -103,6 +130,7 @@ export function useWorkflowDrop({
       if (ticket !== ticketRef.current) {
         return;
       }
+      inFlightRef.current = null;
       // The no-workflow branch, and the only one that has to be invisible.
       if (response?.status !== WORKFLOW_STATUS_WORKFLOW || !response.workflow) {
         return;
@@ -115,21 +143,35 @@ export function useWorkflowDrop({
         error: "",
       });
     },
-    [enabled, projectId, token],
+    [enabled, projectId, token, supersede],
   );
 
   // "Use this workflow" — build the recipe and hand it to the SAME launch the viewer's
-  // "Use this recipe" uses. The panel closes either way: a launch that bailed (a project switch
-  // raced the hydration) has already navigated to the studio, and leaving the panel over it would
-  // be worse than closing.
+  // "Use this recipe" uses.
+  //
+  // The panel then closes for every outcome BUT one. A launch that bailed on a hydration race has
+  // already navigated to the studio, and leaving the panel over it would be worse than closing.
+  // A launch that REFUSED — today, a viewport locked to the Simple UI, where the Advanced
+  // workspace this prefill lands in cannot be opened at all — has navigated nowhere, so closing
+  // the panel would leave the button looking like it worked. That one keeps the panel and says
+  // why.
   const useWorkflow = useCallback(async () => {
     const current = offer;
     if (!current?.share || typeof launchRecipe !== "function") {
       return;
     }
     const recipe = recipeFromWorkflowShare(current.share, current.report);
+    const outcome = await launchRecipe({
+      recipe,
+      replaySeed: workflowReplaySeed(current.share),
+    });
+    if (outcome?.ok === false && outcome.reason === "locked") {
+      setOffer((existing) =>
+        existing ? { ...existing, launchError: outcome.detail ?? "" } : existing,
+      );
+      return;
+    }
     dismiss();
-    await launchRecipe({ recipe, replaySeed: workflowReplaySeed(current.share) });
   }, [offer, launchRecipe, dismiss]);
 
   // "Import the image too" — the ordinary upload path, which is what records

--- a/apps/web/src/hooks/useWorkflowDrop.test.jsx
+++ b/apps/web/src/hooks/useWorkflowDrop.test.jsx
@@ -1,0 +1,301 @@
+// "Drop a shared image anywhere → Workflow found → prefill Image Studio" (sc-15951, epic 15945).
+//
+// The behaviour under test is mostly about what does NOT happen: every foreign PNG in the world
+// answers `no_workflow`, and that path has to stay byte-for-byte the swallow it was before this
+// hook existed — no panel, no spinner, no error band.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The transport is stubbed at `inspectWorkflowFile` (not at `apiFetch`): the hook's contract is
+// the endpoint's `{ status, workflow, resolution }` body and its typed `ApiError`s, and pinning
+// it to a FormData round trip would test axum's multipart rather than this hook.
+const inspectWorkflowFile = vi.fn();
+vi.mock("../api.js", async () => {
+  const actual = await vi.importActual("../api.js");
+  return { ...actual, inspectWorkflowFile: (...args) => inspectWorkflowFile(...args) };
+});
+
+import { ApiError } from "../api.js";
+import { inspectFailureMessage, useWorkflowDrop } from "./useWorkflowDrop.js";
+
+const PNG_HEAD = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function pngFile(name = "shared.png") {
+  return new File([new Uint8Array([...PNG_HEAD, 1, 2, 3, 4])], name, { type: "image/png" });
+}
+
+function workflowBody(overrides = {}) {
+  return {
+    status: "workflow",
+    workflow: {
+      sceneworksWorkflow: "image",
+      schemaVersion: 1,
+      mode: "text_to_image",
+      model: "krea_2_turbo",
+      prompt: "a lighthouse in heavy fog",
+      negativePrompt: "",
+      seed: 4242,
+      width: 1024,
+      height: 1024,
+      count: 4,
+      advanced: { steps: 28 },
+    },
+    resolution: {
+      model: {
+        slug: "krea_2_turbo",
+        state: "resolved",
+        catalogId: "krea_2_turbo",
+        name: "Krea 2 Turbo",
+        detail: "Krea 2 Turbo is installed on this machine.",
+      },
+      loras: [],
+      styles: [],
+      inputs: [],
+      omitted: [],
+      runnable: true,
+      inputImagesRequired: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("useWorkflowDrop", () => {
+  let container;
+  let root;
+  let hook;
+
+  function Harness(props) {
+    hook = useWorkflowDrop(props);
+    return null;
+  }
+
+  const render = async (props) => {
+    await act(async () => root.render(<Harness {...props} />));
+  };
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    inspectWorkflowFile.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("opens the offer when the dropped image carries a workflow", async () => {
+    inspectWorkflowFile.mockResolvedValue(workflowBody());
+    await render({ projectId: "project_1", token: "t" });
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile());
+    });
+    expect(hook.offer?.share?.prompt).toBe("a lighthouse in heavy fog");
+    expect(hook.offer?.report?.model?.state).toBe("resolved");
+    const [sent, options] = inspectWorkflowFile.mock.calls[0];
+    expect(sent.name).toBe("shared.png");
+    expect(options).toEqual({ projectId: "project_1", token: "t" });
+  });
+
+  it("does nothing at all for an image with no workflow — the common case", async () => {
+    inspectWorkflowFile.mockResolvedValue({
+      status: "no_workflow",
+      workflow: null,
+      resolution: null,
+      detail: "This image carries no SceneWorks workflow…",
+    });
+    await render({});
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile("holiday.png"));
+    });
+    expect(hook.offer).toBeNull();
+  });
+
+  it("never asks the server about a file that is not a PNG", async () => {
+    await render({});
+    await act(async () => {
+      await hook.handleDroppedFile(new File(["not an image"], "notes.txt", { type: "text/plain" }));
+    });
+    expect(inspectWorkflowFile).not.toHaveBeenCalled();
+    expect(hook.offer).toBeNull();
+  });
+
+  it("does nothing while disabled", async () => {
+    inspectWorkflowFile.mockResolvedValue(workflowBody());
+    await render({ enabled: false });
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile());
+    });
+    expect(inspectWorkflowFile).not.toHaveBeenCalled();
+    expect(hook.offer).toBeNull();
+  });
+
+  it("shows the sentence for a file that claims a workflow it cannot read", async () => {
+    inspectWorkflowFile.mockRejectedValue(
+      new ApiError("This PNG could not be read far enough to look for a workflow.", {
+        status: 422,
+        code: "workflow_inspect_unreadable",
+      }),
+    );
+    await render({});
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile());
+    });
+    expect(hook.offer?.error).toContain("could not be read far enough");
+    expect(hook.offer?.share).toBeNull();
+  });
+
+  it("stays silent for a failure that says nothing about the file", async () => {
+    // A network drop, an axum plain-text multipart rejection (no `code` at all), or a `not_png`
+    // that slipped past the prescreen. None of them is worth a modal the user did not ask for.
+    for (const error of [
+      new ApiError("Failed to fetch", {}),
+      new ApiError("Request failed with 400", { status: 400 }),
+      new ApiError("Not a PNG", { status: 400, code: "workflow_inspect_not_png" }),
+      new ApiError("bad multipart", { status: 400, code: "workflow_inspect_bad_multipart" }),
+    ]) {
+      inspectWorkflowFile.mockReset();
+      inspectWorkflowFile.mockRejectedValue(error);
+      await render({});
+      await act(async () => {
+        await hook.handleDroppedFile(pngFile());
+      });
+      expect(hook.offer).toBeNull();
+    }
+  });
+
+  it("lets a second drop supersede a slow first one", async () => {
+    let releaseFirst;
+    let firstReached;
+    const firstInFlight = new Promise((resolve) => {
+      firstReached = resolve;
+    });
+    inspectWorkflowFile
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFirst = () =>
+              resolve(
+                workflowBody({ workflow: { ...workflowBody().workflow, prompt: "stale" } }),
+              );
+            firstReached();
+          }),
+      )
+      .mockResolvedValueOnce(workflowBody());
+    await render({});
+    let firstDrop;
+    await act(async () => {
+      firstDrop = hook.handleDroppedFile(pngFile("first.png"));
+      // Wait until the first inspect is genuinely in flight, so the race under test is
+      // "a response arrives late", not "a drop was superseded before it left".
+      await firstInFlight;
+    });
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile("second.png"));
+    });
+    await act(async () => {
+      releaseFirst();
+      await firstDrop;
+    });
+    expect(hook.offer?.share?.prompt).toBe("a lighthouse in heavy fog");
+  });
+
+  it("hands the recipe to the shared launch and closes", async () => {
+    inspectWorkflowFile.mockResolvedValue(workflowBody());
+    const launchRecipe = vi.fn(async () => true);
+    await render({ launchRecipe });
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile());
+    });
+    await act(async () => {
+      await hook.useWorkflow();
+    });
+    expect(launchRecipe).toHaveBeenCalledTimes(1);
+    const { recipe, replaySeed } = launchRecipe.mock.calls[0][0];
+    expect(recipe.model).toBe("krea_2_turbo");
+    expect(recipe.prompt).toBe("a lighthouse in heavy fog");
+    // The shared image's own seed, and ONE image — not the batch of four it came from.
+    expect(replaySeed).toBe("4242");
+    expect(recipe.normalizedSettings.count).toBe(1);
+    expect(hook.offer).toBeNull();
+  });
+
+  it("imports through the ordinary upload path and keeps the offer open", async () => {
+    inspectWorkflowFile.mockResolvedValue(workflowBody());
+    const importAsset = vi.fn(async () => ({ id: "asset_9" }));
+    await render({ importAsset });
+    const file = pngFile();
+    await act(async () => {
+      await hook.handleDroppedFile(file);
+    });
+    await act(async () => {
+      await hook.importImage();
+    });
+    expect(importAsset).toHaveBeenCalledWith(file, { throwOnError: true });
+    expect(hook.importState.done).toBe(true);
+    // "too", not "instead": the workflow is still there to take into the studio.
+    expect(hook.offer?.share).toBeTruthy();
+  });
+
+  it("reports an import failure without losing the offer", async () => {
+    inspectWorkflowFile.mockResolvedValue(workflowBody());
+    await render({ importAsset: vi.fn(async () => { throw new Error("Create or open a project first."); }) });
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile());
+    });
+    await act(async () => {
+      await hook.importImage();
+    });
+    expect(hook.importState.error).toBe("Create or open a project first.");
+    expect(hook.offer?.share).toBeTruthy();
+  });
+
+  it("dismisses the offer, and a late inspect cannot reopen it", async () => {
+    let release;
+    let reached;
+    const inFlight = new Promise((resolve) => {
+      reached = resolve;
+    });
+    inspectWorkflowFile.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve(workflowBody());
+          reached();
+        }),
+    );
+    await render({});
+    let pending;
+    await act(async () => {
+      pending = hook.handleDroppedFile(pngFile());
+      await inFlight;
+    });
+    await act(async () => hook.dismiss());
+    await act(async () => {
+      release();
+      await pending;
+    });
+    expect(hook.offer).toBeNull();
+  });
+});
+
+describe("inspectFailureMessage", () => {
+  it("passes through the sentences the API wrote for a person", () => {
+    expect(
+      inspectFailureMessage(
+        new ApiError("Two workflow chunks.", { status: 422, code: "workflow_inspect_unreadable" }),
+      ),
+    ).toBe("Two workflow chunks.");
+  });
+
+  it("is null for everything else, including a body with no code at all", () => {
+    expect(inspectFailureMessage(null)).toBeNull();
+    expect(inspectFailureMessage(new ApiError("boom", { status: 400 }))).toBeNull();
+    expect(
+      inspectFailureMessage(new ApiError("", { status: 500, code: "workflow_inspect_read_failed" })),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/useWorkflowDrop.test.jsx
+++ b/apps/web/src/hooks/useWorkflowDrop.test.jsx
@@ -74,6 +74,15 @@ describe("useWorkflowDrop", () => {
     await act(async () => root.render(<Harness {...props} />));
   };
 
+  // Start a drop and let the prescreen (an async range read off the file) finish, WITHOUT waiting
+  // for the inspect it then starts — which is the state the abort tests need to observe.
+  const startDrop = async (file) => {
+    await act(async () => {
+      hook.handleDroppedFile(file);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  };
+
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     inspectWorkflowFile.mockReset();
@@ -98,7 +107,66 @@ describe("useWorkflowDrop", () => {
     expect(hook.offer?.report?.model?.state).toBe("resolved");
     const [sent, options] = inspectWorkflowFile.mock.calls[0];
     expect(sent.name).toBe("shared.png");
-    expect(options).toEqual({ projectId: "project_1", token: "t" });
+    expect(options.projectId).toBe("project_1");
+    expect(options.token).toBe("t");
+    // A cancellable upload: the endpoint stages up to 512 MiB before it reads a byte, so an
+    // abandoned inspect has to STOP rather than merely have its answer ignored.
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect(options.signal.aborted).toBe(false);
+  });
+
+  it("aborts the in-flight inspect when a second drop supersedes it", async () => {
+    let firstSignal = null;
+    inspectWorkflowFile.mockImplementation(
+      (file, options) =>
+        new Promise((resolve) => {
+          if (!firstSignal) {
+            firstSignal = options.signal;
+            return; // never settles — the first upload is still running
+          }
+          resolve(workflowBody());
+        }),
+    );
+    await render({ projectId: "project_1", token: "t" });
+    await startDrop(pngFile("first.png"));
+    expect(firstSignal?.aborted).toBe(false);
+    await act(async () => {
+      await hook.handleDroppedFile(pngFile("second.png"));
+    });
+    expect(firstSignal.aborted).toBe(true);
+  });
+
+  it("aborts the in-flight inspect on unmount", async () => {
+    let signal = null;
+    inspectWorkflowFile.mockImplementation(
+      (file, options) =>
+        new Promise(() => {
+          signal = options.signal;
+        }),
+    );
+    await render({ projectId: "project_1", token: "t" });
+    await startDrop(pngFile());
+    expect(signal?.aborted).toBe(false);
+    // Unmount the harness (rather than the root, which afterEach still owns) — the cleanup
+    // effect is what has to abandon the request.
+    await act(async () => root.render(null));
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("aborts the in-flight inspect when the panel is dismissed", async () => {
+    let signal = null;
+    inspectWorkflowFile.mockImplementation(
+      (file, options) =>
+        new Promise(() => {
+          signal = options.signal;
+        }),
+    );
+    await render({ projectId: "project_1", token: "t" });
+    await startDrop(pngFile());
+    await act(async () => {
+      hook.dismiss();
+    });
+    expect(signal.aborted).toBe(true);
   });
 
   it("does nothing at all for an image with no workflow — the common case", async () => {

--- a/apps/web/src/imageMultiPhase.js
+++ b/apps/web/src/imageMultiPhase.js
@@ -187,6 +187,46 @@ export function serializePhases(phases = [], selectedLoras = []) {
   });
 }
 
+// The exact inverse of `serializePhases`: read a recorded `advanced.phases` list back into the
+// editor's id-keyed shape, resolving each `index` against the LoRA ids the studio is about to
+// select (sc-15951).
+//
+// Replay needs this because the emitted contract is index-keyed and the editor is id-keyed, and
+// nothing else in the app converts back. Without it a shared — or re-run — 3-phase schedule loads
+// as a single-pass render, which is a DIFFERENT image rather than a degraded one: the phases are
+// what decide how many steps run with which adapters attached.
+//
+// `selectedLoraIds` must be the same order `serializePhases` would emit against (the studio's
+// `selectedLoraIds`, which is `request.loras` order). An index with no LoRA behind it is dropped —
+// a share whose LoRA did not resolve here has nothing to point at, and repointing it at a
+// neighbour would silently attach the wrong adapter. Duplicates collapse, mirroring the forward
+// direction, so a round trip is stable.
+export function deserializePhases(phases = [], selectedLoraIds = []) {
+  if (!Array.isArray(phases)) {
+    return [];
+  }
+  return phases.map((phase) => {
+    const steps = Math.trunc(Number(phase?.steps));
+    const guidance = Number(phase?.guidance);
+    const seen = new Set();
+    return {
+      steps: Number.isFinite(steps) ? steps : 0,
+      guidance: Number.isFinite(guidance) ? guidance : 0,
+      loras: (Array.isArray(phase?.loras) ? phase.loras : []).flatMap((ref) => {
+        const index = Number(ref?.index);
+        const id = Number.isInteger(index) && index >= 0 ? selectedLoraIds[index] : undefined;
+        if (id == null || seen.has(id)) {
+          return [];
+        }
+        seen.add(id);
+        const weight = Number(ref?.weight);
+        const hasWeight = ref?.weight != null && ref.weight !== "" && Number.isFinite(weight);
+        return [{ id, weight: hasWeight ? weight : null }];
+      }),
+    };
+  });
+}
+
 // The multi-phase rule set, in the app-wide validation vocabulary (epic 10644). Errors, not silent
 // requirements: an enabled-but-broken phase list blocks Generate and nothing else on the form
 // explains why. Returns [] when the editor is disabled — a disabled editor emits no phases, so a

--- a/apps/web/src/imageMultiPhase.test.js
+++ b/apps/web/src/imageMultiPhase.test.js
@@ -9,6 +9,7 @@ import {
   acceleratorLoraIndex,
   addPhase,
   buildTurboFinishPhases,
+  deserializePhases,
   effectiveTotalSteps,
   modelSupportsMultiPhase,
   movePhase,
@@ -222,5 +223,56 @@ describe("multiPhaseIssues — the requirement/error split (epic 10644)", () => 
   it("passes a valid canonical list", () => {
     const phases = buildTurboFinishPhases([STYLE, TURBO]);
     expect(summarize(multiPhaseIssues({ enabled: true, phases })).ready).toBe(true);
+  });
+});
+
+describe("deserializePhases", () => {
+  const SELECTED = ["lora_grain", "krea2_turbo_accel"];
+
+  it("resolves each phase's index back to the LoRA id the editor holds", () => {
+    expect(
+      deserializePhases(
+        [
+          { steps: 4, guidance: 3.5, loras: [] },
+          { steps: 4, guidance: 0, loras: [{ index: 1, weight: 0.9 }] },
+        ],
+        SELECTED,
+      ),
+    ).toEqual([
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 4, guidance: 0, loras: [{ id: "krea2_turbo_accel", weight: 0.9 }] },
+    ]);
+  });
+
+  it("round-trips with serializePhases", () => {
+    // The pair has to be an exact inverse, because a replayed schedule is re-emitted by
+    // `serializePhases` on the very next submit — a lossy read would change the image the
+    // second time it ran.
+    const selectedLoras = SELECTED.map((id) => ({ id }));
+    const emitted = [
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 6, guidance: 0, loras: [{ index: 1, weight: 0.9 }] },
+      { steps: 2, guidance: 1.5, loras: [{ index: 0 }] },
+    ];
+    expect(serializePhases(deserializePhases(emitted, SELECTED), selectedLoras)).toEqual(emitted);
+  });
+
+  it("drops a reference to a LoRA that is not there rather than repointing it", () => {
+    // Repointing at a neighbour would silently activate a DIFFERENT adapter, which is worse than
+    // a phase that runs base-only.
+    expect(deserializePhases([{ steps: 4, guidance: 1, loras: [{ index: 7 }] }], SELECTED)).toEqual([
+      { steps: 4, guidance: 1, loras: [] },
+    ]);
+    expect(deserializePhases([{ steps: 4, guidance: 1, loras: [{ index: 0 }] }], [])).toEqual([
+      { steps: 4, guidance: 1, loras: [] },
+    ]);
+  });
+
+  it("collapses duplicates and survives a malformed list", () => {
+    expect(
+      deserializePhases([{ steps: 4, guidance: 1, loras: [{ index: 0 }, { index: 0 }] }], SELECTED),
+    ).toEqual([{ steps: 4, guidance: 1, loras: [{ id: "lora_grain", weight: null }] }]);
+    expect(deserializePhases(null, SELECTED)).toEqual([]);
+    expect(deserializePhases([{}], SELECTED)).toEqual([{ steps: 0, guidance: 0, loras: [] }]);
   });
 });

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -8,6 +8,7 @@ import { StudioLoraImportPanel } from "../components/StudioLoraImportPanel.jsx";
 import { MultiPhaseEditor } from "../components/MultiPhaseEditor.jsx";
 import {
   buildTurboFinishPhases,
+  deserializePhases,
   modelSupportsMultiPhase,
   multiPhaseIssues as computeMultiPhaseIssues,
   serializePhases,
@@ -1576,6 +1577,50 @@ export function ImageStudio() {
     setControlnetScale(rawSettings.controlnetConditioningScale ?? rawSettings.controlnetScale ?? settings.controlnetScale ?? controlnetScale);
     setTrueCfgScale(rawSettings.trueCfgScale ?? settings.trueCfgScale ?? trueCfgScale);
     setViewAngle(rawSettings.viewAngle ?? settings.viewAngle ?? "");
+    // The rest of the allow-listed knobs (sc-15951). Every one of these travels in a shared
+    // image's envelope AND is recorded on a generated asset's recipe, so leaving them out made
+    // both replay paths quietly produce a different image — the recipe said "PiD decoder on,
+    // control strength 0.9" and the studio rendered with neither.
+    //
+    // ORDERING. `setControlMode` / `setControlScale` / `setTextStyleGain` are also written by the
+    // model-change reset above (and by its late-catalog twin), which `setModel` a few lines up
+    // will trigger on the NEXT commit. Both are disarmed for this path by the `skip*` /
+    // `referenceTuningDeclaredArmed` flags set at the top of this effect, which is what lets the
+    // assignments here stand — see the ordering test in `ImageStudio.recipeKnobs.test.jsx`, which
+    // replays a control recipe onto a DIFFERENT model and asserts the recipe's values survive the
+    // reset rather than the model's defaults.
+    //
+    // The booleans hydrate from `=== true` rather than falling back to their sticky values: each
+    // is emitted by `buildImageJobAdvanced` only when it is ON, so an absent key means the run had
+    // it off, and inheriting the user's current toggle would replay someone else's recipe with a
+    // decoder they never used. The numbers keep the current value when absent, matching the
+    // tuning knobs above.
+    //
+    // `replayNumber` keeps the current value for an ABSENT knob rather than for a zero one:
+    // `finiteRecipeNumber(null)` is 0 (`Number(null) === 0`), so reading these through it alone
+    // would turn "the run recorded nothing" into "the run recorded zero" — a 0.0 control strength
+    // is a real, very different setting.
+    const replayNumber = (value, fallback) =>
+      value === null || value === undefined || value === ""
+        ? fallback
+        : (finiteRecipeNumber(value) ?? fallback);
+    setEnhancePrompt(rawSettings.enhancePrompt === true);
+    setUsePid(rawSettings.usePid === true);
+    setPidTarget(rawSettings.pidTarget === "2k" ? "2k" : "4k");
+    setFaceRestore(rawSettings.faceRestore === true);
+    setImg2imgStrength(replayNumber(rawSettings.strength, img2imgStrength));
+    setTextStyleGain(replayNumber(rawSettings.textStyleGain, textStyleGain));
+    if (rawSettings.controlMode) {
+      setControlMode(rawSettings.controlMode);
+    }
+    setControlScale(replayNumber(rawSettings.controlScale, controlScale));
+    // Multi-phase denoise (epic 13879 S5). The recorded list is index-keyed against the job's own
+    // LoRA stack; the editor is id-keyed, so `deserializePhases` resolves it against the ids this
+    // launch is selecting in the very same commit. Absent → the editor is cleared AND switched
+    // off, because a stale schedule left enabled would silently re-shape the next render.
+    const restoredPhases = deserializePhases(rawSettings.phases ?? [], loraIds);
+    setMultiPhasePhases(restoredPhases);
+    setMultiPhaseEnabled(restoredPhases.length > 0);
     setSelectedPoseIds([]);
     if (nextMode === "edit_image") {
       setSourceAssetId(launchRequest.sourceAssetId ?? launchRequest.assetId ?? settings.sourceAssetId ?? "");

--- a/apps/web/src/screens/ImageStudio.recipeKnobs.test.jsx
+++ b/apps/web/src/screens/ImageStudio.recipeKnobs.test.jsx
@@ -1,0 +1,387 @@
+// Every allow-listed knob a replayed recipe carries reaches a real Image Studio control
+// (sc-15951, epic 15945).
+//
+// WHY THIS FILE EXISTS. The first cut of the dropped-workflow panel displayed ten knobs —
+// `enhancePrompt`, `usePid`, `pidTarget`, `strength`, `textStyleGain`, `faceRestore`,
+// `controlMode`, `controlScale`, `poses`, `phases` — as ordinary "Settings" rows beside
+// "Steps — 28", while the injection effect named none of them. The user was told a recipe replayed
+// faithfully when it had not, which is the exact failure epic 15945 exists to prevent.
+//
+// So every assertion here reads the RENDERED CONTROL, not the recipe and not the adapter. A test
+// that asserted `rawAdapterSettings` would have passed against the broken build: the values were
+// always in the recipe: nothing read them.
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, apiFetch: vi.fn(async () => ({})) };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { ImageStudio } from "./ImageStudio.jsx";
+
+// One model that advertises every lane the knobs belong to, so a single mount can observe all of
+// them: img2img, Krea's text-style gain, strict control (pose/canny/depth), FLUX-style prompt
+// enhancement, a PiD backbone, and the acceleration LoRA compat that gates multi-phase denoise.
+const EVERY_LANE = {
+  id: "krea_2_raw",
+  name: "Krea 2 Raw",
+  type: "image",
+  family: "krea2",
+  capabilities: ["text_to_image"],
+  installState: "installed",
+  defaults: { resolution: "1024x1024" },
+  limits: {
+    resolutions: ["1024x1024", "1536x1024"],
+    samplers: ["default", "euler"],
+    schedulers: ["default", "shift"],
+  },
+  loraCompatibility: { types: ["acceleration"] },
+  ui: {
+    img2img: true,
+    textStyleGain: { default: 1.0, min: 0.25, max: 1.75, step: 0.05, label: "Text style" },
+    controlModes: ["pose", "canny", "depth"],
+    controlScale: { default: 0.7, min: 0, max: 2, step: 0.05 },
+    promptEnhance: true,
+    pid: { checkpointId: "pid_qwenimage" },
+  },
+};
+
+// A SECOND installed model, so a recipe can move the studio off whatever it mounted on — which is
+// what arms the model-change reset the control knobs have to survive.
+const OTHER_MODEL = {
+  ...EVERY_LANE,
+  id: "z_image_turbo",
+  name: "Z Image Turbo",
+  family: "z-image",
+  loraCompatibility: {},
+  ui: {
+    ...EVERY_LANE.ui,
+    controlScale: { default: 0.25, min: 0, max: 2, step: 0.05 },
+    textStyleGain: { default: 1.0, min: 0.25, max: 1.75, step: 0.05, label: "Text style" },
+  },
+};
+
+const PID_CHECKPOINT = { id: "pid_qwenimage", name: "PiD decoder", installState: "installed" };
+
+const ACCEL_LORA = {
+  id: "krea2_turbo_accel",
+  name: "Krea 2 Turbo accelerator",
+  family: "krea2",
+  scope: "global",
+  installState: "installed",
+  role: "accelerator",
+  type: "acceleration",
+};
+const STYLE_LORA = {
+  id: "lora_grain",
+  name: "Film grain",
+  family: "krea2",
+  scope: "global",
+  installState: "installed",
+};
+
+function baseContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    characters: [],
+    createImageJob: vi.fn(),
+    createPreset: vi.fn(),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    purgeAsset: vi.fn(),
+    gpuOptions: [],
+    imageModels: [EVERY_LANE, OTHER_MODEL],
+    models: [EVERY_LANE, OTHER_MODEL, PID_CHECKPOINT],
+    importAsset: vi.fn(),
+    latestImageAssets: [],
+    recentImageAssets: [],
+    studioLaunch: null,
+    imageLocalJobs: [],
+    loras: [ACCEL_LORA, STYLE_LORA],
+    jobAction: vi.fn(),
+    rememberLocalGenerationJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    presets: [],
+    requestedGpu: "",
+    selectedAsset: null,
+    setRequestedGpu: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    ...overrides,
+  };
+}
+
+// The advanced disclosures render their children only when open, and their open state is part of
+// the persisted studio snapshot — so the snapshot is how the test opens them, without simulating
+// three clicks that are not what is under test.
+function seedOpenDisclosures(extra = {}) {
+  window.localStorage.setItem(
+    "sceneworks-studio-image-project_1",
+    JSON.stringify({ advancedOpen: true, multiPhaseOpen: true, ...extra }),
+  );
+}
+
+function launch(recipe, overrides = {}) {
+  return {
+    id: `launch_${Math.random().toString(16).slice(2)}`,
+    view: "Image",
+    recipe,
+    replaySeed: null,
+    ...overrides,
+  };
+}
+
+// The knobs under test, as one recipe. Values are deliberately non-default so a control still on
+// its model default cannot pass by accident.
+function everyKnobRecipe(overrides = {}) {
+  return {
+    mode: "text_to_image",
+    model: EVERY_LANE.id,
+    prompt: "a lighthouse in heavy fog",
+    negativePrompt: "",
+    loras: [],
+    normalizedSettings: { width: 1024, height: 1024, count: 1 },
+    rawAdapterSettings: {
+      steps: 28,
+      guidanceScale: 4.5,
+      enhancePrompt: true,
+      usePid: true,
+      pidTarget: "2k",
+      strength: 0.35,
+      textStyleGain: 1.45,
+      faceRestore: true,
+      controlMode: "depth",
+      controlScale: 0.85,
+      ...overrides,
+    },
+  };
+}
+
+describe("a replayed recipe reaches every allow-listed control", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    seedOpenDisclosures();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const checkbox = (labelText) =>
+    [...document.body.querySelectorAll("label")]
+      .find((node) => node.textContent.includes(labelText))
+      ?.querySelector('input[type="checkbox"]');
+  const control = (labelText, selector = "input, select") =>
+    [...document.body.querySelectorAll("label")]
+      .find((node) => node.textContent.trim().startsWith(labelText))
+      ?.querySelector(selector);
+  const buttonByText = (text) =>
+    [...document.body.querySelectorAll("button")].find((node) =>
+      node.textContent.includes(text),
+    );
+  const click = async (node) =>
+    act(async () => node.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  // The strict-control disclosure keeps its own local open state (collapsed by default), so the
+  // panel has to be expanded before its controls are in the DOM at all.
+  const openStructureControl = () => click(buttonByText("Structure control"));
+  const activeControlModeLabel = () =>
+    document.body.querySelector(".control-mode-tab.active")?.textContent.trim();
+  const modelSelect = () =>
+    [...document.body.querySelectorAll("select")].find((node) =>
+      [...node.options].some((option) => option.value === EVERY_LANE.id),
+    );
+  const phaseTitles = () =>
+    [...document.body.querySelectorAll(".multiphase-phase-title")].map((node) =>
+      node.textContent.trim(),
+    );
+  const multiPhaseToggle = () =>
+    document.body.querySelector(".multiphase-section input[type='checkbox']") ??
+    [...document.body.querySelectorAll("label")]
+      .find((node) => node.textContent.includes("Multi-phase"))
+      ?.querySelector('input[type="checkbox"]');
+  // The studio writes its live state through to this snapshot, which is where the phase list can
+  // be read in the editor's own id-keyed shape — the remapped structure, not a rendering of it.
+  const persistedStudioSettings = () =>
+    JSON.parse(window.localStorage.getItem("sceneworks-studio-image-project_1") ?? "{}");
+
+  it("sets prompt upsampling, the PiD decoder and its output tier", async () => {
+    await render(baseContext({ studioLaunch: launch(everyKnobRecipe()) }));
+
+    expect(checkbox("Enhance prompt").checked).toBe(true);
+    expect(checkbox("PiD decoder").checked).toBe(true);
+    expect(document.body.querySelector(".pid-target-select select").value).toBe("2k");
+  });
+
+  it("leaves the boolean decoders OFF when the recipe did not record them", async () => {
+    // `buildImageJobAdvanced` emits these only when they are on, so an absent key means the run had
+    // them off — inheriting the user's own sticky toggle would replay someone else's recipe with a
+    // decoder they never used.
+    seedOpenDisclosures({ enhancePrompt: true, usePid: true, pidTarget: "2k" });
+    const recipe = everyKnobRecipe();
+    delete recipe.rawAdapterSettings.enhancePrompt;
+    delete recipe.rawAdapterSettings.usePid;
+    delete recipe.rawAdapterSettings.pidTarget;
+    await render(baseContext({ studioLaunch: launch(recipe) }));
+
+    expect(checkbox("Enhance prompt").checked).toBe(false);
+    expect(checkbox("PiD decoder").checked).toBe(false);
+  });
+
+  it("sets the Krea text-style gain", async () => {
+    await render(baseContext({ studioLaunch: launch(everyKnobRecipe()) }));
+
+    expect(control("Text style").value).toBe("1.45");
+  });
+
+  it("sets the control type and control strength", async () => {
+    await render(baseContext({ studioLaunch: launch(everyKnobRecipe()) }));
+    await openStructureControl();
+
+    expect(activeControlModeLabel()).toBe("Depth");
+    expect(document.body.querySelector(".control-scale input").value).toBe("0.85");
+  });
+
+  // THE ORDERING PROOF. `setModel` arms the model-change reset (`ImageStudio.jsx`), which writes
+  // `setControlMode` / `setControlScale` / `setTextStyleGain` from the NEW model's declared
+  // defaults — on the commit AFTER this effect ran. So a recipe that moves the studio to a
+  // DIFFERENT model is the only shape that can catch that reset clobbering the replay, and it is
+  // the shape "Use this workflow" takes almost every time.
+  //
+  // The two models declare different `controlScale` defaults (0.25 → 0.7), so a reset that won
+  // would leave a value that is neither the recipe's nor a coincidence.
+  it("keeps the recipe's control knobs when the launch also changes the model", async () => {
+    seedOpenDisclosures({ model: OTHER_MODEL.id, controlMode: "pose", controlScale: 0.25 });
+    const recipe = everyKnobRecipe();
+    expect(recipe.model).toBe(EVERY_LANE.id);
+    expect(EVERY_LANE.ui.controlScale.default).not.toBe(recipe.rawAdapterSettings.controlScale);
+
+    await render(baseContext({ studioLaunch: launch(recipe) }));
+    await openStructureControl();
+
+    expect(modelSelect().value).toBe(EVERY_LANE.id);
+    expect(activeControlModeLabel()).toBe("Depth");
+    // 0.7 here would mean the model-change reset landed after the recipe and won.
+    expect(document.body.querySelector(".control-scale input").value).toBe("0.85");
+    expect(control("Text style").value).toBe("1.45");
+  });
+
+  it("sets img2img strength, which the reference slider shows once a reference is picked", async () => {
+    const asset = {
+      id: "asset_ref",
+      type: "image",
+      projectId: "project_1",
+      displayName: "A lighthouse",
+      status: {},
+      file: { path: "assets/images/a.png", mimeType: "image/png" },
+    };
+    await render(baseContext({ assets: [asset], studioLaunch: launch(everyKnobRecipe()) }));
+
+    // The slider renders only once there is a reference to be strong RELATIVE TO, so picking one
+    // is the user step this replay cannot perform for them. The point of the assertion is that the
+    // strength waiting behind it is the recipe's, not the 0.5 default.
+    await click(buttonByText("Image reference"));
+    await click(buttonByText("Select reference image"));
+    await click(document.body.querySelector(".asset-picker-card"));
+    await click(buttonByText("Use Selection"));
+
+    expect(document.body.querySelector(".img2img-strength input").value).toBe("0.35");
+  });
+
+  it("sets face restoration on the pose panel", async () => {
+    const reference = {
+      id: "asset_face",
+      type: "image",
+      projectId: "project_1",
+      displayName: "Mira",
+      status: {},
+      file: { path: "assets/images/mira.png", mimeType: "image/png" },
+    };
+    const character = {
+      id: "char_1",
+      name: "Mira",
+      looks: [],
+      approvedReferences: [{ assetId: reference.id, asset: reference }],
+    };
+    const poseModel = {
+      ...EVERY_LANE,
+      capabilities: ["text_to_image", "character_image"],
+      ui: { ...EVERY_LANE.ui, poseLibrary: true },
+    };
+    const recipe = everyKnobRecipe();
+    recipe.mode = "character_image";
+    recipe.normalizedSettings = { ...recipe.normalizedSettings, characterId: character.id };
+    recipe.rawAdapterSettings.referenceAssetId = reference.id;
+
+    await render(
+      baseContext({
+        assets: [reference],
+        characters: [character],
+        imageModels: [poseModel, OTHER_MODEL],
+        models: [poseModel, OTHER_MODEL, PID_CHECKPOINT],
+        studioLaunch: launch(recipe),
+      }),
+    );
+
+    expect(checkbox("Restore face").checked).toBe(true);
+  });
+
+  // Multi-phase denoise. A 3-phase schedule replaying as a single pass is a DIFFERENT image, not a
+  // degraded one, so the schedule has to survive — including the `loras[].index` -> resolved-id
+  // remap, which is the only genuinely new code on this path.
+  it("replays a multi-phase schedule, remapping each phase's LoRA index to its id", async () => {
+    const recipe = everyKnobRecipe();
+    recipe.loras = [{ id: STYLE_LORA.id, weight: 0.8 }, { id: ACCEL_LORA.id }];
+    recipe.rawAdapterSettings.phases = [
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 6, guidance: 0, loras: [{ index: 1, weight: 0.9 }] },
+      { steps: 2, guidance: 1.5, loras: [{ index: 0 }] },
+    ];
+    await render(baseContext({ studioLaunch: launch(recipe) }));
+
+    // The editor is on screen with all three phases — a single-pass replay would show none.
+    expect(phaseTitles()).toEqual(["Phase 1", "Phase 2", "Phase 3"]);
+    expect(multiPhaseToggle().checked).toBe(true);
+
+    // …and each phase's LoRA reference now names the resolved LoRA by its stable id, which is the
+    // shape the editor mutates and `serializePhases` turns back into an index at submit.
+    expect(persistedStudioSettings().multiPhasePhases).toEqual([
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 6, guidance: 0, loras: [{ id: ACCEL_LORA.id, weight: 0.9 }] },
+      { steps: 2, guidance: 1.5, loras: [{ id: STYLE_LORA.id, weight: null }] },
+    ]);
+  });
+
+  it("clears a stale schedule when the replayed recipe has no phases", async () => {
+    seedOpenDisclosures({
+      multiPhaseEnabled: true,
+      multiPhasePhases: [{ steps: 8, guidance: 2, loras: [] }],
+    });
+    await render(baseContext({ studioLaunch: launch(everyKnobRecipe()) }));
+
+    expect(phaseTitles()).toEqual([]);
+    expect(multiPhaseToggle().checked).toBe(false);
+  });
+});

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -17065,6 +17065,23 @@ button.audio-wave {
   font-weight: 600;
   overflow-wrap: anywhere;
 }
+/* A knob that travelled in the file but reaches no Image Studio control. Struck through and
+   labelled rather than merely dimmed: a dimmed row still reads as "applied, quietly", which is
+   the misreading this mark exists to prevent (sc-15951). */
+.workflow-drop-settings li.not-restored strong {
+  color: var(--text-muted);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+.workflow-drop-setting-mark {
+  flex: 0 0 auto;
+  font-style: normal;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--warn);
+  white-space: nowrap;
+}
 .workflow-drop-note {
   margin: 0;
   font-size: 12.5px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -16982,3 +16982,181 @@ button.audio-wave {
 .asset-audio-stage__transport .audio-clock {
   font-size: 15px;
 }
+
+/* Dropped-workflow offer (sc-15951, epic 15945) — "Workflow found", opened by an image drop
+   no in-app dropzone claimed. The report block below it is shared with sc-15952. */
+.workflow-drop-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 560px;
+  max-width: calc(100% - 32px);
+  max-height: 88vh;
+  overflow-y: auto;
+  padding: 20px 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+.workflow-drop-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 650;
+}
+.workflow-drop-lede {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+.workflow-drop-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+.workflow-drop-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.workflow-drop-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.workflow-drop-field-value {
+  font-size: 13px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+.workflow-drop-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.workflow-drop-prompt p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.workflow-drop-settings ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 4px 14px;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+}
+.workflow-drop-settings li {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.workflow-drop-settings li strong {
+  color: var(--text);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.workflow-drop-note {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+.workflow-drop-note.warn {
+  color: var(--warn);
+}
+.workflow-drop-error {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--danger);
+}
+.workflow-drop-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* The resolution report (sc-15950's output). Shared presentation — sc-15952 renders the same
+   component for an already-imported asset, so nothing here may be drop-specific. */
+.workflow-req {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg);
+}
+.workflow-req-empty {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+.workflow-req-verdict {
+  margin: 0;
+  font-size: 12.5px;
+  font-weight: 600;
+}
+.workflow-req-verdict.ok {
+  color: var(--success);
+}
+.workflow-req-verdict.warn {
+  color: var(--warn);
+}
+.workflow-req-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.workflow-req-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.workflow-req-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  overflow-wrap: anywhere;
+}
+.workflow-req-detail {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+.workflow-req-chip {
+  flex: none;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.workflow-req-ok {
+  background: color-mix(in oklch, var(--success) 18%, transparent);
+  color: var(--success);
+}
+.workflow-req-warn {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.workflow-req-bad {
+  background: var(--danger-soft);
+  color: var(--danger);
+}

--- a/apps/web/src/workflowDropRouting.test.jsx
+++ b/apps/web/src/workflowDropRouting.test.jsx
@@ -7,10 +7,11 @@
 // DocumentStudio, PoseLibraryScreen). If the inspector could see their files it would open a
 // "Workflow found" panel over an upload that was already happening.
 //
-// So this file dispatches REAL bubbling drops through the two the acceptance criteria name and
-// asserts, on each, that the component handled it and the inspector never saw it. Nothing here
-// stubs the dropzone: the assertion is worthless unless the component's own `preventDefault` is
-// the thing being tested.
+// So this file dispatches REAL bubbling drops through every one of them and asserts, on each, that
+// the component handled it and the inspector never saw it. Nothing here stubs the dropzone: the
+// assertion is worthless unless the component's own `preventDefault` is the thing being tested.
+// (Four cases cover five dropzones — `PoseLibraryScreen` draws none of its own; it renders
+// `DatasetAddDialog`, so that case is literally the same handler.)
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -30,9 +31,26 @@ vi.mock("react-konva", async () => {
 });
 
 import { ImageEditSourcePickerField } from "./components/AssetPicker.jsx";
+import { DatasetAddDialog } from "./components/DatasetAddDialog.jsx";
 import { AppContext } from "./context/AppContext.js";
 import { useDropNavigationGuard } from "./hooks/useDropNavigationGuard.js";
+import { DocumentStudio } from "./screens/DocumentStudio.jsx";
 import { ImageEditor } from "./screens/ImageEditor.jsx";
+
+// Document Studio gates its compose form (and therefore its filmstrip) on an interleave-capable
+// model being present, so the drop target does not exist without one.
+const INTERLEAVE_MODEL = {
+  id: "sensenova_u1",
+  name: "SenseNova U1",
+  type: "image",
+  family: "sensenova",
+  capabilities: ["interleave"],
+  installState: "installed",
+  defaults: { resolution: "1024x1024" },
+  limits: { resolutions: ["1024x1024"] },
+  loraCompatibility: {},
+  ui: {},
+};
 
 function pngFile(name = "shared.png") {
   return new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], name, { type: "image/png" });
@@ -173,5 +191,116 @@ describe("the workflow inspector never steals a claimed drop", () => {
     });
     expect(event.defaultPrevented).toBe(true);
     expect(inspect).toHaveBeenCalledWith(file);
+  });
+});
+
+// The other three real dropzones. `PoseLibraryScreen` is covered by the `DatasetAddDialog` case:
+// it does not draw a dropzone of its own — it renders that dialog (with `fileHint`/`title`
+// overrides), so the handler under test is literally the same one.
+describe("the other dropzones keep their drops too", () => {
+  let container;
+  let root;
+  let inspect;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    inspect = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const render = async (ui) => {
+    await act(async () => root.render(ui));
+    await act(async () => {});
+  };
+
+  const click = async (node) =>
+    act(async () => node.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+  it("DatasetAddDialog — and therefore PoseLibraryScreen, which renders it", async () => {
+    const onImport = vi.fn();
+    await render(
+      <>
+        <Guard onUnclaimedFileDrop={inspect} />
+        <DatasetAddDialog
+          assets={[]}
+          characters={[]}
+          onAdd={() => {}}
+          onClose={() => {}}
+          onImport={onImport}
+        />
+      </>,
+    );
+    // The dialog portals to <body>; React attaches its delegated listeners to portal containers
+    // too, so a drop dispatched inside it runs the dialog's own handler first.
+    const dropzone = document.querySelector(".dataset-add-dropzone");
+    expect(dropzone).toBeTruthy();
+
+    const file = pngFile("dataset.png");
+    let event;
+    await act(async () => {
+      event = dispatchDrop(dropzone, [file]);
+    });
+
+    expect(onImport).toHaveBeenCalledTimes(1);
+    expect(onImport.mock.calls[0][0][0]).toBe(file);
+    expect(event.defaultPrevented).toBe(true);
+    expect(inspect).not.toHaveBeenCalled();
+  });
+
+  it("the Document Studio storyboard frame", async () => {
+    const importAsset = vi.fn(async () => ({ id: "asset_1" }));
+    await render(
+      <>
+        <Guard onUnclaimedFileDrop={inspect} />
+        <AppContext.Provider
+          value={{
+            activeProject: { id: "project_1", name: "My Project" },
+            assets: [],
+            characters: [],
+            createInterleaveJob: vi.fn(),
+            createModelDownloadJob: vi.fn(),
+            documentLocalJobs: [],
+            gpuOptions: [],
+            imageModels: [INTERLEAVE_MODEL],
+            importAsset,
+            jobs: [],
+            jobAction: vi.fn(),
+            models: [INTERLEAVE_MODEL],
+            rememberLocalGenerationJob: vi.fn(),
+            requestedGpu: "",
+            setActiveView: vi.fn(),
+            setRequestedGpu: vi.fn(),
+          }}
+        >
+          <DocumentStudio />
+        </AppContext.Provider>
+      </>,
+    );
+    // The filmstrip starts empty, so the frame that owns the drop handler has to exist first.
+    await click(
+      [...container.querySelectorAll("button")].find((node) =>
+        node.textContent.includes("Add frame"),
+      ),
+    );
+    const frame = container.querySelector(".doc-frame");
+    expect(frame).toBeTruthy();
+
+    const file = pngFile("frame.png");
+    let event;
+    await act(async () => {
+      event = dispatchDrop(frame, [file]);
+    });
+
+    expect(importAsset).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+    expect(inspect).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/workflowDropRouting.test.jsx
+++ b/apps/web/src/workflowDropRouting.test.jsx
@@ -1,0 +1,177 @@
+// The drop no dropzone claimed, and the drops that WERE claimed (sc-15951, epic 15945).
+//
+// `useDropNavigationGuard` is a window-level fallback: it acts only on a drag whose
+// `defaultPrevented` is still false by the time the event reaches `window`. sc-15951 hangs the
+// workflow inspector off that same branch, which puts one thing at risk — the five real dropzones
+// that handle their own drops (AssetPicker, the Image Editor canvas, DatasetAddDialog,
+// DocumentStudio, PoseLibraryScreen). If the inspector could see their files it would open a
+// "Workflow found" panel over an upload that was already happening.
+//
+// So this file dispatches REAL bubbling drops through the two the acceptance criteria name and
+// asserts, on each, that the component handled it and the inspector never saw it. Nothing here
+// stubs the dropzone: the assertion is worthless unless the component's own `preventDefault` is
+// the thing being tested.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// konva's node build needs the native `canvas` package. The editor's empty state never mounts
+// the <Stage>, so stub react-konva exactly as `screens/ImageEditor.test.jsx` does.
+vi.mock("react-konva", async () => {
+  const ReactModule = await import("react");
+  const passthrough = (name) => ({ children }) =>
+    ReactModule.createElement("div", { "data-konva": name }, children);
+  return {
+    Stage: passthrough("stage"),
+    Layer: passthrough("layer"),
+    Image: () => null,
+    Rect: () => null,
+  };
+});
+
+import { ImageEditSourcePickerField } from "./components/AssetPicker.jsx";
+import { AppContext } from "./context/AppContext.js";
+import { useDropNavigationGuard } from "./hooks/useDropNavigationGuard.js";
+import { ImageEditor } from "./screens/ImageEditor.jsx";
+
+function pngFile(name = "shared.png") {
+  return new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], name, { type: "image/png" });
+}
+
+// A native drop with real files, dispatched at `target` so it bubbles through the component's
+// own React handler on its way to the window guard — the exact path a user's drop takes.
+function dispatchDrop(target, files) {
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  event.dataTransfer = { dropEffect: "copy", files, types: ["Files"] };
+  target.dispatchEvent(event);
+  return event;
+}
+
+function Guard({ onUnclaimedFileDrop }) {
+  useDropNavigationGuard({ onUnclaimedFileDrop });
+  return null;
+}
+
+describe("the workflow inspector never steals a claimed drop", () => {
+  let container;
+  let root;
+  let inspect;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    inspect = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const render = async (ui) => {
+    await act(async () => root.render(ui));
+    await act(async () => {});
+  };
+
+  const buttonByLabel = (label) =>
+    [...document.querySelectorAll("button")].find((node) => node.textContent.trim() === label);
+
+  const click = async (node) =>
+    act(async () => node.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+  it("AssetPicker's upload dropzone still gets the file, and the inspector does not", async () => {
+    const importAsset = vi.fn(async () => ({ id: "asset_1" }));
+    await render(
+      <>
+        <Guard onUnclaimedFileDrop={inspect} />
+        <ImageEditSourcePickerField
+          assets={[]}
+          characters={[]}
+          importAsset={importAsset}
+          label="Source image"
+          onChange={() => {}}
+          value=""
+        />
+      </>,
+    );
+    await click(buttonByLabel("Select image"));
+    await click(buttonByLabel("File Upload"));
+    // The picker modal portals to <body>; React attaches its delegated listeners to portal
+    // containers too, so a drop dispatched here runs the picker's own handler first.
+    const dropzone = document.querySelector(".dataset-add-dropzone");
+    expect(dropzone).toBeTruthy();
+
+    const file = pngFile();
+    let event;
+    await act(async () => {
+      event = dispatchDrop(dropzone, [file]);
+    });
+
+    expect(importAsset).toHaveBeenCalledTimes(1);
+    expect(importAsset.mock.calls[0][0]).toBe(file);
+    expect(event.defaultPrevented).toBe(true);
+    expect(inspect).not.toHaveBeenCalled();
+  });
+
+  it("the Image Editor canvas still claims its drop, and the inspector does not see it", async () => {
+    await render(
+      <>
+        <Guard onUnclaimedFileDrop={inspect} />
+        <AppContext.Provider
+          value={{
+            activeProject: null,
+            assets: [],
+            characters: [],
+            setPreviewAsset: vi.fn(),
+            token: "",
+            requestedGpu: "auto",
+            jobs: [],
+            importAsset: vi.fn(),
+            purgeAsset: vi.fn(),
+            registerLeaveGuard: vi.fn(() => () => {}),
+            trackEditorScratchOp: vi.fn(),
+            releaseEditorScratchOp: vi.fn(),
+            registerEditorScratchClaim: vi.fn(() => () => {}),
+            imageModels: [],
+          }}
+        >
+          <ImageEditor />
+        </AppContext.Provider>
+      </>,
+    );
+    const canvas = container.querySelector(".ie-canvas");
+    expect(canvas).toBeTruthy();
+
+    let event;
+    await act(async () => {
+      event = dispatchDrop(canvas, [pngFile("edit-me.png")]);
+    });
+
+    // The canvas's own handler ran (it is what calls preventDefault), so the window guard bows
+    // out and the inspector is never offered a file the editor is already opening.
+    expect(event.defaultPrevented).toBe(true);
+    expect(inspect).not.toHaveBeenCalled();
+  });
+
+  it("a drop on neutral chrome — nothing in the tree claims it — reaches the inspector", async () => {
+    // The other half of the same rule: with the very same components mounted, a drop that lands
+    // somewhere none of them handles is the one sc-15951 acts on.
+    await render(
+      <>
+        <Guard onUnclaimedFileDrop={inspect} />
+        <div className="neutral-chrome" />
+      </>,
+    );
+    const neutral = container.querySelector(".neutral-chrome");
+    const file = pngFile();
+    let event;
+    await act(async () => {
+      event = dispatchDrop(neutral, [file]);
+    });
+    expect(event.defaultPrevented).toBe(true);
+    expect(inspect).toHaveBeenCalledWith(file);
+  });
+});

--- a/apps/web/src/workflowShare.js
+++ b/apps/web/src/workflowShare.js
@@ -1,0 +1,312 @@
+// Reading a dropped image's embedded workflow, and turning it into something the Image Studio
+// can be prefilled with (sc-15951, epic 15945).
+//
+// The envelope contract is `docs/workflow-share-envelope.md`; the resolution report is
+// `crates/sceneworks-core/src/workflow_resolution.rs`. Nothing here re-derives either — this
+// module only bridges the two onto the shape the studio's existing replay seam already accepts
+// (`recipe.normalizedSettings` / `recipe.rawAdapterSettings`, read by the injection effect in
+// `screens/ImageStudio.jsx`).
+//
+// # The one rule
+//
+// **Import what resolves, name what does not, never silently substitute.** Every requirement the
+// report had to look up — the model, each LoRA, each style axis — is prefilled ONLY in
+// `resolved` state. A requirement in any other state is left out of the recipe entirely and is
+// named by the panel instead, because the alternatives are both lies: prefilling a catalog id the
+// studio's own pickers filter out (they drop `installState === "missing"` rows) drops it
+// silently, and falling back to a default model would reproduce someone else's image with our
+// model.
+
+// `status` values of `POST /api/v1/workflows/inspect`. Both keys are always present in the body,
+// so a reader branches on `status` rather than on the absence of `workflow`.
+export const WORKFLOW_STATUS_WORKFLOW = "workflow";
+export const WORKFLOW_STATUS_NO_WORKFLOW = "no_workflow";
+
+// The first eight bytes of every PNG (the signature the endpoint's own `NotPng` check reads).
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+// `MAX_WORKFLOW_INSPECT_BYTES` in `apps/rust-api/src/lib.rs`. Mirrored rather than fetched: it
+// exists here to stop an upload that is already known to 413, and a client that is one release
+// behind the server simply declines a file the server would have accepted, which is the safe way
+// for the two to disagree.
+export const MAX_WORKFLOW_INSPECT_BYTES = 512 * 1024 * 1024;
+
+// A `Blob`'s bytes, through whichever reader this runtime has.
+//
+// `Blob.arrayBuffer` is the direct route and is what every shipping shell uses. jsdom's `Blob`
+// does not implement it, and neither did some older WebViews — so `FileReader`, which every one
+// of them has, is the fallback rather than the feature being unavailable off the browser.
+function readBlobBytes(blob) {
+  if (typeof blob.arrayBuffer === "function") {
+    return blob.arrayBuffer().then((buffer) => new Uint8Array(buffer));
+  }
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("Could not read the dropped file."));
+    reader.onload = () => resolve(new Uint8Array(reader.result));
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+// Whether a dropped file is worth sending to `POST /api/v1/workflows/inspect`.
+//
+// This is the whole reason the drop path does not just POST whatever it was given. The endpoint
+// stages the entire body to disk BEFORE it looks at the first byte, and a scan miss is O(file) —
+// so dragging a 400 MB TIFF onto the app would upload 400 MB to be told "not a PNG". Two cheap
+// local checks close that:
+//
+// * **The PNG signature**, read out of the first eight bytes with `Blob.slice` — a range read, not
+//   a load of the file. Only a PNG can carry the chunk at all, so anything else is rejected here
+//   and the drop stays exactly today's silent swallow.
+// * **The server's own cap**, so a file guaranteed to come back 413 is never sent.
+//
+// Anything that throws (a permission-revoked drag, an environment with no `Blob.arrayBuffer`)
+// answers `false`: an unreadable file is not a workflow candidate, and today's behaviour is the
+// correct fallback for every uncertainty on this path.
+export async function looksLikeWorkflowCandidate(file) {
+  if (!file || typeof file.slice !== "function") {
+    return false;
+  }
+  const size = Number(file.size);
+  if (!Number.isFinite(size) || size < PNG_SIGNATURE.length || size > MAX_WORKFLOW_INSPECT_BYTES) {
+    return false;
+  }
+  try {
+    const bytes = await readBlobBytes(file.slice(0, PNG_SIGNATURE.length));
+    return PNG_SIGNATURE.every((byte, index) => bytes[index] === byte);
+  } catch {
+    return false;
+  }
+}
+
+// ---- Reading the report -------------------------------------------------------------------
+
+function requirementResolved(requirement) {
+  return requirement?.state === "resolved";
+}
+
+// The local catalog id to prefill for a looked-up requirement, or null.
+//
+// `catalogId` is set whenever the report MATCHED a row, including one that is merely installable.
+// The `resolved` gate on top of it is deliberate: the studio's model list
+// (`generationModelsForType`) and its LoRA picker (`compatibleLoras`) both drop rows that are not
+// on disk, so seeding an installable id would set a value with no option behind it — a blank
+// control, or a selection that vanishes on the next render. Named in the panel instead.
+function resolvedCatalogId(requirement) {
+  return requirementResolved(requirement) ? (requirement.catalogId ?? null) : null;
+}
+
+// The model catalog id to select, or null when this install cannot resolve the envelope's model.
+export function workflowModelId(report) {
+  return resolvedCatalogId(report?.model);
+}
+
+// The `{ id, weight }` list the studio's LoRA picker can seed from — resolved entries only, in
+// envelope order.
+export function workflowLoras(report) {
+  const requirements = Array.isArray(report?.loras) ? report.loras : [];
+  return requirements
+    .map((requirement) => {
+      const id = resolvedCatalogId(requirement);
+      if (!id) {
+        return null;
+      }
+      return Number.isFinite(Number(requirement.weight))
+        ? { id, weight: Number(requirement.weight) }
+        : { id };
+    })
+    .filter(Boolean);
+}
+
+// Whether the live Style-catalog axis (`styleId`) resolved here.
+//
+// Gates the style round-trip: the studio re-selects its Style picker only when BOTH
+// `rawAdapterSettings.styleId` and a string `rawAdapterSettings.stylePrompt` are present, and it
+// then seeds the prompt box with the RAW pre-style prompt so submit recomposes. With the style
+// absent from this catalog that recomposition cannot happen, so both keys are dropped and the
+// already-composed `prompt` is used verbatim — which is the closest this install can get to the
+// image that was shared.
+function styleIdResolved(report) {
+  const styles = Array.isArray(report?.styles) ? report.styles : [];
+  const live = styles.find((style) => style.field === "styleId");
+  return live ? requirementResolved(live) : false;
+}
+
+// Every requirement that is not resolved, as the sentences the report already wrote. The panel
+// renders these; nothing here rewords them.
+export function workflowUnresolved(report) {
+  if (!report) {
+    return [];
+  }
+  const rows = [];
+  if (report.model && report.model.state !== "resolved") {
+    rows.push({ kind: "model", state: report.model.state, detail: report.model.detail });
+  }
+  for (const lora of report.loras ?? []) {
+    if (lora.state !== "resolved") {
+      rows.push({ kind: "lora", state: lora.state, detail: lora.detail });
+    }
+  }
+  for (const style of report.styles ?? []) {
+    if (style.state !== "resolved") {
+      rows.push({ kind: "style", state: style.state, detail: style.detail });
+    }
+  }
+  for (const input of report.inputs ?? []) {
+    rows.push({ kind: "input", state: input.state, detail: input.detail });
+  }
+  for (const entry of report.omitted ?? []) {
+    rows.push({ kind: "omitted", state: "missing", detail: entry.detail });
+  }
+  return rows;
+}
+
+// ---- The adapter --------------------------------------------------------------------------
+
+// The seed of THIS image, as the launch's `replaySeed`.
+//
+// Passed as a string so a seed of 0 survives the studio's `!= null && !== ""` guard, and so a
+// large value is not reformatted by a round trip through Number.
+export function workflowReplaySeed(share) {
+  const seed = share?.seed;
+  return seed === null || seed === undefined || seed === "" ? null : String(seed);
+}
+
+// A `WorkflowShare` (plus this install's resolution report) as a studio recipe.
+//
+// The shape is the one `crates/sceneworks-core/src/project_store.rs` writes for a generated
+// asset, because that is what the ImageStudio injection effect reads — this returns the same
+// object the "Use this recipe" path hands it, so there is exactly one prefill path.
+//
+// `report` is not optional in spirit: with it absent nothing that had to be looked up is
+// prefilled, since without a report this module cannot tell a resolvable model from one that
+// would leave the studio's picker blank.
+export function recipeFromWorkflowShare(share, report = null) {
+  if (!share) {
+    return null;
+  }
+  // `share.advanced` is already the allow-listed, re-sanitized map the reader produced, and the
+  // studio's replay effect reads exactly these keys out of `rawAdapterSettings` — so it is copied
+  // across rather than re-filtered here. (Copied, never aliased: the panel still renders the
+  // envelope and must not see the studio-facing edits below.)
+  const rawSettings = { ...(share.advanced ?? {}) };
+  if (!styleIdResolved(report)) {
+    delete rawSettings.styleId;
+    delete rawSettings.stylePrompt;
+  }
+  if (share.upscale) {
+    rawSettings.upscale = { ...share.upscale };
+  }
+  if (share.fitMode) {
+    rawSettings.fitMode = share.fitMode;
+  }
+
+  const normalizedSettings = {};
+  const width = Number(share.width);
+  const height = Number(share.height);
+  if (Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0) {
+    normalizedSettings.width = width;
+    normalizedSettings.height = height;
+  }
+  // COUNT IS NOT REPLAYED. The envelope's `seed` identifies ONE image while `count` came from the
+  // batch the run requested, so replaying both would reproduce the shared image as the first of an
+  // N-image batch — N-1 images the user did not ask for, each burning a generation. The recipe
+  // therefore always asks for one, and the panel states the file was one of a batch of N so the
+  // fact is reported rather than lost.
+  normalizedSettings.count = 1;
+
+  const recipe = {
+    mode: share.mode ?? "text_to_image",
+    prompt: share.prompt ?? "",
+    negativePrompt: share.negativePrompt ?? "",
+    seed: share.seed ?? null,
+    loras: workflowLoras(report),
+    normalizedSettings,
+    rawAdapterSettings: rawSettings,
+  };
+  const modelId = workflowModelId(report);
+  if (modelId) {
+    recipe.model = modelId;
+  }
+  const stylePreset = report?.styles?.find(
+    (style) => style.field === "stylePreset" && style.state === "resolved",
+  );
+  if (stylePreset) {
+    recipe.stylePreset = stylePreset.id;
+  }
+  return recipe;
+}
+
+// ---- Display ------------------------------------------------------------------------------
+
+const MODE_LABELS = {
+  text_to_image: "Text to image",
+  edit_image: "Edit image",
+  character_image: "Character image",
+  reference_image: "Reference image",
+  pose_image: "Pose image",
+};
+
+// Human labels for the envelope's `advanced` keys. A key with no entry is shown under its own
+// name rather than hidden — this panel's job is to show what is in the file, and a knob nobody
+// wrote a label for is still a knob that changes the image.
+const SETTING_LABELS = {
+  resolution: "Resolution",
+  sampler: "Sampler",
+  scheduler: "Scheduler",
+  schedulerShift: "Schedule shift",
+  steps: "Steps",
+  guidanceScale: "Guidance",
+  guidanceMethod: "Guidance method",
+  enhancePrompt: "Prompt upsampling",
+  usePid: "PiD decoder",
+  pidTarget: "PiD output",
+  ipAdapterScale: "Reference strength",
+  controlnetConditioningScale: "Identity structure",
+  trueCfgScale: "Variation strength",
+  strength: "img2img strength",
+  viewAngle: "Head angle",
+  textStyleGain: "Text-style gain",
+  faceRestore: "Face restoration",
+  controlMode: "Control type",
+  controlScale: "Control strength",
+  styleId: "Style",
+  cnScale: "Tile ControlNet",
+  angleSet: "Angle set",
+  imageGuidanceScale: "Reference guidance",
+};
+
+// Keys whose value is prose or a structure the panel shows elsewhere (or cannot render as a
+// one-line scalar). Skipped from the settings grid, never from the file.
+const SETTING_SKIP = new Set(["stylePrompt", "systemMessage", "structuredPrompt", "poses", "phases"]);
+
+export function workflowModeLabel(share) {
+  const mode = share?.mode;
+  return MODE_LABELS[mode] ?? (typeof mode === "string" && mode ? mode : "Unknown mode");
+}
+
+// The allow-listed advanced knobs, as `{ key, label, value }` rows fit for a definition list.
+export function workflowSettingRows(share) {
+  const settings = share?.advanced;
+  if (!settings || typeof settings !== "object") {
+    return [];
+  }
+  return Object.keys(settings)
+    .filter((key) => !SETTING_SKIP.has(key))
+    .map((key) => ({ key, label: SETTING_LABELS[key] ?? key, value: settings[key] }))
+    .filter((row) => row.value !== null && row.value !== undefined && row.value !== "")
+    .map((row) => ({
+      ...row,
+      value: typeof row.value === "boolean" ? (row.value ? "On" : "Off") : String(row.value),
+    }));
+}
+
+// "1024 × 1024", or null when the envelope carried no geometry.
+export function workflowResolutionLabel(share) {
+  const width = Number(share?.width);
+  const height = Number(share?.height);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return `${width} × ${height}`;
+}

--- a/apps/web/src/workflowShare.js
+++ b/apps/web/src/workflowShare.js
@@ -16,6 +16,12 @@
 // studio's own pickers filter out (they drop `installState === "missing"` rows) drops it
 // silently, and falling back to a default model would reproduce someone else's image with our
 // model.
+//
+// The same rule has a second half, and it is the one this module got wrong first: a knob that
+// travels in the envelope but reaches no Image Studio control is ALSO a silent substitution — the
+// studio keeps whatever it was already on while the panel says "PiD decoder — On". So
+// [`ADVANCED_PREFILL`] below is the single table both halves read: the recipe carries exactly the
+// keys the studio applies, and the panel marks exactly the rest as not restored.
 
 // `status` values of `POST /api/v1/workflows/inspect`. Both keys are always present in the body,
 // so a reader branches on `status` rather than on the absence of `workflow`.
@@ -132,8 +138,16 @@ function styleIdResolved(report) {
   return live ? requirementResolved(live) : false;
 }
 
-// Every requirement that is not resolved, as the sentences the report already wrote. The panel
+// Every requirement that BLOCKS replay, as the sentences the report already wrote. The panel
 // renders these; nothing here rewords them.
+//
+// `inputs` are deliberately absent, mirroring `ResolutionReport::runnable`
+// (`crates/sceneworks-core/src/workflow_resolution.rs`), which excludes them for the reason
+// written there: nothing on this machine could ever have supplied someone else's source image, so
+// an input is a thing the user provides and not a thing this install lacks. Counting them here
+// made the verdict read "2 things in this recipe cannot be reproduced on this install" for a
+// perfectly runnable edit recipe whose only "problem" was that it starts from an image. The panel
+// still renders every input row — the count is what excludes them.
 export function workflowUnresolved(report) {
   if (!report) {
     return [];
@@ -152,13 +166,101 @@ export function workflowUnresolved(report) {
       rows.push({ kind: "style", state: style.state, detail: style.detail });
     }
   }
-  for (const input of report.inputs ?? []) {
-    rows.push({ kind: "input", state: input.state, detail: input.detail });
-  }
   for (const entry of report.omitted ?? []) {
     rows.push({ kind: "omitted", state: "missing", detail: entry.detail });
   }
   return rows;
+}
+
+// ---- What the studio actually does with each allow-listed knob ------------------------------
+
+// The three fates an `advanced` key can meet on the way into Image Studio.
+export const PREFILL_CONTROL = "control"; // the replay effect sets a control from it
+export const PREFILL_PROMPT = "prompt"; // applied, but as prompt text — the panel shows it there
+export const PREFILL_NONE = "none"; // it travels, and this studio has nowhere to put it
+
+// **The one table both halves of the panel read.**
+//
+// The envelope's allow-list is `ADVANCED_KEY_RULES` in `crates/sceneworks-core/src/workflow_share.rs`
+// and is pinned to the `advanced-shared` table of `docs/workflow-share-envelope.md`. That list
+// answers "may this key leave the machine?". It says nothing about whether the RECEIVING studio has
+// a control for it — and those are different questions, because an image envelope carries keys from
+// four lanes (the Image Studio, the standalone Detail pass, the Character studio's angle set, the
+// interleaved-document lane) while this prefill lands in exactly one of them.
+//
+// Splitting that judgement across two places is what shipped ten knobs — `enhancePrompt`, `usePid`,
+// `pidTarget`, `strength`, `textStyleGain`, `faceRestore`, `controlMode`, `controlScale`, `poses`,
+// `phases` — displayed as ordinary "Settings" rows beside "Steps — 28" while none of them reached a
+// control. The user was told a recipe replayed faithfully when it had not, which is the exact
+// failure epic 15945 exists to prevent.
+//
+// So there is one table, and two readers of it:
+//
+// * `recipeFromWorkflowShare` copies across exactly the `control` / `prompt` keys, so the recipe
+//   the studio receives contains nothing the studio ignores;
+// * `workflowSettingRows` marks exactly the `none` keys as not restored, and
+//   `workflowNotRestored` folds them into the panel's verdict.
+//
+// A key that appears in the envelope and NOT in this table is treated as `none`: rendered, marked
+// as not restored, and left out of the recipe. The safe default is "the user is told", never "it
+// quietly disappears".
+export const ADVANCED_PREFILL = {
+  resolution: { label: "Resolution", prefill: PREFILL_CONTROL },
+  structuredPrompt: { label: "Structured prompt", prefill: PREFILL_PROMPT },
+  sampler: { label: "Sampler", prefill: PREFILL_CONTROL },
+  scheduler: { label: "Scheduler", prefill: PREFILL_CONTROL },
+  schedulerShift: { label: "Schedule shift", prefill: PREFILL_CONTROL },
+  steps: { label: "Steps", prefill: PREFILL_CONTROL },
+  guidanceScale: { label: "Guidance", prefill: PREFILL_CONTROL },
+  guidanceMethod: { label: "Guidance method", prefill: PREFILL_CONTROL },
+  enhancePrompt: { label: "Prompt upsampling", prefill: PREFILL_CONTROL },
+  usePid: { label: "PiD decoder", prefill: PREFILL_CONTROL },
+  pidTarget: { label: "PiD output", prefill: PREFILL_CONTROL },
+  ipAdapterScale: { label: "Reference strength", prefill: PREFILL_CONTROL },
+  controlnetConditioningScale: { label: "Identity structure", prefill: PREFILL_CONTROL },
+  trueCfgScale: { label: "Variation strength", prefill: PREFILL_CONTROL },
+  strength: { label: "img2img strength", prefill: PREFILL_CONTROL },
+  viewAngle: { label: "Head angle", prefill: PREFILL_CONTROL },
+  textStyleGain: { label: "Text-style gain", prefill: PREFILL_CONTROL },
+  faceRestore: { label: "Face restoration", prefill: PREFILL_CONTROL },
+  controlMode: { label: "Control type", prefill: PREFILL_CONTROL },
+  controlScale: { label: "Control strength", prefill: PREFILL_CONTROL },
+  styleId: { label: "Style", prefill: PREFILL_CONTROL },
+  stylePrompt: { label: "Pre-style prompt", prefill: PREFILL_PROMPT },
+  phases: { label: "Multi-phase denoise", prefill: PREFILL_CONTROL },
+  // The five that travel and land nowhere. Each names why, because "not restored" without a
+  // reason reads like a bug.
+  poses: {
+    label: "Poses",
+    prefill: PREFILL_NONE,
+    detail:
+      "The coordinates travelled, but the pose-library ids that named them deliberately do not — " +
+      "so there is nothing for the pose picker to select. Tracked by sc-16132.",
+  },
+  cnScale: {
+    label: "Tile ControlNet",
+    prefill: PREFILL_NONE,
+    detail: "A knob of the standalone Detail pass, which Image Studio does not run.",
+  },
+  angleSet: {
+    label: "Angle set",
+    prefill: PREFILL_NONE,
+    detail: "A Character Studio turnaround request. Image Studio has no angle-set control.",
+  },
+  systemMessage: {
+    label: "System prompt",
+    prefill: PREFILL_NONE,
+    detail: "A Document Studio interleave setting. Image Studio has no system prompt.",
+  },
+  imageGuidanceScale: {
+    label: "Reference guidance",
+    prefill: PREFILL_NONE,
+    detail: "A Document Studio interleave setting. Image Studio has no control for it.",
+  },
+};
+
+function prefillDisposition(key) {
+  return ADVANCED_PREFILL[key]?.prefill ?? PREFILL_NONE;
 }
 
 // ---- The adapter --------------------------------------------------------------------------
@@ -185,14 +287,28 @@ export function recipeFromWorkflowShare(share, report = null) {
   if (!share) {
     return null;
   }
-  // `share.advanced` is already the allow-listed, re-sanitized map the reader produced, and the
-  // studio's replay effect reads exactly these keys out of `rawAdapterSettings` — so it is copied
-  // across rather than re-filtered here. (Copied, never aliased: the panel still renders the
-  // envelope and must not see the studio-facing edits below.)
-  const rawSettings = { ...(share.advanced ?? {}) };
+  // The studio-facing copy of the envelope's settings: exactly the keys `ADVANCED_PREFILL` says
+  // the replay effect reads, and nothing else. Filtered rather than copied wholesale so the recipe
+  // cannot carry a key the studio ignores while the panel presents it as restored — the two now
+  // disagree only if someone edits the table, which is the point of there being a table.
+  // (Built fresh, never aliased: the panel still renders the envelope and must not see the
+  // studio-facing edits below.)
+  const rawSettings = {};
+  for (const [key, value] of Object.entries(share.advanced ?? {})) {
+    if (value !== null && value !== undefined && prefillDisposition(key) !== PREFILL_NONE) {
+      rawSettings[key] = value;
+    }
+  }
   if (!styleIdResolved(report)) {
     delete rawSettings.styleId;
     delete rawSettings.stylePrompt;
+  }
+  // The multi-phase schedule, reindexed onto the LoRA stack this install will actually hold.
+  const phases = workflowPhases(share, report);
+  if (phases) {
+    rawSettings.phases = phases;
+  } else {
+    delete rawSettings.phases;
   }
   if (share.upscale) {
     rawSettings.upscale = { ...share.upscale };
@@ -228,13 +344,63 @@ export function recipeFromWorkflowShare(share, report = null) {
   if (modelId) {
     recipe.model = modelId;
   }
-  const stylePreset = report?.styles?.find(
-    (style) => style.field === "stylePreset" && style.state === "resolved",
-  );
-  if (stylePreset) {
-    recipe.stylePreset = stylePreset.id;
-  }
+  // `stylePreset` is NOT set here even when it resolved. Nothing in `apps/web/src` reads
+  // `recipe.stylePreset` — the studio's preset seam is `launchRequest.presetId`, a different
+  // launch shape entirely — so assigning it was a dead write that made the panel's "Style — <name>
+  // [Ready]" row a claim about an axis that reaches no control. The row is marked not-restored
+  // instead (see `workflowNotRestored`).
   return recipe;
+}
+
+// The envelope's multi-phase schedule, reindexed onto the LoRA stack this install will hold — or
+// null when there is no schedule to replay.
+//
+// `advanced.phases[].loras[].index` is a position in the ORIGINAL request's LoRA list. The recipe's
+// list is `workflowLoras(report)`, which drops every LoRA this install could not resolve, so those
+// positions no longer line up: a 3-LoRA share whose first LoRA is missing would have every phase
+// pointing one slot too far right, silently activating the WRONG adapter — worse than not
+// replaying at all. So the map is envelope index → position in the resolved subset, and a phase
+// reference to a LoRA that did not resolve is dropped rather than repointed. (The dropped LoRA is
+// already named by the report, so the loss is visible.)
+//
+// The output stays in the index shape the recorded-recipe path also uses, so `ImageStudio`'s
+// replay effect has ONE thing to deserialize (`imageMultiPhase.deserializePhases`) rather than a
+// share-shaped branch beside a recipe-shaped one.
+export function workflowPhases(share, report = null) {
+  const phases = share?.advanced?.phases;
+  if (!Array.isArray(phases) || phases.length === 0) {
+    return null;
+  }
+  const requirements = Array.isArray(report?.loras) ? report.loras : [];
+  const compacted = new Map();
+  let position = 0;
+  requirements.forEach((requirement, index) => {
+    if (resolvedCatalogId(requirement)) {
+      compacted.set(index, position);
+      position += 1;
+    }
+  });
+  return phases.map((phase) => {
+    const steps = Math.trunc(Number(phase?.steps));
+    const out = { steps: Number.isFinite(steps) ? steps : 0 };
+    const guidance = Number(phase?.guidance);
+    if (Number.isFinite(guidance)) {
+      out.guidance = guidance;
+    }
+    out.loras = (Array.isArray(phase?.loras) ? phase.loras : []).flatMap((ref) => {
+      const index = compacted.get(Number(ref?.index));
+      if (index === undefined) {
+        return [];
+      }
+      const entry = { index };
+      const weight = Number(ref?.weight);
+      if (ref?.weight != null && ref.weight !== "" && Number.isFinite(weight)) {
+        entry.weight = weight;
+      }
+      return [entry];
+    });
+    return out;
+  });
 }
 
 // ---- Display ------------------------------------------------------------------------------
@@ -247,58 +413,116 @@ const MODE_LABELS = {
   pose_image: "Pose image",
 };
 
-// Human labels for the envelope's `advanced` keys. A key with no entry is shown under its own
-// name rather than hidden — this panel's job is to show what is in the file, and a knob nobody
-// wrote a label for is still a knob that changes the image.
-const SETTING_LABELS = {
-  resolution: "Resolution",
-  sampler: "Sampler",
-  scheduler: "Scheduler",
-  schedulerShift: "Schedule shift",
-  steps: "Steps",
-  guidanceScale: "Guidance",
-  guidanceMethod: "Guidance method",
-  enhancePrompt: "Prompt upsampling",
-  usePid: "PiD decoder",
-  pidTarget: "PiD output",
-  ipAdapterScale: "Reference strength",
-  controlnetConditioningScale: "Identity structure",
-  trueCfgScale: "Variation strength",
-  strength: "img2img strength",
-  viewAngle: "Head angle",
-  textStyleGain: "Text-style gain",
-  faceRestore: "Face restoration",
-  controlMode: "Control type",
-  controlScale: "Control strength",
-  styleId: "Style",
-  cnScale: "Tile ControlNet",
-  angleSet: "Angle set",
-  imageGuidanceScale: "Reference guidance",
-};
+// How long a prose value may run inside a one-line settings row before it is elided. The full
+// text is in the file either way; this is a row, not a document viewer.
+const PROSE_ROW_MAX_CHARS = 90;
 
-// Keys whose value is prose or a structure the panel shows elsewhere (or cannot render as a
-// one-line scalar). Skipped from the settings grid, never from the file.
-const SETTING_SKIP = new Set(["stylePrompt", "systemMessage", "structuredPrompt", "poses", "phases"]);
+// One row's value, as a string. Collections say how many they are rather than dumping coordinates
+// (a 12-pose selection is ~800 numbers), and prose is elided rather than allowed to run the row
+// off the panel.
+function settingValueLabel(key, value) {
+  if (typeof value === "boolean") {
+    return value ? "On" : "Off";
+  }
+  if (Array.isArray(value)) {
+    const noun = key === "phases" ? "phase" : key === "poses" ? "pose" : "entry";
+    const plural = noun === "entry" ? "entries" : `${noun}s`;
+    return `${value.length} ${value.length === 1 ? noun : plural}`;
+  }
+  if (value && typeof value === "object") {
+    return "Recorded";
+  }
+  const text = String(value);
+  return text.length > PROSE_ROW_MAX_CHARS ? `${text.slice(0, PROSE_ROW_MAX_CHARS - 1)}…` : text;
+}
 
 export function workflowModeLabel(share) {
   const mode = share?.mode;
   return MODE_LABELS[mode] ?? (typeof mode === "string" && mode ? mode : "Unknown mode");
 }
 
-// The allow-listed advanced knobs, as `{ key, label, value }` rows fit for a definition list.
-export function workflowSettingRows(share) {
+// The allow-listed advanced knobs as `{ key, label, value, restored, detail }` rows fit for a
+// definition list — every row carrying whether "Use this workflow" will actually apply it.
+//
+// `restored` is read from `ADVANCED_PREFILL`, the same table `recipeFromWorkflowShare` filters the
+// recipe with, so a row cannot claim an application the prefill does not perform. A key this build
+// has no entry for is rendered under its own name and marked NOT restored, because an unrecognized
+// knob is one this studio certainly has no control for.
+//
+// Only the `prompt`-fated keys are omitted: `stylePrompt` and `structuredPrompt` ARE applied, and
+// the panel already shows their content in the prompt block above the grid, so a second row would
+// be a duplicate rather than a disclosure.
+//
+// `report` is what makes `styleId` honest. It is a `control` key, but the recipe carries it ONLY
+// when the style resolved here (see `recipeFromWorkflowShare`) — so with the style absent from this
+// catalog the row has to say so rather than inherit the table's optimism.
+export function workflowSettingRows(share, report = null) {
   const settings = share?.advanced;
   if (!settings || typeof settings !== "object") {
     return [];
   }
+  const styleResolvedHere = styleIdResolved(report);
   return Object.keys(settings)
-    .filter((key) => !SETTING_SKIP.has(key))
-    .map((key) => ({ key, label: SETTING_LABELS[key] ?? key, value: settings[key] }))
-    .filter((row) => row.value !== null && row.value !== undefined && row.value !== "")
+    .filter((key) => prefillDisposition(key) !== PREFILL_PROMPT)
+    .map((key) => ({ key, value: settings[key] }))
+    .filter(
+      (row) =>
+        row.value !== null &&
+        row.value !== undefined &&
+        row.value !== "" &&
+        !(Array.isArray(row.value) && row.value.length === 0),
+    )
+    .map((row) => {
+      const styleUnavailable = row.key === "styleId" && !styleResolvedHere;
+      return {
+        key: row.key,
+        label: ADVANCED_PREFILL[row.key]?.label ?? row.key,
+        value: settingValueLabel(row.key, row.value),
+        restored: prefillDisposition(row.key) === PREFILL_CONTROL && !styleUnavailable,
+        detail: styleUnavailable
+          ? "This install does not have that style, so the prompt is used exactly as it was already composed."
+          : (ADVANCED_PREFILL[row.key]?.detail ?? "This build has no control for this setting."),
+      };
+    });
+}
+
+// Everything the panel promises will NOT survive "Use this workflow", as report-shaped rows.
+//
+// Two sources, one list, because the user's question is one question — "what will I not get?" —
+// and answering it in two places is how one of them goes stale:
+//
+// * the `advanced` knobs that reach no Image Studio control (`workflowSettingRows`, above); and
+// * a RESOLVED `stylePreset`. The report says "Ready" for it because the preset is installed here,
+//   which is true and beside the point: the recipe seam this prefill uses carries no preset (the
+//   studio takes one through `launchRequest.presetId`, a different launch shape), so an installed
+//   preset is as unrestored as a missing one. An UNRESOLVED `stylePreset` is left out — it is
+//   already a blocking row in the report, and listing it twice would double-count it.
+//
+// The panel's verdict counts this list, which is what stops successful transport being punished:
+// a pose selection DROPPED over the writer's cap lands in `omitted` and forces `runnable: false`,
+// so before this existed the only silent case was the one where the poses arrived intact.
+export function workflowNotRestored(share, report = null) {
+  const rows = workflowSettingRows(share, report)
+    .filter((row) => !row.restored)
     .map((row) => ({
-      ...row,
-      value: typeof row.value === "boolean" ? (row.value ? "On" : "Off") : String(row.value),
+      kind: "setting",
+      key: row.key,
+      title: `${row.label} — ${row.value}`,
+      detail: row.detail,
     }));
+  for (const style of report?.styles ?? []) {
+    if (style.field === "stylePreset" && style.state === "resolved") {
+      rows.push({
+        kind: "style",
+        key: "stylePreset",
+        title: `Style preset — ${style.name ?? style.id}`,
+        detail:
+          "Installed here, but this replay path carries no preset — the studio keeps the preset " +
+          "it is already on.",
+      });
+    }
+  }
+  return rows;
 }
 
 // "1024 × 1024", or null when the envelope carried no geometry.

--- a/apps/web/src/workflowShare.test.js
+++ b/apps/web/src/workflowShare.test.js
@@ -2,12 +2,22 @@
 // `WorkflowShare` becomes the recipe the Image Studio's existing injection effect already reads.
 import { describe, expect, it } from "vitest";
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import {
+  ADVANCED_PREFILL,
   looksLikeWorkflowCandidate,
   MAX_WORKFLOW_INSPECT_BYTES,
+  PREFILL_CONTROL,
+  PREFILL_NONE,
+  PREFILL_PROMPT,
   recipeFromWorkflowShare,
   workflowLoras,
   workflowModelId,
+  workflowNotRestored,
+  workflowPhases,
   workflowReplaySeed,
   workflowResolutionLabel,
   workflowSettingRows,
@@ -296,8 +306,24 @@ describe("workflowUnresolved", () => {
         runnable: false,
       }),
     );
-    expect(rows.map((row) => row.kind)).toEqual(["model", "lora", "style", "input", "omitted"]);
+    // `input` is absent on purpose: `ResolutionReport::runnable` excludes input images (nothing on
+    // this machine could ever have supplied someone else's source image), so counting them here
+    // made a perfectly runnable edit share read "2 things … cannot be reproduced on this install".
+    // The panel still RENDERS every input row — this list is what the verdict counts.
+    expect(rows.map((row) => row.kind)).toEqual(["model", "lora", "style", "omitted"]);
     expect(rows.map((row) => row.detail)).toContain("The LoRA list was not recorded.");
+  });
+
+  it("counts nothing for a runnable recipe that merely needs an image from the user", () => {
+    const rows = workflowUnresolved(
+      report({
+        inputs: [
+          { kind: "source", count: 1, state: "userSupplied", detail: "Needs a source image." },
+        ],
+        runnable: true,
+      }),
+    );
+    expect(rows).toEqual([]);
   });
 
   it("is empty for a fully resolved report", () => {
@@ -323,5 +349,217 @@ describe("display helpers", () => {
     expect(byKey.someFutureKnob.label).toBe("someFutureKnob");
     // Prose and structures are shown elsewhere, not squeezed into the scalar grid.
     expect(byKey.stylePrompt).toBeUndefined();
+  });
+});
+
+// ---- The one table both halves read -----------------------------------------------------------
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENVELOPE_DOC = resolve(HERE, "../../../docs/workflow-share-envelope.md");
+
+// The `advanced` keys the ENVELOPE can carry, read out of the pinned table in
+// `docs/workflow-share-envelope.md`. That table is itself pinned to `ADVANCED_KEY_RULES` in both
+// directions by `crates/sceneworks-core/tests/workflow_share_doc.rs`, so reading it here fails the
+// moment a key is added to the contract and not to `ADVANCED_PREFILL` — which is what stops a new
+// knob being displayed as restored while reaching no control.
+function sharedAdvancedKeysFromTheContract() {
+  const doc = readFileSync(ENVELOPE_DOC, "utf8");
+  const block = doc.split("<!-- PINNED: advanced-shared -->")[1]?.split("<!-- END PINNED")[0] ?? "";
+  const keys = [...block.matchAll(/^\|\s*`([A-Za-z][\w.]*)`\s*\|/gm)].map((match) => match[1]);
+  expect(keys.length).toBeGreaterThan(20); // the parse still works
+  return keys;
+}
+
+// A plausible value per key, so one envelope can carry the whole table.
+function sampleValueFor(key) {
+  switch (key) {
+    case "poses":
+      return [{ keypoints: [1, 2] }, { keypoints: [3, 4] }];
+    case "phases":
+      return [{ steps: 4, guidance: 3.5, loras: [] }];
+    case "structuredPrompt":
+      return { intent: "a lighthouse" };
+    case "enhancePrompt":
+    case "usePid":
+    case "faceRestore":
+      return true;
+    case "pidTarget":
+      return "2k";
+    case "controlMode":
+      return "depth";
+    case "sampler":
+      return "euler";
+    case "scheduler":
+      return "shift";
+    case "guidanceMethod":
+      return "cfg";
+    case "resolution":
+      return "1024x1536";
+    case "styleId":
+      return "ghibli";
+    case "stylePrompt":
+      return "a lighthouse";
+    case "systemMessage":
+      return "You are a storyboard artist.";
+    case "viewAngle":
+      return "three_quarter";
+    case "angleSet":
+      return "turnaround_4";
+    default:
+      return 0.75;
+  }
+}
+
+describe("ADVANCED_PREFILL is the source of truth for both the prefill and the panel", () => {
+  it("classifies every advanced key the envelope contract can carry, and no others", () => {
+    expect(Object.keys(ADVANCED_PREFILL).sort()).toEqual(sharedAdvancedKeysFromTheContract().sort());
+  });
+
+  it("gives every entry a known disposition, and every unapplied one a reason", () => {
+    for (const entry of Object.values(ADVANCED_PREFILL)) {
+      expect([PREFILL_CONTROL, PREFILL_PROMPT, PREFILL_NONE]).toContain(entry.prefill);
+      expect(entry.label.length).toBeGreaterThan(0);
+      if (entry.prefill === PREFILL_NONE) {
+        // "Not restored" with no reason reads like a bug rather than a decision.
+        expect(entry.detail?.length ?? 0).toBeGreaterThan(20);
+      } else {
+        expect(entry.detail).toBeUndefined();
+      }
+    }
+  });
+
+  // THE ANTI-DRIFT TEST. Marking is worthless if it can disagree with the prefill, so both are
+  // derived from the same table against ONE envelope carrying every key: whatever the recipe
+  // carries is exactly what the panel does not mark, and vice versa.
+  it("marks exactly the rows the recipe does not carry", () => {
+    const everyKey = Object.fromEntries(
+      Object.keys(ADVANCED_PREFILL).map((key) => [key, sampleValueFor(key)]),
+    );
+    const here = report({
+      styles: [{ field: "styleId", id: "ghibli", name: "Ghibli", state: "resolved", detail: "ok" }],
+    });
+    const recipe = recipeFromWorkflowShare(share({ advanced: everyKey }), here);
+    const rows = workflowSettingRows(share({ advanced: everyKey }), here);
+
+    const carried = new Set(Object.keys(recipe.rawAdapterSettings));
+    for (const row of rows) {
+      expect(row.restored).toBe(carried.has(row.key));
+      if (!row.restored) {
+        expect(row.detail.length).toBeGreaterThan(20);
+      }
+    }
+    // …and the unrestored ones are exactly the five lanes an image envelope carries that this
+    // studio has no control for, plus `poses`, whose ids the contract deliberately drops.
+    expect(
+      rows
+        .filter((row) => !row.restored)
+        .map((row) => row.key)
+        .sort(),
+    ).toEqual(["angleSet", "cnScale", "imageGuidanceScale", "poses", "systemMessage"]);
+  });
+
+  // `styleId` is the one CONDITIONAL entry: it is applied, but only when this install has the
+  // style — so its row follows the report rather than the table's optimism.
+  it("marks a styleId this install does not have, and restores one it does", () => {
+    const styled = share({ advanced: { styleId: "ghibli", stylePrompt: "a lighthouse" } });
+    const absent = workflowSettingRows(styled, report());
+    expect(absent[0].key).toBe("styleId");
+    expect(absent[0].restored).toBe(false);
+    expect(recipeFromWorkflowShare(styled, report()).rawAdapterSettings.styleId).toBeUndefined();
+
+    const here = report({
+      styles: [{ field: "styleId", id: "ghibli", name: "Ghibli", state: "resolved", detail: "ok" }],
+    });
+    expect(workflowSettingRows(styled, here)[0].restored).toBe(true);
+    expect(recipeFromWorkflowShare(styled, here).rawAdapterSettings.styleId).toBe("ghibli");
+  });
+
+  it("keeps a key the panel has never heard of out of the recipe, and marks it", () => {
+    const unknown = share({ advanced: { someFutureKnob: "on" } });
+    const rows = workflowSettingRows(unknown);
+    expect(rows.map((row) => row.key)).toEqual(["someFutureKnob"]);
+    expect(rows[0].restored).toBe(false);
+    expect(recipeFromWorkflowShare(unknown, report()).rawAdapterSettings.someFutureKnob).toBeUndefined();
+  });
+});
+
+describe("workflowNotRestored", () => {
+  it("names the knobs that travelled intact and still land nowhere", () => {
+    const rows = workflowNotRestored(
+      share({
+        advanced: { steps: 28, cnScale: 0.4, poses: [{ keypoints: [] }, { keypoints: [] }] },
+      }),
+    );
+    expect(rows.map((row) => row.key)).toEqual(["cnScale", "poses"]);
+    // Successful transport must not be punished with silence: a 2-pose selection that arrived
+    // perfectly is now reported as loudly as one the writer dropped over its cap (`omitted`).
+    expect(rows.find((row) => row.key === "poses").title).toBe("Poses — 2 poses");
+  });
+
+  it("names a RESOLVED style preset, which is installed here and still not replayed", () => {
+    const styles = [
+      { field: "stylePreset", id: "cine", name: "Cinematic", state: "resolved", detail: "ok" },
+    ];
+    const rows = workflowNotRestored(share({ advanced: {} }), report({ styles }));
+    expect(rows.map((row) => row.key)).toEqual(["stylePreset"]);
+    // …and the recipe no longer carries the dead `stylePreset` assignment nothing ever read.
+    expect(recipeFromWorkflowShare(share(), report({ styles })).stylePreset).toBeUndefined();
+  });
+
+  it("leaves an UNRESOLVED style preset to the report, which already blocks on it", () => {
+    const styles = [
+      { field: "stylePreset", id: "cine", name: "Cinematic", state: "missing", detail: "gone" },
+    ];
+    expect(workflowNotRestored(share({ advanced: {} }), report({ styles }))).toEqual([]);
+    expect(workflowUnresolved(report({ styles, runnable: false })).map((row) => row.kind)).toEqual([
+      "style",
+    ]);
+  });
+});
+
+describe("workflowPhases", () => {
+  const loraRequirement = (name, catalogId) => ({
+    name,
+    state: catalogId ? "resolved" : "missing",
+    catalogId: catalogId ?? undefined,
+    detail: "…",
+  });
+
+  it("reindexes each phase's LoRA references onto the resolved subset", () => {
+    // The envelope's indices point into the ORIGINAL request's LoRA list. `workflowLoras` drops the
+    // unresolved middle entry, so index 2 has to become index 1 — leaving it alone would silently
+    // activate a different adapter, which is worse than not replaying the schedule at all.
+    const withLoras = report({
+      loras: [
+        loraRequirement("Grain", "film_grain"),
+        loraRequirement("A private LoRA", null),
+        loraRequirement("Turbo", "krea2_turbo_accel"),
+      ],
+      runnable: false,
+    });
+    const phases = workflowPhases(
+      share({
+        advanced: {
+          phases: [
+            { steps: 4, guidance: 3.5, loras: [] },
+            { steps: 4, guidance: 0, loras: [{ index: 2, weight: 0.9 }, { index: 1 }] },
+            { steps: 2, guidance: 1, loras: [{ index: 0 }] },
+          ],
+        },
+      }),
+      withLoras,
+    );
+    expect(phases).toEqual([
+      { steps: 4, guidance: 3.5, loras: [] },
+      { steps: 4, guidance: 0, loras: [{ index: 1, weight: 0.9 }] },
+      { steps: 2, guidance: 1, loras: [{ index: 0 }] },
+    ]);
+    expect(workflowLoras(withLoras)).toEqual([{ id: "film_grain" }, { id: "krea2_turbo_accel" }]);
+  });
+
+  it("is null when the envelope carried no schedule", () => {
+    expect(workflowPhases(share(), report())).toBeNull();
+    expect(workflowPhases(share({ advanced: { phases: [] } }), report())).toBeNull();
+    expect(recipeFromWorkflowShare(share(), report()).rawAdapterSettings.phases).toBeUndefined();
   });
 });

--- a/apps/web/src/workflowShare.test.js
+++ b/apps/web/src/workflowShare.test.js
@@ -1,0 +1,327 @@
+// The drop path's client-side half (sc-15951, epic 15945): what is worth uploading, and how a
+// `WorkflowShare` becomes the recipe the Image Studio's existing injection effect already reads.
+import { describe, expect, it } from "vitest";
+
+import {
+  looksLikeWorkflowCandidate,
+  MAX_WORKFLOW_INSPECT_BYTES,
+  recipeFromWorkflowShare,
+  workflowLoras,
+  workflowModelId,
+  workflowReplaySeed,
+  workflowResolutionLabel,
+  workflowSettingRows,
+  workflowUnresolved,
+} from "./workflowShare.js";
+
+const PNG_HEAD = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function pngFile(name = "shared.png", trailing = 64) {
+  const bytes = new Uint8Array([...PNG_HEAD, ...new Array(trailing).fill(0)]);
+  return new File([bytes], name, { type: "image/png" });
+}
+
+function share(overrides = {}) {
+  return {
+    sceneworksWorkflow: "image",
+    schemaVersion: 1,
+    producer: { name: "SceneWorks", url: "https://example.invalid", version: "0.8.1" },
+    mode: "text_to_image",
+    model: "krea_2_turbo",
+    prompt: "a lighthouse in heavy fog, cinematic",
+    negativePrompt: "text, watermark",
+    seed: 880412,
+    width: 1024,
+    height: 1536,
+    count: 4,
+    advanced: { steps: 28, guidanceScale: 3.5, sampler: "euler", resolution: "1024x1536" },
+    ...overrides,
+  };
+}
+
+function report(overrides = {}) {
+  return {
+    model: {
+      slug: "krea_2_turbo",
+      state: "resolved",
+      catalogId: "krea_2_turbo",
+      name: "Krea 2 Turbo",
+      detail: "Krea 2 Turbo is installed on this machine.",
+    },
+    loras: [],
+    styles: [],
+    inputs: [],
+    omitted: [],
+    runnable: true,
+    inputImagesRequired: 0,
+    ...overrides,
+  };
+}
+
+describe("looksLikeWorkflowCandidate", () => {
+  it("accepts a PNG", async () => {
+    await expect(looksLikeWorkflowCandidate(pngFile())).resolves.toBe(true);
+  });
+
+  it("refuses a non-PNG without asking the server", async () => {
+    // The whole point of the prescreen: the endpoint stages the WHOLE body to disk before it
+    // looks at a byte, so a 400 MB TIFF would be uploaded just to be told it is not a PNG.
+    const tiff = new File([new Uint8Array([0x49, 0x49, 0x2a, 0x00, 1, 2, 3, 4, 5])], "scan.tiff", {
+      type: "image/tiff",
+    });
+    await expect(looksLikeWorkflowCandidate(tiff)).resolves.toBe(false);
+    const text = new File(["a plain note, dropped by accident"], "notes.txt", {
+      type: "text/plain",
+    });
+    await expect(looksLikeWorkflowCandidate(text)).resolves.toBe(false);
+  });
+
+  it("refuses a file over the endpoint's own cap rather than uploading it to be 413'd", async () => {
+    const huge = pngFile("huge.png");
+    Object.defineProperty(huge, "size", { value: MAX_WORKFLOW_INSPECT_BYTES + 1 });
+    await expect(looksLikeWorkflowCandidate(huge)).resolves.toBe(false);
+  });
+
+  it("refuses a file too short to hold a signature, and a non-file", async () => {
+    await expect(looksLikeWorkflowCandidate(new File([new Uint8Array([0x89])], "x.png"))).resolves.toBe(
+      false,
+    );
+    await expect(looksLikeWorkflowCandidate(null)).resolves.toBe(false);
+    await expect(looksLikeWorkflowCandidate({})).resolves.toBe(false);
+  });
+
+  it("answers false rather than throwing when the file cannot be read", async () => {
+    const unreadable = {
+      size: 4096,
+      slice: () => ({
+        arrayBuffer: () => Promise.reject(new Error("permission revoked")),
+      }),
+    };
+    await expect(looksLikeWorkflowCandidate(unreadable)).resolves.toBe(false);
+  });
+});
+
+describe("recipeFromWorkflowShare", () => {
+  it("populates the fields the studio's injection effect reads", () => {
+    const recipe = recipeFromWorkflowShare(share(), report());
+    expect(recipe.mode).toBe("text_to_image");
+    expect(recipe.model).toBe("krea_2_turbo");
+    expect(recipe.prompt).toBe("a lighthouse in heavy fog, cinematic");
+    expect(recipe.negativePrompt).toBe("text, watermark");
+    expect(recipe.normalizedSettings.width).toBe(1024);
+    expect(recipe.normalizedSettings.height).toBe(1536);
+    // `recipeResolution` builds "1024x1536" out of these, which is what setResolution takes.
+    expect(recipe.rawAdapterSettings.steps).toBe(28);
+    expect(recipe.rawAdapterSettings.guidanceScale).toBe(3.5);
+    expect(recipe.rawAdapterSettings.sampler).toBe("euler");
+  });
+
+  it("always asks for ONE image, whatever batch the shared file came out of", () => {
+    // The envelope's seed identifies one image; `count` came from the batch the run requested.
+    // Replaying both would reproduce the shared image as the first of a 4-image batch.
+    const recipe = recipeFromWorkflowShare(share({ count: 4 }), report());
+    expect(recipe.normalizedSettings.count).toBe(1);
+  });
+
+  it("does not prefill a model this install cannot resolve", () => {
+    const missing = report({
+      model: {
+        slug: "some_private_model",
+        state: "missing",
+        detail: "No model matching `some_private_model` is in this install's catalog…",
+      },
+      runnable: false,
+    });
+    const recipe = recipeFromWorkflowShare(share({ model: "some_private_model" }), missing);
+    expect(recipe.model).toBeUndefined();
+    expect(recipe.prompt).toBe("a lighthouse in heavy fog, cinematic");
+  });
+
+  it("does not prefill a model that is merely installable — the picker would drop it", () => {
+    // `generationModelsForType` filters on `modelInstallComplete`, so an id with no row behind
+    // it would set a select to a value that has no option. Named in the panel instead.
+    const installable = report({
+      model: {
+        slug: "krea_2_turbo",
+        state: "installable",
+        catalogId: "krea_2_turbo",
+        name: "Krea 2 Turbo",
+        install: { method: "POST", path: "/api/v1/models/krea_2_turbo/download" },
+        detail: "Krea 2 Turbo is in the model catalog but is not downloaded…",
+      },
+      runnable: false,
+    });
+    expect(recipeFromWorkflowShare(share(), installable).model).toBeUndefined();
+    expect(workflowModelId(installable)).toBeNull();
+  });
+
+  it("selects resolved LoRAs by catalog id with their weights, and drops the rest", () => {
+    const withLoras = report({
+      loras: [
+        {
+          name: "Film Grain",
+          repo: "acme/film-grain",
+          weight: 0.65,
+          state: "resolved",
+          catalogId: "film_grain",
+          detail: "Film Grain is installed.",
+        },
+        {
+          name: "Someone's private LoRA",
+          state: "missing",
+          detail: "No LoRA on this install matches `Someone's private LoRA`…",
+        },
+        {
+          name: "Aurora",
+          state: "installable",
+          catalogId: "aurora_v3",
+          detail: "Aurora is in the LoRA catalog but is not downloaded…",
+        },
+      ],
+      runnable: false,
+    });
+    expect(workflowLoras(withLoras)).toEqual([{ id: "film_grain", weight: 0.65 }]);
+    expect(recipeFromWorkflowShare(share(), withLoras).loras).toEqual([
+      { id: "film_grain", weight: 0.65 },
+    ]);
+  });
+
+  it("carries a resolved LoRA with no recorded weight as a bare id", () => {
+    const withLora = report({
+      loras: [{ name: "Film Grain", state: "resolved", catalogId: "film_grain", detail: "ok" }],
+    });
+    expect(workflowLoras(withLora)).toEqual([{ id: "film_grain" }]);
+  });
+
+  it("keeps the style round-trip only when the style catalog has the id", () => {
+    const styled = share({
+      styleId: "ghibli-style",
+      advanced: { styleId: "ghibli-style", stylePrompt: "a lighthouse", steps: 20 },
+    });
+    const resolvedStyle = report({
+      styles: [
+        {
+          field: "styleId",
+          id: "ghibli-style",
+          state: "resolved",
+          name: "Ghibli Style",
+          detail: "ok",
+        },
+      ],
+    });
+    const kept = recipeFromWorkflowShare(styled, resolvedStyle);
+    expect(kept.rawAdapterSettings.styleId).toBe("ghibli-style");
+    expect(kept.rawAdapterSettings.stylePrompt).toBe("a lighthouse");
+
+    // Unresolved: dropping both keys is what makes the studio use the already-COMPOSED prompt
+    // instead of re-selecting a picker entry this catalog does not have.
+    const missingStyle = report({
+      styles: [
+        {
+          field: "styleId",
+          id: "ghibli-style",
+          state: "missing",
+          detail: "No style matching `ghibli-style`…",
+        },
+      ],
+      runnable: false,
+    });
+    const dropped = recipeFromWorkflowShare(styled, missingStyle);
+    expect(dropped.rawAdapterSettings.styleId).toBeUndefined();
+    expect(dropped.rawAdapterSettings.stylePrompt).toBeUndefined();
+    expect(dropped.prompt).toBe("a lighthouse in heavy fog, cinematic");
+  });
+
+  it("moves the top-level upscale and fitMode into the raw settings the effect reads", () => {
+    const edit = share({
+      mode: "edit_image",
+      fitMode: "contain",
+      upscale: { enabled: true, factor: 2, engine: "seedvr2", softness: 0.2 },
+    });
+    const recipe = recipeFromWorkflowShare(edit, report());
+    expect(recipe.mode).toBe("edit_image");
+    expect(recipe.rawAdapterSettings.fitMode).toBe("contain");
+    expect(recipe.rawAdapterSettings.upscale).toEqual({
+      enabled: true,
+      factor: 2,
+      engine: "seedvr2",
+      softness: 0.2,
+    });
+  });
+
+  it("does not alias the envelope's own advanced map", () => {
+    // The panel renders the envelope beside the recipe; a shared reference would let the
+    // studio-facing edits (the style strip, the upscale graft) rewrite what is displayed.
+    const source = share({ styleId: "x", advanced: { styleId: "x", stylePrompt: "raw", steps: 4 } });
+    recipeFromWorkflowShare(source, report({ runnable: false }));
+    expect(source.advanced.styleId).toBe("x");
+    expect(source.advanced.stylePrompt).toBe("raw");
+  });
+
+  it("prefills nothing that had to be looked up when no report was supplied", () => {
+    const recipe = recipeFromWorkflowShare(share());
+    expect(recipe.model).toBeUndefined();
+    expect(recipe.loras).toEqual([]);
+    expect(recipe.prompt).toBe("a lighthouse in heavy fog, cinematic");
+  });
+
+  it("is null for a null share", () => {
+    expect(recipeFromWorkflowShare(null, report())).toBeNull();
+  });
+});
+
+describe("workflowReplaySeed", () => {
+  it("reproduces this image's own seed, including zero", () => {
+    expect(workflowReplaySeed(share({ seed: 880412 }))).toBe("880412");
+    expect(workflowReplaySeed(share({ seed: 0 }))).toBe("0");
+  });
+
+  it("is null when the file recorded no seed", () => {
+    expect(workflowReplaySeed(share({ seed: null }))).toBeNull();
+    expect(workflowReplaySeed({})).toBeNull();
+  });
+});
+
+describe("workflowUnresolved", () => {
+  it("names every requirement that does not resolve, omissions included", () => {
+    const rows = workflowUnresolved(
+      report({
+        model: { slug: "x", state: "missing", detail: "no model" },
+        loras: [{ name: "y", state: "installable", detail: "not downloaded" }],
+        styles: [{ field: "styleId", id: "z", state: "missing", detail: "no style" }],
+        inputs: [
+          { kind: "source", count: 1, state: "userSupplied", detail: "Needs a source image." },
+        ],
+        omitted: [{ field: "loras", detail: "The LoRA list was not recorded." }],
+        runnable: false,
+      }),
+    );
+    expect(rows.map((row) => row.kind)).toEqual(["model", "lora", "style", "input", "omitted"]);
+    expect(rows.map((row) => row.detail)).toContain("The LoRA list was not recorded.");
+  });
+
+  it("is empty for a fully resolved report", () => {
+    expect(workflowUnresolved(report())).toEqual([]);
+    expect(workflowUnresolved(null)).toEqual([]);
+  });
+});
+
+describe("display helpers", () => {
+  it("labels the geometry, or nothing when the envelope carried none", () => {
+    expect(workflowResolutionLabel(share())).toBe("1024 × 1536");
+    expect(workflowResolutionLabel(share({ width: null, height: null }))).toBeNull();
+  });
+
+  it("shows every advanced knob in the file, labelled where a label exists", () => {
+    const rows = workflowSettingRows(
+      share({ advanced: { steps: 28, someFutureKnob: "on", usePid: true, stylePrompt: "hidden" } }),
+    );
+    const byKey = Object.fromEntries(rows.map((row) => [row.key, row]));
+    expect(byKey.steps.label).toBe("Steps");
+    expect(byKey.usePid.value).toBe("On");
+    // A knob nobody has written a label for is still a knob that changed the image.
+    expect(byKey.someFutureKnob.label).toBe("someFutureKnob");
+    // Prose and structures are shown elsewhere, not squeezed into the scalar grid.
+    expect(byKey.stylePrompt).toBeUndefined();
+  });
+});

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -433,6 +433,26 @@ exist:
 Both of those are in `workflow_share_doc.rs`, not in the lint file above. A green
 `workflow_share.rs` is not the finish line.
 
+#### And say what the receiving studio does with it
+
+An `allow` decides that the key may leave the machine. It says nothing about whether the install
+that opens the file has a control for it — and those are different questions, because an image
+envelope carries keys from four lanes (the Image Studio, the standalone Detail pass, the Character
+studio's angle set, the interleaved-document lane) while the "use this workflow" prefill lands in
+exactly one of them.
+
+So a shared key also needs a row in `ADVANCED_PREFILL` (`apps/web/src/workflowShare.js`), which is
+read by BOTH halves of the offer panel: the recipe carries exactly the keys marked as reaching a
+control, and the panel marks exactly the rest as "not restored", with the reason you write there. A
+key with no row is treated as not restored — rendered and marked, never silently dropped — and
+`workflowShare.test.js` fails if this document's [Shared](#shared) table and that map disagree in
+either direction.
+
+That guardrail exists because the first cut of the panel displayed ten knobs — `enhancePrompt`,
+`usePid`, `pidTarget`, `strength`, `textStyleGain`, `faceRestore`, `controlMode`, `controlScale`,
+`poses`, `phases` — as ordinary settings rows while none of them reached a control. Being told a
+recipe replayed faithfully when it did not is the failure this whole contract exists to prevent.
+
 If the value is authored text the user typed rather than a slug, say so in the reason and add it to
 `PROSE_KEYS` — which makes it path-exempt, so you are also adding a field to the privacy callout at
 the top of this document and must add that row too.


### PR DESCRIPTION
[sc-15951](https://app.shortcut.com/sceneworks/story/15951) — epic 15945.

The ComfyUI moment: someone sends you an image, you drag it onto SceneWorks, you are in Image Studio with their settings loaded.

## Where it hooks in

`useDropNavigationGuard` (issue #1308) already swallows drags no in-app dropzone claimed, and it already distinguishes claimed from unclaimed with one test: `event.defaultPrevented` is still false by the time the event reaches `window`, because every real dropzone calls `preventDefault()` as the event bubbles through it. sc-15951 hangs the inspector off **that same branch, unchanged** — it is inside the existing `if (event.defaultPrevented) return;` guard, so a drop AssetPicker / the Image Editor canvas / DatasetAddDialog / DocumentStudio / PoseLibraryScreen handled can never reach it.

Two further narrowings keep today's behaviour where an offer would be meaningless: only `drop` (never `dragover`), and only a drag carrying **exactly one** file — a text or URL drag carries none, and a multi-file drag is a bulk gesture no single-recipe offer could answer honestly.

`apps/web/src/workflowDropRouting.test.jsx` proves it by dispatching real bubbling drops through the two components the ACs name — the real `ImageEditSourcePickerField` upload dropzone (its `importAsset` still gets the file) and the real `ImageEditor` canvas — and asserting the inspector was never offered either. A third case mounts the same tree and drops on neutral chrome, where it is.

## The client prescreen

`POST /api/v1/workflows/inspect` stages the whole body to disk **before** it looks at the first byte, and a scan miss is O(file). So the client checks two things locally before sending anything:

- the **PNG signature**, read out of the first eight bytes via `Blob.slice` (a range read, not a load) — only a PNG can carry the chunk, so a 400 MB TIFF is refused here rather than uploaded to be told it is not a PNG;
- the endpoint's own **512 MiB cap**, so a body guaranteed to come back 413 is never sent.

`Blob.arrayBuffer` with a `FileReader` fallback, because jsdom and some older WebViews lack the former.

## What does NOT happen

`no_workflow` is the common case — every foreign PNG in the world — and it is byte-for-byte the pre-existing swallow: no panel, no spinner, no error band, nothing optimistic to un-render. Failures that say nothing about the file (a network drop, an axum plain-text multipart rejection with no `code`, a `not_png` that slipped the prescreen) are silent too. Only the closed set of "about your file" codes gets a sentence.

## Prefill goes through the existing seam

`launchImageRecipe` is extracted from `sendAssetRecipeToImage` and is now **the** path into the ImageStudio injection effect, shared by the viewer's "Use this recipe" and by "Use this workflow". `recipeFromWorkflowShare` adapts the envelope onto the recipe shape that seam already accepts (`normalizedSettings` / `rawAdapterSettings`). No second prefill path exists.

## Two things it refuses to do quietly

**Never silently substitute.** Only requirements in state `resolved` are prefilled. `installable` is deliberately not enough: `generationModelsForType` and `compatibleLoras` both drop rows that are not on disk, so seeding an installable id would set a control with no option behind it — silent loss wearing the costume of a successful replay. A model this install cannot resolve is left unset and the panel says, in as many words, that Image Studio keeps the model it is already on. Same rule strips `styleId`/`stylePrompt` when the style axis does not resolve, which makes the studio use the already-composed prompt instead of re-selecting a picker entry this catalog does not have.

**`count` is not replayed.** The envelope's `seed` identifies ONE image while `count` came from the batch the run requested, so a naive replay would reproduce the shared image as the first of an N-image batch — N-1 generations nobody asked for. The recipe always asks for one; the panel reports "this image was one of a batch of N" so the fact is stated rather than lost. (sc-15952's story comment raises the same question.)

`omitted` is load-bearing and rendered as such: a recipe whose LoRAs were dropped over the cap is not a LoRA-free recipe, and it serializes identically to one, so the marker is the only thing between the user and a confidently wrong replay.

## For sc-15952

`components/WorkflowResolutionReport.jsx` is a component of its own precisely so the missing-inputs panel renders the same report the same way rather than growing a second description of it. `workflowShare.js` (the adapter, the resolved-only readers, `workflowUnresolved`) is drop-agnostic too.

## Tests

- `apps/web/src/workflowShare.test.js` — 22 tests: prescreen (PNG / non-PNG / oversize / unreadable), the adapter, the resolved-only rule, count, the style round-trip, no-aliasing.
- `apps/web/src/hooks/useWorkflowDrop.test.jsx` — 15 tests: the workflow / no-workflow / not-a-PNG / disabled branches, the showable-vs-silent failure split, supersession, dismissal, launch, import.
- `apps/web/src/hooks/useDropNavigationGuard.test.jsx` — the 4 pre-existing plus 6 for the hand-off, including "never offers a drop a real dropzone claimed".
- `apps/web/src/workflowDropRouting.test.jsx` — the AssetPicker + ImageEditor regression, through the real components.
- `apps/web/src/components/WorkflowDropPanel.test.jsx` — 10 tests: missing model named, omitted collections not presented as absence, user-supplied inputs, the batch note, the three actions.

Full web suite: **218 files, 3160 tests, all passing.** `eslint src` clean, `npm run web:build` clean, `npm run check` clean. `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` clean; `cargo test --workspace --no-fail-fast` has the same 23 pre-existing rustls "No provider set" failures (sc-15337) and no others — the sc-15948 web-app coverage lint and the doc pins are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
