### PR TITLE
fix(memory): make web gates backend-aware (sc-15613)

### DIFF
--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -735,7 +735,13 @@ pub struct GpuInfo {
     platform: String,
     devices: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    memory_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory_mb: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     unified_memory_mb: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_memory_mb: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     wired_limit_mb: Option<u64>,
 }
@@ -1238,13 +1244,17 @@ pub fn get_gpu_info() -> GpuInfo {
         GpuInfo {
             platform: "macos".to_owned(),
             devices,
+            memory_kind: unified_memory_mb.map(|_| "unified"),
+            memory_mb: unified_memory_mb,
             unified_memory_mb,
+            gpu_memory_mb: None,
             wired_limit_mb,
         }
     }
     #[cfg(target_os = "windows")]
     {
         let mut devices = Vec::new();
+        let mut gpu_memory_mb = None;
         if let Some(output) = run_capture(
             "nvidia-smi",
             &[
@@ -1255,7 +1265,14 @@ pub fn get_gpu_info() -> GpuInfo {
             for line in output.lines() {
                 let parts: Vec<&str> = line.split(',').map(str::trim).collect();
                 match parts.as_slice() {
-                    [name, memory, ..] => devices.push(format!("{name} ({memory} MB)")),
+                    [name, memory, ..] => {
+                        devices.push(format!("{name} ({memory} MB)"));
+                        if let Ok(value) = memory.parse::<u64>() {
+                            gpu_memory_mb = Some(
+                                gpu_memory_mb.map_or(value, |current: u64| current.max(value)),
+                            );
+                        }
+                    }
                     [name] => devices.push((*name).to_owned()),
                     _ => {}
                 }
@@ -1264,19 +1281,42 @@ pub fn get_gpu_info() -> GpuInfo {
         GpuInfo {
             platform: "windows".to_owned(),
             devices,
+            memory_kind: gpu_memory_mb.map(|_| "dedicated"),
+            memory_mb: gpu_memory_mb,
             unified_memory_mb: None,
+            gpu_memory_mb,
             wired_limit_mb: None,
         }
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        let devices = run_capture("nvidia-smi", &["--query-gpu=name", "--format=csv,noheader"])
-            .map(|output| output.lines().map(str::to_owned).collect())
-            .unwrap_or_default();
+        let mut devices = Vec::new();
+        let mut gpu_memory_mb = None;
+        if let Some(output) = run_capture(
+            "nvidia-smi",
+            &[
+                "--query-gpu=name,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+        ) {
+            for line in output.lines() {
+                let parts: Vec<&str> = line.split(',').map(str::trim).collect();
+                if let [name, memory, ..] = parts.as_slice() {
+                    devices.push(format!("{name} ({memory} MB)"));
+                    if let Ok(value) = memory.parse::<u64>() {
+                        gpu_memory_mb =
+                            Some(gpu_memory_mb.map_or(value, |current: u64| current.max(value)));
+                    }
+                }
+            }
+        }
         GpuInfo {
             platform: "linux".to_owned(),
             devices,
+            memory_kind: gpu_memory_mb.map(|_| "dedicated"),
+            memory_mb: gpu_memory_mb,
             unified_memory_mb: None,
+            gpu_memory_mb,
             wired_limit_mb: None,
         }
     }

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -253,6 +253,12 @@ pub(crate) struct HostCapabilitiesResponse {
     /// API host OS (`macos`/`windows`/`linux`) so the client gates with the right
     /// memory concept (unified vs VRAM).
     pub(crate) platform: &'static str,
+    /// Active memory pool and its kind. Kept as a pair so clients cannot silently treat
+    /// shared system memory as dedicated VRAM (or the reverse).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) memory_kind: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) memory_gb: Option<f64>,
     /// Unified system memory (GB) — the macOS MLX worker reports `sysctl hw.memsize`.
     /// `None` when no MLX worker is registered.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -180,7 +180,7 @@ async fn host_capabilities_requires_token_and_reports_host_memory() {
     assert_eq!(status, StatusCode::OK);
 
     let (status, caps) = request_with_headers(
-        app,
+        app.clone(),
         "GET",
         "/api/v1/host-capabilities",
         Value::Null,
@@ -189,8 +189,48 @@ async fn host_capabilities_requires_token_and_reports_host_memory() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(caps["unifiedMemoryGb"], 128.0);
+    if std::env::consts::OS == "macos" {
+        assert_eq!(caps["memoryKind"], "unified");
+        assert_eq!(caps["memoryGb"], 128.0);
+    } else {
+        assert!(caps.get("memoryKind").is_none());
+        assert!(caps.get("memoryGb").is_none());
+    }
     // No host paths or secrets leak through this endpoint.
     assert!(caps.get("directories").is_none());
+
+    let (status, _) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/workers/register",
+        json!({
+            "workerId": "cuda-test",
+            "gpuId": "cuda:0",
+            "capabilities": [],
+            "loadedModels": [],
+            "utilization": { "memoryTotalMb": 24576 }
+        }),
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, caps) = request_with_headers(
+        app,
+        "GET",
+        "/api/v1/host-capabilities",
+        Value::Null,
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(caps["gpuMemoryGb"], 24.0);
+    if std::env::consts::OS == "macos" {
+        assert_eq!(caps["memoryKind"], "unified");
+        assert_eq!(caps["memoryGb"], 128.0);
+    } else {
+        assert_eq!(caps["memoryKind"], "dedicated");
+        assert_eq!(caps["memoryGb"], 24.0);
+    }
 }
 
 #[tokio::test]

--- a/apps/rust-api/src/workers.rs
+++ b/apps/rust-api/src/workers.rs
@@ -110,8 +110,15 @@ pub(crate) async fn host_capabilities(
         })
         .max()
         .map(mb_to_gb);
+    let (memory_kind, memory_gb) = if std::env::consts::OS == "macos" {
+        (unified_memory_gb.map(|_| "unified"), unified_memory_gb)
+    } else {
+        (gpu_memory_gb.map(|_| "dedicated"), gpu_memory_gb)
+    };
     Ok(Json(HostCapabilitiesResponse {
         platform: std::env::consts::OS,
+        memory_kind,
+        memory_gb,
         unified_memory_gb,
         gpu_memory_gb,
     }))

--- a/apps/web/src/hooks/useHostMemory.js
+++ b/apps/web/src/hooks/useHostMemory.js
@@ -2,27 +2,28 @@ import { useEffect, useState } from "react";
 import { apiFetch } from "../api.js";
 import { serverToken } from "../credentials.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
+import { hostMemoryFromCapabilities, hostMemoryFromGpuInfo } from "../hostMemory.js";
 
-// The host's unified memory (GPU VRAM off Mac) in GB, or `null` until the probe resolves / when the
-// signal is unavailable. Desktop reads the Tauri GPU probe (`get_gpu_info`); a remote LAN browser reads
-// the auth-protected REST host-capabilities signal derived from the registered GPU worker (epic 4484
-// story 9). Extracted verbatim from ModelManagerScreen's probe so the Models download suggestion and
-// the studios' capability-aware default tier (`suggestTier`) budget against the SAME memory reading.
+// The host's active accelerator-memory pool, typed as unified memory or dedicated VRAM, or `null`
+// until the probe resolves / when the signal is unavailable. Desktop reads the Tauri GPU probe
+// (`get_gpu_info`); a remote LAN browser reads the auth-protected REST host-capabilities signal
+// derived from the registered GPU worker (epic 4484 story 9). All model and studio surfaces consume
+// this hook so their tier and resolution gates budget against the same typed reading.
 //
 // `null` is a valid, safe value everywhere it flows: `tierFits`/`suggestTier` treat an unknown memory as
 // "fits" (never withhold a tier on missing data), so the capability default leans to the highest tier
 // until the reading lands — and the worker's own capability downtier (sc-10733) still clamps a
 // non-explicit pick to what actually fits, so a brief high default never OOMs a constrained host.
-export function useUnifiedMemoryGb() {
-  const [unifiedMemoryGb, setUnifiedMemoryGb] = useState(null);
+export function useHostMemory() {
+  const [hostMemory, setHostMemory] = useState(null);
   useEffect(() => {
     let cancelled = false;
     if (isDesktop) {
-      // Desktop: read unified memory straight from the Tauri GPU probe.
+      // Desktop: read the typed accelerator-memory pool from the Tauri GPU probe.
       tauriInvoke("get_gpu_info")
         .then((info) => {
-          if (!cancelled && info && typeof info.unifiedMemoryMb === "number") {
-            setUnifiedMemoryGb(info.unifiedMemoryMb / 1024);
+          if (!cancelled) {
+            setHostMemory(hostMemoryFromGpuInfo(info));
           }
         })
         .catch(() => {});
@@ -34,10 +35,7 @@ export function useUnifiedMemoryGb() {
           if (cancelled || !caps) {
             return;
           }
-          const gb = caps.unifiedMemoryGb ?? caps.gpuMemoryGb;
-          if (typeof gb === "number") {
-            setUnifiedMemoryGb(gb);
-          }
+          setHostMemory(hostMemoryFromCapabilities(caps));
         })
         .catch(() => {});
     }
@@ -45,5 +43,5 @@ export function useUnifiedMemoryGb() {
       cancelled = true;
     };
   }, []);
-  return unifiedMemoryGb;
+  return hostMemory;
 }

--- a/apps/web/src/hostMemory.js
+++ b/apps/web/src/hostMemory.js
@@ -1,0 +1,85 @@
+export const HOST_MEMORY_KINDS = Object.freeze({
+  unified: "unified",
+  dedicated: "dedicated",
+});
+
+function positiveNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function normalizedHostMemory(gb, kind, platform) {
+  const value = positiveNumber(gb);
+  if (value === null || !Object.values(HOST_MEMORY_KINDS).includes(kind)) {
+    return null;
+  }
+  return {
+    gb: value,
+    kind,
+    platform: typeof platform === "string" ? platform : null,
+  };
+}
+
+// The runtime capability decides which backend is active; memory kind only decides whether this
+// reading can safely budget that backend. A Mac in MLX observe mode, for example, can report unified
+// memory while the active lane is still Candle. Treat that mismatch as unknown rather than selecting
+// the wrong lane's evidence or pretending shared RAM is dedicated VRAM.
+export function hostMemoryGbForBackend(hostMemory, backend) {
+  const expectedKind =
+    backend === "mlx" ? HOST_MEMORY_KINDS.unified : HOST_MEMORY_KINDS.dedicated;
+  return hostMemory?.kind === expectedKind ? positiveNumber(hostMemory.gb) : null;
+}
+
+// Normalize the desktop Tauri probe without collapsing unified memory and dedicated VRAM into one
+// untyped scalar. New desktop builds provide memoryKind/memoryMb; the named legacy fields keep the
+// web compatible with an older sidecar during an app update.
+export function hostMemoryFromGpuInfo(info) {
+  if (!info || typeof info !== "object") {
+    return null;
+  }
+  const memoryMb = positiveNumber(info.memoryMb);
+  const normalized = normalizedHostMemory(
+    memoryMb === null ? null : memoryMb / 1024,
+    info.memoryKind,
+    info.platform,
+  );
+  if (normalized) {
+    return normalized;
+  }
+  const unified = positiveNumber(info.unifiedMemoryMb);
+  if (unified !== null) {
+    return normalizedHostMemory(unified / 1024, HOST_MEMORY_KINDS.unified, info.platform);
+  }
+  const dedicated = positiveNumber(info.gpuMemoryMb);
+  return dedicated === null
+    ? null
+    : normalizedHostMemory(dedicated / 1024, HOST_MEMORY_KINDS.dedicated, info.platform);
+}
+
+// Normalize the remote REST probe. memoryKind/memoryGb is the authoritative pair; the old named
+// fields remain a compatibility fallback and are selected by platform rather than null-coalescing
+// across memory kinds.
+export function hostMemoryFromCapabilities(caps) {
+  if (!caps || typeof caps !== "object") {
+    return null;
+  }
+  const normalized = normalizedHostMemory(
+    caps.memoryGb,
+    caps.memoryKind,
+    caps.platform,
+  );
+  if (normalized) {
+    return normalized;
+  }
+  if (caps.platform === "macos") {
+    return normalizedHostMemory(
+      caps.unifiedMemoryGb,
+      HOST_MEMORY_KINDS.unified,
+      caps.platform,
+    );
+  }
+  return normalizedHostMemory(
+    caps.gpuMemoryGb,
+    HOST_MEMORY_KINDS.dedicated,
+    caps.platform,
+  );
+}

--- a/apps/web/src/hostMemory.test.js
+++ b/apps/web/src/hostMemory.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  hostMemoryFromCapabilities,
+  hostMemoryFromGpuInfo,
+  hostMemoryGbForBackend,
+} from "./hostMemory.js";
+
+describe("typed host memory", () => {
+  it("keeps an 8 GB unified pool distinct from 8 GB dedicated VRAM", () => {
+    expect(
+      hostMemoryFromCapabilities({
+        platform: "macos",
+        memoryKind: "unified",
+        memoryGb: 8,
+      }),
+    ).toEqual({ gb: 8, kind: "unified", platform: "macos" });
+    expect(
+      hostMemoryFromCapabilities({
+        platform: "windows",
+        memoryKind: "dedicated",
+        memoryGb: 8,
+      }),
+    ).toEqual({ gb: 8, kind: "dedicated", platform: "windows" });
+  });
+
+  it("uses platform-specific legacy fields without cross-kind null coalescing", () => {
+    expect(
+      hostMemoryFromCapabilities({
+        platform: "windows",
+        unifiedMemoryGb: 128,
+        gpuMemoryGb: 24,
+      }),
+    ).toEqual({ gb: 24, kind: "dedicated", platform: "windows" });
+    expect(
+      hostMemoryFromCapabilities({
+        platform: "macos",
+        unifiedMemoryGb: 64,
+        gpuMemoryGb: 24,
+      }),
+    ).toEqual({ gb: 64, kind: "unified", platform: "macos" });
+  });
+
+  it("normalizes the desktop probe for both memory kinds", () => {
+    expect(
+      hostMemoryFromGpuInfo({
+        platform: "macos",
+        memoryKind: "unified",
+        memoryMb: 8192,
+      }),
+    ).toMatchObject({ gb: 8, kind: "unified" });
+    expect(
+      hostMemoryFromGpuInfo({
+        platform: "windows",
+        gpuMemoryMb: 8192,
+      }),
+    ).toMatchObject({ gb: 8, kind: "dedicated" });
+  });
+
+  it("uses the active backend as authority and rejects a mismatched memory kind", () => {
+    const unified = { gb: 8, kind: "unified", platform: "macos" };
+    const dedicated = { gb: 8, kind: "dedicated", platform: "windows" };
+    expect(hostMemoryGbForBackend(unified, "mlx")).toBe(8);
+    expect(hostMemoryGbForBackend(unified, "candle")).toBeNull();
+    expect(hostMemoryGbForBackend(dedicated, "candle")).toBe(8);
+    expect(hostMemoryGbForBackend(dedicated, "mlx")).toBeNull();
+  });
+});

--- a/apps/web/src/memoryFloorCatalogParity.test.js
+++ b/apps/web/src/memoryFloorCatalogParity.test.js
@@ -714,31 +714,9 @@ describe("catalog memory floors: duplicate tier keys cannot reach the client", (
 // the evidence sweeps cannot, and it is why "label ≥ what tierFits demands" is the invariant that makes the
 // class unrepeatable rather than merely fixing the instance.
 //
-// WHY IT IS ASSERTED ON THE MLX LANE ONLY. `tierFits` is lane-BLIND and MLX-flavoured in both of its parts:
-// its input is `variantFootprintBytes` (disk × 1.0 + a 14 GiB transient measured by the MLX
-// `footprint_measure.rs` harness at 1024², an Apple unified-memory quantity) and its criterion is
-// `peak <= host × 0.9`, the MLX budget. On MLX that makes the invariant hold BY CONSTRUCTION —
-// `hostGbForPeakGb(_, "mlx")` is `ceil(peak / 0.9)`, literally `tierFits`'s own boundary.
-//
-// On candle it is not an invariant, it is a category error, and asserting it there would overwrite every
-// number this PR's review confirmed. Measured against the shipped catalog (`wouldRaise`, below): requiring
-// it on candle would raise 754 (model, os, subset, eligibility, tier) rows across 26 models — 698 of them
-// on install-sets whose candle coverage is COMPLETE, i.e. where no fill is involved and the quoted figure
-// is purely the candle gate's own arithmetic. The example that carries the argument is `lens_turbo` q8:
-// its `candle.vramGbByTier.q8` of 42 puts the gate at 44, which is the number the row shows, while
-// `tierFits`'s MLX budget demands 50 for the same tier off its 30.50 GiB on-disk size (+14 GiB transient
-// = 44.50, and `ceil(44.50 / 0.9)` = 50). Those gate figures are the ones the candle lane itself admits
-// at (`peak + 2` on `candle.vramGbByTier`, a discrete-VRAM measurement), so raising them would re-create
-// precisely the over-warning MAJOR 3 removed.
-//
-// An earlier revision of this paragraph cited `flux_dev` 34→51 and `sd3_5_medium` 36→42 alongside
-// `lens_turbo`, which MIXED TWO FRAMINGS: both of those figures come from a tier with NO candle evidence
-// at all (`flux_dev` bf16, `sd3_5_medium` q8 — neither has a `vramGbByTier` row), so neither can appear in
-// `wouldRaise` (it requires lane evidence) and neither entry has COMPLETE candle coverage. What those two
-// contribute is a DIFFERENT tier: `flux_dev` q8 at 35 against the shown 34, and `sd3_5_medium` q4/bf16 at
-// 41/44 against the shown 36. The corrected figures above are derived by the test, not transcribed.
-// The candle lane's correct analogue is its own gate's criterion, which is what the evidence sweeps above
-// already assert with zero violations.
+// SC-15613 makes that picker lane-aware. MLX still compares its own footprint against a shared-pool
+// budget; Candle reads only `candle.vramGbByTier` and applies the worker-owned dedicated-VRAM slack.
+// Missing Candle evidence remains unknown/fail-open and must never borrow the MLX footprint.
 // ---------------------------------------------------------------------------------------------------
 
 // The candle-only tiers' host-eligibility gates, as `SimpleModelManager` derives them from live workers.
@@ -868,15 +846,9 @@ describe("catalog memory floors: the label never contradicts the module's own pi
     expect(subsetsCovered).toBeGreaterThanOrEqual(400);
   });
 
-  it("records WHY the same invariant is not asserted on the candle lane", () => {
-    // A manifest fact, pinned so the asymmetry above cannot be mistaken for an oversight — and so that if it
-    // ever stopped being true, the choice would be revisited rather than silently inherited.
-    //
-    // `tierFits`'s MLX budget demands strictly MORE than the candle gate on the shipped corpus, including on
-    // entries whose candle coverage is COMPLETE (so no fill is involved and the figure is purely the gate's
-    // own arithmetic). Forcing agreement would raise those confirmed numbers.
-    const wouldRaise = [];
-    const wouldRaiseComplete = [];
+  it("Candle: every evidenced installed tier fits at the dedicated-VRAM host the label quotes", () => {
+    const violations = [];
+    let asserted = 0;
     for (const row of SWEEP) {
       if (row.backend !== "candle" || row.subset.length === 0) {
         continue;
@@ -886,39 +858,22 @@ describe("catalog memory floors: the label never contradicts the module's own pi
         continue;
       }
       const eligible = row.subset.filter((t) => tierHostEligible(t, row.eligibility));
-      // COMPLETE candle coverage: every eligible installed tier has its own `vramGbByTier` row, so no fill
-      // and no blanket substitution is involved and `shown` is purely the candle gate's own arithmetic.
-      const completeCoverage =
-        eligible.length > 0 && eligible.every((t) => laneEvidenceGb(row.model, row.os, t) !== null);
       for (const tier of eligible) {
         const variant = row.entry.variants.find((v) => v.variant === tier);
-        const footprint = variantFootprintBytes(variant);
         const evidence = laneEvidenceGb(row.model, row.os, tier);
-        if (footprint === null || evidence === null || tierFits(variant, shown)) {
+        if (evidence === null) {
           continue;
         }
-        // The candle GATE is satisfied at the quoted host; only the MLX-flavoured `tierFits` is not.
-        expect(shown, `${row.id} ${tier}: the candle gate must still be satisfied`).toBeGreaterThanOrEqual(
-          hostGbForPeakGb(evidence, "candle"),
-        );
-        wouldRaise.push(`${row.id} ${tier}`);
-        if (completeCoverage) {
-          wouldRaiseComplete.push(`${row.id} ${tier}`);
+        asserted++;
+        if (!tierFits(variant, shown, { backend: "candle", model: row.entry })) {
+          violations.push(
+            `${row.id} on ${row.os} [${row.subset.join(",")}]: ${tier} rejected at ${shown} GB`,
+          );
         }
       }
     }
-    // FLOORS NEAR THE REAL FIGURES, not a token ">= 50". The previous floor was 50 against an actual 644,
-    // so a >10x erosion of the fact it protects would have gone unnoticed; these sit ~80% of the measured
-    // values (754 / 698 / 26 / 65 at the time of writing) so real erosion reds while routine catalog churn
-    // does not. The COMPLETE-coverage subset is asserted SEPARATELY because that is the load-bearing half
-    // of the claim above — an over-count driven purely by fill-based rows would not support it.
-    expect(wouldRaise.length).toBeGreaterThanOrEqual(600);
-    expect(wouldRaiseComplete.length).toBeGreaterThanOrEqual(550);
-    expect(new Set(wouldRaise.map((row) => row.split(" ")[0])).size).toBeGreaterThanOrEqual(20);
-    expect(new Set(wouldRaise).size).toBeGreaterThanOrEqual(50);
-    // `lens_turbo` q8 is the example the comment argues from, and it is a COMPLETE-coverage row.
-    expect(wouldRaiseComplete).toContain("lens_turbo q8");
-    expect(wouldRaise.join(",")).toContain("flux_dev");
+    expect(violations.join("\n")).toBe("");
+    expect(asserted).toBeGreaterThanOrEqual(500);
   });
 
   it("pins that the linux projection is byte-identical to windows, so two OSes sweep exhaustively", () => {

--- a/apps/web/src/resolutionMemory.js
+++ b/apps/web/src/resolutionMemory.js
@@ -130,7 +130,11 @@ export function resolutionFitsMemory(model, resolution, unifiedMemoryGb, options
   if (required == null) {
     return true;
   }
-  return required <= unifiedMemoryGb * MEMORY_HEADROOM_FRACTION;
+  // `candle.minMemoryGb` is already a dedicated-VRAM host requirement. Applying the MLX 0.9
+  // shared-pool budget to it would mix memory kinds and hide resolutions on CUDA hosts.
+  return backend === "candle"
+    ? required <= unifiedMemoryGb
+    : required <= unifiedMemoryGb * MEMORY_HEADROOM_FRACTION;
 }
 
 // Filter a list of "WxH" buckets to those that fit `unifiedMemoryGb`, preserving order. The studio's

--- a/apps/web/src/resolutionMemory.test.js
+++ b/apps/web/src/resolutionMemory.test.js
@@ -92,6 +92,17 @@ describe("resolutionFitsMemory", () => {
       resolutionFitsMemory(model, "2048x2048", exactBudgetGb - 0.001, { backend: "mlx" }),
     ).toBe(false);
   });
+
+  it("uses the dedicated-VRAM host boundary on Candle instead of the MLX fraction", () => {
+    const required = predictedResolutionPeakGb(kreaModel(), "2048x2048", "candle");
+    expect(resolutionFitsMemory(kreaModel(), "2048x2048", required, { backend: "candle" })).toBe(
+      true,
+    );
+    expect(
+      resolutionFitsMemory(kreaModel(), "2048x2048", required - 0.001, { backend: "candle" }),
+    ).toBe(false);
+    expect(required / MEMORY_HEADROOM_FRACTION).toBeGreaterThan(required);
+  });
 });
 
 describe("predictedResolutionPeakGb", () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -152,7 +152,8 @@ import {
   tierPickerOptions,
 } from "../quantTier.js";
 import { suggestTier } from "../tierSuggestion.js";
-import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
+import { useHostMemory } from "../hooks/useHostMemory.js";
+import { hostMemoryGbForBackend } from "../hostMemory.js";
 import { readLastTier } from "../lastTierStore.js";
 import {
   PROMPT_REFINE_MODEL_ID,
@@ -861,10 +862,12 @@ export function ImageStudio() {
   // default), so a small model (SANA-Sprint) defaults to bf16 and a heavy one on a small Mac to what
   // fits — instead of a flat q8. `null` memory (probe pending / unavailable) leans to the highest tier;
   // the worker's capability downtier (sc-10733) still clamps a non-explicit pick to what actually fits.
-  const unifiedMemoryGb = useUnifiedMemoryGb();
+  const hostMemory = useHostMemory();
+  const activeBackend = macCapabilities?.macGatingActive ? "mlx" : "candle";
+  const unifiedMemoryGb = hostMemoryGbForBackend(hostMemory, activeBackend);
   const autoTier = useMemo(
-    () => suggestTier(selectedModel, unifiedMemoryGb),
-    [selectedModel, unifiedMemoryGb],
+    () => suggestTier(selectedModel, unifiedMemoryGb, { backend: activeBackend }),
+    [selectedModel, unifiedMemoryGb, activeBackend],
   );
   const { quantTier, tierSwitching, handleTierChange } = useQuantTierPicker({
     screen: TIER_SCREEN,
@@ -1152,12 +1155,13 @@ export function ImageStudio() {
     const declared = selectedModel?.limits?.resolutions?.length
       ? selectedModel.limits.resolutions
       : DEFAULT_RESOLUTION_OPTIONS;
-    const backend = macCapabilities?.macGatingActive ? "mlx" : "candle";
-    const gated = fitsResolutionOptions(selectedModel, declared, unifiedMemoryGb, { backend });
+    const gated = fitsResolutionOptions(selectedModel, declared, unifiedMemoryGb, {
+      backend: activeBackend,
+    });
     // Never collapse to an empty picker: if the gate somehow trims everything (it never trims
     // ≤1536², so this is defensive), fall back to the declared list.
     return gated.length > 0 ? gated : declared;
-  }, [selectedModel, unifiedMemoryGb, macCapabilities]);
+  }, [selectedModel, unifiedMemoryGb, activeBackend]);
   // Reference-image auto-preset (sc-8109, epic 8102): when a captioning reference
   // image's natural dimensions become known, snap the resolution picker to whichever
   // option best matches its aspect ratio. The caption's bboxes are normalized 0–1000
@@ -1189,7 +1193,6 @@ export function ImageStudio() {
   // override on the Windows/Linux candle build (e.g. Lens exposes the curated menu
   // only on candle; SDXL only on MLX). The advanced panel hides the dropdowns when
   // the menu has fewer than 2 options (epic 1753 §7.4).
-  const activeBackend = macCapabilities?.macGatingActive ? "mlx" : "candle";
   const samplerOptions = useMemo(
     () => samplerOptionsFromModel(selectedModel, activeBackend),
     [selectedModel, activeBackend],

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WAN_MOE_PAIRED_LORA_MODEL_IDS, terminalStatuses } from "../constants.js";
-import { hasPresentCredential, loadCredentials, serverToken } from "../credentials.js";
+import { hasPresentCredential, loadCredentials } from "../credentials.js";
 import {
   extractFamilies,
   loraHasResolvableFamily,
@@ -13,12 +13,12 @@ import {
 } from "../presetUtils.js";
 import { useAppContext } from "../context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macModelBlock } from "../macGating.js";
-import { apiFetch } from "../api.js";
 import { appConfirm } from "../appConfirm.jsx";
 import { KeywordTagEditor } from "../components/KeywordTagEditor.jsx";
-import { isDesktop, tauriInvoke } from "../runtime.js";
+import { useHostMemory } from "../hooks/useHostMemory.js";
+import { hostMemoryGbForBackend } from "../hostMemory.js";
 import { tierLabel } from "../quantTier.js";
-import { suggestTier, tierFits } from "../tierSuggestion.js";
+import { blanketFloorGb, suggestTier, tierFits } from "../tierSuggestion.js";
 import { safeExternalUrl } from "../urls.js";
 
 function matchesFamily(item, familyFilter) {
@@ -382,6 +382,7 @@ function orderedMatrixVariants(model) {
 function ModelTierDownloadPanel({
   model,
   unifiedMemoryGb,
+  backend,
   downloadJobs,
   licenseAckRequired,
   onDownloadVariant,
@@ -389,7 +390,7 @@ function ModelTierDownloadPanel({
   deletingItem,
 }) {
   const variants = orderedMatrixVariants(model);
-  const suggested = suggestTier(model, unifiedMemoryGb);
+  const suggested = suggestTier(model, unifiedMemoryGb, { backend });
   // In-flight download job per tier, keyed by the job payload's `variant` (sc-8508 records it).
   const activeJobByTier = new Map();
   for (const job of downloadJobs) {
@@ -464,7 +465,7 @@ function ModelTierDownloadPanel({
           // model-level warning: q4/q8 that actually fit show nothing; only a genuinely over-budget tier
           // (e.g. bf16 on a small Mac) is flagged. Advisory only — SUGGEST-NEVER-WITHHOLD (epic 8506
           // decision 1) keeps every tier's checkbox enabled regardless.
-          const overBudget = !tierFits(variant, unifiedMemoryGb);
+          const overBudget = !tierFits(variant, unifiedMemoryGb, { backend, model });
           // A torn tier: the cache holds SOME of this tier's declared files but not all. Distinct from
           // both "installed" and "not installed" (sc-12279).
           const incomplete = !installed && variant.cacheState === "incomplete";
@@ -738,11 +739,9 @@ export function ModelManagerScreen() {
       setActiveTab(prevTab || "image");
     }
   };
-  // Read the host's memory so MLX models can be gated against their memory tier.
-  // Desktop reads it from the Tauri GPU probe; a remote LAN browser reads the
-  // auth-protected REST signal (epic 4484 story 9). `isDesktop`/`tauriInvoke` come
-  // from the unified runtime helper (story 6).
-  const [unifiedMemoryGb, setUnifiedMemoryGb] = useState(null);
+  const hostMemory = useHostMemory();
+  const memoryBackend = macCapabilities?.macGatingActive ? "mlx" : "candle";
+  const unifiedMemoryGb = hostMemoryGbForBackend(hostMemory, memoryBackend);
   // "Update" orchestration for convert-at-install models (epic 10285): re-download the newer
   // source checkpoint, then auto-fire the re-convert once that download completes. Maps a model id
   // to the specific download job id we're waiting on — a specific id (not "any completed download")
@@ -820,39 +819,6 @@ export function ModelManagerScreen() {
         : current,
     );
   }, [importForm.family]);
-
-  useEffect(() => {
-    let cancelled = false;
-    if (isDesktop) {
-      // Desktop: read unified memory straight from the Tauri GPU probe.
-      tauriInvoke("get_gpu_info")
-        .then((info) => {
-          if (!cancelled && info && typeof info.unifiedMemoryMb === "number") {
-            setUnifiedMemoryGb(info.unifiedMemoryMb / 1024);
-          }
-        })
-        .catch(() => {});
-    } else {
-      // Remote LAN browser (epic 4484 story 9): the Tauri probe is unavailable, so
-      // read the host's memory from the auth-protected REST signal derived from the
-      // registered GPU worker (unified memory on macOS / GPU VRAM on Windows). Without
-      // this, memory gating would silently no-op for remote users.
-      apiFetch("/api/v1/host-capabilities", serverToken())
-        .then((caps) => {
-          if (cancelled || !caps) {
-            return;
-          }
-          const gb = caps.unifiedMemoryGb ?? caps.gpuMemoryGb;
-          if (typeof gb === "number") {
-            setUnifiedMemoryGb(gb);
-          }
-        })
-        .catch(() => {});
-    }
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     if (!hasGatedModel) {
@@ -1210,8 +1176,10 @@ export function ModelManagerScreen() {
     const deleteKey = `model:${model.id}`;
     const canDelete = Boolean(onDeleteModel) && model.removable !== false;
     // MLX (macOS) variant: only present when the catalog computed mlxConversionState.
+    // Conversion state is a platform capability supplied by the API, not a memory measurement.
+    // Keep that control surface intact while guarding the MLX memory block by the active lane.
     const mlxState = model.mlxConversionState;
-    const mlxMinGb = model.mlx?.minMemoryGb ?? null;
+    const mlxMinGb = memoryBackend === "mlx" ? blanketFloorGb(model, "mlx") : null;
     const mlxEnoughMemory = unifiedMemoryGb == null || mlxMinGb == null || unifiedMemoryGb >= mlxMinGb;
     const convertJobs = convertJobsFor(model);
     const convertJob = convertJobs.find((job) => !terminalStatuses.has(job.status));
@@ -1367,6 +1335,7 @@ export function ModelManagerScreen() {
           <ModelTierDownloadPanel
             model={model}
             unifiedMemoryGb={unifiedMemoryGb}
+            backend={memoryBackend}
             downloadJobs={downloadJobs}
             licenseAckRequired={licenseAckRequired}
             onDownloadVariant={onDownloadVariant}

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -949,7 +949,7 @@ describe("ModelManagerScreen remote memory gating (REST)", () => {
     delete window.__TAURI__;
     apiFetch = vi.fn(async (path) => {
       if (path === "/api/v1/host-capabilities") {
-        return { platform: "macos", unifiedMemoryGb: 16 };
+        return { platform: "macos", memoryKind: "unified", memoryGb: 16 };
       }
       return [];
     });
@@ -982,6 +982,7 @@ describe("ModelManagerScreen remote memory gating (REST)", () => {
       jobs: [],
       loras: [],
       models,
+      macCapabilities: { macGatingActive: true },
       presets: [],
       jobAction: () => {},
       setActiveView: () => {},
@@ -1025,6 +1026,7 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
   let createModelDownloadJob;
   let deleteModelVariant;
   let hostMemoryGb;
+  let hostPlatform;
   let ModelManagerScreen;
   let AppContext;
 
@@ -1032,16 +1034,16 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
 
   // A quant-matrix model in the sc-8508 /models shape: hasVariantMatrix + a per-tier variants[]
   // carrying variant / installState / downloadSizeBytes / footprint. Tiers are sized so the RAM
-  // suggestion lands on q4 at 32 GB (budget 25.6 GB: q4 est 6 GB fits; q8/bf16 overflow) and on bf16
-  // at 512 GB (budget 409 GB: bf16 est 36 GB fits).
+  // suggestion lands on q4 at 32 GB (budget 28.8 GB: q4 estimated peak 18 GB fits; q8/bf16 overflow)
+  // and on bf16 at 512 GB (budget 460.8 GB: bf16 estimated peak 38 GB fits).
   function matrixModel({ installed = [] } = {}) {
     // diskGb (on-disk footprint, req #1 — this is what the row must render) is deliberately distinct
     // from downloadGb (compressed download) so the assertions prove the displayed size comes from
     // footprint.diskSizeBytes, not downloadSizeBytes. The RAM suggestion keys off diskGb.
     const tiers = [
-      { variant: "q4", diskGb: 4, downloadGb: 3 }, // est 6 GB
-      { variant: "q8", diskGb: 18, downloadGb: 15 }, // est 27 GB > 25.6 → excluded at 32 GB
-      { variant: "bf16", diskGb: 24, downloadGb: 20 }, // est 36 GB > 25.6 → excluded at 32 GB
+      { variant: "q4", diskGb: 4, downloadGb: 3 }, // est 18 GB
+      { variant: "q8", diskGb: 18, downloadGb: 15 }, // est 32 GB > 28.8 → excluded at 32 GB
+      { variant: "bf16", diskGb: 24, downloadGb: 20 }, // est 38 GB > 28.8 → excluded at 32 GB
     ];
     return {
       id: "z_image_turbo",
@@ -1081,11 +1083,16 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
     delete window.__TAURI__;
     hostMemoryGb = 32;
+    hostPlatform = "macos";
     createModelDownloadJob = vi.fn(async () => ({ id: "job", payload: {} }));
     deleteModelVariant = vi.fn(async () => ({ reclaimedBytes: 1, reclaimedLabel: "18.0 GB" }));
     apiFetch = vi.fn(async (path) => {
       if (path === "/api/v1/host-capabilities") {
-        return { platform: "macos", unifiedMemoryGb: hostMemoryGb };
+        return {
+          platform: hostPlatform,
+          memoryKind: hostPlatform === "macos" ? "unified" : "dedicated",
+          memoryGb: hostMemoryGb,
+        };
       }
       return [];
     });
@@ -1118,6 +1125,7 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
       jobs: [],
       loras: [],
       models,
+      macCapabilities: { macGatingActive: hostPlatform === "macos" },
       presets: [],
       jobAction: () => {},
       setActiveView: () => {},
@@ -1143,6 +1151,20 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
   function tierRows() {
     return [...container.querySelectorAll(".model-tier-row")];
   }
+
+  it("uses Candle tier evidence for a dedicated-VRAM host", async () => {
+    hostPlatform = "windows";
+    hostMemoryGb = 12;
+    const model = {
+      ...matrixModel(),
+      candle: { vramGbByTier: { q4: 6, q8: 10, bf16: 20 } },
+    };
+    await render([model]);
+    const suggested = tierRows().find((row) =>
+      row.querySelector(".model-tier-suggested-badge"),
+    );
+    expect(suggested?.textContent).toContain("Q8");
+  });
 
   it("renders a per-tier panel with each tier's size + install state for a matrix model", async () => {
     await render([matrixModel({ installed: ["q8"] })]);

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -4,7 +4,8 @@ import { useAppContext } from "../context/AppContext.js";
 import { imageModelServesMode } from "../modelEligibility.js";
 import { findModelEditLora, loraIsInstalled } from "../presetUtils.js";
 import { fitsResolutionOptions } from "../resolutionMemory.js";
-import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
+import { useHostMemory } from "../hooks/useHostMemory.js";
+import { hostMemoryGbForBackend } from "../hostMemory.js";
 import { resultGridColumns } from "./breakpoint.js";
 import { describeResolution, resolutionSummary } from "./aspect.js";
 import { preferredResolution } from "./modelDefaults.js";
@@ -58,7 +59,9 @@ export function SimpleImageStudio() {
   } = useAppContext();
   const { breakpoint, openSheet, closeSheet, openGuide, toast, referenceRequest, clearReferenceRequest } =
     useSimpleUi();
-  const unifiedMemoryGb = useUnifiedMemoryGb();
+  const hostMemory = useHostMemory();
+  const memoryBackend = macCapabilities?.macGatingActive ? "mlx" : "candle";
+  const unifiedMemoryGb = hostMemoryGbForBackend(hostMemory, memoryBackend);
   const refine = useSimpleRefine("image");
 
   // Sticky across navigation (this studio unmounts when you leave it) — everything the user
@@ -99,10 +102,11 @@ export function SimpleImageStudio() {
     const declared = selectedModel?.limits?.resolutions?.length
       ? selectedModel.limits.resolutions
       : DEFAULT_RESOLUTIONS;
-    const backend = macCapabilities?.macGatingActive ? "mlx" : "candle";
-    const gated = fitsResolutionOptions(selectedModel, declared, unifiedMemoryGb, { backend });
+    const gated = fitsResolutionOptions(selectedModel, declared, unifiedMemoryGb, {
+      backend: memoryBackend,
+    });
     return gated.length ? gated : declared;
-  }, [selectedModel, macCapabilities, unifiedMemoryGb]);
+  }, [selectedModel, unifiedMemoryGb, memoryBackend]);
 
   // Seed from the model's DECLARED default, not `limits.resolutions[0]` — for 16 shipped
   // image models those differ (z_image declares 1024², its list leads with 768²), so [0]
@@ -236,6 +240,7 @@ export function SimpleImageStudio() {
         convRotEligible: workerAdvertises(visibleWorkers, "int8_convrot"),
         nvfp4Eligible: workerAdvertises(visibleWorkers, "nvfp4"),
         unifiedMemoryGb,
+        backend: memoryBackend,
       });
       const request = buildSimpleImageRequest({
         prompt: prompt.trim(),

--- a/apps/web/src/simple/SimpleModelManager.jsx
+++ b/apps/web/src/simple/SimpleModelManager.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { terminalStatuses } from "../constants.js";
-import { useUnifiedMemoryGb } from "../hooks/useUnifiedMemoryGb.js";
+import { useHostMemory } from "../hooks/useHostMemory.js";
 import { blanketFloorGb, declaredFloorHostGb, installedFloorHostGb } from "../tierSuggestion.js";
 import { workerAdvertises } from "./simpleJobs.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
@@ -36,7 +36,7 @@ export function SimpleModelManager() {
     visibleWorkers = [],
   } = useAppContext();
   const { toast, openInAdvanced } = useSimpleUi();
-  const unifiedMemoryGb = useUnifiedMemoryGb();
+  const hostMemory = useHostMemory();
   const [tab, setTab] = useState("image");
   // Which lane's memory evidence the rows quote. Same derivation as ImageStudio / SimpleImageStudio —
   // the memory numbers are per-backend and must not be crossed (see `needsLabel`).
@@ -161,8 +161,10 @@ export function SimpleModelManager() {
         <p className="su-empty">No {TABS.find((entry) => entry.id === tab)?.label.toLowerCase()} entries in the catalog.</p>
       )}
 
-      {unifiedMemoryGb ? (
-        <p className="su-empty">This machine reports {unifiedMemoryGb.toFixed(0)} GB of usable memory.</p>
+      {hostMemory ? (
+        <p className="su-empty">
+          This machine reports {hostMemory.gb.toFixed(0)} GB of {hostMemory.kind} memory.
+        </p>
       ) : null}
     </div>
   );

--- a/apps/web/src/simple/simpleJobs.js
+++ b/apps/web/src/simple/simpleJobs.js
@@ -44,7 +44,12 @@ export function workerAdvertises(workers, capability) {
 // sticky first, then the global quality setting, then the capability-aware Auto suggestion —
 // all clamped to what's actually installed.
 export function resolveSimpleTier(model, screen, options = {}) {
-  const { convRotEligible = false, nvfp4Eligible = false, unifiedMemoryGb = null } = options;
+  const {
+    convRotEligible = false,
+    nvfp4Eligible = false,
+    unifiedMemoryGb = null,
+    backend = "mlx",
+  } = options;
   const tierOptions = { convRotEligible, nvfp4Eligible };
   const available = installedTiers(model, tierOptions);
   if (available.length === 0) {
@@ -55,7 +60,7 @@ export function resolveSimpleTier(model, screen, options = {}) {
     defaultTierSelection(model, sticky, {
       ...tierOptions,
       defaultQuality: readDefaultGenerationQuality(),
-      autoTier: suggestTier(model, unifiedMemoryGb),
+      autoTier: suggestTier(model, unifiedMemoryGb, { backend }),
     }) ?? "";
   return {
     quantTier,

--- a/apps/web/src/tierSuggestion.js
+++ b/apps/web/src/tierSuggestion.js
@@ -592,15 +592,21 @@ function fidelityRank(tier) {
 // Whether a variant's PEAK footprint fits within `unifiedMemoryGb` with headroom. When the memory
 // signal is unknown (null) OR the tier has no estimable footprint, we treat it as fitting — we never
 // withhold or block a tier on missing data; the worst case is suggesting a heavier tier.
-export function tierFits(variant, unifiedMemoryGb) {
-  if (unifiedMemoryGb == null || !Number.isFinite(unifiedMemoryGb)) {
+export function tierFits(variant, hostMemoryGb, options = {}) {
+  if (hostMemoryGb == null || !Number.isFinite(hostMemoryGb)) {
     return true;
+  }
+  if (options.backend === "candle") {
+    const tier = variant?.variant;
+    const peak = tier ? peakGbByTier(options.model, "candle").get(tier) ?? null : null;
+    // Missing Candle evidence is unknown, never permission to borrow the MLX footprint.
+    return peak === null ? true : peak + CANDLE_HEADROOM_GB <= hostMemoryGb;
   }
   const footprint = variantFootprintBytes(variant);
   if (footprint === null) {
     return true;
   }
-  const budgetBytes = unifiedMemoryGb * BYTES_PER_GB * MEMORY_HEADROOM_FRACTION;
+  const budgetBytes = hostMemoryGb * BYTES_PER_GB * MEMORY_HEADROOM_FRACTION;
   return footprint.bytes <= budgetBytes;
 }
 
@@ -611,7 +617,7 @@ export function tierFits(variant, unifiedMemoryGb) {
 //
 // This never affects installability — it just picks which tier to pre-select/highlight. A 32 GB host
 // lands on q4, a 512 GB Studio on bf16, and either can override.
-export function suggestTier(model, unifiedMemoryGb) {
+export function suggestTier(model, hostMemoryGb, options = {}) {
   const tiers = declaredTiers(model);
   if (tiers.length === 0) {
     return null;
@@ -624,7 +630,7 @@ export function suggestTier(model, unifiedMemoryGb) {
   // `tiers` is already highest-fidelity first; the first that fits wins.
   for (const tier of tiers) {
     const variant = byKey.get(tier);
-    if (variant && tierFits(variant, unifiedMemoryGb)) {
+    if (variant && tierFits(variant, hostMemoryGb, { ...options, model })) {
       return tier;
     }
   }

--- a/apps/web/src/tierSuggestion.test.js
+++ b/apps/web/src/tierSuggestion.test.js
@@ -175,9 +175,34 @@ describe("tierFits", () => {
     expect(tierFits(atBudget, budgetGb)).toBe(true);
     expect(tierFits(overBudget, budgetGb)).toBe(false);
   });
+
+  it("uses Candle VRAM evidence and never the variant's MLX footprint on a CUDA host", () => {
+    const variant = { variant: "q4", footprint: { peakMemoryBytes: 100 * GB } };
+    const model = { candle: { vramGbByTier: { q4: 6 } } };
+    expect(tierFits(variant, 8, { backend: "candle", model })).toBe(true);
+    expect(tierFits(variant, 7, { backend: "candle", model })).toBe(false);
+    expect(tierFits(variant, 8, { backend: "mlx", model })).toBe(false);
+  });
+
+  it("fails open when Candle has no evidence instead of borrowing MLX measurements", () => {
+    const variant = { variant: "q8", footprint: { peakMemoryBytes: 100 * GB } };
+    expect(tierFits(variant, 8, { backend: "candle", model: { candle: {} } })).toBe(true);
+  });
 });
 
 describe("suggestTier", () => {
+  it("suggests from the Candle ladder on a dedicated-VRAM host", () => {
+    const model = {
+      ...matrixModel([
+        { variant: "q4", peakGb: 100 },
+        { variant: "q8", peakGb: 100 },
+        { variant: "bf16", peakGb: 100 },
+      ]),
+      candle: { vramGbByTier: { q4: 6, q8: 10, bf16: 20 } },
+    };
+    expect(suggestTier(model, 12, { backend: "candle" })).toBe("q8");
+  });
+
   it("suggests q4 on a 32 GB host when the larger tiers overflow the budget (acceptance)", () => {
     // Peak-based budget on 32 GB = 32 × 0.9 = 28.8 GB. Estimated peak = diskGb × 1.0 + 14 GB transient.
     // Size q8/bf16 to exceed the budget so only q4 fits (a 32 GB user sees q4 pre-selected).

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -644,7 +644,7 @@
                 "type": "integer",
                 "minimum": 1,
                 "x-sceneworks-contract": "advisory",
-                "x-sceneworks-readers": [{ "path": "apps/web/src/screens/ModelManagerScreen.jsx", "anchor": "model.mlx?.minMemoryGb" }],
+                "x-sceneworks-readers": [{ "path": "apps/web/src/screens/ModelManagerScreen.jsx", "anchor": "blanketFloorGb(model, \"mlx\")" }],
                 "description": "Minimum unified memory (GB) to run this model on MLX. Mirrors MlxVideoAdapter.estimate_requirements peak_gb."
               },
               "calibrations": {


### PR DESCRIPTION
## Summary
- carry a typed unified-vs-dedicated host memory signal through Tauri and REST probes
- keep the active runtime backend authoritative and fail open when the reported memory kind does not match its lane
- make tier and resolution suggestions consume only the active backend evidence across advanced and simple surfaces
- extend catalog parity coverage to Candle without borrowing MLX footprint measurements

## Foundation boundary
This is shared admission and presentation infrastructure only. It adds no provider, model-family, model implementation, calibration row, or signoff data.

## Validation
- independent adversarial review: approved at exact head 2bcba181 with confidence 0.99
- full web suite: 221 files, 3,208 tests passed
- focused backend-memory suite: 283 tests passed before rebase; 176 composition tests passed after rebase
- web production build and ESLint passed
- Rust API all-target clippy passed
- typed host-capabilities Rust test passed
- desktop package check and 28 focused tests passed
- cargo fmt check passed

Local desktop all-target clippy still reports two pre-existing macOS-only dead-code warnings in setup.rs; the hosted Windows lane is the authoritative desktop platform check.

Shortcut: sc-15613