### PR TITLE
feat(workflow-share): privacy — embed setting, first-run disclosure, and Save As without the workflow (sc-15953)

### DIFF
--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -1090,12 +1090,20 @@ pub async fn save_image_export(
 /// user returns to their last-used save location (sc-8737); an empty/missing/non-existent
 /// hint is ignored. Returns `Ok(None)` when the user cancels the dialog and `Ok(Some(dest))`
 /// with the absolute destination path on success.
+///
+/// `without_workflow` (sc-15953) writes the copy with any embedded `sceneworks:workflow` chunk
+/// excised, for a user who wants to share the image but not the recipe that made it. It is a
+/// byte-level removal, not a re-encode — `copy_without_workflow_chunk` copies IHDR, every IDAT and
+/// IEND through unchanged — so the saved file has the same pixels as the same compressed data, and
+/// a source with nothing to strip goes through the same `std::fs::copy` the plain save uses. The
+/// SOURCE asset is never touched: this is one copy written differently, not a cleanup pass.
 #[tauri::command]
 pub async fn save_asset_as(
     app: AppHandle,
     source_path: String,
     suggested_filename: String,
     start_dir: Option<String>,
+    without_workflow: Option<bool>,
 ) -> Result<Option<String>, String> {
     // Guard the SOURCE before opening any dialog: only files inside the SceneWorks data
     // dir / HF cache may be copied out.
@@ -1117,7 +1125,12 @@ pub async fn save_asset_as(
         return Ok(None);
     };
 
-    std::fs::copy(&source, &destination).map_err(|error| error.to_string())?;
+    if without_workflow.unwrap_or(false) {
+        sceneworks_core::workflow_png::copy_without_workflow_chunk(&source, &destination)
+            .map_err(|error| error.to_string())?;
+    } else {
+        std::fs::copy(&source, &destination).map_err(|error| error.to_string())?;
+    }
     Ok(Some(destination.to_string_lossy().into_owned()))
 }
 

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1258,6 +1258,7 @@ fn create_app_with_state_mode(
         )),
         media_tickets: Arc::new(TicketStore::new(MEDIA_TICKET_TTL_SECONDS)),
         thumbnail_generation_slots: Arc::new(tokio::sync::Semaphore::new(2)),
+        workflow_strip_slots: Arc::new(tokio::sync::Semaphore::new(WORKFLOW_STRIP_SLOTS)),
         auth_throttle: Arc::new(AuthThrottle::default()),
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
@@ -1924,6 +1925,30 @@ async fn verify_access(
 const GRID_THUMBNAIL_SIZE: u32 = 384;
 const PROJECT_MEDIA_CACHE_CONTROL: &str = "private, max-age=31536000, immutable";
 
+/// How many `?stripWorkflow=true` downloads may be in flight at once (sc-15953).
+///
+/// Two, mirroring `thumbnail_generation_slots` — the other derived representation of this same
+/// route, and the precedent for gating one. A strip is not CPU-bound the way a thumbnail is; what
+/// it holds is MEMORY, for as long as the response body is being written to a client that may be
+/// on a slow link. Ungated, the ceiling was the product of the file size and the number of
+/// simultaneous callers, with nothing in the path to say no.
+const WORKFLOW_STRIP_SLOTS: usize = 2;
+
+/// Largest PNG this route will rewrite in memory to remove a workflow chunk. 128 MiB.
+///
+/// The walk needs the tail of the file, so the whole thing is read; the cost therefore follows the
+/// asset. A generated image is nowhere near this — measured through the repo's own writer on an
+/// INCOMPRESSIBLE render, the worst case for a PNG, 1024² is 3.0 MiB, 2048² is 12.0 MiB and 4096²
+/// is 48.0 MiB, and 4096² is the largest thing SceneWorks renders. An IMPORTED asset is bounded
+/// only by `MAX_UPLOAD_BYTES` = 2 GiB, which is what this exists to refuse. 128 MiB is ~2.7× the
+/// largest file the writer produces, so nothing SceneWorks made is ever turned away, and with
+/// [`WORKFLOW_STRIP_SLOTS`] it bounds the route at 256 MiB rather than at multiple gigabytes.
+///
+/// Refused rather than silently served whole: "here is your copy without the workflow" answered
+/// with the original file is the one outcome this feature must never produce, so an image too
+/// large to rewrite gets a 413 that says why.
+const MAX_WORKFLOW_STRIP_BYTES: u64 = 128 * 1024 * 1024;
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ProjectFileQuery {
@@ -1979,7 +2004,7 @@ async fn get_project_file(
                 "stripWorkflow cannot be combined with thumbnail",
             ));
         }
-        return stripped_project_file_response(&project_file, &headers).await;
+        return stripped_project_file_response(&state, &project_file, &headers).await;
     }
 
     // One fixed representation prevents unbounded cache variants. Derivatives
@@ -2181,7 +2206,7 @@ fn ensure_grid_thumbnail(source_path: &FsPath, cache_root: &FsPath) -> Result<Pa
 /// walk of the PNG chunk framing that copies IHDR, every IDAT and IEND through unchanged, so the
 /// served body is the file minus one slice rather than a re-encode. Nothing here decodes a pixel.
 ///
-/// Three things this branch has to get right that the streaming path does not:
+/// Five things this branch has to get right that the streaming path does not:
 ///
 /// * **Only a PNG is read into memory.** The workflow chunk only ever exists in a PNG, so anything
 ///   else is served by the ordinary path — a video does not get buffered because someone appended
@@ -2190,10 +2215,29 @@ fn ensure_grid_thumbnail(source_path: &FsPath, cache_root: &FsPath) -> Result<Pa
 /// * **The ETag must differ from the full file's.** `project_file_etag` is derived from the source
 ///   metadata, and the route sets `immutable` caching — so reusing it would let a cache answer a
 ///   strip request with the unstripped body it already holds. The variant tag is folded in.
+/// * **Revalidation is ETag-ONLY.** The distinct ETag is half a fix on its own, and the missing
+///   half was a live hole: both representations are derived from the same file, so they carry the
+///   same `Last-Modified`, and a client that had done a plain GET could hand that date back on a
+///   strip request and be told `304 Not Modified` — reusing the full body, workflow intact. The
+///   date cannot distinguish the two representations, so it does not get a vote here; only the
+///   variant tag does. `project_file_is_not_modified` still owns the ordinary path, where one URL
+///   means one body and a date is a sound answer.
 /// * **No byte ranges.** The body is a rewritten buffer whose offsets do not match the file on
 ///   disk, so `Accept-Ranges: none` and a `Range` header is ignored rather than answered against
 ///   the wrong length. This is a download, not a `<video src>`.
