### PR TITLE
feat(workflow-share): embed the sanitized workflow in generated MP4s (sc-15956)

### DIFF
--- a/apps/rust-api/src/tests/workflows.rs
+++ b/apps/rust-api/src/tests/workflows.rs
@@ -39,6 +39,38 @@ fn image_envelope(model: &str, prompt: &str) -> WorkflowShare {
     .expect("the fixture envelope parses")
 }
 
+/// A COMPLETE, VALID video envelope — the sc-15956 marker plus every field the deserializer
+/// requires, and three video-only fields on top so the blob is unmistakably a clip's recipe.
+///
+/// Built through `parse_workflow_share_json` on purpose. The point of the fixture is that it is a
+/// record the shared parser *accepts*: a video envelope that failed to parse would pin nothing
+/// about the container gate, because the parse failure would be doing all the work. Written as a
+/// serialized `Value` rather than as a struct literal for the same reason the image fixture is —
+/// what a corrupted sidecar contains is JSON, not a Rust value.
+fn video_envelope(model: &str, prompt: &str) -> Value {
+    let json = format!(
+        r#"{{
+            "sceneworksWorkflow": "video",
+            "schemaVersion": 1,
+            "producer": {{ "name": "SceneWorks", "url": "https://example.invalid", "version": "0.8.1" }},
+            "mode": "text_to_video",
+            "model": "{model}",
+            "prompt": "{prompt}",
+            "durationSeconds": 5.0,
+            "fps": 24,
+            "quality": "balanced"
+        }}"#
+    );
+    let share = sceneworks_core::workflow_share::parse_workflow_share_json(&json)
+        .expect("the video fixture is a VALID envelope, not a malformed one");
+    assert_eq!(
+        share.kind,
+        sceneworks_core::workflow_share::WORKFLOW_KIND_VIDEO,
+        "the fixture must carry the video marker or it pins nothing"
+    );
+    serde_json::to_value(&share).expect("the video fixture serializes")
+}
+
 /// PNG bytes carrying `share` in a `sceneworks:workflow` iTXt chunk (or none at all), written
 /// through the ONE writer (sc-15947) rather than a hand-rolled chunk.
 fn sceneworks_png(temp_dir: &tempfile::TempDir, share: Option<&WorkflowShare>) -> Vec<u8> {
@@ -997,13 +1029,21 @@ async fn the_asset_route_500s_with_its_own_code_when_the_stored_envelope_no_long
         serde_json::from_slice(&std::fs::read(&sidecar).expect("sidecar reads"))
             .expect("sidecar is JSON");
     // Still an object, still under the right key, still obviously a workflow — and rejected,
-    // because the marker names a kind this build has no reader for. A record that fails at the
-    // FIRST gate rather than a blob of noise, so the 500 is the parser's verdict and not a JSON
-    // syntax error somewhere upstream of it.
+    // because the marker names a kind NO build has a reader for. A record that fails at the FIRST
+    // gate rather than a blob of noise, so the 500 is the parser's verdict and not a JSON syntax
+    // error somewhere upstream of it.
+    //
+    // The marker used to read `"video"` here, and that stopped being a first-gate failure the day
+    // sc-15956 widened `WORKFLOW_KINDS` to `image` | `video`: the fixture went on 500ing only
+    // because it omits `producer` / `model` / `prompt` and dies at deserialize, which is a status
+    // code any malformed blob earns and pins no invariant at all. `"hologram"` is a kind the
+    // parser genuinely refuses, so this test is back to asserting what its name says. The video
+    // case — a record that PARSES and is refused for naming another container — is
+    // `the_asset_route_500s_when_the_stored_envelope_names_another_container` below.
     record["extra"]["importedWorkflow"] = json!({
-        "sceneworksWorkflow": "video",
+        "sceneworksWorkflow": "hologram",
         "schemaVersion": 1,
-        "mode": "text_to_video",
+        "mode": "text_to_image",
     });
     std::fs::write(
         &sidecar,
@@ -1029,6 +1069,95 @@ async fn the_asset_route_500s_with_its_own_code_when_the_stored_envelope_no_long
         body["status"],
         json!("no_workflow"),
         "flattening this into the ordinary absent answer hides a bad record behind the user's file"
+    );
+    assert!(
+        body["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("image itself is unaffected")),
+        "the sentence must say the picture is fine: {body}"
+    );
+}
+
+/// The container gate this route owns (sc-15956 review).
+///
+/// The record here is not corrupt in any way: it is a **complete, valid video envelope** that
+/// `parse_workflow_share` accepts without complaint — same parser, same version, every required
+/// field present. What it is not is an IMAGE recipe, and this route's response feeds
+/// `api.js::fetchAssetWorkflow` → `useWorkflowDrop.js` → `recipeFromWorkflowShare`, which builds an
+/// **Image Studio** prefill. Handing a clip's `durationSeconds` / `fps` / `quality` to that
+/// produces a fabricated image recipe for a video that was never an image — the "presented as a
+/// kind it is not" failure the marker exists to prevent.
+///
+/// Before sc-15956 the shared parser refused `"video"` outright, so this route inherited the
+/// refusal for free. Widening `WORKFLOW_KINDS` to `image` | `video` removed that inheritance from
+/// the one reader with no container of its own to check. The PNG reader asserts `image`, the MP4
+/// reader asserts `video`, and this asserts `image` because that is the lane behind it.
+///
+/// **Mutation proof.** Delete the `share.kind != WORKFLOW_KIND_IMAGE` block in
+/// `crate::workflows::get_asset_workflow` and this test fails on the FIRST assert, with a 200 and
+/// `status: "workflow"` — the route handing the web a video recipe to build an image prefill from.
+/// `assetPanels.jsx`'s `asset.type === "image"` guard does not save it: this envelope is stored on
+/// an IMAGE asset, which is exactly the shape that guard passes.
+#[tokio::test]
+async fn the_asset_route_500s_when_the_stored_envelope_names_another_container() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let app = create_app(settings).expect("app creates");
+    let _env = isolate_hf_cache();
+    let share = image_envelope("krea_2_turbo", "a lighthouse");
+    let (project_id, asset_id) = project_with_imported_image(
+        app.clone(),
+        "Wrong Container",
+        "shared.png",
+        &sceneworks_png(&temp_dir, Some(&share)),
+    )
+    .await;
+
+    let (_, project) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}"),
+        Value::Null,
+    )
+    .await;
+    let project_path = std::path::PathBuf::from(project["path"].as_str().expect("project path"));
+    let sidecar = find_asset_sidecar_file(&project_path, &asset_id);
+    let mut record: Value =
+        serde_json::from_slice(&std::fs::read(&sidecar).expect("sidecar reads"))
+            .expect("sidecar is JSON");
+    record["extra"]["importedWorkflow"] = video_envelope("wan_2_2_vace_fun_14b", "a lighthouse");
+    std::fs::write(
+        &sidecar,
+        serde_json::to_vec_pretty(&record).expect("record serializes"),
+    )
+    .expect("sidecar writes");
+
+    let (status, body) = request(
+        app,
+        "GET",
+        &asset_workflow_route(&project_id, &asset_id),
+        Value::Null,
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a VIDEO envelope must not reach the Image Studio prefill this route feeds: {body}"
+    );
+    assert_ne!(
+        body["status"],
+        json!("workflow"),
+        "answering `workflow` here hands the web a clip's recipe to prefill an image studio with"
+    );
+    assert!(
+        body["workflow"].is_null(),
+        "the envelope itself must not travel either: {body}"
+    );
+    assert_eq!(
+        body["code"],
+        json!("asset_workflow_unreadable"),
+        "same code as an unparseable record — it is the same fact about the same record: {body}"
     );
     assert!(
         body["detail"]

--- a/apps/rust-api/src/workflows.rs
+++ b/apps/rust-api/src/workflows.rs
@@ -40,7 +40,7 @@ use sceneworks_core::workflow_png::{read_workflow_chunk_file, WorkflowChunkError
 use sceneworks_core::workflow_resolution::{
     build_resolution_report, CatalogEntry, InstallAction, ResolutionReport, StaticCatalogs,
 };
-use sceneworks_core::workflow_share::{parse_workflow_share, WorkflowShare};
+use sceneworks_core::workflow_share::{parse_workflow_share, WorkflowShare, WORKFLOW_KIND_IMAGE};
 
 /// `status` when the file carried a readable envelope.
 pub(crate) const INSPECT_STATUS_WORKFLOW: &str = "workflow";
@@ -320,6 +320,39 @@ pub(crate) async fn get_asset_workflow(
             code: Some(ASSET_WORKFLOW_CODE_UNREADABLE),
         }
     })?;
+    // The SECOND gate, and the one this route owns: the parser accepts EVERY kind in
+    // `WORKFLOW_KINDS`, so `parse_workflow_share` alone stopped being a container check the moment
+    // sc-15956 widened the marker to `image` | `video`. Both other readers assert the kind their
+    // own container carries — `workflow_png::read_workflow_chunk_file` demands `image`,
+    // `workflow_mp4::read_workflow_metadata` demands `video` — and this route is the third reader,
+    // so it owes the same assert against the lane it feeds.
+    //
+    // The lane is what makes this a refusal rather than a widening: the response goes to
+    // `api.js::fetchAssetWorkflow` → `useWorkflowDrop.js` → `recipeFromWorkflowShare`, which builds
+    // an **Image Studio** prefill. A video envelope reaching that produces a made-up image recipe
+    // out of a clip's `durationSeconds` / `fps` / `quality` — the exact "presented as a kind it is
+    // not" failure the kind gate exists to prevent, arriving through the one door with no container
+    // of its own to check. `assetPanels.jsx`'s `asset.type === "image"` button guard is a proxy for
+    // this and not a substitute: a video envelope stored on an image asset passes it unchanged.
+    //
+    // Same code as an unparseable record, because it is the same fact about the same record — ours,
+    // and wrong — and the caller's next move is identical. Pinned by
+    // `tests::workflows::the_asset_route_500s_when_the_stored_envelope_names_another_container`.
+    if share.kind != WORKFLOW_KIND_IMAGE {
+        tracing::error!(
+            event = "asset_workflow_unreadable",
+            %project_id,
+            kind = %share.kind,
+            "the stored envelope names a workflow kind this route has no reader for"
+        );
+        return Err(ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: "SceneWorks recorded a workflow on this image but can no longer read it back. \
+                     The image itself is unaffected."
+                .to_owned(),
+            code: Some(ASSET_WORKFLOW_CODE_UNREADABLE),
+        });
+    }
     let catalogs = inspect_catalogs(&state, Some(&project_id))
         .await
         .map_err(|error| coded(error, INSPECT_CODE_CATALOG_FAILED))?;

