### PR TITLE
Add Image Studio Hires.fix two-pass generation

### DIFF
--- a/apps/web/src/imageJobRequest.js
+++ b/apps/web/src/imageJobRequest.js
@@ -89,6 +89,11 @@ export function buildImageJobRequest(state) {
     upscaleFactor,
     upscaleEngine,
     upscaleSoftness,
+    hiresFixEnabled,
+    hiresFixSteps,
+    hiresFixDenoisingStrength,
+    hiresFixUpscaleBy,
+    hiresFixCfgScale,
     // Advanced knobs (delegated to buildImageJobAdvanced).
     sampler,
     scheduler,
@@ -229,6 +234,20 @@ export function buildImageJobRequest(state) {
             engine: upscaleEngine,
             // SeedVR2-only detail/softness knob (sc-4815); omitted for engines that ignore it.
             ...(upscaleEngineHasSoftness(upscaleEngine) ? { softness: upscaleSoftness } : {}),
+          },
+        }
+      : {}),
+    ...(hiresFixEnabled
+      ? {
+          hiresFix: {
+            enabled: true,
+            steps:
+              hiresFixSteps === "" || hiresFixSteps == null ? 0 : Number(hiresFixSteps),
+            denoisingStrength: Number(hiresFixDenoisingStrength),
+            upscaleBy: Number(hiresFixUpscaleBy),
+            ...(hiresFixCfgScale === "" || hiresFixCfgScale == null
+              ? {}
+              : { cfgScale: Number(hiresFixCfgScale) }),
           },
         }
       : {}),