+/// * **The memory is bounded, twice over.** The whole file is read at once — a walk of the chunk
+///   framing has to see the tail — so the cost scales with the asset, and an imported PNG is
+///   bounded only by `MAX_UPLOAD_BYTES` = 2 GiB. [`WORKFLOW_STRIP_SLOTS`] caps the concurrency
+///   the way `thumbnail_generation_slots` does for the sibling derived representation on this same
+///   route, and [`MAX_WORKFLOW_STRIP_BYTES`] caps the per-request size. Between them the route's
+///   ceiling is a fixed number rather than "however many clients ask at once".
+///
+/// The body is assembled without a second copy. `strip_workflow_chunk` would build a new buffer
+/// of its own — ~2N peak for a file of N bytes — so this calls the walk that underlies it
+/// (`workflow_chunk_spans`) and serves the KEPT spans as `Bytes` slices of the one buffer already
+/// read. `Bytes` slices are refcounted views, so the peak is N and the excision costs nothing.
 async fn stripped_project_file_response(
+    state: &AppState,
     project_file: &sceneworks_core::project_store::ProjectFile,
     request_headers: &HeaderMap,
 ) -> Result<Response, ApiError> {
@@ -2205,7 +2249,8 @@ async fn stripped_project_file_response(
 
     if project_file.content_type != "image/png" {
         // Nothing of ours can be in it. Fall back to the ordinary streaming response so a video or
-        // a JPEG is served exactly as it always was, under its own ETag.
+        // a JPEG is served exactly as it always was, under its own ETag — and under the ordinary
+        // revalidation rules too, because this is not a variant: the bytes are the file's.
         let etag = project_file_etag(&metadata);
         let headers = project_file_response_headers(
             &project_file.content_type,
@@ -2225,7 +2270,7 @@ async fn stripped_project_file_response(
     }
 
     let etag = variant_etag(&project_file_etag(&metadata), "nw");
-    if project_file_is_not_modified(request_headers, &etag, last_modified) {
+    if if_none_match_matches(request_headers, &etag) {
         let headers = project_file_response_headers(
             &project_file.content_type,
             metadata.len(),
@@ -2235,16 +2280,30 @@ async fn stripped_project_file_response(
         return Ok(not_modified_response(headers));
     }
 
-    let bytes = tokio::task::spawn_blocking(move || {
+    if metadata.len() > MAX_WORKFLOW_STRIP_BYTES {
+        return Err(ApiError::payload_too_large(format!(
+            "This image is {} MiB, over the {} MiB SceneWorks will rewrite in memory to remove a \
+             workflow. Save it normally and remove the block with another tool.",
+            metadata.len() / (1024 * 1024),
+            MAX_WORKFLOW_STRIP_BYTES / (1024 * 1024)
+        )));
+    }
+
+    let permit = state
+        .workflow_strip_slots
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+
+    let (bytes, spans) = tokio::task::spawn_blocking(move || {
         let original = std::fs::read(&path)?;
-        // A PNG whose framing cannot be walked is an ERROR, never the original bytes: "here is your
-        // copy without the workflow" must not be answered with a file that may still carry one.
-        match sceneworks_core::workflow_png::strip_workflow_chunk(&original) {
-            // Nothing of ours in it — the file already is what was asked for.
-            Ok(None) => Ok(original),
-            Ok(Some(stripped)) => Ok(stripped),
-            Err(error) => Err(std::io::Error::other(error.to_string())),
-        }
+        // A PNG that cannot be accounted for chunk by chunk is an ERROR, never the original bytes:
+        // "here is your copy without the workflow" must not be answered with a file that may still
+        // carry one. An empty span list is the honest "nothing of ours is in it".
+        let spans = sceneworks_core::workflow_png::workflow_chunk_spans(&original)
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        Ok::<_, std::io::Error>((original, spans))
     })
     .await
     .map_err(|error| ApiError::internal(error.to_string()))?
@@ -2257,16 +2316,50 @@ async fn stripped_project_file_response(
         ApiError::bad_request("This image could not be rewritten without its workflow.")
     })?;
 
+    // One allocation for the whole response: `Bytes::from` takes the read buffer over, and every
+    // slice below is a refcounted view into it rather than a copy.
+    let bytes = axum::body::Bytes::from(bytes);
+    let kept = sceneworks_core::workflow_png::kept_spans(bytes.len(), &spans);
+    let served: Vec<axum::body::Bytes> = kept
+        .iter()
+        .map(|span| bytes.slice(span.start..span.end))
+        .collect();
+    let served_len: u64 = served.iter().map(|slice| slice.len() as u64).sum();
+
     let mut headers = project_file_response_headers(
         &project_file.content_type,
-        bytes.len() as u64,
+        served_len,
         &etag,
         last_modified,
     )?;
     headers.insert(header::ACCEPT_RANGES, HeaderValue::from_static("none"));
-    let mut response = Body::from(bytes).into_response();
+    // The permit rides with the stream rather than being dropped here: the buffer is alive until
+    // the last slice has been written, so releasing the slot at this line would let the next
+    // request in while this one's memory is still held.
+    let mut response = Body::from_stream(stream::iter(served.into_iter().map(move |slice| {
+        let _permit = &permit;
+        Ok::<_, std::convert::Infallible>(slice)
+    })))
+    .into_response();
     response.headers_mut().extend(headers);
     Ok(response)
+}
+
+/// Whether `If-None-Match` names `etag` (or `*`).
+///
+/// The ETag half of [`project_file_is_not_modified`], on its own, for the derived representations
+/// whose `Last-Modified` is the source file's and therefore cannot tell one representation from
+/// another.
+fn if_none_match_matches(request_headers: &HeaderMap, etag: &str) -> bool {
+    request_headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .any(|candidate| candidate == "*" || candidate == etag)
+        })
 }
 
 /// A 304 carrying `headers` minus the content length, which a body-less response must not declare.
@@ -2339,19 +2432,19 @@ fn project_file_response_headers(
     Ok(headers)
 }
 
+/// Ordinary revalidation for a representation whose bytes ARE the file's: the ETag when the client
+/// sent one, the modification date otherwise.
+///
+/// Deliberately not used by the strip variant. `If-Modified-Since` is an answer about the FILE, and
+/// a derived representation shares its file with the original — see
+/// [`stripped_project_file_response`], which revalidates on the tag alone.
 fn project_file_is_not_modified(
     request_headers: &HeaderMap,
     etag: &str,
     last_modified: Option<SystemTime>,
 ) -> bool {
-    if let Some(value) = request_headers
-        .get(header::IF_NONE_MATCH)
-        .and_then(|value| value.to_str().ok())
-    {
-        return value
-            .split(',')
-            .map(str::trim)
-            .any(|candidate| candidate == "*" || candidate == etag);
+    if request_headers.contains_key(header::IF_NONE_MATCH) {
+        return if_none_match_matches(request_headers, etag);
     }
     let Some(modified) = last_modified else {
         return false;

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -2207,8 +2207,12 @@ async fn stripped_project_file_response(
         // Nothing of ours can be in it. Fall back to the ordinary streaming response so a video or
         // a JPEG is served exactly as it always was, under its own ETag.
         let etag = project_file_etag(&metadata);
-        let headers =
-            project_file_response_headers(&project_file.content_type, metadata.len(), &etag, last_modified)?;
+        let headers = project_file_response_headers(
+            &project_file.content_type,
+            metadata.len(),
+            &etag,
+            last_modified,
+        )?;
         if project_file_is_not_modified(request_headers, &etag, last_modified) {
             return Ok(not_modified_response(headers));
         }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1925,8 +1925,19 @@ const GRID_THUMBNAIL_SIZE: u32 = 384;
 const PROJECT_MEDIA_CACHE_CONTROL: &str = "private, max-age=31536000, immutable";
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ProjectFileQuery {
     thumbnail: Option<u32>,
+    /// Serve the file with any embedded `sceneworks:workflow` chunk removed (sc-15953).
+    ///
+    /// A query param on the existing route rather than a new endpoint, because the browser
+    /// "Save As without the workflow" is a bare `<a download>` and cannot transform bytes or set
+    /// headers. That constraint also decides the shape: in remote/LAN mode the anchor authenticates
+    /// with a `?ticket=` media ticket, whose allow-list (`auth::is_ticketed_media_path`) matches on
+    /// the PATH and is GET-only — so keeping the strip on this path means the download works
+    /// remotely with no change to the ticket rules at all. A separate endpoint would have needed a
+    /// new entry in that allow-list, which is the surface hardest to widen safely.
+    strip_workflow: Option<bool>,
 }
 
 async fn get_project_file(
@@ -1959,6 +1970,17 @@ async fn get_project_file(
             );
         }
     })?;
+
+    // "Download without the workflow" (sc-15953). Answered here, before the thumbnail and
+    // streaming branches, because it is the one variant whose body is not the file on disk.
+    if query.strip_workflow.unwrap_or(false) {
+        if query.thumbnail.is_some() {
+            return Err(ApiError::bad_request(
+                "stripWorkflow cannot be combined with thumbnail",
+            ));
+        }
+        return stripped_project_file_response(&project_file, &headers).await;
+    }
 
     // One fixed representation prevents unbounded cache variants. Derivatives
     // are generated on first use, so assets written before this route existed
@@ -2151,6 +2173,117 @@ fn ensure_grid_thumbnail(source_path: &FsPath, cache_root: &FsPath) -> Result<Pa
         }
     }
     Ok(target)
+}
+
+/// Serve a project file with any embedded workflow chunk excised (sc-15953).
+///
+/// The stripping itself is `sceneworks_core::workflow_png::strip_workflow_chunk` — a byte-level
+/// walk of the PNG chunk framing that copies IHDR, every IDAT and IEND through unchanged, so the
+/// served body is the file minus one slice rather than a re-encode. Nothing here decodes a pixel.
+///
+/// Three things this branch has to get right that the streaming path does not:
+///
+/// * **Only a PNG is read into memory.** The workflow chunk only ever exists in a PNG, so anything
+///   else is served by the ordinary path — a video does not get buffered because someone appended
+///   the flag to its URL. A non-PNG asked for stripped is not an error either: it genuinely carries
+///   no workflow, and saying so by serving it is the honest answer.
+/// * **The ETag must differ from the full file's.** `project_file_etag` is derived from the source
+///   metadata, and the route sets `immutable` caching — so reusing it would let a cache answer a
+///   strip request with the unstripped body it already holds. The variant tag is folded in.
+/// * **No byte ranges.** The body is a rewritten buffer whose offsets do not match the file on
+///   disk, so `Accept-Ranges: none` and a `Range` header is ignored rather than answered against
+///   the wrong length. This is a download, not a `<video src>`.
+async fn stripped_project_file_response(
+    project_file: &sceneworks_core::project_store::ProjectFile,
+    request_headers: &HeaderMap,
+) -> Result<Response, ApiError> {
+    let path = project_file.path.clone();
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let last_modified = metadata.modified().ok();
+
+    if project_file.content_type != "image/png" {
+        // Nothing of ours can be in it. Fall back to the ordinary streaming response so a video or
+        // a JPEG is served exactly as it always was, under its own ETag.
+        let etag = project_file_etag(&metadata);
+        let headers =
+            project_file_response_headers(&project_file.content_type, metadata.len(), &etag, last_modified)?;
+        if project_file_is_not_modified(request_headers, &etag, last_modified) {
+            return Ok(not_modified_response(headers));
+        }
+        let file = tokio::fs::File::open(&path)
+            .await
+            .map_err(|error| ApiError::internal(error.to_string()))?;
+        let mut response = Body::from_stream(ReaderStream::new(file)).into_response();
+        response.headers_mut().extend(headers);
+        return Ok(response);
+    }
+
+    let etag = variant_etag(&project_file_etag(&metadata), "nw");
+    if project_file_is_not_modified(request_headers, &etag, last_modified) {
+        let headers = project_file_response_headers(
+            &project_file.content_type,
+            metadata.len(),
+            &etag,
+            last_modified,
+        )?;
+        return Ok(not_modified_response(headers));
+    }
+
+    let bytes = tokio::task::spawn_blocking(move || {
+        let original = std::fs::read(&path)?;
+        // A PNG whose framing cannot be walked is an ERROR, never the original bytes: "here is your
+        // copy without the workflow" must not be answered with a file that may still carry one.
+        match sceneworks_core::workflow_png::strip_workflow_chunk(&original) {
+            // Nothing of ours in it — the file already is what was asked for.
+            Ok(None) => Ok(original),
+            Ok(Some(stripped)) => Ok(stripped),
+            Err(error) => Err(std::io::Error::other(error.to_string())),
+        }
+    })
+    .await
+    .map_err(|error| ApiError::internal(error.to_string()))?
+    .map_err(|error| {
+        tracing::debug!(
+            event = "project_file_strip_failed",
+            error = %error,
+            "could not serve a project file without its workflow"
+        );
+        ApiError::bad_request("This image could not be rewritten without its workflow.")
+    })?;
+
+    let mut headers = project_file_response_headers(
+        &project_file.content_type,
+        bytes.len() as u64,
+        &etag,
+        last_modified,
+    )?;
+    headers.insert(header::ACCEPT_RANGES, HeaderValue::from_static("none"));
+    let mut response = Body::from(bytes).into_response();
+    response.headers_mut().extend(headers);
+    Ok(response)
+}
+
+/// A 304 carrying `headers` minus the content length, which a body-less response must not declare.
+fn not_modified_response(headers: HeaderMap) -> Response {
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::NOT_MODIFIED;
+    *response.headers_mut() = headers;
+    response.headers_mut().remove(header::CONTENT_LENGTH);
+    response
+}
+
+/// Distinguish a derived representation's ETag from the source file's.
+///
+/// The route caches `immutable`, so two representations of one URL sharing a tag is a correctness
+/// bug and not a missed optimization: a client holding the full file would revalidate a strip
+/// request as `304 Not Modified` and reuse the body with the workflow still in it.
+fn variant_etag(base: &str, variant: &str) -> String {
+    match base.strip_suffix('"') {
+        Some(head) => format!("{head}-{variant}\""),
+        None => format!("{base}-{variant}"),
+    }
 }
 
 fn project_file_etag(metadata: &std::fs::Metadata) -> String {

--- a/apps/rust-api/src/preferences.rs
+++ b/apps/rust-api/src/preferences.rs
@@ -119,6 +119,18 @@ pub(crate) struct UiPreferences {
     /// sc-15953 owns the Settings toggle and the first-run disclosure that write it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     embed_workflow_in_images: Option<bool>,
+    /// Whether the one-time embedded-workflow disclosure has been shown and dismissed (sc-15953).
+    ///
+    /// Durable rather than a browser flag because the desktop shell serves the UI from a
+    /// `127.0.0.1:<port>` origin that changes each launch, taking origin-keyed storage with it — a
+    /// `localStorage`-only "already told them" flag would re-show the notice on every launch.
+    ///
+    /// Absent means NOT shown, and that is the state an install upgrading into this build is in:
+    /// embedding defaults ON, so someone who has been generating for months has never been told,
+    /// and the notice fires once for them rather than only for fresh installs. Nothing ever writes
+    /// `false` back — this only goes from absent to `true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    workflow_embed_notice_seen: Option<bool>,
 }
 
 /// Retained workspaces in a studio-settings map. The map grows by one entry per workspace the
@@ -348,6 +360,13 @@ pub(crate) async fn set_ui_preferences(
         // normalization — an out-of-vocabulary value cannot parse.
         if let Some(embed_workflow_in_images) = payload.embed_workflow_in_images {
             prefs.embed_workflow_in_images = Some(embed_workflow_in_images);
+        }
+        // One-way (sc-15953): once the disclosure has been shown it stays shown. A payload
+        // carrying `false` is ignored rather than obeyed, so no unrelated client — or a stale
+        // cached copy of an older preferences object PUT back wholesale — can make a user who has
+        // already been told see the notice again.
+        if payload.workflow_embed_notice_seen == Some(true) {
+            prefs.workflow_embed_notice_seen = Some(true);
         }
         if let Some(active_view) = normalize_preference_id(payload.active_view.as_deref(), 48) {
             prefs.active_view = Some(active_view);

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -289,6 +289,13 @@ pub struct AppState {
     pub(crate) media_tickets: Arc<TicketStore>,
     /// Bounds CPU and memory consumed by on-demand Library thumbnail backfills.
     pub(crate) thumbnail_generation_slots: Arc<Semaphore>,
+    /// Bounds memory consumed by `?stripWorkflow=true` downloads (sc-15953).
+    ///
+    /// The sibling of `thumbnail_generation_slots`, deliberately: they are the two derived
+    /// representations of the same route, and both read a whole file into memory. A strip holds
+    /// the source buffer for as long as the response body is being written, so without a gate the
+    /// ceiling is "however many clients ask at once" times the file size.
+    pub(crate) workflow_strip_slots: Arc<Semaphore>,
     // sc-8870 (F-068): per-peer-IP failed-token throttle for the auth oracle.
     pub(crate) auth_throttle: Arc<AuthThrottle>,
     pub(crate) manifest_cache: Arc<Mutex<ManifestCache>>,

--- a/apps/rust-api/src/tests/media.rs
+++ b/apps/rust-api/src/tests/media.rs
@@ -330,6 +330,177 @@ async fn project_file_route_serves_a_copy_without_the_workflow() {
 }
 
 #[tokio::test]
+async fn a_strip_request_cannot_revalidate_into_the_unstripped_body() {
+    // The distinct variant ETag was only half the fix, and the missing half was reachable: both
+    // representations of this URL are derived from ONE file, so they carry the same
+    // `Last-Modified`. A client that had already done a plain GET could hand that date back on a
+    // strip request and — reproduced at the head this fixes — be answered `304 Not Modified` with
+    // an empty body, whereupon it reuses the full file it already holds, workflow and all. A 304 is
+    // "what you have is what you would get", which for this pair is false.
+    //
+    // So the strip variant revalidates on the tag ALONE. Both directions are pinned below: the
+    // date must not produce a 304, and the correct tag still must.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Revalidate" }),
+    )
+    .await;
+    let project_id = created["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
+    let embedded = workflow_png_bytes(&temp_dir, Some("a lighthouse in fog"));
+    std::fs::write(project_path.join("assets/images/shot.png"), &embedded).expect("writes");
+    let uri = format!("/api/v1/projects/{project_id}/files/assets/images/shot.png");
+
+    // What a browser has after an ordinary view of the image.
+    let (status, plain_headers, _) =
+        request_raw(app.clone(), "GET", &uri, Body::empty(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    let header = |headers: &axum::http::HeaderMap, name: &str| {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_owned()
+    };
+    let plain_last_modified = header(&plain_headers, "last-modified");
+    let plain_etag = header(&plain_headers, "etag");
+    assert!(
+        !plain_last_modified.is_empty(),
+        "the plain GET dates itself"
+    );
+
+    // The exact revalidation a cache builds from that response, aimed at the strip variant.
+    let (status, _, body) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("{uri}?stripWorkflow=true"),
+        Body::empty(),
+        &[("if-modified-since", plain_last_modified.as_str())],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a strip request carrying the PLAIN response's If-Modified-Since must not 304 — the two \
+         representations share a modification date and the client would reuse the unstripped body"
+    );
+    assert_eq!(
+        sceneworks_core::workflow_png::read_workflow_chunk(&body),
+        Ok(None),
+        "and the body it does get must actually be stripped"
+    );
+
+    // The plain response's ETag must not open the door either.
+    let (status, _, _) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("{uri}?stripWorkflow=true"),
+        Body::empty(),
+        &[("if-none-match", plain_etag.as_str())],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "the plain ETag is a different tag");
+
+    // And the converse: the ordinary representation must not be revalidated by the STRIP tag.
+    let (_, strip_headers, _) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("{uri}?stripWorkflow=true"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    let strip_etag = header(&strip_headers, "etag");
+    let (status, _, _) = request_raw(
+        app.clone(),
+        "GET",
+        &uri,
+        Body::empty(),
+        &[("if-none-match", strip_etag.as_str())],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Revalidation is not simply disabled: the variant's OWN tag still saves the transfer, which
+    // is what keeps this a correctness fix rather than a cache being switched off.
+    let (status, _, body) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("{uri}?stripWorkflow=true"),
+        Body::empty(),
+        &[("if-none-match", strip_etag.as_str())],
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_MODIFIED);
+    assert!(body.is_empty());
+
+    // The plain representation keeps date-based revalidation, so this narrowing is confined to the
+    // variant that needed it.
+    let (status, _, _) = request_raw(
+        app,
+        "GET",
+        &uri,
+        Body::empty(),
+        &[("if-modified-since", plain_last_modified.as_str())],
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_MODIFIED);
+}
+
+#[tokio::test]
+async fn an_oversized_image_is_refused_rather_than_served_with_its_workflow() {
+    // The strip reads the whole file — the walk has to reach the tail — so the cost follows the
+    // asset, and an imported PNG is bounded only by MAX_UPLOAD_BYTES = 2 GiB. Past the cap the
+    // answer is a 413 that says why, NEVER the file itself: "your copy without the workflow"
+    // answered with the original is the one outcome this feature must not produce.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Oversize" }),
+    )
+    .await;
+    let project_id = created["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
+
+    // Not a real PNG, and deliberately so: the cap is checked on the file's SIZE before a byte is
+    // read, which is the property under test. Writing 129 MiB of a real render would make the test
+    // slow to prove the same thing.
+    let media_path = project_path.join("assets/images/huge.png");
+    let oversized = crate::MAX_WORKFLOW_STRIP_BYTES + 1;
+    let file = std::fs::File::create(&media_path).expect("creates");
+    file.set_len(oversized).expect("sizes the fixture");
+    drop(file);
+
+    let uri = format!("/api/v1/projects/{project_id}/files/assets/images/huge.png");
+    let (status, _, body) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("{uri}?stripWorkflow=true"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(
+        String::from_utf8_lossy(&body).contains("128"),
+        "the refusal must name the limit: {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    // The ordinary download of the same file is untouched — the cap is on the rewrite, not on the
+    // asset.
+    let (status, _, _) = request_raw(app, "GET", &uri, Body::empty(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
 async fn a_media_ticket_authorizes_the_stripped_download_too() {
     // The remote/LAN half of the AC. `<a download>` cannot attach a header, so the anchor carries
     // a `?ticket=` media ticket — and the ticket allow-list matches on the PATH and is GET-only.

--- a/apps/rust-api/src/tests/media.rs
+++ b/apps/rust-api/src/tests/media.rs
@@ -177,6 +177,220 @@ async fn project_file_route_backfills_and_reuses_bounded_thumbnails() {
     assert_eq!(original_response, original_bytes);
 }
 
+/// A PNG carrying (or not carrying) a `sceneworks:workflow` chunk, written through the ONE writer
+/// rather than a hand-rolled chunk.
+fn workflow_png_bytes(temp_dir: &tempfile::TempDir, prompt: Option<&str>) -> Vec<u8> {
+    let rgb = image::RgbImage::from_fn(24, 18, |x, y| {
+        image::Rgb([(x * 9) as u8, (y * 13) as u8, 96])
+    });
+    let share = prompt.map(|prompt| {
+        sceneworks_core::workflow_share::parse_workflow_share_json(&format!(
+            r#"{{
+                "sceneworksWorkflow": "image",
+                "schemaVersion": 1,
+                "producer": {{ "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" }},
+                "mode": "text_to_image",
+                "model": "z_image_turbo",
+                "prompt": "{prompt}"
+            }}"#
+        ))
+        .expect("the fixture envelope parses")
+    });
+    let path = temp_dir
+        .path()
+        .join(format!("fixture-{}.png", uuid::Uuid::new_v4().simple()));
+    sceneworks_core::workflow_png::write_workflow_chunk(&rgb, &path, share.as_ref())
+        .expect("the fixture PNG writes");
+    std::fs::read(&path).expect("the fixture PNG reads")
+}
+
+#[tokio::test]
+async fn project_file_route_serves_a_copy_without_the_workflow() {
+    // sc-15953: the browser "Save without the workflow" is a bare `<a download>`, which cannot
+    // transform bytes — so the strip is a query param on the file route the anchor already points
+    // at. What must be true: the served body reads back with NO workflow through the sc-15947
+    // reader, the PIXELS are unchanged, and the file on disk is untouched.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Strip" }),
+    )
+    .await;
+    let project_id = created["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
+
+    let embedded = workflow_png_bytes(&temp_dir, Some("a lighthouse in fog"));
+    let media_path = project_path.join("assets/images/shot.png");
+    std::fs::write(&media_path, &embedded).expect("media writes");
+    let uri = format!("/api/v1/projects/{project_id}/files/assets/images/shot.png");
+
+    // Without the flag the route still serves the file exactly as it is, chunk and all.
+    let (status, _, plain) = request_raw(app.clone(), "GET", &uri, Body::empty(), &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(plain, embedded);
+    assert!(sceneworks_core::workflow_png::read_workflow_chunk(&plain)
+        .expect("the served file reads")
+        .is_some());
+
+    let (status, headers, stripped) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("{uri}?stripWorkflow=true"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        sceneworks_core::workflow_png::read_workflow_chunk(&stripped),
+        Ok(None),
+        "the downloaded copy must carry no workflow"
+    );
+    // Visually identical, and by the strongest available statement of it: nothing re-encoded, so
+    // the pixels decode to the same buffer the source does.
+    let decode = |bytes: &[u8]| {
+        image::load_from_memory_with_format(bytes, image::ImageFormat::Png)
+            .expect("decodes")
+            .to_rgb8()
+    };
+    assert_eq!(decode(&stripped).as_raw(), decode(&embedded).as_raw());
+    assert_eq!(
+        stripped.len().to_string(),
+        headers
+            .get("content-length")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default(),
+        "the length header must describe the stripped body, not the file on disk"
+    );
+    // The route caches `immutable`, so the two representations of this URL must not share an ETag
+    // or a client holding the full file would revalidate the strip request into a cache hit on the
+    // body that still has the workflow in it.
+    let plain_etag = {
+        let (_, headers, _) = request_raw(app.clone(), "GET", &uri, Body::empty(), &[]).await;
+        headers
+            .get("etag")
+            .and_then(|value| value.to_str().ok())
+            .expect("an etag")
+            .to_owned()
+    };
+    let stripped_etag = headers
+        .get("etag")
+        .and_then(|value| value.to_str().ok())
+        .expect("an etag");
+    assert_ne!(stripped_etag, plain_etag);
+    // The body is a rewritten buffer whose offsets are not the file's, so ranges are off.
+    assert_eq!(
+        headers.get("accept-ranges").and_then(|v| v.to_str().ok()),
+        Some("none")
+    );
+
+    // Nothing retroactive: the asset on disk is byte-for-byte what it was.
+    assert_eq!(std::fs::read(&media_path).expect("reads"), embedded);
+
+    // A PNG that never carried one is served unchanged rather than refused or rewritten.
+    let clean = workflow_png_bytes(&temp_dir, None);
+    std::fs::write(project_path.join("assets/images/clean.png"), &clean).expect("writes");
+    let (status, _, served) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/files/assets/images/clean.png?stripWorkflow=true"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(served, clean);
+
+    // Neither is a non-PNG: it cannot be carrying one of ours, so the honest answer is the file.
+    std::fs::write(project_path.join("assets/videos/clip.mp4"), b"0123456789").expect("writes");
+    let (status, _, served) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/files/assets/videos/clip.mp4?stripWorkflow=true"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(served, b"0123456789");
+
+    // And the two derived representations are mutually exclusive rather than silently one of them.
+    let (status, _, _) = request_raw(
+        app,
+        "GET",
+        &format!("{uri}?stripWorkflow=true&thumbnail=384"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn a_media_ticket_authorizes_the_stripped_download_too() {
+    // The remote/LAN half of the AC. `<a download>` cannot attach a header, so the anchor carries
+    // a `?ticket=` media ticket — and the ticket allow-list matches on the PATH and is GET-only.
+    // Keeping the strip on the existing file path is what makes it work out here with no change to
+    // that allow-list; this test is what says so rather than leaving it to inspection.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.access_token = "secret-token".to_owned();
+    let app = create_app(settings).expect("app creates");
+    let (_, created) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Ticketed" }),
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    let project_id = created["id"].as_str().expect("project id").to_owned();
+    let project_path = std::path::PathBuf::from(created["path"].as_str().unwrap());
+    let embedded = workflow_png_bytes(&temp_dir, Some("a lighthouse in fog"));
+    std::fs::write(project_path.join("assets/images/shot.png"), &embedded).expect("writes");
+    let uri = format!("/api/v1/projects/{project_id}/files/assets/images/shot.png");
+
+    let (status, ticket) = request_with_headers(
+        app.clone(),
+        "POST",
+        "/api/v1/files/ticket",
+        Value::Null,
+        &[("x-sceneworks-token", "secret-token")],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let ticket = ticket["ticket"].as_str().expect("a ticket").to_owned();
+
+    // Unticketed and untokened: still refused, so the query param is not a way around auth.
+    let (status, _, _) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("{uri}?stripWorkflow=true"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // The shape the anchor actually builds: the strip param, then the ticket appended after it.
+    let (status, _, stripped) = request_raw(
+        app,
+        "GET",
+        &format!("{uri}?stripWorkflow=true&ticket={ticket}"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        sceneworks_core::workflow_png::read_workflow_chunk(&stripped),
+        Ok(None)
+    );
+}
+
 #[tokio::test]
 async fn project_file_route_serves_byte_ranges() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/rust-api/src/tests/workflows.rs
+++ b/apps/rust-api/src/tests/workflows.rs
@@ -1088,3 +1088,95 @@ async fn the_asset_route_404s_for_an_asset_that_does_not_exist() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
+
+// ---------------------------------------------------------------------------
+// The embed preference and its first-run disclosure (sc-15953)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn the_embed_toggle_and_its_disclosure_flag_persist_where_the_worker_looks() {
+    // The Settings toggle's whole job is to land `embedWorkflowInImages` in the file the WORKER
+    // re-reads at its PNG write seam, per job — so this asserts against that reader rather than
+    // against the route's own echo, and asserts the merge is partial in both directions.
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let config_dir = settings.config_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    // An untouched install: nothing stored, and every reader resolves that to ON.
+    assert!(sceneworks_core::app_paths::embed_workflow_in_images(
+        &config_dir
+    ));
+
+    let (status, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "embedWorkflowInImages": false }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["embedWorkflowInImages"], false);
+    assert!(
+        !sceneworks_core::app_paths::embed_workflow_in_images(&config_dir),
+        "the worker's own reader must see the opt-out on the next job, with no restart"
+    );
+
+    // An unrelated preference write must not disturb it — the failure this guards is a client
+    // PUTting a whole cached preferences object and silently turning embedding back on.
+    let (_, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "theme": "dark" }),
+    )
+    .await;
+    assert_eq!(saved["embedWorkflowInImages"], false);
+    assert!(!sceneworks_core::app_paths::embed_workflow_in_images(
+        &config_dir
+    ));
+
+    // And back on, because the toggle has to work in both directions.
+    let (_, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "embedWorkflowInImages": true }),
+    )
+    .await;
+    assert_eq!(saved["embedWorkflowInImages"], true);
+    assert!(sceneworks_core::app_paths::embed_workflow_in_images(
+        &config_dir
+    ));
+
+    // The disclosure flag. Absent until dismissed, which is what makes an install upgrading into
+    // this build get the notice once rather than never.
+    let (_, prefs) = request(app.clone(), "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert!(prefs.get("workflowEmbedNoticeSeen").is_none());
+
+    let (_, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "workflowEmbedNoticeSeen": true }),
+    )
+    .await;
+    assert_eq!(saved["workflowEmbedNoticeSeen"], true);
+
+    // One-way. "Never repeated" has to survive a client that PUTs a stale preferences object back
+    // wholesale, so a `false` is ignored rather than obeyed.
+    let (_, saved) = request(
+        app.clone(),
+        "PUT",
+        "/api/v1/ui-preferences",
+        json!({ "workflowEmbedNoticeSeen": false }),
+    )
+    .await;
+    assert_eq!(saved["workflowEmbedNoticeSeen"], true);
+
+    // It survives a restart because it is on disk, not in the browser's origin-keyed storage —
+    // which the desktop shell throws away every launch.
+    let (_, prefs) = request(app, "GET", "/api/v1/ui-preferences", Value::Null).await;
+    assert_eq!(prefs["workflowEmbedNoticeSeen"], true);
+    assert_eq!(prefs["embedWorkflowInImages"], true);
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -33,8 +33,10 @@ import { useWorkflowDrop } from "./hooks/useWorkflowDrop.js";
 import { WorkflowDropPanel } from "./components/WorkflowDropPanel.jsx";
 import { WorkflowEmbedNotice } from "./components/WorkflowEmbedNotice.jsx";
 import {
+  persistWorkflowEmbedPreference,
   readEmbedWorkflowInImages,
   readWorkflowEmbedNoticeSeen,
+  subscribeWorkflowEmbedFlags,
   writeEmbedWorkflowInImages,
   writeWorkflowEmbedNoticeSeen,
 } from "./workflowEmbed.js";
@@ -757,17 +759,52 @@ export function App() {
   const workflowEmbedRef = useRef({ hydrated: false, embed: true, seen: false });
   workflowEmbedRef.current.embed = embedWorkflow;
   workflowEmbedRef.current.seen = workflowEmbedNoticeSeen;
-  const changeEmbedWorkflow = useCallback((next) => {
-    setEmbedWorkflow(next);
-    writeEmbedWorkflowInImages(next);
-    putUiPreferences({ embedWorkflowInImages: next }).catch(() => {});
-  }, []);
+  // Both writes go through `persistWorkflowEmbedPreference`, which retries and then REPORTS. A
+  // swallowed `.catch(() => {})` is wrong for this pair specifically: localStorage is only an
+  // instant-paint mirror, and on the desktop shell it is wiped by the per-launch origin — so a
+  // dropped PUT is not "saved locally", it is a privacy opt-out that reverts to ON at the next
+  // launch, or a disclosure that fires again as though it had never been dismissed. Both are
+  // things the user should be told about rather than discover.
+  const changeEmbedWorkflow = useCallback(
+    (next) => {
+      setEmbedWorkflow(next);
+      writeEmbedWorkflowInImages(next);
+      persistWorkflowEmbedPreference({ embedWorkflowInImages: next }).catch(() => {
+        pushNotice(
+          "workflow-embed",
+          "Could not save whether generated images include their recipe. The setting is active now but may revert when SceneWorks restarts.",
+        );
+      });
+    },
+    [pushNotice],
+  );
   const dismissWorkflowEmbedNotice = useCallback(() => {
     setWorkflowEmbedNoticeOpen(false);
     setWorkflowEmbedNoticeSeen(true);
     writeWorkflowEmbedNoticeSeen(true);
-    putUiPreferences({ workflowEmbedNoticeSeen: true }).catch(() => {});
-  }, []);
+    persistWorkflowEmbedPreference({ workflowEmbedNoticeSeen: true }).catch(() => {
+      pushNotice(
+        "workflow-embed",
+        "Could not record that this notice was dismissed, so it may appear again.",
+      );
+    });
+  }, [pushNotice]);
+  // A second tab that was already mounted when the notice was dismissed holds `seen: false` and
+  // would show the disclosure again on its own next generation — "once" being per tab rather than
+  // per user. The mirror write raises a `storage` event in every other tab, so they follow.
+  useEffect(
+    () =>
+      subscribeWorkflowEmbedFlags(({ embed, seen }) => {
+        setEmbedWorkflow(embed);
+        // One-way: see `subscribeWorkflowEmbedFlags`. `seen` is a record that something was said,
+        // and another tab clearing its storage is not evidence it never was.
+        if (seen) {
+          setWorkflowEmbedNoticeSeen(true);
+          setWorkflowEmbedNoticeOpen(false);
+        }
+      }),
+    [],
+  );
   // The observable event the disclosure hangs off: a generation was accepted while embedding is
   // on. Submission rather than completion, so the user is told BEFORE the files with their prompt
   // in them exist — and only on a job the API actually took, so a failed POST does not burn it.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -3388,8 +3388,10 @@ export function App() {
         <AppLiveContext.Provider value={appLiveValue}>
           <SimpleShell
             accent={accent}
+            embedWorkflow={embedWorkflow}
             lockedToSimple={uiModeLocked}
             onAccentChange={changeAccent}
+            onEmbedWorkflowChange={changeEmbedWorkflow}
             onModeChange={setUiModeOverride}
             onScreenChange={setSimpleActiveScreen}
             onSimpleDefaultChange={changeSimpleUiDefault}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -31,6 +31,13 @@ import { useAccessGate } from "./hooks/useAccessGate.js";
 import { useDropNavigationGuard } from "./hooks/useDropNavigationGuard.js";
 import { useWorkflowDrop } from "./hooks/useWorkflowDrop.js";
 import { WorkflowDropPanel } from "./components/WorkflowDropPanel.jsx";
+import { WorkflowEmbedNotice } from "./components/WorkflowEmbedNotice.jsx";
+import {
+  readEmbedWorkflowInImages,
+  readWorkflowEmbedNoticeSeen,
+  writeEmbedWorkflowInImages,
+  writeWorkflowEmbedNoticeSeen,
+} from "./workflowEmbed.js";
 import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { ScreenActiveContext } from "./context/ScreenActiveContext.js";
@@ -731,6 +738,46 @@ export function App() {
     writeStoredSimpleDefault(next);
     putUiPreferences({ simpleUi: next }).catch(() => {});
   }, []);
+  // Embedded workflow (sc-15953, epic 15945). `embedWorkflow` is the durable
+  // `embedWorkflowInImages` preference; the WORKER reads it off ui-preferences.json at the PNG
+  // write seam on every job, so a flip here lands on the next generation with no restart. Same
+  // durable contract as theme/accent, and for a sharper reason: the desktop shell's per-launch
+  // origin wipes localStorage, so a preference stored only there would silently revert to the ON
+  // default on the next launch — turning a deliberate privacy opt-out back on.
+  const [embedWorkflow, setEmbedWorkflow] = useState(readEmbedWorkflowInImages);
+  // Whether the one-time disclosure has been shown and dismissed, and whether it is on screen now.
+  // `seen` is durable for the same reason; `open` is this session's.
+  const [workflowEmbedNoticeSeen, setWorkflowEmbedNoticeSeen] = useState(
+    readWorkflowEmbedNoticeSeen,
+  );
+  const [workflowEmbedNoticeOpen, setWorkflowEmbedNoticeOpen] = useState(false);
+  // Read by the generation trigger below, which is memoized and would otherwise close over stale
+  // values — and gated on the durable GET having landed, so a generation submitted in the first
+  // few hundred milliseconds after a desktop relaunch cannot re-show a notice already dismissed.
+  const workflowEmbedRef = useRef({ hydrated: false, embed: true, seen: false });
+  workflowEmbedRef.current.embed = embedWorkflow;
+  workflowEmbedRef.current.seen = workflowEmbedNoticeSeen;
+  const changeEmbedWorkflow = useCallback((next) => {
+    setEmbedWorkflow(next);
+    writeEmbedWorkflowInImages(next);
+    putUiPreferences({ embedWorkflowInImages: next }).catch(() => {});
+  }, []);
+  const dismissWorkflowEmbedNotice = useCallback(() => {
+    setWorkflowEmbedNoticeOpen(false);
+    setWorkflowEmbedNoticeSeen(true);
+    writeWorkflowEmbedNoticeSeen(true);
+    putUiPreferences({ workflowEmbedNoticeSeen: true }).catch(() => {});
+  }, []);
+  // The observable event the disclosure hangs off: a generation was accepted while embedding is
+  // on. Submission rather than completion, so the user is told BEFORE the files with their prompt
+  // in them exist — and only on a job the API actually took, so a failed POST does not burn it.
+  const noteGenerationForWorkflowEmbed = useCallback((job) => {
+    const state = workflowEmbedRef.current;
+    if (!job || !state.hydrated || !state.embed || state.seen) {
+      return;
+    }
+    setWorkflowEmbedNoticeOpen(true);
+  }, []);
   const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
   const localGenerationJobIdsRef = useRef(localGenerationJobIds);
@@ -1381,6 +1428,19 @@ export function App() {
           // doesn't throw away what they typed while the GET was in flight.
           setStudioRestoreEpoch((epoch) => epoch + 1);
         }
+        // The embedded-workflow preference and its disclosure flag (sc-15953). Both ABSENT
+        // states are meaningful and both are the permissive one: absent embedding means ON (the
+        // worker's own reader agrees), and an absent notice flag means the user has never been
+        // told — which is exactly the state an install upgrading into this build is in, so the
+        // disclosure fires once for them rather than only for fresh installs.
+        if (typeof prefs?.embedWorkflowInImages === "boolean") {
+          setEmbedWorkflow(prefs.embedWorkflowInImages);
+          writeEmbedWorkflowInImages(prefs.embedWorkflowInImages);
+        }
+        if (typeof prefs?.workflowEmbedNoticeSeen === "boolean") {
+          setWorkflowEmbedNoticeSeen(prefs.workflowEmbedNoticeSeen);
+          writeWorkflowEmbedNoticeSeen(prefs.workflowEmbedNoticeSeen);
+        }
         const persistedView = prefs?.activeView;
         if (navSections.some((section) => section.items.some((item) => item.id === persistedView))) {
           setActiveView(persistedView);
@@ -1388,7 +1448,12 @@ export function App() {
       })
       .catch(() => {})
       .finally(() => {
-        if (!cancelled) setNavigationHydrated(true);
+        if (!cancelled) {
+          // Only now may the disclosure fire: before this, `seen` is whatever localStorage said,
+          // which on the desktop shell is a fresh empty store every launch.
+          workflowEmbedRef.current.hydrated = true;
+          setNavigationHydrated(true);
+        }
       });
     return () => {
       cancelled = true;
@@ -2143,8 +2208,12 @@ export function App() {
         requestedGpu,
         setJobs,
         setError,
+        // sc-15953: the one image-generation choke point every studio goes through (Image Studio,
+        // Simple, and the Character studio's angle/pose forms all call this), so the first-run
+        // disclosure hangs off it rather than off each lane's submit button.
+        afterCreate: noteGenerationForWorkflowEmbed,
       }),
-    [token, activeProject, requestedGpu, setError],
+    [token, activeProject, requestedGpu, setError, noteGenerationForWorkflowEmbed],
   );
 
   // Standalone video upscale (epic 4811 / sc-4816): the net-new `video_upscale` job runs
@@ -3462,6 +3531,16 @@ export function App() {
           <p className="notice error" key={notice.kind}>{notice.message}</p>
         ))}
 
+        {workflowEmbedNoticeOpen ? (
+          <WorkflowEmbedNotice
+            onDismiss={dismissWorkflowEmbedNotice}
+            onOpenSettings={() => {
+              dismissWorkflowEmbedNotice();
+              setActiveView("Settings");
+            }}
+          />
+        ) : null}
+
         {showSetupWizard ? (
           <SetupWizard
             jobs={jobs}
@@ -3489,8 +3568,10 @@ export function App() {
         {activeView === "Settings" ? (
           <SettingsScreen
             accent={accent}
+            embedWorkflow={embedWorkflow}
             lockedToSimple={uiModeLocked}
             onAccentChange={changeAccent}
+            onEmbedWorkflowChange={changeEmbedWorkflow}
             onSimpleDefaultChange={changeSimpleUiDefault}
             simpleDefault={simpleUiDefault}
           />

--- a/apps/web/src/App.workflowEmbed.test.jsx
+++ b/apps/web/src/App.workflowEmbed.test.jsx
@@ -1,0 +1,179 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeEventSource, response, settle } from "./main.testSupport.jsx";
+import { click } from "./testUtils/dom.js";
+import { resetStartupTimingForTests } from "./startupTiming.js";
+import { resetAccessTokenForTests } from "./accessToken.js";
+
+// The first-run embedded-workflow disclosure (sc-15953), asserted through the REAL App shell.
+//
+// The observable event is "a generation was accepted while embedding is on", which App hangs off
+// the `afterCreate` hook of the ONE image-job creator every studio goes through. Rather than
+// driving a whole studio form to reach it, this captures the hook App actually hands that creator
+// and calls it — so what is under test is App's wiring, its once-only rule and its persistence,
+// without a test that would break the next time a studio's submit button moved.
+const hoisted = vi.hoisted(() => ({ afterCreate: null }));
+
+vi.mock("./createJob.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    makeCreateJob(options) {
+      if (options.definition === actual.CREATE_JOB_DEFINITIONS.image) {
+        hoisted.afterCreate = options.afterCreate;
+      }
+      return actual.makeCreateJob(options);
+    },
+  };
+});
+
+const { App } = await import("./main.jsx");
+
+const NOTICE_TITLE = "Your generated images carry their recipe";
+
+function fakeApi(storedPreferences) {
+  return vi.fn((url, init) => {
+    const path = new URL(url).pathname;
+    if (path.endsWith("/health")) {
+      return Promise.resolve(response({ status: "ok", authRequired: false }));
+    }
+    if (path.endsWith("/access")) {
+      return Promise.resolve(response({ authRequired: false }));
+    }
+    if (path.endsWith("/jobs/events/ticket")) {
+      return Promise.resolve(response({ ticket: "stream-ticket" }));
+    }
+    if (path.endsWith("/projects")) {
+      return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+    }
+    if (path.endsWith("/ui-preferences")) {
+      if (init?.method === "PUT") {
+        return Promise.resolve(response({ ...storedPreferences, ...JSON.parse(init.body) }));
+      }
+      return Promise.resolve(response(storedPreferences));
+    }
+    return Promise.resolve(response([]));
+  });
+}
+
+function preferenceWrites() {
+  return global.fetch.mock.calls
+    .filter(
+      ([url, init]) =>
+        new URL(url).pathname.endsWith("/ui-preferences") && init?.method === "PUT",
+    )
+    .map(([, init]) => JSON.parse(init.body));
+}
+
+const noticeIsShowing = () => document.body.textContent.includes(NOTICE_TITLE);
+
+describe("App — the one-time embedded-workflow disclosure (sc-15953)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    resetAccessTokenForTests();
+    window.innerWidth = 1440;
+    hoisted.afterCreate = null;
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container.remove();
+    resetStartupTimingForTests();
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function renderApp(storedPreferences = {}) {
+    global.fetch = fakeApi(storedPreferences);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+  }
+
+  async function generate() {
+    expect(hoisted.afterCreate, "App must hand the image-job creator an afterCreate hook").toBeTypeOf(
+      "function",
+    );
+    await act(async () => {
+      hoisted.afterCreate({ id: "job-1" });
+    });
+    await settle();
+  }
+
+  it("is not on screen until a generation is submitted", async () => {
+    // It is a disclosure about what a generated file will carry, so it has nothing to say to
+    // someone who has not generated anything.
+    await renderApp();
+    expect(noticeIsShowing()).toBe(false);
+  });
+
+  it("appears on the first generation, is dismissible, and never comes back", async () => {
+    await renderApp();
+    await generate();
+    expect(noticeIsShowing()).toBe(true);
+
+    const dismiss = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent.trim() === "Got it",
+    );
+    expect(dismiss, "a dismiss button").toBeTruthy();
+    await click(dismiss);
+    await settle();
+
+    expect(noticeIsShowing()).toBe(false);
+    // Durable, not a browser flag: the desktop shell's origin changes each launch and would take
+    // localStorage with it, re-showing the notice forever.
+    expect(preferenceWrites()).toContainEqual({ workflowEmbedNoticeSeen: true });
+
+    // A second, third and fourth generation in the same session must not bring it back.
+    await generate();
+    await generate();
+    expect(noticeIsShowing()).toBe(false);
+  });
+
+  it("never appears for a user who has already been told, across a relaunch", async () => {
+    // The stored flag is what a restart restores. This is the case that would regress into
+    // "fires on every launch" if the flag lived only in localStorage.
+    await renderApp({ workflowEmbedNoticeSeen: true });
+    await generate();
+    expect(noticeIsShowing()).toBe(false);
+  });
+
+  it("fires once for an install that was already generating before the feature shipped", async () => {
+    // The upgrade case. An existing install has no stored flag — which reads as "never told" —
+    // and embedding defaults ON, so this is exactly the user the disclosure exists for. A
+    // mechanism keyed on "this is a fresh install" would stay silent here.
+    await renderApp({ theme: "dark", accent: "coral", defaultGenerationQuality: "q8" });
+    await generate();
+    expect(noticeIsShowing()).toBe(true);
+  });
+
+  it("stays silent when the user has turned embedding off", async () => {
+    // Nothing is being disclosed, because nothing is being embedded.
+    await renderApp({ embedWorkflowInImages: false });
+    await generate();
+    expect(noticeIsShowing()).toBe(false);
+  });
+
+  it("does not fire for a POST the API refused", async () => {
+    // `afterCreate` only runs on a job the server accepted; a failed submit writes no file and
+    // must not burn the one disclosure the user gets.
+    await renderApp();
+    await act(async () => {
+      hoisted.afterCreate(null);
+    });
+    await settle();
+    expect(noticeIsShowing()).toBe(false);
+  });
+});

--- a/apps/web/src/assetActions.js
+++ b/apps/web/src/assetActions.js
@@ -74,6 +74,15 @@ export function suggestedFilename(asset) {
   return `${base}.${ext}`;
 }
 
+// Whether "Save without workflow" is worth offering for this asset (sc-15953). The workflow
+// envelope only ever rides in a PNG, so for anything else the option would be a control that does
+// nothing — and offering it would imply the file might be carrying one. Deliberately a check on
+// the FORMAT, not on whether this particular file has a chunk: answering that needs the bytes, and
+// the answer is the same either way (a PNG with no chunk saves as a plain copy).
+export function assetCanCarryWorkflow(asset) {
+  return assetExtension(asset) === "png";
+}
+
 // localStorage key + in-memory fallback for the last directory a Save As succeeded in
 // (sc-8737). Persisted across reloads so the next Save As dialog re-opens where the user
 // last saved. localStorage access is guarded (private-mode / non-browser env can throw or
@@ -127,11 +136,24 @@ function resolveAbsolutePath(asset) {
   });
 }
 
+// Ask the file route for a copy with the embedded workflow chunk removed (sc-15953). A bare
+// `<a download>` cannot transform bytes or set headers, so the strip has to happen server-side;
+// this is a query param on the URL the anchor already points at, which means the media ticket
+// remote/LAN mode appends (`?ticket=…`, matched on the PATH by a GET-only allow-list) keeps
+// working with no change to the ticket rules.
+export function stripWorkflowUrl(href) {
+  if (!href) {
+    return href;
+  }
+  return `${href}${href.includes("?") ? "&" : "?"}stripWorkflow=true`;
+}
+
 // Trigger a normal browser download of the asset's served URL. Uses a transient
 // `<a download>` click, which is the portable way to name a cross-origin-safe,
 // same-origin download without a fetch/blob round-trip. Content-agnostic.
-function browserDownload(asset) {
-  const href = assetUrl(asset);
+function browserDownload(asset, { withoutWorkflow = false } = {}) {
+  const base = assetUrl(asset);
+  const href = withoutWorkflow ? stripWorkflowUrl(base) : base;
   if (!href) {
     throw new Error("This asset has no downloadable URL.");
   }
@@ -153,12 +175,12 @@ function browserDownload(asset) {
 //   - Browser/LAN: trigger a normal download of the asset URL. Returns null (there's no
 //     destination path to report).
 // Works for both image and video assets.
-export async function saveAssetAs(asset) {
+export async function saveAssetAs(asset, { withoutWorkflow = false } = {}) {
   if (!asset) {
     throw new Error("An asset is required.");
   }
   if (!isDesktop) {
-    browserDownload(asset);
+    browserDownload(asset, { withoutWorkflow });
     return null;
   }
   const absolutePath = await resolveAbsolutePath(asset);
@@ -168,6 +190,9 @@ export async function saveAssetAs(asset) {
   const args = {
     sourcePath: absolutePath,
     suggestedFilename: suggestedFilename(asset),
+    // sc-15953. Always sent so the desktop command's argument is never absent-by-accident; the
+    // Rust side treats a missing value as false either way.
+    withoutWorkflow,
   };
   if (startDir) {
     args.startDir = startDir;

--- a/apps/web/src/assetActions.test.js
+++ b/apps/web/src/assetActions.test.js
@@ -89,6 +89,7 @@ describe("saveAssetAs — desktop (sc-8727)", () => {
     expect(invoke).toHaveBeenNthCalledWith(2, "save_asset_as", {
       sourcePath: "/data/project_1/assets/images/Mira.png",
       suggestedFilename: "Mira.png",
+      withoutWorkflow: false,
     });
     expect(dest).toBe("/Users/me/Desktop/Mira.png");
   });
@@ -106,6 +107,7 @@ describe("saveAssetAs — desktop (sc-8727)", () => {
     expect(invoke).toHaveBeenNthCalledWith(2, "save_asset_as", {
       sourcePath: "/data/project_1/assets/videos/Clip.mp4",
       suggestedFilename: "Clip.mp4",
+      withoutWorkflow: false,
     });
   });
 
@@ -280,5 +282,76 @@ describe("revealAsset (sc-8727)", () => {
   it("throws in browser mode (desktop-only)", async () => {
     const { revealAsset } = await importBrowser();
     await expect(revealAsset(IMAGE_ASSET)).rejects.toThrow(/desktop app/i);
+  });
+});
+
+describe("Save without the workflow (sc-15953)", () => {
+  it("only offers the option for a PNG, the one format the envelope rides in", async () => {
+    const { assetCanCarryWorkflow } = await importBrowser();
+    expect(assetCanCarryWorkflow(IMAGE_ASSET)).toBe(true);
+    expect(assetCanCarryWorkflow(VIDEO_ASSET)).toBe(false);
+    expect(
+      assetCanCarryWorkflow({ file: { path: "a/b.jpg", mimeType: "image/jpeg" } }),
+    ).toBe(false);
+    // The mime fallback, for an asset whose path carries no extension.
+    expect(assetCanCarryWorkflow({ file: { path: "a/b", mimeType: "image/png" } })).toBe(true);
+    expect(assetCanCarryWorkflow(null)).toBe(false);
+  });
+
+  it("asks the desktop command for the stripping copy", async () => {
+    const invoke = vi.fn(async (command) => {
+      if (command === "resolve_asset_path") return "/data/project_1/assets/images/Mira.png";
+      if (command === "save_asset_as") return "/Users/me/Desktop/Mira.png";
+      return null;
+    });
+    const { saveAssetAs } = await importDesktop(invoke);
+
+    await saveAssetAs(IMAGE_ASSET, { withoutWorkflow: true });
+
+    expect(invoke).toHaveBeenNthCalledWith(2, "save_asset_as", {
+      sourcePath: "/data/project_1/assets/images/Mira.png",
+      suggestedFilename: "Mira.png",
+      withoutWorkflow: true,
+    });
+  });
+
+  it("asks the file route to strip for a browser download", async () => {
+    // A bare <a download> cannot transform bytes, so the flag has to ride on the URL.
+    const { saveAssetAs } = await importBrowser();
+    const clicked = [];
+    vi.spyOn(window.HTMLAnchorElement.prototype, "click").mockImplementation(function mockClick() {
+      clicked.push({ href: this.href, download: this.download });
+    });
+
+    await saveAssetAs(IMAGE_ASSET, { withoutWorkflow: true });
+
+    expect(clicked[0].href).toContain("stripWorkflow=true");
+    expect(clicked[0].download).toBe("Mira.png");
+  });
+
+  it("appends the flag as another pair so a media ticket on the same URL survives", async () => {
+    // In remote/LAN mode `assetUrl` already carries `?ticket=…`. The ticket allow-list matches on
+    // the PATH and pulls the ticket out of an `&`-separated pair, so the strip flag must be
+    // appended rather than replace the query.
+    const { stripWorkflowUrl } = await importBrowser();
+    expect(stripWorkflowUrl("/api/v1/projects/p/files/a.png")).toBe(
+      "/api/v1/projects/p/files/a.png?stripWorkflow=true",
+    );
+    expect(stripWorkflowUrl("/api/v1/projects/p/files/a.png?ticket=abc")).toBe(
+      "/api/v1/projects/p/files/a.png?ticket=abc&stripWorkflow=true",
+    );
+    expect(stripWorkflowUrl("")).toBe("");
+  });
+
+  it("still saves the ordinary copy by default", async () => {
+    const { saveAssetAs } = await importBrowser();
+    const clicked = [];
+    vi.spyOn(window.HTMLAnchorElement.prototype, "click").mockImplementation(function mockClick() {
+      clicked.push({ href: this.href });
+    });
+
+    await saveAssetAs(IMAGE_ASSET);
+
+    expect(clicked[0].href).not.toContain("stripWorkflow");
   });
 });

--- a/apps/web/src/components/Icons.jsx
+++ b/apps/web/src/components/Icons.jsx
@@ -96,6 +96,10 @@ export const Icon = {
   // the preview/warning banner. Additive — no existing render site changes.
   Menu: (p) => <I {...p} d="M4 6h16M4 12h16M4 18h16" />,
   Download: (p) => <I {...p} d="M12 3v11M8 10.5l4 4 4-4M4 19h16" />,
+  // "Download, with the embedded recipe struck out" (sc-15953). Sits beside `Download` in the
+  // Simple shell, which is the DEFAULT on a phone and where a right-click context menu — the only
+  // other place this control exists — is not reachable at all.
+  DownloadStripped: (p) => <I {...p} d="M12 3v9M8.5 9l3.5 3.5L15.5 9M4 19h16M5 4l14 13" />,
   Check: (p) => <I {...p} d="M4 12.5L9 17.5 20 6.5" />,
   Warning: (p) => <I {...p} d="M12 3l9.5 17H2.5zM12 9v5M12 17.5h.01" />,
 };

--- a/apps/web/src/components/WorkflowEmbedNotice.jsx
+++ b/apps/web/src/components/WorkflowEmbedNotice.jsx
@@ -3,8 +3,8 @@ import { Icon } from "./Icons.jsx";
 import {
   SAVE_WITHOUT_WORKFLOW_LABEL,
   WORKFLOW_SHARE_DOC_URL,
-  inFileSentence,
-  notInFileSentence,
+  inFileItems,
+  notInFileItems,
   proseFieldSentence,
 } from "../workflowEmbed.js";
 
@@ -41,11 +41,21 @@ export function WorkflowEmbedDetails() {
         Face repo id and is not treated as a location.
       </p>
       <p className="settings-note">
-        <strong>Also in the file:</strong> {inFileSentence()}.
+        <strong>Also in the file:</strong>
       </p>
+      <ul className="settings-note settings-note-list">
+        {inFileItems().map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
       <p className="settings-note">
-        <strong>Not in the file:</strong> {notInFileSentence()}.
+        <strong>Not in the file:</strong>
       </p>
+      <ul className="settings-note settings-note-list">
+        {notInFileItems().map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
       <p className="settings-note">
         Turning this off applies from the next generation. Images already on disk keep the block
         they were written with — to share one of those without it, use{" "}

--- a/apps/web/src/components/WorkflowEmbedNotice.jsx
+++ b/apps/web/src/components/WorkflowEmbedNotice.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Icon } from "./Icons.jsx";
 import {
+  SAVE_WITHOUT_WORKFLOW_LABEL,
   WORKFLOW_SHARE_DOC_URL,
+  inFileSentence,
+  notInFileSentence,
   proseFieldSentence,
 } from "../workflowEmbed.js";
 
@@ -11,9 +14,13 @@ import {
 // Both live here so there is ONE set of claims about what leaves with an image. Every sentence
 // below is checked against `docs/workflow-share-envelope.md`, which is itself pinned in both
 // directions against the shipped sanitizer by `crates/sceneworks-core/tests/workflow_share_doc.rs`.
-// The list of path-exempt prose fields is not written out as prose at all — it is rendered from
-// `EMBEDDED_PROSE_FIELDS`, which that same Rust test pins against the doc's `prose-fields` table,
-// so a seventh prose field cannot be added to the sanitizer without this copy failing a test.
+//
+// The three lists are not written out as prose at all. They are rendered from
+// `EMBEDDED_PROSE_FIELDS`, `WORKFLOW_FIELDS_IN_FILE` and `WORKFLOW_FIELDS_NOT_IN_FILE`, each of
+// which that same Rust test pins against a table in the document — so a seventh prose field, a new
+// allow-listed advanced setting, or a withheld key that quietly became shared all fail this copy
+// rather than silently going unmentioned in it. That gap was real: `advanced.poses` (the
+// `keypoints` / `hands` / `face` coordinate arrays) travelled while the copy named none of it.
 //
 // The standing failure mode this epic keeps hitting is an artifact claiming a stronger guarantee
 // than the code delivers. So the wording is deliberately narrow: it says what IS in the file rather
@@ -34,21 +41,15 @@ export function WorkflowEmbedDetails() {
         Face repo id and is not treated as a location.
       </p>
       <p className="settings-note">
-        <strong>Also in the file:</strong> the generation mode, the model and style names, the seed
-        for this image, its size, how it was fitted, how many images the run asked for, any upscale
-        settings, LoRA names, weights and Hugging Face repo ids, the shared generation settings
-        (sampler, steps, guidance and the like), which kinds of input image the recipe needs, and
-        the SceneWorks version that wrote the file.
+        <strong>Also in the file:</strong> {inFileSentence()}.
       </p>
       <p className="settings-note">
-        <strong>Not in the file:</strong> your user or machine name, project, job and asset ids, any
-        timestamp, the other seeds in a batch, the input images themselves, and this
-        machine&apos;s quality tier, attention kernel or GPU.
+        <strong>Not in the file:</strong> {notInFileSentence()}.
       </p>
       <p className="settings-note">
         Turning this off applies from the next generation. Images already on disk keep the block
         they were written with — to share one of those without it, use{" "}
-        <strong>Save without workflow</strong>.
+        <strong>{SAVE_WITHOUT_WORKFLOW_LABEL}</strong>.
       </p>
       <p className="settings-note">
         <a href={WORKFLOW_SHARE_DOC_URL} rel="noreferrer noopener" target="_blank">

--- a/apps/web/src/components/WorkflowEmbedNotice.jsx
+++ b/apps/web/src/components/WorkflowEmbedNotice.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Icon } from "./Icons.jsx";
+import {
+  WORKFLOW_SHARE_DOC_URL,
+  proseFieldSentence,
+} from "../workflowEmbed.js";
+
+// The user-facing copy for the embedded-workflow feature (sc-15953, epic 15945): the block of
+// detail under the Settings toggle, and the one-time first-run disclosure.
+//
+// Both live here so there is ONE set of claims about what leaves with an image. Every sentence
+// below is checked against `docs/workflow-share-envelope.md`, which is itself pinned in both
+// directions against the shipped sanitizer by `crates/sceneworks-core/tests/workflow_share_doc.rs`.
+// The list of path-exempt prose fields is not written out as prose at all — it is rendered from
+// `EMBEDDED_PROSE_FIELDS`, which that same Rust test pins against the doc's `prose-fields` table,
+// so a seventh prose field cannot be added to the sanitizer without this copy failing a test.
+//
+// The standing failure mode this epic keeps hitting is an artifact claiming a stronger guarantee
+// than the code delivers. So the wording is deliberately narrow: it says what IS in the file rather
+// than promising the file is safe, it names the two-segment-path hole rather than claiming every
+// path is caught, and it says the switch applies to the NEXT generation rather than implying
+// anything about images already on disk.
+
+// The paragraphs under the Settings toggle. Also rendered inside the first-run notice, so the two
+// surfaces cannot drift.
+export function WorkflowEmbedDetails() {
+  return (
+    <>
+      <p className="settings-note">
+        <strong>Your prompt travels as you wrote it.</strong> {proseFieldSentence()} are recorded
+        exactly as authored, so a file path or a client&apos;s name typed into any of them leaves
+        with every copy of the image. Every other value is dropped if it looks like a file path —
+        except a two-segment name like <code>Clients/Acme</code>, which is the shape of a Hugging
+        Face repo id and is not treated as a location.
+      </p>
+      <p className="settings-note">
+        <strong>Also in the file:</strong> the generation mode, the model and style names, the seed
+        for this image, its size, how it was fitted, how many images the run asked for, any upscale
+        settings, LoRA names, weights and Hugging Face repo ids, the shared generation settings
+        (sampler, steps, guidance and the like), which kinds of input image the recipe needs, and
+        the SceneWorks version that wrote the file.
+      </p>
+      <p className="settings-note">
+        <strong>Not in the file:</strong> your user or machine name, project, job and asset ids, any
+        timestamp, the other seeds in a batch, the input images themselves, and this
+        machine&apos;s quality tier, attention kernel or GPU.
+      </p>
+      <p className="settings-note">
+        Turning this off applies from the next generation. Images already on disk keep the block
+        they were written with — to share one of those without it, use{" "}
+        <strong>Save without workflow</strong>.
+      </p>
+      <p className="settings-note">
+        <a href={WORKFLOW_SHARE_DOC_URL} rel="noreferrer noopener" target="_blank">
+          What travels, exactly
+        </a>
+      </p>
+    </>
+  );
+}
+
+// The one-time disclosure. Rendered the first time a generation is submitted while embedding is on
+// and the user has never been told; dismissing it records a durable server-side flag, so it does
+// not come back on the next launch (the desktop shell's per-launch origin makes a localStorage-only
+// flag useless for this).
+//
+// Deliberately NOT a modal. It is a disclosure, not a decision — blocking a generation the user
+// already asked for to make them read a paragraph would train them to dismiss it unread, which is
+// the opposite of the point.
+export function WorkflowEmbedNotice({ onDismiss, onOpenSettings }) {
+  return (
+    <section
+      aria-labelledby="workflow-embed-notice-title"
+      className="settings-notice workflow-embed-notice"
+      role="region"
+    >
+      <Icon.Warning size={16} />
+      <div>
+        <div className="workflow-embed-notice-title" id="workflow-embed-notice-title">
+          Your generated images carry their recipe
+        </div>
+        <WorkflowEmbedDetails />
+        <div className="settings-button-row">
+          {onOpenSettings ? (
+            <button className="settings-btn" onClick={onOpenSettings} type="button">
+              Open settings
+            </button>
+          ) : null}
+          <button className="settings-btn" onClick={onDismiss} type="button">
+            Got it
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/assetPanels.contextMenu.test.jsx
+++ b/apps/web/src/components/assetPanels.contextMenu.test.jsx
@@ -13,11 +13,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const actionMocks = vi.hoisted(() => ({
   saveAssetAs: vi.fn(),
   revealAsset: vi.fn(),
+  // sc-15953: the menu asks whether the asset's format can carry a workflow before offering the
+  // "save a copy without it" row. Mocked to the real predicate's answer for a PNG.
+  assetCanCarryWorkflow: vi.fn(() => true),
 }));
 
 vi.mock("../assetActions.js", () => ({
   saveAssetAs: actionMocks.saveAssetAs,
   revealAsset: actionMocks.revealAsset,
+  assetCanCarryWorkflow: actionMocks.assetCanCarryWorkflow,
 }));
 
 // Mutable desktop flag driven per-suite. The component reads `isDesktop` at module
@@ -191,6 +195,31 @@ describe("FullscreenPreview context menu (desktop)", () => {
         .click();
     });
     expect(actionMocks.revealAsset).toHaveBeenCalledWith(imageAsset);
+  });
+
+  it("offers a without-the-workflow copy for a format that can carry one (sc-15953)", async () => {
+    await renderPreview(baseProps({ asset: imageAsset }));
+    await rightClickStage();
+    const label = "Save a copy without the workflow…";
+    expect(menuItemLabels()).toContain(label);
+
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-context-menu-item")]
+        .find((button) => button.textContent.trim() === label)
+        .click();
+    });
+    expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(imageAsset, { withoutWorkflow: true });
+    // The plain Save As stays exactly what it was — this is an extra copy, not a replacement.
+    expect(actionMocks.saveAssetAs).not.toHaveBeenCalledWith(imageAsset);
+  });
+
+  it("omits it for a format the envelope cannot ride in (sc-15953)", async () => {
+    // Offering a no-op control would imply the file might be carrying a workflow.
+    actionMocks.assetCanCarryWorkflow.mockReturnValueOnce(false);
+    await renderPreview(baseProps({ asset: videoAsset }));
+    await rightClickStage();
+    expect(menuItemLabels()).not.toContain("Save a copy without the workflow…");
+    expect(menuItemLabels()).toContain("Save As…");
   });
 
   it("Zoom In / Zoom Out / Fit menu items drive the view transform", async () => {

--- a/apps/web/src/components/assetPanels.contextMenu.test.jsx
+++ b/apps/web/src/components/assetPanels.contextMenu.test.jsx
@@ -129,6 +129,11 @@ function menuItemLabels() {
   );
 }
 
+// The always-visible footer row, as opposed to what a right-click reveals (sc-15953).
+function footerButtonLabels() {
+  return [...document.body.querySelectorAll(".preview-actions button")].map((b) => b.textContent.trim());
+}
+
 async function loadComponent(isDesktop) {
   runtimeState.isDesktop = isDesktop;
   vi.resetModules();
@@ -215,11 +220,38 @@ describe("FullscreenPreview context menu (desktop)", () => {
 
   it("omits it for a format the envelope cannot ride in (sc-15953)", async () => {
     // Offering a no-op control would imply the file might be carrying a workflow.
-    actionMocks.assetCanCarryWorkflow.mockReturnValueOnce(false);
+    // `mockReturnValue`, not `…Once`: TWO surfaces ask the predicate now — the menu row and the
+    // visible button beside Save As — and a one-shot stub would answer the button and leave the
+    // menu on the default.
+    actionMocks.assetCanCarryWorkflow.mockReturnValue(false);
     await renderPreview(baseProps({ asset: videoAsset }));
     await rightClickStage();
     expect(menuItemLabels()).not.toContain("Save a copy without the workflow…");
     expect(menuItemLabels()).toContain("Save As…");
+    expect(footerButtonLabels()).not.toContain("Save a copy without the workflow…");
+    actionMocks.assetCanCarryWorkflow.mockReturnValue(true);
+  });
+
+  it("puts the same copy behind a visible button, not only a right-click (sc-15953)", async () => {
+    // The option existed ONLY in the context menu, which is unreachable on a touch device and
+    // undiscoverable everywhere else — for the one action a user takes specifically because the
+    // file is about to leave their machine.
+    await renderPreview(baseProps({ asset: imageAsset }));
+    const label = "Save a copy without the workflow…";
+    expect(footerButtonLabels()).toContain(label);
+    // Beside the plain Save As rather than instead of it.
+    expect(footerButtonLabels()).toContain("Save As…");
+
+    await act(async () => {
+      [...document.body.querySelectorAll(".preview-actions button")]
+        .find((button) => button.textContent.trim() === label)
+        .click();
+    });
+    expect(actionMocks.saveAssetAs).toHaveBeenCalledWith(imageAsset, { withoutWorkflow: true });
+    // And it is the SAME string the menu row uses, so the settings copy telling a user to look for
+    // it names one control rather than three.
+    await rightClickStage();
+    expect(menuItemLabels()).toContain(label);
   });
 
   it("Zoom In / Zoom Out / Fit menu items drive the view transform", async () => {

--- a/apps/web/src/components/assetPanels.fullscreen.test.jsx
+++ b/apps/web/src/components/assetPanels.fullscreen.test.jsx
@@ -11,11 +11,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const actionMocks = vi.hoisted(() => ({
   saveAssetAs: vi.fn(),
   revealAsset: vi.fn(),
+  // sc-15953: the menu asks whether the asset's format can carry a workflow before offering the
+  // "save a copy without it" row. Mocked to the real predicate's answer for a PNG.
+  assetCanCarryWorkflow: vi.fn(() => true),
 }));
 
 vi.mock("../assetActions.js", () => ({
   saveAssetAs: actionMocks.saveAssetAs,
   revealAsset: actionMocks.revealAsset,
+  assetCanCarryWorkflow: actionMocks.assetCanCarryWorkflow,
 }));
 
 // Mutable runtime state driven per-suite. The component reads `isDesktop` at module

--- a/apps/web/src/components/assetPanels.importedRecipe.test.jsx
+++ b/apps/web/src/components/assetPanels.importedRecipe.test.jsx
@@ -8,7 +8,13 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../assetActions.js", () => ({ saveAssetAs: vi.fn(), revealAsset: vi.fn() }));
+// `assetCanCarryWorkflow` gates the without-the-workflow save beside Save As (sc-15953). Answered
+// false here so the footer row this suite counts is the one it was written against.
+vi.mock("../assetActions.js", () => ({
+  saveAssetAs: vi.fn(),
+  revealAsset: vi.fn(),
+  assetCanCarryWorkflow: () => false,
+}));
 vi.mock("../runtime.js", () => ({
   isDesktop: false,
   tauriInvoke: vi.fn(),

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -3,6 +3,7 @@ import { isAbortError } from "../api.js";
 import { appConfirm } from "../appConfirm.jsx";
 import { assetMatchesCharacter } from "../characterMembership.js";
 import { assetCanCarryWorkflow, saveAssetAs, revealAsset } from "../assetActions.js";
+import { SAVE_WITHOUT_WORKFLOW_LABEL } from "../workflowEmbed.js";
 import { isDesktop, isPageFullscreen, setViewerFullscreen } from "../runtime.js";
 import {
   AssetMedia,
@@ -1121,11 +1122,13 @@ function FullscreenPreviewComponent({
       // sc-15953: a copy with the embedded recipe removed, for sharing an image without the
       // prompt that made it. Offered only for PNGs, the one format the envelope rides in. The
       // asset itself is untouched — this writes one copy differently, it does not clean the
-      // library, which is why the label says "Save a copy".
+      // library, which is why the label says "Save a copy". The label is the shared constant so
+      // the menu, the button beside Save As and the settings copy that tells you to use it cannot
+      // name three different controls.
       if (assetCanCarryWorkflow(displayedAsset)) {
         items.push({
           key: "save-as-without-workflow",
-          label: "Save a copy without the workflow…",
+          label: `${SAVE_WITHOUT_WORKFLOW_LABEL}…`,
           onSelect: () => saveAssetAs(displayedAsset, { withoutWorkflow: true }),
         });
       }
@@ -1331,6 +1334,20 @@ function FullscreenPreviewComponent({
             <button onClick={() => saveAssetAs(displayedAsset)} type="button">
               Save As…
             </button>
+            {/* Its without-the-recipe sibling (sc-15953). The option existed only behind a
+                right-click, which makes "discoverable" untrue for the one action a user takes
+                specifically because they are about to send the file to someone else. PNGs only —
+                the envelope rides in no other format, and offering it elsewhere would imply the
+                file might be carrying one. */}
+            {assetCanCarryWorkflow(displayedAsset) ? (
+              <button
+                onClick={() => saveAssetAs(displayedAsset, { withoutWorkflow: true })}
+                title="Write one copy with the embedded recipe removed. The asset itself is left alone."
+                type="button"
+              >
+                {SAVE_WITHOUT_WORKFLOW_LABEL}…
+              </button>
+            ) : null}
             {/* Videos re-run from their recipe exactly as images do, seed and all (sc-12324) —
                 the affordance follows the recipe, not the media type. */}
             {hasRecordedRecipe ? (

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { isAbortError } from "../api.js";
 import { appConfirm } from "../appConfirm.jsx";
 import { assetMatchesCharacter } from "../characterMembership.js";
-import { saveAssetAs, revealAsset } from "../assetActions.js";
+import { assetCanCarryWorkflow, saveAssetAs, revealAsset } from "../assetActions.js";
 import { isDesktop, isPageFullscreen, setViewerFullscreen } from "../runtime.js";
 import {
   AssetMedia,
@@ -1118,6 +1118,17 @@ function FullscreenPreviewComponent({
       const items = [
         { key: "save-as", label: "Save As…", onSelect: () => saveAssetAs(displayedAsset) },
       ];
+      // sc-15953: a copy with the embedded recipe removed, for sharing an image without the
+      // prompt that made it. Offered only for PNGs, the one format the envelope rides in. The
+      // asset itself is untouched — this writes one copy differently, it does not clean the
+      // library, which is why the label says "Save a copy".
+      if (assetCanCarryWorkflow(displayedAsset)) {
+        items.push({
+          key: "save-as-without-workflow",
+          label: "Save a copy without the workflow…",
+          onSelect: () => saveAssetAs(displayedAsset, { withoutWorkflow: true }),
+        });
+      }
       if (isDesktop) {
         items.push({ key: "reveal", label: "Reveal in Finder/Explorer", onSelect: () => revealAsset(displayedAsset) });
       }

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -20,6 +20,7 @@ import { writeClipboardText } from "../clipboard.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { ModeTabs } from "../components/generationStudio.jsx";
+import { WorkflowEmbedDetails } from "../components/WorkflowEmbedNotice.jsx";
 import { ACCENTS } from "../accents.js";
 import { describeDevice } from "../deviceSummary.js";
 import { useAppContext } from "../context/AppContext.js";
@@ -65,6 +66,8 @@ export function SettingsScreen({
   simpleDefault = false,
   onSimpleDefaultChange,
   lockedToSimple = false,
+  embedWorkflow = true,
+  onEmbedWorkflowChange,
 }) {
   // theme/changeTheme and the worker registry come from the app context (the same values the
   // topbar toggle and Simple Settings read); accent + the Simple-mode default are drilled from
@@ -488,6 +491,34 @@ export function SettingsScreen({
 
         {activeTab === "settings" ? (
           <div className="settings-tab-body">
+            {/* Sharing (sc-15953). The toggle writes `embedWorkflowInImages` into
+                ui-preferences.json, which the WORKER re-reads at its PNG write seam on every job —
+                so the change lands on the next generation with no restart. The copy under it is
+                the same block the first-run disclosure shows; see WorkflowEmbedNotice.jsx for why
+                its claims are shaped the way they are. */}
+            <div className="settings-group-title">Sharing</div>
+            <div className="settings-row">
+              <div>
+                <div className="settings-row-title">Include the recipe in generated images</div>
+                <div className="settings-row-sub">
+                  New PNGs carry a small block of JSON, so dropping one back into SceneWorks
+                  reloads the recipe that made it.
+                </div>
+              </div>
+              <button
+                aria-checked={embedWorkflow}
+                aria-label="Include the recipe in generated images"
+                className={embedWorkflow ? "settings-toggle on" : "settings-toggle"}
+                onClick={() => onEmbedWorkflowChange?.(!embedWorkflow)}
+                role="switch"
+                type="button"
+              >
+                <span />
+              </button>
+            </div>
+            <WorkflowEmbedDetails />
+            <div className="work-panel-divider" />
+
             {isDesktop ? (
               <>
                 <div className="settings-group-title">Storage</div>

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -682,3 +682,90 @@ describe("SettingsScreen appearance settings", () => {
     expect(container.textContent).not.toContain("the sidebar switch overrides it");
   });
 });
+
+describe("SettingsScreen embedded-workflow toggle (sc-15953)", () => {
+  let container;
+  let root;
+  let SettingsScreen;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    delete window.__TAURI__;
+    vi.resetModules();
+    vi.doMock("../api.js", () => ({
+      apiFetch: vi.fn(async () => []),
+      isAbortError: () => false,
+      API_BASE_URL: "",
+      eventUrl: () => "",
+    }));
+    SettingsScreen = await loadScreen();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.doUnmock("../api.js");
+    vi.restoreAllMocks();
+  });
+
+  async function openSharing(props) {
+    await renderScreen(root, SettingsScreen, props);
+    await openTab(container, "Settings");
+  }
+
+  const toggle = () =>
+    container.querySelector('[aria-label="Include the recipe in generated images"]');
+
+  it("is discoverable under Sharing and reflects the preference", async () => {
+    await openSharing({ embedWorkflow: true });
+    expect(container.textContent).toContain("Sharing");
+    expect(toggle().getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("forwards a change in both directions", async () => {
+    const onEmbedWorkflowChange = vi.fn();
+    await openSharing({ embedWorkflow: true, onEmbedWorkflowChange });
+    await click(toggle());
+    expect(onEmbedWorkflowChange).toHaveBeenCalledWith(false);
+
+    onEmbedWorkflowChange.mockClear();
+    await openSharing({ embedWorkflow: false, onEmbedWorkflowChange });
+    await click(toggle());
+    expect(onEmbedWorkflowChange).toHaveBeenCalledWith(true);
+  });
+
+  it("names every path-exempt prose field rather than summarizing them", async () => {
+    // The claim a user acts on before sharing. Rendered from the list that
+    // `the_settings_copy_names_exactly_the_path_exempt_prose_fields` (Rust) pins against the
+    // contract doc, so this asserts the UI actually shows what that list holds.
+    const { EMBEDDED_PROSE_FIELDS } = await import("../workflowEmbed.js");
+    await openSharing({ embedWorkflow: true });
+    for (const [, label] of EMBEDDED_PROSE_FIELDS) {
+      expect(container.textContent).toContain(label);
+    }
+  });
+
+  it("does not imply that turning it off cleans images already on disk", async () => {
+    await openSharing({ embedWorkflow: true });
+    const copy = container.textContent;
+    expect(copy).toContain("Turning this off applies from the next generation");
+    expect(copy).toContain("Images already on disk keep the block they were written with");
+    // The wording that would be a lie. Nothing rewrites an existing asset.
+    expect(copy).not.toContain("removes it from");
+    expect(copy).not.toMatch(/clean(s|ed)? (up )?(your )?existing/i);
+  });
+
+  it("links to the contract document", async () => {
+    await openSharing({ embedWorkflow: true });
+    const link = [...container.querySelectorAll("a")].find((anchor) =>
+      anchor.href.includes("workflow-share-envelope.md"),
+    );
+    expect(link).toBeTruthy();
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+});

--- a/apps/web/src/simple/SimpleSettings.jsx
+++ b/apps/web/src/simple/SimpleSettings.jsx
@@ -13,6 +13,7 @@ import {
 import { describeDevice } from "../deviceSummary.js";
 import { loadCredentials, saveCredential } from "../credentials.js";
 import { Chips } from "./studioParts.jsx";
+import { WorkflowEmbedDetails } from "../components/WorkflowEmbedNotice.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
 
 // Simple Settings (design handoff): Appearance (theme + accent), Generation (default
@@ -23,7 +24,15 @@ import { useSimpleUi } from "./SimpleUiContext.js";
 // through the shared keychain/REST transport — so a change made here is the same change
 // made there. Nothing in this screen is Simple-only state.
 
-export function SimpleSettings({ accent, onAccentChange, simpleDefault, onSimpleDefaultChange, lockedToSimple }) {
+export function SimpleSettings({
+  accent,
+  onAccentChange,
+  simpleDefault,
+  onSimpleDefaultChange,
+  lockedToSimple,
+  embedWorkflow = true,
+  onEmbedWorkflowChange,
+}) {
   const { theme, changeTheme, visibleWorkers = [], macCapabilities } = useAppContext();
   const { toast } = useSimpleUi();
   const [quality, setQuality] = useState(readDefaultGenerationQuality);
@@ -173,6 +182,38 @@ export function SimpleSettings({ accent, onAccentChange, simpleDefault, onSimple
           >
             <span />
           </button>
+        </div>
+      </div>
+
+      {/* Sharing (sc-15953). The same durable preference the advanced Settings screen writes and
+          the worker re-reads at its PNG write seam — this shell is the DEFAULT on a phone, so
+          leaving the switch out of it would make "discoverable" untrue for most of the people
+          the disclosure is aimed at. */}
+      <div className="su-group">
+        <div className="su-group-title">Sharing</div>
+        <div className="su-card su-card--split">
+          <div>
+            <div className="su-card-title">Include the recipe in generated images</div>
+            <div className="su-card-sub">
+              New PNGs carry a small block of JSON, so dropping one back into SceneWorks reloads the
+              recipe that made it.
+            </div>
+          </div>
+          <button
+            aria-checked={embedWorkflow}
+            aria-label="Include the recipe in generated images"
+            className={embedWorkflow ? "su-toggle on" : "su-toggle"}
+            onClick={() => onEmbedWorkflowChange?.(!embedWorkflow)}
+            role="switch"
+            type="button"
+          >
+            <span />
+          </button>
+        </div>
+        <div className="su-card">
+          <div className="su-card-body">
+            <WorkflowEmbedDetails />
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/simple/SimpleSettings.test.jsx
+++ b/apps/web/src/simple/SimpleSettings.test.jsx
@@ -111,3 +111,67 @@ describe("SimpleSettings — durable default-quality write (sc-15136)", () => {
     );
   });
 });
+
+describe("SimpleSettings — embedded-workflow toggle (sc-15953)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    apiFetch.mockClear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    window.localStorage.clear();
+  });
+
+  async function render(props) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={APP_CONTEXT}>
+          <SimpleUiContext.Provider value={SIMPLE_UI}>
+            <SimpleSettings
+              accent="violet"
+              lockedToSimple={false}
+              onAccentChange={vi.fn()}
+              onSimpleDefaultChange={vi.fn()}
+              simpleDefault={false}
+              {...props}
+            />
+          </SimpleUiContext.Provider>
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  const toggle = () =>
+    container.querySelector('[aria-label="Include the recipe in generated images"]');
+
+  it("is reachable in the shell a phone gets by default", async () => {
+    // Simple is the default on a phone, so a switch that only existed in the advanced Settings
+    // screen would make "discoverable" untrue for most of the people the disclosure is aimed at.
+    await render({ embedWorkflow: true });
+    expect(container.textContent).toContain("Sharing");
+    expect(toggle().getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("forwards a change to the same durable handler the advanced screen uses", async () => {
+    const onEmbedWorkflowChange = vi.fn();
+    await render({ embedWorkflow: true, onEmbedWorkflowChange });
+    await click(toggle());
+    expect(onEmbedWorkflowChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows the same claims about what travels", async () => {
+    const { EMBEDDED_PROSE_FIELDS } = await import("../workflowEmbed.js");
+    await render({ embedWorkflow: true });
+    for (const [, label] of EMBEDDED_PROSE_FIELDS) {
+      expect(container.textContent).toContain(label);
+    }
+    expect(container.textContent).toContain("Turning this off applies from the next generation");
+  });
+});

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -75,6 +75,8 @@ const PERSIST_DEBOUNCE_MS = 400;
 export function SimpleShell({
   accent,
   onAccentChange,
+  embedWorkflow = true,
+  onEmbedWorkflowChange,
   simpleDefault,
   onSimpleDefaultChange,
   onModeChange,
@@ -363,8 +365,10 @@ export function SimpleShell({
               {screen === "settings" ? (
                 <SimpleSettings
                   accent={accent}
+                  embedWorkflow={embedWorkflow}
                   lockedToSimple={lockedToSimple}
                   onAccentChange={onAccentChange}
+                  onEmbedWorkflowChange={onEmbedWorkflowChange}
                   onSimpleDefaultChange={onSimpleDefaultChange}
                   simpleDefault={simpleDefault}
                 />

--- a/apps/web/src/simple/studioParts.download.test.jsx
+++ b/apps/web/src/simple/studioParts.download.test.jsx
@@ -1,0 +1,141 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SimpleUiContext } from "./SimpleUiContext.js";
+import { mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+// sc-15953 — the Simple shell has a without-the-workflow download.
+//
+// The finding this file exists for: `WorkflowEmbedDetails`, which the Simple Settings screen
+// renders, tells the user that to share an image already on disk without its recipe they should use
+// "Save a copy without the workflow". The only place that control existed was the ADVANCED shell's
+// right-click context menu. The Simple shell's only egress was `DownloadButton`, a bare
+// `<a href={assetUrl(asset)} download>` with no strip param — and the same argument that puts the
+// toggle in this shell ("it is the default on a phone") makes the missing remedy worse, because a
+// phone has no right-click.
+//
+// `assetMedia.jsx` is mocked at the URL seam so the anchor's href is a fixed, inspectable string;
+// everything else here is the real component.
+
+vi.mock("../components/assetMedia.jsx", () => ({
+  assetUrl: (asset) => (asset?.relativePath ? `/api/v1/projects/p1/files/${asset.relativePath}` : ""),
+  AssetThumbnail: () => null,
+}));
+
+const { DownloadButton } = await import("./studioParts.jsx");
+
+const SIMPLE_UI = { toast: vi.fn(), breakpoint: "desktop" };
+
+function pngAsset(overrides = {}) {
+  return {
+    id: "asset_1",
+    displayName: "shot.png",
+    relativePath: "assets/images/shot.png",
+    file: { path: "assets/images/shot.png", mimeType: "image/png" },
+    ...overrides,
+  };
+}
+
+function anchors(container) {
+  return [...container.querySelectorAll("a")].map((a) => a.getAttribute("href"));
+}
+
+function buttons(container) {
+  return [...container.querySelectorAll("button")];
+}
+
+describe("DownloadButton — the without-workflow copy (sc-15953)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    SIMPLE_UI.toast.mockClear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+  });
+
+  async function render(asset, props = {}) {
+    await act(async () => {
+      root.render(
+        <SimpleUiContext.Provider value={SIMPLE_UI}>
+          <DownloadButton asset={asset} {...props} />
+        </SimpleUiContext.Provider>,
+      );
+    });
+  }
+
+  it("offers a second anchor carrying the strip param for a PNG", async () => {
+    await render(pngAsset());
+    const hrefs = anchors(container);
+    expect(hrefs).toContain("/api/v1/projects/p1/files/assets/images/shot.png");
+    expect(hrefs).toContain("/api/v1/projects/p1/files/assets/images/shot.png?stripWorkflow=true");
+    // A real anchor, not a fetch: the media URL already carries the auth ticket in remote mode
+    // (sc-8810), and the strip is a query param on the path that ticket's allow-list matches on.
+    expect(buttons(container)).toHaveLength(2);
+  });
+
+  it("names the control exactly as every other surface does", async () => {
+    await render(pngAsset());
+    const label = buttons(container)[1].getAttribute("aria-label");
+    expect(label).toBe("Save a copy without the workflow");
+    // Reachable by touch: it is a button in the flow, not a right-click target.
+    expect(buttons(container)[1].getAttribute("title")).toBe(label);
+  });
+
+  it("clicks the stripped anchor, not the plain one", async () => {
+    await render(pngAsset());
+    const clicked = [];
+    for (const anchor of container.querySelectorAll("a")) {
+      anchor.click = () => clicked.push(anchor.getAttribute("href"));
+    }
+    await act(async () => {
+      buttons(container)[1].click();
+    });
+    expect(clicked).toEqual([
+      "/api/v1/projects/p1/files/assets/images/shot.png?stripWorkflow=true",
+    ]);
+    expect(SIMPLE_UI.toast).toHaveBeenCalledWith("Downloading without the recipe…");
+  });
+
+  it("leaves the plain download exactly what it was", async () => {
+    await render(pngAsset());
+    const clicked = [];
+    for (const anchor of container.querySelectorAll("a")) {
+      anchor.click = () => clicked.push(anchor.getAttribute("href"));
+    }
+    await act(async () => {
+      buttons(container)[0].click();
+    });
+    expect(clicked).toEqual(["/api/v1/projects/p1/files/assets/images/shot.png"]);
+    expect(SIMPLE_UI.toast).toHaveBeenCalledWith("Downloading…");
+  });
+
+  it("omits it for a format the envelope cannot ride in", async () => {
+    // Offering a control that can do nothing would imply the file might be carrying a workflow.
+    await render(
+      pngAsset({
+        displayName: "clip.mp4",
+        relativePath: "assets/videos/clip.mp4",
+        file: { path: "assets/videos/clip.mp4", mimeType: "video/mp4" },
+      }),
+    );
+    expect(buttons(container)).toHaveLength(1);
+    expect(anchors(container)).toEqual(["/api/v1/projects/p1/files/assets/videos/clip.mp4"]);
+  });
+
+  it("omits it when the asset has no URL at all", async () => {
+    await render({ id: "asset_2", displayName: "pending.png" });
+    expect(buttons(container)).toHaveLength(1);
+  });
+
+  it("labels itself in the preview variant, where there is room for words", async () => {
+    await render(pngAsset(), { className: "", label: "Download" });
+    expect(buttons(container).map((b) => b.textContent.trim())).toEqual([
+      "Download",
+      "Without recipe",
+    ]);
+  });
+});

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useRef, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { AssetThumbnail, assetUrl } from "../components/assetMedia.jsx";
+import { assetCanCarryWorkflow, stripWorkflowUrl } from "../assetActions.js";
+import { SAVE_WITHOUT_WORKFLOW_LABEL } from "../workflowEmbed.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 import { terminalStatuses } from "../constants.js";
 import { STYLE_GROUPS } from "../data/styleCatalog.js";
@@ -305,15 +307,28 @@ export function StudioResults({ job, assets, type, columns, meta, pendingCount =
 
 // Download uses a real anchor (the media URL already carries the auth ticket in
 // remote-auth mode, sc-8810) rather than a fetch — the browser owns the save dialog.
+//
+// A PNG gets a SECOND anchor, pointed at the same URL with `?stripWorkflow=true` (sc-15953). The
+// settings copy in this very shell tells the user to reach for "Save a copy without the workflow"
+// when sharing an image already on disk, and until this existed the only place that control lived
+// was the advanced shell's right-click context menu. The Simple shell is the default on a phone,
+// and a phone has no right-click — so the copy was naming a control this shell did not have. The
+// strip is server-side because a bare `<a download>` cannot transform bytes; everything here is
+// one query param on the URL the anchor already points at, ticket and all.
 export function DownloadButton({ asset, className = "su-result-action su-result-action--dl", label = null }) {
   const anchorRef = useRef(null);
+  const strippedRef = useRef(null);
   const { toast } = useSimpleUi();
+  const href = assetUrl(asset);
+  // On the FORMAT, not on whether this particular file has a chunk: answering that needs the bytes,
+  // and the answer is the same either way — a PNG with no chunk downloads as a plain copy.
+  const canStrip = Boolean(href) && assetCanCarryWorkflow(asset);
   return (
     <>
       <a
         aria-hidden="true"
         download={asset.displayName ?? ""}
-        href={assetUrl(asset)}
+        href={href}
         ref={anchorRef}
         style={{ display: "none" }}
         tabIndex={-1}
@@ -332,6 +347,33 @@ export function DownloadButton({ asset, className = "su-result-action su-result-
         <Icon.Download size={label ? 15 : 14} />
         {label}
       </button>
+      {canStrip ? (
+        <>
+          <a
+            aria-hidden="true"
+            download={asset.displayName ?? ""}
+            href={stripWorkflowUrl(href)}
+            ref={strippedRef}
+            style={{ display: "none" }}
+            tabIndex={-1}
+          >
+            download without the workflow
+          </a>
+          <button
+            aria-label={SAVE_WITHOUT_WORKFLOW_LABEL}
+            className={className}
+            onClick={() => {
+              strippedRef.current?.click();
+              toast("Downloading without the recipe…");
+            }}
+            title={SAVE_WITHOUT_WORKFLOW_LABEL}
+            type="button"
+          >
+            <Icon.DownloadStripped size={label ? 15 : 14} />
+            {label ? "Without recipe" : null}
+          </button>
+        </>
+      ) : null}
     </>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14541,6 +14541,29 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--text-muted);
 }
 
+/* The one-time embedded-workflow disclosure (sc-15953). Reuses the warn-bordered band, but
+   carries a title, several paragraphs and its own buttons rather than one line of text. */
+.workflow-embed-notice {
+  margin-bottom: var(--gap-3);
+}
+
+.workflow-embed-notice > div {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  min-width: 0;
+}
+
+.workflow-embed-notice-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.workflow-embed-notice .settings-button-row {
+  margin-top: 3px;
+}
+
 /*
  * WorkerProgressCard (sc-2083) — unified worker/job progress component.
  * See docs/design/worker-progress-card.md. Replaces .local-job-card, .job-row,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14564,6 +14564,21 @@ details[open] > summary.lora-scope-group-heading::before,
   margin-top: 3px;
 }
 
+/* The "also in the file" / "not in the file" bullets (sc-15953). A LIST rather than one long
+   comma-joined sentence: several of these phrases carry their own commas and dashes, so joined
+   into a paragraph a reader cannot tell where one claim ends and the next begins — on the surface
+   whose entire job is to be read before a file is sent to someone else. `-3px` pulls the list up
+   under its "Also in the file:" lead-in so the two read as one block. */
+.settings-note-list {
+  margin: -3px 0 0;
+  padding-left: 17px;
+  list-style: disc;
+}
+
+.settings-note-list > li {
+  margin: 2px 0;
+}
+
 /*
  * WorkerProgressCard (sc-2083) — unified worker/job progress component.
  * See docs/design/worker-progress-card.md. Replaces .local-job-card, .job-row,

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -91,14 +91,14 @@ function joinLabels(labels) {
 // covers several keys ("its size" is `width` and `height`). Repeats collapse when the sentence is
 // built, so the reader sees the phrase once and the pin still sees every key.
 
-const L_MARKER = "a marker saying this is a SceneWorks recipe, and which version of the format";
-const L_PRODUCER = "the SceneWorks name, project URL and released version of the build that wrote it";
+const L_MARKER = "a marker saying this is a SceneWorks recipe, and which version of the format it is";
+const L_PRODUCER = "the SceneWorks name, project URL and released version of the build that wrote the file";
 const L_MODE = "the generation mode";
 const L_NAMES = "the model and style names";
-const L_PROSE = "the prompt fields named above";
+const L_PROSE = "the prompt fields named above, verbatim";
 const L_SEED = "the seed for this image";
-const L_SIZE = "its size";
-const L_FIT = "how it was fitted";
+const L_SIZE = "the image size the run asked for";
+const L_FIT = "how a source image was fitted";
 const L_COUNT = "how many images the run asked for";
 const L_UPSCALE = "any upscale settings";
 const L_LORAS = "LoRA names, weights and Hugging Face repo ids";
@@ -111,7 +111,7 @@ const L_POSES =
   "the pose, hand and face coordinates a pose selection produced — landmark arrays derived from a reference photo, facial landmarks included";
 const L_PHASES = "the multi-phase denoise schedule, with each phase's steps, guidance and LoRA weights";
 const L_INPUTS = "which kinds of input image the recipe needs and how many of each";
-const L_OMITTED = "a note of any list that was too long to record";
+const L_OMITTED = "a note naming any list that was too long to record";
 
 // Every field the envelope can carry, and what the copy says about it. Keys prefixed `advanced.`
 // are the allow-listed advanced settings; the rest are top-level envelope fields.
@@ -214,18 +214,22 @@ export const WORKFLOW_FIELDS_NOT_IN_FILE = Object.freeze([
 // beside the keyed list so the sentence reads as one thought.
 const UNKEYED_ABSENCES = Object.freeze([N_IDENTITY, N_TIME, N_IMAGES]);
 
-// "the generation mode, the model and style names, …" — the rendered "Also in the file" list.
-export function inFileSentence() {
-  return joinLabels(WORKFLOW_FIELDS_IN_FILE.map(([, label]) => label));
+// The bullets of the "Also in the file" list: every declared label, in order, repeats collapsed.
+//
+// A LIST rather than one comma-joined sentence, and not for taste. Several of these phrases carry
+// their own commas and dashes ("the pose, hand and face coordinates … facial landmarks included"),
+// so joining fifteen of them produces a paragraph in which a reader cannot tell where one claim ends
+// and the next begins — on the surface whose whole job is to be read before sharing a file.
+export function inFileItems() {
+  return [...new Set(WORKFLOW_FIELDS_IN_FILE.map(([, label]) => label))];
 }
 
-// The rendered "Not in the file" list. The unkeyed absences lead, because they are what a user
-// scans for first.
-export function notInFileSentence() {
-  return joinLabels([
-    ...UNKEYED_ABSENCES,
-    ...WORKFLOW_FIELDS_NOT_IN_FILE.map(([, label]) => label),
-  ]);
+// The bullets of "Not in the file". The unkeyed absences lead, because they are what a user scans
+// for first.
+export function notInFileItems() {
+  return [
+    ...new Set([...UNKEYED_ABSENCES, ...WORKFLOW_FIELDS_NOT_IN_FILE.map(([, label]) => label)]),
+  ];
 }
 
 function readFlag(key, fallback) {

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -15,13 +15,27 @@
 // Absent means ON for the preference, and NOT SEEN for the notice. Both defaults match the Rust
 // reader's: `embed_workflow_in_images_from_json` treats an absent key as `true`.
 
+import { putUiPreferences } from "./uiPreferences.js";
+
 const EMBED_STORAGE_KEY = "sceneworks-embed-workflow";
 const NOTICE_STORAGE_KEY = "sceneworks-embed-workflow-notice-seen";
 
-// The doc that is the contract for what travels. Rooted at `PRODUCER_URL` — the same repository
-// URL the envelope itself carries — so the link in the app and the link in a shared file agree.
-export const WORKFLOW_SHARE_DOC_URL =
-  "https://github.com/SceneWorks/SceneWorks/blob/main/docs/workflow-share-envelope.md";
+// The repository URL the envelope itself carries in `producer.url`, so a file that reaches a
+// stranger is self-identifying. Pinned against the Rust `PRODUCER_URL` by
+// `the_settings_copy_names_exactly_the_path_exempt_prose_fields`.
+export const PRODUCER_URL = "https://github.com/SceneWorks/SceneWorks";
+
+// The doc that is the contract for what travels, DERIVED from `PRODUCER_URL` rather than written
+// out beside it — the link in the app and the link in a shared file are then the same URL by
+// construction instead of by a comment saying they are.
+export const WORKFLOW_SHARE_DOC_URL = `${PRODUCER_URL}/blob/main/docs/workflow-share-envelope.md`;
+
+// The ONE name for the control that writes a copy with the recipe taken out. Three surfaces say it
+// — the context menu, the button beside Save As, and the settings copy that tells you to use it —
+// and before this they said three different things. `the_settings_copy_names_the_save_without_
+// workflow_control_once` pins it against docs/workflow-share-envelope.md as well, so the document
+// and the button agree too.
+export const SAVE_WITHOUT_WORKFLOW_LABEL = "Save a copy without the workflow";
 
 // The fields recorded exactly as the user authored them, and deliberately EXEMPT from the
 // filesystem-path guard that drops every other field that looks like a location. This is the one
@@ -42,8 +56,176 @@ export const EMBEDDED_PROSE_FIELDS = Object.freeze([
 
 // "the prompt, the negative prompt, … and the structured prompt the model received".
 export function proseFieldSentence() {
-  const names = EMBEDDED_PROSE_FIELDS.map(([, label]) => label);
-  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+  return joinLabels(EMBEDDED_PROSE_FIELDS.map(([, label]) => label));
+}
+
+// "a, b, … and z", with repeats collapsed and declaration order preserved.
+function joinLabels(labels) {
+  const unique = [...new Set(labels)];
+  if (unique.length < 2) {
+    return unique[0] ?? "";
+  }
+  return `${unique.slice(0, -1).join(", ")} and ${unique[unique.length - 1]}`;
+}
+
+// ---------------------------------------------------------------------------
+// The two lists a user acts on
+// ---------------------------------------------------------------------------
+//
+// "Also in the file" and "Not in the file" are the paragraphs someone reads before deciding whether
+// to send an image to a client, and until now they were prose pinned to nothing. That is not a
+// theoretical gap: `advanced.poses` — the `keypoints` / `hands` / `face` coordinate arrays derived
+// from a reference photo, facial landmarks included — travels, and the copy named none of it while
+// the very next paragraph said the input images do not travel. A reader could reasonably conclude
+// that nothing derived from a reference leaves, which is the forbidden direction: claiming more
+// privacy than the allow-list delivers.
+//
+// So both lists are declared per KEY, exactly the way `EMBEDDED_PROSE_FIELDS` is, and the sentences
+// are rendered from them rather than written out. `the_settings_copy_accounts_for_every_shared_and
+// _withheld_field` in `crates/sceneworks-core/tests/workflow_share_doc.rs` pins the keys against the
+// `envelope-fields`, `advanced-shared` and `advanced-withheld` tables of
+// docs/workflow-share-envelope.md in both directions. A new allow-listed setting therefore cannot
+// reach a shared image without someone deciding, in this file, what the copy says about it.
+//
+// Labels are shared constants rather than repeated string literals, because one phrase legitimately
+// covers several keys ("its size" is `width` and `height`). Repeats collapse when the sentence is
+// built, so the reader sees the phrase once and the pin still sees every key.
+
+const L_MARKER = "a marker saying this is a SceneWorks recipe, and which version of the format";
+const L_PRODUCER = "the SceneWorks name, project URL and released version of the build that wrote it";
+const L_MODE = "the generation mode";
+const L_NAMES = "the model and style names";
+const L_PROSE = "the prompt fields named above";
+const L_SEED = "the seed for this image";
+const L_SIZE = "its size";
+const L_FIT = "how it was fitted";
+const L_COUNT = "how many images the run asked for";
+const L_UPSCALE = "any upscale settings";
+const L_LORAS = "LoRA names, weights and Hugging Face repo ids";
+const L_SETTINGS =
+  "the shared generation settings (sampler, scheduler, steps, guidance, strength and the other numeric knobs)";
+const L_PASSES =
+  "which optional passes ran — caption upsampling, the PiD decoder and its tier, face restoration — and the control type";
+const L_ANGLE = "the head angle or turnaround the run asked for";
+const L_POSES =
+  "the pose, hand and face coordinates a pose selection produced — landmark arrays derived from a reference photo, facial landmarks included";
+const L_PHASES = "the multi-phase denoise schedule, with each phase's steps, guidance and LoRA weights";
+const L_INPUTS = "which kinds of input image the recipe needs and how many of each";
+const L_OMITTED = "a note of any list that was too long to record";
+
+// Every field the envelope can carry, and what the copy says about it. Keys prefixed `advanced.`
+// are the allow-listed advanced settings; the rest are top-level envelope fields.
+export const WORKFLOW_FIELDS_IN_FILE = Object.freeze([
+  ["sceneworksWorkflow", L_MARKER],
+  ["schemaVersion", L_MARKER],
+  ["producer.name", L_PRODUCER],
+  ["producer.url", L_PRODUCER],
+  ["producer.version", L_PRODUCER],
+  ["mode", L_MODE],
+  ["model", L_NAMES],
+  ["stylePreset", L_NAMES],
+  ["styleId", L_NAMES],
+  ["advanced.styleId", L_NAMES],
+  ["prompt", L_PROSE],
+  ["negativePrompt", L_PROSE],
+  ["advanced.stylePrompt", L_PROSE],
+  ["advanced.systemMessage", L_PROSE],
+  ["advanced.structuredPrompt", L_PROSE],
+  ["seed", L_SEED],
+  ["width", L_SIZE],
+  ["height", L_SIZE],
+  ["advanced.resolution", L_SIZE],
+  ["fitMode", L_FIT],
+  ["count", L_COUNT],
+  ["upscale.enabled", L_UPSCALE],
+  ["upscale.factor", L_UPSCALE],
+  ["upscale.engine", L_UPSCALE],
+  ["upscale.softness", L_UPSCALE],
+  ["loras[].name", L_LORAS],
+  ["loras[].weight", L_LORAS],
+  ["loras[].repo", L_LORAS],
+  ["advanced", L_SETTINGS],
+  ["advanced.sampler", L_SETTINGS],
+  ["advanced.scheduler", L_SETTINGS],
+  ["advanced.schedulerShift", L_SETTINGS],
+  ["advanced.steps", L_SETTINGS],
+  ["advanced.guidanceScale", L_SETTINGS],
+  ["advanced.guidanceMethod", L_SETTINGS],
+  ["advanced.trueCfgScale", L_SETTINGS],
+  ["advanced.strength", L_SETTINGS],
+  ["advanced.cnScale", L_SETTINGS],
+  ["advanced.controlScale", L_SETTINGS],
+  ["advanced.ipAdapterScale", L_SETTINGS],
+  ["advanced.controlnetConditioningScale", L_SETTINGS],
+  ["advanced.textStyleGain", L_SETTINGS],
+  ["advanced.imageGuidanceScale", L_SETTINGS],
+  ["advanced.enhancePrompt", L_PASSES],
+  ["advanced.usePid", L_PASSES],
+  ["advanced.pidTarget", L_PASSES],
+  ["advanced.faceRestore", L_PASSES],
+  ["advanced.controlMode", L_PASSES],
+  ["advanced.viewAngle", L_ANGLE],
+  ["advanced.angleSet", L_ANGLE],
+  ["advanced.poses", L_POSES],
+  ["advanced.phases", L_PHASES],
+  ["inputs[].kind", L_INPUTS],
+  ["inputs[].count", L_INPUTS],
+  ["inputs[].controlMode", L_INPUTS],
+  ["omitted", L_OMITTED],
+]);
+
+const N_IDENTITY = "your user or machine name";
+const N_PROJECT = "project, job and asset ids";
+const N_TIME = "any timestamp";
+const N_SEEDS = "the other seeds in a batch";
+// Deliberately carries its own caveat. "The input images themselves" sitting next to a claim that
+// the file is otherwise clean invites the reading that nothing derived from a reference travels —
+// and `advanced.poses`, listed above, is exactly that.
+const N_IMAGES = "the input images themselves, though what a pose selection traced from one does travel";
+const N_BUDGET = "this machine's quality tier, attention kernel or GPU";
+const N_LOCAL = "local library ids — a Key Point collection, a control image, a trained overlay, a recipe preset";
+
+// What the copy claims is absent. Every key here must be absent from BOTH doc tables above, which
+// is the direction that matters: a withheld key that quietly became shared would otherwise leave
+// this paragraph claiming a privacy the file no longer has.
+export const WORKFLOW_FIELDS_NOT_IN_FILE = Object.freeze([
+  ["projectId", N_PROJECT],
+  ["projectName", N_PROJECT],
+  ["jobId", N_PROJECT],
+  ["assetId", N_PROJECT],
+  ["generationSetId", N_PROJECT],
+  ["characterId", N_PROJECT],
+  ["characterLookId", N_PROJECT],
+  ["seeds", N_SEEDS],
+  ["advanced.quantTier", N_BUDGET],
+  ["advanced.mlxQuantize", N_BUDGET],
+  ["advanced.mlxQuantizeExplicit", N_BUDGET],
+  ["advanced.convRot", N_BUDGET],
+  ["advanced.flashAttn", N_BUDGET],
+  ["advanced.keypointCollectionId", N_LOCAL],
+  ["advanced.controlImage", N_LOCAL],
+  ["advanced.controlWeights", N_LOCAL],
+  ["advanced.recipePresetId", N_LOCAL],
+  ["advanced.presetMissingLoras", N_LOCAL],
+]);
+
+// The absences with no field name to pin, because the envelope has no slot for them at all — they
+// are left behind by the field list being closed rather than by a rule written against a key. Kept
+// beside the keyed list so the sentence reads as one thought.
+const UNKEYED_ABSENCES = Object.freeze([N_IDENTITY, N_TIME, N_IMAGES]);
+
+// "the generation mode, the model and style names, …" — the rendered "Also in the file" list.
+export function inFileSentence() {
+  return joinLabels(WORKFLOW_FIELDS_IN_FILE.map(([, label]) => label));
+}
+
+// The rendered "Not in the file" list. The unkeyed absences lead, because they are what a user
+// scans for first.
+export function notInFileSentence() {
+  return joinLabels([
+    ...UNKEYED_ABSENCES,
+    ...WORKFLOW_FIELDS_NOT_IN_FILE.map(([, label]) => label),
+  ]);
 }
 
 function readFlag(key, fallback) {
@@ -95,4 +277,66 @@ export function readWorkflowEmbedNoticeSeen() {
 
 export function writeWorkflowEmbedNoticeSeen(value) {
   return writeFlag(NOTICE_STORAGE_KEY, value);
+}
+
+// Write one of these two flags to the DURABLE store, retrying before giving up.
+//
+// `.catch(() => {})` was not good enough here, and for a reason specific to this pair. The
+// localStorage mirror is an instant-paint cache and nothing more — on the desktop shell the UI runs
+// at the API's per-launch `http://127.0.0.1:<port>` origin, so that mirror is a fresh empty store
+// every launch. A dropped PUT therefore does not degrade to "saved locally", it degrades to "not
+// saved at all", and the two failures that follow are the ones a user notices: a deliberate privacy
+// opt-out silently reverting to the ON default, and a one-time disclosure firing again as though it
+// had never been dismissed.
+//
+// So: three attempts with a doubling backoff, and the rejection is propagated rather than eaten, so
+// the caller can tell the user the setting did not stick. `sleep` is injectable because a test that
+// proves the retry should not spend a second doing it.
+export async function persistWorkflowEmbedPreference(
+  patch,
+  { attempts = 3, delayMs = 400, sleep } = {},
+) {
+  const wait = sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  let lastError = new Error("The preference write was never attempted.");
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (attempt > 0) {
+      await wait(delayMs * 2 ** (attempt - 1));
+    }
+    try {
+      await putUiPreferences(patch);
+      return true;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+// Watch the localStorage mirror for changes made by ANOTHER tab.
+//
+// Two tabs of the browser shell are two independent React trees. Before this, a second tab that was
+// already mounted when the notice was dismissed went on holding `seen: false` and would show the
+// disclosure again on its own next generation — the "once" in "shown once" being per tab rather
+// than per user.
+//
+// `seen` moves in ONE direction only. It is a record that something was said, so another tab
+// clearing its storage is not evidence the user was never told, and letting it move back would make
+// a `localStorage.clear()` in one tab re-arm the disclosure in every other. The embed preference is
+// mirrored both ways, because that one genuinely is a setting with two states.
+export function subscribeWorkflowEmbedFlags(onChange) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  const handler = (event) => {
+    // A null key is the whole store being cleared, which touches both of ours.
+    if (event.key !== null && event.key !== EMBED_STORAGE_KEY && event.key !== NOTICE_STORAGE_KEY) {
+      return;
+    }
+    onChange({
+      embed: readEmbedWorkflowInImages(),
+      seen: readWorkflowEmbedNoticeSeen() || undefined,
+    });
+  };
+  window.addEventListener("storage", handler);
+  return () => window.removeEventListener("storage", handler);
 }

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -1,0 +1,98 @@
+// The `embedWorkflowInImages` preference, its first-run disclosure, and the copy both surfaces
+// show (sc-15953, epic 15945).
+//
+// The preference itself is already plumbed: `PUT /api/v1/ui-preferences` persists it into
+// `ui-preferences.json`, and the WORKER reads it straight off that file at the PNG write seam
+// through `sceneworks_core::app_paths::embed_workflow_in_images`. So flipping it here takes effect
+// on the next job with no restart, and nothing in the web app has to tell the worker anything.
+//
+// Two durable flags, both server-side, both mirrored into localStorage only as an instant-paint
+// cache. The durable copy is not an optimization — on the desktop shell the UI runs at the API's
+// per-launch `http://127.0.0.1:<port>` origin, so origin-keyed localStorage does NOT survive a
+// relaunch. A "we already told them" flag that lived only in localStorage would re-fire the
+// disclosure on every launch, which is the failure mode the once-only requirement names.
+//
+// Absent means ON for the preference, and NOT SEEN for the notice. Both defaults match the Rust
+// reader's: `embed_workflow_in_images_from_json` treats an absent key as `true`.
+
+const EMBED_STORAGE_KEY = "sceneworks-embed-workflow";
+const NOTICE_STORAGE_KEY = "sceneworks-embed-workflow-notice-seen";
+
+// The doc that is the contract for what travels. Rooted at `PRODUCER_URL` — the same repository
+// URL the envelope itself carries — so the link in the app and the link in a shared file agree.
+export const WORKFLOW_SHARE_DOC_URL =
+  "https://github.com/SceneWorks/SceneWorks/blob/main/docs/workflow-share-envelope.md";
+
+// The fields recorded exactly as the user authored them, and deliberately EXEMPT from the
+// filesystem-path guard that drops every other field that looks like a location. This is the one
+// claim in the settings copy that must not drift, because it is the claim a user acts on before
+// sharing — so it is a declared list rather than a sentence, and
+// `the_settings_copy_names_exactly_the_path_exempt_prose_fields` in
+// `crates/sceneworks-core/tests/workflow_share_doc.rs` pins the left column against the
+// `prose-fields` table of docs/workflow-share-envelope.md, in both directions. A seventh prose
+// field added to the sanitizer fails this file, not just the doc.
+export const EMBEDDED_PROSE_FIELDS = Object.freeze([
+  ["prompt", "the prompt"],
+  ["negativePrompt", "the negative prompt"],
+  ["advanced.stylePrompt", "the style prompt"],
+  ["advanced.systemMessage", "the system message"],
+  ["advanced.structuredPrompt.intent", "a structured prompt's intent"],
+  ["advanced.structuredPrompt.runtimePrompt", "the structured prompt the model received"],
+]);
+
+// "the prompt, the negative prompt, … and the structured prompt the model received".
+export function proseFieldSentence() {
+  const names = EMBEDDED_PROSE_FIELDS.map(([, label]) => label);
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+function readFlag(key, fallback) {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+  try {
+    const stored = window.localStorage.getItem(key);
+    if (stored === "true") {
+      return true;
+    }
+    if (stored === "false") {
+      return false;
+    }
+    return fallback;
+  } catch {
+    // Private mode / blocked storage. The durable server copy still carries it.
+    return fallback;
+  }
+}
+
+function writeFlag(key, value) {
+  if (typeof window === "undefined") {
+    return Boolean(value);
+  }
+  try {
+    window.localStorage.setItem(key, value ? "true" : "false");
+  } catch {
+    // Private mode / quota — the durable server copy still carries it.
+  }
+  return Boolean(value);
+}
+
+// Whether a generated PNG carries the recipe. Absent means ON, matching the worker's reader.
+export function readEmbedWorkflowInImages() {
+  return readFlag(EMBED_STORAGE_KEY, true);
+}
+
+export function writeEmbedWorkflowInImages(value) {
+  return writeFlag(EMBED_STORAGE_KEY, value);
+}
+
+// Whether the first-run disclosure has already been shown and dismissed. Absent means NOT seen,
+// which is what makes an existing install upgrading into this build get the notice once: the
+// default is silently ON, and someone who has been generating for months has never been told.
+export function readWorkflowEmbedNoticeSeen() {
+  return readFlag(NOTICE_STORAGE_KEY, false);
+}
+
+export function writeWorkflowEmbedNoticeSeen(value) {
+  return writeFlag(NOTICE_STORAGE_KEY, value);
+}

--- a/apps/web/src/workflowEmbed.test.js
+++ b/apps/web/src/workflowEmbed.test.js
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  EMBEDDED_PROSE_FIELDS,
+  WORKFLOW_SHARE_DOC_URL,
+  proseFieldSentence,
+  readEmbedWorkflowInImages,
+  readWorkflowEmbedNoticeSeen,
+  writeEmbedWorkflowInImages,
+  writeWorkflowEmbedNoticeSeen,
+} from "./workflowEmbed.js";
+
+afterEach(() => {
+  try {
+    globalThis.localStorage?.clear();
+  } catch {
+    // no-op
+  }
+});
+
+describe("the embed preference cache (sc-15953)", () => {
+  it("defaults ON when nothing is stored, matching the worker's own reader", () => {
+    // `embed_workflow_in_images_from_json` resolves an absent key to true. If this cache
+    // disagreed, the toggle would render OFF on a fresh install while every image embedded.
+    expect(readEmbedWorkflowInImages()).toBe(true);
+  });
+
+  it("round-trips both values", () => {
+    expect(writeEmbedWorkflowInImages(false)).toBe(false);
+    expect(readEmbedWorkflowInImages()).toBe(false);
+    expect(writeEmbedWorkflowInImages(true)).toBe(true);
+    expect(readEmbedWorkflowInImages()).toBe(true);
+  });
+
+  it("ignores a value it did not write rather than reading it as OFF", () => {
+    globalThis.localStorage.setItem("sceneworks-embed-workflow", "maybe");
+    expect(readEmbedWorkflowInImages()).toBe(true);
+  });
+});
+
+describe("the first-run disclosure flag (sc-15953)", () => {
+  it("defaults to NOT SEEN, so an upgrading install is told once", () => {
+    // An install that has been generating for months has never been shown this. Defaulting to
+    // "seen" would mean the silently-on default is only ever disclosed to fresh installs.
+    expect(readWorkflowEmbedNoticeSeen()).toBe(false);
+  });
+
+  it("round-trips", () => {
+    writeWorkflowEmbedNoticeSeen(true);
+    expect(readWorkflowEmbedNoticeSeen()).toBe(true);
+  });
+});
+
+describe("the copy's field list (sc-15953)", () => {
+  it("lists the six path-exempt prose fields, keyed by their envelope path", () => {
+    // The set itself is pinned against docs/workflow-share-envelope.md's `prose-fields` table by
+    // `the_settings_copy_names_exactly_the_path_exempt_prose_fields` in
+    // crates/sceneworks-core/tests/workflow_share_doc.rs. What is asserted HERE is only the shape
+    // the UI relies on: pairs of (envelope path, human label), all non-empty.
+    expect(EMBEDDED_PROSE_FIELDS.length).toBe(6);
+    for (const entry of EMBEDDED_PROSE_FIELDS) {
+      expect(entry).toHaveLength(2);
+      expect(typeof entry[0]).toBe("string");
+      expect(entry[0].length).toBeGreaterThan(0);
+      expect(entry[1].length).toBeGreaterThan(0);
+    }
+    expect(EMBEDDED_PROSE_FIELDS.map(([key]) => key)).toContain("prompt");
+  });
+
+  it("renders every field into the sentence the settings copy shows", () => {
+    const sentence = proseFieldSentence();
+    for (const [, label] of EMBEDDED_PROSE_FIELDS) {
+      expect(sentence).toContain(label);
+    }
+    // Read as a list rather than as a run-on: the last item is joined with "and".
+    expect(sentence).toContain(` and ${EMBEDDED_PROSE_FIELDS.at(-1)[1]}`);
+  });
+
+  it("links to the contract document rather than to a marketing page", () => {
+    expect(WORKFLOW_SHARE_DOC_URL).toContain("docs/workflow-share-envelope.md");
+    expect(WORKFLOW_SHARE_DOC_URL.startsWith("https://")).toBe(true);
+  });
+});

--- a/apps/web/src/workflowEmbed.test.js
+++ b/apps/web/src/workflowEmbed.test.js
@@ -10,8 +10,8 @@ const {
   WORKFLOW_FIELDS_IN_FILE,
   WORKFLOW_FIELDS_NOT_IN_FILE,
   WORKFLOW_SHARE_DOC_URL,
-  inFileSentence,
-  notInFileSentence,
+  inFileItems,
+  notInFileItems,
   persistWorkflowEmbedPreference,
   proseFieldSentence,
   readEmbedWorkflowInImages,
@@ -110,7 +110,7 @@ describe("the two lists a user acts on (sc-15953)", () => {
     // The finding: `advanced.poses` reduces to the `keypoints` / `hands` / `face` arrays —
     // coordinates derived from a reference photo, facial landmarks included — and the copy named
     // none of it, folding them under "the shared generation settings … and the like".
-    const sentence = inFileSentence();
+    const sentence = inFileItems().join(" | ");
     for (const word of ["pose", "hand", "face"]) {
       expect(sentence).toContain(word);
     }
@@ -122,21 +122,22 @@ describe("the two lists a user acts on (sc-15953)", () => {
   it("does not let 'not in the file' imply nothing derived from a reference travels", () => {
     // "The input images themselves" sitting in a list of absences invites exactly that reading,
     // which is the forbidden direction: claiming more privacy than the allow-list delivers.
-    const sentence = notInFileSentence();
+    const sentence = notInFileItems().join(" | ");
     expect(sentence).toContain("the input images themselves");
     expect(sentence).toContain("what a pose selection traced from one does travel");
   });
 
   it("renders every declared label into its sentence, with repeats collapsed", () => {
-    const rendered = inFileSentence();
+    const rendered = inFileItems().join(" | ");
     for (const [, label] of WORKFLOW_FIELDS_IN_FILE) {
       expect(rendered).toContain(label);
     }
     for (const [, label] of WORKFLOW_FIELDS_NOT_IN_FILE) {
-      expect(notInFileSentence()).toContain(label);
+      expect(notInFileItems()).toContain(label);
     }
-    // `width` and `height` share one phrase; the reader must see it once.
-    expect(rendered.split("its size")).toHaveLength(2);
+    // `width` and `height` share one phrase; the reader must see one bullet, not two.
+    expect(inFileItems().length).toBeLessThan(WORKFLOW_FIELDS_IN_FILE.length);
+    expect(new Set(inFileItems()).size).toBe(inFileItems().length);
   });
 
   it("keys both lists by envelope path, so the Rust pin has something to match", () => {

--- a/apps/web/src/workflowEmbed.test.js
+++ b/apps/web/src/workflowEmbed.test.js
@@ -1,14 +1,30 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
+const putUiPreferences = vi.fn();
+vi.mock("./uiPreferences.js", () => ({ putUiPreferences: (...args) => putUiPreferences(...args) }));
+
+const {
   EMBEDDED_PROSE_FIELDS,
+  PRODUCER_URL,
+  SAVE_WITHOUT_WORKFLOW_LABEL,
+  WORKFLOW_FIELDS_IN_FILE,
+  WORKFLOW_FIELDS_NOT_IN_FILE,
   WORKFLOW_SHARE_DOC_URL,
+  inFileSentence,
+  notInFileSentence,
+  persistWorkflowEmbedPreference,
   proseFieldSentence,
   readEmbedWorkflowInImages,
   readWorkflowEmbedNoticeSeen,
+  subscribeWorkflowEmbedFlags,
   writeEmbedWorkflowInImages,
   writeWorkflowEmbedNoticeSeen,
-} from "./workflowEmbed.js";
+} = await import("./workflowEmbed.js");
+
+beforeEach(() => {
+  putUiPreferences.mockReset();
+  putUiPreferences.mockResolvedValue(undefined);
+});
 
 afterEach(() => {
   try {
@@ -79,5 +95,139 @@ describe("the copy's field list (sc-15953)", () => {
   it("links to the contract document rather than to a marketing page", () => {
     expect(WORKFLOW_SHARE_DOC_URL).toContain("docs/workflow-share-envelope.md");
     expect(WORKFLOW_SHARE_DOC_URL.startsWith("https://")).toBe(true);
+    // DERIVED from the URL the envelope itself carries, not written out beside it. The prefix used
+    // to be a hardcoded string under a comment claiming it was rooted here, with nothing checking.
+    expect(WORKFLOW_SHARE_DOC_URL.startsWith(`${PRODUCER_URL}/`)).toBe(true);
+  });
+});
+
+describe("the two lists a user acts on (sc-15953)", () => {
+  // The SET of keys is pinned against the doc's tables in both directions by
+  // `the_settings_copy_accounts_for_every_shared_and_withheld_field`. What is asserted here is what
+  // the user actually reads.
+
+  it("names the pose, hand and FACE coordinates in what travels", () => {
+    // The finding: `advanced.poses` reduces to the `keypoints` / `hands` / `face` arrays —
+    // coordinates derived from a reference photo, facial landmarks included — and the copy named
+    // none of it, folding them under "the shared generation settings … and the like".
+    const sentence = inFileSentence();
+    for (const word of ["pose", "hand", "face"]) {
+      expect(sentence).toContain(word);
+    }
+    expect(sentence).toContain("facial landmarks");
+    // And the multi-phase schedule, the other thing a user would recognise but never saw named.
+    expect(sentence).toContain("multi-phase denoise schedule");
+  });
+
+  it("does not let 'not in the file' imply nothing derived from a reference travels", () => {
+    // "The input images themselves" sitting in a list of absences invites exactly that reading,
+    // which is the forbidden direction: claiming more privacy than the allow-list delivers.
+    const sentence = notInFileSentence();
+    expect(sentence).toContain("the input images themselves");
+    expect(sentence).toContain("what a pose selection traced from one does travel");
+  });
+
+  it("renders every declared label into its sentence, with repeats collapsed", () => {
+    const rendered = inFileSentence();
+    for (const [, label] of WORKFLOW_FIELDS_IN_FILE) {
+      expect(rendered).toContain(label);
+    }
+    for (const [, label] of WORKFLOW_FIELDS_NOT_IN_FILE) {
+      expect(notInFileSentence()).toContain(label);
+    }
+    // `width` and `height` share one phrase; the reader must see it once.
+    expect(rendered.split("its size")).toHaveLength(2);
+  });
+
+  it("keys both lists by envelope path, so the Rust pin has something to match", () => {
+    for (const list of [WORKFLOW_FIELDS_IN_FILE, WORKFLOW_FIELDS_NOT_IN_FILE]) {
+      const keys = list.map(([key]) => key);
+      expect(new Set(keys).size).toBe(keys.length);
+      for (const [key, label] of list) {
+        expect(typeof key).toBe("string");
+        expect(key.length).toBeGreaterThan(0);
+        expect(label.length).toBeGreaterThan(0);
+      }
+    }
+    expect(WORKFLOW_FIELDS_IN_FILE.map(([key]) => key)).toContain("advanced.poses");
+    expect(WORKFLOW_FIELDS_NOT_IN_FILE.map(([key]) => key)).toContain("advanced.quantTier");
+  });
+
+  it("names the without-workflow control once, for every surface to reuse", () => {
+    expect(SAVE_WITHOUT_WORKFLOW_LABEL.length).toBeGreaterThan(0);
+    // No trailing ellipsis in the constant: the surfaces that open a dialog add their own.
+    expect(SAVE_WITHOUT_WORKFLOW_LABEL.endsWith("…")).toBe(false);
+  });
+});
+
+describe("persisting a flag durably (sc-15953)", () => {
+  const noSleep = () => Promise.resolve();
+
+  it("returns on the first success without retrying", async () => {
+    await expect(
+      persistWorkflowEmbedPreference({ embedWorkflowInImages: false }, { sleep: noSleep }),
+    ).resolves.toBe(true);
+    expect(putUiPreferences).toHaveBeenCalledTimes(1);
+    expect(putUiPreferences).toHaveBeenCalledWith({ embedWorkflowInImages: false });
+  });
+
+  it("retries a transient failure rather than dropping the write", async () => {
+    // The localStorage mirror is wiped by the desktop shell's per-launch origin, so a dropped PUT
+    // is not "saved locally" — it is a privacy opt-out that reverts to ON at the next launch.
+    putUiPreferences.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce(undefined);
+    await expect(
+      persistWorkflowEmbedPreference({ workflowEmbedNoticeSeen: true }, { sleep: noSleep }),
+    ).resolves.toBe(true);
+    expect(putUiPreferences).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates the failure once the attempts are spent, instead of swallowing it", async () => {
+    putUiPreferences.mockRejectedValue(new Error("401"));
+    await expect(
+      persistWorkflowEmbedPreference({ workflowEmbedNoticeSeen: true }, { sleep: noSleep }),
+    ).rejects.toThrow("401");
+    expect(putUiPreferences).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("following another tab (sc-15953)", () => {
+  function fireStorage(key) {
+    globalThis.dispatchEvent(new globalThis.StorageEvent("storage", { key }));
+  }
+
+  it("carries a dismissal into a tab that was already mounted", async () => {
+    // Two tabs are two React trees. Before this, a second tab went on holding `seen: false` and
+    // re-showed the disclosure on its own next generation — "once" being per tab, not per user.
+    const seen = [];
+    const unsubscribe = subscribeWorkflowEmbedFlags((state) => seen.push(state));
+    writeWorkflowEmbedNoticeSeen(true);
+    fireStorage("sceneworks-embed-workflow-notice-seen");
+    expect(seen.at(-1).seen).toBe(true);
+
+    // The embed preference is mirrored BOTH ways: it is a setting with two states.
+    writeEmbedWorkflowInImages(false);
+    fireStorage("sceneworks-embed-workflow");
+    expect(seen.at(-1).embed).toBe(false);
+    unsubscribe();
+  });
+
+  it("never moves the disclosure flag back to unseen", async () => {
+    // A record that something was said. Another tab clearing its storage is not evidence the user
+    // was never told, and letting it move back would re-arm the notice everywhere.
+    writeWorkflowEmbedNoticeSeen(true);
+    const seen = [];
+    const unsubscribe = subscribeWorkflowEmbedFlags((state) => seen.push(state));
+    globalThis.localStorage.clear();
+    fireStorage(null);
+    expect(seen.at(-1).seen).toBeUndefined();
+    unsubscribe();
+  });
+
+  it("ignores an unrelated key so a busy tab is not re-rendered by every write", () => {
+    const seen = [];
+    const unsubscribe = subscribeWorkflowEmbedFlags((state) => seen.push(state));
+    fireStorage("sceneworks-theme");
+    expect(seen).toHaveLength(0);
+    unsubscribe();
   });
 });

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -386,50 +386,180 @@ const CHUNK_OVERHEAD: usize = 12;
 /// byte*, over both DEFLATE regimes and four sizes.
 ///
 /// # Errors
-/// [`WorkflowChunkError::Png`] when `bytes` start with the PNG signature but the chunk framing
-/// could not be walked to the end. That is deliberately an error rather than a quiet "nothing to
-/// strip": for a file we cannot walk, "there is no workflow chunk in it" is not something we know,
-/// and a caller asking for a stripped copy must refuse rather than hand over the original.
+/// [`WorkflowChunkError::Png`] whenever the file cannot be accounted for chunk by chunk — see
+/// [`workflow_chunk_spans`] for the three shapes that means. That is deliberately an error rather
+/// than a quiet "nothing to strip": for a file we cannot walk, "there is no workflow chunk in it"
+/// is not something we know, and a caller asking for a stripped copy must refuse rather than hand
+/// over the original.
 pub fn strip_workflow_chunk(bytes: &[u8]) -> Result<Option<Vec<u8>>, WorkflowChunkError> {
-    if bytes.len() < PNG_SIGNATURE.len() || bytes[..PNG_SIGNATURE.len()] != PNG_SIGNATURE {
+    let spans = workflow_chunk_spans(bytes)?;
+    if spans.is_empty() {
+        // No output buffer is allocated on this path at all. The caller uses the source bytes, and
+        // the common case — a PNG with nothing of ours in it, or a file that is not a PNG — costs
+        // the walk and nothing else.
         return Ok(None);
     }
-    let mut out = Vec::with_capacity(bytes.len());
-    out.extend_from_slice(&PNG_SIGNATURE);
+    let mut out = Vec::with_capacity(bytes.len() - spans.iter().map(Span::len).sum::<usize>());
+    for kept in kept_spans(bytes.len(), &spans) {
+        out.extend_from_slice(&bytes[kept.start..kept.end]);
+    }
+    Ok(Some(out))
+}
+
+/// A half-open byte range of a PNG. A `std::ops::Range` in all but name; a named struct because
+/// `Range` is not `Copy` and these are passed around by value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    /// First byte of the span.
+    pub start: usize,
+    /// One past the last byte.
+    pub end: usize,
+}
+
+impl Span {
+    /// How many bytes the span covers.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    /// Whether the span covers no bytes. Never true for a span this module produces.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.start >= self.end
+    }
+}
+
+/// The byte spans a strip would remove from `bytes`, ascending and non-overlapping.
+///
+/// The ONE walk. [`strip_workflow_chunk`] builds its output from this, and so does the API's
+/// download route — which serves the kept spans as slices of the buffer it already read rather
+/// than copying them into a second one, so a strip costs the file once instead of twice. Two
+/// callers, one set of rules; a hole closed here is closed in both.
+///
+/// An empty result means "there is nothing of ours in this file and we are sure of that", which is
+/// what licenses a caller to use the source bytes unchanged.
+///
+/// # What it refuses, and why each one is a leak if it does not
+///
+/// Every byte of the file has to be accounted for. A chunk we walked is classified — ours and
+/// removed, or someone else's and kept. Bytes we could NOT walk are the dangerous ones, because
+/// "we did not find a workflow chunk there" and "there is no workflow chunk there" are different
+/// statements and only the second one is safe to act on.
+///
+/// * **The walk never reaches IEND.** A PNG truncated at a chunk boundary used to walk clean:
+///   every chunk parsed, our chunk was excised, and the result was an `Ok(Some(…))` PNG with no
+///   IEND in it. "Save a copy without the workflow" then wrote an undecodable file and reported
+///   success. There is no partial-credit answer here — refuse.
+/// * **A tail after IEND that is not chunk framing and carries our keyword.** Trailing bytes past
+///   IEND are not chunks under the spec, and a file with a tail we did not write should survive
+///   the round trip, so a tail that cannot be walked is copied through. But copying through is
+///   only honest when there is nothing of ours in it: a `sceneworks:workflow` chunk hidden in an
+///   unwalkable tail was returned as `Ok(None)` — "use the source unchanged" — with the prompt
+///   still in the file, and, when a strippable chunk sat pre-IDAT as well, as `Ok(Some(…))` and a
+///   cheerful "I removed one". Our own reader stops at IEND so it would not read the leftover
+///   back, which is exactly why this had to be found by grepping the bytes rather than by asking
+///   the reader: a stranger's tooling and a raw byte search both find it, and that is the threat
+///   model. So the unwalkable remainder is scanned for [`WORKFLOW_CHUNK_KEYWORD`] and refused if
+///   it is there.
+/// * **Framing that runs past the end of the file before IEND.** Unchanged: a chunk header
+///   claiming more bytes than the file holds means the PNG is malformed and no copy can be vouched
+///   for.
+///
+/// The keyword scan is deliberately confined to the unwalkable remainder rather than run over the
+/// whole file. Every walked chunk was already classified on purpose, and a foreign chunk whose
+/// *text* merely mentions our keyword — a note, a ComfyUI graph naming it — is a file we must
+/// still be able to save. Only unaccounted-for bytes get the blunt instrument.
+///
+/// # Errors
+/// [`WorkflowChunkError::Png`], with a detail naming which of the three it was.
+pub fn workflow_chunk_spans(bytes: &[u8]) -> Result<Vec<Span>, WorkflowChunkError> {
+    if bytes.len() < PNG_SIGNATURE.len() || bytes[..PNG_SIGNATURE.len()] != PNG_SIGNATURE {
+        return Ok(Vec::new());
+    }
+    let mut spans: Vec<Span> = Vec::new();
     let mut cursor = PNG_SIGNATURE.len();
-    let mut removed = 0_usize;
     let mut past_iend = false;
 
     while cursor < bytes.len() {
         let Some(end) = chunk_end(bytes, cursor) else {
-            // Framing we cannot walk. Trailing bytes after IEND are not chunks under the spec and
-            // are copied through so a file with a tail we did not write survives the round trip;
-            // anything else means the PNG is malformed and the caller must not get a copy we
-            // cannot vouch for.
-            if past_iend {
-                out.extend_from_slice(&bytes[cursor..]);
-                break;
+            if !past_iend {
+                return Err(WorkflowChunkError::Png {
+                    detail: format!("the chunk at byte {cursor} runs past the end of the file"),
+                });
             }
-            return Err(WorkflowChunkError::Png {
-                detail: format!("the chunk at byte {cursor} runs past the end of the file"),
-            });
+            let tail = &bytes[cursor..];
+            if contains_workflow_keyword(tail) {
+                return Err(WorkflowChunkError::Png {
+                    detail: format!(
+                        "{} bytes of trailing data at byte {cursor} are not chunk framing and \
+                         carry `{WORKFLOW_CHUNK_KEYWORD}`, so a copy of this file cannot be \
+                         vouched for",
+                        tail.len()
+                    ),
+                });
+            }
+            // Benign trailing bytes. Not walkable, nothing of ours in them, so they ride through.
+            return Ok(spans);
         };
         let kind = &bytes[cursor + 4..cursor + 8];
         if kind == b"IEND" {
             past_iend = true;
         }
         if is_workflow_text_chunk(kind, &bytes[cursor + 8..end - 4]) {
-            removed += end - cursor;
-        } else {
-            out.extend_from_slice(&bytes[cursor..end]);
+            spans.push(Span { start: cursor, end });
         }
         cursor = end;
     }
 
-    if removed == 0 {
-        return Ok(None);
+    if !past_iend {
+        return Err(WorkflowChunkError::Png {
+            detail: format!(
+                "the chunk framing ends at byte {cursor} without an IEND, so this PNG is \
+                 truncated and a copy of it would not decode"
+            ),
+        });
     }
-    Ok(Some(out))
+    Ok(spans)
+}
+
+/// The complement of `removed` over `0..total`: the spans a strip keeps, ascending.
+///
+/// Shared with the API's download route so the served body and [`strip_workflow_chunk`]'s buffer
+/// are assembled from the same arithmetic rather than two hand-rolled loops.
+#[must_use]
+pub fn kept_spans(total: usize, removed: &[Span]) -> Vec<Span> {
+    let mut kept = Vec::with_capacity(removed.len() + 1);
+    let mut cursor = 0_usize;
+    for span in removed {
+        if span.start > cursor {
+            kept.push(Span {
+                start: cursor,
+                end: span.start,
+            });
+        }
+        cursor = span.end;
+    }
+    if cursor < total {
+        kept.push(Span {
+            start: cursor,
+            end: total,
+        });
+    }
+    kept
+}
+
+/// Whether [`WORKFLOW_CHUNK_KEYWORD`] appears anywhere in `haystack`, as raw bytes.
+///
+/// The same thing a `grep` for our keyword would find, which is the point: the guard it backs is
+/// about what a stranger's tooling can dig out of bytes we could not parse, not about what our own
+/// reader would load.
+fn contains_workflow_keyword(haystack: &[u8]) -> bool {
+    let needle = WORKFLOW_CHUNK_KEYWORD.as_bytes();
+    haystack.len() >= needle.len()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
 }
 
 /// One past the CRC of the chunk starting at `cursor`, or `None` when the header or the payload it
@@ -1239,6 +1369,194 @@ mod tests {
             strip_workflow_chunk(&liar),
             Err(WorkflowChunkError::Png { .. })
         ));
+    }
+
+    /// A workflow chunk whose declared length is a lie, so the walker cannot step over it — the
+    /// shape that hides one in a region no chunk walk can account for. Uncompressed, so the
+    /// envelope text sits in the file as plain bytes a `grep` would find.
+    fn unwalkable_hidden_chunk(envelope: &str) -> Vec<u8> {
+        framed_chunk(
+            b"iTXt",
+            &itxt_data(WORKFLOW_CHUNK_KEYWORD, false, envelope.as_bytes()),
+            Some(0x7FFF_FFFF),
+        )
+    }
+
+    /// Whether `bytes` carry `needle` anywhere — a raw byte search, which is what a stranger's
+    /// tooling does and what the reader's IEND-stopping walk does NOT do.
+    fn byte_search(bytes: &[u8], needle: &[u8]) -> bool {
+        bytes.len() >= needle.len() && bytes.windows(needle.len()).any(|window| window == needle)
+    }
+
+    #[test]
+    fn a_workflow_chunk_hiding_past_iend_refuses_instead_of_reporting_success() {
+        // Two reproduced failures, both of which falsified the invariant three lines above this
+        // module's `strip_workflow_chunk`: "a caller asking for a stripped copy must refuse rather
+        // than hand over the original".
+        //
+        // The escape hatch was the post-IEND copy-through. Trailing bytes past IEND are not chunks
+        // under the spec, so a tail that cannot be walked was copied through verbatim to let a file
+        // with a foreign tail survive the round trip. But that also copied through anything hidden
+        // in it — and our own reader stops at IEND, so it reads the result back as clean. Only a
+        // raw byte search finds the leftover, which is precisely the threat model: the file has
+        // left the machine and it is a stranger's tooling doing the looking.
+        let envelope = minimal_envelope_json("the prompt that must not leave");
+        let secret = b"the prompt that must not leave";
+        let hidden = unwalkable_hidden_chunk(&envelope);
+
+        // (1) TAIL ONLY. Reproduced at the head this fixes as `Ok(None)` — which every caller reads
+        //     as "use the source unchanged" — with the envelope still in the served bytes.
+        let mut tail_only = png_with(&[]);
+        tail_only.extend_from_slice(&hidden);
+        assert!(
+            byte_search(&tail_only, secret),
+            "the fixture must actually carry the secret or it proves nothing"
+        );
+        assert!(
+            read_workflow_chunk(&tail_only) == Ok(None),
+            "our own reader stops at IEND, so it reports this file as clean — which is why the \
+             guard cannot be built out of what the reader can see"
+        );
+        assert!(
+            matches!(
+                strip_workflow_chunk(&tail_only),
+                Err(WorkflowChunkError::Png { .. })
+            ),
+            "a workflow chunk in an unwalkable tail must REFUSE, not answer Ok(None): got {:?}",
+            strip_workflow_chunk(&tail_only)
+        );
+
+        // (2) A STRIPPABLE CHUNK PRE-IDAT AND A HIDDEN COPY IN THE TAIL. The worse one: reproduced
+        //     as `Ok(Some(…))`, i.e. "I removed one", with the keyword AND the prompt still in the
+        //     bytes handed back. A caller cannot tell that answer from a clean strip.
+        let mut both = png_with_workflow_text(&envelope);
+        both.extend_from_slice(&hidden);
+        let stripped = strip_workflow_chunk(&both);
+        assert!(
+            matches!(stripped, Err(WorkflowChunkError::Png { .. })),
+            "a file with one strippable chunk and one hidden past IEND must refuse rather than \
+             report a removal it did not fully make: got {stripped:?}"
+        );
+        // And say so about the right thing, so the log line names the tail rather than reading as
+        // a generic "corrupt PNG".
+        let Err(WorkflowChunkError::Png { detail }) = stripped else {
+            unreachable!("asserted above")
+        };
+        assert!(
+            detail.contains(WORKFLOW_CHUNK_KEYWORD) && detail.contains("trailing"),
+            "the refusal must name what it found and where: {detail:?}"
+        );
+
+        // (3) The copy helper is the seam a user actually touches, and it reported `Ok(true)` for
+        //     case (2) while writing a file that still contained the prompt. It must refuse, and
+        //     it must not leave a destination behind for the user to share by mistake.
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("hidden.png");
+        let destination = directory.path().join("shared.png");
+        std::fs::write(&source, &both).expect("writes the fixture");
+        assert!(
+            matches!(
+                copy_without_workflow_chunk(&source, &destination),
+                Err(WorkflowChunkError::Png { .. })
+            ),
+            "the copy helper must not report success over a file it cannot fully clean"
+        );
+        assert!(
+            !destination.exists(),
+            "a refused strip must leave no file behind — a half-cleaned copy on disk is the thing \
+             the user goes on to share"
+        );
+    }
+
+    #[test]
+    fn a_benign_unwalkable_tail_still_rides_through_the_strip() {
+        // The other half of the guard above, and the half that stops it becoming "refuse any file
+        // with a tail". Bytes past IEND that are not chunk framing and carry nothing of ours are
+        // still copied through verbatim, so a file some other tool appended to survives the round
+        // trip with its tail intact.
+        let envelope = minimal_envelope_json("a lighthouse");
+        let tail = b"\x00\x01not chunk framing, just bytes someone appended";
+        let mut file = png_with_workflow_text(&envelope);
+        file.extend_from_slice(tail);
+
+        let stripped = strip_workflow_chunk(&file)
+            .expect("a benign tail must not be an error")
+            .expect("and the pre-IDAT chunk is still removed");
+        let mut expected = png_with(&[]);
+        expected.extend_from_slice(tail);
+        assert!(
+            stripped == expected,
+            "the tail must survive byte for byte alongside the excision"
+        );
+        assert_eq!(read_workflow_chunk(&stripped), Ok(None));
+    }
+
+    #[test]
+    fn a_png_whose_framing_ends_without_an_iend_refuses() {
+        // Reproduced at the head this fixes as `Ok(Some(…))`: every chunk walked cleanly, our chunk
+        // was excised, and the caller got a PNG with no IEND in it. "Save a copy without the
+        // workflow" then wrote an undecodable file and reported success — the strip was honest and
+        // the artifact was junk, which is its own way of failing the user.
+        let full = png_with_workflow_text(&minimal_envelope_json("a lighthouse"));
+        let no_iend = &full[..iend_offset(&full)];
+        // The cut is at a chunk boundary, so nothing about the framing is malformed — this is not
+        // the pre-existing "runs past the end of the file" case wearing a different hat.
+        assert_eq!(
+            chunk_end(no_iend, AFTER_IHDR),
+            Some(AFTER_IHDR + framed_workflow_chunk_len(&minimal_envelope_json("a lighthouse"))),
+            "the fixture must be cut at a chunk boundary or it tests the wrong guard"
+        );
+        let result = strip_workflow_chunk(no_iend);
+        assert!(
+            matches!(result, Err(WorkflowChunkError::Png { .. })),
+            "a PNG whose framing ends without an IEND must refuse: got {result:?}"
+        );
+        let Err(WorkflowChunkError::Png { detail }) = result else {
+            unreachable!("asserted above")
+        };
+        assert!(
+            detail.contains("IEND"),
+            "the refusal must name the missing IEND: {detail:?}"
+        );
+
+        // And a file with NOTHING of ours in it is refused on the same ground rather than quietly
+        // answered Ok(None) — the promise is about the walk, not about what the walk found.
+        assert!(matches!(
+            strip_workflow_chunk(&png_with(&[])[..iend_offset(&png_with(&[]))]),
+            Err(WorkflowChunkError::Png { .. })
+        ));
+    }
+
+    #[test]
+    fn the_kept_spans_are_the_complement_of_the_removed_ones() {
+        // The API's download route slices the file it already read by these spans instead of
+        // copying the kept bytes into a second buffer, so an off-by-one here is a corrupt download
+        // rather than a failed test. Pinned against the buffer-building path, which cannot drift
+        // from it because both go through `kept_spans`.
+        let embedded = png_with_workflow_text(&minimal_envelope_json("a lighthouse"));
+        let spans = workflow_chunk_spans(&embedded).expect("walks");
+        assert_eq!(spans.len(), 1, "one chunk in, one span out");
+
+        let mut assembled = Vec::new();
+        for kept in kept_spans(embedded.len(), &spans) {
+            assembled.extend_from_slice(&embedded[kept.start..kept.end]);
+        }
+        assert!(
+            assembled
+                == strip_workflow_chunk(&embedded)
+                    .expect("strips")
+                    .expect("had something to strip"),
+            "assembling the kept spans must reproduce the stripped buffer exactly"
+        );
+        assert!(assembled == png_with(&[]));
+
+        // Degenerate shapes, so the helper is not only exercised through one happy case.
+        assert_eq!(kept_spans(10, &[]), vec![Span { start: 0, end: 10 }]);
+        assert_eq!(kept_spans(10, &[Span { start: 0, end: 10 }]), vec![]);
+        assert_eq!(
+            kept_spans(10, &[Span { start: 0, end: 4 }, Span { start: 6, end: 8 }]),
+            vec![Span { start: 4, end: 6 }, Span { start: 8, end: 10 }]
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -1253,7 +1253,10 @@ mod tests {
             .expect("strips")
             .expect("had something to strip");
         assert_eq!(read_workflow_chunk(&stripped), Ok(None));
-        assert!(stripped == png_with(&[]), "the tail chunk was excised whole");
+        assert!(
+            stripped == png_with(&[]),
+            "the tail chunk was excised whole"
+        );
 
         // Both at once — the duplicate case that reads as an error rather than a workflow. A file
         // the reader refuses is still a file with our prompt in it, so it must strip clean.
@@ -1262,9 +1265,11 @@ mod tests {
             &framed(&workflow_chunk(envelope.clone())),
         );
         assert_eq!(
-            read_workflow_chunk(&strip_workflow_chunk(&both)
-                .expect("strips")
-                .expect("had something to strip")),
+            read_workflow_chunk(
+                &strip_workflow_chunk(&both)
+                    .expect("strips")
+                    .expect("had something to strip")
+            ),
             Ok(None)
         );
 
@@ -1274,11 +1279,15 @@ mod tests {
             let mut data = WORKFLOW_CHUNK_KEYWORD.as_bytes().to_vec();
             data.push(0);
             data.extend_from_slice(b"whatever a foreign writer put here");
-            let spliced =
-                splice_after_ihdr(&png_with(&[]), &framed_chunk(kind, &data, None));
+            let spliced = splice_after_ihdr(&png_with(&[]), &framed_chunk(kind, &data, None));
             let stripped = strip_workflow_chunk(&spliced)
                 .expect("strips")
-                .unwrap_or_else(|| panic!("{} under our keyword must be taken out", String::from_utf8_lossy(kind)));
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{} under our keyword must be taken out",
+                        String::from_utf8_lossy(kind)
+                    )
+                });
             assert!(stripped == png_with(&[]));
         }
     }
@@ -1292,9 +1301,7 @@ mod tests {
             parse_workflow_share_json(&minimal_envelope_json("a lighthouse")).expect("parses");
 
         write_workflow_chunk(&rgb_fixture(), &source, Some(&envelope)).expect("writes");
-        assert!(read_workflow_chunk_file(&source)
-            .expect("reads")
-            .is_some());
+        assert!(read_workflow_chunk_file(&source).expect("reads").is_some());
         assert_eq!(
             copy_without_workflow_chunk(&source, &destination),
             Ok(true),
@@ -1304,9 +1311,7 @@ mod tests {
 
         // The source is untouched: turning the switch off, or saving one copy without the
         // workflow, changes nothing about files already written.
-        assert!(read_workflow_chunk_file(&source)
-            .expect("reads")
-            .is_some());
+        assert!(read_workflow_chunk_file(&source).expect("reads").is_some());
 
         // A source with nothing to strip goes through `std::fs::copy`, so the plain and the
         // without-workflow save produce the same file.

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -348,6 +348,141 @@ fn encode_png_with_text<W: Write>(
 }
 
 // ---------------------------------------------------------------------------
+// Strip
+// ---------------------------------------------------------------------------
+
+/// The three PNG text-chunk types a keyword can appear under.
+///
+/// [`write_workflow_chunk`] only ever emits `iTXt`, and [`read_workflow_chunk`] only ever reads
+/// `iTXt` (`png` files a `tEXt` under `uncompressed_latin1_text` and a `zTXt` under
+/// `compressed_latin1_text`, neither of which the reader looks at). The stripper is broader than
+/// both on purpose: it is a privacy operation, and "we would not have read it back" is not a reason
+/// to hand a stranger a chunk with our keyword on it. Being broader can only ever remove more.
+const TEXT_CHUNK_TYPES: [&[u8; 4]; 3] = [b"iTXt", b"tEXt", b"zTXt"];
+
+/// Bytes of PNG chunk framing that are not the payload: the 4-byte length, the 4-byte type and the
+/// 4-byte CRC.
+const CHUNK_OVERHEAD: usize = 12;
+
+/// Excise every [`WORKFLOW_CHUNK_KEYWORD`] text chunk from PNG `bytes`, without re-encoding
+/// anything (sc-15953).
+///
+/// `Ok(None)` means there was nothing to take out and the caller should use the source bytes
+/// unchanged — a PNG with no workflow chunk, or a file that is not a PNG at all. The second case is
+/// not a failure: [`write_workflow_chunk`] only ever writes into a PNG, so a JPEG or an MP4 cannot
+/// be carrying one, and a "save without the workflow" of a video has nothing to do.
+///
+/// # Why excise rather than decode and re-encode
+///
+/// A re-encode is a *new* file that happens to have the same pixels. This is the old file minus a
+/// slice: the signature, IHDR, PLTE, every IDAT and IEND are copied through byte for byte, so the
+/// pixels are not merely equal — the compressed image data is the same bytes it was, and no encoder
+/// setting, filter choice or `image`/`png` version is in the path at all. Each PNG chunk carries its
+/// own CRC over its own type and data, so removing one whole chunk leaves every other chunk's CRC
+/// still correct; nothing is recomputed.
+///
+/// `strip_of_an_embedded_png_is_byte_identical_to_the_none_path` in `tests/workflow_png.rs` proves
+/// it the strongest way available: stripping the `Some` output yields the `None` output *byte for
+/// byte*, over both DEFLATE regimes and four sizes.
+///
+/// # Errors
+/// [`WorkflowChunkError::Png`] when `bytes` start with the PNG signature but the chunk framing
+/// could not be walked to the end. That is deliberately an error rather than a quiet "nothing to
+/// strip": for a file we cannot walk, "there is no workflow chunk in it" is not something we know,
+/// and a caller asking for a stripped copy must refuse rather than hand over the original.
+pub fn strip_workflow_chunk(bytes: &[u8]) -> Result<Option<Vec<u8>>, WorkflowChunkError> {
+    if bytes.len() < PNG_SIGNATURE.len() || bytes[..PNG_SIGNATURE.len()] != PNG_SIGNATURE {
+        return Ok(None);
+    }
+    let mut out = Vec::with_capacity(bytes.len());
+    out.extend_from_slice(&PNG_SIGNATURE);
+    let mut cursor = PNG_SIGNATURE.len();
+    let mut removed = 0_usize;
+    let mut past_iend = false;
+
+    while cursor < bytes.len() {
+        let Some(end) = chunk_end(bytes, cursor) else {
+            // Framing we cannot walk. Trailing bytes after IEND are not chunks under the spec and
+            // are copied through so a file with a tail we did not write survives the round trip;
+            // anything else means the PNG is malformed and the caller must not get a copy we
+            // cannot vouch for.
+            if past_iend {
+                out.extend_from_slice(&bytes[cursor..]);
+                break;
+            }
+            return Err(WorkflowChunkError::Png {
+                detail: format!("the chunk at byte {cursor} runs past the end of the file"),
+            });
+        };
+        let kind = &bytes[cursor + 4..cursor + 8];
+        if kind == b"IEND" {
+            past_iend = true;
+        }
+        if is_workflow_text_chunk(kind, &bytes[cursor + 8..end - 4]) {
+            removed += end - cursor;
+        } else {
+            out.extend_from_slice(&bytes[cursor..end]);
+        }
+        cursor = end;
+    }
+
+    if removed == 0 {
+        return Ok(None);
+    }
+    Ok(Some(out))
+}
+
+/// One past the CRC of the chunk starting at `cursor`, or `None` when the header or the payload it
+/// declares runs past the end of `bytes`.
+fn chunk_end(bytes: &[u8], cursor: usize) -> Option<usize> {
+    let header = bytes.get(cursor..cursor + 8)?;
+    let length = usize::try_from(u32::from_be_bytes(header[..4].try_into().ok()?)).ok()?;
+    let end = cursor.checked_add(CHUNK_OVERHEAD)?.checked_add(length)?;
+    (end <= bytes.len()).then_some(end)
+}
+
+/// Whether a chunk of type `kind` carrying `data` is a text chunk under our keyword.
+///
+/// All three text types lay their payload out as `keyword NUL …`, so the keyword is the payload up
+/// to its first NUL in every case. Matched byte-exactly: PNG keywords are case-sensitive, and
+/// [`read_workflow_chunk`] resolves the keyword the same way, so `Sceneworks:Workflow` is a
+/// different keyword to both halves.
+fn is_workflow_text_chunk(kind: &[u8], data: &[u8]) -> bool {
+    if !TEXT_CHUNK_TYPES.iter().any(|text| *text == kind) {
+        return false;
+    }
+    let keyword = data.split(|byte| *byte == 0).next().unwrap_or_default();
+    keyword == WORKFLOW_CHUNK_KEYWORD.as_bytes()
+}
+
+/// Copy `source` to `destination` with any [`WORKFLOW_CHUNK_KEYWORD`] chunk excised, and report
+/// whether one was there (sc-15953).
+///
+/// The "Save As without the workflow" seam. A file with nothing to strip is copied through
+/// [`std::fs::copy`] — the same call the plain Save As makes — so the two paths produce the same
+/// file for a source that never carried a chunk, rather than one of them rewriting it.
+///
+/// # Errors
+/// [`WorkflowChunkError::Io`] if the source cannot be read or the destination cannot be written,
+/// and whatever [`strip_workflow_chunk`] returns for a PNG whose framing cannot be walked.
+pub fn copy_without_workflow_chunk(
+    source: &Path,
+    destination: &Path,
+) -> Result<bool, WorkflowChunkError> {
+    let bytes = std::fs::read(source).map_err(|error| io_error(&error))?;
+    match strip_workflow_chunk(&bytes)? {
+        Some(stripped) => {
+            std::fs::write(destination, stripped).map_err(|error| io_error(&error))?;
+            Ok(true)
+        }
+        None => {
+            std::fs::copy(source, destination).map_err(|error| io_error(&error))?;
+            Ok(false)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Read
 // ---------------------------------------------------------------------------
 
@@ -1016,6 +1151,173 @@ mod tests {
             ITXtChunk::new("Sceneworks:Workflow", "case matters"),
         ];
         assert_eq!(read_workflow_chunk(&png_with(&foreign)), Ok(None));
+    }
+
+    // ---------------------------------------------------------------------
+    // Strip (sc-15953)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn stripping_removes_the_chunk_and_leaves_the_rest_of_the_file_alone() {
+        let embedded = png_with_workflow_text(&minimal_envelope_json("a lighthouse"));
+        let plain = png_with(&[]);
+        let stripped = strip_workflow_chunk(&embedded)
+            .expect("an embedded PNG strips")
+            .expect("and reports that something was taken out");
+
+        // The read side agrees the chunk is gone…
+        assert_eq!(read_workflow_chunk(&stripped), Ok(None));
+        // …and what is left is the same file the None arm writes for the same pixels, byte for
+        // byte. That is the pixel-identity proof: IHDR and every IDAT are the original's own bytes.
+        assert!(
+            stripped == plain,
+            "the stripped file is {} bytes and the plain one {}",
+            stripped.len(),
+            plain.len()
+        );
+    }
+
+    #[test]
+    fn a_png_with_nothing_of_ours_in_it_reports_nothing_to_strip() {
+        // Ok(None) is "use the source unchanged", which is what keeps the strip path from
+        // rewriting a file that never carried a chunk. A foreign writer's text chunks stay put:
+        // stripping ours is not a licence to scrub someone else's metadata out of their image.
+        let foreign = png_with(&[
+            ITXtChunk::new("parameters", "steps: 28, sampler: euler"),
+            ITXtChunk::new("prompt", "{\"1\":{\"class_type\":\"KSampler\"}}"),
+            ITXtChunk::new("Sceneworks:Workflow", "case matters"),
+        ]);
+        assert_eq!(strip_workflow_chunk(&foreign), Ok(None));
+        assert_eq!(strip_workflow_chunk(&png_with(&[])), Ok(None));
+    }
+
+    #[test]
+    fn a_file_that_is_not_a_png_has_nothing_to_strip() {
+        // The write path only ever writes into a PNG, so a JPEG or an MP4 cannot be carrying one of
+        // ours. "Save without the workflow" on a video is a plain copy, not an error.
+        for input in [
+            b"".as_slice(),
+            b"\x89PNG".as_slice(),
+            b"\xff\xd8\xff\xe0JFIF".as_slice(),
+            b"{\"sceneworksWorkflow\":\"image\"}".as_slice(),
+        ] {
+            assert_eq!(
+                strip_workflow_chunk(input),
+                Ok(None),
+                "{} bytes of non-PNG must be a clean no-op",
+                input.len()
+            );
+        }
+    }
+
+    #[test]
+    fn a_png_whose_framing_cannot_be_walked_refuses_rather_than_returning_the_original() {
+        // The privacy-critical failure mode. Ok(None) means "use the source unchanged", so
+        // answering it for a file we could not walk would hand the user a copy that may still carry
+        // the chunk while telling them it does not. A truncated file must be an error.
+        let full = png_with_workflow_text(&minimal_envelope_json("a lighthouse"));
+        let truncated = &full[..full.len() - 6];
+        assert!(
+            matches!(
+                strip_workflow_chunk(truncated),
+                Err(WorkflowChunkError::Png { .. })
+            ),
+            "a truncated PNG must refuse, got {:?}",
+            strip_workflow_chunk(truncated)
+        );
+        // And a chunk header claiming more than the file holds, which is the same class through a
+        // different door.
+        let liar = splice_after_ihdr(
+            &png_with(&[]),
+            &framed_chunk(
+                b"iTXt",
+                &itxt_data(WORKFLOW_CHUNK_KEYWORD, false, b"{}"),
+                Some(0x7FFF_FFFF),
+            ),
+        );
+        assert!(matches!(
+            strip_workflow_chunk(&liar),
+            Err(WorkflowChunkError::Png { .. })
+        ));
+    }
+
+    #[test]
+    fn stripping_reaches_every_place_a_chunk_can_hide() {
+        // Post-IDAT is where sc-15949's foreign writers put theirs and where the reader's second
+        // pass looks, so the stripper has to go there too — a strip that only cleared the metadata
+        // proper would leave a readable workflow in the file it just promised had none.
+        let envelope = minimal_envelope_json("behind the image data");
+        let tail = splice_before_iend(&png_with(&[]), &framed(&workflow_chunk(envelope.clone())));
+        assert!(read_workflow_chunk(&tail).expect("reads").is_some());
+        let stripped = strip_workflow_chunk(&tail)
+            .expect("strips")
+            .expect("had something to strip");
+        assert_eq!(read_workflow_chunk(&stripped), Ok(None));
+        assert!(stripped == png_with(&[]), "the tail chunk was excised whole");
+
+        // Both at once — the duplicate case that reads as an error rather than a workflow. A file
+        // the reader refuses is still a file with our prompt in it, so it must strip clean.
+        let both = splice_before_iend(
+            &png_with_workflow_text(&envelope),
+            &framed(&workflow_chunk(envelope.clone())),
+        );
+        assert_eq!(
+            read_workflow_chunk(&strip_workflow_chunk(&both)
+                .expect("strips")
+                .expect("had something to strip")),
+            Ok(None)
+        );
+
+        // And under the other two text-chunk types, which our writer never emits and our reader
+        // never reads — the stripper is broader than both on purpose.
+        for kind in [b"tEXt", b"zTXt"] {
+            let mut data = WORKFLOW_CHUNK_KEYWORD.as_bytes().to_vec();
+            data.push(0);
+            data.extend_from_slice(b"whatever a foreign writer put here");
+            let spliced =
+                splice_after_ihdr(&png_with(&[]), &framed_chunk(kind, &data, None));
+            let stripped = strip_workflow_chunk(&spliced)
+                .expect("strips")
+                .unwrap_or_else(|| panic!("{} under our keyword must be taken out", String::from_utf8_lossy(kind)));
+            assert!(stripped == png_with(&[]));
+        }
+    }
+
+    #[test]
+    fn the_copy_helper_strips_or_copies_and_says_which() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let source = directory.path().join("embedded.png");
+        let destination = directory.path().join("shared.png");
+        let envelope =
+            parse_workflow_share_json(&minimal_envelope_json("a lighthouse")).expect("parses");
+
+        write_workflow_chunk(&rgb_fixture(), &source, Some(&envelope)).expect("writes");
+        assert!(read_workflow_chunk_file(&source)
+            .expect("reads")
+            .is_some());
+        assert_eq!(
+            copy_without_workflow_chunk(&source, &destination),
+            Ok(true),
+            "the source carried a chunk, so the copy reports removing one"
+        );
+        assert_eq!(read_workflow_chunk_file(&destination), Ok(None));
+
+        // The source is untouched: turning the switch off, or saving one copy without the
+        // workflow, changes nothing about files already written.
+        assert!(read_workflow_chunk_file(&source)
+            .expect("reads")
+            .is_some());
+
+        // A source with nothing to strip goes through `std::fs::copy`, so the plain and the
+        // without-workflow save produce the same file.
+        let plain = directory.path().join("plain.png");
+        let plain_copy = directory.path().join("plain-copy.png");
+        write_workflow_chunk(&rgb_fixture(), &plain, None).expect("writes");
+        assert_eq!(copy_without_workflow_chunk(&plain, &plain_copy), Ok(false));
+        assert_eq!(
+            std::fs::read(&plain).expect("reads"),
+            std::fs::read(&plain_copy).expect("reads")
+        );
     }
 
     // ---------------------------------------------------------------------

--- a/crates/sceneworks-core/tests/workflow_png.rs
+++ b/crates/sceneworks-core/tests/workflow_png.rs
@@ -559,9 +559,7 @@ fn the_save_as_seam_strips_without_touching_the_source() {
         before,
         "the source asset must be byte-for-byte what it was"
     );
-    assert!(read_workflow_chunk_file(&source)
-        .expect("reads")
-        .is_some());
+    assert!(read_workflow_chunk_file(&source).expect("reads").is_some());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sceneworks-core/tests/workflow_png.rs
+++ b/crates/sceneworks-core/tests/workflow_png.rs
@@ -20,8 +20,9 @@ use std::path::{Path, PathBuf};
 use image::{ImageFormat, Rgb, RgbImage};
 use sceneworks_core::contracts::{Asset, JsonObject};
 use sceneworks_core::workflow_png::{
-    read_workflow_chunk, read_workflow_chunk_file, workflow_chunk_size, write_workflow_chunk,
-    MAX_WORKFLOW_TEXT_BYTES, WORKFLOW_CHUNK_KEYWORD,
+    copy_without_workflow_chunk, read_workflow_chunk, read_workflow_chunk_file,
+    strip_workflow_chunk, workflow_chunk_size, write_workflow_chunk, MAX_WORKFLOW_TEXT_BYTES,
+    WORKFLOW_CHUNK_KEYWORD,
 };
 use sceneworks_core::workflow_share::{build_workflow_share, WorkflowShare};
 use serde_json::{json, Value};
@@ -457,6 +458,110 @@ fn the_some_path_is_the_none_path_plus_the_chunk() {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Save As without the workflow (sc-15953)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn strip_of_an_embedded_png_is_byte_identical_to_the_none_path() {
+    // The AC asks the stripped output to be visually identical to the source, and this asserts the
+    // strongest form of that rather than a PSNR: the stripped file IS the file the `None` arm
+    // writes for the same pixels, byte for byte. Nothing re-encodes — IHDR and every IDAT are the
+    // embedded file's own bytes minus one slice — so "visually identical" is not a measurement, it
+    // is the same compressed image data it always was.
+    //
+    // The same two DEFLATE regimes and the same four sizes as
+    // `the_some_path_is_the_none_path_plus_the_chunk`, for the same reason: a stripper tested only
+    // on an incompressible 9x7 fixture would pass while silently re-encoding a real render.
+    type Fixture = fn(u32, u32) -> RgbImage;
+    let fixtures: [(&str, Fixture); 2] = [("noise", noisy_rgb), ("render", soft_render_rgb)];
+
+    let directory = tempfile::tempdir().expect("temp dir");
+    let envelope = golden_envelope();
+    let chunk_size = workflow_chunk_size(&envelope).expect("the chunk encodes");
+
+    for (label, build) in fixtures {
+        for (width, height) in [(9, 7), (67, 41), (512, 512), (1024, 1024)] {
+            let rgb = build(width, height);
+            let name = format!("{label}-{width}x{height}");
+            let embedded = directory.path().join(format!("embedded-{name}.png"));
+            let plain = directory.path().join(format!("plain-{name}.png"));
+            write_workflow_chunk(&rgb, &embedded, Some(&envelope)).expect("writes with a chunk");
+            write_workflow_chunk(&rgb, &plain, None).expect("writes without one");
+
+            let embedded_bytes = fs::read(&embedded).expect("reads");
+            let plain_bytes = fs::read(&plain).expect("reads");
+            let stripped = strip_workflow_chunk(&embedded_bytes)
+                .expect("an embedded PNG strips")
+                .expect("and had a chunk to take out");
+
+            assert_eq!(
+                embedded_bytes.len() - stripped.len(),
+                chunk_size,
+                "on {name} the strip removed {} bytes but the chunk measures {chunk_size}",
+                embedded_bytes.len() - stripped.len()
+            );
+            assert!(
+                stripped == plain_bytes,
+                "on {name} the stripped file is not the None-path file: {} bytes against {}",
+                stripped.len(),
+                plain_bytes.len()
+            );
+            // The production stripper and the hand-rolled one this file already uses to prove the
+            // write path must agree; two independent walks of the same framing is what stops a
+            // subtle off-by-one in either being invisible.
+            let (by_hand, removed_by_hand) = strip_workflow_chunks(&embedded_bytes);
+            assert_eq!(removed_by_hand, chunk_size);
+            assert!(stripped == by_hand, "the two strippers disagree on {name}");
+
+            // And the AC's own assertion, stated in its own terms: read the output back with the
+            // sc-15947 reader and find no workflow, while the source still has one.
+            let out = directory.path().join(format!("stripped-{name}.png"));
+            fs::write(&out, &stripped).expect("writes");
+            assert_eq!(read_workflow_chunk_file(&out), Ok(None));
+            assert!(read_workflow_chunk_file(&embedded)
+                .expect("the source still reads")
+                .is_some());
+
+            // Pixels, decoded, for the reader who wants it said in pixels rather than in bytes.
+            assert_eq!(
+                image::open(&out).expect("decodes").to_rgb8().as_raw(),
+                rgb.as_raw(),
+                "on {name} the stripped image does not decode to the source pixels"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_save_as_seam_strips_without_touching_the_source() {
+    // What the desktop "Save As without the workflow" command does, end to end: the copy on disk
+    // has no chunk, and the asset the user still owns is untouched. Turning the feature off — or
+    // sharing one copy without it — changes nothing about files already written, and the UI says
+    // so because this is what the code does.
+    let directory = tempfile::tempdir().expect("temp dir");
+    let source = directory.path().join("asset.png");
+    let shared = directory.path().join("shared.png");
+    let rgb = soft_render_rgb(256, 256);
+    write_workflow_chunk(&rgb, &source, Some(&golden_envelope())).expect("writes");
+    let before = fs::read(&source).expect("reads");
+
+    assert_eq!(copy_without_workflow_chunk(&source, &shared), Ok(true));
+    assert_eq!(read_workflow_chunk_file(&shared), Ok(None));
+    assert_eq!(
+        image::open(&shared).expect("decodes").to_rgb8().as_raw(),
+        rgb.as_raw()
+    );
+    assert_eq!(
+        fs::read(&source).expect("reads"),
+        before,
+        "the source asset must be byte-for-byte what it was"
+    );
+    assert!(read_workflow_chunk_file(&source)
+        .expect("reads")
+        .is_some());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sceneworks-core/tests/workflow_share_doc.rs
+++ b/crates/sceneworks-core/tests/workflow_share_doc.rs
@@ -761,6 +761,66 @@ fn the_doc_lists_exactly_the_path_exempt_prose_fields() {
     }
 }
 
+/// The web module that holds the Settings copy's one machine-checkable claim (sc-15953).
+const SETTINGS_COPY_PATH: &str = "apps/web/src/workflowEmbed.js";
+
+#[test]
+fn the_settings_copy_names_exactly_the_path_exempt_prose_fields() {
+    // The settings toggle's copy is the most user-visible place a claim about this contract can be
+    // wrong, and "your prompt travels as you wrote it" is the claim a user acts on before sharing.
+    // So the six fields are not written out as a sentence in the JSX — they are rendered from a
+    // declared list, and this pins that list against the same `prose-fields` table the sanitizer
+    // itself is pinned to. A seventh prose field added to `PROSE_KEYS` therefore fails three
+    // things: the doc, the sanitizer's own lint, and the copy that would otherwise have gone on
+    // naming six.
+    let source = read_repo_file(SETTINGS_COPY_PATH);
+    let anchor = "EMBEDDED_PROSE_FIELDS = Object.freeze([";
+    let start = source.find(anchor).unwrap_or_else(|| {
+        panic!(
+            "{SETTINGS_COPY_PATH} no longer declares {anchor:?}. The settings copy's field list is \
+             pinned to the {DOC_PATH} `prose-fields` table; if it moved, teach this lint where."
+        )
+    }) + anchor.len();
+    let rest = &source[start..];
+    let end = rest
+        .find("]);")
+        .unwrap_or_else(|| panic!("{SETTINGS_COPY_PATH}: EMBEDDED_PROSE_FIELDS is never closed"));
+
+    let mut listed: BTreeSet<String> = BTreeSet::new();
+    for line in rest[..end].lines() {
+        let Some(open) = line.trim().strip_prefix("[\"") else {
+            continue;
+        };
+        let Some(close) = open.find('"') else { continue };
+        listed.insert(open[..close].to_owned());
+    }
+    let documented = pinned_set(&doc(), "prose-fields", 0);
+
+    let missing: Vec<&String> = documented.difference(&listed).collect();
+    assert!(
+        missing.is_empty(),
+        "{SETTINGS_COPY_PATH} does not list {missing:?}, which the `prose-fields` table in \
+         {DOC_PATH} says travels exactly as the user typed it. The settings copy would be telling \
+         someone their prompt is safe while a field that carries a filesystem path is not named."
+    );
+    let invented: Vec<&String> = listed.difference(&documented).collect();
+    assert!(
+        invented.is_empty(),
+        "{SETTINGS_COPY_PATH} lists {invented:?} as travelling verbatim, which the `prose-fields` \
+         table in {DOC_PATH} does not. The copy is claiming something about the file that is not \
+         true of it."
+    );
+
+    // And the copy points at the document this test reads, so the "what travels, exactly" link is
+    // the contract rather than a page that happens to exist.
+    let link_target = DOC_PATH.replace('\\', "/");
+    assert!(
+        source.contains(&link_target),
+        "{SETTINGS_COPY_PATH} must link to {link_target} — the copy is a summary, and the summary \
+         has to be able to send the user to the exact list"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // The ceilings, found by experiment
 // ---------------------------------------------------------------------------

--- a/crates/sceneworks-core/tests/workflow_share_doc.rs
+++ b/crates/sceneworks-core/tests/workflow_share_doc.rs
@@ -791,7 +791,9 @@ fn the_settings_copy_names_exactly_the_path_exempt_prose_fields() {
         let Some(open) = line.trim().strip_prefix("[\"") else {
             continue;
         };
-        let Some(close) = open.find('"') else { continue };
+        let Some(close) = open.find('"') else {
+            continue;
+        };
         listed.insert(open[..close].to_owned());
     }
     let documented = pinned_set(&doc(), "prose-fields", 0);

--- a/crates/sceneworks-core/tests/workflow_share_doc.rs
+++ b/crates/sceneworks-core/tests/workflow_share_doc.rs
@@ -761,8 +761,163 @@ fn the_doc_lists_exactly_the_path_exempt_prose_fields() {
     }
 }
 
-/// The web module that holds the Settings copy's one machine-checkable claim (sc-15953).
+/// The web module that holds the Settings copy's machine-checkable claims (sc-15953).
 const SETTINGS_COPY_PATH: &str = "apps/web/src/workflowEmbed.js";
+
+/// The first quoted string of every `["key", LABEL],` entry of a `Object.freeze([…])` list in
+/// [`SETTINGS_COPY_PATH`], as a set.
+///
+/// Only the KEY is read. The labels beside them are shared constants rather than literals — one
+/// phrase legitimately covers several keys — and the prose is not what these lints check: the
+/// question is whether every field the contract carries has been *classified* by someone writing
+/// the copy, which is the step that would have caught `advanced.poses` going unnamed.
+///
+/// Panics when the list is gone, for the reason every parser in this file does: a lint that
+/// quietly finds nothing passes against a file that was emptied.
+fn declared_keys(name: &str) -> BTreeSet<String> {
+    let source = read_repo_file(SETTINGS_COPY_PATH);
+    let anchor = format!("{name} = Object.freeze([");
+    let start = source.find(&anchor).unwrap_or_else(|| {
+        panic!(
+            "{SETTINGS_COPY_PATH} no longer declares {anchor:?}. The settings copy's field lists \
+             are pinned to the tables in {DOC_PATH}; if one moved, teach this lint where."
+        )
+    }) + anchor.len();
+    let rest = &source[start..];
+    let end = rest
+        .find("]);")
+        .unwrap_or_else(|| panic!("{SETTINGS_COPY_PATH}: {name} is never closed"));
+
+    let mut listed: BTreeSet<String> = BTreeSet::new();
+    for line in rest[..end].lines() {
+        let Some(open) = line.trim().strip_prefix("[\"") else {
+            continue;
+        };
+        let Some(close) = open.find('"') else {
+            continue;
+        };
+        let key = open[..close].to_owned();
+        assert!(
+            listed.insert(key.clone()),
+            "{SETTINGS_COPY_PATH}: {name} lists {key:?} twice"
+        );
+    }
+    assert!(
+        !listed.is_empty(),
+        "{SETTINGS_COPY_PATH}: {name} parsed to no keys at all"
+    );
+    listed
+}
+
+/// The `advanced-shared` / `advanced-withheld` keys as the settings copy spells them: prefixed,
+/// because `styleId` is both a top-level envelope field and an advanced setting and the copy has to
+/// be able to say something about each.
+fn prefixed_advanced(block: &str) -> BTreeSet<String> {
+    pinned_set(&doc(), block, 0)
+        .into_iter()
+        .map(|key| format!("advanced.{key}"))
+        .collect()
+}
+
+#[test]
+fn the_settings_copy_accounts_for_every_shared_and_withheld_field() {
+    // The finding this test exists for: "Also in the file" and "Not in the file" are the two
+    // paragraphs a user acts on before sending an image to a client, and they were pinned to
+    // NOTHING. `advanced.poses` — the `keypoints` / `hands` / `face` coordinate arrays, facial
+    // landmarks included — reached the file while the copy named none of it, and the next paragraph
+    // said "the input images themselves" are not in the file, which invites exactly the wrong
+    // reading: that nothing derived from a reference travels. Claiming more privacy than the
+    // allow-list delivers is the forbidden direction, and this is the surface where it matters.
+    //
+    // So both lists are declared per key and pinned here in both directions. What this buys is not
+    // that the prose is good — no lint can say that — but that a field cannot reach a shared image
+    // without a human deciding, in the copy, what to say about it.
+    let mut shared = pinned_set(&doc(), "envelope-fields", 0);
+    shared.extend(prefixed_advanced("advanced-shared"));
+    assert_same_set(
+        &shared,
+        &declared_keys("WORKFLOW_FIELDS_IN_FILE"),
+        "envelope-fields + advanced-shared",
+        &format!("{SETTINGS_COPY_PATH}'s WORKFLOW_FIELDS_IN_FILE"),
+    );
+
+    // The withheld half. Every key the contract classified as withheld must be spoken for by the
+    // "Not in the file" list, so a decision someone wrote down against a key is a decision the user
+    // is actually told about.
+    let withheld = prefixed_advanced("advanced-withheld");
+    let claimed_absent = declared_keys("WORKFLOW_FIELDS_NOT_IN_FILE");
+    let unspoken: Vec<&String> = withheld.difference(&claimed_absent).collect();
+    assert!(
+        unspoken.is_empty(),
+        "{SETTINGS_COPY_PATH}'s WORKFLOW_FIELDS_NOT_IN_FILE does not account for {unspoken:?}, \
+         which the `advanced-withheld` table in {DOC_PATH} says is deliberately dropped. A \
+         withheld key nobody mentions is a decision the user never hears about."
+    );
+
+    // And the direction that is a leak rather than an omission: nothing the copy claims is ABSENT
+    // may appear in either table of things that travel. This is what would fire the day someone
+    // moved `quantTier` from withheld to shared and left the paragraph promising it stays home.
+    let contradicted: Vec<&String> = claimed_absent.intersection(&shared).collect();
+    assert!(
+        contradicted.is_empty(),
+        "{SETTINGS_COPY_PATH} tells the user {contradicted:?} are NOT in the file, but {DOC_PATH} \
+         lists them among the fields that travel. The copy is claiming a privacy the allow-list \
+         does not deliver, which is the one direction this contract must never drift in."
+    );
+}
+
+#[test]
+fn the_settings_copy_names_the_save_without_workflow_control_once() {
+    // Three surfaces name this control — the context menu, the button beside Save As, and the copy
+    // that tells you to use it — and they said three different things ("Save without workflow",
+    // "Save a copy without the workflow…", and a third in the document). A user told to look for a
+    // control that is not spelled that way anywhere is a user who concludes it does not exist.
+    let source = read_repo_file(SETTINGS_COPY_PATH);
+    let anchor = "SAVE_WITHOUT_WORKFLOW_LABEL = \"";
+    let start = source
+        .find(anchor)
+        .unwrap_or_else(|| panic!("{SETTINGS_COPY_PATH} no longer declares {anchor:?}"))
+        + anchor.len();
+    let label = &source[start
+        ..start
+            + source[start..]
+                .find('"')
+                .unwrap_or_else(|| panic!("{SETTINGS_COPY_PATH}: the label is never closed"))];
+    assert!(
+        !label.is_empty(),
+        "{SETTINGS_COPY_PATH}: the label parsed as empty"
+    );
+    assert!(
+        doc().contains(label),
+        "{DOC_PATH} must name the control exactly as the UI does ({label:?}); the document is what \
+         a user is sent to when the copy says to use it"
+    );
+}
+
+#[test]
+fn the_settings_copy_derives_its_doc_link_from_the_producer_url() {
+    // The link in the app and the link a shared file carries in `producer.url` have to be the same
+    // repository, or "what travels, exactly" sends someone somewhere the envelope does not vouch
+    // for. It used to be a hardcoded URL under a comment CLAIMING it was rooted at PRODUCER_URL,
+    // with nothing deriving or checking that — so the full prefix is pinned here, not just the
+    // path substring.
+    let source = read_repo_file(SETTINGS_COPY_PATH);
+    let declared = format!("PRODUCER_URL = \"{PRODUCER_URL}\";");
+    assert!(
+        source.contains(&declared),
+        "{SETTINGS_COPY_PATH} must declare {declared:?} — the web copy's idea of the project URL \
+         and the one the envelope carries are the same fact"
+    );
+    let derived = format!(
+        "WORKFLOW_SHARE_DOC_URL = `${{PRODUCER_URL}}/blob/main/{}`;",
+        DOC_PATH.replace('\\', "/")
+    );
+    assert!(
+        source.contains(&derived),
+        "{SETTINGS_COPY_PATH} must derive the doc link as {derived:?} rather than writing the URL \
+         out beside PRODUCER_URL, where the two can drift apart silently"
+    );
+}
 
 #[test]
 fn the_settings_copy_names_exactly_the_path_exempt_prose_fields() {
@@ -773,29 +928,7 @@ fn the_settings_copy_names_exactly_the_path_exempt_prose_fields() {
     // itself is pinned to. A seventh prose field added to `PROSE_KEYS` therefore fails three
     // things: the doc, the sanitizer's own lint, and the copy that would otherwise have gone on
     // naming six.
-    let source = read_repo_file(SETTINGS_COPY_PATH);
-    let anchor = "EMBEDDED_PROSE_FIELDS = Object.freeze([";
-    let start = source.find(anchor).unwrap_or_else(|| {
-        panic!(
-            "{SETTINGS_COPY_PATH} no longer declares {anchor:?}. The settings copy's field list is \
-             pinned to the {DOC_PATH} `prose-fields` table; if it moved, teach this lint where."
-        )
-    }) + anchor.len();
-    let rest = &source[start..];
-    let end = rest
-        .find("]);")
-        .unwrap_or_else(|| panic!("{SETTINGS_COPY_PATH}: EMBEDDED_PROSE_FIELDS is never closed"));
-
-    let mut listed: BTreeSet<String> = BTreeSet::new();
-    for line in rest[..end].lines() {
-        let Some(open) = line.trim().strip_prefix("[\"") else {
-            continue;
-        };
-        let Some(close) = open.find('"') else {
-            continue;
-        };
-        listed.insert(open[..close].to_owned());
-    }
+    let listed = declared_keys("EMBEDDED_PROSE_FIELDS");
     let documented = pinned_set(&doc(), "prose-fields", 0);
 
     let missing: Vec<&String> = documented.difference(&listed).collect();
@@ -814,10 +947,11 @@ fn the_settings_copy_names_exactly_the_path_exempt_prose_fields() {
     );
 
     // And the copy points at the document this test reads, so the "what travels, exactly" link is
-    // the contract rather than a page that happens to exist.
+    // the contract rather than a page that happens to exist. The FULL URL, prefix included, is
+    // pinned by `the_settings_copy_derives_its_doc_link_from_the_producer_url`.
     let link_target = DOC_PATH.replace('\\', "/");
     assert!(
-        source.contains(&link_target),
+        read_repo_file(SETTINGS_COPY_PATH).contains(&link_target),
         "{SETTINGS_COPY_PATH} must link to {link_target} — the copy is a summary, and the summary \
          has to be able to send the user to the exact list"
     );

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -571,18 +571,35 @@ the PNG write seam.
   which excises the chunk from the copied bytes and leaves the asset alone. The browser and LAN
   download does the same server-side, through `?stripWorkflow=true` on the file route.
 
-The switch lives in **Settings → Settings → Sharing**, and the copy under it is the summary this
-document is the long form of. Two things keep the two from drifting: the summary links here, and
-the six path-exempt prose fields are rendered in the UI from a declared list that
-`the_settings_copy_names_exactly_the_path_exempt_prose_fields` pins against the `prose-fields`
-table above, in both directions — so a seventh prose field fails the settings copy as loudly as it
-fails this document.
+That control is named by exactly one constant, `SAVE_WITHOUT_WORKFLOW_LABEL`, and it is reachable
+from three places rather than one: a button beside **Save As…** in the advanced preview, the
+right-click context menu there, and a second download button in the Simple shell. All three, because
+the copy above tells a user to go and find it — and the Simple shell is the default on a phone,
+where a right-click does not exist.
+
+The switch lives in **Settings → Settings → Sharing** and, in the Simple shell, under **Sharing** on
+its Settings screen. The copy under it is the summary this document is the long form of. What keeps
+the two from drifting is that the summary links here and that its three lists — the path-exempt prose
+fields, what is in the file, and what is not — are rendered in the UI from declared lists that
+[How this document is kept honest](#how-this-document-is-kept-honest) pins against the tables above,
+in both directions.
+
+The strip itself refuses rather than guesses. A PNG whose chunk framing cannot be walked to an IEND,
+or whose unwalkable trailing bytes carry `sceneworks:workflow`, is an error and not a copy: "here is
+your file without the workflow" answered with the original, or with a truncated file that does not
+decode, are both worse than saying no. The server route bounds what one request may cost — it serves
+the kept spans as views into the single buffer it read, behind a small semaphore and a size cap — and
+revalidates the stripped representation on its own ETag alone, because it shares a modification date
+with the full file and a date cannot tell the two apart.
 
 A one-time disclosure is shown the first time a generation is submitted while embedding is on. It
 is dismissible and never repeated; the "already told them" flag is `workflowEmbedNoticeSeen` in the
 same preference file, durable rather than browser-side because the desktop shell serves the UI from
 an origin that changes each launch. An absent flag means "not told", so an install upgrading into a
-build that embeds gets the notice once rather than never.
+build that embeds gets the notice once rather than never. The durable write retries and then reports
+its failure rather than swallowing it — a dropped PUT does not degrade to "saved locally" when the
+mirror is wiped every launch — and a dismissal in one browser tab carries to the others through the
+mirror's `storage` event, so "once" is per user rather than per tab.
 
 ## How this document is kept honest
 
@@ -603,6 +620,17 @@ code does not have fails, and a thing the code has that is not a row here fails 
 | `builder-fields` | The fields of the `AdvancedBuilder` struct, so a registry entry that grows a field a contributor is never told to fill fails. |
 | `rule-helpers` | The `const fn … -> AdvancedKeyRule` constructors in `workflow_share.rs`, so a helper this section does not mention fails. |
 | `lints` | Each named test exists in `crates/sceneworks-core/tests/workflow_share.rs`. |
+
+The web copy is pinned against the same blocks, so the summary a user reads before sharing cannot
+outrun the contract:
+
+| Claim in `apps/web/src/workflowEmbed.js` | Pinned against |
+| --- | --- |
+| `EMBEDDED_PROSE_FIELDS` — the fields that travel exactly as typed | `prose-fields`, both directions. |
+| `WORKFLOW_FIELDS_IN_FILE` — the "Also in the file" list | `envelope-fields` plus `advanced-shared` (prefixed `advanced.`), both directions. A new allow-listed setting cannot reach a shared image until someone decides, in the copy, what to say about it. |
+| `WORKFLOW_FIELDS_NOT_IN_FILE` — the "Not in the file" list | Every `advanced-withheld` key must appear, and **no** key it names may appear in either table above. That second half is the direction that is a leak rather than an omission: it fires the day a withheld key becomes shared and the paragraph goes on promising it stays home. |
+| `SAVE_WITHOUT_WORKFLOW_LABEL` | This document must name the control with the same string the UI does. |
+| `PRODUCER_URL` / `WORKFLOW_SHARE_DOC_URL` | The Rust `PRODUCER_URL`, whole; the doc link is derived from it rather than written out beside it. |
 
 Three claims outside a pinned block are checked too, because each had a way to drift silently:
 

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -566,9 +566,23 @@ the PNG write seam.
   than "not found" — a sharing violation, an ACL error — embedding is off. "Absent" and "unreadable"
   are different states, and collapsing them is how a deliberate opt-out silently inverts itself. A
   file that is present and readable but not parseable falls back to the default, which is on.
-- Turning it off changes nothing about images already written. The chunk is in those files.
+- Turning it off changes nothing about images already written. The chunk is in those files. To
+  share one of those without the block, use **Save a copy without the workflow** on the asset —
+  which excises the chunk from the copied bytes and leaves the asset alone. The browser and LAN
+  download does the same server-side, through `?stripWorkflow=true` on the file route.
 
-The settings UI and its first-run disclosure are sc-15953's, not this document's.
+The switch lives in **Settings → Settings → Sharing**, and the copy under it is the summary this
+document is the long form of. Two things keep the two from drifting: the summary links here, and
+the six path-exempt prose fields are rendered in the UI from a declared list that
+`the_settings_copy_names_exactly_the_path_exempt_prose_fields` pins against the `prose-fields`
+table above, in both directions — so a seventh prose field fails the settings copy as loudly as it
+fails this document.
+
+A one-time disclosure is shown the first time a generation is submitted while embedding is on. It
+is dismissible and never repeated; the "already told them" flag is `workflowEmbedNoticeSeen` in the
+same preference file, durable rather than browser-side because the desktop shell serves the UI from
+an origin that changes each launch. An absent flag means "not told", so an install upgrading into a
+build that embeds gets the notice once rather than never.
 
 ## How this document is kept honest
 


### PR DESCRIPTION
Closes [sc-15953](https://app.shortcut.com/sceneworks/story/15953).

The user-facing half of epic 15945. sc-15948 reads `embedWorkflowInImages` at the write seam; this story owns the surfaces that write it, the disclosure that says it is on, and the two ways to share an image without the recipe.

## The setting

**Settings → Settings → Sharing** carries the toggle. It writes the preference the worker already re-reads at its PNG write seam on every job, so a flip lands on the next generation with no restart — `the_embed_toggle_and_its_disclosure_flag_persist_where_the_worker_looks` asserts that through `sceneworks_core::app_paths::embed_workflow_in_images` rather than through the route's own echo.

## The copy

The recurring defect on this epic is an artifact claiming a stronger guarantee than the code delivers, and settings copy is the most user-visible place that could land. So:

- The six path-exempt prose fields are **not written out as a sentence**. They are rendered from `EMBEDDED_PROSE_FIELDS` in `apps/web/src/workflowEmbed.js`, and `the_settings_copy_names_exactly_the_path_exempt_prose_fields` pins that list against the `prose-fields` table of `docs/workflow-share-envelope.md` in both directions. A seventh prose field added to the sanitizer fails the settings copy as loudly as it fails the doc.
- The copy names the **two-segment-path hole** (`Clients/Acme` is the shape of a HF repo id and is not treated as a location) rather than claiming every path is caught.
- It lists `producer.version` ("the SceneWorks version that wrote the file") and `count` ("how many images the run asked for") as things that travel.
- It says the switch applies **from the next generation** and that images already on disk keep the block they were written with — with a `not.toMatch` test against the wording that would imply a retroactive clean.
- It links to the contract doc, and that link is pinned too.

## First-run disclosure

**Trigger:** a generation accepted while embedding is on, hung off the `afterCreate` hook of the one image-job creator every studio goes through. Submission rather than completion, so the user is told before the files with their prompt in them exist.

**Flag:** `workflowEmbedNoticeSeen`, a durable server preference. Not localStorage — the desktop shell serves the UI from an origin that changes each launch, so a browser-side flag would re-show the notice forever. The merge is **one-way**: a payload carrying `false` is ignored, so a client PUTting a stale preferences object cannot make it reappear.

**Upgrade case:** absent means "not told". An install that has been generating for months has a silently-on default and has never been told, so the notice fires once for them rather than only for fresh installs.

## Strip: excise, not re-encode

`strip_workflow_chunk` walks the PNG chunk framing and drops our text chunks. IHDR, PLTE, every IDAT and IEND are copied through byte for byte, so the compressed image data is the same bytes it was — no encoder, filter or `image`/`png` version is in the path. Each chunk carries its own CRC over its own type and data, so nothing is recomputed.

`strip_of_an_embedded_png_is_byte_identical_to_the_none_path` proves it the strongest way available: stripping the `Some` output yields the **`None` output byte for byte**, over both DEFLATE regimes and four sizes, cross-checked against the independent hand-rolled stripper the write-path test already uses. No PSNR needed.

A PNG whose framing cannot be walked is an **error**, never the original bytes: "here is your copy without the workflow" must not be answered with a file that may still carry one.

## Egress

- **Desktop:** `save_asset_as` grows `without_workflow`. A source with nothing to strip goes through the same `std::fs::copy` the plain save uses. The source asset is never touched.
- **Browser/LAN:** `?stripWorkflow=true` on the existing file route. A query param on the path the media ticket's GET-only allow-list already covers, so remote/LAN works with **no change to the ticket rules** — a separate endpoint would have needed a new entry in the surface hardest to widen safely. `a_media_ticket_authorizes_the_stripped_download_too` pins it. The variant carries its own ETag (the route caches `immutable`, so a shared tag would let a cache answer a strip request with the unstripped body) and `Accept-Ranges: none`.

## Tests

Web: 228 files / 3312 tests pass, eslint clean, `web:build` clean. Rust: `sceneworks-core` and `sceneworks-rust-api` green, fmt + clippy clean, desktop crate compiles and its 102 tests pass. `cargo test --workspace --no-fail-fast` shows the same 23 pre-existing rustls `No provider set` failures (sc-15337) and no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)