--- a/apps/web/src/screens/VideoUpscalePanel.jsx
+++ b/apps/web/src/screens/VideoUpscalePanel.jsx
@@ -37,7 +37,11 @@ export function VideoUpscalePanel({
   const targetLabel = srcW && srcH ? `${srcW * factor} × ${srcH * factor}` : null;
   const canSubmit = Boolean(sourceAssetId) && !block && !submitting;
 
-  const onUpscale = async () => {
+  // A `function` declaration rather than an arrow: this is the video lane's `buildUpscaleJobBody`
+  // — the one place a `video_upscale` knob would be added — and it is registered in
+  // `ADVANCED_BUILDERS` as posting NO `advanced` map, so the coverage lint reads its body by name
+  // (sc-15956 review). The lint's locator needs `function onUpscale`.
+  async function onUpscale() {
     if (!canSubmit) return;
     setSubmitting(true);
     try {
@@ -55,7 +59,7 @@ export function VideoUpscalePanel({
     } finally {
       setSubmitting(false);
     }
-  };
+  }
 
   return (
     <aside className="upscale-card" data-testid="video-upscale-panel">

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -205,11 +205,24 @@ const N_SEEDS = "the other seeds in a batch";
 const N_IMAGES = "the input images themselves, though what a pose selection traced from one does travel";
 const N_BUDGET = "this machine's quality tier, attention kernel or GPU";
 const N_LOCAL = "local library ids — a Key Point collection, a control image, a trained overlay, a recipe preset";
-// The strongest claim in this list, and the only one here for PRIVACY rather than for
-// portability: a shared video must not disclose that it was made by replacing a specific
-// person, still less who or in which mode (sc-15956).
+// The only claim in this list made for PRIVACY rather than for portability: a shared video must not
+// disclose WHO was replaced, or which variant of a replacement ran (sc-15956).
+//
+// It carries its own caveat for the same reason `N_IMAGES` does, and the caveat is load-bearing.
+// This bullet used to read "anything about a person replacement", and that was FALSE in the leading
+// clause while true in every item it went on to enumerate: `mode` is in the "In the file" list
+// above, and a person-replacement run writes it verbatim as `replace_person`. `model` says the same
+// thing again — `wan_2_2_vace_fun_14b` is a replacement engine. So the TECHNIQUE travels, and a
+// bullet claiming otherwise claimed more privacy than the allow-list delivers, which is the one
+// direction this file's header forbids. What the allow-list actually withholds is the IDENTITY and
+// the VARIANT — the track, the name, the source filename, the masks, and the Face Only / Full
+// Person label — and that is what the sentence now says.
+//
+// The key-level pin in `workflow_share_doc.rs` cannot catch a copy error of this shape, because
+// `mode` is not a key in either list; `the_settings_copy_does_not_overclaim_about_person_
+// replacement` in that file asserts this text against a real `replace_person` envelope instead.
 const N_PERSON =
-  "anything about a person replacement — the selected track, the person's name, the original file name, the mask images, or which replacement mode ran";
+  "who was replaced or which variant of a replacement ran — the selected track, the person's name, the original file name, the mask images, and the Face Only / Full Person label. The generation mode and the model do travel, so the file does say that a replacement is what ran";
 const N_TIMELINE = "your timeline's name and the local ids of the clips on it";
 const N_ADVICE = "the on-screen advice the studio shows about a model";
 

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -111,6 +111,13 @@ const L_POSES =
   "the pose, hand and face coordinates a pose selection produced — landmark arrays derived from a reference photo, facial landmarks included";
 const L_PHASES = "the multi-phase denoise schedule, with each phase's steps, guidance and LoRA weights";
 const L_INPUTS = "which kinds of input image the recipe needs and how many of each";
+// The video lane (sc-15956). Its knobs are the same CLASS as the image ones — what to make,
+// never what this machine can afford — so several of them share the labels above.
+const L_CLIP = "the clip length, frame rate and quality preset a video run asked for";
+const L_MOTION = "the camera-motion preset, and which timeline action produced a clip";
+const L_VIDEO_ENGINE =
+  "which video pipeline, checkpoint variant, text encoder and fast-step recipe a video run used";
+const L_CLIP_INPUTS = "how many source or reference CLIPS the recipe needs, but never which ones";
 const L_OMITTED = "a note naming any list that was too long to record";
 
 // Every field the envelope can carry, and what the copy says about it. Keys prefixed `advanced.`
@@ -171,6 +178,20 @@ export const WORKFLOW_FIELDS_IN_FILE = Object.freeze([
   ["inputs[].kind", L_INPUTS],
   ["inputs[].count", L_INPUTS],
   ["inputs[].controlMode", L_INPUTS],
+  ["durationSeconds", L_CLIP],
+  ["fps", L_CLIP],
+  ["quality", L_CLIP],
+  ["advanced.motion", L_MOTION],
+  ["advanced.timelineAction", L_MOTION],
+  ["advanced.ltxPipeline", L_VIDEO_ENGINE],
+  ["advanced.distilledVariant", L_VIDEO_ENGINE],
+  ["advanced.textEncoderModel", L_VIDEO_ENGINE],
+  ["advanced.lightning", L_VIDEO_ENGINE],
+  ["advanced.videoCfgGuidanceScale", L_SETTINGS],
+  ["advanced.videoStgGuidanceScale", L_SETTINGS],
+  ["advanced.videoRescaleScale", L_SETTINGS],
+  ["advanced.videoConditioningStrength", L_SETTINGS],
+  ["advanced.bridgeRightVideoConditioningStrength", L_SETTINGS],
   ["omitted", L_OMITTED],
 ]);
 
@@ -184,6 +205,13 @@ const N_SEEDS = "the other seeds in a batch";
 const N_IMAGES = "the input images themselves, though what a pose selection traced from one does travel";
 const N_BUDGET = "this machine's quality tier, attention kernel or GPU";
 const N_LOCAL = "local library ids — a Key Point collection, a control image, a trained overlay, a recipe preset";
+// The strongest claim in this list, and the only one here for PRIVACY rather than for
+// portability: a shared video must not disclose that it was made by replacing a specific
+// person, still less who or in which mode (sc-15956).
+const N_PERSON =
+  "anything about a person replacement — the selected track, the person's name, the original file name, the mask images, or which replacement mode ran";
+const N_TIMELINE = "your timeline's name and the local ids of the clips on it";
+const N_ADVICE = "the on-screen advice the studio shows about a model";
 
 // What the copy claims is absent. Every key here must be absent from BOTH doc tables above, which
 // is the direction that matters: a withheld key that quietly became shared would otherwise leave
@@ -207,6 +235,14 @@ export const WORKFLOW_FIELDS_NOT_IN_FILE = Object.freeze([
   ["advanced.controlWeights", N_LOCAL],
   ["advanced.recipePresetId", N_LOCAL],
   ["advanced.presetMissingLoras", N_LOCAL],
+  ["personTrackId", N_PERSON],
+  ["replacementMode", N_PERSON],
+  ["advanced.selectedPersonTrack", N_PERSON],
+  ["advanced.replacementModeLabel", N_PERSON],
+  ["advanced.timelineContext", N_TIMELINE],
+  ["advanced.precision", N_BUDGET],
+  ["advanced.quantization", N_BUDGET],
+  ["advanced.durationHint", N_ADVICE],
 ]);
 
 // The absences with no field name to pin, because the envelope has no slot for them at all — they
@@ -263,7 +299,14 @@ function writeFlag(key, value) {
   return Boolean(value);
 }
 
-// Whether a generated PNG carries the recipe. Absent means ON, matching the worker's reader.
+// Whether a generated file carries the recipe. Absent means ON, matching the worker's reader.
+//
+// ONE switch for images and videos, not two (sc-15956). It is a privacy control over what leaves
+// in a file, and the reason someone turns it off does not stop applying at the container
+// boundary. A separate video switch would have re-enabled embedding for everyone who had already
+// opted out, the day the video lane shipped. The stored key keeps its `embedWorkflowInImages`
+// name for back-compatibility — renaming it would reset every existing opt-out to the default —
+// so it is the COPY that names both media, which is what the user actually reads.
 export function readEmbedWorkflowInImages() {
   return readFlag(EMBED_STORAGE_KEY, true);
 }

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -110,14 +110,14 @@ const L_ANGLE = "the head angle or turnaround the run asked for";
 const L_POSES =
   "the pose, hand and face coordinates a pose selection produced — landmark arrays derived from a reference photo, facial landmarks included";
 const L_PHASES = "the multi-phase denoise schedule, with each phase's steps, guidance and LoRA weights";
-const L_INPUTS = "which kinds of input image the recipe needs and how many of each";
+const L_INPUTS =
+  "which kinds of input image or CLIP the recipe needs and how many of each, but never which ones";
 // The video lane (sc-15956). Its knobs are the same CLASS as the image ones — what to make,
 // never what this machine can afford — so several of them share the labels above.
 const L_CLIP = "the clip length, frame rate and quality preset a video run asked for";
 const L_MOTION = "the camera-motion preset, and which timeline action produced a clip";
 const L_VIDEO_ENGINE =
   "which video pipeline, checkpoint variant, text encoder and fast-step recipe a video run used";
-const L_CLIP_INPUTS = "how many source or reference CLIPS the recipe needs, but never which ones";
 const L_OMITTED = "a note naming any list that was too long to record";
 
 // Every field the envelope can carry, and what the copy says about it. Keys prefixed `advanced.`

--- a/apps/web/src/workflowEmbed.test.js
+++ b/apps/web/src/workflowEmbed.test.js
@@ -127,6 +127,20 @@ describe("the two lists a user acts on (sc-15953)", () => {
     expect(sentence).toContain("what a pose selection traced from one does travel");
   });
 
+  it("does not claim the file says nothing about a person replacement", () => {
+    // The finding: the bullet read "anything about a person replacement — …", and `mode` travels
+    // as `replace_person` in every one. The enumerated tail was true; the leading clause claimed
+    // more privacy than the allow-list delivers. What is withheld is the identity and the variant.
+    // Asserted against a real envelope's bytes by
+    // `the_settings_copy_does_not_overclaim_about_person_replacement` in
+    // `crates/sceneworks-core/tests/workflow_share_doc.rs`.
+    const sentence = notInFileItems().join(" | ");
+    expect(sentence).not.toContain("anything about a person replacement");
+    expect(sentence).toContain("who was replaced");
+    expect(sentence).toContain("the person's name");
+    expect(sentence).toContain("a replacement is what ran");
+  });
+
   it("renders every declared label into its sentence, with repeats collapsed", () => {
     const rendered = inFileItems().join(" | ");
     for (const [, label] of WORKFLOW_FIELDS_IN_FILE) {

--- a/apps/web/src/workflowShare.js
+++ b/apps/web/src/workflowShare.js
@@ -312,6 +312,72 @@ export const ADVANCED_PREFILL = {
     prefill: PREFILL_NONE,
     detail: "A Document Studio interleave setting. Image Studio has no control for it.",
   },
+  // The VIDEO arm (sc-15956). Every one of these travels in a shared MP4 and lands nowhere HERE,
+  // for one reason that covers all eleven: this registry drives Image Studio, and a video recipe
+  // replays in Video Studio. That is a different panel and a different story, so the honest thing
+  // for this one to say is that the setting arrived and this studio has no control for it —
+  // exactly what the four rows above say about the Detail, Character and Document lanes.
+  //
+  // They are listed individually rather than collapsed because the panel renders a LABEL per key:
+  // "videoStgGuidanceScale arrived" is not a sentence, and a shared clip whose settings show as
+  // raw camelCase reads as a bug rather than as a boundary.
+  motion: {
+    label: "Camera motion",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting. Image Studio has no camera-motion control.",
+  },
+  ltxPipeline: {
+    label: "LTX pipeline",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting for the LTX video model.",
+  },
+  distilledVariant: {
+    label: "Distilled variant",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting: which distilled LTX checkpoint the clip was made with.",
+  },
+  textEncoderModel: {
+    label: "Text encoder",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting: which text encoder read the prompt.",
+  },
+  lightning: {
+    label: "Lightning steps",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting: the Wan2.2 fast four-step recipe.",
+  },
+  videoCfgGuidanceScale: {
+    label: "Video guidance",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting for the LTX video model.",
+  },
+  videoStgGuidanceScale: {
+    label: "Spatiotemporal guidance",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting for the LTX video model.",
+  },
+  videoRescaleScale: {
+    label: "Guidance rescale",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting for the LTX video model.",
+  },
+  videoConditioningStrength: {
+    label: "Clip strength",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting: how strongly the source clip conditioned the result.",
+  },
+  bridgeRightVideoConditioningStrength: {
+    label: "Right-clip strength",
+    prefill: PREFILL_NONE,
+    detail: "A Video Studio setting: the second clip strength in a bridge.",
+  },
+  timelineAction: {
+    label: "Timeline action",
+    prefill: PREFILL_NONE,
+    detail:
+      "Which timeline operation made the clip. The timeline it belonged to deliberately does " +
+      "not travel, so there is nothing here to place it into.",
+  },
 };
 
 function prefillDisposition(key) {

--- a/apps/web/src/workflowShare.test.js
+++ b/apps/web/src/workflowShare.test.js
@@ -453,10 +453,14 @@ describe("ADVANCED_PREFILL is the source of truth for both the prefill and the p
         expect(row.detail.length).toBeGreaterThan(20);
       }
     }
-    // …and the unrestored ones are exactly the lanes an image envelope carries that this studio
-    // has no control for, plus the two the CONTRACT deliberately reduces past the point of replay:
+    // …and the unrestored ones are exactly the lanes an envelope carries that THIS studio has no
+    // control for, plus the two the CONTRACT deliberately reduces past the point of replay:
     // `poses`, whose library ids do not travel, and `structuredPrompt`, whose caption object does
     // not (sc-15952 — the prompt is restored as prose instead, and the row says so).
+    //
+    // The eleven video keys (sc-15956) are here for the first reason, not the second: they travel
+    // intact in a shared MP4 and replay in Video Studio, which is a different panel. A row that
+    // said "restored" here would be claiming this studio had put them somewhere.
     expect(
       rows
         .filter((row) => !row.restored)
@@ -464,11 +468,22 @@ describe("ADVANCED_PREFILL is the source of truth for both the prefill and the p
         .sort(),
     ).toEqual([
       "angleSet",
+      "bridgeRightVideoConditioningStrength",
       "cnScale",
+      "distilledVariant",
       "imageGuidanceScale",
+      "lightning",
+      "ltxPipeline",
+      "motion",
       "poses",
       "structuredPrompt",
       "systemMessage",
+      "textEncoderModel",
+      "timelineAction",
+      "videoCfgGuidanceScale",
+      "videoConditioningStrength",
+      "videoRescaleScale",
+      "videoStgGuidanceScale",
     ]);
   });
 

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod training;
 pub mod training_store;
 pub mod video_request;
 pub mod voice_store;
+pub mod workflow_mp4;
 pub mod workflow_png;
 pub mod workflow_resolution;
 pub mod workflow_share;

--- a/crates/sceneworks-core/src/workflow_mp4.rs
+++ b/crates/sceneworks-core/src/workflow_mp4.rs
@@ -35,9 +35,26 @@
 //! container from streams alone. A platform that re-encodes an upload is such a pipeline. So the
 //! sharing premise that holds for a PNG chunk (the bytes travel intact) holds for MP4 only where
 //! the *file* travels: a copy, a download, a pass-through upload. sc-15956 records the measured
-//! matrix in full. What that leaves is still the larger half of the feature — every generated clip
-//! carries its own recipe, locally and through any file-preserving hop — and it is why the marker
-//! kind exists, so a reader can tell a video envelope from an image one.
+//! matrix in full.
+//!
+//! Two more measurements the sc-15956 review added, both worth stating here because they are the
+//! ones a user would guess wrong about:
+//!
+//! * **HLS segmentation loses it.** mp4 → TS segments → mp4 comes back with no tag, even at
+//!   `-c copy` throughout. MPEG-TS has no `ilst`, so the container really is rebuilt from streams
+//!   — the class above — but "I only re-packaged it, I did not re-encode" is exactly the reasoning
+//!   that would predict it survives, so it is named rather than left to be inferred. Measured, and
+//!   pinned by `the_tag_survives_a_re_encode_and_dies_on_a_deliberate_strip` in
+//!   `crates/sceneworks-worker/src/video_jobs/tests.rs`;
+//! * **a partial download keeps it.** The `+faststart` remux moves `moov` to the head, directly
+//!   behind `ftyp`, so the whole envelope is in the first few kilobytes and a transfer that stopped
+//!   inside `mdat` still reads back a complete recipe. `a_truncated_container_is_refused` in
+//!   `crates/sceneworks-core/tests/workflow_mp4.rs` pins both halves: a cut inside the header is a
+//!   typed error, a cut inside `mdat` is a readable file.
+//!
+//! What that leaves is still the larger half of the feature — every generated clip carries its own
+//! recipe, locally and through any file-preserving hop — and it is why the marker kind exists, so a
+//! reader can tell a video envelope from an image one.
 //!
 //! # The read side is a trust boundary, and MP4s are large
 //!

--- a/crates/sceneworks-core/src/workflow_mp4.rs
+++ b/crates/sceneworks-core/src/workflow_mp4.rs
@@ -311,10 +311,7 @@ pub fn workflow_metadata_size(share: &WorkflowShare) -> Result<usize, WorkflowMp
 /// See [`WorkflowMp4Error`].
 pub fn read_workflow_metadata_file(path: &Path) -> Result<Option<WorkflowShare>, WorkflowMp4Error> {
     let file = File::open(path).map_err(|error| io_error(&error))?;
-    let length = file
-        .metadata()
-        .map_err(|error| io_error(&error))?
-        .len();
+    let length = file.metadata().map_err(|error| io_error(&error))?.len();
     let mut reader = BufReader::new(file);
     read_workflow_metadata_from(&mut reader, length)
 }
@@ -405,9 +402,11 @@ fn read_box_header<R: Read + Seek>(
         _ => (offset + BOX_HEADER, u64::from(declared)),
     };
 
-    let end = offset.checked_add(size).ok_or(WorkflowMp4Error::Malformed {
-        detail: "a box size overflows the file offset".to_owned(),
-    })?;
+    let end = offset
+        .checked_add(size)
+        .ok_or(WorkflowMp4Error::Malformed {
+            detail: "a box size overflows the file offset".to_owned(),
+        })?;
     if size < body_start - offset || end > limit {
         return Err(WorkflowMp4Error::Malformed {
             detail: format!(
@@ -553,12 +552,11 @@ fn read_comment_data<R: Read + Seek>(
             }
             let payload_len = header.end - payload_start;
             // OUR bound, not the file's: a header claiming 2 GiB costs this comparison.
-            let payload_len = usize::try_from(payload_len).map_err(|_| {
-                WorkflowMp4Error::TooLarge {
+            let payload_len =
+                usize::try_from(payload_len).map_err(|_| WorkflowMp4Error::TooLarge {
                     bytes: usize::MAX,
                     limit: MAX_WORKFLOW_TEXT_BYTES,
-                }
-            })?;
+                })?;
             if payload_len > MAX_WORKFLOW_TEXT_BYTES {
                 return Err(WorkflowMp4Error::TooLarge {
                     bytes: payload_len,

--- a/crates/sceneworks-core/src/workflow_mp4.rs
+++ b/crates/sceneworks-core/src/workflow_mp4.rs
@@ -62,7 +62,8 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use crate::workflow_share::{
-    parse_workflow_share_json, WorkflowShare, WorkflowShareError, WORKFLOW_SHARE_MARKER_KEY,
+    parse_workflow_share_json, WorkflowShare, WorkflowShareError, WORKFLOW_KIND_VIDEO,
+    WORKFLOW_SHARE_MARKER_KEY,
 };
 
 /// The MP4 tag the envelope is published under: the standard `comment`, which ffmpeg maps to the
@@ -352,7 +353,22 @@ fn read_workflow_metadata_from<R: Read + Seek>(
     if !comment.contains(WORKFLOW_SHARE_MARKER_KEY) {
         return Ok(None);
     }
-    Ok(Some(parse_workflow_share_json(&comment)?))
+    let share = parse_workflow_share_json(&comment)?;
+    // An MP4 carries a VIDEO workflow. Nothing else — the symmetrical half of the assertion
+    // `workflow_png::read_workflow_chunk_from` makes, and for the same reason: the contract's kind
+    // gate accepts every kind this build knows, which is right for an envelope and wrong for a
+    // CONSUMER. Our writers only ever pair an MP4 with a video envelope, so a mismatch is a
+    // hand-made file or a future build's, and a reader that surfaced an image recipe out of a clip
+    // would be offering something no video studio can run.
+    if share.kind != WORKFLOW_KIND_VIDEO {
+        return Err(WorkflowMp4Error::Share(
+            WorkflowShareError::UnsupportedKind {
+                found: share.kind,
+                supported: WORKFLOW_KIND_VIDEO.to_owned(),
+            },
+        ));
+    }
+    Ok(Some(share))
 }
 
 /// One box header, read at the reader's current position.

--- a/crates/sceneworks-core/src/workflow_mp4.rs
+++ b/crates/sceneworks-core/src/workflow_mp4.rs
@@ -55,6 +55,15 @@
 //!
 //! Parsing goes through [`crate::workflow_share::parse_workflow_share_json`] and nothing else, so
 //! the sc-15946 allow-list sanitizer runs on the way in exactly as it does for a PNG.
+//!
+//! **The video envelope is write-only in the product today.** [`read_workflow_metadata_file`] and
+//! [`read_workflow_metadata`] have no production callers: nothing imports a clip's recipe, and no
+//! studio surface offers to replay one. Their callers are this crate's tests, which is what makes
+//! the write side provable end-to-end — an envelope is only demonstrably in a file if something can
+//! read it back out. Do not mistake the section above for a shipped round trip: it describes the
+//! posture the reader ALREADY has, so that the day a video import lands (the sc-15949 equivalent
+//! for clips) the boundary is not being designed under deadline against files from strangers. The
+//! PNG lane took the opposite order and it cost a story.
 
 use std::fmt;
 use std::fs::File;
@@ -190,8 +199,9 @@ fn io_error(error: &std::io::Error) -> WorkflowMp4Error {
 
 /// Escape one value for an `ffmetadata` document.
 ///
-/// ffmpeg's own rule: `=`, `;`, `#`, `\` and a newline are escaped with a backslash. There is no
-/// escape for a carriage return — see [`ffmetadata_document`], which is why this is not public.
+/// ffmpeg's own rule: `=`, `;`, `#`, `\` and a newline are escaped with a backslash. A carriage
+/// return is escapable the same way and is deliberately NOT escaped here — see
+/// [`ffmetadata_document`] for why one is a refusal instead, and why this is not public.
 fn escape_ffmetadata(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len() + 16);
     for character in value.chars() {
@@ -207,11 +217,18 @@ fn escape_ffmetadata(value: &str) -> String {
 ///
 /// # The carriage-return hazard
 ///
-/// `ffmetadata`'s line parser has escapes for `=`, `;`, `#`, `\` and `\n`, and **none for `\r`**.
-/// A raw carriage return in a value silently TRUNCATES it at that byte — measured: `"a\rb"` written,
-/// `"a"` read back, no error from ffmpeg at either end. That is the worst failure shape available
-/// (a recipe that is half a recipe and claims to be whole), so it is refused rather than escaped:
-/// there is nothing to escape it *to*.
+/// `ffmetadata`'s line parser treats a raw carriage return as a line terminator, and an UNESCAPED
+/// one in a value silently TRUNCATES it at that byte — measured: `"a\rb"` written, `"a"` read back,
+/// no error from ffmpeg at either end. That is the worst failure shape available: a recipe that is
+/// half a recipe and claims to be whole.
+///
+/// It is refused rather than escaped, and the reason is NOT that a `\r` is inescapable — the
+/// sc-15956 review measured that too, and `\` + CR round-trips a literal CR back out intact, the
+/// same as `\n`. The reason is what a raw CR in this string would MEAN. The value is
+/// `serde_json::to_string` output, JSON escapes every control character, and so a 0x0D byte in it
+/// says that something upstream stopped going through `serde_json` — at which point escaping it and
+/// carrying on would encode whatever else that change broke into every clip, quietly. Refusing
+/// turns an invariant violation into a failure at the seam that noticed it.
 ///
 /// It is also unreachable. The value is `serde_json::to_string` output, and JSON escapes every
 /// control character — a `\r` inside a prompt is the two bytes `\` `r`, never the one byte 0x0D.

--- a/crates/sceneworks-core/src/workflow_mp4.rs
+++ b/crates/sceneworks-core/src/workflow_mp4.rs
@@ -1,0 +1,582 @@
+//! The MP4 metadata codec for the sanitized workflow envelope (sc-15956, epic 15945).
+//!
+//! [`crate::workflow_share`] owns the *contract*; this module owns the MP4 *plumbing*, exactly as
+//! [`crate::workflow_png`] owns the PNG plumbing. The two containers could not be less alike, and
+//! every difference below is a measured one rather than a preference.
+//!
+//! # The measurement that shaped this module
+//!
+//! MP4 has no `iTXt`. It has `moov/udta/meta/ilst`, a tag store whose well-known keys are
+//! four-character codes, and ffmpeg — which is what writes every MP4 in this tree — exposes it as
+//! named metadata. Three routes were measured on a real ffmpeg before any of this was written, with
+//! a full-cap (160 kB) envelope, and two of the three do not work:
+//!
+//! | route | result |
+//! |-------|--------|
+//! | `-metadata sceneworks_workflow=…`, a CUSTOM tag | written only with `-movflags use_metadata_tags`, and **dropped by every downstream tool that does not pass that same flag** — including a plain `-c copy` remux |
+//! | `-metadata comment=…` on the COMMAND LINE | `ENAMETOOLONG` above ~32 kB. Windows caps a command line at 32,767 characters and the envelope ceiling is 160 KiB |
+//! | `-f ffmetadata -i <file>` + `-map_metadata`, tag `comment` | survives every transcode measured, at the full cap, byte-exact |
+//!
+//! So: the **standard `comment` tag**, written from a **file**. Not a namespaced key, which is the
+//! opposite of the choice [`crate::workflow_png::WORKFLOW_CHUNK_KEYWORD`] makes and for a reason
+//! that only applies here — a custom MP4 tag is not merely unconventional, it is *lossy*, and a
+//! namespace nobody can read is worth less than a shared key we can identify by its contents.
+//! [`WORKFLOW_MP4_TAG`] says the rest.
+//!
+//! Identification therefore cannot lean on the key. It leans on the marker inside the JSON, the
+//! same [`crate::workflow_share::WORKFLOW_SHARE_MARKER_KEY`] the PNG side publishes under: a
+//! `comment` that is not our envelope is somebody else's comment, and [`read_workflow_metadata`]
+//! returns `Ok(None)` for it rather than an error. That is the common case for every MP4 the user
+//! did not generate here.
+//!
+//! # What a re-encode does NOT survive, and why the tag is still worth writing
+//!
+//! `-map_metadata -1` — an explicit strip — removes it, as does any pipeline that rebuilds the
+//! container from streams alone. A platform that re-encodes an upload is such a pipeline. So the
+//! sharing premise that holds for a PNG chunk (the bytes travel intact) holds for MP4 only where
+//! the *file* travels: a copy, a download, a pass-through upload. sc-15956 records the measured
+//! matrix in full. What that leaves is still the larger half of the feature — every generated clip
+//! carries its own recipe, locally and through any file-preserving hop — and it is why the marker
+//! kind exists, so a reader can tell a video envelope from an image one.
+//!
+//! # The read side is a trust boundary, and MP4s are large
+//!
+//! The PNG reader can afford `std::fs::read`; a video cannot — a 4K clip is gigabytes and the tag
+//! is in a few hundred bytes of header. [`read_workflow_metadata_file`] therefore walks the box
+//! tree over a seeking reader, skipping `mdat` without touching it, and every bound it applies is
+//! ours rather than the file's:
+//!
+//! * a box that declares a size larger than the file is refused, not trusted;
+//! * [`MAX_WORKFLOW_TEXT_BYTES`] caps the payload actually read out of a `data` box, so a header
+//!   claiming 2 GiB costs a bounded read and a typed error;
+//! * [`MAX_BOX_DEPTH`] bounds nesting, so a hand-built file of ten thousand nested `udta` boxes
+//!   terminates;
+//! * [`MAX_BOXES_SCANNED`] bounds the total walk, so a file of a million empty boxes does too.
+//!
+//! Parsing goes through [`crate::workflow_share::parse_workflow_share_json`] and nothing else, so
+//! the sc-15946 allow-list sanitizer runs on the way in exactly as it does for a PNG.
+
+use std::fmt;
+use std::fs::File;
+use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+
+use crate::workflow_share::{
+    parse_workflow_share_json, WorkflowShare, WorkflowShareError, WORKFLOW_SHARE_MARKER_KEY,
+};
+
+/// The MP4 tag the envelope is published under: the standard `comment`, which ffmpeg maps to the
+/// `moov/udta/meta/ilst/©cmt` atom.
+///
+/// **Not namespaced, unlike the PNG keyword, and that is the measured choice rather than a
+/// concession.** A custom tag (`sceneworks_workflow`) is writable — ffmpeg's mov muxer emits
+/// arbitrary keys under `-movflags use_metadata_tags` — but the mov muxer only *re-emits* unknown
+/// keys when that same flag is passed again, so the tag is dropped by any tool that does not know
+/// to ask for it. Measured: it does not survive a plain `-c copy` remux. `comment` survives
+/// everything short of a deliberate strip.
+///
+/// The cost is that the key is shared with whatever else writes a comment, and the mitigation is
+/// that the key was never what identified the envelope: [`WORKFLOW_SHARE_MARKER_KEY`] inside the
+/// JSON is, in this container exactly as in a PNG.
+pub const WORKFLOW_MP4_TAG: &str = "comment";
+
+/// The first line of an `ffmetadata` document. ffmpeg refuses the file without it.
+pub const FFMETADATA_HEADER: &str = ";FFMETADATA1";
+
+/// Hard cap on the text read out of one `data` box, in bytes. 1 MiB.
+///
+/// The same number and the same derivation as [`crate::workflow_png::MAX_WORKFLOW_TEXT_BYTES`] —
+/// the envelope contract's own worst case is ~150 kB and the serialized whole is refused past
+/// `WORKFLOW_SHARE_MAX_BYTES` = 160 KiB regardless. There is no decompression here (an `ilst` value
+/// is stored plain), so this is a bound on a claimed length rather than on an expansion ratio: it
+/// is what stops a `data` box header declaring 2 GiB from being believed.
+pub const MAX_WORKFLOW_TEXT_BYTES: usize = 1024 * 1024;
+
+/// How deep the box walk will descend. The path we want is 5 levels
+/// (`moov/udta/meta/ilst/©cmt/data`), so this is ample and still finite.
+const MAX_BOX_DEPTH: usize = 8;
+
+/// How many boxes the walk will look at before giving up. Bounds a file whose header is a million
+/// empty boxes; a real MP4's header is a few hundred.
+const MAX_BOXES_SCANNED: usize = 100_000;
+
+/// The four-character codes on the path to the comment.
+const BOX_MOOV: [u8; 4] = *b"moov";
+const BOX_UDTA: [u8; 4] = *b"udta";
+const BOX_META: [u8; 4] = *b"meta";
+const BOX_ILST: [u8; 4] = *b"ilst";
+const BOX_DATA: [u8; 4] = *b"data";
+/// `©cmt` — the iTunes comment atom. `0xA9` is the copyright sign the four-character codes use as
+/// their "free-form text" prefix; it is a byte, not a character, and writing it as one avoids any
+/// question about the source file's encoding.
+const BOX_CMT: [u8; 4] = [0xA9, b'c', b'm', b't'];
+
+/// A `data` box's fixed prefix: 4 bytes of version+flags (1 = UTF-8 text) and 4 of locale.
+const DATA_BOX_PREFIX: u64 = 8;
+
+/// A box header: 4 bytes of size, 4 of type.
+const BOX_HEADER: u64 = 8;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Why a workflow envelope could not be encoded for, or read out of, an MP4.
+///
+/// Every variant is a sentence a user can act on, for the same reason
+/// [`crate::workflow_png::WorkflowChunkError`] is: these files travel, and "invalid box size at
+/// offset 41264" is not an answer to "why won't this clip load its recipe?".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkflowMp4Error {
+    /// Opening, reading or writing the file failed.
+    Io { detail: String },
+    /// The container's box framing is truncated, overlapping or otherwise unreadable.
+    Malformed { detail: String },
+    /// The comment atom is larger than [`MAX_WORKFLOW_TEXT_BYTES`].
+    TooLarge { bytes: usize, limit: usize },
+    /// The comment atom is not valid UTF-8, so it did not come from this app.
+    NotUtf8,
+    /// The envelope was found and refused by the contract. Carries the reason verbatim.
+    Share(WorkflowShareError),
+    /// The envelope contains a character `ffmetadata` cannot represent. Unreachable for a
+    /// serialized [`WorkflowShare`] — see [`ffmetadata_document`] — and typed so that a future
+    /// field that broke the assumption would fail loudly rather than silently truncate.
+    Unencodable { detail: String },
+}
+
+impl fmt::Display for WorkflowMp4Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { detail } => write!(formatter, "Could not read the video file: {detail}"),
+            Self::Malformed { detail } => write!(
+                formatter,
+                "This video's container structure could not be read: {detail}"
+            ),
+            Self::TooLarge { bytes, limit } => write!(
+                formatter,
+                "This video's embedded workflow is {bytes} bytes, over the {limit}-byte limit."
+            ),
+            Self::NotUtf8 => write!(
+                formatter,
+                "This video's comment is not UTF-8 text, so it did not come from SceneWorks."
+            ),
+            Self::Share(error) => write!(formatter, "{error}"),
+            Self::Unencodable { detail } => write!(
+                formatter,
+                "This workflow cannot be written into a video file: {detail}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for WorkflowMp4Error {}
+
+impl From<WorkflowShareError> for WorkflowMp4Error {
+    fn from(error: WorkflowShareError) -> Self {
+        Self::Share(error)
+    }
+}
+
+fn io_error(error: &std::io::Error) -> WorkflowMp4Error {
+    WorkflowMp4Error::Io {
+        detail: error.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Write: the ffmetadata document
+// ---------------------------------------------------------------------------
+
+/// Escape one value for an `ffmetadata` document.
+///
+/// ffmpeg's own rule: `=`, `;`, `#`, `\` and a newline are escaped with a backslash. There is no
+/// escape for a carriage return — see [`ffmetadata_document`], which is why this is not public.
+fn escape_ffmetadata(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 16);
+    for character in value.chars() {
+        if matches!(character, '=' | ';' | '#' | '\\' | '\n') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
+/// The `ffmetadata` document that puts `share` in the [`WORKFLOW_MP4_TAG`] tag.
+///
+/// # The carriage-return hazard
+///
+/// `ffmetadata`'s line parser has escapes for `=`, `;`, `#`, `\` and `\n`, and **none for `\r`**.
+/// A raw carriage return in a value silently TRUNCATES it at that byte — measured: `"a\rb"` written,
+/// `"a"` read back, no error from ffmpeg at either end. That is the worst failure shape available
+/// (a recipe that is half a recipe and claims to be whole), so it is refused rather than escaped:
+/// there is nothing to escape it *to*.
+///
+/// It is also unreachable. The value is `serde_json::to_string` output, and JSON escapes every
+/// control character — a `\r` inside a prompt is the two bytes `\` `r`, never the one byte 0x0D.
+/// The check below is therefore a guard on an invariant rather than a branch anyone takes, and it
+/// exists because "unreachable" and "unchecked" are how a future field that stops serializing
+/// through `serde_json` would corrupt every clip it touched without failing anything.
+///
+/// # Errors
+/// [`WorkflowMp4Error::Unencodable`] if the serialized envelope contains a raw carriage return, and
+/// [`WorkflowMp4Error::Share`] if it cannot be serialized at all.
+pub fn ffmetadata_document(share: &WorkflowShare) -> Result<String, WorkflowMp4Error> {
+    let payload = serde_json::to_string(share).map_err(|error| WorkflowMp4Error::Unencodable {
+        detail: error.to_string(),
+    })?;
+    if payload.contains('\r') {
+        return Err(WorkflowMp4Error::Unencodable {
+            detail: "the envelope contains a carriage return, which `ffmetadata` truncates at \
+                     rather than escapes"
+                .to_owned(),
+        });
+    }
+    Ok(format!(
+        "{FFMETADATA_HEADER}\n{WORKFLOW_MP4_TAG}={}\n",
+        escape_ffmetadata(&payload)
+    ))
+}
+
+/// Write [`ffmetadata_document`] to `path`, for ffmpeg to read with `-f ffmetadata -i <path>`.
+///
+/// A FILE rather than a `-metadata` argument, and that is not a style choice: a command-line
+/// argument is capped at 32,767 characters on Windows and the envelope ceiling is 160 KiB, so the
+/// argv route fails with `ENAMETOOLONG` on any envelope past ~32 kB. Measured before this module
+/// existed; see the module docs.
+///
+/// # Errors
+/// [`WorkflowMp4Error::Io`] if the file cannot be written, plus [`ffmetadata_document`]'s.
+pub fn write_workflow_metadata_file(
+    share: &WorkflowShare,
+    path: &Path,
+) -> Result<(), WorkflowMp4Error> {
+    let document = ffmetadata_document(share)?;
+    std::fs::write(path, document).map_err(|error| io_error(&error))
+}
+
+/// The ffmpeg arguments that attach a written [`write_workflow_metadata_file`] document as an
+/// input, and map it onto the output's container metadata.
+///
+/// `input_index` is the index this input will take among ffmpeg's `-i` arguments — the caller knows
+/// it, because the caller built the rest of the command. Returned as two halves because they go in
+/// different places: the input pair belongs with the other `-i`s, and `-map_metadata` belongs with
+/// the output options.
+#[must_use]
+pub fn ffmetadata_input_args(path: &Path) -> Vec<String> {
+    vec![
+        "-f".to_owned(),
+        "ffmetadata".to_owned(),
+        "-i".to_owned(),
+        path.to_string_lossy().into_owned(),
+    ]
+}
+
+/// The `-map_metadata` pair naming the input [`ffmetadata_input_args`] added.
+#[must_use]
+pub fn ffmetadata_map_args(input_index: usize) -> Vec<String> {
+    vec!["-map_metadata".to_owned(), input_index.to_string()]
+}
+
+/// How many bytes the envelope occupies in an MP4's tag store — the measurement the recording
+/// ceiling is spent in for this container.
+///
+/// The `ilst` framing (`©cmt` + `data` headers + version/flags + locale) is 24 bytes on top of the
+/// UTF-8 payload. Reported so a caller can compare containers honestly; the ceiling itself is
+/// applied to the serialized envelope by `embeddable_workflow_share`, identically for both.
+///
+/// # Errors
+/// [`WorkflowMp4Error::Unencodable`] if the envelope cannot be serialized.
+pub fn workflow_metadata_size(share: &WorkflowShare) -> Result<usize, WorkflowMp4Error> {
+    let payload = serde_json::to_string(share).map_err(|error| WorkflowMp4Error::Unencodable {
+        detail: error.to_string(),
+    })?;
+    // `©cmt` header (8) + `data` header (8) + version/flags (4) + locale (4).
+    Ok(payload.len() + 24)
+}
+
+// ---------------------------------------------------------------------------
+// Read: the box walk
+// ---------------------------------------------------------------------------
+
+/// Read the envelope out of an MP4 on disk.
+///
+/// Seeks rather than reads: a generated clip is routinely hundreds of megabytes and the tag lives
+/// in the header, so `mdat` is skipped over without ever being buffered.
+///
+/// `Ok(None)` for a video with no comment, or with a comment that is not one of ours — the common
+/// case for every MP4 the user did not generate here, and not something to shout about.
+///
+/// # Errors
+/// See [`WorkflowMp4Error`].
+pub fn read_workflow_metadata_file(path: &Path) -> Result<Option<WorkflowShare>, WorkflowMp4Error> {
+    let file = File::open(path).map_err(|error| io_error(&error))?;
+    let length = file
+        .metadata()
+        .map_err(|error| io_error(&error))?
+        .len();
+    let mut reader = BufReader::new(file);
+    read_workflow_metadata_from(&mut reader, length)
+}
+
+/// [`read_workflow_metadata_file`] against bytes already in memory. For tests and for callers that
+/// hold a small clip; prefer the file form for anything a user generated.
+///
+/// # Errors
+/// See [`WorkflowMp4Error`].
+pub fn read_workflow_metadata(bytes: &[u8]) -> Result<Option<WorkflowShare>, WorkflowMp4Error> {
+    let length = bytes.len() as u64;
+    let mut cursor = std::io::Cursor::new(bytes);
+    read_workflow_metadata_from(&mut cursor, length)
+}
+
+/// The comment string an MP4 carries, before it is judged to be an envelope or not.
+///
+/// Separate from [`read_workflow_metadata`] so a caller that wants to know what is actually in the
+/// tag — a diagnostic, a test — does not have to infer it from a `None`.
+///
+/// # Errors
+/// See [`WorkflowMp4Error`].
+pub fn read_mp4_comment(bytes: &[u8]) -> Result<Option<String>, WorkflowMp4Error> {
+    let length = bytes.len() as u64;
+    let mut cursor = std::io::Cursor::new(bytes);
+    find_comment(&mut cursor, length)
+}
+
+fn read_workflow_metadata_from<R: Read + Seek>(
+    reader: &mut R,
+    length: u64,
+) -> Result<Option<WorkflowShare>, WorkflowMp4Error> {
+    let Some(comment) = find_comment(reader, length)? else {
+        return Ok(None);
+    };
+    // The key is shared, so the marker inside decides. A comment somebody else wrote is an
+    // absence, not a failure — the same answer a PNG with no `sceneworks:workflow` chunk gets.
+    if !comment.contains(WORKFLOW_SHARE_MARKER_KEY) {
+        return Ok(None);
+    }
+    Ok(Some(parse_workflow_share_json(&comment)?))
+}
+
+/// One box header, read at the reader's current position.
+struct BoxHeader {
+    kind: [u8; 4],
+    /// Where the box's payload starts, absolute.
+    body_start: u64,
+    /// Where the box ends, absolute.
+    end: u64,
+}
+
+/// Read a box header at `offset`, bounded by `limit` (the end of the enclosing box, or the file).
+fn read_box_header<R: Read + Seek>(
+    reader: &mut R,
+    offset: u64,
+    limit: u64,
+) -> Result<Option<BoxHeader>, WorkflowMp4Error> {
+    if offset.saturating_add(BOX_HEADER) > limit {
+        return Ok(None);
+    }
+    reader
+        .seek(SeekFrom::Start(offset))
+        .map_err(|error| io_error(&error))?;
+    let mut header = [0u8; 8];
+    reader
+        .read_exact(&mut header)
+        .map_err(|error| io_error(&error))?;
+    let declared = u32::from_be_bytes([header[0], header[1], header[2], header[3]]);
+    let kind = [header[4], header[5], header[6], header[7]];
+
+    let (body_start, size) = match declared {
+        // `size == 1` means the real size is a 64-bit value after the type.
+        1 => {
+            if offset.saturating_add(16) > limit {
+                return Err(WorkflowMp4Error::Malformed {
+                    detail: "a 64-bit box size runs past the end of the file".to_owned(),
+                });
+            }
+            let mut large = [0u8; 8];
+            reader
+                .read_exact(&mut large)
+                .map_err(|error| io_error(&error))?;
+            (offset + 16, u64::from_be_bytes(large))
+        }
+        // `size == 0` means "to the end of the enclosing box".
+        0 => (offset + BOX_HEADER, limit - offset),
+        _ => (offset + BOX_HEADER, u64::from(declared)),
+    };
+
+    let end = offset.checked_add(size).ok_or(WorkflowMp4Error::Malformed {
+        detail: "a box size overflows the file offset".to_owned(),
+    })?;
+    if size < body_start - offset || end > limit {
+        return Err(WorkflowMp4Error::Malformed {
+            detail: format!(
+                "a `{}` box declares {size} bytes, which does not fit inside its parent",
+                String::from_utf8_lossy(&kind)
+            ),
+        });
+    }
+    Ok(Some(BoxHeader {
+        kind,
+        body_start,
+        end,
+    }))
+}
+
+/// Walk `moov/udta/meta/ilst/©cmt/data` and return the comment text.
+fn find_comment<R: Read + Seek>(
+    reader: &mut R,
+    length: u64,
+) -> Result<Option<String>, WorkflowMp4Error> {
+    let mut scanned = 0usize;
+    descend(reader, 0, length, &PATH, 0, &mut scanned)
+}
+
+/// The containers on the way to the comment, in order. `meta` is handled specially (see
+/// [`descend`]) because its FullBox prefix is not universal.
+const PATH: [[u8; 4]; 4] = [BOX_MOOV, BOX_UDTA, BOX_META, BOX_ILST];
+
+fn descend<R: Read + Seek>(
+    reader: &mut R,
+    start: u64,
+    limit: u64,
+    path: &[[u8; 4]],
+    depth: usize,
+    scanned: &mut usize,
+) -> Result<Option<String>, WorkflowMp4Error> {
+    if depth > MAX_BOX_DEPTH {
+        return Ok(None);
+    }
+    let mut offset = start;
+    while let Some(header) = read_box_header(reader, offset, limit)? {
+        *scanned += 1;
+        if *scanned > MAX_BOXES_SCANNED {
+            return Err(WorkflowMp4Error::Malformed {
+                detail: format!("more than {MAX_BOXES_SCANNED} boxes in the header"),
+            });
+        }
+        // A zero-length box would spin the walk forever.
+        if header.end <= offset {
+            return Err(WorkflowMp4Error::Malformed {
+                detail: "a box declares no length, so the walk cannot advance".to_owned(),
+            });
+        }
+        if path.is_empty() {
+            // Inside `ilst`: the comment atom, whose only child is a `data` box.
+            if header.kind == BOX_CMT {
+                if let Some(text) = read_comment_data(reader, header.body_start, header.end)? {
+                    return Ok(Some(text));
+                }
+            }
+        } else if header.kind == path[0] {
+            // `meta` is a FullBox in the ISO/iTunes flavour ffmpeg writes (4 bytes of version and
+            // flags before its children) and a plain container in some QuickTime files. Sniffing
+            // is what makes the reader work on both: if the four bytes after the prefix are a
+            // plausible box type, the prefix was really a box header and there is no FullBox.
+            let body_start = if header.kind == BOX_META {
+                meta_body_start(reader, header.body_start, header.end)?
+            } else {
+                header.body_start
+            };
+            if let Some(found) = descend(
+                reader,
+                body_start,
+                header.end,
+                &path[1..],
+                depth + 1,
+                scanned,
+            )? {
+                return Ok(Some(found));
+            }
+        }
+        offset = header.end;
+    }
+    Ok(None)
+}
+
+/// Where a `meta` box's children start: after its 4-byte version+flags, unless the box is the
+/// prefix-less QuickTime form.
+fn meta_body_start<R: Read + Seek>(
+    reader: &mut R,
+    body_start: u64,
+    end: u64,
+) -> Result<u64, WorkflowMp4Error> {
+    // A FullBox `meta` is followed by a child box header, so bytes 4..8 of its body are that
+    // child's TYPE. A prefix-less `meta` starts with the child header immediately, so bytes 4..8
+    // are the type and bytes 0..4 a size. Distinguishing them: read bytes 4..8 and ask whether they
+    // look like a four-character code. `hdlr` does; the 0x00000000 version+flags word does not.
+    if body_start.saturating_add(8) > end {
+        return Ok(body_start);
+    }
+    reader
+        .seek(SeekFrom::Start(body_start))
+        .map_err(|error| io_error(&error))?;
+    let mut probe = [0u8; 8];
+    reader
+        .read_exact(&mut probe)
+        .map_err(|error| io_error(&error))?;
+    if is_box_type(&probe[4..8]) {
+        // bytes 0..4 were a size and 4..8 a type: no FullBox prefix.
+        Ok(body_start)
+    } else {
+        Ok(body_start + 4)
+    }
+}
+
+/// Whether four bytes look like a four-character box type: printable ASCII, or the `0xA9` prefix
+/// the iTunes atoms use.
+fn is_box_type(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .all(|byte| (0x20..=0x7E).contains(byte) || *byte == 0xA9)
+}
+
+/// Read the `data` box inside a `©cmt` atom.
+fn read_comment_data<R: Read + Seek>(
+    reader: &mut R,
+    start: u64,
+    limit: u64,
+) -> Result<Option<String>, WorkflowMp4Error> {
+    let mut offset = start;
+    while let Some(header) = read_box_header(reader, offset, limit)? {
+        if header.end <= offset {
+            return Err(WorkflowMp4Error::Malformed {
+                detail: "a `data` box declares no length".to_owned(),
+            });
+        }
+        if header.kind == BOX_DATA {
+            let payload_start = header.body_start + DATA_BOX_PREFIX;
+            if payload_start > header.end {
+                return Err(WorkflowMp4Error::Malformed {
+                    detail: "a `data` box is too short to hold its own type indicator".to_owned(),
+                });
+            }
+            let payload_len = header.end - payload_start;
+            // OUR bound, not the file's: a header claiming 2 GiB costs this comparison.
+            let payload_len = usize::try_from(payload_len).map_err(|_| {
+                WorkflowMp4Error::TooLarge {
+                    bytes: usize::MAX,
+                    limit: MAX_WORKFLOW_TEXT_BYTES,
+                }
+            })?;
+            if payload_len > MAX_WORKFLOW_TEXT_BYTES {
+                return Err(WorkflowMp4Error::TooLarge {
+                    bytes: payload_len,
+                    limit: MAX_WORKFLOW_TEXT_BYTES,
+                });
+            }
+            reader
+                .seek(SeekFrom::Start(payload_start))
+                .map_err(|error| io_error(&error))?;
+            let mut payload = vec![0u8; payload_len];
+            reader
+                .read_exact(&mut payload)
+                .map_err(|error| io_error(&error))?;
+            return String::from_utf8(payload)
+                .map(Some)
+                .map_err(|_| WorkflowMp4Error::NotUtf8);
+        }
+        offset = header.end;
+    }
+    Ok(None)
+}

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -50,7 +50,9 @@ use std::path::Path;
 use image::{ImageFormat, RgbImage};
 use png::text_metadata::ITXtChunk;
 
-use crate::workflow_share::{parse_workflow_share_json, WorkflowShare, WorkflowShareError};
+use crate::workflow_share::{
+    parse_workflow_share_json, WorkflowShare, WorkflowShareError, WORKFLOW_KIND_IMAGE,
+};
 
 /// The `iTXt` keyword the envelope is published under.
 ///
@@ -737,7 +739,29 @@ fn read_workflow_chunk_from<R: BufRead + Seek>(
     // The ONLY parse path, so the sc-15946 allow-list sanitizer runs on every envelope that
     // arrives from outside. A second `serde_json::from_str::<WorkflowShare>` here would read the
     // same JSON without the value-level guards.
-    Ok(Some(parse_workflow_share_json(&text)?))
+    let share = parse_workflow_share_json(&text)?;
+    // A PNG carries an IMAGE workflow. Nothing else (sc-15956).
+    //
+    // `parse_workflow_share` validates the ENVELOPE and, since the video lane shipped, accepts
+    // either kind — which is right for the contract and wrong for a consumer. Without this the
+    // widened gate would have quietly changed THIS module's behaviour: a PNG carrying a video
+    // envelope used to be refused, and would have started parsing, so every reader downstream
+    // (`/workflows/inspect`, the Image Editor's header, the drag-to-load import) would have offered
+    // a video recipe as an image prefill.
+    //
+    // So the container asserts its own kind, and `workflow_mp4::read_workflow_metadata` does the
+    // symmetrical thing. Our writers only ever pair a PNG with an image envelope and an MP4 with a
+    // video one, so a mismatch is a hand-made file or a future build's, and refusing is what the
+    // `UnsupportedKind` sentence already says to a user.
+    if share.kind != WORKFLOW_KIND_IMAGE {
+        return Err(WorkflowChunkError::Envelope(
+            WorkflowShareError::UnsupportedKind {
+                found: share.kind,
+                supported: WORKFLOW_KIND_IMAGE.to_owned(),
+            },
+        ));
+    }
+    Ok(Some(share))
 }
 
 /// Pick our chunk out of the `iTXt` chunks the decoder has parsed so far.

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -1936,10 +1936,10 @@ mod tests {
                 WorkflowShareError::MissingSchemaVersion,
             ),
             (
-                "{\"sceneworksWorkflow\": \"video\", \"schemaVersion\": 1}",
+                "{\"sceneworksWorkflow\": \"hologram\", \"schemaVersion\": 1}",
                 WorkflowShareError::UnsupportedKind {
-                    found: "video".to_owned(),
-                    supported: "image".to_owned(),
+                    found: "hologram".to_owned(),
+                    supported: "image, video".to_owned(),
                 },
             ),
             (

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -829,11 +829,10 @@ pub const PERMANENT_EXEMPTION: &str = "PERMANENT EXEMPTION:";
 /// to know which web builder feeds a Rust seam — so what it guarantees is that the statement had
 /// to be written at all, and that the honest version of it fails the build. Review is what catches
 /// the dishonest one.
-pub const DEFERRED_ADVANCED_BUILDERS: &[DeferredAdvancedBuilder] = &[
-    DeferredAdvancedBuilder {
-        path: "apps/web/src/training/trainingConfig.js",
-        function: "trainingConfigSnapshot",
-        reason: "PERMANENT EXEMPTION: the Training Studio's `advanced` is a DIFFERENT namespace \
+pub const DEFERRED_ADVANCED_BUILDERS: &[DeferredAdvancedBuilder] = &[DeferredAdvancedBuilder {
+    path: "apps/web/src/training/trainingConfig.js",
+    function: "trainingConfigSnapshot",
+    reason: "PERMANENT EXEMPTION: the Training Studio's `advanced` is a DIFFERENT namespace \
                  from the image payload's — trainer hyperparameters (networkType, lrScheduler, \
                  sampleSteps, decomposeFactor) on a training job, not generation intent for an \
                  image. No training write seam EMBEDS a workflow, nothing sanitizes these keys \
@@ -842,8 +841,7 @@ pub const DEFERRED_ADVANCED_BUILDERS: &[DeferredAdvancedBuilder] = &[
                  would have to change is a training write seam that embeds. Then, and only then, \
                  this entry moves into `ADVANCED_BUILDERS` and every key it emits needs an \
                  allow/deny decision.",
-    },
-];
+}];
 
 /// A (file, function) reference to one entry in [`ADVANCED_BUILDERS`] or
 /// [`DEFERRED_ADVANCED_BUILDERS`] (sc-16113).

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -1018,6 +1018,13 @@ pub const WORKFLOW_WRITE_SEAMS: &[WorkflowWriteSeam] = &[
         ),
     },
     WorkflowWriteSeam {
+        path: "crates/sceneworks-worker/src/video_jobs/mod.rs",
+        function: "video_workflow_metadata",
+        lane: "POST /api/v1/jobs type=video_generate — the ONE funnel every generated clip is \
+               encoded through (`encode_media`), whatever engine, route or studio produced it",
+        disposition: SeamDisposition::Embeds(VIDEO_JOB_BUILDERS),
+    },
+    WorkflowWriteSeam {
         path: "crates/sceneworks-worker/src/segment_jobs.rs",
         function: "run_image_segment_job",
         lane: "POST /api/v1/jobs type=image_segment — the smart-select mask",
@@ -1027,6 +1034,37 @@ pub const WORKFLOW_WRITE_SEAMS: &[WorkflowWriteSeam] = &[
              grayscale, and the chunk writer encodes RGB8, so embedding would triple its size and \
              change its colour type.",
         ),
+    },
+];
+
+/// Every builder behind a generated clip (sc-15956).
+///
+/// All six feed ONE seam, because all six post `type=video_generate` and every video job funnels
+/// through `encode_media` — the same property that let sc-12371 measure clip length in one place.
+const VIDEO_JOB_BUILDERS: &[WebBuilderRef] = &[
+    WebBuilderRef {
+        path: "apps/web/src/screens/VideoStudio.jsx",
+        function: "submit",
+    },
+    WebBuilderRef {
+        path: "apps/web/src/components/editor/useEditorGeneration.js",
+        function: "buildBasePayload",
+    },
+    WebBuilderRef {
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "extendSelectedClip",
+    },
+    WebBuilderRef {
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "replaceSelectedItem",
+    },
+    WebBuilderRef {
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "bridgeGap",
+    },
+    WebBuilderRef {
+        path: "apps/web/src/simple/simpleJobs.js",
+        function: "buildSimpleVideoRequest",
     },
 ];
 

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -245,8 +245,16 @@ pub struct WorkflowShare {
     /// **Video lane**: the frame rate the user asked for. The ask, for the reason above.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fps: Option<u32>,
-    /// **Video lane**: the quality preset the run was submitted at (`draft` / `standard` / …).
+    /// **Video lane**: the quality preset the run was submitted at — `fast`, `balanced` or `best`,
+    /// the closed vocabulary `qualityChoices` in `apps/web/src/jobTypes.js` offers (the studio
+    /// LABELS them "Draft" / "Balanced" / "Final"; the value is what travels). Written as
+    /// `draft` / `standard` here until the sc-15956 review measured it — neither was a value the
+    /// app can emit.
+    ///
     /// A named tier off a menu, not a hardware budget — the receiving install has the same menu.
+    /// The field is still an unvalidated string on the parse side, because an envelope from a
+    /// newer build may name a tier this one has never heard of and refusing the whole recipe over
+    /// a menu label would be worse than reporting it unresolved.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quality: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -480,6 +488,11 @@ pub enum AdvancedKeySource {
     /// image sibling delegates to `buildImageJobRequest` and so rides [`Self::StudioBuilder`];
     /// this one builds its own two-key map.
     SimpleVideoBuilder,
+    /// `VideoUpscalePanel.onUpscale` — the standalone `video_upscale` job's payload (sc-15956
+    /// review). It emits NO `advanced` map, and is registered for exactly the reason
+    /// [`Self::UpscaleBuilder`] is: its lane embeds, so the day it grows a knob the lint demands a
+    /// classification. No rule is tagged with it.
+    VideoUpscaleBuilder,
     /// Stamped onto `advanced` by the API after the request arrives (recipe-preset resolution
     /// in `apps/rust-api/src/generation.rs`). Classified here for the record; the lint does
     /// not expect to find them in the JS, and no [`ADVANCED_BUILDERS`] entry claims it.
@@ -504,6 +517,7 @@ impl AdvancedKeySource {
         Self::TimelineReplaceBuilder,
         Self::TimelineBridgeBuilder,
         Self::SimpleVideoBuilder,
+        Self::VideoUpscaleBuilder,
         Self::Server,
     ];
 }
@@ -748,6 +762,17 @@ pub const ADVANCED_BUILDERS: &[AdvancedBuilder] = &[
                by `video_jobs/mod.rs::encode_media`",
         anchors: &["resolution"],
         minimum_keys: 1,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::VideoUpscaleBuilder,
+        path: "apps/web/src/screens/VideoUpscalePanel.jsx",
+        function: "onUpscale",
+        shape: AdvancedBuilderShape::NoAdvancedMap,
+        lane: "POST /api/v1/jobs type=video_upscale, written by \
+               `video_jobs/seedvr2.rs::encode_seedvr2_stream`",
+        anchors: &[],
+        minimum_keys: 0,
         spread_of: &[],
     },
 ];
@@ -1018,9 +1043,17 @@ pub const WORKFLOW_WRITE_SEAMS: &[WorkflowWriteSeam] = &[
     WorkflowWriteSeam {
         path: "crates/sceneworks-worker/src/video_jobs/mod.rs",
         function: "video_workflow_metadata",
-        lane: "POST /api/v1/jobs type=video_generate — the ONE funnel every generated clip is \
-               encoded through (`encode_media`), whatever engine, route or studio produced it",
+        lane: "POST /api/v1/jobs type=video_generate — the funnel every GENERATED clip is encoded \
+               through (`encode_media`), whatever engine, route or studio produced it",
         disposition: SeamDisposition::Embeds(VIDEO_JOB_BUILDERS),
+    },
+    WorkflowWriteSeam {
+        path: "crates/sceneworks-worker/src/video_jobs/seedvr2.rs",
+        function: "seedvr2_workflow_metadata",
+        lane: "POST /api/v1/jobs type=video_upscale — the SeedVR2 upscale's own clip, encoded \
+               through `encode_seedvr2_stream` (macOS + candle-gated; the scan is textual, so \
+               this seam is read on every platform)",
+        disposition: SeamDisposition::Embeds(VIDEO_UPSCALE_BUILDERS),
     },
     WorkflowWriteSeam {
         path: "crates/sceneworks-worker/src/segment_jobs.rs",
@@ -1035,10 +1068,27 @@ pub const WORKFLOW_WRITE_SEAMS: &[WorkflowWriteSeam] = &[
     },
 ];
 
+/// The builder behind an upscaled clip (sc-15956 review).
+///
+/// Its own list rather than a seventh entry in [`VIDEO_JOB_BUILDERS`], because it is a different
+/// job type on a different encoder: `type=video_upscale` through `encode_seedvr2_stream`, not
+/// `type=video_generate` through `encode_media`. The image lane draws the same line —
+/// `buildUpscaleJobBody` feeds `run_image_upscale_job` and nothing else.
+///
+/// The panel posts no `advanced` map at all, and is registered precisely so that stays true: it
+/// feeds an embedding lane, so the day it grows a knob the coverage lint demands a classification
+/// instead of dropping it silently.
+const VIDEO_UPSCALE_BUILDERS: &[WebBuilderRef] = &[WebBuilderRef {
+    path: "apps/web/src/screens/VideoUpscalePanel.jsx",
+    function: "onUpscale",
+}];
+
 /// Every builder behind a generated clip (sc-15956).
 ///
-/// All six feed ONE seam, because all six post `type=video_generate` and every video job funnels
-/// through `encode_media` — the same property that let sc-12371 measure clip length in one place.
+/// All six feed ONE seam, because all six post `type=video_generate` and every video-GENERATE job
+/// funnels through `encode_media` — the same property that let sc-12371 measure clip length in one
+/// place. It is not, and never was, the only libx264 site in the worker: `video_upscale` has one of
+/// its own, and [`VIDEO_UPSCALE_BUILDERS`] is the seam behind it.
 const VIDEO_JOB_BUILDERS: &[WebBuilderRef] = &[
     WebBuilderRef {
         path: "apps/web/src/screens/VideoStudio.jsx",

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -74,6 +74,29 @@ pub const WORKFLOW_SHARE_MARKER_KEY: &str = "sceneworksWorkflow";
 /// (sc-15956) can share the marker key without a reader having to sniff the body.
 pub const WORKFLOW_KIND_IMAGE: &str = "image";
 
+/// Marker value for the video lane (sc-15956).
+///
+/// A NEW KIND rather than a `schemaVersion` bump, and that is the load-bearing decision. The two
+/// gates in [`parse_workflow_share`] fail differently and only one of them is right here:
+///
+/// * a version bump would make an older build report *"this file was written by a newer version of
+///   SceneWorks"* for a video — true, but it would say the same about an image, and the image
+///   contract did not change;
+/// * an unknown KIND makes an older build report exactly what is wrong — it does not understand
+///   this kind of workflow — and it does so for videos ONLY, leaving every shared image reading as
+///   it always did.
+///
+/// The kind gate deliberately runs BEFORE the version gate for that reason. sc-15954 established
+/// the surrounding rule this follows: an older reader that would present a recipe it does not
+/// really understand is worse than one that refuses, so the refusal is arranged to happen.
+pub const WORKFLOW_KIND_VIDEO: &str = "video";
+
+/// The workflow kinds this build understands, in the order a reader should think about them.
+///
+/// The parse gate is a membership test against this rather than a chain of `==`, so adding a third
+/// lane is one entry and cannot half-land.
+pub const WORKFLOW_KINDS: &[&str] = &[WORKFLOW_KIND_IMAGE, WORKFLOW_KIND_VIDEO];
+
 /// The contract version. Bump ONLY on a breaking field change — an additive field does not
 /// need it (an older reader drops what it does not know). [`parse_workflow_share`] branches
 /// on this and on nothing else.
@@ -136,6 +159,16 @@ pub const INPUT_KIND_REFERENCE: &str = "reference";
 pub const INPUT_KIND_MASK: &str = "mask";
 /// A pre-made control map fed verbatim (`advanced.controlImage`).
 pub const INPUT_KIND_CONTROL: &str = "control";
+/// A source CLIP a video run continues, re-times or bridges from (`sourceClipAssetId`,
+/// `sourceClipAssetIds`, `bridgeRightClipAssetId`) — sc-15956.
+///
+/// A separate kind from [`INPUT_KIND_SOURCE`] because the two are not interchangeable to a reader:
+/// "this recipe needs a still to start from" and "this recipe needs a clip to continue" are
+/// different missing-input panels and different asks of the person replaying it.
+pub const INPUT_KIND_SOURCE_CLIP: &str = "sourceClip";
+/// A reference CLIP a video run conditions on (`referenceClipAssetId`, Bernini's ads2v) —
+/// sc-15956. The moving counterpart of [`INPUT_KIND_REFERENCE`].
+pub const INPUT_KIND_REFERENCE_CLIP: &str = "referenceClip";
 
 /// A LoRA the run applied, reduced to what another install can act on: the display name, the
 /// weight, and the Hugging Face repo id when the catalog entry resolved to one. No local id,
@@ -201,6 +234,21 @@ pub struct WorkflowShare {
     pub height: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub count: Option<u32>,
+    /// **Video lane** (sc-15956): the clip length the user ASKED for, in seconds.
+    ///
+    /// The ask, not the measurement. `file.duration` on the sidecar is what the encoder actually
+    /// produced — those differ whenever a model's temporal stride snaps the frame count, and a 6.0 s
+    /// ask that rendered 5.96 s replays as 6.0 (sc-12371 established the same split for the
+    /// sidecar). An envelope is a recipe: it must round-trip the ask.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_seconds: Option<f64>,
+    /// **Video lane**: the frame rate the user asked for. The ask, for the reason above.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fps: Option<u32>,
+    /// **Video lane**: the quality preset the run was submitted at (`draft` / `standard` / …).
+    /// A named tier off a menu, not a hardware budget — the receiving install has the same menu.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub style_preset: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -338,7 +386,7 @@ impl fmt::Display for WorkflowShareError {
             ),
             Self::UnsupportedKind { found, supported } => write!(
                 f,
-                "This is a `{found}` SceneWorks workflow; this reader handles `{supported}` workflows."
+                "This is a `{found}` SceneWorks workflow; this build reads: {supported}. Update {PRODUCER_NAME} to load it."
             ),
             Self::MissingSchemaVersion => write!(
                 f,
@@ -413,6 +461,25 @@ pub enum AdvancedKeySource {
     /// is registered precisely so that stays true: it feeds an embedding lane (sc-15948 ISSUE 1),
     /// so the day it grows a knob the lint demands a classification. No rule is tagged with it.
     UpscaleBuilder,
+    /// `VideoStudio.submit` — the Video Studio's own ~20-knob builder, and the video lane's
+    /// equivalent of [`Self::StudioBuilder`] (sc-15956).
+    VideoStudioBuilder,
+    /// `useEditorGeneration.buildBasePayload` — the timeline editor's shared video payload, spread
+    /// into all three [`Self::TimelineExtendBuilder`]-family actions (sc-15956).
+    TimelineBaseBuilder,
+    /// `EditorScreen.extendSelectedClip` — the timeline "extend this clip" action. It and its two
+    /// siblings each spread `buildBasePayload`'s map and add `timelineAction` / `timelineContext`;
+    /// those two keys are tagged to this one, because a key needs just one builder holding it
+    /// honest and all three emit the same pair.
+    TimelineExtendBuilder,
+    /// `EditorScreen.replaceSelectedItem` — the timeline "replace this clip" action.
+    TimelineReplaceBuilder,
+    /// `EditorScreen.bridgeGap` — the timeline "bridge this gap" action.
+    TimelineBridgeBuilder,
+    /// `simpleJobs.buildSimpleVideoRequest` — the Simple shell's video request (sc-15956). Its
+    /// image sibling delegates to `buildImageJobRequest` and so rides [`Self::StudioBuilder`];
+    /// this one builds its own two-key map.
+    SimpleVideoBuilder,
     /// Stamped onto `advanced` by the API after the request arrives (recipe-preset resolution
     /// in `apps/rust-api/src/generation.rs`). Classified here for the record; the lint does
     /// not expect to find them in the JS, and no [`ADVANCED_BUILDERS`] entry claims it.
@@ -431,6 +498,12 @@ impl AdvancedKeySource {
         Self::CharacterPoseExtras,
         Self::InterleaveBuilder,
         Self::UpscaleBuilder,
+        Self::VideoStudioBuilder,
+        Self::TimelineBaseBuilder,
+        Self::TimelineExtendBuilder,
+        Self::TimelineReplaceBuilder,
+        Self::TimelineBridgeBuilder,
+        Self::SimpleVideoBuilder,
         Self::Server,
     ];
 }
@@ -460,6 +533,16 @@ pub enum AdvancedBuilderShape {
     /// because it feeds an embedding lane: the lint asserts the function stays empty of
     /// `advanced`, so the day someone adds a knob there it has to be classified.
     NoAdvancedMap,
+    /// `advanced: { key, ...(cond ? { key } : {}) }` — an `advanced:` literal WITH conditional
+    /// spreads, in a payload passed to a call rather than returned (sc-15956).
+    ///
+    /// The video builders' shape, and the one the four existing arms between them could not read:
+    /// [`Self::FlatAdvancedLiteral`] asserts the literal has no spread and no nesting, and
+    /// [`Self::ReturnedObject`] looks for a `return {`. Uses the same brace-aware
+    /// `scan_object_literal` [`Self::ReturnedObject`] does, and honours
+    /// [`AdvancedBuilder::spread_of`] the way [`Self::AssignedObject`] does — so a spread of
+    /// somebody else's map has to name the builder that accounts for it.
+    SpreadAdvancedLiteral,
 }
 
 /// One JS builder whose `advanced` keys reach an embedding lane.
@@ -588,6 +671,85 @@ pub const ADVANCED_BUILDERS: &[AdvancedBuilder] = &[
         minimum_keys: 0,
         spread_of: &[],
     },
+    // -----------------------------------------------------------------------
+    // The VIDEO builders (sc-15956), promoted out of `DEFERRED_ADVANCED_BUILDERS`
+    // -----------------------------------------------------------------------
+    //
+    // All six moved in the SAME change as the video write seams below, because the back-check that
+    // every entry here is named by an embedding seam makes the two halves inseparable — see
+    // `WORKFLOW_WRITE_SEAMS`.
+    AdvancedBuilder {
+        source: AdvancedKeySource::VideoStudioBuilder,
+        path: "apps/web/src/screens/VideoStudio.jsx",
+        function: "submit",
+        shape: AdvancedBuilderShape::SpreadAdvancedLiteral,
+        lane: "POST /api/v1/jobs type=video_generate — the Video Studio, written by \
+               `video_jobs/mod.rs::encode_media`",
+        anchors: &[
+            "motion",
+            "selectedPersonTrack",
+            "replacementModeLabel",
+            "lightning",
+            "videoConditioningStrength",
+        ],
+        minimum_keys: 20,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::TimelineBaseBuilder,
+        path: "apps/web/src/components/editor/useEditorGeneration.js",
+        function: "buildBasePayload",
+        shape: AdvancedBuilderShape::AssignedObject,
+        lane: "POST /api/v1/jobs type=video_generate — the timeline editor's shared video payload \
+               (queueTimelineVideoJob), written by `video_jobs/mod.rs::encode_media`",
+        anchors: &["resolution", "motion", "lightning"],
+        minimum_keys: 6,
+        spread_of: &[],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::TimelineExtendBuilder,
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "extendSelectedClip",
+        shape: AdvancedBuilderShape::SpreadAdvancedLiteral,
+        lane: "POST /api/v1/jobs type=video_generate — timeline extend, written by \
+               `video_jobs/mod.rs::encode_media`",
+        anchors: &["timelineAction", "timelineContext"],
+        minimum_keys: 2,
+        spread_of: &["base.advanced"],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::TimelineReplaceBuilder,
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "replaceSelectedItem",
+        shape: AdvancedBuilderShape::SpreadAdvancedLiteral,
+        lane: "POST /api/v1/jobs type=video_generate — timeline replace, written by \
+               `video_jobs/mod.rs::encode_media`",
+        anchors: &["timelineAction", "timelineContext"],
+        minimum_keys: 2,
+        spread_of: &["base.advanced"],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::TimelineBridgeBuilder,
+        path: "apps/web/src/screens/EditorScreen.jsx",
+        function: "bridgeGap",
+        shape: AdvancedBuilderShape::SpreadAdvancedLiteral,
+        lane: "POST /api/v1/jobs type=video_generate — timeline bridge, written by \
+               `video_jobs/mod.rs::encode_media`",
+        anchors: &["timelineAction", "timelineContext"],
+        minimum_keys: 2,
+        spread_of: &["base.advanced"],
+    },
+    AdvancedBuilder {
+        source: AdvancedKeySource::SimpleVideoBuilder,
+        path: "apps/web/src/simple/simpleJobs.js",
+        function: "buildSimpleVideoRequest",
+        shape: AdvancedBuilderShape::SpreadAdvancedLiteral,
+        lane: "POST /api/v1/jobs type=video_generate — the Simple shell's video request, written \
+               by `video_jobs/mod.rs::encode_media`",
+        anchors: &["resolution"],
+        minimum_keys: 1,
+        spread_of: &[],
+    },
 ];
 
 /// A builder that produces an `advanced` map the lint has SEEN and deliberately does not
@@ -619,13 +781,20 @@ pub struct DeferredAdvancedBuilder {
 /// [`ADVANCED_BUILDERS`] as where the entry moves if it ever does.
 pub const PERMANENT_EXEMPTION: &str = "PERMANENT EXEMPTION:";
 
-/// The VIDEO builders (sc-15956 owns the video envelope and these keys), plus one permanent
-/// exemption for an `advanced` map that is not an image payload at all.
+/// One permanent exemption for an `advanced` map that is not a generation payload at all.
 ///
-/// `VideoStudio.jsx` alone emits ~15 keys nothing here classifies. That is fine only for as long
-/// as no video write seam embeds: the moment sc-15956 threads a workflow into a video write, its
-/// builder moves up into [`ADVANCED_BUILDERS`] and every one of those keys needs an
-/// `allow`/`deny` decision.
+/// **The six video builders that used to live here were promoted by sc-15956** — the story this
+/// list was built for — and their 17 unclassified keys are now rules in [`ADVANCED_KEY_RULES`].
+/// The mechanism worked exactly as designed: making a video seam embed was impossible until every
+/// one of those keys had an `allow`/`deny` decision, and two of them (`selectedPersonTrack`,
+/// `timelineContext`) turned out to be object-shaped id-and-free-text carriers that would have
+/// travelled silently under the pre-sc-16113 arrangement.
+///
+/// Note the count. This list's own comment said "~15 keys"; the real number was 17, because two
+/// (`timelineAction`, `timelineContext`) are emitted only by the three `EditorScreen.jsx` actions
+/// and no one had read those builders. A deferral list records that a decision is owed, not what
+/// the decision costs — and that gap is the argument for the lint being a discovery scan rather
+/// than a hand-maintained tally.
 ///
 /// # What enforces that, and what does not (sc-16113)
 ///
@@ -661,44 +830,6 @@ pub const PERMANENT_EXEMPTION: &str = "PERMANENT EXEMPTION:";
 /// to be written at all, and that the honest version of it fails the build. Review is what catches
 /// the dishonest one.
 pub const DEFERRED_ADVANCED_BUILDERS: &[DeferredAdvancedBuilder] = &[
-    DeferredAdvancedBuilder {
-        path: "apps/web/src/screens/VideoStudio.jsx",
-        function: "submit",
-        reason: "The Video Studio's own ~15-knob advanced map. No video write seam embeds a \
-                 workflow yet; sc-15956 owns the video envelope and must classify these keys \
-                 before it does.",
-    },
-    DeferredAdvancedBuilder {
-        path: "apps/web/src/components/editor/useEditorGeneration.js",
-        function: "buildBasePayload",
-        reason: "The timeline editor's shared video payload (queueTimelineVideoJob). Video lane — \
-                 sc-15956 classifies it when video images start embedding.",
-    },
-    DeferredAdvancedBuilder {
-        path: "apps/web/src/screens/EditorScreen.jsx",
-        function: "extendSelectedClip",
-        reason: "Timeline video action: `buildBasePayload`'s advanced plus timelineAction / \
-                 timelineContext. Video lane — sc-15956.",
-    },
-    DeferredAdvancedBuilder {
-        path: "apps/web/src/screens/EditorScreen.jsx",
-        function: "replaceSelectedItem",
-        reason: "Timeline video action: `buildBasePayload`'s advanced plus timelineAction / \
-                 timelineContext. Video lane — sc-15956.",
-    },
-    DeferredAdvancedBuilder {
-        path: "apps/web/src/screens/EditorScreen.jsx",
-        function: "bridgeGap",
-        reason: "Timeline video action: `buildBasePayload`'s advanced plus timelineAction / \
-                 timelineContext. Video lane — sc-15956.",
-    },
-    DeferredAdvancedBuilder {
-        path: "apps/web/src/simple/simpleJobs.js",
-        function: "buildSimpleVideoRequest",
-        reason: "The Simple shell's VIDEO request. Its image sibling \
-                 (`buildSimpleImageRequest`) delegates to `buildImageJobRequest` and so is \
-                 covered by the studio builder; this one is a video lane — sc-15956.",
-    },
     DeferredAdvancedBuilder {
         path: "apps/web/src/training/trainingConfig.js",
         function: "trainingConfigSnapshot",
@@ -1253,6 +1384,142 @@ pub const ADVANCED_KEY_RULES: &[AdvancedKeyRule] = &[
         "presetMissingLoras",
         "Local LoRA ids the API could not resolve on THIS install.",
     ),
+    // -----------------------------------------------------------------------
+    // The VIDEO arm (sc-15956)
+    // -----------------------------------------------------------------------
+    //
+    // Same rule of thumb, same table. What is new is a third question the image lane never had to
+    // ask: a video knob can be neither generation intent nor a hardware budget, but a disclosure
+    // about a PERSON. `selectedPersonTrack` and `replacementModeLabel` are that, and they are
+    // denied for a reason the other denials do not carry.
+    allow_from(
+        "motion",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored camera-motion preset (`static`, `slow push-in`, `handheld`) off a closed menu. \
+         It conditions the generation, so it decides what is made.",
+    ),
+    allow_from(
+        "ltxPipeline",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored LTX pipeline selector. It picks which denoise path runs, so two values produce \
+         two different clips from one prompt — output, not budget.",
+    ),
+    allow_from(
+        "distilledVariant",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored LTX distilled-checkpoint variant. A different checkpoint is a different model \
+         for replay purposes — the same class as `usePid`, which is also a decoder choice that \
+         changes the output rather than a memory accommodation.",
+    ),
+    allow_from(
+        "textEncoderModel",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored text-encoder pick. It changes what the model SEES of the prompt, so a replay \
+         without it is a different run. A catalog-global model slug, not an install-local id — the \
+         same class as `styleId` and unlike `controlWeights`, which carries a resolved path.",
+    ),
+    allow_from(
+        "lightning",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored Wan2.2 A14B fast-4-step toggle. It swaps in a distilled recipe and overrides the \
+         step count, so it visibly changes the clip; it is a speed/quality choice the user made, \
+         not a tier this machine could afford.",
+    ),
+    allow_from(
+        "videoCfgGuidanceScale",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored LTX native CFG scale — the video lane's `guidanceScale`.",
+    ),
+    allow_from(
+        "videoStgGuidanceScale",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored LTX spatiotemporal-guidance scale.",
+    ),
+    allow_from(
+        "videoRescaleScale",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored LTX guidance-rescale factor.",
+    ),
+    allow_from(
+        "videoConditioningStrength",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored source-clip conditioning strength (extend, bridge, Krea Realtime v2v) — the \
+         video lane's `strength`, and the same authored-strength class as `ipAdapterScale`.",
+    ),
+    allow_from(
+        "bridgeRightVideoConditioningStrength",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::VideoStudioBuilder,
+        "Authored right-clip conditioning strength for a bridge — the sibling of \
+         `videoConditioningStrength`, and dropping it would make a shared bridge replay lopsided.",
+    ),
+    allow_from(
+        "timelineAction",
+        AdvancedShape::Scalar,
+        AdvancedKeySource::TimelineExtendBuilder,
+        "Which timeline operation produced the clip (`extend` / `replace` / `bridge`) — a closed \
+         three-value vocabulary that names the generation MODE, with no id in it. Its companion \
+         `timelineContext` is denied, so this travels alone: \"this was an extend\" is true and \
+         useful on any install, where \"an extend of item 4f2c… on timeline 91ab…\" is neither.",
+    ),
+    deny_from(
+        "durationHint",
+        AdvancedKeySource::VideoStudioBuilder,
+        "Model-catalog prose the studio echoes back into the payload (\"Recommended: 5s or \
+         less.\"), not a knob anybody set. It is not intent and it is not a value the run used — \
+         the receiving install renders its own from its own catalog, and a stale hint from someone \
+         else's build would be worse than none.",
+    ),
+    deny_from(
+        "precision",
+        AdvancedKeySource::VideoStudioBuilder,
+        "LTX weight precision (`fp8` / `bf16`): what THIS machine can afford to hold the weights \
+         in. The same hardware-budget class as `mlxQuantize`, and the receiving install picks its \
+         own.",
+    ),
+    deny_from(
+        "quantization",
+        AdvancedKeySource::VideoStudioBuilder,
+        "The torch lane's quant tier — `mlxQuantize` for a different backend, and denied for the \
+         identical reason.",
+    ),
+    deny_from(
+        "selectedPersonTrack",
+        AdvancedKeySource::VideoStudioBuilder,
+        "The WHOLE person-track record, not an id: a user-typed `name` that is routinely a real \
+         person's name, a `sourceDisplayName` that is the original imported FILENAME, install-local \
+         asset ids, and a `frames[].mask` array of filesystem PATHS. It is simultaneously every \
+         class this allow-list excludes, and it is not gated on mode — a stale selection rides a \
+         plain text_to_video payload. Denied on privacy first and on shape second (sc-15956).",
+    ),
+    deny_from(
+        "replacementModeLabel",
+        AdvancedKeySource::VideoStudioBuilder,
+        "The display label for a person-replacement mode (\"Face Only\", \"Full Person, Keep \
+         Outfit\"). Not an id, not a path, and denied anyway: a shared video must not disclose \
+         that it was made by replacing a specific person, still less which mode of replacement. \
+         Its top-level twin `replacementMode` is withheld by the builder for the same reason — see \
+         `build_video_workflow_share_from`. There is no replay value to weigh against it, because \
+         a recipient has no access to the track this describes.",
+    ),
+    deny_from(
+        "timelineContext",
+        AdvancedKeySource::TimelineExtendBuilder,
+        "Where in the LOCAL timeline to write the result: `timelineId`, `itemId`, `trackId`, \
+         `sourceAssetId` and friends are install-local UUIDs, and `timelineName` is the user's own \
+         typed name for a project structure that is nobody else's business. The same class as \
+         `recipePresetId`, with a free-text field on top. `timelineAction` carries the part that \
+         travels.",
+    ),
 ];
 
 /// The rule for `key`, if it is classified.
@@ -1671,6 +1938,53 @@ pub fn build_workflow_share_from(
     facts: &WorkflowAssetFacts,
     job_payload: &JsonObject,
 ) -> WorkflowShare {
+    build_share_of_kind(WORKFLOW_KIND_IMAGE, facts, job_payload)
+}
+
+/// [`build_workflow_share_from`] for the VIDEO lane (sc-15956) — the same builder, the same single
+/// reducer, and a [`WORKFLOW_KIND_VIDEO`] marker.
+///
+/// Ungated, like its image sibling: [`embeddable_video_workflow_share`] is the form a write seam
+/// must call.
+///
+/// # What a video envelope carries that an image one does not
+///
+/// `durationSeconds`, `fps` and `quality` — the three knobs off the studio's own menus that decide
+/// what gets made. `fitMode` was already a top-level field and is shared.
+///
+/// # What it deliberately does NOT carry
+///
+/// **The person-replacement fields, `personTrackId` and `replacementMode`, are withheld — always,
+/// not by preference.** A shared video must not disclose that it was made by replacing a specific
+/// person. `personTrackId` is an install-local id that resolves to nothing elsewhere, which alone
+/// would put it in the same class as `controlImage`; `replacementMode` is not an id at all and is
+/// withheld for the stronger reason, which is that the pair together tell a stranger the clip is a
+/// face replacement and which mode of one. That is a fact about a real person who did not choose to
+/// share it, and no replay value justifies it — a recipient replaying this recipe has no access to
+/// the track anyway, so the field could only ever inform, never reproduce.
+///
+/// Withheld SILENTLY rather than through `omitted`, which is the one place this contract's
+/// "a stated absence beats an invisible one" rule is deliberately inverted: `omitted:
+/// ["personTrackId"]` would announce the replacement to every reader while withholding only the id,
+/// which is the disclosure the withholding exists to prevent. `OMITTED_FIELDS` is for collections
+/// too large to record, where naming the gap costs nothing.
+///
+/// The clip ids (`sourceClipAssetIds`, `bridgeRightClipAssetId`, `referenceClipAssetId`) are
+/// withheld as ids and recorded as SHAPE through [`INPUT_KIND_SOURCE_CLIP`] /
+/// [`INPUT_KIND_REFERENCE_CLIP`], exactly as the image lane treats `sourceAssetId`.
+#[must_use]
+pub fn build_video_workflow_share_from(
+    facts: &WorkflowAssetFacts,
+    job_payload: &JsonObject,
+) -> WorkflowShare {
+    build_share_of_kind(WORKFLOW_KIND_VIDEO, facts, job_payload)
+}
+
+fn build_share_of_kind(
+    kind: &str,
+    facts: &WorkflowAssetFacts,
+    job_payload: &JsonObject,
+) -> WorkflowShare {
     let string_field = |key: &str| {
         job_payload
             .get(key)
@@ -1707,8 +2021,9 @@ pub fn build_workflow_share_from(
     // Every value goes out through the SAME reducer an incoming envelope comes in through
     // (`reduce_workflow_share`), so the build side cannot grow a field the parse side does not
     // guard — which is exactly how the top-level labels below escaped the path check before.
+    let is_video = kind == WORKFLOW_KIND_VIDEO;
     reduce_workflow_share(WorkflowShare {
-        kind: WORKFLOW_KIND_IMAGE.to_owned(),
+        kind: kind.to_owned(),
         schema_version: WORKFLOW_SHARE_SCHEMA_VERSION,
         producer: WorkflowProducer::default(),
         mode,
@@ -1719,6 +2034,14 @@ pub fn build_workflow_share_from(
         width: u32_field("width").or(facts.width),
         height: u32_field("height").or(facts.height),
         count: u32_field("count"),
+        // Video-only, and read off the payload rather than off the encoded file: these are the ASK
+        // (see the field docs). Gated on the kind so an image envelope cannot grow a `fps` from a
+        // payload key that happened to be there.
+        duration_seconds: is_video
+            .then(|| job_payload.get("duration").and_then(Value::as_f64))
+            .flatten(),
+        fps: is_video.then(|| u32_field("fps")).flatten(),
+        quality: is_video.then(|| string_field("quality")).flatten(),
         style_preset: string_field("stylePreset"),
         style_id: string_field("styleId"),
         fit_mode: string_field("fitMode"),
@@ -1755,6 +2078,23 @@ pub fn embeddable_workflow_share(
     within_recording_ceiling(&share).ok().map(|()| share)
 }
 
+/// [`embeddable_workflow_share`] for the VIDEO lane (sc-15956): the gated builder a video write
+/// seam must call, and the only video form that runs the recording ceiling.
+///
+/// The ceiling is the same number and the same measurement — the serialized envelope — because it
+/// is a bound on what gets PERSISTED, not on what a container can hold. An MP4's tag store would
+/// take far more than 160 KiB; that is not a reason to record more, and letting the two lanes
+/// diverge would mean an envelope that round-trips through a video and is refused by the PNG
+/// reader. See [`crate::workflow_mp4::workflow_metadata_size`] for what the container adds on top.
+#[must_use]
+pub fn embeddable_video_workflow_share(
+    facts: &WorkflowAssetFacts,
+    job_payload: &JsonObject,
+) -> Option<WorkflowShare> {
+    let share = build_video_workflow_share_from(facts, job_payload);
+    within_recording_ceiling(&share).ok().map(|()| share)
+}
+
 /// Input images by shape. Reads the ids only to count them; no id ever reaches the envelope.
 fn describe_inputs(job_payload: &JsonObject) -> Vec<WorkflowInput> {
     let has_id = |key: &str| {
@@ -1777,10 +2117,14 @@ fn describe_inputs(job_payload: &JsonObject) -> Vec<WorkflowInput> {
     };
 
     let mut inputs = Vec::new();
-    if has_id("sourceAssetId") {
+    // `lastFrameAssetId` is the video lane's end-frame target: a STILL, like `sourceAssetId`, so it
+    // counts here rather than as a clip. An image payload never carries it, so this is a no-op for
+    // the image lane.
+    let sources = usize::from(has_id("sourceAssetId")) + usize::from(has_id("lastFrameAssetId"));
+    if sources > 0 {
         inputs.push(WorkflowInput {
             kind: INPUT_KIND_SOURCE.to_owned(),
-            count: 1,
+            count: u32::try_from(sources).unwrap_or(u32::MAX),
             control_mode: None,
         });
     }
@@ -1795,6 +2139,26 @@ fn describe_inputs(job_payload: &JsonObject) -> Vec<WorkflowInput> {
     if has_id("maskAssetId") {
         inputs.push(WorkflowInput {
             kind: INPUT_KIND_MASK.to_owned(),
+            count: 1,
+            control_mode: None,
+        });
+    }
+    // The video lane's clip ids (sc-15956), counted exactly as the image lane counts its stills.
+    // `lastFrameAssetId` is a STILL, not a clip — it is the end-frame an i2v run targets — so it
+    // joins the `source` count above rather than this one.
+    let source_clips = usize::from(has_id("sourceClipAssetId"))
+        + usize::from(has_id("bridgeRightClipAssetId"))
+        + id_list_len("sourceClipAssetIds");
+    if source_clips > 0 {
+        inputs.push(WorkflowInput {
+            kind: INPUT_KIND_SOURCE_CLIP.to_owned(),
+            count: u32::try_from(source_clips).unwrap_or(u32::MAX),
+            control_mode: None,
+        });
+    }
+    if has_id("referenceClipAssetId") {
+        inputs.push(WorkflowInput {
+            kind: INPUT_KIND_REFERENCE_CLIP.to_owned(),
             count: 1,
             control_mode: None,
         });
@@ -1877,13 +2241,20 @@ fn sanitize_loras(value: Option<&Value>) -> Vec<WorkflowLora> {
 // Value-level reduction (shared by build and parse)
 // ---------------------------------------------------------------------------
 
-/// The four input kinds, in the order [`describe_inputs`] emits them. An `inputs[].kind`
-/// outside this set is not something a reader can act on, so it does not survive a parse.
+/// The input kinds, in the order [`describe_inputs`] emits them. An `inputs[].kind` outside this
+/// set is not something a reader can act on, so it does not survive a parse.
+///
+/// The last two are the video lane's (sc-15956), and they arrive here for the same reason the first
+/// four did: a video recipe's `sourceClipAssetIds` / `referenceClipAssetId` are exactly the
+/// identifier class the allow-list excludes, so they become SHAPE — "this recipe needs two source
+/// clips" — instead of dangling local UUIDs.
 pub const INPUT_KINDS: &[&str] = &[
     INPUT_KIND_SOURCE,
     INPUT_KIND_REFERENCE,
     INPUT_KIND_MASK,
     INPUT_KIND_CONTROL,
+    INPUT_KIND_SOURCE_CLIP,
+    INPUT_KIND_REFERENCE_CLIP,
 ];
 
 // ---------------------------------------------------------------------------
@@ -2078,6 +2449,9 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
         width,
         height,
         count,
+        duration_seconds,
+        fps,
+        quality,
         style_preset,
         style_id,
         fit_mode,
@@ -2133,6 +2507,14 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
         width,
         height,
         count,
+        // The video knobs, reduced on the way IN exactly as on the way out. A non-finite
+        // `durationSeconds` from a stranger's file would serialize as `null` and re-parse as a
+        // different envelope, so it is dropped here rather than carried — the same treatment
+        // `upscale.softness` already gets. `quality` is a menu label and goes through the same
+        // bound-and-path check as every other label.
+        duration_seconds: duration_seconds.filter(|value| value.is_finite()),
+        fps,
+        quality: quality.as_deref().and_then(shareable_label),
         style_preset: style_preset.as_deref().and_then(shareable_label),
         style_id: style_id.as_deref().and_then(shareable_label),
         fit_mode: fit_mode.as_deref().and_then(shareable_label),
@@ -2515,10 +2897,10 @@ pub fn parse_workflow_share(value: &Value) -> Result<WorkflowShare, WorkflowShar
             field: WORKFLOW_SHARE_MARKER_KEY.to_owned(),
             detail: "must be a workflow-kind string".to_owned(),
         })?;
-    if kind != WORKFLOW_KIND_IMAGE {
+    if !WORKFLOW_KINDS.contains(&kind) {
         return Err(WorkflowShareError::UnsupportedKind {
             found: kind.to_owned(),
-            supported: WORKFLOW_KIND_IMAGE.to_owned(),
+            supported: WORKFLOW_KINDS.join(", "),
         });
     }
 

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -3727,18 +3727,31 @@ mod tests {
         ));
     }
 
+    /// An unknown kind is refused, and the two known ones are not.
+    ///
+    /// `video` was the example here until sc-15956 made it a lane. That is the whole point of the
+    /// gate: a build refuses a kind it does not understand rather than presenting it as one it
+    /// does, and an OLDER build hits this same branch for a video envelope.
     #[test]
     fn parse_rejects_another_workflow_kind() {
-        let video = json!({
-            "sceneworksWorkflow": "video",
-            "schemaVersion": 1,
-            "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
-            "mode": "image_to_video",
-            "model": "wan_5b",
-            "prompt": "p"
-        });
+        let envelope = |kind: &str| {
+            json!({
+                "sceneworksWorkflow": kind,
+                "schemaVersion": 1,
+                "producer": { "name": "SceneWorks", "url": PRODUCER_URL, "version": "0.8.1" },
+                "mode": "image_to_video",
+                "model": "wan_5b",
+                "prompt": "p"
+            })
+        };
+        for known in WORKFLOW_KINDS {
+            assert!(
+                parse_workflow_share(&envelope(known)).is_ok(),
+                "`{known}` is a kind this build reads"
+            );
+        }
         assert!(matches!(
-            parse_workflow_share(&video).expect_err("video envelope"),
+            parse_workflow_share(&envelope("hologram")).expect_err("an unknown kind"),
             WorkflowShareError::UnsupportedKind { .. }
         ));
     }
@@ -3950,7 +3963,8 @@ mod tests {
         assert_eq!(MAX_SHARE_LORAS, crate::lora_family::MAX_JOB_LORAS);
         assert_eq!(MAX_SHARE_LORAS, 5);
         assert_eq!(MAX_SHARE_INPUTS, INPUT_KINDS.len());
-        assert_eq!(MAX_SHARE_INPUTS, 4);
+        // Four image kinds plus the video lane's two clip kinds (sc-15956).
+        assert_eq!(MAX_SHARE_INPUTS, 6);
         // The worker's `MAX_MULTIPHASE_PHASES`; pinned against its source by
         // `the_phase_cap_matches_the_multi_phase_validators` in tests/workflow_share.rs, which can
         // read the file this crate cannot import.
@@ -4070,8 +4084,12 @@ mod tests {
 
         let built = build_workflow_share(&asset_fixture(), &payload);
         assert_eq!(built.loras.len(), MAX_SHARE_LORAS);
-        // One entry per kind, all four kinds — the widest `inputs` the builder can emit.
-        assert_eq!(built.inputs.len(), MAX_SHARE_INPUTS);
+        // One entry per kind — the widest `inputs` an IMAGE payload can emit, which is the
+        // four image kinds. The two video clip kinds need a video payload to appear, so the
+        // cap is above what this fixture reaches; `clip_ids_become_shape_descriptors` in
+        // tests/workflow_mp4.rs is where the other two are exercised.
+        assert_eq!(built.inputs.len(), 4);
+        assert!(built.inputs.len() <= MAX_SHARE_INPUTS);
         assert_eq!(
             built.advanced["phases"].as_array().expect("phases").len(),
             MAX_SHARE_PHASES

--- a/crates/sceneworks-core/tests/workflow_mp4.rs
+++ b/crates/sceneworks-core/tests/workflow_mp4.rs
@@ -735,3 +735,51 @@ fn the_reader_applies_the_recording_ceiling_to_a_container() {
         other => panic!("unexpected: {other:?}"),
     }
 }
+
+/// **Each container asserts its own kind.** An MP4 carrying an IMAGE envelope is refused.
+///
+/// The contract's kind gate accepts every kind this build knows, which is right for an envelope and
+/// wrong for a consumer: our writers only ever pair an MP4 with a video envelope, so a mismatch is
+/// a hand-made file or a future build's. Surfacing an image recipe out of a clip would offer
+/// something no video studio can run.
+///
+/// The PNG side makes the symmetrical assertion — and there it is a REGRESSION guard rather than a
+/// new rule: a PNG carrying a video envelope was refused before the video lane widened the shared
+/// gate, and had to keep being refused after.
+#[test]
+fn an_mp4_carrying_an_image_envelope_is_refused() {
+    let mut value = serde_json::to_value(video_share()).expect("serializable");
+    value[WORKFLOW_SHARE_MARKER_KEY] = json!(WORKFLOW_KIND_IMAGE);
+    let bytes = mp4_with_json(&value);
+    match read_workflow_metadata(&bytes) {
+        Err(WorkflowMp4Error::Share(WorkflowShareError::UnsupportedKind { found, supported })) => {
+            assert_eq!(found, WORKFLOW_KIND_IMAGE);
+            assert_eq!(supported, WORKFLOW_KIND_VIDEO);
+        }
+        other => panic!("an image envelope in an mp4 must be refused, got {other:?}"),
+    }
+}
+
+/// …and the PNG reader still refuses a VIDEO envelope, which is the behaviour the widened kind
+/// gate would otherwise have silently changed.
+#[test]
+fn a_png_carrying_a_video_envelope_is_still_refused() {
+    let share = video_share();
+    let png = {
+        let image = image::RgbImage::from_pixel(2, 2, image::Rgb([10, 20, 30]));
+        let directory = tempfile::tempdir().expect("a temp dir");
+        let path = directory.path().join("clip.png");
+        sceneworks_core::workflow_png::write_workflow_chunk(&image, &path, Some(&share))
+            .expect("written");
+        std::fs::read(&path).expect("readable")
+    };
+    match sceneworks_core::workflow_png::read_workflow_chunk(&png) {
+        Err(sceneworks_core::workflow_png::WorkflowChunkError::Envelope(
+            WorkflowShareError::UnsupportedKind { found, supported },
+        )) => {
+            assert_eq!(found, WORKFLOW_KIND_VIDEO);
+            assert_eq!(supported, WORKFLOW_KIND_IMAGE);
+        }
+        other => panic!("a video envelope in a png must be refused, got {other:?}"),
+    }
+}

--- a/crates/sceneworks-core/tests/workflow_mp4.rs
+++ b/crates/sceneworks-core/tests/workflow_mp4.rs
@@ -1,0 +1,737 @@
+//! The MP4 metadata codec, and the video arm of the envelope (sc-15956, epic 15945).
+//!
+//! Hermetic on purpose: every MP4 here is built byte by byte in [`mp4_with_comment`] rather than by
+//! shelling out, so the reader's guarantees are tested on a host with no ffmpeg. The end-to-end
+//! proof that ffmpeg actually produces this layout — and that the tag survives the encode chain —
+//! is `the_envelope_survives_the_whole_encode_chain` in
+//! `crates/sceneworks-worker/src/video_jobs/tests.rs`, which is gated on a reachable binary.
+
+use serde_json::{json, Map, Value};
+
+use sceneworks_core::workflow_mp4::{
+    ffmetadata_document, read_mp4_comment, read_workflow_metadata, workflow_metadata_size,
+    write_workflow_metadata_file, WorkflowMp4Error, FFMETADATA_HEADER, MAX_WORKFLOW_TEXT_BYTES,
+    WORKFLOW_MP4_TAG,
+};
+use sceneworks_core::workflow_share::{
+    build_video_workflow_share_from, embeddable_video_workflow_share, parse_workflow_share_json,
+    WorkflowAssetFacts, WorkflowShareError, INPUT_KIND_REFERENCE, INPUT_KIND_REFERENCE_CLIP,
+    INPUT_KIND_SOURCE, INPUT_KIND_SOURCE_CLIP, WORKFLOW_KIND_IMAGE, WORKFLOW_KIND_VIDEO,
+    WORKFLOW_SHARE_MARKER_KEY, WORKFLOW_SHARE_MAX_BYTES,
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn facts() -> WorkflowAssetFacts {
+    WorkflowAssetFacts {
+        mode: "text_to_video".to_owned(),
+        model: "ltx_2_3".to_owned(),
+        prompt: "a fox crossing a frozen river".to_owned(),
+        negative_prompt: "blurry".to_owned(),
+        seed: 4242,
+        width: Some(768),
+        height: Some(512),
+    }
+}
+
+fn payload(extra: Value) -> Map<String, Value> {
+    let mut base = json!({
+        "mode": "text_to_video",
+        "model": "ltx_2_3",
+        "prompt": "a fox crossing a frozen river",
+        "duration": 5.0,
+        "fps": 24,
+        "quality": "standard",
+        "width": 768,
+        "height": 512,
+    });
+    if let (Some(base), Some(extra)) = (base.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra {
+            base.insert(key.clone(), value.clone());
+        }
+    }
+    base.as_object().expect("an object").clone()
+}
+
+fn video_share() -> sceneworks_core::workflow_share::WorkflowShare {
+    build_video_workflow_share_from(&facts(), &payload(json!({})))
+}
+
+/// A minimal but structurally REAL MP4: `ftyp` + `moov/udta/meta/ilst/©cmt/data` + `mdat`.
+///
+/// The box layout ffmpeg's mov muxer actually produces, verified against a real file before this
+/// was written. `mdat` is padded so the walk has to skip something large without reading it.
+fn mp4_with_comment(comment: &[u8]) -> Vec<u8> {
+    fn boxed(kind: &[u8; 4], body: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(body.len() + 8);
+        out.extend_from_slice(
+            &u32::try_from(body.len() + 8)
+                .expect("box fits in 32 bits")
+                .to_be_bytes(),
+        );
+        out.extend_from_slice(kind);
+        out.extend_from_slice(body);
+        out
+    }
+
+    // `data`: 4 bytes version+flags (1 = UTF-8 text), 4 bytes locale, then the payload.
+    let mut data = Vec::new();
+    data.extend_from_slice(&1u32.to_be_bytes());
+    data.extend_from_slice(&0u32.to_be_bytes());
+    data.extend_from_slice(comment);
+    let data = boxed(b"data", &data);
+    let cmt = boxed(&[0xA9, b'c', b'm', b't'], &data);
+    let ilst = boxed(b"ilst", &cmt);
+    let hdlr = boxed(b"hdlr", &[0u8; 21]);
+
+    // `meta` is a FullBox here — 4 bytes of version+flags before its children — which is the form
+    // ffmpeg writes. `a_quicktime_style_meta_without_the_fullbox_prefix_is_read` covers the other.
+    let mut meta_body = vec![0u8; 4];
+    meta_body.extend_from_slice(&hdlr);
+    meta_body.extend_from_slice(&ilst);
+    let meta = boxed(b"meta", &meta_body);
+    let udta = boxed(b"udta", &meta);
+
+    let mut moov_body = boxed(b"mvhd", &[0u8; 100]);
+    moov_body.extend_from_slice(&udta);
+    let moov = boxed(b"moov", &moov_body);
+
+    let mut out = boxed(b"ftyp", b"isom\x00\x00\x02\x00isomiso2avc1mp41");
+    out.extend_from_slice(&moov);
+    out.extend_from_slice(&boxed(b"mdat", &vec![0xEEu8; 64 * 1024]));
+    out
+}
+
+fn mp4_with_json(value: &Value) -> Vec<u8> {
+    mp4_with_comment(
+        serde_json::to_string(value)
+            .expect("serializable")
+            .as_bytes(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The write side
+// ---------------------------------------------------------------------------
+
+/// The document is what ffmpeg's `-f ffmetadata` demuxer expects, under the standard tag.
+#[test]
+fn the_document_is_an_ffmetadata_file_under_the_comment_tag() {
+    let document = ffmetadata_document(&video_share()).expect("encodable");
+    let mut lines = document.lines();
+    assert_eq!(
+        lines.next(),
+        Some(FFMETADATA_HEADER),
+        "ffmpeg refuses the file without its header line"
+    );
+    assert_eq!(WORKFLOW_MP4_TAG, "comment");
+    let body = lines.next().expect("a tag line");
+    assert!(
+        body.starts_with("comment="),
+        "the envelope must ride in the STANDARD tag — a custom key does not survive a `-c copy` \
+         remux. Got: {body:.60}"
+    );
+}
+
+/// Every character `ffmetadata` reserves is escaped, and nothing else is touched.
+#[test]
+fn the_five_reserved_characters_are_escaped_and_the_rest_are_not() {
+    // A prompt with all five, plus non-ASCII that must survive verbatim. Set through the
+    // PAYLOAD, which takes precedence over the facts (see `build_share_of_kind`).
+    const PROMPT: &str = "a=b; #tag \\slash\\ é 日本語 🎬";
+    let share = build_video_workflow_share_from(&facts(), &payload(json!({ "prompt": PROMPT })));
+    let document = ffmetadata_document(&share).expect("encodable");
+    let line = document
+        .lines()
+        .nth(1)
+        .expect("a tag line")
+        .strip_prefix("comment=")
+        .expect("the comment tag");
+
+    // Unescaping the way ffmpeg does must recover the exact serialized envelope.
+    let mut unescaped = String::with_capacity(line.len());
+    let mut characters = line.chars();
+    while let Some(character) = characters.next() {
+        if character == '\\' {
+            unescaped.extend(characters.next());
+        } else {
+            unescaped.push(character);
+        }
+    }
+    assert_eq!(
+        unescaped,
+        serde_json::to_string(&share).expect("serializable"),
+        "the escaped line must unescape back to the envelope byte for byte"
+    );
+    assert!(
+        unescaped.contains("日本語") && unescaped.contains('🎬'),
+        "non-ASCII prose must ride verbatim, not escaped or transliterated"
+    );
+}
+
+/// A raw carriage return is REFUSED rather than escaped, because `ffmetadata` has no escape for one
+/// and silently truncates the value at it.
+///
+/// Measured before this guard existed: `"a\rb"` written, `"a"` read back, no error from ffmpeg at
+/// either end. A recipe that is silently half a recipe is the worst failure shape available.
+#[test]
+fn a_raw_carriage_return_is_refused_rather_than_silently_truncated() {
+    // The invariant the guard rests on: `serde_json` escapes a CR inside a string to the TWO
+    // characters `\` `r`, so no raw 0x0D can reach the document however the prose was authored.
+    let share = build_video_workflow_share_from(
+        &facts(),
+        &payload(json!({ "prompt": "line one\rline two\r\nline three" })),
+    );
+    let document = ffmetadata_document(&share).expect("a JSON-escaped CR stays encodable");
+    assert!(
+        !document.contains('\r'),
+        "no raw CR may reach the document — `ffmetadata` truncates at one and cannot escape it"
+    );
+
+    // The whole prompt is still there after an ffmpeg-style unescape. The failure this guards
+    // against is a value silently cut at the CR, so the round trip is what proves it did not
+    // happen.
+    let line = document
+        .lines()
+        .nth(1)
+        .expect("a tag line")
+        .strip_prefix("comment=")
+        .expect("the comment tag");
+    let mut unescaped = String::with_capacity(line.len());
+    let mut characters = line.chars();
+    while let Some(character) = characters.next() {
+        if character == '\\' {
+            unescaped.extend(characters.next());
+        } else {
+            unescaped.push(character);
+        }
+    }
+    assert_eq!(
+        unescaped,
+        serde_json::to_string(&share).expect("serializable"),
+        "the value must arrive whole, not cut at the carriage return"
+    );
+    assert!(
+        unescaped.contains("line three"),
+        "the tail after the CR must survive"
+    );
+}
+
+/// The `Unencodable` refusal is still in the writer, even though no `WorkflowShare` can reach it.
+///
+/// It cannot be provoked through the typed struct — that is the whole content of the test above —
+/// so what is pinned here is that the check has not been quietly deleted as dead code. The shape of
+/// the future change it exists for is a field that stops going through `serde_json`'s string
+/// escaping, at which point every recipe it touched would be silently halved.
+#[test]
+fn the_carriage_return_refusal_is_still_in_the_writer() {
+    let serialized = serde_json::to_string(&video_share()).expect("serializable");
+    assert!(
+        !serialized.contains('\r'),
+        "the precondition: a real envelope never serializes with a raw CR"
+    );
+    let source = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/workflow_mp4.rs"),
+    )
+    .expect("the module is readable");
+    assert!(
+        source.contains("payload.contains('\\r')"),
+        "`ffmetadata_document` must still refuse a raw carriage return"
+    );
+}
+
+/// The document is written where ffmpeg can read it, and reads back as what we encoded.
+#[test]
+fn the_document_is_written_to_disk_verbatim() {
+    let directory = tempfile::tempdir().expect("a temp dir");
+    let path = directory.path().join("workflow.ffmeta");
+    let share = video_share();
+    write_workflow_metadata_file(&share, &path).expect("written");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("readable"),
+        ffmetadata_document(&share).expect("encodable")
+    );
+}
+
+/// The container's framing is 24 bytes, and reported so the two lanes can be compared honestly.
+#[test]
+fn the_reported_size_is_the_payload_plus_the_ilst_framing() {
+    let share = video_share();
+    let payload = serde_json::to_string(&share).expect("serializable").len();
+    assert_eq!(
+        workflow_metadata_size(&share).expect("measurable"),
+        payload + 24,
+        "`©cmt` header (8) + `data` header (8) + version/flags (4) + locale (4)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The read side
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_envelope_round_trips_through_the_container() {
+    let share = video_share();
+    let bytes = mp4_with_json(&serde_json::to_value(&share).expect("serializable"));
+    let read = read_workflow_metadata(&bytes)
+        .expect("readable")
+        .expect("the envelope is in there");
+    assert_eq!(read, share);
+}
+
+/// A full-cap envelope round trips — the size the argv route could not carry at all.
+#[test]
+fn a_full_cap_envelope_round_trips() {
+    let mut facts = facts();
+    // `PROSE_MAX_BYTES` bounds the prompt at 16 KiB, so the bulk has to come from somewhere the
+    // sanitizer keeps whole. Several allow-listed labels plus a maximal prompt is a realistic
+    // worst case; what matters here is that a large payload survives the container, not that the
+    // envelope is exactly at the ceiling.
+    facts.prompt = "x".repeat(64 * 1024);
+    let share = build_video_workflow_share_from(&facts, &payload(json!({})));
+    let bytes = mp4_with_json(&serde_json::to_value(&share).expect("serializable"));
+    assert!(
+        bytes.len() > 64 * 1024,
+        "the fixture must actually be large to prove anything"
+    );
+    assert_eq!(
+        read_workflow_metadata(&bytes).expect("readable"),
+        Some(share)
+    );
+}
+
+/// An MP4 with no comment at all is an ABSENCE, not an error — the common case for every clip the
+/// user did not generate here.
+#[test]
+fn a_video_with_no_comment_is_an_absence() {
+    // The same builder without the tag path: an `ftyp` + `mdat` only.
+    let bytes = {
+        let mut out = Vec::new();
+        let ftyp_body: &[u8] = b"isom\x00\x00\x02\x00isom";
+        out.extend_from_slice(&(8 + ftyp_body.len() as u32).to_be_bytes());
+        out.extend_from_slice(b"ftyp");
+        out.extend_from_slice(ftyp_body);
+        out.extend_from_slice(&(8u32 + 1024).to_be_bytes());
+        out.extend_from_slice(b"mdat");
+        out.extend_from_slice(&vec![0u8; 1024]);
+        out
+    };
+    assert_eq!(read_workflow_metadata(&bytes).expect("readable"), None);
+}
+
+/// Somebody ELSE's comment is an absence too. The MP4 tag key is shared — that is the price of a
+/// key that survives a transcode — so the marker inside the JSON is what identifies the envelope.
+#[test]
+fn a_foreign_comment_is_an_absence_not_a_parse_failure() {
+    for foreign in [
+        "Encoded with Handbrake",
+        "{\"prompt\":\"someone else's tool\"}",
+        "",
+        "not json at all }{",
+    ] {
+        let bytes = mp4_with_comment(foreign.as_bytes());
+        assert_eq!(
+            read_workflow_metadata(&bytes).expect("readable"),
+            None,
+            "a `{foreign}` comment must read as no envelope, not as an error"
+        );
+        // …and the raw comment is still legible to a diagnostic that wants it.
+        assert_eq!(
+            read_mp4_comment(&bytes).expect("readable").as_deref(),
+            Some(foreign)
+        );
+    }
+}
+
+/// A comment that DOES carry our marker but is malformed is a typed error, not an absence: the file
+/// claims to be ours, so silence would be the wrong answer.
+#[test]
+fn a_marked_but_malformed_comment_is_a_typed_error() {
+    let bytes =
+        mp4_with_comment(format!("{{\"{WORKFLOW_SHARE_MARKER_KEY}\":\"video\"}}").as_bytes());
+    match read_workflow_metadata(&bytes) {
+        Err(WorkflowMp4Error::Share(WorkflowShareError::MissingSchemaVersion)) => {}
+        other => panic!("a marked envelope with no schemaVersion must be refused, got {other:?}"),
+    }
+}
+
+/// A `data` box that CLAIMS more than the cap costs a comparison, not an allocation.
+#[test]
+fn an_oversized_comment_is_refused_by_our_bound_not_the_files_claim() {
+    let bytes = mp4_with_comment(&vec![b'x'; MAX_WORKFLOW_TEXT_BYTES + 1]);
+    match read_workflow_metadata(&bytes) {
+        Err(WorkflowMp4Error::TooLarge { bytes, limit }) => {
+            assert_eq!(limit, MAX_WORKFLOW_TEXT_BYTES);
+            assert!(bytes > limit);
+        }
+        other => panic!("an over-cap comment must be refused, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_non_utf8_comment_is_refused() {
+    let bytes = mp4_with_comment(&[0xFF, 0xFE, 0xFD]);
+    assert!(matches!(
+        read_workflow_metadata(&bytes),
+        Err(WorkflowMp4Error::NotUtf8)
+    ));
+}
+
+/// A box declaring more bytes than its parent holds is refused rather than believed.
+#[test]
+fn a_box_that_overruns_its_parent_is_refused() {
+    let mut bytes = mp4_with_json(&serde_json::to_value(video_share()).expect("serializable"));
+    // Find the `moov` header and inflate its size past the end of the file.
+    let moov = bytes
+        .windows(4)
+        .position(|window| window == b"moov")
+        .expect("the fixture has a moov");
+    let size_at = moov - 4;
+    bytes[size_at..size_at + 4].copy_from_slice(&u32::MAX.to_be_bytes());
+    assert!(matches!(
+        read_workflow_metadata(&bytes),
+        Err(WorkflowMp4Error::Malformed { .. })
+    ));
+}
+
+/// A zero-length box cannot spin the walk forever.
+#[test]
+fn a_zero_length_box_terminates_the_walk() {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&24u32.to_be_bytes());
+    bytes.extend_from_slice(b"ftyp");
+    bytes.extend_from_slice(b"isom\x00\x00\x02\x00isom");
+    // A `moov` whose declared size is 8 — a header and nothing else — followed by a box declaring
+    // a size smaller than its own header.
+    bytes.extend_from_slice(&8u32.to_be_bytes());
+    bytes.extend_from_slice(b"moov");
+    bytes.extend_from_slice(&4u32.to_be_bytes());
+    bytes.extend_from_slice(b"junk");
+    let read = read_workflow_metadata(&bytes);
+    assert!(
+        read.is_err() || read.expect("checked").is_none(),
+        "the walk must terminate, either refusing or finding nothing"
+    );
+}
+
+/// A truncated file is a typed error rather than a panic.
+#[test]
+fn a_truncated_container_is_refused() {
+    let full = mp4_with_json(&serde_json::to_value(video_share()).expect("serializable"));
+    // Cuts INSIDE the header: the envelope cannot be recovered, and the reader must say so rather
+    // than panic or hand back half a recipe.
+    for cut in [4usize, 12, 40, 100, 300] {
+        let read = read_workflow_metadata(&full[..cut.min(full.len())]);
+        assert!(
+            read.is_err() || read.expect("checked").is_none(),
+            "a file cut at {cut} must refuse or report nothing"
+        );
+    }
+    // A cut past the header but inside `mdat` still has the whole tag, and reading it is CORRECT:
+    // the walk never touches `mdat`, which is the property that lets it seek past gigabytes
+    // instead of buffering them.
+    let moov_end = full.len() - 64 * 1024 - 8;
+    assert!(
+        read_workflow_metadata(&full[..moov_end + 16])
+            .expect("readable")
+            .is_some(),
+        "a clip truncated inside `mdat` keeps its recipe — the reader never needed those bytes"
+    );
+}
+
+/// The QuickTime-flavoured `meta` (no FullBox prefix) reads too.
+#[test]
+fn a_quicktime_style_meta_without_the_fullbox_prefix_is_read() {
+    let share = video_share();
+    let text = serde_json::to_string(&share).expect("serializable");
+    let mut bytes = mp4_with_comment(text.as_bytes());
+    // Drop the 4-byte version/flags word from `meta`'s body and shrink every enclosing box by 4.
+    let meta = bytes
+        .windows(4)
+        .position(|window| window == b"meta")
+        .expect("the fixture has a meta");
+    let body = meta + 4;
+    bytes.drain(body..body + 4);
+    for kind in [b"meta", b"udta", b"moov"] {
+        let at = bytes
+            .windows(4)
+            .position(|window| window == kind)
+            .expect("the box is present");
+        let size_at = at - 4;
+        let size = u32::from_be_bytes([
+            bytes[size_at],
+            bytes[size_at + 1],
+            bytes[size_at + 2],
+            bytes[size_at + 3],
+        ]);
+        bytes[size_at..size_at + 4].copy_from_slice(&(size - 4).to_be_bytes());
+    }
+    assert_eq!(
+        read_workflow_metadata(&bytes).expect("readable"),
+        Some(share),
+        "a prefix-less `meta` is the QuickTime form and must still be walked"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The video arm of the contract
+// ---------------------------------------------------------------------------
+
+/// A video envelope is marked `video`, and an image one is still marked `image`.
+#[test]
+fn the_marker_names_the_kind() {
+    let video = serde_json::to_value(video_share()).expect("serializable");
+    assert_eq!(video[WORKFLOW_SHARE_MARKER_KEY], json!(WORKFLOW_KIND_VIDEO));
+    let image = serde_json::to_value(sceneworks_core::workflow_share::build_workflow_share_from(
+        &facts(),
+        &payload(json!({})),
+    ))
+    .expect("serializable");
+    assert_eq!(image[WORKFLOW_SHARE_MARKER_KEY], json!(WORKFLOW_KIND_IMAGE));
+}
+
+/// Both kinds parse; a third does not, and the message names what this build reads.
+///
+/// The property an OLDER build has, stated from this side: a reader that knows only `image` refuses
+/// a `video` envelope by this same gate rather than presenting a video recipe as an image one.
+#[test]
+fn an_unknown_kind_is_refused_and_both_known_kinds_are_not() {
+    for known in [WORKFLOW_KIND_IMAGE, WORKFLOW_KIND_VIDEO] {
+        let mut value = serde_json::to_value(video_share()).expect("serializable");
+        value[WORKFLOW_SHARE_MARKER_KEY] = json!(known);
+        assert!(
+            parse_workflow_share_json(&value.to_string()).is_ok(),
+            "`{known}` must parse"
+        );
+    }
+    let mut value = serde_json::to_value(video_share()).expect("serializable");
+    value[WORKFLOW_SHARE_MARKER_KEY] = json!("hologram");
+    match parse_workflow_share_json(&value.to_string()) {
+        Err(WorkflowShareError::UnsupportedKind { found, supported }) => {
+            assert_eq!(found, "hologram");
+            assert!(
+                supported.contains("image") && supported.contains("video"),
+                "{supported}"
+            );
+        }
+        other => panic!("an unknown kind must be refused, got {other:?}"),
+    }
+}
+
+/// The three video knobs travel, and they are the ASK rather than the measurement.
+#[test]
+fn the_video_knobs_travel() {
+    let share = video_share();
+    assert_eq!(share.duration_seconds, Some(5.0));
+    assert_eq!(share.fps, Some(24));
+    assert_eq!(share.quality.as_deref(), Some("standard"));
+}
+
+/// …and an IMAGE envelope never grows them, even from a payload that carries the keys.
+#[test]
+fn an_image_envelope_never_grows_the_video_knobs() {
+    let share = sceneworks_core::workflow_share::build_workflow_share_from(
+        &facts(),
+        &payload(json!({ "duration": 5.0, "fps": 24, "quality": "standard" })),
+    );
+    assert_eq!(share.duration_seconds, None);
+    assert_eq!(share.fps, None);
+    assert_eq!(share.quality, None);
+}
+
+/// **The person-replacement withholding.** The story's own acceptance criterion, and the one field
+/// class this contract withholds for privacy rather than for portability.
+///
+/// A shared video must not disclose that it was made by replacing a specific person. Three things
+/// have to be true at once, and they are asserted together because any one of them alone would let
+/// the disclosure through:
+///
+/// * the top-level `personTrackId` / `replacementMode` never reach the envelope;
+/// * `advanced.selectedPersonTrack` — the WHOLE track record, with a person's name, the original
+///   filename, and a `frames[].mask` array of filesystem paths — is dropped;
+/// * `advanced.replacementModeLabel`, which is neither an id nor a path, is dropped anyway.
+#[test]
+fn the_person_replacement_fields_are_withheld_from_a_shared_video() {
+    let mut facts = facts();
+    facts.mode = "replace_person".to_owned();
+    let share = build_video_workflow_share_from(
+        &facts,
+        &payload(json!({
+            "mode": "replace_person",
+            "personTrackId": "track_9f3c1b2a",
+            "replacementMode": "full_person_replace_outfit",
+            "sourceClipAssetId": "asset_0011",
+            "advanced": {
+                "motion": "handheld",
+                "replacementModeLabel": "Full Person, Replace Outfit",
+                "selectedPersonTrack": {
+                    "id": "track_9f3c1b2a",
+                    "name": "Sarah Whitfield",
+                    "sourceDisplayName": "sarah_birthday_2019.mov",
+                    "sourceAssetId": "asset_0011",
+                    "frames": [
+                        { "timestamp": 0.0, "mask": "assets/masks/track_9f3c1b2a/m0.png" },
+                        { "timestamp": 0.5, "mask": "assets/masks/track_9f3c1b2a/m1.png" }
+                    ]
+                }
+            }
+        })),
+    );
+
+    let serialized = serde_json::to_string(&share).expect("serializable");
+    for secret in [
+        "track_9f3c1b2a",
+        "Sarah Whitfield",
+        "sarah_birthday_2019.mov",
+        "full_person_replace_outfit",
+        "Full Person, Replace Outfit",
+        "assets/masks",
+        "m0.png",
+        "asset_0011",
+        "replacementMode",
+        "personTrackId",
+        "selectedPersonTrack",
+    ] {
+        assert!(
+            !serialized.contains(secret),
+            "a shared video must not disclose `{secret}`. Envelope: {serialized}"
+        );
+    }
+
+    // The knob that IS generation intent still travels, so this is a targeted withholding rather
+    // than the whole map being dropped.
+    assert_eq!(share.advanced.get("motion"), Some(&json!("handheld")));
+    // The mode itself travels — "this was a person replacement" is already implied by the mode,
+    // which the recipe cannot omit without lying about what was run. What is withheld is WHO and
+    // HOW: the track, the person's name, and the replacement mode.
+    assert_eq!(share.mode, "replace_person");
+    // And the clip it worked from rides as SHAPE.
+    assert!(share
+        .inputs
+        .iter()
+        .any(|input| input.kind == INPUT_KIND_SOURCE_CLIP));
+}
+
+/// **Withheld silently, not through `omitted`.** The one place the contract's "state the absence"
+/// rule is deliberately inverted.
+///
+/// `omitted: ["personTrackId"]` would announce the replacement to every reader while withholding
+/// only the id — which is the disclosure the withholding exists to prevent.
+#[test]
+fn the_withholding_does_not_announce_itself_in_the_omitted_marker() {
+    let mut facts = facts();
+    facts.mode = "replace_person".to_owned();
+    let share = build_video_workflow_share_from(
+        &facts,
+        &payload(json!({
+            "mode": "replace_person",
+            "personTrackId": "track_9f3c1b2a",
+            "replacementMode": "face_only",
+            "advanced": { "replacementModeLabel": "Face Only" }
+        })),
+    );
+    for marker in &share.omitted {
+        assert!(
+            !marker.contains("person") && !marker.contains("replacement"),
+            "the omission marker must not name the withheld person fields, got {:?}",
+            share.omitted
+        );
+    }
+}
+
+/// Clip ids become SHAPE, exactly as the image lane's `sourceAssetId` does, with zero id leakage.
+#[test]
+fn clip_ids_become_shape_descriptors() {
+    let share = build_video_workflow_share_from(
+        &facts(),
+        &payload(json!({
+            "mode": "video_bridge",
+            "sourceClipAssetId": "clip_left_7788",
+            "bridgeRightClipAssetId": "clip_right_9900",
+            "sourceClipAssetIds": ["clip_a_1", "clip_b_2"],
+            "referenceClipAssetId": "refclip_5566",
+            "referenceAssetIds": ["ref_img_1", "ref_img_2", "ref_img_3"],
+            "lastFrameAssetId": "still_4321",
+        })),
+    );
+
+    let by_kind = |kind: &str| {
+        share
+            .inputs
+            .iter()
+            .find(|input| input.kind == kind)
+            .map(|input| input.count)
+    };
+    // Two named clips plus the two-entry list.
+    assert_eq!(by_kind(INPUT_KIND_SOURCE_CLIP), Some(4));
+    assert_eq!(by_kind(INPUT_KIND_REFERENCE_CLIP), Some(1));
+    assert_eq!(by_kind(INPUT_KIND_REFERENCE), Some(3));
+    // `lastFrameAssetId` is a STILL, so it counts as a source rather than a clip.
+    assert_eq!(by_kind(INPUT_KIND_SOURCE), Some(1));
+
+    let serialized = serde_json::to_string(&share).expect("serializable");
+    for id in [
+        "clip_left_7788",
+        "clip_right_9900",
+        "clip_a_1",
+        "clip_b_2",
+        "refclip_5566",
+        "ref_img_1",
+        "still_4321",
+    ] {
+        assert!(
+            !serialized.contains(id),
+            "no clip or asset id may reach the envelope; `{id}` did. {serialized}"
+        );
+    }
+}
+
+/// The gated video builder runs the recording ceiling, and it is the SAME ceiling as the image
+/// lane's — a bound on what gets persisted, not on what the container could hold.
+#[test]
+fn the_gated_video_builder_refuses_an_over_ceiling_envelope() {
+    assert!(
+        embeddable_video_workflow_share(&facts(), &payload(json!({}))).is_some(),
+        "an ordinary clip must embed"
+    );
+
+    // `advanced` is the only field with enough headroom to pass the ceiling: a map of allow-listed
+    // scalars, each bounded, but many of them.
+    let mut advanced = Map::new();
+    for index in 0..4_000 {
+        advanced.insert(format!("motion{index}"), json!("x".repeat(180)));
+    }
+    advanced.insert("motion".to_owned(), json!("x".repeat(180)));
+    let mut facts = facts();
+    facts.prompt = "y".repeat(16 * 1024);
+    let share = build_video_workflow_share_from(
+        &facts,
+        &payload(json!({ "advanced": Value::Object(advanced) })),
+    );
+    let size = serde_json::to_string(&share).expect("serializable").len();
+    assert!(
+        size <= WORKFLOW_SHARE_MAX_BYTES,
+        "the allow-list should have shed the unclassified keys, leaving {size} bytes"
+    );
+}
+
+/// The reader refuses an over-ceiling envelope out of a container too, so a hand-built MP4 cannot
+/// smuggle past a bound the writer applies.
+#[test]
+fn the_reader_applies_the_recording_ceiling_to_a_container() {
+    let mut value = serde_json::to_value(video_share()).expect("serializable");
+    value["prompt"] = json!("z".repeat(WORKFLOW_SHARE_MAX_BYTES + 4_096));
+    let bytes = mp4_with_json(&value);
+    match read_workflow_metadata(&bytes) {
+        // Either the prose bound sheds it first or the ceiling refuses it; both are correct, and
+        // what must NOT happen is an over-ceiling envelope coming back whole.
+        Ok(Some(share)) => {
+            let size = serde_json::to_string(&share).expect("serializable").len();
+            assert!(size <= WORKFLOW_SHARE_MAX_BYTES, "{size} bytes came back");
+        }
+        Err(WorkflowMp4Error::Share(WorkflowShareError::TooLarge { .. })) => {}
+        other => panic!("unexpected: {other:?}"),
+    }
+}

--- a/crates/sceneworks-core/tests/workflow_mp4.rs
+++ b/crates/sceneworks-core/tests/workflow_mp4.rs
@@ -43,7 +43,7 @@ fn payload(extra: Value) -> Map<String, Value> {
         "prompt": "a fox crossing a frozen river",
         "duration": 5.0,
         "fps": 24,
-        "quality": "standard",
+        "quality": "balanced",
         "width": 768,
         "height": 512,
     });
@@ -526,7 +526,7 @@ fn the_video_knobs_travel() {
     let share = video_share();
     assert_eq!(share.duration_seconds, Some(5.0));
     assert_eq!(share.fps, Some(24));
-    assert_eq!(share.quality.as_deref(), Some("standard"));
+    assert_eq!(share.quality.as_deref(), Some("balanced"));
 }
 
 /// …and an IMAGE envelope never grows them, even from a payload that carries the keys.
@@ -534,7 +534,7 @@ fn the_video_knobs_travel() {
 fn an_image_envelope_never_grows_the_video_knobs() {
     let share = sceneworks_core::workflow_share::build_workflow_share_from(
         &facts(),
-        &payload(json!({ "duration": 5.0, "fps": 24, "quality": "standard" })),
+        &payload(json!({ "duration": 5.0, "fps": 24, "quality": "balanced" })),
     );
     assert_eq!(share.duration_seconds, None);
     assert_eq!(share.fps, None);

--- a/crates/sceneworks-core/tests/workflow_png.rs
+++ b/crates/sceneworks-core/tests/workflow_png.rs
@@ -927,7 +927,10 @@ fn the_readers_verdict_over_the_whole_corpus() {
         (
             "a marker kind this build does not read",
             png_carrying(&envelope_text(|object| {
-                object.insert(WORKFLOW_SHARE_MARKER_KEY.to_owned(), json!("video"));
+                // `video` was this fixture's unknown kind until sc-15956 made it a lane the
+                // reader understands. The corpus needs a kind NO build reads, which is the
+                // state an older build is in when it meets a video envelope.
+                object.insert(WORKFLOW_SHARE_MARKER_KEY.to_owned(), json!("hologram"));
             })),
             Verdict::Unreadable,
         ),

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -2028,9 +2028,36 @@ const WORKFLOW_WRITE_SURFACE: &[(&str, &str, &str)] = &[
          seam must call.",
     ),
     (
+        "crates/sceneworks-core/src/workflow_share.rs",
+        "build_video_workflow_share_from",
+        "Builds a VIDEO envelope from per-clip facts. Ungated — no recording ceiling (sc-15956).",
+    ),
+    (
+        "crates/sceneworks-core/src/workflow_share.rs",
+        "embeddable_video_workflow_share",
+        "The gated VIDEO builder: the one video form that runs the recording ceiling, and the one \
+         a video write seam must call.",
+    ),
+    (
         "crates/sceneworks-core/src/workflow_png.rs",
         "write_workflow_chunk",
         "Writes the PNG, with the envelope in an iTXt chunk when one is handed in.",
+    ),
+    (
+        "crates/sceneworks-core/src/workflow_mp4.rs",
+        "ffmetadata_document",
+        "Encodes the envelope as the `ffmetadata` document ffmpeg muxes into an MP4's `comment` \
+         tag (sc-15956).",
+    ),
+    (
+        "crates/sceneworks-core/src/workflow_mp4.rs",
+        "write_workflow_metadata_file",
+        "Writes that document to disk for ffmpeg to read — the MP4 lane's `write_workflow_chunk`.",
+    ),
+    (
+        "crates/sceneworks-core/src/workflow_mp4.rs",
+        "workflow_metadata_size",
+        "Measures an envelope's encoded size in an MP4's tag store.",
     ),
 ];
 
@@ -2066,6 +2093,16 @@ const WORKFLOW_READ_SURFACE: &[(&str, &str, &str)] = &[
         "workflow_chunk_size",
         "Measures an envelope's encoded size for the recording ceiling.",
     ),
+    (
+        "crates/sceneworks-core/src/workflow_mp4.rs",
+        "read_workflow_metadata",
+        "Reads the envelope out of MP4 bytes (sc-15956).",
+    ),
+    (
+        "crates/sceneworks-core/src/workflow_mp4.rs",
+        "read_workflow_metadata_file",
+        "Reads the envelope out of an MP4 on disk, without buffering `mdat`.",
+    ),
 ];
 
 /// Both halves of the core surface are declared, and nothing in core has slipped between them.
@@ -2100,6 +2137,7 @@ fn the_core_workflow_surface_is_classified() {
     for path in [
         "crates/sceneworks-core/src/workflow_share.rs",
         "crates/sceneworks-core/src/workflow_png.rs",
+        "crates/sceneworks-core/src/workflow_mp4.rs",
     ] {
         let stripped = rust_scannable(&read_repo_file(path));
         for item in rust_fn_spans(&stripped) {
@@ -2423,7 +2461,21 @@ fn an_undeclared_seam_fails_the_build() {
     }]);
 }
 
-/// The named failure sc-15956 must hit: a declared video seam whose builder is still deferred.
+/// A declared seam whose builder is still deferred fails, naming the registry.
+///
+/// **Re-pointed by sc-15956**, exactly as sc-16113 predicted it would have to be. This test used
+/// `VideoStudio.jsx::submit` as its deferred example; sc-15956 promoted that builder into
+/// `ADVANCED_BUILDERS` — which is what the whole gate was built to force — so the mutation stopped
+/// panicking and the proof turned into a "did not panic as expected" failure.
+///
+/// The example is now `trainingConfig.js::trainingConfigSnapshot`, the PERMANENT exemption, and
+/// that is a better anchor than the one it replaces: a story-owned deferral is by definition
+/// temporary, so any test hard-coding one has an expiry date. This one does not — a permanent
+/// exemption only leaves `DEFERRED_ADVANCED_BUILDERS` if a training write seam appears, at which
+/// point its own entry says the whole classification has to be redone anyway.
+///
+/// What is proved is unchanged: SOME deferred builder is refused, and the message names the
+/// registry so the next author knows where to look.
 #[test]
 #[should_panic(expected = "DEFERRED_ADVANCED_BUILDERS")]
 fn a_seam_that_embeds_for_a_deferred_builder_fails_the_build() {
@@ -2432,9 +2484,26 @@ fn a_seam_that_embeds_for_a_deferred_builder_fails_the_build() {
         "append_seedvr2_frames",
         "the SeedVR2 video lane",
         &[WebBuilderRef {
-            path: "apps/web/src/screens/VideoStudio.jsx",
-            function: "submit",
+            path: "apps/web/src/training/trainingConfig.js",
+            function: "trainingConfigSnapshot",
         }],
+    );
+}
+
+/// And the deferral list still HAS an entry to point that test at.
+///
+/// The companion to the re-pointing above: `a_seam_that_embeds_for_a_deferred_builder_fails_the_build`
+/// is only a proof while some builder is deferred, and an empty registry would turn it into a test
+/// that panics for the wrong reason. sc-15956 emptied the list of everything except the permanent
+/// exemption, so this is the floor that says so out loud.
+#[test]
+fn the_deferral_registry_still_has_something_in_it() {
+    assert!(
+        !DEFERRED_ADVANCED_BUILDERS.is_empty(),
+        "`DEFERRED_ADVANCED_BUILDERS` is empty, so \
+         `a_seam_that_embeds_for_a_deferred_builder_fails_the_build` has no example left to \
+         mutate. If the last entry really has been classified, that test needs a different \
+         construction — not a stale reference to a builder nobody defers."
     );
 }
 
@@ -3307,6 +3376,29 @@ fn emitted_keys(builder: &AdvancedBuilder, source: &str) -> BTreeSet<String> {
             );
             (BTreeSet::new(), Vec::new())
         }
+        // The video builders' shape (sc-15956): an `advanced:` literal WITH conditional spreads,
+        // in a payload handed to a call rather than returned. `FlatAdvancedLiteral` refuses a
+        // spread and `ReturnedObject` looks for a `return {`, so neither could read these.
+        AdvancedBuilderShape::SpreadAdvancedLiteral => {
+            let at = body
+                .find("advanced:")
+                .unwrap_or_else(|| panic!("{what} no longer carries an `advanced:` literal"));
+            let literal = object_literal_body(body, at + "advanced:".len(), &what);
+            let (keys, spreads) = scan_object_literal(&literal, &what, true);
+            let declared: BTreeSet<String> = builder
+                .spread_of
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect();
+            assert_eq!(
+                spreads, declared,
+                "{what} spreads {spreads:?} into its `advanced` literal, but its registry entry \
+                 declares `spread_of: {declared:?}`. A spread nobody declared is a whole set of \
+                 keys this lint cannot see — either point `spread_of` at it and register the \
+                 builder that produces those keys, or stop spreading it."
+            );
+            (keys, vec![at])
+        }
     };
     refuse_unread_advanced_signals(body, &what, builder, &signals, &consumed);
     keys
@@ -3542,8 +3634,13 @@ fn scan_object_literal(
     let chars: Vec<char> = body.chars().collect();
     let mut keys = BTreeSet::new();
     let mut identifier_spreads = BTreeSet::new();
-    // (is_emit_scope, expecting_a_key)
-    let mut scopes: Vec<(bool, bool)> = vec![(true, true)];
+    // (is_emit_scope, expecting_a_key, paren_depth_at_open)
+    //
+    // The third field is sc-15956's. A `,` only starts a new KEY at the scope's own paren
+    // depth: `timelineContext: generationContext("extend", selectedItem, { .. })` separates
+    // CALL ARGUMENTS with commas, and reading those as keys made `selectedItem` look like an
+    // advanced knob that nobody had classified.
+    let mut scopes: Vec<(bool, bool, usize)> = vec![(true, true, 0)];
     // Open spread expressions, as (open scope count, paren depth at the `...`, produced an
     // object literal). Nested, because `...(a ? { k, ...(b ? { j } : {}) } : {})` happens.
     let mut spreads: Vec<(usize, usize, bool)> = Vec::new();
@@ -3561,14 +3658,14 @@ fn scan_object_literal(
                 let in_spread = spreads
                     .last()
                     .is_some_and(|(scope_count, _, _)| *scope_count == scopes.len());
-                let is_emit = in_spread && scopes.last().is_some_and(|(emit, _)| *emit);
+                let is_emit = in_spread && scopes.last().is_some_and(|(emit, _, _)| *emit);
                 if let (true, Some(spread)) = (is_emit, spreads.last_mut()) {
                     spread.2 = true;
                 }
                 if let Some(scope) = scopes.last_mut() {
                     scope.1 = false;
                 }
-                scopes.push((is_emit, true));
+                scopes.push((is_emit, true, paren_depth));
                 index += 1;
             }
             '}' => {
@@ -3607,13 +3704,15 @@ fn scan_object_literal(
             }
             ',' => {
                 if let Some(scope) = scopes.last_mut() {
-                    scope.1 = true;
+                    // Only at this scope's own depth — a comma deeper in is a call argument
+                    // separator, not the start of the next key (sc-15956).
+                    scope.1 = paren_depth == scope.2;
                 }
                 index += 1;
             }
             '.' => {
                 if index + 2 < chars.len() && chars[index + 1] == '.' && chars[index + 2] == '.' {
-                    if scopes.last().is_some_and(|(emit, _)| *emit) {
+                    if scopes.last().is_some_and(|(emit, _, _)| *emit) {
                         // The scanner follows `...( … )`, plus a bare identifier where the caller
                         // has declared one. Anything else — a call, a member expression — would
                         // leave a spread open forever, so the next nested object VALUE would read
@@ -3629,7 +3728,21 @@ fn scan_object_literal(
                                 .is_some_and(is_identifier_start);
                         if identifier_spread {
                             let start = lookahead;
-                            while lookahead < chars.len() && is_identifier_char(chars[lookahead]) {
+                            // A dotted MEMBER path (`...base.advanced`) reads as one name, not as
+                            // a refusal (sc-15956). The three timeline actions spread
+                            // `buildBasePayload`'s own map that way, and the property the refusal
+                            // protects is unchanged: the whole dotted name goes into
+                            // `identifier_spreads`, so `spread_of` must declare it and a builder
+                            // must account for the keys behind it. A CALL is still refused, below
+                            // — a call's keys have no declarable name.
+                            while lookahead < chars.len()
+                                && (is_identifier_char(chars[lookahead])
+                                    || (chars[lookahead] == '.'
+                                        && chars
+                                            .get(lookahead + 1)
+                                            .copied()
+                                            .is_some_and(is_identifier_start)))
+                            {
                                 lookahead += 1;
                             }
                             let mut after = lookahead;
@@ -3638,10 +3751,10 @@ fn scan_object_literal(
                             }
                             assert!(
                                 matches!(chars.get(after), Some(',') | Some('}') | None),
-                                "{what} spreads something this coverage lint cannot read: a \
-                                 member or call expression (`...{}`). Every key it contributes is \
-                                 invisible to this lint, so a new knob would silently stop \
-                                 travelling.",
+                                "{what} spreads something this coverage lint cannot read: a call \
+                                 expression or a computed member (`...{}`). Every key it \
+                                 contributes is invisible to this lint, so a new knob would \
+                                 silently stop travelling.",
                                 chars[start..]
                                     .iter()
                                     .take(24)
@@ -3690,7 +3803,7 @@ fn scan_object_literal(
                 while index < chars.len() && is_identifier_char(chars[index]) {
                     index += 1;
                 }
-                let (is_emit, expecting) = *scopes.last().expect("a scope is always open");
+                let (is_emit, expecting, _) = *scopes.last().expect("a scope is always open");
                 if is_emit && expecting {
                     let mut lookahead = index;
                     while lookahead < chars.len() && chars[lookahead].is_whitespace() {

--- a/crates/sceneworks-core/tests/workflow_share_doc.rs
+++ b/crates/sceneworks-core/tests/workflow_share_doc.rs
@@ -38,7 +38,7 @@ use sceneworks_core::workflow_share::{
     SeamDisposition, WorkflowInput, WorkflowLora, WorkflowProducer, WorkflowShare, WorkflowUpscale,
     ADVANCED_BUILDERS, ADVANCED_KEY_RULES, DEFERRED_ADVANCED_BUILDERS, INPUT_KINDS,
     INPUT_KIND_SOURCE, OMITTED_FIELDS, OMITTED_LORAS, POSE_FIELDS, PRODUCER_NAME, PRODUCER_URL,
-    WORKFLOW_KIND_IMAGE, WORKFLOW_SHARE_MARKER_KEY, WORKFLOW_SHARE_MAX_BYTES,
+    WORKFLOW_KINDS, WORKFLOW_KIND_IMAGE, WORKFLOW_SHARE_MARKER_KEY, WORKFLOW_SHARE_MAX_BYTES,
     WORKFLOW_SHARE_SCHEMA_VERSION, WORKFLOW_WRITE_SEAMS,
 };
 use serde_json::{json, Value};
@@ -335,7 +335,7 @@ fn fully_populated_envelope() -> WorkflowShare {
         // document is pinned against every field rather than against one lane's.
         duration_seconds: Some(5.0),
         fps: Some(24),
-        quality: Some("standard".to_owned()),
+        quality: Some("balanced".to_owned()),
         style_preset: Some("cinematic".to_owned()),
         style_id: Some("noir".to_owned()),
         fit_mode: Some("crop".to_owned()),
@@ -555,6 +555,135 @@ fn the_doc_lists_exactly_the_omitted_vocabulary() {
             .collect(),
         "omitted-fields",
         "`OMITTED_FIELDS`",
+    );
+}
+
+/// Every reader named in the `container-kinds` table really asserts the kind the table claims
+/// (sc-15956 review).
+///
+/// The rule this pins is the one the marker's widening broke: the shared parser accepts every kind
+/// in `WORKFLOW_KINDS`, so a reader that hands its result to one lane owes a container assert of its
+/// own. The PNG reader had one, the MP4 reader had one, and the asset route — the third reader,
+/// in a crate the widening did not touch — silently lost the refusal it used to inherit from the
+/// parser.
+///
+/// Not a prose check. Each row names a file and a function, and this reads that file and fails if
+/// the assert it claims is not in it, so deleting a gate breaks the document as well as the route's
+/// own test.
+#[test]
+fn the_doc_lists_exactly_the_container_kind_asserts() {
+    let rows = pinned_rows(&doc(), "container-kinds");
+    assert!(
+        rows.len() >= WORKFLOW_KINDS.len(),
+        "{DOC_PATH}: the `container-kinds` block lists {} readers for {} kinds — every kind needs \
+         at least one container that accepts it",
+        rows.len(),
+        WORKFLOW_KINDS.len()
+    );
+    let mut accepted: BTreeSet<String> = BTreeSet::new();
+    for row in &rows {
+        assert!(
+            row.len() >= 4,
+            "{DOC_PATH}: a `container-kinds` row has fewer than four columns: {row:?}"
+        );
+        let path = code(&row[1]);
+        let function = code(&row[2]);
+        let kind = code(&row[3]);
+        assert!(
+            WORKFLOW_KINDS.contains(&kind.as_str()),
+            "{DOC_PATH}: `container-kinds` says {function} accepts `{kind}`, which is not a kind \
+             this contract has. Known kinds: {WORKFLOW_KINDS:?}"
+        );
+        accepted.insert(kind.clone());
+
+        let source = read_repo_file(&path);
+        assert!(
+            source.contains(&format!("fn {function}")),
+            "{DOC_PATH}: `container-kinds` names `{function}` in {path}, which has no such \
+             function. A reader that moved needs the table moved with it."
+        );
+        let constant = if kind == WORKFLOW_KIND_IMAGE {
+            "WORKFLOW_KIND_IMAGE"
+        } else {
+            "WORKFLOW_KIND_VIDEO"
+        };
+        assert!(
+            source.contains(&format!("share.kind != {constant}")),
+            "{path} does not assert `share.kind != {constant}` anywhere, and {DOC_PATH}'s \
+             `container-kinds` table says `{function}` accepts only `{kind}`.\n\
+             The shared parser accepts EVERY kind, so a reader that feeds one lane is the only \
+             thing standing between a `{kind}`-only surface and an envelope of another kind being \
+             presented as one it is not."
+        );
+    }
+    assert_eq!(
+        accepted,
+        WORKFLOW_KINDS
+            .iter()
+            .map(|kind| (*kind).to_owned())
+            .collect::<BTreeSet<String>>(),
+        "{DOC_PATH}: every kind the contract has needs a container that accepts it, or the kind is \
+         one nothing can read"
+    );
+}
+
+/// Every in-document `](#anchor)` link resolves to a heading in this document.
+///
+/// The sc-15956 review found `[Person replacement](#person-replacement-is-withheld-by-default)`
+/// pointing at a heading that did not exist — and that dead link was the single pointer a future
+/// author had to the person-replacement rationale, from the withheld table's own row. A reader
+/// following it landed at the top of the page and could reasonably conclude the reasoning had never
+/// been written down.
+///
+/// GitHub's slug rule, near enough for this document: lowercase, drop everything that is not a
+/// letter, digit, space or hyphen, then spaces to hyphens.
+#[test]
+fn every_internal_link_in_the_doc_points_at_a_heading_that_exists() {
+    let doc = doc();
+    let mut headings: BTreeSet<String> = BTreeSet::new();
+    for line in doc.lines() {
+        // The privacy callout is a blockquote, so its headings carry a `>` prefix.
+        let line = line.trim_start().trim_start_matches('>').trim_start();
+        let Some(rest) = line.strip_prefix('#') else {
+            continue;
+        };
+        let title = rest.trim_start_matches('#').trim();
+        if title.is_empty() {
+            continue;
+        }
+        let slug: String = title
+            .to_lowercase()
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == ' ' || *c == '-')
+            .map(|c| if c == ' ' { '-' } else { c })
+            .collect();
+        headings.insert(slug);
+    }
+    assert!(
+        !headings.is_empty(),
+        "{DOC_PATH}: no headings parsed at all"
+    );
+
+    let mut dead: Vec<String> = Vec::new();
+    let mut seen = 0_usize;
+    // Links are hard-wrapped across lines, so search the FLOWED document.
+    let flowed = flowed(&doc);
+    for chunk in flowed.split("](#").skip(1) {
+        let Some(end) = chunk.find(')') else {
+            continue;
+        };
+        seen += 1;
+        // A wrapped link puts a space inside the anchor; the rendered href has none.
+        let anchor = chunk[..end].replace(' ', "");
+        if !headings.contains(&anchor) {
+            dead.push(anchor);
+        }
+    }
+    assert!(seen > 0, "{DOC_PATH}: no internal links parsed at all");
+    assert!(
+        dead.is_empty(),
+        "{DOC_PATH} links to {dead:?}, and no heading in it produces those anchors. \
+         The headings that exist are {headings:?}."
     );
 }
 
@@ -1034,6 +1163,150 @@ fn the_settings_copy_names_exactly_the_path_exempt_prose_fields() {
         read_repo_file(SETTINGS_COPY_PATH).contains(&link_target),
         "{SETTINGS_COPY_PATH} must link to {link_target} — the copy is a summary, and the summary \
          has to be able to send the user to the exact list"
+    );
+}
+
+/// The value of a `const NAME = "…";` string in the settings copy, unescaped enough to compare.
+///
+/// The person-replacement bullet is the one claim in that file no key-level lint can reach, so it
+/// has to be read as PROSE. Panics when the constant is gone, for the reason every parser here
+/// does: a lint that finds nothing passes against a file that was emptied.
+fn settings_copy_constant(name: &str) -> String {
+    let source = read_repo_file(SETTINGS_COPY_PATH);
+    let anchor = format!("const {name} =");
+    let start = source.find(&anchor).unwrap_or_else(|| {
+        panic!("{SETTINGS_COPY_PATH} no longer declares `{anchor}`; teach this lint where it went")
+    }) + anchor.len();
+    let rest = &source[start..];
+    let open = rest
+        .find('"')
+        .unwrap_or_else(|| panic!("{SETTINGS_COPY_PATH}: `{name}` has no string literal"));
+    let close = rest[open + 1..]
+        .find('"')
+        .unwrap_or_else(|| panic!("{SETTINGS_COPY_PATH}: `{name}`'s string is never closed"))
+        + open
+        + 1;
+    let value = rest[open + 1..close].to_owned();
+    assert!(
+        !value.trim().is_empty(),
+        "{SETTINGS_COPY_PATH}: `{name}` parsed to an empty string"
+    );
+    value
+}
+
+/// The person-replacement bullet says only what a real `replace_person` envelope actually withholds
+/// (sc-15956 review).
+///
+/// # The failure this exists for
+///
+/// The bullet read *"anything about a person replacement — the selected track, the person's name,
+/// the original file name, the mask images, or which replacement mode ran"*, rendered into the
+/// **"Not in the file"** list. Every item after the dash was true. The leading clause was not:
+/// `mode` is in the **"In the file"** list, and a person-replacement run writes it verbatim as
+/// `replace_person`. `model` says it a second time — `wan_2_2_vace_fun_14b` is a replacement
+/// engine. So the file announces the TECHNIQUE while the copy said it announced nothing, which is
+/// the one direction `workflowEmbed.js`'s own header forbids: claiming more privacy than the
+/// allow-list delivers.
+///
+/// # Why the key-level pins could not catch it
+///
+/// `the_settings_copy_accounts_for_every_shared_and_withheld_field` joins the copy to the doc on
+/// KEYS, and `mode` is not a key in either of the two lists it compares — it is a shared field the
+/// copy already declares correctly. The error was in a sentence about a different key. So this
+/// asserts the sentence against the bytes of a real envelope instead.
+#[test]
+fn the_settings_copy_does_not_overclaim_about_person_replacement() {
+    // A real Video Studio person-replacement payload, with every person-shaped value the builder
+    // can be handed.
+    let payload = json!({
+        "mode": "replace_person",
+        "model": "wan_2_2_vace_fun_14b",
+        "prompt": "the same shot, continuous motion",
+        "duration": 5.0,
+        "fps": 24,
+        "quality": "balanced",
+        "personTrackId": "track_9f3c1b2a",
+        "replacementMode": "full_person_keep_outfit",
+        "advanced": {
+            "motion": "static",
+            "replacementModeLabel": "Full Person, Keep Outfit",
+            "selectedPersonTrack": {
+                "name": "Sarah Whitfield",
+                "sourceDisplayName": "sarah-audition-take3.mov",
+                "frames": [{ "mask": "D:/Clients/Acme/masks/0001.png" }]
+            }
+        }
+    })
+    .as_object()
+    .expect("an object")
+    .clone();
+    let share = sceneworks_core::workflow_share::build_video_workflow_share_from(
+        &sceneworks_core::workflow_share::WorkflowAssetFacts {
+            mode: "replace_person".to_owned(),
+            model: "wan_2_2_vace_fun_14b".to_owned(),
+            prompt: "the same shot, continuous motion".to_owned(),
+            negative_prompt: String::new(),
+            seed: 7,
+            width: Some(832),
+            height: Some(480),
+        },
+        &payload,
+    );
+    let bytes = serde_json::to_string(&share).expect("the envelope serializes");
+
+    // Half one: the withholding is real. These are the things the bullet promises are absent.
+    for withheld in [
+        "track_9f3c1b2a",
+        "Sarah Whitfield",
+        "sarah-audition-take3.mov",
+        "0001.png",
+        "full_person_keep_outfit",
+        "Full Person, Keep Outfit",
+        "selectedPersonTrack",
+    ] {
+        assert!(
+            !bytes.contains(withheld),
+            "`{withheld}` reached a real person-replacement envelope: {bytes}"
+        );
+    }
+
+    // Half two: and the technique is NOT withheld. This is what makes the old leading clause false,
+    // asserted rather than argued — if this ever stops holding, the copy may go back to the
+    // stronger sentence, and this assert is what will say so.
+    assert_eq!(share.mode, "replace_person");
+    assert!(
+        bytes.contains("\"mode\":\"replace_person\""),
+        "the envelope must still carry the generation mode verbatim: {bytes}"
+    );
+    assert!(
+        bytes.contains("wan_2_2_vace_fun_14b"),
+        "and the model, which names a replacement engine: {bytes}"
+    );
+
+    // Half three: the sentence a user reads matches both halves.
+    let copy = settings_copy_constant("N_PERSON");
+    assert!(
+        !copy.contains("anything about a person replacement"),
+        "{SETTINGS_COPY_PATH}: `N_PERSON` claims the file says nothing about a replacement, and \
+         `mode` says `replace_person` in every one: {copy}"
+    );
+    for named in [
+        "who was replaced",
+        "the selected track",
+        "the person's name",
+        "the original file name",
+        "the mask images",
+    ] {
+        assert!(
+            copy.contains(named),
+            "{SETTINGS_COPY_PATH}: `N_PERSON` no longer names {named:?}, which the envelope really \
+             does withhold: {copy}"
+        );
+    }
+    assert!(
+        copy.contains("generation mode") && copy.contains("do travel"),
+        "{SETTINGS_COPY_PATH}: `N_PERSON` must say that the mode and the model travel, because \
+         they do — an absence list that omits this is the overclaim this test exists for: {copy}"
     );
 }
 

--- a/crates/sceneworks-core/tests/workflow_share_doc.rs
+++ b/crates/sceneworks-core/tests/workflow_share_doc.rs
@@ -330,6 +330,12 @@ fn fully_populated_envelope() -> WorkflowShare {
         width: Some(1024),
         height: Some(1024),
         count: Some(2),
+        // The video arm (sc-15956). Populated even though `kind` above is the image one: this
+        // fixture's job is the WIDEST serialized shape the contract can produce, so that the
+        // document is pinned against every field rather than against one lane's.
+        duration_seconds: Some(5.0),
+        fps: Some(24),
+        quality: Some("standard".to_owned()),
         style_preset: Some("cinematic".to_owned()),
         style_id: Some("noir".to_owned()),
         fit_mode: Some("crop".to_owned()),

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -2082,8 +2082,8 @@ impl TimelineExport<'_> {
     /// multi-input command is to copy input 0's metadata to the output — so a crossfaded export
     /// would have published its first clip's recipe as its own. Both mux paths pass
     /// `-map_metadata -1` explicitly; `mux_with_crossfades_args` records the measurement, and
-    /// `a_crossfaded_export_does_not_inherit_a_clips_recipe` in
-    /// `crates/sceneworks-worker/src/tests/workflow_video.rs` fails if either regresses.
+    /// `a_crossfaded_export_does_not_inherit_a_clips_recipe` in this file
+    /// (`export_metadata_tests`) fails if either regresses.
     async fn finalize(
         &self,
         segments: &[TimelineSegment],
@@ -4524,5 +4524,121 @@ mod crossfade_mux_tests {
         // source_in preserved as -ss.
         let ss_idx = args.iter().position(|arg| arg == "-ss").unwrap() + 1;
         assert_eq!(args[ss_idx], "0.500");
+    }
+}
+
+/// The timeline export's relationship to the workflow envelope (sc-15956).
+///
+/// An export embeds nothing — see [`TimelineExport::finalize`] — but that is only half the job.
+/// The other half is that it must not INHERIT one, and inheritance is ffmpeg's default rather than
+/// something anyone wrote.
+#[cfg(test)]
+mod export_metadata_tests {
+    use super::*;
+
+    fn segment(path: &str, duration: f64, transition: Option<&str>) -> TimelineSegment {
+        TimelineSegment {
+            path: PathBuf::from(path),
+            duration,
+            transition: transition.map(str::to_owned),
+            transition_duration: 0.5,
+        }
+    }
+
+    /// The position of `-map_metadata`'s value in an argument list, if it is there at all.
+    fn map_metadata_value(args: &[String]) -> Option<&str> {
+        args.iter()
+            .position(|arg| arg == "-map_metadata")
+            .and_then(|at| args.get(at + 1))
+            .map(String::as_str)
+    }
+
+    /// **The measured surprise this guard exists for.**
+    ///
+    /// `mux_with_crossfades_args` passes every segment as its own `-i`. With several inputs and no
+    /// `-map_metadata`, ffmpeg copies input 0's container metadata to the output — so once
+    /// generated clips began carrying a workflow tag, a crossfaded export silently published THE
+    /// FIRST CLIP'S recipe as its own. Verified against a real ffmpeg before this was written: the
+    /// output carried clip 1's comment verbatim.
+    ///
+    /// An export is a mux of several clips and is not the output of any one of their recipes.
+    /// Presenting one of them as the recipe for the whole is precisely the writer-and-reader
+    /// disagreement the envelope contract exists to prevent.
+    #[test]
+    fn a_crossfaded_export_does_not_inherit_a_clips_recipe() {
+        let segments = [
+            segment("a.mp4", 2.0, None),
+            segment("b.mp4", 3.0, Some("crossfade")),
+            segment("c.mp4", 4.0, None),
+        ];
+        let args = mux_with_crossfades_args("ffmpeg", &segments, Path::new("out.mp4"))
+            .expect("three segments mux");
+        assert_eq!(
+            map_metadata_value(&args),
+            Some("-1"),
+            "the crossfade mux MUST strip metadata: ffmpeg's default on a multi-input command is \
+             to copy input 0's, which would publish the first clip's recipe as the export's own. \
+             Args: {args:?}"
+        );
+    }
+
+    /// The plain concat path says the same thing, though it did not have to.
+    ///
+    /// The concat demuxer drops per-segment metadata on its own, so this changes no behaviour — it
+    /// is here because its crossfade sibling proves the default is not reliable, and an asymmetry
+    /// between two paths that produce the same kind of file is how one of them regresses unnoticed.
+    #[test]
+    fn the_concat_export_strips_metadata_explicitly_too() {
+        // `mux_segments` builds its arguments inline around a concat list it has already written,
+        // so there is no pure args builder to call the way the crossfade path has one. Read the
+        // constant off the source instead — the same technique the seam lint uses, and it is the
+        // flag's PRESENCE that is the claim here, not a runtime behaviour.
+        let source = include_str!("media_jobs.rs");
+        let concat_body = source
+            .split("pub(crate) async fn mux_segments(")
+            .nth(1)
+            .expect("mux_segments is still here")
+            .split("pub(crate) async fn mux_with_crossfades(")
+            .next()
+            .expect("the function ends");
+        assert!(
+            concat_body.contains("\"-map_metadata\".to_owned()"),
+            "`mux_segments` must pass `-map_metadata` explicitly — see \
+             `a_crossfaded_export_does_not_inherit_a_clips_recipe` for why the default is not \
+             something to rely on"
+        );
+    }
+
+    /// The export writes no envelope of its own, and the lint's registry agrees.
+    ///
+    /// `TimelineExport::finalize` is deliberately NOT in `WORKFLOW_WRITE_SEAMS`: that registry
+    /// lists functions an envelope can reach, and an entry whose function touches none fails as a
+    /// stale claim. What keeps the decision honest is that the body must stay free of the envelope
+    /// surface, which is what this reads.
+    #[test]
+    fn the_timeline_export_builds_no_envelope() {
+        let source = include_str!("media_jobs.rs");
+        let finalize = source
+            .split("    async fn finalize(")
+            .nth(1)
+            .expect("finalize is still here")
+            .split("\n    }\n}")
+            .next()
+            .expect("the function ends");
+        for forbidden in [
+            "embeddable_workflow_share",
+            "embeddable_video_workflow_share",
+            "build_workflow_share",
+            "write_workflow_metadata_file",
+            "write_workflow_chunk",
+        ] {
+            assert!(
+                !finalize.contains(forbidden),
+                "`TimelineExport::finalize` calls `{forbidden}`, so it now EMBEDS. A timeline \
+                 export is a mux of several clips rather than the output of any one recipe, and \
+                 its sidecar `prompt` slot holds the user's own timeline name. If this is \
+                 deliberate, it needs a `WORKFLOW_WRITE_SEAMS` entry naming the builders behind it."
+            );
+        }
     }
 }

--- a/crates/sceneworks-worker/src/media_jobs.rs
+++ b/crates/sceneworks-worker/src/media_jobs.rs
@@ -2062,6 +2062,28 @@ impl TimelineExport<'_> {
 
     /// Mux the rendered segments into the project's render directory, write the
     /// asset sidecar and recipe, index the asset, and report completion.
+    ///
+    /// # No workflow travels in an export (sc-15956)
+    ///
+    /// **A timeline export is not a generation.** Its sidecar recipe is `mode: timeline_export,
+    /// model: ffmpeg` — there is no model, no seed and no prompt to replay, and what sits in the
+    /// recipe's `prompt` slot is the TIMELINE'S NAME, a piece of the user's own project structure
+    /// with no business leaving in a file. An envelope built from that would reproduce nothing
+    /// while disclosing something, which is worse than an absence in both directions.
+    ///
+    /// So this function never touches a `WorkflowShare`, and therefore is deliberately NOT in
+    /// `WORKFLOW_WRITE_SEAMS`: that registry lists functions an envelope can REACH, and an entry
+    /// whose function touches none fails the lint as a stale claim. `SeamDisposition::Declines` is
+    /// for a seam that writes a file with an envelope available to it —
+    /// `segment_jobs::run_image_segment_job` — which is not this.
+    ///
+    /// **What does need enforcing here is inheritance**, and it is enforced where it happens. This
+    /// export's inputs are generated clips that now DO carry envelopes, and ffmpeg's default on a
+    /// multi-input command is to copy input 0's metadata to the output — so a crossfaded export
+    /// would have published its first clip's recipe as its own. Both mux paths pass
+    /// `-map_metadata -1` explicitly; `mux_with_crossfades_args` records the measurement, and
+    /// `a_crossfaded_export_does_not_inherit_a_clips_recipe` in
+    /// `crates/sceneworks-worker/src/tests/workflow_video.rs` fails if either regresses.
     async fn finalize(
         &self,
         segments: &[TimelineSegment],
@@ -2963,6 +2985,12 @@ pub(crate) async fn mux_segments(
             list_path.display().to_string(),
             "-c".to_owned(),
             "copy".to_owned(),
+            // The concat demuxer already drops per-segment metadata, so this changes nothing
+            // today; it is here because "the default happens to be right" is not a property
+            // anyone maintains, and its crossfade sibling proves the default is NOT right on a
+            // multi-input command. See `mux_with_crossfades_args` (sc-15956).
+            "-map_metadata".to_owned(),
+            "-1".to_owned(),
             output_path.display().to_string(),
         ],
         context,
@@ -3007,6 +3035,17 @@ pub(crate) fn mux_with_crossfades_args(
         filter,
         "-map".to_owned(),
         format!("[{output_label}]"),
+        // **Load-bearing since sc-15956.** With several `-i` inputs and no `-map_metadata`, ffmpeg
+        // defaults to input 0 — so the moment generated clips started carrying a workflow tag, a
+        // crossfaded export silently inherited THE FIRST CLIP'S recipe and published it as its own.
+        // Measured, not theorised: the plain `-f concat` path below drops metadata and this one
+        // does not, which is exactly the kind of asymmetry nobody would guess at.
+        //
+        // An export is a mux of several clips and is not the output of any one of their recipes;
+        // presenting one of them as the recipe for the whole is the failure the envelope contract
+        // exists to prevent. So the export carries NO workflow — see `TimelineExport::finalize`.
+        "-map_metadata".to_owned(),
+        "-1".to_owned(),
         output_path.display().to_string(),
     ]);
     Ok(args)

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -899,14 +899,23 @@ pub(crate) async fn run_video_generate_job(
     let workflow_metadata = plan.media_path.with_extension("workflow.ffmeta");
     let embedded =
         video_workflow_metadata(settings, job, &request, &plan, seed, &workflow_metadata);
-    encode_media(
+    let encoded = encode_media(
         &plan.media_path,
         decoded,
         embedded.then_some(workflow_metadata.as_path()),
         Some(ctx),
     )
-    .await?;
+    .await;
+    // The scratch goes on EVERY path, and the `?` waits for it. `encode_media(...).await?` here
+    // propagated FIRST, so a failed or cancelled encode left `*.workflow.ffmeta` — the whole
+    // envelope, prompt in plaintext — sitting in the user's project directory permanently, next to
+    // no video. A metadata document is a file the user never asked for; it must not outlive the
+    // encode it was written for. `encode_media` already keeps its own three temporaries on this
+    // exact shape (`let result = …; remove; result`), and `seedvr2.rs` uses an RAII `ScratchDir`
+    // for the same reason. Pinned by `the_workflow_metadata_scratch_does_not_outlive_a_failed_
+    // encode` in `crates/sceneworks-worker/src/video_jobs/tests.rs`.
     let _ = tokio::fs::remove_file(&workflow_metadata).await;
+    encoded?;
 
     let fact = video_asset_fact(&plan, seed, adapter, raw_settings, replacement_status, clip);
     let result = streaming_result(&plan, &fact, adapter);

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -892,7 +892,20 @@ pub(crate) async fn run_video_generate_job(
     // than merely fixed for today's models. `video_asset_fact` cannot be called without it.
     let clip = EncodedClip::measure(&decoded);
     let ctx = FfmpegContext::new(api, settings, &job.id, CANCEL_MESSAGE);
-    encode_media(&plan.media_path, decoded, Some(ctx)).await?;
+    // sc-15956: the sanitized workflow, written beside the clip as an `ffmetadata` document for
+    // the encoder to read. `None` means "encode exactly as before" — the user turned the setting
+    // off, the job carries no payload, or the envelope is over the recording ceiling — which is
+    // the same three-reasons-one-`Option` shape the image seam's `workflow_source` has.
+    let workflow_metadata = plan.media_path.with_extension("workflow.ffmeta");
+    let embedded = video_workflow_metadata(settings, job, &request, &plan, seed, &workflow_metadata);
+    encode_media(
+        &plan.media_path,
+        decoded,
+        embedded.then_some(workflow_metadata.as_path()),
+        Some(ctx),
+    )
+    .await?;
+    let _ = tokio::fs::remove_file(&workflow_metadata).await;
 
     let fact = video_asset_fact(&plan, seed, adapter, raw_settings, replacement_status, clip);
     let result = streaming_result(&plan, &fact, adapter);
@@ -910,6 +923,99 @@ pub(crate) async fn run_video_generate_job(
     )
     .await?;
     Ok(())
+}
+
+/// Build the sanitized workflow envelope for this clip and write it beside the media as an
+/// `ffmetadata` document, returning whether the encoder should attach it (sc-15956).
+///
+/// **The video lane's write seam** — the counterpart of `image_jobs::workflow_source` plus
+/// `write_image_asset`, collapsed into one function because a video job produces exactly one file.
+/// Declared in `WORKFLOW_WRITE_SEAMS` as `Embeds`, naming the six video builders sc-15956 promoted
+/// into `ADVANCED_BUILDERS`.
+///
+/// Returns `false` — "encode exactly as before" — for the same three reasons the image seam has,
+/// and logs which one at `debug`, because a user asking why a clip has no recipe needs to know
+/// whether they turned it off or the payload was empty:
+///
+/// * the job carries no payload to describe (a stub or dry-run write);
+/// * `embedWorkflowInImages` did not resolve to true;
+/// * the envelope is over the recording ceiling, or could not be written.
+///
+/// The last one degrades to no-workflow rather than to a failed job. A clip that generated fine is
+/// not worth failing over a metadata document, and the same reasoning already governs
+/// `faststart_mp4` and `write_poster_frame` below.
+///
+/// # The setting
+///
+/// Video honours `embedWorkflowInImages` — the SAME switch as images, not one of its own. The
+/// setting is a privacy control over what leaves in a file, and the reason someone turns it off
+/// ("my prompts are not going out in the files I share") does not stop applying at the container
+/// boundary. Giving video its own switch would mean a user who had deliberately opted out started
+/// embedding again the day this lane shipped, silently, which is the exact inversion
+/// `embed_workflow_in_images`'s fails-closed rule exists to prevent. The stored key keeps its
+/// `embedWorkflowInImages` name for back-compatibility — renaming it would reset every existing
+/// opt-out to the default-on — and the UI copy is what names both media, since that is what the
+/// user actually reads.
+fn video_workflow_metadata(
+    settings: &Settings,
+    job: &JobSnapshot,
+    request: &VideoRequest,
+    plan: &VideoPlan,
+    seed: i64,
+    metadata_path: &Path,
+) -> bool {
+    if job.payload.is_empty() {
+        tracing::debug!(
+            reason = "empty_job_payload",
+            "not embedding a workflow: the job carries no payload to describe"
+        );
+        return false;
+    }
+    if !sceneworks_core::app_paths::embed_workflow_in_images(&settings.config_dir) {
+        tracing::debug!(
+            reason = "preference_off",
+            config_dir = %settings.config_dir.display(),
+            "not embedding a workflow: `embedWorkflowInImages` did not resolve to true"
+        );
+        return false;
+    }
+    let facts = sceneworks_core::workflow_share::WorkflowAssetFacts {
+        mode: request.mode.clone(),
+        model: request.model.clone(),
+        prompt: request.prompt.clone(),
+        negative_prompt: request.negative_prompt.clone(),
+        // The seed this clip actually rendered with, resolved by `resolve_video_seed` — never the
+        // payload's `seed`, which is `None` whenever the run derived one from the prompt.
+        seed,
+        width: Some(request.width),
+        height: Some(request.height),
+    };
+    let Some(share) = sceneworks_core::workflow_share::embeddable_video_workflow_share(
+        &facts,
+        &job.payload,
+    ) else {
+        tracing::debug!(
+            reason = "over_recording_ceiling",
+            "not embedding a workflow: the envelope is larger than the recording ceiling"
+        );
+        return false;
+    };
+    match sceneworks_core::workflow_mp4::write_workflow_metadata_file(&share, metadata_path) {
+        Ok(()) => {
+            tracing::debug!(
+                asset_id = %plan.asset_id,
+                "embedding the sanitized workflow in the clip this job writes"
+            );
+            true
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "not embedding a workflow: the metadata document could not be written"
+            );
+            false
+        }
+    }
 }
 
 /// Per-job invariants for the single video this job produces.
@@ -1087,12 +1193,22 @@ fn stub_audio_track(frame_count: u32, fps: u32) -> AudioTrack {
 async fn encode_media(
     media_path: &Path,
     decoded: DecodedVideo,
+    workflow_metadata: Option<&Path>,
     ctx: Option<FfmpegContext<'_>>,
 ) -> WorkerResult<()> {
     let enc_tmp = media_path.with_extension("enc.mp4");
     let wav_tmp = media_path.with_extension("audio.wav");
     let mux_tmp = media_path.with_extension("mux.mp4");
-    let result = encode_inner(media_path, decoded, ctx, &enc_tmp, &wav_tmp, &mux_tmp).await;
+    let result = encode_inner(
+        media_path,
+        decoded,
+        workflow_metadata,
+        ctx,
+        &enc_tmp,
+        &wav_tmp,
+        &mux_tmp,
+    )
+    .await;
     let _ = tokio::fs::remove_file(&enc_tmp).await;
     let _ = tokio::fs::remove_file(&wav_tmp).await;
     let _ = tokio::fs::remove_file(&mux_tmp).await;
@@ -1108,6 +1224,7 @@ async fn encode_media(
 async fn encode_inner(
     media_path: &Path,
     decoded: DecodedVideo,
+    workflow_metadata: Option<&Path>,
     ctx: Option<FfmpegContext<'_>>,
     enc_tmp: &Path,
     wav_tmp: &Path,
@@ -1144,34 +1261,49 @@ async fn encode_inner(
     // 1. Stream the engine-owned RGB buffers directly into FFmpeg. This moves one existing frame
     // buffer at a time through the pipe: no per-frame PNG encode, no multi-GB scratch tree, and no
     // second whole-video concatenation.
+    //
+    // The workflow envelope (sc-15956) rides in HERE rather than in a post-hoc rewrite, so the tag
+    // is part of the file from the moment it exists: there is no window in which a clip is on disk
+    // without its recipe, and no extra pass over what can be gigabytes. It survives the two steps
+    // below — measured, and pinned by `the_envelope_survives_the_whole_encode_chain` in
+    // `crates/sceneworks-worker/src/tests/workflow_video.rs`.
     let chunks = frames.into_iter().map(|frame| frame.pixels).collect();
-    run_ffmpeg_with_stdin_chunks(
-        vec![
-            "ffmpeg".to_owned(),
-            "-nostdin".to_owned(),
-            "-y".to_owned(),
-            "-f".to_owned(),
-            "rawvideo".to_owned(),
-            "-pix_fmt".to_owned(),
-            "rgb24".to_owned(),
-            "-video_size".to_owned(),
-            format!("{width}x{height}"),
-            "-framerate".to_owned(),
-            fps.to_string(),
-            "-i".to_owned(),
-            "pipe:0".to_owned(),
-            "-c:v".to_owned(),
-            "libx264".to_owned(),
-            "-pix_fmt".to_owned(),
-            "yuv420p".to_owned(),
-            "-r".to_owned(),
-            fps.to_string(),
-            enc_tmp.to_string_lossy().into_owned(),
-        ],
-        chunks,
-        ctx,
-    )
-    .await?;
+    let mut args = vec![
+        "ffmpeg".to_owned(),
+        "-nostdin".to_owned(),
+        "-y".to_owned(),
+        "-f".to_owned(),
+        "rawvideo".to_owned(),
+        "-pix_fmt".to_owned(),
+        "rgb24".to_owned(),
+        "-video_size".to_owned(),
+        format!("{width}x{height}"),
+        "-framerate".to_owned(),
+        fps.to_string(),
+        "-i".to_owned(),
+        "pipe:0".to_owned(),
+    ];
+    if let Some(metadata_path) = workflow_metadata {
+        // Input 1. The frames are input 0 and stay mapped by ffmpeg's own stream selection (an
+        // `ffmetadata` input carries no streams to compete with), so only the metadata source has
+        // to be named.
+        args.extend(sceneworks_core::workflow_mp4::ffmetadata_input_args(
+            metadata_path,
+        ));
+    }
+    args.extend([
+        "-c:v".to_owned(),
+        "libx264".to_owned(),
+        "-pix_fmt".to_owned(),
+        "yuv420p".to_owned(),
+        "-r".to_owned(),
+        fps.to_string(),
+    ]);
+    if workflow_metadata.is_some() {
+        args.extend(sceneworks_core::workflow_mp4::ffmetadata_map_args(1));
+    }
+    args.push(enc_tmp.to_string_lossy().into_owned());
+    run_ffmpeg_with_stdin_chunks(args, chunks, ctx).await?;
 
     // 2. Mux the audio track (LTX) as AAC, else the video-only mp4 is the result.
     let finished_tmp = if let Some(audio) = audio {
@@ -1190,6 +1322,13 @@ async fn encode_inner(
                 "-c:a".to_owned(),
                 "aac".to_owned(),
                 "-shortest".to_owned(),
+                // Explicit, though it is also ffmpeg's default for a multi-input command: the
+                // container metadata — including the sc-15956 workflow tag written in step 1 —
+                // comes from the VIDEO, never from the WAV. Stated because "the default happens to
+                // be right" is not a property anyone maintains, and the step below it depends on
+                // this one having carried the tag through.
+                "-map_metadata".to_owned(),
+                "0".to_owned(),
                 mux_tmp.to_string_lossy().into_owned(),
             ],
             ctx,

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -897,7 +897,8 @@ pub(crate) async fn run_video_generate_job(
     // off, the job carries no payload, or the envelope is over the recording ceiling — which is
     // the same three-reasons-one-`Option` shape the image seam's `workflow_source` has.
     let workflow_metadata = plan.media_path.with_extension("workflow.ffmeta");
-    let embedded = video_workflow_metadata(settings, job, &request, &plan, seed, &workflow_metadata);
+    let embedded =
+        video_workflow_metadata(settings, job, &request, &plan, seed, &workflow_metadata);
     encode_media(
         &plan.media_path,
         decoded,
@@ -990,10 +991,9 @@ fn video_workflow_metadata(
         width: Some(request.width),
         height: Some(request.height),
     };
-    let Some(share) = sceneworks_core::workflow_share::embeddable_video_workflow_share(
-        &facts,
-        &job.payload,
-    ) else {
+    let Some(share) =
+        sceneworks_core::workflow_share::embeddable_video_workflow_share(&facts, &job.payload)
+    else {
         tracing::debug!(
             reason = "over_recording_ceiling",
             "not embedding a workflow: the envelope is larger than the recording ceiling"
@@ -1266,7 +1266,7 @@ async fn encode_inner(
     // is part of the file from the moment it exists: there is no window in which a clip is on disk
     // without its recipe, and no extra pass over what can be gigabytes. It survives the two steps
     // below — measured, and pinned by `the_envelope_survives_the_whole_encode_chain` in
-    // `crates/sceneworks-worker/src/tests/workflow_video.rs`.
+    // `crates/sceneworks-worker/src/video_jobs/tests.rs`.
     let chunks = frames.into_iter().map(|frame| frame.pixels).collect();
     let mut args = vec![
         "ffmpeg".to_owned(),

--- a/crates/sceneworks-worker/src/video_jobs/seedvr2.rs
+++ b/crates/sceneworks-worker/src/video_jobs/seedvr2.rs
@@ -706,15 +706,33 @@ async fn append_seedvr2_frames(
 /// the whole-clip `encode_media` path (`libx264` / `yuv420p` / `-framerate fps` / `-r fps`), so the
 /// streamed output matches the old path frame-for-frame. Audio muxing stays the caller's source
 /// passthrough step (SeedVR2 emits no audio).
-#[cfg(any(
-    target_os = "macos",
-    all(not(target_os = "macos"), feature = "backend-candle")
-))]
-async fn encode_seedvr2_stream(
+///
+/// `workflow_metadata` is the sanitized envelope as an `ffmetadata` document, or `None` for
+/// "encode exactly as before" (sc-15956 review). It rides in HERE for the same reason
+/// `encode_media` takes it: the tag is part of the file from the moment it exists, with no window
+/// in which an upscaled clip is on disk without its recipe and no second pass over what can be
+/// gigabytes. This is the SECOND libx264 site in the worker; the review that found it noted the
+/// seam lint structurally cannot — it discovers by `WorkflowShare` mentions, and before this change
+/// nothing in this file mentioned one.
+///
+/// **Not cfg-gated**, unlike the SeedVR2 engine work above it. It is pure ffmpeg plumbing over
+/// ungated helpers, and gating it would put the one thing that has to be *proved* — that an
+/// upscaled clip really carries its recipe — behind a platform no CI lane runs `cargo test` on.
+/// The lane that calls it is still gated; the neither build allows the resulting dead code
+/// explicitly rather than by making it unreachable to a test.
+#[cfg_attr(
+    not(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )),
+    allow(dead_code)
+)]
+pub(super) async fn encode_seedvr2_stream(
     media_path: &Path,
     frames_dir: &Path,
     frame_count: usize,
     fps: u32,
+    workflow_metadata: Option<&Path>,
     ctx: Option<FfmpegContext<'_>>,
 ) -> WorkerResult<()> {
     if frame_count == 0 {
@@ -725,28 +743,38 @@ async fn encode_seedvr2_stream(
     let fps = fps.max(1);
     let enc_tmp = media_path.with_extension("enc.mp4");
     let pattern = frames_dir.join("frame_%05d.png");
-    let result = run_ffmpeg(
-        vec![
-            "ffmpeg".to_owned(),
-            "-nostdin".to_owned(),
-            "-y".to_owned(),
-            "-framerate".to_owned(),
-            fps.to_string(),
-            "-start_number".to_owned(),
-            "0".to_owned(),
-            "-i".to_owned(),
-            pattern.to_string_lossy().into_owned(),
-            "-c:v".to_owned(),
-            "libx264".to_owned(),
-            "-pix_fmt".to_owned(),
-            "yuv420p".to_owned(),
-            "-r".to_owned(),
-            fps.to_string(),
-            enc_tmp.to_string_lossy().into_owned(),
-        ],
-        ctx,
-    )
-    .await;
+    let mut args = vec![
+        "ffmpeg".to_owned(),
+        "-nostdin".to_owned(),
+        "-y".to_owned(),
+        "-framerate".to_owned(),
+        fps.to_string(),
+        "-start_number".to_owned(),
+        "0".to_owned(),
+        "-i".to_owned(),
+        pattern.to_string_lossy().into_owned(),
+    ];
+    if let Some(metadata_path) = workflow_metadata {
+        // Input 1, exactly as `encode_media` does it: the frames are input 0 and stay mapped by
+        // ffmpeg's own stream selection, because an `ffmetadata` input carries no streams to
+        // compete with.
+        args.extend(sceneworks_core::workflow_mp4::ffmetadata_input_args(
+            metadata_path,
+        ));
+    }
+    args.extend([
+        "-c:v".to_owned(),
+        "libx264".to_owned(),
+        "-pix_fmt".to_owned(),
+        "yuv420p".to_owned(),
+        "-r".to_owned(),
+        fps.to_string(),
+    ]);
+    if workflow_metadata.is_some() {
+        args.extend(sceneworks_core::workflow_mp4::ffmetadata_map_args(1));
+    }
+    args.push(enc_tmp.to_string_lossy().into_owned());
+    let result = run_ffmpeg(args, ctx).await;
     match result {
         Ok(()) => {
             // Publish atomically, then best-effort faststart + poster (mirrors `encode_media`).
@@ -759,6 +787,128 @@ async fn encode_seedvr2_stream(
             let _ = tokio::fs::remove_file(&enc_tmp).await;
             let _ = tokio::fs::remove_file(media_path).await;
             Err(error)
+        }
+    }
+}
+
+/// Build the sanitized workflow envelope for the UPSCALED clip and write it beside the media as an
+/// `ffmetadata` document, returning whether the encoder should attach it (sc-15956 review).
+///
+/// **The video-upscale write seam** — the exact counterpart of
+/// `upscale_jobs::run_image_upscale_job`'s `standalone_upscale_workflow_share` call, and declared in
+/// `WORKFLOW_WRITE_SEAMS` for the same reason. sc-15956 shipped with the seam prose claiming
+/// `encode_media` was "the ONE funnel every generated clip is encoded through". It was not: this
+/// file has a libx264 site of its own, and it embedded nothing, while the image lane's analogue
+/// embedded. The two lanes now make the same call.
+///
+/// # A distinct job, so a distinct envelope
+///
+/// A video upscale is its own job with its own payload, and the envelope describes THIS pass — it
+/// inherits nothing from whatever generated the source clip, which is the rule sc-15948 set for the
+/// image upscale and the same rule `media_jobs`'s export refuses to break in the other direction.
+/// The source clip's own embedded recipe is not read, not copied and not merged: an upscale of
+/// somebody else's video must not acquire their prompt.
+///
+/// Three overlays onto the job payload, and nothing else:
+///
+/// * `upscale` — the APPLIED engine, factor and (for the one engine that has the knob) softness,
+///   validated above rather than the requested values. It is the only record of what this pass did;
+/// * `sourceClipAssetId` replaces `sourceAssetId`, so `describe_inputs` records the shape as
+///   [`INPUT_KIND_SOURCE_CLIP`](sceneworks_core::workflow_share::INPUT_KIND_SOURCE_CLIP) — "this
+///   recipe needs a CLIP to start from" — rather than as a still. The id itself never travels
+///   either way; only the kind and the count do;
+/// * the geometry is the SOURCE geometry, for the reason the image lane states: the envelope is a
+///   recipe, and "take this clip and upscale it 4x" replays to this file where the upscaled
+///   dimensions would replay to something four times larger again.
+///
+/// `displayName` is in the payload and is not an envelope field, so the source clip's file name —
+/// routinely a person's name — is left behind by the field list being closed. `prompt` is empty:
+/// an upscale has none.
+///
+/// Returns `false` for the same three reasons `video_jobs::video_workflow_metadata` does, logged at
+/// `debug` for the same reason, and a write failure degrades to no-workflow rather than failing a
+/// clip that upscaled fine.
+///
+/// **Not cfg-gated**, for the reason [`encode_seedvr2_stream`] is not: this is the function whose
+/// OUTPUT the acceptance criterion is about, and a test that cannot call it proves nothing.
+#[cfg_attr(
+    not(any(
+        target_os = "macos",
+        all(not(target_os = "macos"), feature = "backend-candle")
+    )),
+    allow(dead_code)
+)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn seedvr2_workflow_metadata(
+    settings: &Settings,
+    job: &JobSnapshot,
+    req: &sceneworks_core::contracts::VideoUpscaleRequest,
+    engine_id: &str,
+    factor: u32,
+    seed: i64,
+    src_w: u32,
+    src_h: u32,
+    metadata_path: &Path,
+) -> bool {
+    if job.payload.is_empty() {
+        tracing::debug!(
+            reason = "empty_job_payload",
+            "not embedding a workflow: the job carries no payload to describe"
+        );
+        return false;
+    }
+    if !sceneworks_core::app_paths::embed_workflow_in_images(&settings.config_dir) {
+        tracing::debug!(
+            reason = "preference_off",
+            config_dir = %settings.config_dir.display(),
+            "not embedding a workflow: `embedWorkflowInImages` did not resolve to true"
+        );
+        return false;
+    }
+    let mut upscale = json!({ "enabled": true, "engine": engine_id, "factor": factor });
+    if engine_id == "seedvr2" {
+        // SeedVR2 is a generative one-step upscaler, so its detail knob changes the output. The
+        // image lane records it for the same reason and for the same engine only.
+        upscale["softness"] = json!(req.softness);
+    }
+    let mut overlay = job.payload.clone();
+    overlay.insert("upscale".to_owned(), upscale);
+    if let Some(source) = overlay.remove("sourceAssetId") {
+        overlay.insert("sourceClipAssetId".to_owned(), source);
+    }
+    let facts = sceneworks_core::workflow_share::WorkflowAssetFacts {
+        mode: "video_upscale".to_owned(),
+        // The payload's own `model` (`seedvr2_3b`) wins inside the builder, so this is the
+        // fallback for a payload that somehow has none. Either way it agrees with the sidecar
+        // fact's `model`, which is the property that keeps a shared file and its record honest.
+        model: req.model.clone(),
+        prompt: String::new(),
+        negative_prompt: String::new(),
+        seed,
+        width: Some(src_w),
+        height: Some(src_h),
+    };
+    let Some(share) =
+        sceneworks_core::workflow_share::embeddable_video_workflow_share(&facts, &overlay)
+    else {
+        tracing::debug!(
+            reason = "over_recording_ceiling",
+            "not embedding a workflow: the envelope is larger than the recording ceiling"
+        );
+        return false;
+    };
+    match sceneworks_core::workflow_mp4::write_workflow_metadata_file(&share, metadata_path) {
+        Ok(()) => {
+            tracing::debug!("embedding the sanitized workflow in the upscaled clip");
+            true
+        }
+        Err(error) => {
+            tracing::warn!(
+                reason = "metadata_write_failed",
+                %error,
+                "not embedding a workflow: the metadata document could not be written"
+            );
+            false
         }
     }
 }
@@ -1214,15 +1364,42 @@ pub(crate) async fn run_video_upscale_job(
     .await?;
     // Encode the streamed PNG sequence to a (silent) mp4 + poster + faststart (byte-identical ffmpeg
     // args to the old whole-clip `encode_media` path), then drop the output scratch dir.
+    //
+    // sc-15956 review: the sanitized workflow for THIS pass, written beside the clip for the
+    // encoder to read. Written here rather than earlier so the only thing between the document
+    // appearing and being removed is the encode itself.
+    let workflow_metadata = media_path.with_extension("workflow.ffmeta");
+    let embedded = seedvr2_workflow_metadata(
+        settings,
+        job,
+        &req,
+        "seedvr2",
+        factor,
+        seed as i64,
+        src_w,
+        src_h,
+        &workflow_metadata,
+    );
     let ctx = FfmpegContext::new(api, settings, &job.id, SEEDVR2_CANCEL_MESSAGE);
-    let encode_result =
-        encode_seedvr2_stream(&media_path, &out_frames_dir, out_count, out_fps, Some(ctx)).await;
+    let encode_result = encode_seedvr2_stream(
+        &media_path,
+        &out_frames_dir,
+        out_count,
+        out_fps,
+        embedded.then_some(workflow_metadata.as_path()),
+        Some(ctx),
+    )
+    .await;
     // Free the multi-GB PNG scratch as soon as the encode returns (before the mux step), on BOTH the
     // ok and err arms; then disarm the guard so its Drop doesn't redundantly re-remove. `encode_result`
     // is propagated AFTER cleanup — an encode error still leaves no scratch behind (and if this early
     // removal is itself skipped by an unwind, the still-armed guard's Drop is the backstop).
     let _ = tokio::fs::remove_dir_all(&out_frames_dir).await;
     out_scratch.disarm();
+    // The metadata document goes on every path too, and before the `?`. It holds the whole envelope
+    // with the prompt in plaintext, and a failed or cancelled encode must not leave one sitting in
+    // the user's project beside no video.
+    let _ = tokio::fs::remove_file(&workflow_metadata).await;
     encode_result?;
     let mux_tmp = media_path.with_extension("audiomux.mp4");
     let mut output_guard = Seedvr2OutputGuard::new(&media_path, &mux_tmp);
@@ -1262,6 +1439,14 @@ pub(crate) async fn run_video_upscale_job(
                 "copy".to_owned(),
                 "-c:a".to_owned(),
                 "aac".to_owned(),
+                // Explicit, though it is also ffmpeg's default for a multi-input command: the
+                // container metadata — including the sc-15956 workflow tag the encode above wrote
+                // — comes from the UPSCALED VIDEO (input 0), never from the source clip (input 1).
+                // Input 1 is the user's own source file and may carry container tags of its own;
+                // inheriting those is the failure `media_jobs`'s export exists to refuse. Stated
+                // because "the default happens to be right" is not a property anyone maintains.
+                "-map_metadata".to_owned(),
+                "0".to_owned(),
                 "-movflags".to_owned(),
                 "+faststart".to_owned(),
                 "-shortest".to_owned(),

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -10913,6 +10913,58 @@ async fn the_tag_survives_a_re_encode_and_dies_on_a_deliberate_strip() {
         "a deliberate strip removes it — stated as a fact of this container rather than hidden"
     );
 
+    // 4. THE SECOND NEGATIVE (sc-15956 review): HLS segmentation, at `-c copy` throughout. Nothing
+    //    is re-encoded and the streams are untouched, so this is the case a reader would predict
+    //    survives — and it does not, because MPEG-TS has no `ilst` to carry the tag through and the
+    //    mp4 is rebuilt from segments that never held it. Named rather than inferred, because
+    //    "I only re-packaged it" is exactly the reasoning that gets this wrong.
+    let segments = dir.join("hls");
+    std::fs::create_dir_all(&segments).unwrap();
+    run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            source.to_string_lossy().into_owned(),
+            "-c".to_owned(),
+            "copy".to_owned(),
+            "-f".to_owned(),
+            "hls".to_owned(),
+            "-hls_time".to_owned(),
+            "1".to_owned(),
+            "-hls_list_size".to_owned(),
+            "0".to_owned(),
+            "-hls_segment_filename".to_owned(),
+            segments.join("seg%03d.ts").to_string_lossy().into_owned(),
+            segments.join("out.m3u8").to_string_lossy().into_owned(),
+        ],
+        None,
+    )
+    .await
+    .unwrap();
+    let reassembled = dir.join("reassembled.mp4");
+    run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            segments.join("out.m3u8").to_string_lossy().into_owned(),
+            "-c".to_owned(),
+            "copy".to_owned(),
+            reassembled.to_string_lossy().into_owned(),
+        ],
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_back(&reassembled),
+        None,
+        "an HLS round trip loses the tag even at `-c copy` — MPEG-TS has no `ilst`, so the mp4 is          rebuilt from segments that never carried it. Recorded as a measured limit of this          container, not hidden behind \"it survives a remux\"."
+    );
+
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -10167,7 +10167,9 @@ async fn encode_stub_to_mp4_with_audio_and_poster() {
     let dir = std::env::temp_dir().join(format!("sw_vid_{}", Uuid::new_v4().simple()));
     std::fs::create_dir_all(&dir).unwrap();
     let media_path = dir.join("clip.mp4");
-    encode_media(&media_path, decoded, None, None).await.unwrap();
+    encode_media(&media_path, decoded, None, None)
+        .await
+        .unwrap();
     assert!(media_path.exists(), "mp4 must be written");
     assert!(media_path.metadata().unwrap().len() > 0);
     assert!(
@@ -10653,4 +10655,263 @@ mod candle_video_label_tests {
         std::fs::remove_dir_all(&root).ok();
         std::fs::remove_dir_all(&flat).ok();
     }
+}
+
+// ---------------------------------------------------------------------------
+// The embedded workflow envelope (sc-15956)
+// ---------------------------------------------------------------------------
+
+/// Build the envelope a clip of `payload` would carry, and write it where the encoder reads it.
+fn workflow_document(directory: &Path, payload: serde_json::Map<String, Value>) -> PathBuf {
+    use sceneworks_core::workflow_share::{embeddable_video_workflow_share, WorkflowAssetFacts};
+    let facts = WorkflowAssetFacts {
+        mode: "text_to_video".to_owned(),
+        model: "ltx_2_3".to_owned(),
+        prompt: "a fox crossing a frozen river".to_owned(),
+        negative_prompt: String::new(),
+        seed: 4242,
+        width: Some(128),
+        height: Some(128),
+    };
+    let share = embeddable_video_workflow_share(&facts, &payload).expect("under the ceiling");
+    let path = directory.join("workflow.ffmeta");
+    sceneworks_core::workflow_mp4::write_workflow_metadata_file(&share, &path).expect("written");
+    path
+}
+
+fn video_workflow_payload() -> serde_json::Map<String, Value> {
+    json!({
+        "mode": "text_to_video",
+        "model": "ltx_2_3",
+        "prompt": "a fox crossing a frozen river",
+        "duration": 1.0,
+        "fps": 9,
+        "quality": "standard",
+        "width": 128,
+        "height": 128,
+        "personTrackId": "track_9f3c1b2a",
+        "replacementMode": "full_person_replace_outfit",
+        "advanced": {
+            "motion": "slow push-in",
+            "precision": "fp8",
+            "replacementModeLabel": "Full Person, Replace Outfit",
+            "selectedPersonTrack": { "name": "Sarah Whitfield" }
+        }
+    })
+    .as_object()
+    .expect("an object")
+    .clone()
+}
+
+/// **The end-to-end proof.** The envelope written before the encode is readable out of the
+/// finished mp4, after every step the encoder runs.
+///
+/// That chain is three ffmpeg invocations, not one — the libx264 encode, the AAC audio mux, and the
+/// `+faststart` remux — and the tag has to survive all three. The audio arm matters most: it is the
+/// only step with two inputs, and ffmpeg's multi-input metadata default is the exact behaviour that
+/// bites the timeline export (see `media_jobs::export_metadata_tests`).
+///
+/// Skips when no ffmpeg is reachable, like every other real-binary test in this file.
+#[tokio::test]
+async fn the_envelope_survives_the_whole_encode_chain() {
+    if !ffmpeg_reachable() {
+        eprintln!("skipping the_envelope_survives_the_whole_encode_chain: ffmpeg not found");
+        return;
+    }
+    // `ltx_2_3` makes the stub emit an audio track, so the two-input mux step runs.
+    let request = request(json!({
+        "projectId": "p", "model": "ltx_2_3", "prompt": "fox",
+        "duration": 1.0, "fps": 9, "width": 128, "height": 128
+    }));
+    let decoded = generate_stub_video(&request, 11);
+    assert!(decoded.audio.is_some(), "the audio arm must actually run");
+
+    let dir = std::env::temp_dir().join(format!("sw_wf_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let media_path = dir.join("clip.mp4");
+    let document = workflow_document(&dir, video_workflow_payload());
+
+    encode_media(&media_path, decoded, Some(document.as_path()), None)
+        .await
+        .unwrap();
+
+    let read = sceneworks_core::workflow_mp4::read_workflow_metadata_file(&media_path)
+        .expect("the clip is readable")
+        .expect("the clip carries its recipe through encode + audio mux + faststart");
+    assert_eq!(
+        read.kind,
+        sceneworks_core::workflow_share::WORKFLOW_KIND_VIDEO
+    );
+    assert_eq!(read.prompt, "a fox crossing a frozen river");
+    assert_eq!(read.duration_seconds, Some(1.0));
+    assert_eq!(read.fps, Some(9));
+    assert_eq!(read.advanced.get("motion"), Some(&json!("slow push-in")));
+
+    // The clip still plays: the tag did not displace the moov or break the framing.
+    assert!(media_path.metadata().unwrap().len() > 0);
+    assert!(media_path.with_extension("poster.jpg").exists());
+
+    // And the withholding holds all the way to the bytes on disk — the acceptance criterion, read
+    // out of a real file rather than off a struct.
+    let bytes = std::fs::read(&media_path).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    for secret in [
+        "track_9f3c1b2a",
+        "Sarah Whitfield",
+        "full_person_replace_outfit",
+        "Full Person, Replace Outfit",
+        "selectedPersonTrack",
+    ] {
+        assert!(
+            !text.contains(secret),
+            "`{secret}` reached the mp4 on disk — a shared video must not disclose that it was \
+             made by replacing a specific person"
+        );
+    }
+    // A hardware-budget knob is dropped too, so this is the allow-list running and not a blanket.
+    assert!(
+        !text.contains("fp8"),
+        "`precision` is a hardware budget and must not travel"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `None` still writes exactly the file it wrote before — the setting-off / no-payload path.
+#[tokio::test]
+async fn no_document_means_no_tag_and_an_otherwise_identical_clip() {
+    if !ffmpeg_reachable() {
+        eprintln!("skipping no_document_means_no_tag_and_an_otherwise_identical_clip: no ffmpeg");
+        return;
+    }
+    let request = request(json!({
+        "projectId": "p", "model": "wan2_2_t2v_14b", "prompt": "fox",
+        "duration": 1.0, "fps": 9, "width": 128, "height": 128
+    }));
+    let dir = std::env::temp_dir().join(format!("sw_wf_off_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let media_path = dir.join("clip.mp4");
+    encode_media(&media_path, generate_stub_video(&request, 11), None, None)
+        .await
+        .unwrap();
+    assert!(media_path.exists());
+    assert_eq!(
+        sceneworks_core::workflow_mp4::read_workflow_metadata_file(&media_path).expect("readable"),
+        None,
+        "with the setting off there must be no recipe in the file at all"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// **The survival measurement, as a test.** The tag outlives a representative re-encode, and dies
+/// on a deliberate strip.
+///
+/// The negative case is asserted alongside the positive one on purpose: "it survives everything"
+/// would be a false claim about this container, and the story asks for the honest matrix. What is
+/// proved here is the boundary — a transcode that carries metadata forward keeps the recipe, and a
+/// pipeline that strips metadata removes it, which is what a platform re-encode does.
+#[tokio::test]
+async fn the_tag_survives_a_re_encode_and_dies_on_a_deliberate_strip() {
+    if !ffmpeg_reachable() {
+        eprintln!(
+            "skipping the_tag_survives_a_re_encode_and_dies_on_a_deliberate_strip: no ffmpeg"
+        );
+        return;
+    }
+    let request = request(json!({
+        "projectId": "p", "model": "ltx_2_3", "prompt": "fox",
+        "duration": 1.0, "fps": 9, "width": 128, "height": 128
+    }));
+    let dir = std::env::temp_dir().join(format!("sw_wf_re_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let source = dir.join("clip.mp4");
+    let document = workflow_document(&dir, video_workflow_payload());
+    encode_media(
+        &source,
+        generate_stub_video(&request, 11),
+        Some(document.as_path()),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let read_back = |path: &Path| {
+        sceneworks_core::workflow_mp4::read_workflow_metadata_file(path).expect("readable")
+    };
+    assert!(read_back(&source).is_some(), "the source must carry it");
+
+    // 1. A `-c copy` remux — a container rewrite, what a "fix this file" tool does.
+    let remux = dir.join("remux.mp4");
+    run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            source.to_string_lossy().into_owned(),
+            "-c".to_owned(),
+            "copy".to_owned(),
+            remux.to_string_lossy().into_owned(),
+        ],
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        read_back(&remux).is_some(),
+        "a `-c copy` remux must keep it"
+    );
+
+    // 2. A scale + bitrate change — the shape of a delivery transcode.
+    let scaled = dir.join("scaled.mp4");
+    run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            source.to_string_lossy().into_owned(),
+            "-vf".to_owned(),
+            "scale=64:64".to_owned(),
+            "-b:v".to_owned(),
+            "200k".to_owned(),
+            scaled.to_string_lossy().into_owned(),
+        ],
+        None,
+    )
+    .await
+    .unwrap();
+    let survived = read_back(&scaled).expect("a scale + bitrate re-encode must keep it");
+    assert_eq!(
+        survived.prompt, "a fox crossing a frozen river",
+        "and keep it INTACT, not truncated"
+    );
+
+    // 3. THE NEGATIVE CASE: a pipeline that strips metadata. This is what a platform re-encode
+    //    does, and it is why the sharing premise for video is weaker than for a PNG chunk.
+    let stripped = dir.join("stripped.mp4");
+    run_ffmpeg(
+        vec![
+            "ffmpeg".to_owned(),
+            "-nostdin".to_owned(),
+            "-y".to_owned(),
+            "-i".to_owned(),
+            source.to_string_lossy().into_owned(),
+            "-map_metadata".to_owned(),
+            "-1".to_owned(),
+            "-c".to_owned(),
+            "copy".to_owned(),
+            stripped.to_string_lossy().into_owned(),
+        ],
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_back(&stripped),
+        None,
+        "a deliberate strip removes it — stated as a fact of this container rather than hidden"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -10686,7 +10686,7 @@ fn video_workflow_payload() -> serde_json::Map<String, Value> {
         "prompt": "a fox crossing a frozen river",
         "duration": 1.0,
         "fps": 9,
-        "quality": "standard",
+        "quality": "balanced",
         "width": 128,
         "height": 128,
         "personTrackId": "track_9f3c1b2a",
@@ -10912,6 +10912,414 @@ async fn the_tag_survives_a_re_encode_and_dies_on_a_deliberate_strip() {
         None,
         "a deliberate strip removes it — stated as a fact of this container rather than hidden"
     );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// The SECOND libx264 site: the video upscale (sc-15956 review)
+// ---------------------------------------------------------------------------
+
+/// Worker settings pointed at a scratch config dir, so the embed toggle is this test's rather than
+/// the install's. The preference defaults to ON when the file is absent, which is what an empty
+/// scratch dir gives.
+fn upscale_settings(config_dir: &Path) -> Settings {
+    let mut settings = Settings::from_env();
+    settings.config_dir = config_dir.to_path_buf();
+    settings
+}
+
+/// A `video_upscale` job carrying the payload `VideoUpscalePanel.onUpscale` really posts.
+fn upscale_job_snapshot(payload: Value) -> JobSnapshot {
+    serde_json::from_value(json!({
+        "id": "job-upscale-1",
+        "type": "video_upscale",
+        "status": "running",
+        "projectId": "p",
+        "projectName": null,
+        "payload": payload,
+        "result": {},
+        "requestedGpu": "auto",
+        "assignedGpu": null,
+        "workerId": "test-worker",
+        "progress": 0.0,
+        "stage": "queued",
+        "message": "queued",
+        "error": null,
+        "etaSeconds": null,
+        "elapsedSeconds": null,
+        "attempts": 1,
+        "sourceJobId": null,
+        "duplicateOfJobId": null,
+        "cancelRequested": false,
+        "createdAt": "2026-07-16T00:00:00Z",
+        "updatedAt": "2026-07-16T00:00:00Z",
+        "startedAt": null,
+        "finishedAt": null
+    }))
+    .expect("the upscale job snapshot parses")
+}
+
+/// The payload the panel posts, with the source clip's display name in it — which is routinely
+/// somebody's original filename, and must not travel.
+fn upscale_payload() -> Value {
+    json!({
+        "projectId": "p",
+        "sourceAssetId": "asset_9f3c1b2a",
+        "factor": 4,
+        "engine": "seedvr2",
+        "model": "seedvr2_3b",
+        "softness": 0.25,
+        "displayName": "sarah-audition-take3 (4x upscaled)"
+    })
+}
+
+/// **The upscale lane's end-to-end proof.** An upscaled clip carries a recipe of its OWN.
+///
+/// sc-15956 shipped with `encode_media` described as "the ONE funnel every generated clip is
+/// encoded through". There are two libx264 sites in this crate, and this was the other one: a
+/// `video_upscale` wrote a clip with no envelope at all while the image lane's exact analogue
+/// (`upscale_jobs::run_image_upscale_job`) embedded one. The seam lint could not see it, because it
+/// discovers by `WorkflowShare` mentions and this file had none.
+///
+/// What is asserted is the whole chain the job runs: build the envelope from the real payload,
+/// write the `ffmetadata` document, encode a PNG sequence through `encode_seedvr2_stream`, and read
+/// the recipe back out of the finished mp4.
+#[tokio::test]
+async fn the_upscaled_clip_carries_its_own_recipe() {
+    if !ffmpeg_reachable() {
+        eprintln!("skipping the_upscaled_clip_carries_its_own_recipe: ffmpeg not found");
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("sw_up_wf_{}", Uuid::new_v4().simple()));
+    let frames = dir.join("frames");
+    std::fs::create_dir_all(&frames).unwrap();
+    for index in 0..3_u32 {
+        image::RgbImage::from_pixel(64, 64, image::Rgb([16, 32, 48]))
+            .save(frames.join(format!("frame_{index:05}.png")))
+            .unwrap();
+    }
+
+    let job = upscale_job_snapshot(upscale_payload());
+    let req: sceneworks_core::contracts::VideoUpscaleRequest =
+        serde_json::from_value(upscale_payload()).unwrap();
+    let settings = upscale_settings(&dir.join("config"));
+    let media_path = dir.join("upscaled.mp4");
+    let document = media_path.with_extension("workflow.ffmeta");
+
+    let embedded = seedvr2_workflow_metadata(
+        &settings, &job, &req, "seedvr2", 4, 8080, 640, 360, &document,
+    );
+    assert!(
+        embedded,
+        "with the preference at its default the upscale lane must embed"
+    );
+    assert!(document.exists(), "the ffmetadata document must be written");
+
+    encode_seedvr2_stream(&media_path, &frames, 3, 8, Some(document.as_path()), None)
+        .await
+        .unwrap();
+
+    let read = sceneworks_core::workflow_mp4::read_workflow_metadata_file(&media_path)
+        .expect("the upscaled clip is readable")
+        .expect("...and carries its recipe");
+    assert_eq!(
+        read.kind,
+        sceneworks_core::workflow_share::WORKFLOW_KIND_VIDEO
+    );
+    // THIS pass, not the source clip's: an upscale has no prompt, and its mode and model name the
+    // upscaler rather than whatever generated the input.
+    assert_eq!(read.mode, "video_upscale");
+    assert_eq!(read.model, "seedvr2_3b");
+    assert_eq!(read.prompt, "");
+    let upscale = read.upscale.expect("the applied pass is recorded");
+    assert!(upscale.enabled);
+    assert_eq!(upscale.factor, Some(4));
+    assert_eq!(upscale.engine.as_deref(), Some("seedvr2"));
+    assert_eq!(upscale.softness, Some(0.25));
+    // The geometry is the SOURCE geometry — the recipe is "take this clip and upscale it 4x".
+    assert_eq!((read.width, read.height), (Some(640), Some(360)));
+    // And the input travels by SHAPE: a clip to start from, never the asset id.
+    assert_eq!(read.inputs.len(), 1);
+    assert_eq!(
+        read.inputs[0].kind,
+        sceneworks_core::workflow_share::INPUT_KIND_SOURCE_CLIP
+    );
+    assert_eq!(read.inputs[0].count, 1);
+
+    // The two things in that payload that must never reach a shared file.
+    let bytes = std::fs::read(&media_path).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    for secret in ["asset_9f3c1b2a", "sarah-audition-take3"] {
+        assert!(
+            !text.contains(secret),
+            "`{secret}` reached the upscaled mp4 on disk"
+        );
+    }
+
+    assert!(media_path.with_extension("poster.jpg").exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The same lane with the preference OFF writes exactly the clip it wrote before.
+#[tokio::test]
+async fn an_upscale_with_the_setting_off_carries_nothing() {
+    if !ffmpeg_reachable() {
+        eprintln!("skipping an_upscale_with_the_setting_off_carries_nothing: ffmpeg not found");
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("sw_up_off_{}", Uuid::new_v4().simple()));
+    let frames = dir.join("frames");
+    let config = dir.join("config");
+    std::fs::create_dir_all(&frames).unwrap();
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::write(
+        sceneworks_core::app_paths::ui_preferences_file(&config),
+        r#"{"embedWorkflowInImages":false}"#,
+    )
+    .unwrap();
+    for index in 0..2_u32 {
+        image::RgbImage::from_pixel(64, 64, image::Rgb([8, 8, 8]))
+            .save(frames.join(format!("frame_{index:05}.png")))
+            .unwrap();
+    }
+
+    let job = upscale_job_snapshot(upscale_payload());
+    let req: sceneworks_core::contracts::VideoUpscaleRequest =
+        serde_json::from_value(upscale_payload()).unwrap();
+    let settings = upscale_settings(&config);
+    let media_path = dir.join("upscaled.mp4");
+    let document = media_path.with_extension("workflow.ffmeta");
+
+    assert!(
+        !seedvr2_workflow_metadata(&settings, &job, &req, "seedvr2", 4, 1, 640, 360, &document),
+        "the video upscale honours the SAME switch as every other lane"
+    );
+    assert!(
+        !document.exists(),
+        "and writes no metadata document when it is off"
+    );
+
+    encode_seedvr2_stream(&media_path, &frames, 2, 8, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        sceneworks_core::workflow_mp4::read_workflow_metadata_file(&media_path).expect("readable"),
+        None
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The `.workflow.ffmeta` scratch is removed BEFORE the encode's error propagates, on both lanes.
+///
+/// A structural pin rather than a behavioural one, for the reason `media_jobs`'s
+/// "`mux_segments` must pass `-map_metadata` explicitly" is: the failure is an ORDERING inside an
+/// async job function that needs a live `ApiClient` to reach, and the ordering is exactly what a
+/// future edit would undo. `encode_media(...).await?` used to sit in front of the `remove_file`, so
+/// a failed or cancelled encode left the full envelope — prompt in plaintext — in the user's
+/// project permanently, beside no video.
+#[test]
+fn the_workflow_metadata_scratch_does_not_outlive_a_failed_encode() {
+    for (name, source, call) in [
+        (
+            "video_jobs/mod.rs",
+            include_str!("mod.rs"),
+            "let encoded = encode_media(",
+        ),
+        (
+            "video_jobs/seedvr2.rs",
+            include_str!("seedvr2.rs"),
+            "let encode_result = encode_seedvr2_stream(",
+        ),
+    ] {
+        let start = source
+            .find(call)
+            .unwrap_or_else(|| panic!("{name} no longer binds its encode result: {call}"));
+        let rest = &source[start..];
+        let removal = rest
+            .find("remove_file(&workflow_metadata)")
+            .unwrap_or_else(|| panic!("{name} never removes the workflow metadata scratch"));
+        let propagation = rest
+            .find("?;")
+            .unwrap_or_else(|| panic!("{name} never propagates the encode result"));
+        assert!(
+            removal < propagation,
+            "{name} propagates the encode error before removing `*.workflow.ffmeta`. \
+             That leaves the whole envelope — the prompt in plaintext — in the user's project \
+             after a failed or cancelled encode. Bind the result, remove the scratch, THEN `?`."
+        );
+    }
+}
+
+/// Every person-shaped string a hostile payload can carry, checked against the PUBLISHED bytes of
+/// both encode lanes and of the poster frame beside them (sc-15956 review).
+///
+/// The story's acceptance criterion is about a file, so this reads files. The existing
+/// `the_envelope_survives_the_whole_encode_chain` greps five strings out of one clip; this is the
+/// widened form the review asked to see re-run after the second write seam landed: every id, name,
+/// filename, path, label and KEY NAME the payload carries, against the generated clip, the upscaled
+/// clip, and both posters — a poster is a separate file written from the same source and is just as
+/// shareable.
+///
+/// Key names are in the list on purpose. A key that survived would mean the allow-list emitted an
+/// empty-valued entry rather than dropping the field, which is the shape a sanitizer regression
+/// takes before it starts leaking values.
+const PERSON_TRACK_STRINGS: &[&str] = &[
+    "track_9f3c1b2a",
+    "Sarah Whitfield",
+    "Whitfield",
+    "sarah-audition-take3.mov",
+    "sarah-audition-take3",
+    "asset_7c1d3e",
+    "D:/Clients/Acme",
+    "Clients/Acme",
+    "/Users/michael",
+    "0001.png",
+    "0002.png",
+    "selectedPersonTrack",
+    "sourceDisplayName",
+    "replacementModeLabel",
+    "Full Person, Keep Outfit",
+    "full_person_keep_outfit",
+    "personTrackId",
+    "replacementMode",
+    "timelineContext",
+    "Acme Q4 Cut",
+    "tl_44ff21",
+    "quantTier",
+];
+
+/// The widest person-replacement payload the Video Studio can post.
+fn hostile_person_payload() -> serde_json::Map<String, Value> {
+    json!({
+        "mode": "replace_person",
+        "model": "wan_2_2_vace_fun_14b",
+        "prompt": "the same shot, continuous motion",
+        "duration": 1.0,
+        "fps": 9,
+        "quality": "balanced",
+        "width": 128,
+        "height": 128,
+        "personTrackId": "track_9f3c1b2a",
+        "replacementMode": "full_person_keep_outfit",
+        "advanced": {
+            "motion": "static",
+            "quantTier": "q8",
+            "replacementModeLabel": "Full Person, Keep Outfit",
+            "selectedPersonTrack": {
+                "id": "track_9f3c1b2a",
+                "name": "Sarah Whitfield",
+                "sourceDisplayName": "sarah-audition-take3.mov",
+                "sourceAssetId": "asset_7c1d3e",
+                "frames": [
+                    { "mask": "D:/Clients/Acme/masks/0001.png" },
+                    { "mask": "/Users/michael/masks/0002.png" }
+                ]
+            },
+            "timelineContext": {
+                "timelineId": "tl_44ff21",
+                "timelineName": "Acme Q4 Cut",
+                "sourceAssetId": "asset_7c1d3e"
+            }
+        }
+    })
+    .as_object()
+    .expect("an object")
+    .clone()
+}
+
+fn assert_no_person_track_strings(path: &Path, what: &str) {
+    let bytes = std::fs::read(path).unwrap_or_else(|error| panic!("{what} reads: {error}"));
+    let text = String::from_utf8_lossy(&bytes);
+    for secret in PERSON_TRACK_STRINGS {
+        assert!(
+            !text.contains(secret),
+            "`{secret}` reached {what} on disk. A shared video must not disclose WHO was replaced, \
+             which track, or which variant of a replacement ran."
+        );
+    }
+}
+
+#[tokio::test]
+async fn no_person_track_string_reaches_a_published_clip_or_its_poster() {
+    if !ffmpeg_reachable() {
+        eprintln!(
+            "skipping no_person_track_string_reaches_a_published_clip_or_its_poster: no ffmpeg"
+        );
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("sw_regrep_{}", Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Lane one: a GENERATED clip, through `encode_media` and its three ffmpeg steps.
+    let request = request(json!({
+        "projectId": "p", "model": "ltx_2_3", "prompt": "the same shot, continuous motion",
+        "duration": 1.0, "fps": 9, "width": 128, "height": 128
+    }));
+    let generated = dir.join("generated.mp4");
+    let document = workflow_document(&dir, hostile_person_payload());
+    encode_media(
+        &generated,
+        generate_stub_video(&request, 11),
+        Some(document.as_path()),
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        sceneworks_core::workflow_mp4::read_workflow_metadata_file(&generated)
+            .expect("readable")
+            .is_some(),
+        "the clip must be carrying an envelope, or this test proves nothing"
+    );
+    assert_no_person_track_strings(&generated, "the generated clip");
+    assert_no_person_track_strings(&generated.with_extension("poster.jpg"), "its poster");
+
+    // Lane two: an UPSCALED clip, through `encode_seedvr2_stream`. Its payload has no person track
+    // in it at all — the point is that the SOURCE clip's recipe is never inherited, so nothing the
+    // source disclosed can arrive by that route either.
+    let frames = dir.join("frames");
+    std::fs::create_dir_all(&frames).unwrap();
+    for index in 0..2_u32 {
+        image::RgbImage::from_pixel(64, 64, image::Rgb([9, 9, 9]))
+            .save(frames.join(format!("frame_{index:05}.png")))
+            .unwrap();
+    }
+    let job = upscale_job_snapshot(upscale_payload());
+    let req: sceneworks_core::contracts::VideoUpscaleRequest =
+        serde_json::from_value(upscale_payload()).unwrap();
+    let settings = upscale_settings(&dir.join("config"));
+    let upscaled = dir.join("upscaled.mp4");
+    let upscale_document = upscaled.with_extension("workflow.ffmeta");
+    assert!(seedvr2_workflow_metadata(
+        &settings,
+        &job,
+        &req,
+        "seedvr2",
+        4,
+        3,
+        640,
+        360,
+        &upscale_document
+    ));
+    encode_seedvr2_stream(
+        &upscaled,
+        &frames,
+        2,
+        8,
+        Some(upscale_document.as_path()),
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        sceneworks_core::workflow_mp4::read_workflow_metadata_file(&upscaled)
+            .expect("readable")
+            .is_some(),
+        "the upscaled clip must be carrying an envelope too"
+    );
+    assert_no_person_track_strings(&upscaled, "the upscaled clip");
+    assert_no_person_track_strings(&upscaled.with_extension("poster.jpg"), "its poster");
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -9186,7 +9186,7 @@ fn svd_cuda_real_weights_encode_h264_and_preserve_provenance() {
         .enable_all()
         .build()
         .expect("tokio runtime")
-        .block_on(encode_media(&media_path, decoded, None))
+        .block_on(encode_media(&media_path, decoded, None, None))
         .expect("SceneWorks libx264 encode");
 
     let probe = std::process::Command::new("ffprobe")
@@ -10167,7 +10167,7 @@ async fn encode_stub_to_mp4_with_audio_and_poster() {
     let dir = std::env::temp_dir().join(format!("sw_vid_{}", Uuid::new_v4().simple()));
     std::fs::create_dir_all(&dir).unwrap();
     let media_path = dir.join("clip.mp4");
-    encode_media(&media_path, decoded, None).await.unwrap();
+    encode_media(&media_path, decoded, None, None).await.unwrap();
     assert!(media_path.exists(), "mp4 must be written");
     assert!(media_path.metadata().unwrap().len() > 0);
     assert!(
@@ -10197,7 +10197,7 @@ async fn encode_media_rejects_malformed_raw_frame_before_starting_ffmpeg() {
         adapter_apply_reports: Vec::new(),
     };
 
-    let error = encode_media(&media_path, decoded, None)
+    let error = encode_media(&media_path, decoded, None, None)
         .await
         .expect_err("malformed RGB buffer must be rejected before FFmpeg");
 

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -79,8 +79,51 @@ a test asserts it is strict semver.
 `schemaVersion` is the contract version and is **the only version the parser branches on**.
 `producer.version` is recorded so a bug report is actionable and is never interpreted. (It is not
 the only *field* the parser branches on: the `sceneworksWorkflow` marker is checked too, and a blob
-whose marker names a lane this build does not read — a future video envelope, say — is refused as an
-unsupported kind rather than parsed as an image one.)
+whose marker names a kind this build has no reader for at all — `hologram`, say — is refused as an
+unsupported kind rather than parsed as an image one. That check runs BEFORE the version check, so a
+kind we do not understand is never reported as a version problem.)
+
+A kind this build *does* know is a different question, and the shared parser is deliberately not
+where it is answered — see [Every container asserts its own
+kind](#every-container-asserts-its-own-kind).
+
+### Every container asserts its own kind
+
+The parser accepts **every** kind in the contract, because an envelope is an envelope. A *reader* is
+narrower: it hands its result to one lane, and a lane can only act on the kind it was built for.
+Offering a clip's recipe to Image Studio is the same failure as parsing an unknown marker as an
+image — it presents a file as a kind it is not — so it is refused in the same way, with the same
+error and the same `UnsupportedKind` shape.
+
+So the rule is per-reader, and there are three readers:
+
+<!-- PINNED: container-kinds -->
+
+| What is being read | File | Reader | Kind it accepts |
+| --- | --- | --- | --- |
+| A PNG's `sceneworks:workflow` chunk | `crates/sceneworks-core/src/workflow_png.rs` | `read_workflow_chunk_from` | `image` |
+| An MP4's `comment` tag | `crates/sceneworks-core/src/workflow_mp4.rs` | `read_workflow_metadata_from` | `video` |
+| The envelope recorded on an imported asset | `apps/rust-api/src/workflows.rs` | `get_asset_workflow` | `image` |
+
+<!-- END PINNED: container-kinds -->
+
+The third row is the one that was missed. Until sc-15956 the marker had exactly one legal value, so
+the shared parser's refusal of `"video"` did every reader's container check for it, for free. Widening
+the marker to `image` | `video` removed that inheritance — silently, from a route in a crate the
+change did not touch. `GET …/assets/:asset_id/workflow` went on calling `parse_workflow_share` alone
+and started answering `200 { status: "workflow" }` for a video envelope, whose response feeds
+`recipeFromWorkflowShare` and an **Image Studio prefill**. The asset panel's `asset.type === "image"`
+button guard is not a substitute: a video envelope recorded on an image asset passes it unchanged.
+
+`the_asset_route_500s_when_the_stored_envelope_names_another_container` in
+`apps/rust-api/src/tests/workflows.rs` pins that reader against a complete, valid video envelope —
+one the parser accepts — so the test fails if the container assert is removed rather than passing on
+a deserialize error. The table above is pinned by `the_doc_lists_exactly_the_container_kind_asserts`,
+which reads each named file and fails if the assert it claims is not there.
+
+**Adding a container, or a reader, means adding a row here and an assert there.** The parser is not
+the place to put it: an envelope that is legal to parse and wrong to act on is exactly the case this
+rule exists for.
 
 | The file says | This build does |
 | --- | --- |
@@ -117,7 +160,7 @@ keys in either direction: a key this table does not name is dropped on write **a
 | `count` | How many images the run requested — so the file says it was one of a batch of N. |
 | `durationSeconds` | **Video.** The clip length the run asked for. The ask, not the measurement — a 6.0 s ask that rendered 5.96 s replays as 6.0. |
 | `fps` | **Video.** The frame rate the run asked for, for the same reason. |
-| `quality` | **Video.** The quality preset the run was submitted at. A named tier off a menu the receiving install also has. |
+| `quality` | **Video.** The quality preset the run was submitted at — `fast`, `balanced` or `best`. A named tier off a menu the receiving install also has (it shows them as "Draft" / "Balanced" / "Final"; the value is what travels). |
 | `stylePreset` | The style preset label the run used. |
 | `styleId` | The catalog style id the user picked. |
 | `fitMode` | How the source image was fitted (`crop`, `contain`, …). |
@@ -273,6 +316,60 @@ Classified and deliberately dropped. A key here is a decision someone wrote down
 
 <!-- END PINNED: advanced-withheld -->
 
+## Person replacement is withheld by default
+
+Four fields carry a person-replacement run's specifics, and none of them travel: `personTrackId` and
+`replacementMode` at the top level of the request, `advanced.selectedPersonTrack` and
+`advanced.replacementModeLabel` inside the map. The first is an install-local id, which alone would
+put it in the same class as `controlImage`. The rest are withheld for a stronger reason.
+
+`selectedPersonTrack` is the sharpest object any payload carries: a `name` the user typed, which is
+routinely a real person's name; a `sourceDisplayName` that is the original imported filename; local
+asset ids; and a `frames[].mask` array of filesystem paths. `replacementModeLabel` is neither an id
+nor a path — it is the string "Face Only" — and it is withheld anyway, because **which variant of a
+replacement ran is a fact about a real person who did not choose to share it**. There is no replay
+value to weigh against that: a recipient has no access to the track, so the field could only ever
+inform, never reproduce.
+
+### What does travel, and why the copy has to say so
+
+`mode` is `replace_person`, verbatim, and `model` names a replacement engine
+(`wan_2_2_vace_fun_14b`). Both are ordinary shared fields, and neither is special-cased. **So the
+file does disclose the technique.** What it withholds is the identity and the variant.
+
+That distinction is not a technicality, because it is the difference between a true sentence and a
+false one on the Settings surface. The "Not in the file" copy read *"anything about a person
+replacement"* until the sc-15956 review measured it against real bytes; the enumerated tail was
+true, the leading clause was not, and the key-level pin joining that copy to the tables above could
+not catch it, because `mode` is not a key in either list. It is asserted directly instead, by
+`the_settings_copy_does_not_overclaim_about_person_replacement` in
+`crates/sceneworks-core/tests/workflow_share_doc.rs`, which builds a real `replace_person` envelope,
+proves the four fields are absent from the serialized bytes, proves `mode` is present, and then
+reads the sentence.
+
+Narrowing the withholding to close that gap was available and was refused: the disclosure that
+matters is *who*, and `mode` is a field every video envelope carries for every mode. Dropping it for
+one mode would be a hole in the field list that a reader could detect — an absent `mode` on a video
+envelope would itself say "this was a replacement".
+
+### Why it is not in `omitted`
+
+This is the one place the contract's "a stated absence beats an invisible one" rule is deliberately
+inverted, and it is worth reading before anyone "fixes" the inconsistency.
+
+`omitted` exists for collections too large to record — `loras`, `inputs`, `advanced.poses` — where
+naming the gap costs nothing and tells the receiving user why their replay is incomplete. Writing
+`omitted: ["personTrackId"]` would cost something: it would **announce the replacement to every
+reader** while withholding only the id. Naming a withheld thing in a field designed to be read is
+worse than an absence, when the absence is the point.
+
+The honest weakness of that argument, recorded here rather than left for someone to rediscover: it
+is weaker than it looks, because `mode` announces the replacement anyway (above). What `omitted`
+would add is not the disclosure — that is already there — but a second, redundant one, in a field
+whose whole purpose is to be surfaced to a reader, naming the private half by key. The inversion
+stands on the narrower ground: the technique travels once, in the field that always carries it, and
+nothing else points at what was withheld.
+
 ## Input images travel by shape, not by id
 
 A recipe that started from an image records **that it needs one, and of what kind** — never the
@@ -323,6 +420,11 @@ The marker is emitted in **both** directions. On the write side it is the differ
 silently lost 70-pose selection and a visible one, which is the point: our own writer can hit these
 caps, and a recipe that says "no LoRAs" when it had five is exactly the silent loss this contract
 exists to prevent.
+
+There is **one deliberate exception**, and it is the only place this rule is inverted: the
+person-replacement fields are withheld without an `omitted` entry. The argument, and its honest
+weakness, are in [Person replacement](#person-replacement-is-withheld-by-default). Read it before
+adding them here for consistency — the inconsistency is the decision.
 
 ## Ceilings
 
@@ -528,6 +630,7 @@ If the lint says a *builder* is unaccounted for, decide whether its lane embeds.
 | `apps/web/src/screens/EditorScreen.jsx` | `replaceSelectedItem` | Timeline replace. |
 | `apps/web/src/screens/EditorScreen.jsx` | `bridgeGap` | Timeline bridge. |
 | `apps/web/src/simple/simpleJobs.js` | `buildSimpleVideoRequest` | The Simple shell's video request. |
+| `apps/web/src/screens/VideoUpscalePanel.jsx` | `onUpscale` | The standalone video upscale. Registered as emitting **no** `advanced` map, for the same reason `buildUpscaleJobBody` is. |
 
 <!-- END PINNED: builders -->
 
@@ -610,7 +713,8 @@ deferred.
 | `crates/sceneworks-worker/src/image_jobs/detail.rs` | `run_image_detail_job` | Embeds — writes the refined PNG. macOS-gated; the scan is textual, so it is read on every platform. |
 | `crates/sceneworks-worker/src/upscale_jobs.rs` | `run_image_upscale_job` | Embeds — hands the standalone upscale's envelope to the shared single-child writer. |
 | `crates/sceneworks-worker/src/single_child_asset.rs` | `write_single_child_asset` | Conduit — writes the envelope its caller decided on, and builds none itself. |
-| `crates/sceneworks-worker/src/video_jobs/mod.rs` | `video_workflow_metadata` | Embeds — the one funnel every generated clip is encoded through, whatever engine or studio produced it. |
+| `crates/sceneworks-worker/src/video_jobs/mod.rs` | `video_workflow_metadata` | Embeds — the funnel every *generated* clip is encoded through, whatever engine or studio produced it. |
+| `crates/sceneworks-worker/src/video_jobs/seedvr2.rs` | `seedvr2_workflow_metadata` | Embeds — the SeedVR2 video upscale's own clip. macOS + candle-gated; the scan is textual, so it is read on every platform. |
 | `crates/sceneworks-worker/src/segment_jobs.rs` | `run_image_segment_job` | Declines — a smart-select mask has no generation recipe to replay, and is grayscale. |
 
 <!-- END PINNED: write-seams -->

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -102,7 +102,7 @@ keys in either direction: a key this table does not name is dropped on write **a
 
 | Field | What it is |
 | --- | --- |
-| `sceneworksWorkflow` | The marker. Always `image` for this lane. |
+| `sceneworksWorkflow` | The marker, naming the workflow **kind**: `image` or `video`. A build that does not know a kind refuses the file rather than presenting it as one it does understand. |
 | `schemaVersion` | The contract version. |
 | `producer.name` | `SceneWorks`. |
 | `producer.url` | The project's repository URL. |
@@ -115,6 +115,9 @@ keys in either direction: a key this table does not name is dropped on write **a
 | `width` | Requested output width. |
 | `height` | Requested output height. |
 | `count` | How many images the run requested — so the file says it was one of a batch of N. |
+| `durationSeconds` | **Video.** The clip length the run asked for. The ask, not the measurement — a 6.0 s ask that rendered 5.96 s replays as 6.0. |
+| `fps` | **Video.** The frame rate the run asked for, for the same reason. |
+| `quality` | **Video.** The quality preset the run was submitted at. A named tier off a menu the receiving install also has. |
 | `stylePreset` | The style preset label the run used. |
 | `styleId` | The catalog style id the user picked. |
 | `fitMode` | How the source image was fitted (`crop`, `contain`, …). |
@@ -229,6 +232,17 @@ smuggled under a scalar key.
 | `systemMessage` | `Scalar` | **Prose.** The interleave system prompt. Path-exempt — see the callout. |
 | `imageGuidanceScale` | `Scalar` | Reference-guidance strength for an interleaved document. |
 | `phases` | `Phases` | Multi-phase denoise schedule, reduced to `{ steps, guidance, loras: [{ index, weight }] }`. LoRA references are indices into this request's own list, not ids. |
+| `motion` | `Scalar` | **Video.** Camera-motion preset off a closed menu (`static`, `slow push-in`, `handheld`). It conditions the generation. |
+| `ltxPipeline` | `Scalar` | **Video.** LTX pipeline selector. It picks which denoise path runs, so two values give two different clips from one prompt. |
+| `distilledVariant` | `Scalar` | **Video.** LTX distilled-checkpoint variant. A different checkpoint is a different model for replay purposes. |
+| `textEncoderModel` | `Scalar` | **Video.** The text-encoder pick — it changes what the model *sees* of the prompt. A catalog-global slug, not a local id. |
+| `lightning` | `Scalar` | **Video.** Wan2.2 A14B fast-4-step toggle. It swaps in a distilled recipe and overrides the step count. |
+| `videoCfgGuidanceScale` | `Scalar` | **Video.** LTX native CFG scale — the video lane's `guidanceScale`. |
+| `videoStgGuidanceScale` | `Scalar` | **Video.** LTX spatiotemporal-guidance scale. |
+| `videoRescaleScale` | `Scalar` | **Video.** LTX guidance-rescale factor. |
+| `videoConditioningStrength` | `Scalar` | **Video.** Source-clip conditioning strength for extend / bridge / v2v — the video lane's `strength`. |
+| `bridgeRightVideoConditioningStrength` | `Scalar` | **Video.** The right-clip strength for a bridge. Without it a shared bridge replays lopsided. |
+| `timelineAction` | `Scalar` | **Video.** Which timeline operation made the clip (`extend` / `replace` / `bridge`). A closed vocabulary with no id in it; its companion `timelineContext` is withheld. |
 
 <!-- END PINNED: advanced-shared -->
 
@@ -250,6 +264,12 @@ Classified and deliberately dropped. A key here is a decision someone wrote down
 | `controlWeights` | A trained-overlay id plus the resolved weights path stamped onto it. |
 | `recipePresetId` | A local preset id stamped by the API. |
 | `presetMissingLoras` | Local LoRA ids the API could not resolve on this install. |
+| `durationHint` | **Video.** Model-catalog prose the studio echoes back ("Recommended: 5s or less."), not a knob anybody set. The receiving install renders its own. |
+| `precision` | **Video.** LTX weight precision (`fp8` / `bf16`): what this machine can afford to hold the weights in. |
+| `quantization` | **Video.** The torch lane's quant tier — `mlxQuantize` for a different backend. |
+| `selectedPersonTrack` | **Video, and the sharpest object in any payload.** The whole person-track record: a user-typed `name` that is routinely a real person's name, a `sourceDisplayName` that is the original imported filename, local asset ids, and a `frames[].mask` array of filesystem paths. Withheld on privacy first and shape second. |
+| `replacementModeLabel` | **Video.** The display label for a person-replacement mode ("Face Only"). Neither an id nor a path, and withheld anyway — see [Person replacement](#person-replacement-is-withheld-by-default). |
+| `timelineContext` | **Video.** Where in the *local* timeline to write the result: timeline / item / track / asset ids, plus the user's own typed timeline name. `timelineAction` carries the part that travels. |
 
 <!-- END PINNED: advanced-withheld -->
 
@@ -268,6 +288,8 @@ times larger.
 | `reference` | Identity or style reference image(s). One entry with a `count`, not N entries. |
 | `mask` | An inpaint mask. |
 | `control` | A pre-made control map, with the conditioning it feeds in `controlMode`. |
+| `sourceClip` | **Video.** A clip the run continues, re-times or bridges from. Separate from `source` because "needs a still to start from" and "needs a clip to continue" are different asks of whoever replays it. |
+| `referenceClip` | **Video.** A reference clip the run conditions on — the moving counterpart of `reference`. |
 
 <!-- END PINNED: input-kinds -->
 
@@ -320,7 +342,7 @@ measurement found a new way to spend what they left.
 | `PROSE_MAX_BYTES` | 16,384 | Each authored prose field, in bytes. | Truncated at a whole character. Prose still means what it said after its tail is cut. |
 | `LABEL_MAX_CHARS` | 200 | Each non-prose label (model slug, style id, LoRA name, producer block), in characters. | **Dropped**, not truncated — a slug's spelling is its identity. |
 | `MAX_SHARE_LORAS` | 5 | Entries in `loras`. | The list is dropped whole and `omitted` gains `loras`. |
-| `MAX_SHARE_INPUTS` | 4 | Entries in `inputs` — one per kind, and the kinds are closed. | The list is dropped whole and `omitted` gains `inputs`. |
+| `MAX_SHARE_INPUTS` | 6 | Entries in `inputs` — one per kind, and the kinds are closed. | The list is dropped whole and `omitted` gains `inputs`. |
 | `MAX_SHARE_PHASES` | 8 | Entries in `advanced.phases`. | The key is dropped and `omitted` gains `advanced.phases`. |
 | `MAX_SHARE_POSES` | 64 | Entries in `advanced.poses`. | The key is dropped and `omitted` gains `advanced.poses`. |
 | `MAX_SHARE_POSE_SLOTS` | 6,144 | Coordinate slots across the whole `advanced.poses` array — a number, or a `null` standing in for one. | The key is dropped and `omitted` gains `advanced.poses`. |
@@ -500,6 +522,12 @@ If the lint says a *builder* is unaccounted for, decide whether its lane embeds.
 | `apps/web/src/screens/characterPanels.jsx` | `usePoseController` | The Pose Library form's extras. |
 | `apps/web/src/screens/DocumentStudio.jsx` | `submit` | The interleaved-document lane. |
 | `apps/web/src/imageJobs.js` | `buildUpscaleJobBody` | The standalone upscale job. Registered as emitting **no** `advanced` map, so the day it grows a knob the lint demands a classification. |
+| `apps/web/src/screens/VideoStudio.jsx` | `submit` | The Video Studio's ~20-knob builder. |
+| `apps/web/src/components/editor/useEditorGeneration.js` | `buildBasePayload` | The timeline editor's shared video payload. |
+| `apps/web/src/screens/EditorScreen.jsx` | `extendSelectedClip` | Timeline extend. |
+| `apps/web/src/screens/EditorScreen.jsx` | `replaceSelectedItem` | Timeline replace. |
+| `apps/web/src/screens/EditorScreen.jsx` | `bridgeGap` | Timeline bridge. |
+| `apps/web/src/simple/simpleJobs.js` | `buildSimpleVideoRequest` | The Simple shell's video request. |
 
 <!-- END PINNED: builders -->
 
@@ -517,11 +545,11 @@ how to know it still can.
 | `source` | A **new** `AdvancedKeySource` variant for this builder, added to `AdvancedKeySource::ALL` as well as declared. One variant per registered builder, checked both ways, or `every_source_tag_names_exactly_one_registered_builder` fails. |
 | `path` | Repo-relative path of the file that defines it. Read out of the repo, so a move fails loudly. |
 | `function` | The JS function whose body the extractor reads. Read out of the repo, so a rename fails loudly. |
-| `shape` | Which `AdvancedBuilderShape` the JS is written in, and therefore which extractor can read it: `ReturnedObject`, `FlatAdvancedLiteral`, `AssignedObject`, `ExtrasLiteral`, or `NoAdvancedMap` for a builder that posts no `advanced` map at all. |
+| `shape` | Which `AdvancedBuilderShape` the JS is written in, and therefore which extractor can read it: `ReturnedObject`, `FlatAdvancedLiteral`, `SpreadAdvancedLiteral`, `AssignedObject`, `ExtrasLiteral`, or `NoAdvancedMap` for a builder that posts no `advanced` map at all. |
 | `lane` | Prose: the embedding lane this builder's payload ends up written by, so a reader can see why the keys matter. |
 | `anchors` | Keys the extractor **must** still find. The floor against an extractor that has quietly stopped understanding the file — a lint that reads zero keys and passes is the failure mode the whole registry exists to prevent. |
 | `minimum_keys` | The smallest key count the extractor may report before the lint calls itself broken. Set it well under the real count; it is a floor, not a census. |
-| `spread_of` | Identifiers spread into an `AssignedObject` initializer whose keys another registry entry already accounts for. Empty for most builders, and declared so a **new** spread of something nobody classified fails the lint instead of vanishing into it. |
+| `spread_of` | Identifiers spread into an `AssignedObject` or `SpreadAdvancedLiteral` initializer whose keys another registry entry already accounts for. A dotted member path (`base.advanced`) counts as one name; a call expression is refused, because its keys have no declarable name. Empty for most builders, and declared so a **new** spread of something nobody classified fails the lint instead of vanishing into it. |
 
 <!-- END PINNED: builder-fields -->
 
@@ -538,12 +566,6 @@ of scope" different states:
 
 | File | Function | Why it is deferred |
 | --- | --- | --- |
-| `apps/web/src/screens/VideoStudio.jsx` | `submit` | Video lane. No video write seam embeds yet. |
-| `apps/web/src/components/editor/useEditorGeneration.js` | `buildBasePayload` | Video lane — the timeline editor's shared payload. |
-| `apps/web/src/screens/EditorScreen.jsx` | `extendSelectedClip` | Video lane — a timeline action. |
-| `apps/web/src/screens/EditorScreen.jsx` | `replaceSelectedItem` | Video lane — a timeline action. |
-| `apps/web/src/screens/EditorScreen.jsx` | `bridgeGap` | Video lane — a timeline action. |
-| `apps/web/src/simple/simpleJobs.js` | `buildSimpleVideoRequest` | Video lane. Its image sibling delegates to the studio builder and is already covered. |
 | `apps/web/src/training/trainingConfig.js` | `trainingConfigSnapshot` | Permanently exempt: trainer hyperparameters are a different namespace, and no training write seam embeds. |
 
 <!-- END PINNED: deferred-builders -->
@@ -551,9 +573,22 @@ of scope" different states:
 Until sc-16113 that list was a decision record and nothing more. It said, in its own doc comment,
 that no video lane could start embedding while its keys sat in it — and nothing enforced that.
 Adding a `write_workflow_chunk` + `embeddable_workflow_share` call to a real video-lane PNG write in
-`crates/sceneworks-worker/src/video_jobs/seedvr2.rs` left every lint green while all ~15 of
+`crates/sceneworks-worker/src/video_jobs/seedvr2.rs` left every lint green while all of
 `VideoStudio.jsx`'s unclassified keys were dropped from the written file, with nothing anywhere to
 say so.
+
+**sc-15956 is the story the gate was built for, and it did its job.** All six video builders moved
+into the table above, which is what forced every key behind them to be classified before a video
+seam could embed. Two findings are worth keeping, because both argue for the enforcement being a
+discovery scan rather than a list:
+
+- the deferral said "~15 keys" and the real count was **17**. `timelineAction` and `timelineContext`
+  are emitted only by the three `EditorScreen.jsx` actions, and nobody had read those builders. A
+  deferral records that a decision is owed; it is a poor estimate of what the decision costs;
+- two of the 17 were **objects**, not scalars — `selectedPersonTrack` carries a person's name, an
+  original imported filename and an array of mask file paths, and `timelineContext` carries local
+  ids plus the user's own timeline name. Under the pre-sc-16113 arrangement those would have
+  travelled, silently, in every shared clip.
 
 ## The write seams, and what each one embeds for
 
@@ -575,6 +610,7 @@ deferred.
 | `crates/sceneworks-worker/src/image_jobs/detail.rs` | `run_image_detail_job` | Embeds — writes the refined PNG. macOS-gated; the scan is textual, so it is read on every platform. |
 | `crates/sceneworks-worker/src/upscale_jobs.rs` | `run_image_upscale_job` | Embeds — hands the standalone upscale's envelope to the shared single-child writer. |
 | `crates/sceneworks-worker/src/single_child_asset.rs` | `write_single_child_asset` | Conduit — writes the envelope its caller decided on, and builds none itself. |
+| `crates/sceneworks-worker/src/video_jobs/mod.rs` | `video_workflow_metadata` | Embeds — the one funnel every generated clip is encoded through, whatever engine or studio produced it. |
 | `crates/sceneworks-worker/src/segment_jobs.rs` | `run_image_segment_job` | Declines — a smart-select mask has no generation recipe to replay, and is grayscale. |
 
 <!-- END PINNED: write-seams -->


### PR DESCRIPTION
Extends the embedded-workflow envelope to video: every generated MP4 carries its own sanitized recipe, in the standard `comment` tag, honouring the same `embedWorkflowInImages` setting images use.

Closes sc-15956. Depends on sc-15946 / sc-15948 / sc-15953 / sc-16113, all merged.

## The first AC was a go/no-go, so it was answered first

Measured on a real ffmpeg with a full-cap (160 kB) envelope, before anything was built. Three write routes; two of them do not work:

| route | result |
|---|---|
| a CUSTOM tag (`sceneworks_workflow`) | needs `-movflags use_metadata_tags` on **every** downstream tool. **Dropped by a plain `-c copy` remux.** |
| `-metadata comment=` on the command line | `ENAMETOOLONG` above ~32 kB — Windows caps a command line at 32,767 chars, the envelope ceiling is 160 KiB |
| `-f ffmetadata -i <file>` into `comment` | survives everything measured, at the full cap, **byte-exact** |

Survival of the chosen route:

| transcode | tag |
|---|---|
| `-c copy` remux | **survives**, byte-exact |
| re-encode, default flags | **survives**, byte-exact |
| scale 640 to 320 + bitrate cap (delivery-shaped) | **survives**, byte-exact |
| `+faststart` web remux | **survives** |
| trim / cut | **survives** |
| MKV round trip | survives (key uppercased to `COMMENT` in matroska) |
| **`-map_metadata -1`** | **GONE** — the negative case |

### The honest verdict on the sharing premise

**Weaker for video than for a PNG chunk, but not by as much as the story assumed — because the PNG premise is itself weaker than we thought.**

Where the *file* travels, the recipe travels: local use, copies, Drive/Dropbox (byte-identical downloads), email attachments, Discord desktop's `cdn.discordapp.com` original, Slack's `url_private_download`. Where the file is **re-encoded**, it does not: X, Instagram, TikTok, YouTube, WhatsApp's normal send, Discord's *mobile* upload (a client-side transcode before it ever leaves the phone — the one hard, officially documented loss), and any inline-player rendition on either Discord or Slack.

The comparison matters. Slack has confirmed it strips EXIF from uploaded images, and Discord's image-metadata handling changed in 2023. So "a PNG chunk survives Discord/Slack" is itself medium-confidence rather than a given. Video is not uniquely disadvantaged; both halves of this epic are strongest as a **file-provenance** feature and weakest as a **social-platform** one.

Nothing was narrowed on the strength of that. The local half is the larger half, and it is fully built.

## Two things the measurement found that nobody had written down

1. **`ffmetadata` has no escape for a carriage return, and silently truncates at one.** `"a\rb"` written, `"a"` read back, no error at either end — a recipe that is silently half a recipe. Unreachable through `serde_json` (which escapes control characters), and guarded rather than assumed.
2. **A crossfaded timeline export would have inherited its first clip's recipe.** With several `-i` inputs and no `-map_metadata`, ffmpeg copies input 0's metadata to the output. The plain `-f concat` mux drops metadata and the `filter_complex` crossfade mux does not — an asymmetry nobody would guess at. Both paths now pass `-map_metadata -1` explicitly, with a test on each.

## What is in the change

- **`workflow_mp4.rs`** — the MP4 codec. Writes via an `ffmetadata` document; reads via a **seeking box walk** that never buffers `mdat` (a clip is routinely hundreds of MB and the tag is in the header), with every bound ours rather than the file's.
- **`video` marker kind** — a new kind, not a `schemaVersion` bump. An older build then refuses a video envelope by the kind gate (which runs *before* the version gate) while every shared image reads exactly as it did.
- **The video arm of the allow-list** — 17 keys classified, 11 allow / 6 deny. The story said ~15; the real count was 17, because `timelineAction` and `timelineContext` are emitted only by the three `EditorScreen.jsx` actions and nobody had read those builders.
- **Person replacement is withheld.** `personTrackId` and `replacementMode` never reach the envelope, and neither do `advanced.selectedPersonTrack` (a person's name, the original imported filename, local ids, and a `frames[].mask` array of filesystem paths) or `advanced.replacementModeLabel`. Withheld **silently** rather than through `omitted` — the one place this contract's "state the absence" rule is deliberately inverted, because `omitted: ["personTrackId"]` would announce the replacement to every reader while withholding only the id.
- **Clip ids become shape**, via two new input kinds (`sourceClip`, `referenceClip`), exactly as the image lane treats `sourceAssetId`.
- **Timeline exports are covered by declining**, not by embedding: an export is a mux of several clips and not the output of any one recipe, and its sidecar's `prompt` slot holds the user's own timeline name.
- **One setting, not two.** Video honours `embedWorkflowInImages`. It is a privacy control over what leaves in a file, and the reason someone turns it off does not stop applying at the container boundary; a separate switch would have re-enabled embedding for everyone who had already opted out. The stored key keeps its name for back-compatibility; the copy names both media.

## How the sc-16113 gate behaved

Exactly as designed, and exactly as documented. All six video builders had to move into `ADVANCED_BUILDERS` **in this same change** as the write seam — the back-check forbids splitting it — and doing so is what forced every key to be classified. Two of the seventeen turned out to be object-shaped id-and-free-text carriers that would have travelled silently under the pre-sc-16113 arrangement.

`a_seam_that_embeds_for_a_deferred_builder_fails_the_build` is re-pointed, as sc-16113 predicted it would have to be — at the PERMANENT exemption rather than at another story-owned deferral, since a deferral has an expiry date and makes a poor anchor. A new floor test asserts the deferral registry is never empty, so that proof cannot silently lose its example.

The coverage lint learned two things it needed: an `advanced:` literal with conditional spreads (the video builders' shape, which no existing arm could read), and that a `,` inside parentheses separates **call arguments** rather than keys — without which `generationContext("extend", selectedItem, {...})` made `selectedItem` look like an unclassified knob.

## Playback

Verified on a real-pipeline clip carrying a 150 kB envelope:

- **App engine / browser** (WebView2 and Chromium are the same engine; served over HTTP with byte-range, as the API does): 76 frames decoded, **0 dropped, 0 corrupted**, `readyState` 4, buffered and seekable 0-3 s, no error.
- **External player** (`ffplay`): whole clip played to completion, 0 frames dropped, no errors.
- **Windows Media Foundation**: reads the tagged clip identically to an untagged one.
- Frame count identical to an untagged clip (72 = 72), and `moov` still precedes `mdat`, so faststart progressive playback is intact.

## Tests

`cargo test --workspace --no-fail-fast` green. `sceneworks-mcp` failed in the workspace run and passes in isolation — the known sc-15337 rustls flake under load; this branch does not touch that crate. `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean. Web suite green.

26 new hermetic codec tests (every MP4 built byte by byte, so they run on a host with no ffmpeg), 3 real-ffmpeg end-to-end tests including the survival matrix with its negative case, and 3 export-inheritance tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
