### PR TITLE
fix(memory): size convert-output tiers (sc-16045)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -3862,13 +3862,73 @@ fn mlx_convert_output_tier_states(
             } else {
                 ("missing", "missing")
             };
+            // Convert-at-install tiers have no downloads[] row of their own, so this runtime catalog
+            // state is the only truthful place to surface their per-tier size. Count the files the
+            // tier can load, including symlinked shared weights: unlike converted_tier_real_bytes
+            // (deletion accounting), this is a residency estimate, not reclaimable disk accounting.
+            let disk_size_bytes = converted_tier_loaded_bytes(&dir);
             json!({
                 "tier": tier,
                 "installState": install_state,
                 "cacheState": cache_state,
+                "diskSizeBytes": disk_size_bytes,
             })
         })
         .collect()
+}
+
+/// Sum the bytes visible to a converted tier load, including symlinked weight files.
+///
+/// This intentionally differs from [`converted_tier_real_bytes`], which excludes symlinks because it
+/// answers "what would deleting this tier reclaim?". The catalog memory floor instead needs "what
+/// bytes can this tier hold resident?", so a shared text encoder or VAE linked into the tier must count.
+/// Directory symlinks are followed because a converter may link a shared component directory rather
+/// than its individual files. Canonical-directory de-duplication prevents cycles and counts a shared
+/// component once even when more than one in-tier path aliases it.
+fn converted_tier_loaded_bytes(tier_dir: &FsPath) -> Option<u64> {
+    let mut total: u64 = 0;
+    let mut stack = vec![tier_dir.to_path_buf()];
+    let mut visited_dirs = std::collections::HashSet::new();
+    let mut visited_files = std::collections::HashSet::new();
+    while let Some(dir) = stack.pop() {
+        let canonical = std::fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+        if !visited_dirs.insert(canonical) {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if is_hidden_file(&path) {
+                continue;
+            }
+            let Ok(link_meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if link_meta.file_type().is_symlink() {
+                if let Ok(target_meta) = std::fs::metadata(&path) {
+                    if target_meta.is_file() {
+                        let canonical =
+                            std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                        if visited_files.insert(canonical) {
+                            total = total.saturating_add(target_meta.len());
+                        }
+                    } else if target_meta.is_dir() {
+                        stack.push(path);
+                    }
+                }
+            } else if link_meta.is_dir() {
+                stack.push(path);
+            } else if link_meta.is_file() {
+                let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                if visited_files.insert(canonical) {
+                    total = total.saturating_add(link_meta.len());
+                }
+            }
+        }
+    }
+    (total > 0).then_some(total)
 }
 
 /// Whether a converted tier subdir holds loadable weights: a non-hidden `.safetensors` / `.index.json`
@@ -6833,6 +6893,23 @@ mod mlx_tier_probe_tests {
             "a torn DiT-only tier must read incomplete, not installed"
         );
         assert_eq!(a["bf16"], ("missing".into(), "missing".into()));
+        let disk_bytes = |states: &[Value], tier: &str| {
+            states
+                .iter()
+                .find(|state| state["tier"] == tier)
+                .and_then(|state| state["diskSizeBytes"].as_u64())
+        };
+        assert_eq!(
+            disk_bytes(&anima, "q4"),
+            Some(3),
+            "the complete tier reports its DiT, text encoder, and VAE bytes"
+        );
+        assert_eq!(
+            disk_bytes(&anima, "q8"),
+            Some(1),
+            "a torn tier reports the bytes that are actually present"
+        );
+        assert_eq!(disk_bytes(&anima, "bf16"), None);
 
         // A convert family with no bespoke predicate keeps the coarse backbone probe — a DiT-only tier
         // reads installed (byte-identical to the pre-sc-13513 behavior for any non-anima convert family).
@@ -6844,6 +6921,27 @@ mod mlx_tier_probe_tests {
         seed_anima_tier(root, "q8", true);
         let a2 = tier_state_map(&mlx_convert_output_tier_states(root, "anima", "anima_base"));
         assert_eq!(a2["q8"], ("installed".into(), "complete".into()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn convert_output_size_counts_shared_directory_symlinks_once() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tier = tmp.path().join("converted/q4");
+        write_weight(&tier, "diffusion_models", "dit.safetensors");
+        let shared = tmp.path().join("source/text_encoders");
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::write(shared.join("encoder.safetensors"), b"shared").unwrap();
+        symlink(&shared, tier.join("text_encoders")).unwrap();
+        // A second alias to the same directory must not double-count the same shared component.
+        symlink(&shared, tier.join("text_encoder_alias")).unwrap();
+
+        assert_eq!(
+            converted_tier_loaded_bytes(&tier),
+            Some(1 + b"shared".len() as u64)
+        );
     }
 
     // Full catalog path: a converted convert-at-install model (Anima) emits `mlxTiers` from
@@ -6911,6 +7009,16 @@ mod mlx_tier_probe_tests {
         assert_eq!(states["bf16"], ("installed".into(), "complete".into()));
         assert_eq!(states["q4"], ("installed".into(), "complete".into()));
         assert_eq!(states["q8"], ("missing".into(), "incomplete".into()));
+        let state_rows = object["mlxTierStates"].as_array().unwrap();
+        let disk_bytes = |tier: &str| {
+            state_rows
+                .iter()
+                .find(|state| state["tier"] == tier)
+                .and_then(|state| state["diskSizeBytes"].as_u64())
+        };
+        assert_eq!(disk_bytes("bf16"), Some(3));
+        assert_eq!(disk_bytes("q4"), Some(3));
+        assert_eq!(disk_bytes("q8"), Some(1));
         // Decoupled from the download matrix — the picker must NOT flip `hasVariantMatrix`.
         assert!(object.get("hasVariantMatrix").is_none());
     }

--- a/apps/web/src/memoryFloorCatalogParity.test.js
+++ b/apps/web/src/memoryFloorCatalogParity.test.js
@@ -1,6 +1,14 @@
-import { readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
 import {
@@ -125,10 +133,10 @@ function loadManifestModels() {
 //     sweep, so nothing asserted about them even though `tierFits` REFUSES bf16 at 48. It is modelled
 //     now, and the sweep bounds those tiers like any other.
 //   * `mlxTierStates` / `mlxTiers` — the convert-at-install tier shapes. `installedTiers`
-//     (quantTier.js:196, :208) has a branch for each, and the mirror emits neither, so BOTH are
-//     unreachable from the sweep; every row below goes through the `hasVariantMatrix` branch. The
-//     convert-at-install models that use them (`anima_*`, `flux2_klein_9b_true_v2`, `ltx_2_3_eros`) also
-//     have no per-tier size anywhere, so their label is always the blanket — tracked separately.
+//     (quantTier.js:196, :208) has a branch for each, and the general mirror emits neither, so BOTH are
+//     unreachable from the sweep; every sweep row below goes through the `hasVariantMatrix` branch.
+//     SC-16045 added runtime `mlxTierStates[].diskSizeBytes`; the targeted real-manifest + real-file
+//     assertion below covers that path, while the broad combinatorial sweep deliberately stays manifest-only.
 //   * SINGLE-VARIANT ENTRIES ARE DROPPED ENTIRELY. `tiersOn` returns [] for a model that projects to just
 //     the `"default"` pseudo-variant, and the sweep `continue`s on that — 33 of the 86 manifest entries on
 //     macOS, 37 of 84 on windows. For those entries `needsLabel`'s blanket fallthrough is the ONLY branch
@@ -205,6 +213,52 @@ const manifestModels = loadManifestModels();
 const OSES = ["macos", "windows"];
 // The lane each OS runs, matching every consumer's `macGatingActive ? "mlx" : "candle"`.
 const BACKEND_FOR_OS = { macos: "mlx", windows: "candle" };
+
+describe("convert-at-install memory floors", () => {
+  it("derives anima_base's bf16-only label from real catalog inputs instead of its blanket", () => {
+    const anima = manifestModels.find((model) => model.id === "anima_base");
+    expect(anima, "anima_base must still be in the real manifest").toBeTruthy();
+    const blanket = blanketFloorGb(anima, "mlx");
+    expect(blanket).toBeGreaterThan(0);
+
+    // The Rust emitter independently tests the same contract from a converted directory. Here the
+    // file's stat supplies runtime data instead of transcribing a model-size literal into the test.
+    const converted = mkdtempSync(join(tmpdir(), "sc-16045-anima-"));
+    const bf16Weights = join(converted, "anima-bf16.safetensors");
+    try {
+      writeFileSync(bf16Weights, "");
+      truncateSync(bf16Weights, 2 * BYTES_PER_GB);
+      const diskSizeBytes = statSync(bf16Weights).size;
+      const entry = {
+        ...anima,
+        installState: "installed",
+        hasVariantMatrix: false,
+        variants: [],
+        mlxTierStates: [
+          {
+            tier: "bf16",
+            installState: "installed",
+            cacheState: "complete",
+            diskSizeBytes,
+          },
+        ],
+      };
+      const shown = shownGb(
+        needsLabel(entry, {
+          backend: "mlx",
+          convRotEligible: true,
+          nvfp4Eligible: true,
+        }),
+      );
+      const estimatedPeak =
+        variantFootprintBytes({ footprint: { diskSizeBytes } }).bytes / BYTES_PER_GB;
+      expect(shown).toBe(hostGbForPeakGb(estimatedPeak, "mlx"));
+      expect(shown).toBeGreaterThan(blanket);
+    } finally {
+      rmSync(converted, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("catalog memory floors: the displayed number satisfies the app's own fit criterion", () => {
   // Every (model, tier) on macOS that carries a real measured MLX footprint. This is the set whose

--- a/apps/web/src/tierSuggestion.js
+++ b/apps/web/src/tierSuggestion.js
@@ -430,7 +430,20 @@ function mlxEstimatedPeakGb(model, tier, options) {
   }
   const variant = (model?.variants ?? []).find((entry) => entry?.variant === tier);
   const footprint = variant ? variantFootprintBytes(variant) : null;
-  return footprint === null ? null : footprint.bytes / BYTES_PER_GB;
+  if (footprint !== null) {
+    return footprint.bytes / BYTES_PER_GB;
+  }
+  // Convert-at-install tiers are runtime outputs, not downloads[], so they have no variants[] row.
+  // The Rust catalog emits their actual load-visible on-disk size on mlxTierStates instead. Apply the
+  // same calibrated disk→resident + transient estimate as variantFootprintBytes so the label and the
+  // download-tier suggestion keep one memory model.
+  const convertState = Array.isArray(model?.mlxTierStates)
+    ? model.mlxTierStates.find((state) => state?.tier === tier)
+    : null;
+  const disk = numberOrNull(convertState?.diskSizeBytes);
+  return disk !== null && disk > 0
+    ? (Math.round(disk * DISK_TO_RESIDENT_MULTIPLIER) + TRANSIENT_HEADROOM_BYTES) / BYTES_PER_GB
+    : null;
 }
 
 // The max peak (GB) over the installed tiers, plus how it was arrived at:

--- a/apps/web/src/tierSuggestion.test.js
+++ b/apps/web/src/tierSuggestion.test.js
@@ -800,7 +800,7 @@ describe("per-tier memory floor: an unevidenced INSTALLED tier is estimated, not
     ).toBe(hostGbForPeakGb(10, "mlx"));
   });
 
-  it("does not quote a partial ceiling for the CONVERT-AT-INSTALL tier shape either", () => {
+  it("uses convert-output disk sizes and keeps legacy size-less catalogs conservative", () => {
     // The same class, on a shape memoryFloorCatalogParity.test.js structurally cannot sweep:
     // convert-at-install models (sc-10730) carry their installed set in `mlxTierStates`, a RUNTIME field
     // the manifest does not declare, so the catalog mirror never produces one. `installedTiers` reads
@@ -808,7 +808,7 @@ describe("per-tier memory floor: an unevidenced INSTALLED tier is estimated, not
     // exist — and a tier present in the install set with no `variants` row is unevidenced AND unestimable.
     //
     // Case 4 has to cover it: with no blanket, the honest answer is silence, not q4's number.
-    const convertAtInstall = (blanket) => ({
+    const convertAtInstall = (blanket, bf16DiskBytes = null) => ({
       id: "synthetic_convert_at_install",
       ...(blanket === null ? {} : { mlx: { minMemoryGb: blanket } }),
       // Not a download matrix: the convert outputs are decoupled from it (sc-10730).
@@ -818,14 +818,23 @@ describe("per-tier memory floor: an unevidenced INSTALLED tier is estimated, not
       ],
       mlxTierStates: [
         { tier: "q4", installState: "installed" },
-        // A convert output with no `variants` row at all — nothing to measure, nothing to estimate.
-        { tier: "bf16", installState: "installed" },
+        {
+          tier: "bf16",
+          installState: "installed",
+          ...(bf16DiskBytes === null ? {} : { diskSizeBytes: bf16DiskBytes }),
+        },
       ],
     });
+    // An older API did not emit diskSizeBytes. It remains unbounded rather than inventing a number.
     expect(installedFloorHostGb(convertAtInstall(null), { backend: "mlx" })).toBeNull();
-    // ...and with a blanket it is the max, exactly as for the download-matrix shape.
+    // ...and with a blanket it keeps the conservative fallback.
     expect(installedFloorHostGb(convertAtInstall(64), { backend: "mlx" })).toBe(64);
     expect(installedFloorHostGb(convertAtInstall(4), { backend: "mlx" })).toBe(hostGbForPeakGb(10, "mlx"));
+    // A current catalog makes the bf16 convert output estimable. Its 32 GiB of weights plus the shared
+    // transient dominates q4's measured 10 GiB and the 4 GB blanket.
+    expect(installedFloorHostGb(convertAtInstall(4, 32 * GB), { backend: "mlx" })).toBe(
+      hostGbForPeakGb(32 + TRANSIENT_HEADROOM_BYTES / GB, "mlx"),
+    );
   });
 
   it("floors a candle-only tier's q8 DEGRADE at the blanket", () => {


### PR DESCRIPTION
## Summary
- emit load-visible per-tier diskSizeBytes for convert-at-install outputs in the shared model catalog
- consume that additive runtime field in the generic MLX installed-memory floor estimator
- preserve conservative behavior for older size-less catalogs and keep Candle evidence isolated

## Scope boundary
Foundation only. No provider or model loader implementation, manifest calibration rows, or per-model signoff changes.

## Validation
- full web suite: 221 files, 3209 tests passed
- focused web suites: 192 tests passed
- web lint and production build passed
- Rust MLX tier probes: 6 passed
- rust-api clippy with warnings denied passed
- cargo fmt and git diff check passed
- independent exact-commit review approved d0b12410, confidence 0.95

Shortcut: SC-16045