--- a/apps/web/src/imageJobRequest.test.js
+++ b/apps/web/src/imageJobRequest.test.js
@@ -54,6 +54,11 @@ function img2imgPidState(overrides = {}) {
     upscaleFactor: 2,
     upscaleEngine: "realesrgan",
     upscaleSoftness: 0.5,
+    hiresFixEnabled: false,
+    hiresFixSteps: 0,
+    hiresFixDenoisingStrength: 0.7,
+    hiresFixUpscaleBy: 2,
+    hiresFixCfgScale: "",
     // Advanced knobs — everything default except the PiD 2K tier.
     sampler: "default",
     scheduler: "default",
@@ -90,6 +95,39 @@ function img2imgPidState(overrides = {}) {
 }
 
 describe("buildImageJobRequest", () => {
+  it("emits Hires.fix only when enabled and preserves inherit semantics", () => {
+    const enabled = buildImageJobRequest(
+      img2imgPidState({
+        img2imgReferenceAssetId: "",
+        usePid: false,
+        hiresFixEnabled: true,
+        hiresFixSteps: "",
+        hiresFixDenoisingStrength: 0.6,
+        hiresFixUpscaleBy: 1.75,
+        hiresFixCfgScale: "",
+      }),
+    );
+    expect(enabled.hiresFix).toEqual({
+      enabled: true,
+      steps: 0,
+      denoisingStrength: 0.6,
+      upscaleBy: 1.75,
+    });
+
+    const overridden = buildImageJobRequest(
+      img2imgPidState({
+        img2imgReferenceAssetId: "",
+        usePid: false,
+        hiresFixEnabled: true,
+        hiresFixSteps: 18,
+        hiresFixCfgScale: 5.5,
+      }),
+    );
+    expect(overridden.hiresFix.steps).toBe(18);
+    expect(overridden.hiresFix.cfgScale).toBe(5.5);
+    expect(buildImageJobRequest(img2imgPidState()).hiresFix).toBeUndefined();
+  });
+
   it("keeps Mage Edit's required source separate from its ordered optional references", () => {
     const request = buildImageJobRequest(
       img2imgPidState({

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -573,6 +573,13 @@ export function ImageStudio() {
   const [upscaleEngine, setUpscaleEngine] = useState(saved.upscaleEngine ?? "real-esrgan");
   // SeedVR2 detail/softness knob (0..1, sc-4815) — only used by the seedvr2 engine.
   const [upscaleSoftness, setUpscaleSoftness] = useState(saved.upscaleSoftness ?? 0);
+  const [hiresFixEnabled, setHiresFixEnabled] = useState(saved.hiresFixEnabled ?? false);
+  const [hiresFixSteps, setHiresFixSteps] = useState(saved.hiresFixSteps ?? 0);
+  const [hiresFixDenoisingStrength, setHiresFixDenoisingStrength] = useState(
+    saved.hiresFixDenoisingStrength ?? 0.7,
+  );
+  const [hiresFixUpscaleBy, setHiresFixUpscaleBy] = useState(saved.hiresFixUpscaleBy ?? 2);
+  const [hiresFixCfgScale, setHiresFixCfgScale] = useState(saved.hiresFixCfgScale ?? "");
   const [submitting, setSubmitting] = useState(false);
   // Auto-expand state (sc-6501): when a structured model is in plain-text mode, Generate first
   // expands the idea into a JSON caption via magic-prompt. `expanding` drives the button label;
@@ -638,14 +645,16 @@ export function ImageStudio() {
     setUpscaleFactor,
   });
 
-  // PiD decode and Upscale both super-resolve, so they're mutually exclusive in the UI (each
-  // disables the other while active). If a saved/preset state carries both on, drop PiD (keep
-  // Upscale) so neither checkbox is left permanently disabled.
+  // PiD, post-generation Upscale, and Hires.fix are mutually exclusive super-resolution paths.
+  // If restored state carries PiD plus either option, keep the explicit upscale process and drop PiD.
   useEffect(() => {
-    if (usePid && upscaleEnabled) {
+    if (usePid && (upscaleEnabled || hiresFixEnabled)) {
       setUsePid(false);
     }
-  }, [usePid, upscaleEnabled, setUsePid]);
+    if (upscaleEnabled && hiresFixEnabled) {
+      setUpscaleEnabled(false);
+    }
+  }, [usePid, upscaleEnabled, hiresFixEnabled, setUsePid]);
 
   useEffect(() => {
     if (mode === "edit_image" && selectedAssetEditableSourceId) {
@@ -1227,6 +1236,49 @@ export function ImageStudio() {
   // these two for the same reason (`showGuidance` / `showNegative`).
   const supportsGuidance = selectedModel?.image?.supportsGuidance !== false;
   const supportsNegativePrompt = selectedModel?.image?.supportsNegativePrompt !== false;
+  const hiresFixModelCapable = Boolean(
+    supportsImg2img || selectedModel?.family === "sdxl",
+  );
+  const hiresFixAccelerationBlocked =
+    model === "realvisxl_lightning" || ["lightning", "lcm", "hyper"].includes(sampler);
+  const hiresFixInputBlocked =
+    Boolean(img2imgReferenceAssetId) ||
+    posePayload.length > 0 ||
+    Boolean(controlPreprocessSourceId) ||
+    Boolean(controlPassthroughId) ||
+    (multiPhaseEnabled && modelSupportsMultiPhase(selectedModel));
+  const hiresFixAvailable =
+    mode === "text_to_image" && hiresFixModelCapable && !hiresFixAccelerationBlocked;
+  const hiresFixDisabled =
+    !hiresFixAvailable || usePid || hiresFixInputBlocked;
+  const hiresFixDisabledReason = !hiresFixModelCapable
+    ? "The selected model does not support the img2img second pass required by Hires.fix."
+    : mode !== "text_to_image"
+      ? "Hires.fix is only available for text-to-image generation."
+      : hiresFixAccelerationBlocked
+        ? "Lightning, LCM, and Hyper samplers do not accept the required img2img second pass."
+        : usePid
+          ? "Disable PiD before enabling Hires.fix."
+          : hiresFixInputBlocked
+            ? "Remove the starting image, strict control, or multi-phase denoise before enabling Hires.fix."
+            : undefined;
+  useEffect(() => {
+    // Keep restored state while the model catalog is still loading. Once the selected model is
+    // resolved, incompatible modes/samplers/inputs turn the option off instead of submitting a
+    // payload the worker must reject.
+    if (
+      hiresFixEnabled &&
+      selectedModel &&
+      (!hiresFixAvailable || hiresFixInputBlocked)
+    ) {
+      setHiresFixEnabled(false);
+    }
+  }, [
+    hiresFixEnabled,
+    selectedModel,
+    hiresFixAvailable,
+    hiresFixInputBlocked,
+  ]);
   const advancedDefaultsModel = useRef(model);
   const skipAdvancedDefaultsReset = useRef(false);
   useEffect(() => {
@@ -1640,6 +1692,12 @@ export function ImageStudio() {
     if (typeof upscale?.softness === "number") {
       setUpscaleSoftness(upscale.softness);
     }
+    const hiresFix = launchRequest.hiresFix ?? rawSettings.hiresFix ?? settings.hiresFix;
+    setHiresFixEnabled(Boolean(hiresFix?.enabled));
+    setHiresFixSteps(hiresFix?.steps ?? 0);
+    setHiresFixDenoisingStrength(hiresFix?.denoisingStrength ?? 0.7);
+    setHiresFixUpscaleBy(hiresFix?.upscaleBy ?? 2);
+    setHiresFixCfgScale(hiresFix?.cfgScale ?? "");
   // The launch id owns this one-shot hydration. Including the local values this
   // effect sets would replay a launch while applying that launch.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1662,6 +1720,13 @@ export function ImageStudio() {
   const { width, height, invalid: dimensionsInvalid } = dimensionEval;
   // A precise, user-facing ERROR (never a raw requirement): names this model's actual range/stride.
   const dimensionError = dimensionConstraintMessage(dimensionEval);
+  const hiresFixTargetWidth = Math.round(width * hiresFixUpscaleBy);
+  const hiresFixTargetHeight = Math.round(height * hiresFixUpscaleBy);
+  const hiresFixTargetInvalid =
+    hiresFixEnabled && (hiresFixTargetWidth > 4096 || hiresFixTargetHeight > 4096);
+  const hiresFixTargetMessage = hiresFixTargetInvalid
+    ? `Hires.fix target ${hiresFixTargetWidth}×${hiresFixTargetHeight} exceeds the 4096px image limit.`
+    : "";
 
   // PiD high-res decode heads-up (sc-10144): PiD super-resolves the base render 4×, so a large base at
   // the default 4K tier is a multi-minute (auto-tiled above 4096², sc-10087) decode that can look hung.
@@ -1812,6 +1877,11 @@ export function ImageStudio() {
       ["upscaleFactor", setUpscaleFactor],
       ["upscaleEngine", setUpscaleEngine],
       ["upscaleSoftness", setUpscaleSoftness],
+      ["hiresFixEnabled", setHiresFixEnabled],
+      ["hiresFixSteps", setHiresFixSteps],
+      ["hiresFixDenoisingStrength", setHiresFixDenoisingStrength],
+      ["hiresFixUpscaleBy", setHiresFixUpscaleBy],
+      ["hiresFixCfgScale", setHiresFixCfgScale],
     ],
     // Restore the saved sub-mode ("type"). Edit presets only surface in edit mode, so
     // this only ever flips between text/character within one workflow.
@@ -1853,6 +1923,11 @@ export function ImageStudio() {
       upscaleFactor,
       upscaleEngine,
       upscaleSoftness,
+      hiresFixEnabled,
+      hiresFixSteps,
+      hiresFixDenoisingStrength,
+      hiresFixUpscaleBy,
+      hiresFixCfgScale,
       // Reference/identity knobs only matter for the character flow; keep them
       // out of plain text/edit presets so they don't carry irrelevant state.
       ...(mode === "character_image"
@@ -1886,6 +1961,11 @@ export function ImageStudio() {
     upscaleFactor,
     upscaleEngine,
     upscaleSoftness,
+    hiresFixEnabled,
+    hiresFixSteps,
+    hiresFixDenoisingStrength,
+    hiresFixUpscaleBy,
+    hiresFixCfgScale,
     selectedLoraIds,
     loraWeights,
     // Krea 2 multi-phase denoise (sc-13885): persist the editor toggle, phase list, and disclosure
@@ -1954,8 +2034,12 @@ export function ImageStudio() {
       setSubmitError(`Install or select a model that supports ${modeLabel} generation.`);
       return;
     }
-    if (dimensionsInvalid) {
-      setSubmitError(dimensionError ?? "Width and height must each be between 256 and 4096.");
+    if (dimensionsInvalid || hiresFixTargetInvalid) {
+      setSubmitError(
+        hiresFixTargetMessage ||
+          dimensionError ||
+          "Width and height must each be between 256 and 4096.",
+      );
       return;
     }
     setSubmitting(true);
@@ -2129,6 +2213,11 @@ export function ImageStudio() {
       upscaleFactor,
       upscaleEngine,
       upscaleSoftness,
+      hiresFixEnabled,
+      hiresFixSteps,
+      hiresFixDenoisingStrength,
+      hiresFixUpscaleBy,
+      hiresFixCfgScale: supportsGuidance ? hiresFixCfgScale : "",
       sampler,
       scheduler,
       schedulerShift,
@@ -2231,8 +2320,12 @@ export function ImageStudio() {
       setBatchConfirmPending(false);
       return;
     }
-    if (dimensionsInvalid) {
-      setBatchError(dimensionError ?? "Width and height must each be between 256 and 4096.");
+    if (dimensionsInvalid || hiresFixTargetInvalid) {
+      setBatchError(
+        hiresFixTargetMessage ||
+          dimensionError ||
+          "Width and height must each be between 256 and 4096.",
+      );
       return;
     }
     setBatchError("");
@@ -3512,7 +3605,7 @@ export function ImageStudio() {
                   >
                     <input
                       checked={usePid}
-                      disabled={upscaleEnabled}
+                      disabled={upscaleEnabled || hiresFixEnabled}
                       onChange={(event) => setUsePid(event.target.checked)}
                       type="checkbox"
                     />
@@ -3547,7 +3640,13 @@ export function ImageStudio() {
                 <input
                   checked={upscaleEnabled}
                   disabled={usePid}
-                  onChange={(event) => setUpscaleEnabled(event.target.checked)}
+                  onChange={(event) => {
+                    const enabled = event.target.checked;
+                    setUpscaleEnabled(enabled);
+                    if (enabled) {
+                      setHiresFixEnabled(false);
+                    }
+                  }}
                   type="checkbox"
                 />
                 Upscale
@@ -3587,6 +3686,96 @@ export function ImageStudio() {
                   />
                   <span>{upscaleSoftness.toFixed(2)}</span>
                 </label>
+              ) : null}
+              <label
+                className="checkline hires-fix-toggle"
+                title={hiresFixDisabledReason}
+              >
+                <input
+                  checked={hiresFixEnabled}
+                  disabled={hiresFixDisabled}
+                  onChange={(event) => {
+                    const enabled = event.target.checked;
+                    setHiresFixEnabled(enabled);
+                    if (enabled) {
+                      setUpscaleEnabled(false);
+                    }
+                  }}
+                  type="checkbox"
+                />
+                Hires.fix
+              </label>
+              {hiresFixEnabled ? (
+                <>
+                  <label title="0 inherits the first-pass step count.">
+                    Hires Steps
+                    <input
+                      aria-label="Hires Steps"
+                      max="150"
+                      min="0"
+                      onChange={(event) => setHiresFixSteps(Number(event.target.value))}
+                      step="1"
+                      type="number"
+                      value={hiresFixSteps}
+                    />
+                  </label>
+                  <label title="How strongly the high-resolution pass may redraw the upscaled first pass.">
+                    Denoising Strength
+                    <input
+                      aria-label="Hires Denoising Strength"
+                      max="1"
+                      min="0"
+                      onChange={(event) =>
+                        setHiresFixDenoisingStrength(Number(event.target.value))
+                      }
+                      step="0.05"
+                      type="range"
+                      value={hiresFixDenoisingStrength}
+                    />
+                    <span>{hiresFixDenoisingStrength.toFixed(2)}</span>
+                  </label>
+                  <label>
+                    Upscale by
+                    <select
+                      aria-label="Hires Upscale by"
+                      onChange={(event) => setHiresFixUpscaleBy(Number(event.target.value))}
+                      value={hiresFixUpscaleBy}
+                    >
+                      {[1.25, 1.5, 1.75, 2, 2.5, 3, 4].map((factor) => (
+                        <option key={factor} value={factor}>
+                          {factor}x
+                        </option>
+                      ))}
+                    </select>
+                    <span
+                      className="field-hint"
+                      role={hiresFixTargetInvalid ? "alert" : undefined}
+                    >
+                      Output {hiresFixTargetWidth}×{hiresFixTargetHeight}
+                      {hiresFixTargetInvalid ? " · exceeds 4096px limit" : ""}
+                    </span>
+                  </label>
+                  <label
+                    title={
+                      supportsGuidance
+                        ? "Blank inherits the first-pass CFG scale."
+                        : "This model does not use CFG."
+                    }
+                  >
+                    Hires CFG Scale
+                    <input
+                      aria-label="Hires CFG Scale"
+                      disabled={!supportsGuidance}
+                      max="60"
+                      min="0"
+                      onChange={(event) => setHiresFixCfgScale(event.target.value)}
+                      placeholder="Inherit"
+                      step="0.1"
+                      type="number"
+                      value={supportsGuidance ? hiresFixCfgScale : ""}
+                    />
+                  </label>
+                </>
               ) : null}
               {supportsNegativePrompt ? (
                 <label className="prompt-field">

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -1194,6 +1194,39 @@ describe("ImageStudio model picker capability gating", () => {
     expect(pid().disabled).toBe(true);
   });
 
+  it("shows Hires.fix settings for img2img models and keeps it exclusive with Upscale", async () => {
+    const HIRES_MODEL = {
+      ...Z_IMAGE,
+      id: "krea_2_turbo",
+      name: "Krea 2 Turbo",
+      family: "krea_2",
+      ui: { img2img: true },
+      image: { supportsGuidance: false, supportsNegativePrompt: false },
+    };
+    await render(baseContext({ imageModels: [HIRES_MODEL], models: [HIRES_MODEL] }));
+    await openAdvanced(container);
+    await act(async () => {});
+
+    const hires = () => container.querySelector('.hires-fix-toggle input[type="checkbox"]');
+    const upscale = () => container.querySelector('.upscale-toggle input[type="checkbox"]');
+    expect(hires()).toBeTruthy();
+    expect(hires().disabled).toBe(false);
+    expect(field(container, "Hires Steps")).toBeFalsy();
+
+    await act(async () => hires().click());
+    expect(field(container, "Hires Steps").value).toBe("0");
+    expect(field(container, "Denoising Strength").value).toBe("0.7");
+    expect(field(container, "Upscale by").value).toBe("2");
+    expect(field(container, "Hires CFG Scale").placeholder).toBe("Inherit");
+    expect(field(container, "Hires CFG Scale").disabled).toBe(true);
+    expect(upscale().checked).toBe(false);
+
+    await act(async () => upscale().click());
+    expect(upscale().checked).toBe(true);
+    expect(hires().checked).toBe(false);
+    expect(field(container, "Hires Steps")).toBeFalsy();
+  });
+
   it("still sends the resolved tier's mlxQuantize when only one tier is installed (sc-12090)", async () => {
     const createImageJob = vi.fn(async () => ({ id: "job-1" }));
     await render(

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -742,6 +742,78 @@ pub fn default_image_upscale_engine() -> String {
     "real-esrgan".to_owned()
 }
 
+/// Optional A1111-style Hires.fix pass for text-to-image generation.
+///
+/// The first pass renders at the requested job dimensions. The worker then resizes that image to
+/// `upscale_by` times the original dimensions and uses it as the img2img initialization for a second
+/// pass. `steps == 0` and `cfg_scale == None` mean "inherit the first-pass value".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HiresFixRequest {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub steps: u32,
+    #[serde(default = "default_hires_denoising_strength")]
+    pub denoising_strength: f64,
+    #[serde(default = "default_hires_upscale_by")]
+    pub upscale_by: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cfg_scale: Option<f64>,
+    #[serde(flatten)]
+    pub extra: ExtraFields,
+}
+
+impl Default for HiresFixRequest {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            steps: 0,
+            denoising_strength: default_hires_denoising_strength(),
+            upscale_by: default_hires_upscale_by(),
+            cfg_scale: None,
+            extra: ExtraFields::default(),
+        }
+    }
+}
+
+impl HiresFixRequest {
+    pub fn is_disabled(&self) -> bool {
+        !self.enabled
+    }
+
+    pub fn effective_steps(&self, first_pass_steps: u32) -> u32 {
+        if self.steps == 0 {
+            first_pass_steps
+        } else {
+            self.steps.clamp(1, 150)
+        }
+    }
+
+    pub fn effective_denoising_strength(&self) -> f32 {
+        self.denoising_strength.clamp(0.0, 1.0) as f32
+    }
+
+    pub fn effective_upscale_by(&self) -> f32 {
+        self.upscale_by.clamp(1.0, 4.0) as f32
+    }
+
+    pub fn effective_cfg_scale(&self, first_pass_cfg: Option<f32>) -> Option<f32> {
+        self.cfg_scale
+            .filter(|value| value.is_finite())
+            .map(|value| value.clamp(0.0, 60.0) as f32)
+            .or(first_pass_cfg)
+    }
+}
+
+pub const fn default_hires_denoising_strength() -> f64 {
+    0.7
+}
+
+pub const fn default_hires_upscale_by() -> f64 {
+    2.0
+}
+
 /// Payload for a standalone `video_upscale` job (epic 4811 / sc-4816). Upscales an existing video
 /// asset with the native-MLX SeedVR2 engine. The target size is `factor × source` unless
 /// `target_width`/`target_height` override it; either way the worker snaps both dims to a multiple of
@@ -1831,6 +1903,35 @@ mod tests {
         assert!(request.is_disabled());
         assert_eq!(request.factor, 2);
         assert_eq!(request.engine, "real-esrgan");
+    }
+
+    #[test]
+    fn hires_fix_request_round_trips_and_inherits_unspecified_values() {
+        let value = json!({
+            "enabled": true,
+            "steps": 0,
+            "denoisingStrength": 0.55,
+            "upscaleBy": 1.75,
+            "cfgScale": 6.5
+        });
+        let request: HiresFixRequest =
+            serde_json::from_value(value.clone()).expect("hires fix request parses");
+
+        assert!(request.enabled);
+        assert_eq!(request.effective_steps(28), 28);
+        assert_eq!(request.effective_cfg_scale(Some(4.0)), Some(6.5));
+        assert_eq!(
+            serde_json::to_value(request).expect("hires fix request serializes"),
+            value
+        );
+
+        let defaults: HiresFixRequest =
+            serde_json::from_value(json!({})).expect("empty hires fix request parses");
+        assert!(defaults.is_disabled());
+        assert_eq!(defaults.effective_steps(24), 24);
+        assert_eq!(defaults.effective_denoising_strength(), 0.7);
+        assert_eq!(defaults.effective_upscale_by(), 2.0);
+        assert_eq!(defaults.effective_cfg_scale(Some(7.0)), Some(7.0));
     }
 
     #[test]

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -24,7 +24,7 @@
 
 use serde_json::Value;
 
-use crate::contracts::{ImageUpscaleRequest, JsonObject};
+use crate::contracts::{HiresFixRequest, ImageUpscaleRequest, JsonObject};
 use crate::payload_util::{
     array_or_empty, clamped_u32, declared_resolution, int_array, nonempty_string_or,
     object_or_empty, optional_i64, optional_id, string_list, string_or,
@@ -161,6 +161,8 @@ pub struct ImageRequest {
     /// generated image with `engine` (`seedvr2` / `real-esrgan`) at `factor` and writes a
     /// second "(Nx upscaled)" asset — mirroring the Python worker. Disabled when omitted.
     pub upscale: ImageUpscaleRequest,
+    /// Optional A1111-style two-pass high-resolution refinement. Disabled when omitted.
+    pub hires_fix: HiresFixRequest,
 }
 
 impl ImageRequest {
@@ -209,6 +211,7 @@ impl ImageRequest {
             model_manifest_entry,
             advanced: object_or_empty(payload, "advanced"),
             upscale: parse_upscale(payload),
+            hires_fix: parse_hires_fix(payload),
         }
     }
 }
@@ -219,6 +222,16 @@ impl ImageRequest {
 fn parse_upscale(payload: &JsonObject) -> ImageUpscaleRequest {
     payload
         .get("upscale")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
+}
+
+/// Parse the optional `hiresFix` object. As with `upscale`, malformed data falls back to the
+/// disabled default so older and hand-authored payloads remain compatibility-safe.
+fn parse_hires_fix(payload: &JsonObject) -> HiresFixRequest {
+    payload
+        .get("hiresFix")
         .cloned()
         .and_then(|value| serde_json::from_value(value).ok())
         .unwrap_or_default()
@@ -264,6 +277,7 @@ mod tests {
         assert!(request.advanced.is_empty());
         // No `upscale` object ⇒ the disabled default (the Image Studio toggle is off).
         assert!(request.upscale.is_disabled());
+        assert!(request.hires_fix.is_disabled());
     }
 
     #[test]
@@ -282,6 +296,30 @@ mod tests {
             "projectId": "p", "upscale": "yes please"
         })));
         assert!(bad.upscale.is_disabled());
+    }
+
+    #[test]
+    fn parses_hires_fix_request_and_malformed_payload_defaults_off() {
+        let request = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p",
+            "hiresFix": {
+                "enabled": true,
+                "steps": 18,
+                "denoisingStrength": 0.6,
+                "upscaleBy": 2.5,
+                "cfgScale": 5.5
+            }
+        })));
+        assert!(request.hires_fix.enabled);
+        assert_eq!(request.hires_fix.steps, 18);
+        assert_eq!(request.hires_fix.effective_denoising_strength(), 0.6);
+        assert_eq!(request.hires_fix.effective_upscale_by(), 2.5);
+        assert_eq!(request.hires_fix.cfg_scale, Some(5.5));
+
+        let bad = ImageRequest::from_payload(&payload(json!({
+            "projectId": "p", "hiresFix": "yes please"
+        })));
+        assert!(bad.hires_fix.is_disabled());
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -221,6 +221,7 @@ pub(crate) async fn run_image_generate_job(
             "Missing payload.projectId".to_owned(),
         ));
     }
+    validate_hires_fix_request(&request)?;
     let project =
         ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
     let project_path = PathBuf::from(project.path);
@@ -1092,6 +1093,12 @@ pub(crate) async fn run_image_generate_job(
     }
 
     if !handled {
+        if request.hires_fix.enabled {
+            return Err(WorkerError::InvalidPayload(
+                "Hires.fix requires a native image engine with img2img support; this job resolved only to the procedural stub."
+                    .to_owned(),
+            ));
+        }
         generate_stub_stream(
             api,
             settings,
@@ -1923,6 +1930,108 @@ fn resolve_family(request: &ImageRequest) -> String {
         }
     }
     String::new()
+}
+
+fn hires_fix_target_dimension(dimension: u32, upscale_by: f32) -> u32 {
+    (dimension as f64 * upscale_by as f64).round() as u32
+}
+
+/// Reject unsupported Hires.fix request shapes before any model load. Hires.fix is a plain
+/// text-to-image second pass: existing edit/control inputs, PiD, multi-phase sampling, and the
+/// separate post-generation upscaler are intentionally mutually exclusive rather than being
+/// silently dropped by a provider.
+fn validate_hires_fix_request(request: &ImageRequest) -> WorkerResult<()> {
+    if request.hires_fix.is_disabled() {
+        return Ok(());
+    }
+    if request.mode != "text_to_image" {
+        return Err(WorkerError::InvalidPayload(
+            "Hires.fix is only available for text-to-image generation.".to_owned(),
+        ));
+    }
+    if request.upscale.enabled {
+        return Err(WorkerError::InvalidPayload(
+            "Hires.fix and the post-generation Upscale option are mutually exclusive.".to_owned(),
+        ));
+    }
+    let family = resolve_family(request);
+    let advertises_img2img = request
+        .model_manifest_entry
+        .get("ui")
+        .and_then(|ui| ui.get("img2img"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if family != "sdxl" && !advertises_img2img {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Hires.fix requires an img2img-capable model; '{}' does not advertise that capability.",
+            request.model
+        )));
+    }
+    let has_edit_or_control_input = request.source_asset_id.is_some()
+        || request.reference_asset_id.is_some()
+        || !request.reference_asset_ids.is_empty()
+        || request.mask_asset_id.is_some()
+        || request.character_id.is_some()
+        || request.character_look_id.is_some()
+        || request
+            .advanced
+            .get("poses")
+            .and_then(Value::as_array)
+            .is_some_and(|poses| !poses.is_empty())
+        || request
+            .advanced
+            .get("controlImage")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.trim().is_empty());
+    if has_edit_or_control_input {
+        return Err(WorkerError::InvalidPayload(
+            "Hires.fix cannot be combined with image-edit, reference, character, mask, or strict-control inputs."
+                .to_owned(),
+        ));
+    }
+    if request
+        .advanced
+        .get("usePid")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(WorkerError::InvalidPayload(
+            "Hires.fix and PiD super-resolution are mutually exclusive.".to_owned(),
+        ));
+    }
+    if request
+        .advanced
+        .get("phases")
+        .and_then(Value::as_array)
+        .is_some_and(|phases| !phases.is_empty())
+    {
+        return Err(WorkerError::InvalidPayload(
+            "Hires.fix cannot be combined with multi-phase sampling.".to_owned(),
+        ));
+    }
+    let acceleration_sampler = request
+        .advanced
+        .get("sampler")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|sampler| matches!(sampler.as_str(), "lightning" | "lcm" | "hyper"));
+    if request.model == "realvisxl_lightning" || acceleration_sampler {
+        return Err(WorkerError::InvalidPayload(
+            "Hires.fix is not supported by Lightning, LCM, or Hyper acceleration samplers because they do not accept the required img2img second pass."
+                .to_owned(),
+        ));
+    }
+    let upscale_by = request.hires_fix.effective_upscale_by();
+    let target_width = hires_fix_target_dimension(request.width, upscale_by);
+    let target_height = hires_fix_target_dimension(request.height, upscale_by);
+    if target_width > 4096 || target_height > 4096 {
+        return Err(WorkerError::InvalidPayload(format!(
+            "Hires.fix target {}x{} exceeds the 4096px image limit; lower the base resolution or Upscale by value.",
+            target_width, target_height
+        )));
+    }
+    Ok(())
 }
 
 /// Resolve the seed for image `index`, matching the Python worker's `resolve_seed`:

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -2853,6 +2853,12 @@ fn mlx_raw_settings(
         "mlxQuantize".to_owned(),
         quant_bits.map(|bits| json!(bits)).unwrap_or(Value::Null),
     );
+    if request.hires_fix.enabled {
+        raw.insert(
+            "hiresFix".to_owned(),
+            serde_json::to_value(&request.hires_fix).expect("HiresFixRequest is serializable"),
+        );
+    }
     raw
 }
 
@@ -3563,6 +3569,190 @@ fn generate_one(
             "generator returned non-image output".to_owned(),
         )),
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct HiresFixPlan {
+    width: u32,
+    height: u32,
+    steps: u32,
+    guidance: Option<f32>,
+    true_cfg: Option<f32>,
+    provider_reference_strength: f32,
+}
+
+fn resolve_hires_fix_plan(
+    request: &ImageRequest,
+    first_pass_steps: u32,
+    first_pass_guidance: Option<f32>,
+    first_pass_true_cfg: Option<f32>,
+) -> Option<HiresFixPlan> {
+    if request.hires_fix.is_disabled() {
+        return None;
+    }
+    let upscale_by = request.hires_fix.effective_upscale_by();
+    let denoising_strength = request.hires_fix.effective_denoising_strength();
+    let family = resolve_family(request);
+    // SDXL and Ideogram expose conventional denoising strength (higher means more regeneration).
+    // The other current img2img providers expose reference fidelity (higher means preserve more),
+    // so translate the user-facing A1111 denoising value at this boundary.
+    let provider_reference_strength = if matches!(family.as_str(), "sdxl" | "ideogram") {
+        denoising_strength
+    } else {
+        1.0 - denoising_strength
+    };
+    let cfg = request
+        .hires_fix
+        .effective_cfg_scale(first_pass_guidance.or(first_pass_true_cfg));
+    Some(HiresFixPlan {
+        width: hires_fix_target_dimension(request.width, upscale_by),
+        height: hires_fix_target_dimension(request.height, upscale_by),
+        steps: request.hires_fix.effective_steps(first_pass_steps),
+        guidance: first_pass_guidance.map(|_| cfg.unwrap_or_default()),
+        true_cfg: first_pass_true_cfg.map(|_| cfg.unwrap_or_default()),
+        provider_reference_strength,
+    })
+}
+
+/// Run the normal first pass followed by an optional high-resolution img2img refinement while
+/// keeping progress monotonic across both denoise schedules.
+#[allow(clippy::too_many_arguments)]
+fn generate_one_with_hires(
+    generator: &dyn Generator,
+    prompt: &str,
+    width: u32,
+    height: u32,
+    seed: i64,
+    steps: u32,
+    guidance: Option<f32>,
+    negative_prompt: Option<String>,
+    reference: Option<&(Image, f32)>,
+    multi_references: &[Image],
+    edit_mask: Option<&Image>,
+    true_cfg: Option<f32>,
+    sampler: Option<&str>,
+    scheduler: Option<&str>,
+    scheduler_shift: Option<f32>,
+    guidance_method: Option<&str>,
+    use_pid: bool,
+    text_style_gain: Option<f32>,
+    memory: Option<gen_core::GenerationMemory>,
+    memory_strategy_context: Option<&gen_core::MemoryRunContext>,
+    enhance: &PromptEnhance,
+    hires_fix: Option<HiresFixPlan>,
+    cancel: &CancelFlag,
+    on_progress: &mut dyn FnMut(Progress),
+) -> WorkerResult<(u32, u32, Vec<u8>)> {
+    let Some(hires) = hires_fix else {
+        return generate_one(
+            generator,
+            prompt,
+            width,
+            height,
+            seed,
+            steps,
+            guidance,
+            negative_prompt,
+            reference,
+            multi_references,
+            edit_mask,
+            true_cfg,
+            sampler,
+            scheduler,
+            scheduler_shift,
+            guidance_method,
+            use_pid,
+            text_style_gain,
+            memory,
+            memory_strategy_context,
+            enhance,
+            cancel,
+            on_progress,
+        );
+    };
+
+    let combined_steps = steps.saturating_add(hires.steps);
+    let mut first_progress = |progress| match progress {
+        Progress::Step { current, .. } => on_progress(Progress::Step {
+            current,
+            total: combined_steps,
+        }),
+        // The first decode is an internal hand-off. The user-visible decode is the final one.
+        Progress::Decoding => {}
+        Progress::Loading(phase) => on_progress(Progress::Loading(phase)),
+    };
+    let (base_width, base_height, base_pixels) = generate_one(
+        generator,
+        prompt,
+        width,
+        height,
+        seed,
+        steps,
+        guidance,
+        negative_prompt.clone(),
+        reference,
+        multi_references,
+        edit_mask,
+        true_cfg,
+        sampler,
+        scheduler,
+        scheduler_shift,
+        guidance_method,
+        use_pid,
+        text_style_gain,
+        memory,
+        memory_strategy_context,
+        enhance,
+        cancel,
+        &mut first_progress,
+    )?;
+    if cancel.is_cancelled() {
+        return Err(WorkerError::Engine("generation cancelled".to_owned()));
+    }
+    let high_res_reference = fit_engine_image(
+        Image {
+            width: base_width,
+            height: base_height,
+            pixels: base_pixels,
+        },
+        hires.width,
+        hires.height,
+        "stretch",
+    )?;
+    let reference = (high_res_reference, hires.provider_reference_strength);
+    let mut second_progress = |progress| match progress {
+        Progress::Step { current, .. } => on_progress(Progress::Step {
+            current: steps.saturating_add(current),
+            total: combined_steps,
+        }),
+        Progress::Decoding => on_progress(Progress::Decoding),
+        Progress::Loading(phase) => on_progress(Progress::Loading(phase)),
+    };
+    generate_one(
+        generator,
+        prompt,
+        hires.width,
+        hires.height,
+        seed,
+        hires.steps,
+        hires.guidance,
+        negative_prompt,
+        Some(&reference),
+        &[],
+        None,
+        hires.true_cfg,
+        sampler,
+        scheduler,
+        scheduler_shift,
+        guidance_method,
+        false,
+        text_style_gain,
+        memory,
+        memory_strategy_context,
+        enhance,
+        cancel,
+        &mut second_progress,
+    )
 }
 
 /// Within-image step fraction mapped into the 0.10..0.95 generation band.
@@ -4784,6 +4974,7 @@ async fn generate_stream(
     // present, otherwise the true-CFG family scale (Chroma). `None` for the guidance-scalar and
     // distilled families, which carry CFG (if any) through `guidance` instead.
     let true_cfg = flux_true_cfg.or(model_true_cfg);
+    let hires_fix = resolve_hires_fix_plan(request, steps, guidance, true_cfg);
 
     // Ideogram 4 (epic 4725, sc-6501) is JSON-caption-only: a raw plain-text prompt is
     // out-of-distribution and stochastically renders the "Image blocked by safety filter"
@@ -4874,13 +5065,13 @@ async fn generate_stream(
         memory_overlays.push("pid".to_owned());
     }
     let mlx_request_inputs = crate::mlx_fit_gate::MlxRequestInputs {
-        width,
-        height,
+        width: hires_fix.map_or(width, |plan| plan.width),
+        height: hires_fix.map_or(height, |plan| plan.height),
         count: request.count,
         mode: request.mode.clone(),
         overlay: (!memory_overlays.is_empty()).then(|| memory_overlays.join("+")),
         adapter_count,
-        has_reference: has_request_reference,
+        has_reference: has_request_reference || hires_fix.is_some(),
         use_pid,
         has_phases: false,
     };
@@ -4961,7 +5152,7 @@ async fn generate_stream(
                     .process_limit_bytes
                     .and_then(crate::generator_cache::apply_request_gpu_memory_limit);
                 let render = |seed: i64, on_progress: &mut dyn FnMut(Progress)| {
-                    generate_one(
+                    generate_one_with_hires(
                         generator,
                         &prompt,
                         width,
@@ -4983,6 +5174,7 @@ async fn generate_stream(
                         Some(memory_evaluation.memory),
                         Some(&memory_evaluation.context),
                         &enhance,
+                        hires_fix,
                         &cancel,
                         on_progress,
                     )
@@ -5701,6 +5893,7 @@ async fn generate_candle_stream(
     let steps = resolve_steps(request, &model);
     let guidance = resolve_guidance(request, &model);
     let true_cfg = resolve_true_cfg(request, &model);
+    let hires_fix = resolve_hires_fix_plan(request, steps, guidance, true_cfg);
     let negative_prompt = resolve_negative_prompt(request, &model);
 
     // Per-payload flash/accel-attention (sc-3674): the UI Advanced toggle sends `advanced.flashAttn`
@@ -6620,7 +6813,7 @@ async fn generate_candle_stream(
         move |generator, tx, cancel| {
             drive_gen_items(tx, seeds, move |_index, seed, on_progress| {
                 let render = |seed: i64, on_progress: &mut dyn FnMut(Progress)| {
-                    generate_one(
+                    generate_one_with_hires(
                         generator,
                         &prompt,
                         width,
@@ -6656,6 +6849,7 @@ async fn generate_candle_stream(
                         generation_memory,
                         memory_strategy_context.as_ref(),
                         &enhance,
+                        hires_fix,
                         &cancel,
                         on_progress,
                     )

--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -342,6 +342,12 @@ fn krea_imported_raw_settings(
         "kreaImportedBase".to_owned(),
         Value::String(format!("{KREA_IMPORTED_BASE_REPO}#{KREA_IMPORTED_BASE_TIER}")),
     );
+    if request.hires_fix.enabled {
+        raw.insert(
+            "hiresFix".to_owned(),
+            serde_json::to_value(&request.hires_fix).expect("HiresFixRequest is serializable"),
+        );
+    }
     raw
 }
 
@@ -460,6 +466,8 @@ async fn generate_krea_imported_stream(
     let (width, height) = (request.width, request.height);
     let steps =
         resolve_advanced_or_manifest_u32(request, "steps", KREA_IMPORTED_DEFAULT_STEPS, 1..=100);
+    let hires_fix = resolve_hires_fix_plan(request, steps, None, None);
+    let enhance = PromptEnhance::default();
     let raw_settings = krea_imported_raw_settings(request, steps, is_edit, adapter_count);
 
     // Per-image work items: (seed, prompt) — `request.count` renders, each its own seed.
@@ -514,6 +522,35 @@ async fn generate_krea_imported_stream(
             drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
+                }
+                if let Some(hires_fix) = hires_fix {
+                    let (out_width, out_height, pixels) = generate_one_with_hires(
+                        model.as_ref(),
+                        &prompt,
+                        width,
+                        height,
+                        seed,
+                        steps,
+                        None,
+                        None,
+                        None,
+                        &[],
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        false,
+                        None,
+                        None,
+                        None,
+                        &enhance,
+                        Some(hires_fix),
+                        &cancel,
+                        on_progress,
+                    )?;
+                    return Ok(Some((seed, out_width, out_height, pixels)));
                 }
                 let request = GenerationRequest {
                     prompt,

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
@@ -249,6 +249,8 @@ async fn generate_sdxl_imported_stream(
     let negative_prompt = (!request.negative_prompt.trim().is_empty())
         .then(|| request.negative_prompt.clone());
     let (width, height) = (request.width, request.height);
+    let hires_fix = resolve_hires_fix_plan(request, steps, Some(guidance), None);
+    let enhance = PromptEnhance::default();
     let work: Vec<(i64, String)> = (0..request.count as usize)
         .map(|index| (resolve_seed(request, index), request.prompt.clone()))
         .collect();
@@ -265,6 +267,12 @@ async fn generate_sdxl_imported_stream(
         "importedCheckpoint".to_owned(),
         Value::String(request.model.clone()),
     );
+    if request.hires_fix.enabled {
+        raw_settings.insert(
+            "hiresFix".to_owned(),
+            serde_json::to_value(&request.hires_fix).expect("HiresFixRequest is serializable"),
+        );
+    }
 
     let mut spec = LoadSpec::new(WeightsSource::File(file.clone())).with_adapters(adapters);
     if let Some(pid) = pid_weights {
@@ -297,6 +305,35 @@ async fn generate_sdxl_imported_stream(
             drive_gen_items(tx, work, move |_index, (seed, prompt), on_progress| {
                 if cancel.is_cancelled() {
                     return Ok(None);
+                }
+                if let Some(hires_fix) = hires_fix {
+                    let (out_width, out_height, pixels) = generate_one_with_hires(
+                        model.as_ref(),
+                        &prompt,
+                        width,
+                        height,
+                        seed,
+                        steps,
+                        Some(guidance),
+                        negative_prompt.clone(),
+                        None,
+                        &[],
+                        None,
+                        None,
+                        sampler.as_deref(),
+                        scheduler.as_deref(),
+                        scheduler_shift,
+                        guidance_method.as_deref(),
+                        use_pid,
+                        None,
+                        None,
+                        None,
+                        &enhance,
+                        Some(hires_fix),
+                        &cancel,
+                        on_progress,
+                    )?;
+                    return Ok(Some((seed, out_width, out_height, pixels)));
                 }
                 let request = GenerationRequest {
                     prompt,

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -18,6 +18,194 @@ fn request(value: Value) -> ImageRequest {
     ImageRequest::from_payload(&value.as_object().cloned().unwrap())
 }
 
+#[test]
+fn hires_fix_preflight_accepts_img2img_models_and_rejects_conflicts() {
+    let valid = request(json!({
+        "projectId": "p",
+        "model": "krea_2_turbo",
+        "width": 1024,
+        "height": 1024,
+        "modelManifestEntry": {
+            "family": "krea_2",
+            "ui": { "img2img": true }
+        },
+        "hiresFix": {
+            "enabled": true,
+            "steps": 12,
+            "denoisingStrength": 0.7,
+            "upscaleBy": 2.0
+        }
+    }));
+    validate_hires_fix_request(&valid).expect("img2img model supports hires fix");
+
+    let with_upscale = request(json!({
+        "projectId": "p",
+        "model": "sdxl",
+        "modelManifestEntry": { "family": "sdxl" },
+        "upscale": { "enabled": true },
+        "hiresFix": { "enabled": true }
+    }));
+    assert!(validate_hires_fix_request(&with_upscale)
+        .unwrap_err()
+        .to_string()
+        .contains("mutually exclusive"));
+
+    let too_large = request(json!({
+        "projectId": "p",
+        "model": "sdxl",
+        "width": 3072,
+        "height": 2048,
+        "modelManifestEntry": { "family": "sdxl" },
+        "hiresFix": { "enabled": true, "upscaleBy": 2.0 }
+    }));
+    assert!(validate_hires_fix_request(&too_large)
+        .unwrap_err()
+        .to_string()
+        .contains("6144x4096"));
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+struct HiresProbeGenerator {
+    descriptor: gen_core::ModelDescriptor,
+    requests: std::sync::Mutex<Vec<GenerationRequest>>,
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+impl HiresProbeGenerator {
+    fn new() -> Self {
+        Self {
+            descriptor: gen_core::ModelDescriptor {
+                id: "hires_probe",
+                family: "test",
+                backend: "test",
+                modality: gen_core::Modality::Image,
+                capabilities: Default::default(),
+                required_components: &[],
+            },
+            requests: Default::default(),
+        }
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+impl Generator for HiresProbeGenerator {
+    fn descriptor(&self) -> &gen_core::ModelDescriptor {
+        &self.descriptor
+    }
+
+    fn validate(&self, _req: &GenerationRequest) -> gen_core::Result<()> {
+        Ok(())
+    }
+
+    fn generate(
+        &self,
+        req: &GenerationRequest,
+        on_progress: &mut dyn FnMut(Progress),
+    ) -> gen_core::Result<GenerationOutput> {
+        let pass = self.requests.lock().unwrap().len() as u8 + 1;
+        self.requests.lock().unwrap().push(req.clone());
+        for current in 1..=req.steps.unwrap_or(1) {
+            on_progress(Progress::Step {
+                current,
+                total: req.steps.unwrap_or(1),
+            });
+        }
+        on_progress(Progress::Decoding);
+        Ok(GenerationOutput::Images(vec![Image {
+            width: req.width,
+            height: req.height,
+            pixels: vec![pass; (req.width * req.height * 3) as usize],
+        }]))
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn hires_fix_runs_two_passes_with_scaled_first_pass_reference_and_monotonic_progress() {
+    let generator = HiresProbeGenerator::new();
+    let cancel = CancelFlag::new();
+    let mut progress = Vec::new();
+    let output = generate_one_with_hires(
+        &generator,
+        "test",
+        4,
+        4,
+        42,
+        2,
+        Some(7.0),
+        Some("bad".to_owned()),
+        None,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+        &PromptEnhance::default(),
+        Some(HiresFixPlan {
+            width: 8,
+            height: 8,
+            steps: 3,
+            guidance: Some(5.5),
+            true_cfg: None,
+            provider_reference_strength: 0.3,
+        }),
+        &cancel,
+        &mut |event| progress.push(event),
+    )
+    .expect("two-pass generation");
+
+    assert_eq!((output.0, output.1), (8, 8));
+    assert!(output.2.iter().all(|pixel| *pixel == 2));
+    let requests = generator.requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!((requests[0].width, requests[0].height), (4, 4));
+    assert_eq!(requests[0].steps, Some(2));
+    assert_eq!((requests[1].width, requests[1].height), (8, 8));
+    assert_eq!(requests[1].steps, Some(3));
+    assert_eq!(requests[1].guidance, Some(5.5));
+    match requests[1].conditioning.as_slice() {
+        [Conditioning::Reference { image, strength }] => {
+            assert_eq!((image.width, image.height), (8, 8));
+            assert!(image.pixels.iter().all(|pixel| *pixel == 1));
+            assert_eq!(*strength, Some(0.3));
+        }
+        other => panic!("expected one high-resolution reference, got {other:?}"),
+    }
+    let steps: Vec<(u32, u32)> = progress
+        .iter()
+        .filter_map(|event| match event {
+            Progress::Step { current, total } => Some((*current, *total)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(steps, vec![(1, 5), (2, 5), (3, 5), (4, 5), (5, 5)]);
+    assert_eq!(
+        progress
+            .iter()
+            .filter(|event| matches!(event, Progress::Decoding))
+            .count(),
+        1
+    );
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn job_weight_resolution_uses_receipt_after_manifest_filename_change() {


### PR DESCRIPTION
## Summary

- add optional A1111-style Hires.fix controls under Image Studio's Upscale Options
- serialize and validate the typed `hiresFix` image-job request contract
- run native generation as a base pass, Lanczos resize, and reference-conditioned img2img second pass
- support generic MLX/Candle and imported SDXL/Krea routes while rejecting incompatible or unsupported combinations
- preserve independent Hires steps, denoising strength, upscale factor, CFG scale, and monotonic progress

## User impact

Image Studio users can opt into a two-pass Hires.fix workflow and configure:

- Hires Steps
- Denoising Strength
- Upscale by
- Hires CFG Scale

The controls are persisted with studio settings and guarded by model capability, input-conflict, sampler, and maximum-dimension validation.

## Validation

- `npm test -- --run src/imageJobRequest.test.js src/screens/ImageStudio.test.jsx` — 97 passed
- ESLint — passed with zero warnings
- Vite production build — passed
- `cargo fmt --all -- --check` — passed
- `cargo test -p sceneworks-core hires_fix --lib` — 2 passed
- `cargo test -p sceneworks-worker hires_fix --lib` — 2 passed
- `cargo check --locked -p sceneworks-worker` — passed

The branch was rebased onto current `origin/main` (`46dde9ed`) before validation. Provider strength semantics were rechecked against inference revision `1ca66939`.

## Tracking

- sc-15984
- sc-15985
- sc-15986

Real-weight supported-hardware acceptance remains tracked by sc-15986 and is not claimed by this PR's weight-free automated validation.
