### PR TITLE
feat(workflow-share): Civitai-readable parameters chunk (sc-15957)

### DIFF
--- a/apps/web/src/components/WorkflowEmbedNotice.jsx
+++ b/apps/web/src/components/WorkflowEmbedNotice.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Icon } from "./Icons.jsx";
 import {
+  GALLERY_READABLE_COPY,
   SAVE_WITHOUT_WORKFLOW_LABEL,
   WORKFLOW_SHARE_DOC_URL,
   inFileItems,
@@ -48,6 +49,9 @@ export function WorkflowEmbedDetails() {
           <li key={item}>{item}</li>
         ))}
       </ul>
+      <p className="settings-note">
+        <strong>Readable by image galleries.</strong> {GALLERY_READABLE_COPY}
+      </p>
       <p className="settings-note">
         <strong>Not in the file:</strong>
       </p>

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -263,6 +263,26 @@ export const WORKFLOW_FIELDS_NOT_IN_FILE = Object.freeze([
 // beside the keyed list so the sentence reads as one thought.
 const UNKEYED_ABSENCES = Object.freeze([N_IDENTITY, N_TIME, N_IMAGES]);
 
+// The second block (sc-15957), and the reason it needs its own sentence rather than a row in the
+// list above.
+//
+// Both lists are pinned per KEY against the two doc tables, and every key in this block is already
+// in `WORKFLOW_FIELDS_IN_FILE` — it carries no field the envelope does not. So the key-level pin is
+// silent about it, exactly the way it was silent about the person-replacement bullet, and for the
+// same structural reason: the claim is about a FORMAT rather than about a field.
+//
+// And it is a claim a user acts on. Someone who reads "your recipe is in the file" pictures a block
+// only SceneWorks understands; what is actually written is a second copy of the prompt, seed and
+// settings in the format Civitai and most galleries read and DISPLAY. Those are different facts
+// about what happens when the image is posted somewhere, and the narrower one would be claiming more
+// privacy than the file delivers — the one direction this file's header forbids.
+//
+// Pinned as prose by `the_settings_copy_says_the_file_is_also_gallery_readable` in
+// `crates/sceneworks-core/tests/workflow_share_doc.rs`, which renders a real envelope's trailer and
+// checks this sentence against it.
+export const GALLERY_READABLE_COPY =
+  "A second copy of the prompt, negative prompt, seed, size, sampler, steps and guidance is written in the format image galleries read, so a site like Civitai displays them beside your image instead of showing it as plain pixels. It is the same information as the block above and nothing more; both are removed together.";
+
 // The bullets of the "Also in the file" list: every declared label, in order, repeats collapsed.
 //
 // A LIST rather than one comma-joined sentence, and not for taste. Several of these phrases carry

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod training_store;
 pub mod video_request;
 pub mod voice_store;
 pub mod workflow_mp4;
+pub mod workflow_parameters;
 pub mod workflow_png;
 pub mod workflow_resolution;
 pub mod workflow_share;

--- a/crates/sceneworks-core/src/workflow_parameters.rs
+++ b/crates/sceneworks-core/src/workflow_parameters.rs
@@ -78,6 +78,21 @@ pub const PARAMETERS_CHUNK_KEYWORD: &str = "parameters";
 /// constant rather than against a copy of the string.
 pub const NEGATIVE_PROMPT_LABEL: &str = "Negative prompt: ";
 
+/// The fewest `Key: value` pairs a trailing line may carry and still be read as one.
+///
+/// A1111's `parse_generation_parameters` pops the last line, counts the pairs its `re_param_code`
+/// finds, and puts the line back into the PROMPT when there are fewer than three. Civitai and the
+/// rest of the ecosystem's parsers inherit the rule. So this is not our threshold and not a style
+/// choice: it is the boundary between a settings line and a line of prompt text, for every reader
+/// this chunk is written for.
+///
+/// [`settings_line`] treats it as a floor and withholds the whole line below it — see the reasoning
+/// there. Public so the corpus in `crates/sceneworks-core/tests/workflow_parameters.rs` can pin the
+/// lanes against it; that file's `parse_a1111` keeps its own literal threshold, because a parser
+/// that took its rule from the renderer it is measuring would agree with it by construction.
+/// `the_local_parser_reads_a_real_a1111_block` joins the two.
+pub const SETTINGS_PAIR_FLOOR: usize = 3;
+
 /// Every key that may appear on the trailing settings line, in emission order.
 ///
 /// The decision record for "omit rather than approximate": a key is here because the envelope holds
@@ -159,10 +174,13 @@ pub const SETTINGS_FIELDS: &[(&str, &str)] = &[
 ///
 /// * **A prompt containing a line that begins `Negative prompt:` will mis-split.** A1111 has the
 ///   same behaviour on its own output; the boundary is positional and there is no escape for it.
-/// * **A settings line of fewer than three pairs is prompt text to A1111's parser.** Our floor is
-///   `Seed` + `Model` + `Version`, which every generated image clears —
-///   `the_settings_line_clears_the_pair_floor_a_gallery_parses_with` in
-///   `crates/sceneworks-core/tests/workflow_parameters.rs` pins that rather than assuming it.
+/// * **A settings line of fewer than three pairs is prompt text to A1111's parser.** Inherited, but
+///   not left to chance: [`SETTINGS_PAIR_FLOOR`] omits the line entirely rather than emitting one a
+///   gallery would append to the prompt. Every shipping lane clears the floor on its own — the
+///   thinnest, a standalone upscale, emits exactly `Seed` + `Model` + `Version` with no margin —
+///   and `the_settings_line_clears_the_pair_floor_a_gallery_parses_with` in
+///   `crates/sceneworks-core/tests/workflow_parameters.rs` pins the lane SHAPES rather than assuming
+///   a well-populated one.
 ///
 /// The authoritative recipe is unaffected by either: it is the `sceneworks:workflow` chunk, and this
 /// block is for display.
@@ -182,7 +200,8 @@ pub fn parameters_text(share: &WorkflowShare, encoded: (u32, u32)) -> String {
     out
 }
 
-/// The trailing `Key: value, Key: value` line, or empty when nothing maps exactly.
+/// The trailing `Key: value, Key: value` line, or empty when nothing maps exactly — or when what
+/// maps is too little for a gallery to recognize as a settings line at all.
 fn settings_line(share: &WorkflowShare, encoded: (u32, u32)) -> String {
     let advanced = &share.advanced;
     // A multi-phase run has no single step count and no single guidance value. Emitting the
@@ -240,6 +259,19 @@ fn settings_line(share: &WorkflowShare, encoded: (u32, u32)) -> String {
         push("Version", share.producer.version.clone());
     }
 
+    // Below the floor the line is not a settings line to anything that reads this chunk — it is a
+    // trailing line of the PROMPT. Emitting it anyway would not "give the reader two fields": it
+    // would make a gallery display `a lighthouse\nSeed: 880412, Version: 0.8.1` as the prompt, which
+    // is a wrong prompt rather than a thin settings block. Omitting the whole line leaves the prompt
+    // correct and the settings absent, and the absent settings were never legible in the first place.
+    //
+    // This is the same "omit rather than approximate" rule the module is built on, applied one level
+    // up: the fields are individually exact and the LINE is still not a statement a reader can act
+    // on, so the line goes. `sceneworks:workflow` is unaffected — the authoritative recipe rides in
+    // the other chunk and carries every one of these fields regardless.
+    if pairs.len() < SETTINGS_PAIR_FLOOR {
+        return String::new();
+    }
     pairs
         .into_iter()
         .map(|(key, value)| format!("{key}: {}", quote(&value)))
@@ -469,8 +501,34 @@ mod tests {
     #[test]
     fn the_version_is_the_envelopes_own_producer_version() {
         // The AC: the two chunks cannot disagree about which build wrote the file.
-        let share = envelope(serde_json::json!({}));
+        //
+        // Carries a seed so the line clears `SETTINGS_PAIR_FLOOR` — without one this envelope emits
+        // Model + Version and the floor guard withholds the whole line, which is the right answer
+        // and the wrong fixture for this question.
+        let share = envelope(serde_json::json!({ "seed": 7 }));
         assert_eq!(share.producer.version, "0.8.1");
         assert!(parameters_text(&share, (1, 1)).ends_with("Version: 0.8.1"));
+    }
+
+    #[test]
+    fn a_line_under_the_pair_floor_is_withheld_rather_than_emitted() {
+        // The cliff, and which way it falls. This envelope maps two fields exactly — Model and
+        // Version — and two pairs is PROMPT to every parser this chunk is written for. Emitting them
+        // would not give a reader a thin settings block, it would give them a wrong prompt.
+        let two = envelope(serde_json::json!({}));
+        assert_eq!(
+            parameters_text(&two, (1, 1)),
+            "a lighthouse in heavy fog",
+            "a sub-floor line must be withheld whole, leaving the prompt correct"
+        );
+
+        // One more mapped field and the line is legible, so it travels. The guard is a floor, not a
+        // preference for silence.
+        let three = envelope(serde_json::json!({ "seed": 7 }));
+        assert_eq!(
+            parameters_text(&three, (1, 1)),
+            "a lighthouse in heavy fog\nSeed: 7, Model: z_image_turbo, Version: 0.8.1"
+        );
+        assert_eq!(SETTINGS_PAIR_FLOOR, 3, "A1111's threshold, not ours");
     }
 }

--- a/crates/sceneworks-core/src/workflow_parameters.rs
+++ b/crates/sceneworks-core/src/workflow_parameters.rs
@@ -1,0 +1,460 @@
+//! The A1111 `parameters` rendering of a sanitized envelope (sc-15957, epic 15945).
+//!
+//! [`crate::workflow_share`] owns the contract, [`crate::workflow_png`] owns the PNG plumbing, and
+//! this module owns one narrow question: **what does a third-party gallery get to display?**
+//!
+//! # This is a display feature, not an interop feature
+//!
+//! Civitai and most image viewers parse the de-facto `parameters` text chunk that AUTOMATIC1111's
+//! WebUI popularised. They *display* generation settings; they do not execute them. That is what
+//! makes this worth doing for models those tools have never heard of — a Krea or FLUX.2 image posted
+//! to a gallery shows its prompt, seed and size instead of arriving as opaque pixels.
+//!
+//! Judge it on that. Nothing here is a replay format: [`crate::workflow_share`]'s
+//! `sceneworks:workflow` envelope is, and it is the one a SceneWorks install reads back.
+//!
+//! # Explicitly not ComfyUI's format
+//!
+//! ComfyUI embeds `workflow` / `prompt` chunks holding a serialized **node graph**. SceneWorks has
+//! no node graph, and emitting a fake one would misrepresent the product. This is the A1111 text
+//! convention and nothing else.
+//!
+//! # Written from the sanitized envelope, never from the raw payload
+//!
+//! [`parameters_text`] takes a [`WorkflowShare`] — the already-allow-listed, already-reduced,
+//! already-path-guarded envelope. It is a second *rendering* of the same data, not a second, laxer
+//! channel: a field the sc-15946 allow-list withholds cannot appear here, because this function
+//! never sees it. `the_parameters_chunk_cannot_carry_a_withheld_field` in
+//! `crates/sceneworks-core/tests/workflow_parameters.rs` seeds a withheld key into a raw payload and
+//! proves it is absent from both chunks.
+//!
+//! The sc-15953 setting therefore governs both chunks together, for free: the writer is handed
+//! `None` when embedding is off, and neither chunk is written.
+//!
+//! # Omit rather than approximate
+//!
+//! The discipline of the whole story. A guessed mapping ships misleading data to a *public gallery*,
+//! which is worse than a shorter trailer, and nobody downstream can tell a guess from a fact. So
+//! every A1111 field is either an exact restatement of something the envelope holds or is left out.
+//! [`SETTINGS_FIELDS`] is the decision record, and the omissions are argued in
+//! [`the omitted fields`](#what-is-deliberately-not-here) below.
+//!
+//! # What is deliberately not here
+//!
+//! | SceneWorks has | A1111 has | Why it is omitted |
+//! | --- | --- | --- |
+//! | `advanced.phases` (multi-phase Krea) | nothing | A schedule of N (steps, guidance) pairs has no single-number form. Its presence also suppresses `Steps` and `CFG scale`, because a top-level number beside a multi-phase schedule describes a run that did not happen. |
+//! | `advanced.textStyleGain` | nothing | A Krea tap-reweight gain. No field means it, and inventing one names a knob no reader can interpret. |
+//! | `advanced.scheduler`, `schedulerShift` | `Schedule type` | A1111's `Schedule type` is a NOISE schedule (Karras, Exponential). Ours is a diffusers scheduler class, which is closer to A1111's *sampler*. Two plausible mappings and no correct one. |
+//! | `advanced.strength` | `Denoising strength` | The sense is lane-dependent — the candle fork lane inverts it (higher is *closer* to the reference). A number whose direction is ambiguous is worse than no number. |
+//! | `upscale.*` | `Hires upscale` / `Hires upscaler` | A1111's hires fix is a specific latent second pass. Ours is a separate post-pass on the decoded image. Same words, different pipeline. |
+//! | `loras[]` | `<lora:name:weight>` in the prompt | A1111 carries LoRAs by rewriting the prompt. Editing the user's prompt to smuggle a resource list in is fabrication — the prompt in this chunk is the prompt they typed. |
+//! | `count` | `Batch size` | Ours is how many images the run asked for; A1111's is the sampler's parallel batch. Near-synonyms that are not the same number. |
+//! | `advanced.controlMode` / `controlScale` | ControlNet extension fields | The ControlNet trailer is a whole sub-format with per-unit indices and model hashes. A partial emission of it reads as a full one. |
+//! | `advanced.faceRestore` | `Face restoration: CodeFormer` | A1111's field names the *engine*. Ours is a boolean and we have no engine name to give. |
+//! | `stylePreset`, `styleId`, `fitMode`, `mode`, `inputs[]` | nothing | No field, near or far. |
+//! | quant tier, attention kernel, GPU | nothing | Never in the envelope at all — the allow-list withholds them, so this rendering could not see them if it wanted to. |
+//!
+//! # Encoding is decided by [`crate::workflow_png`], not here
+//!
+//! This module produces text. Whether that text rides in a `tEXt` or an `iTXt` chunk is a PNG
+//! question and is answered where the chunk is framed; see `parameters_chunk` there.
+
+use serde_json::Value;
+
+use crate::workflow_share::WorkflowShare;
+
+/// The PNG text keyword the A1111 convention publishes under.
+///
+/// Unprefixed, unlike [`crate::workflow_png::WORKFLOW_CHUNK_KEYWORD`], and deliberately so: the
+/// whole value of this chunk is that a reader who has never heard of SceneWorks finds it under the
+/// name it already looks for. Namespacing it would make it correct and useless.
+pub const PARAMETERS_CHUNK_KEYWORD: &str = "parameters";
+
+/// The label A1111 puts in front of the negative prompt, on its own line.
+///
+/// Public because it is the token a parser splits on, and
+/// `crates/sceneworks-core/tests/workflow_parameters.rs` implements that parser against this
+/// constant rather than against a copy of the string.
+pub const NEGATIVE_PROMPT_LABEL: &str = "Negative prompt: ";
+
+/// Every key that may appear on the trailing settings line, in emission order.
+///
+/// The decision record for "omit rather than approximate": a key is here because the envelope holds
+/// something that *is* that field, not something that resembles it. The module docs list what was
+/// left out and why. `the_settings_line_emits_exactly_the_declared_keys` pins this list against the
+/// rendered output of a fully-populated envelope, so a key added to the renderer without being
+/// declared here fails, and a key declared here that nothing can emit fails too.
+pub const SETTINGS_FIELDS: &[(&str, &str)] = &[
+    (
+        "Steps",
+        "`advanced.steps`, when it is a whole number of at least one and no multi-phase schedule \
+         overrides it.",
+    ),
+    (
+        "Sampler",
+        "`advanced.sampler`, verbatim — except the literal `default`, which names no sampler and is \
+         omitted.",
+    ),
+    (
+        "CFG scale",
+        "`advanced.guidanceScale`, only when `advanced.guidanceMethod` is absent. The studio emits \
+         that key only for a method that is NOT plain CFG, so its presence means the number is not \
+         a CFG scale.",
+    ),
+    (
+        "Seed",
+        "`seed`, verbatim — the seed of THIS image, which is the only one the envelope carries.",
+    ),
+    (
+        "Size",
+        "`width` x `height`, only when they are the dimensions of the file being written.",
+    ),
+    (
+        "Model",
+        "`model`, the catalog slug, verbatim. A1111's companion `Model hash` is omitted: we have no \
+         checkpoint hash to give and inventing one would be a claim about bytes we never read.",
+    ),
+    (
+        "Version",
+        "`producer.version` off the envelope's own producer block, so the two chunks in one file \
+         cannot disagree about which build wrote it.",
+    ),
+];
+
+/// Render `share` as the A1111 `parameters` text for an image encoded at `encoded` pixels.
+///
+/// ```text
+/// <prompt>
+/// Negative prompt: <negative>
+/// Steps: N, Sampler: X, CFG scale: N, Seed: N, Size: WxH, Model: <slug>, Version: <version>
+/// ```
+///
+/// The prompt is always the first line, even when it is empty, because the layout is positional:
+/// every parser in the wild treats everything before the `Negative prompt:` line (or before the
+/// trailing settings line, when there is no negative) as the prompt. The negative line is omitted
+/// entirely when there is no negative prompt, which is what A1111 itself does. The settings line is
+/// omitted when nothing on it could be emitted exactly.
+///
+/// # Why `encoded` is a parameter
+///
+/// `Size` is the one field where the envelope and the file can honestly disagree. `width` / `height`
+/// are the geometry the run *asked for*, and the inline-upscale variant deliberately keeps the base
+/// render's numbers (`upscaled_workflow_share` in the worker explains why) while the PNG it is
+/// written into is larger. A1111 papers over the same gap with `Hires upscale: 2`, which we do not
+/// emit — so a reader would see `Size: 1024x1024` stamped on a 2048² image with nothing to explain
+/// it.
+///
+/// So `Size` is emitted only when the envelope's geometry IS the encoded image's. That makes it a
+/// statement about the file rather than an approximation of it, and it costs the field only on the
+/// derived-pass images where it would have been wrong. The base render — every ordinary generation —
+/// matches by construction, because `write_image_asset` builds its envelope from the same width and
+/// height it hands the encoder.
+#[must_use]
+pub fn parameters_text(share: &WorkflowShare, encoded: (u32, u32)) -> String {
+    let mut out = share.prompt.clone();
+    if !share.negative_prompt.is_empty() {
+        out.push('\n');
+        out.push_str(NEGATIVE_PROMPT_LABEL);
+        out.push_str(&share.negative_prompt);
+    }
+    let settings = settings_line(share, encoded);
+    if !settings.is_empty() {
+        out.push('\n');
+        out.push_str(&settings);
+    }
+    out
+}
+
+/// The trailing `Key: value, Key: value` line, or empty when nothing maps exactly.
+fn settings_line(share: &WorkflowShare, encoded: (u32, u32)) -> String {
+    let advanced = &share.advanced;
+    // A multi-phase run has no single step count and no single guidance value. Emitting the
+    // top-level ones beside a schedule that overrode them would describe a run that did not happen,
+    // and a gallery reader has no way to tell. So both are suppressed together — the presence of the
+    // schedule is the signal, and `omitted` carries it too when the schedule itself was too large to
+    // record, which is the same fact arriving by the other door.
+    let multi_phase = advanced.contains_key("phases")
+        || share
+            .omitted
+            .iter()
+            .any(|name| name == crate::workflow_share::OMITTED_PHASES);
+
+    let mut pairs: Vec<(&str, String)> = Vec::with_capacity(SETTINGS_FIELDS.len());
+    let mut push = |key: &'static str, value: String| pairs.push((key, value));
+
+    if !multi_phase {
+        if let Some(steps) = advanced.get("steps").and_then(whole_number) {
+            if steps >= 1 {
+                push("Steps", steps.to_string());
+            }
+        }
+    }
+    if let Some(sampler) = advanced.get("sampler").and_then(Value::as_str) {
+        let sampler = sampler.trim();
+        // `default` is a real value in our vocabulary and means "whatever the engine picks". It is
+        // not the name of a sampler, and writing it into a field a gallery renders as one would
+        // invent a sampler that does not exist.
+        if !sampler.is_empty() && sampler != "default" {
+            push("Sampler", sampler.to_owned());
+        }
+    }
+    // `guidanceMethod` is emitted by the studio builder ONLY when the method is not plain CFG
+    // (`imageJobAdvanced.js` drops the `cfg` no-op), so its presence is exactly the signal that this
+    // number is not a CFG scale.
+    if !multi_phase && !advanced.contains_key("guidanceMethod") {
+        if let Some(scale) = advanced.get("guidanceScale").and_then(finite_number) {
+            push("CFG scale", format_number(scale));
+        }
+    }
+    if let Some(seed) = share.seed {
+        push("Seed", seed.to_string());
+    }
+    if share.width == Some(encoded.0) && share.height == Some(encoded.1) {
+        push("Size", format!("{}x{}", encoded.0, encoded.1));
+    }
+    if !share.model.is_empty() {
+        push("Model", share.model.clone());
+    }
+    // Fed from the envelope's own producer block rather than from `PRODUCER_VERSION` directly, so
+    // the two chunks in one file cannot disagree about which build wrote it. An envelope whose
+    // producer block was reduced to empty (a version that is not strict semver, on the read side)
+    // therefore omits the field rather than substituting this build's.
+    if !share.producer.version.is_empty() {
+        push("Version", share.producer.version.clone());
+    }
+
+    pairs
+        .into_iter()
+        .map(|(key, value)| format!("{key}: {}", quote(&value)))
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
+/// A1111's own quoting rule, mirrored.
+///
+/// `modules/generation_parameters_copypaste.py` JSON-quotes a value containing a comma, a newline or
+/// a colon, because all three are the separators the trailing line is parsed with, and its reader
+/// un-quotes on the way back. Without it a sampler or model slug containing a comma would silently
+/// split into two fields for every reader in the wild.
+fn quote(value: &str) -> String {
+    if value.contains(',') || value.contains('\n') || value.contains(':') {
+        // Infallible for a `str`; the fallback is unreachable and is a fallback rather than an
+        // `expect` because a panic in a metadata renderer would fail a generation that succeeded.
+        serde_json::to_string(value).unwrap_or_else(|_| value.to_owned())
+    } else {
+        value.to_owned()
+    }
+}
+
+/// A JSON number that is a non-negative whole number, whichever way it was spelled.
+///
+/// `8` and `8.0` are the same step count to a user and arrive differently depending on which builder
+/// wrote the payload, so both are read. `8.5` is not a step count and is dropped rather than
+/// rounded — rounding is exactly the kind of quiet approximation this module refuses.
+fn whole_number(value: &Value) -> Option<u64> {
+    if let Some(integer) = value.as_u64() {
+        return Some(integer);
+    }
+    let float = value.as_f64()?;
+    if !float.is_finite() || float < 0.0 || float.fract() != 0.0 || float > 4_294_967_295.0 {
+        return None;
+    }
+    // Exact: the guards above put `float` on a whole number inside u32's range.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    Some(float as u64)
+}
+
+/// A JSON number that is finite. NaN and the infinities are dropped: they render as `NaN` / `inf`,
+/// which is not a guidance scale and would be displayed as one.
+fn finite_number(value: &Value) -> Option<f64> {
+    value.as_f64().filter(|number| number.is_finite())
+}
+
+/// `4.0` as `4`, `3.5` as `3.5`.
+///
+/// A trailing `.0` is what `f64`'s own `Display` produces and is not what any A1111 emitter writes,
+/// so a reader diffing two files would see a difference that is not one.
+fn format_number(value: f64) -> String {
+    if value.fract() == 0.0 && value.abs() < 1e15 {
+        format!("{:.0}", value)
+    } else {
+        format!("{value}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow_share::parse_workflow_share_json;
+
+    fn envelope(extra: serde_json::Value) -> WorkflowShare {
+        let mut object = serde_json::json!({
+            "sceneworksWorkflow": "image",
+            "schemaVersion": 1,
+            "producer": {
+                "name": "SceneWorks",
+                "url": "https://github.com/SceneWorks/SceneWorks",
+                "version": "0.8.1"
+            },
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "prompt": "a lighthouse in heavy fog",
+        });
+        let map = object.as_object_mut().expect("an object");
+        for (key, value) in extra.as_object().expect("extra is an object") {
+            map.insert(key.clone(), value.clone());
+        }
+        parse_workflow_share_json(&object.to_string()).expect("the fixture parses")
+    }
+
+    #[test]
+    fn the_layout_is_the_a1111_one() {
+        let share = envelope(serde_json::json!({
+            "negativePrompt": "text, watermark",
+            "seed": 880_412,
+            "width": 1024,
+            "height": 768,
+            "advanced": { "steps": 28, "sampler": "euler", "guidanceScale": 3.5 },
+        }));
+        assert_eq!(
+            parameters_text(&share, (1024, 768)),
+            "a lighthouse in heavy fog\n\
+             Negative prompt: text, watermark\n\
+             Steps: 28, Sampler: euler, CFG scale: 3.5, Seed: 880412, Size: 1024x768, \
+             Model: z_image_turbo, Version: 0.8.1"
+        );
+    }
+
+    #[test]
+    fn an_empty_negative_prompt_omits_its_whole_line() {
+        // A1111 does the same. An empty `Negative prompt:` line is a claim that the run had one.
+        let share = envelope(serde_json::json!({ "seed": 7 }));
+        let text = parameters_text(&share, (1024, 768));
+        assert!(!text.contains(NEGATIVE_PROMPT_LABEL), "{text:?}");
+        assert_eq!(
+            text,
+            "a lighthouse in heavy fog\nSeed: 7, Model: z_image_turbo, Version: 0.8.1"
+        );
+    }
+
+    #[test]
+    fn a_multi_phase_run_omits_steps_and_cfg_rather_than_picking_one() {
+        // The AC's named case. A Krea multi-phase schedule is N (steps, guidance) pairs; a single
+        // number beside it describes a run that did not happen.
+        let share = envelope(serde_json::json!({
+            "seed": 4,
+            "advanced": {
+                "steps": 28,
+                "guidanceScale": 3.5,
+                "sampler": "euler",
+                "textStyleGain": 1.4,
+                "phases": [
+                    { "steps": 12, "guidance": 4.0 },
+                    { "steps": 16, "guidance": 2.0 }
+                ]
+            },
+        }));
+        let text = parameters_text(&share, (1024, 768));
+        assert!(!text.contains("Steps:"), "{text:?}");
+        assert!(!text.contains("CFG scale:"), "{text:?}");
+        // And nothing invented a field for the schedule or the tap-reweight gain.
+        assert!(
+            !text.contains("phases") && !text.contains("1.4"),
+            "{text:?}"
+        );
+        // The fields that DO map exactly still travel.
+        assert!(
+            text.contains("Sampler: euler") && text.contains("Seed: 4"),
+            "{text:?}"
+        );
+    }
+
+    #[test]
+    fn a_dropped_phase_schedule_suppresses_them_too() {
+        // The schedule can arrive as an `omitted` marker instead of as a key, when it was over the
+        // recording cap. Same fact, other door.
+        let share = envelope(serde_json::json!({
+            "advanced": { "steps": 28, "guidanceScale": 3.5 },
+            "omitted": ["advanced.phases"],
+        }));
+        let text = parameters_text(&share, (1024, 768));
+        assert!(
+            !text.contains("Steps:") && !text.contains("CFG scale:"),
+            "{text:?}"
+        );
+    }
+
+    #[test]
+    fn a_non_cfg_guidance_method_omits_the_cfg_scale() {
+        // `imageJobAdvanced.js` emits `guidanceMethod` only when it is NOT the `cfg` no-op, so its
+        // presence means the number is a CFG++ scale and labelling it `CFG scale` is a guess.
+        let share = envelope(serde_json::json!({
+            "advanced": { "guidanceScale": 3.5, "guidanceMethod": "cfg_pp" },
+        }));
+        assert!(!parameters_text(&share, (1, 1)).contains("CFG scale"));
+
+        let plain = envelope(serde_json::json!({ "advanced": { "guidanceScale": 3.5 } }));
+        assert!(parameters_text(&plain, (1, 1)).contains("CFG scale: 3.5"));
+    }
+
+    #[test]
+    fn a_default_sampler_names_no_sampler_at_all() {
+        let share = envelope(serde_json::json!({ "advanced": { "sampler": "default" } }));
+        assert!(!parameters_text(&share, (1, 1)).contains("Sampler"));
+    }
+
+    #[test]
+    fn size_is_a_statement_about_the_file() {
+        let share = envelope(serde_json::json!({ "width": 1024, "height": 1024 }));
+        assert!(parameters_text(&share, (1024, 1024)).contains("Size: 1024x1024"));
+        // The upscaled variant: the envelope keeps the base render's geometry on purpose, so the
+        // field would be a lie about the file it is stamped on.
+        assert!(!parameters_text(&share, (2048, 2048)).contains("Size"));
+        // And an envelope with no geometry says nothing rather than guessing from the pixels.
+        let bare = envelope(serde_json::json!({}));
+        assert!(!parameters_text(&bare, (1024, 1024)).contains("Size"));
+    }
+
+    #[test]
+    fn steps_are_a_whole_number_or_nothing() {
+        for (value, expected) in [
+            (serde_json::json!(28), Some("Steps: 28")),
+            (serde_json::json!(28.0), Some("Steps: 28")),
+            (serde_json::json!(28.5), None),
+            (serde_json::json!(0), None),
+            (serde_json::json!("28"), None),
+        ] {
+            let share = envelope(serde_json::json!({ "advanced": { "steps": value } }));
+            let text = parameters_text(&share, (1, 1));
+            match expected {
+                Some(fragment) => assert!(text.contains(fragment), "{value} -> {text:?}"),
+                None => assert!(!text.contains("Steps"), "{value} -> {text:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_value_carrying_a_separator_is_quoted_the_way_a1111_quotes_it() {
+        // Otherwise a comma inside a model slug splits one field into two for every reader.
+        assert_eq!(quote("euler"), "euler");
+        assert_eq!(quote("euler, ancestral"), "\"euler, ancestral\"");
+        assert_eq!(quote("a:b"), "\"a:b\"");
+        assert_eq!(quote("two\nlines"), "\"two\\nlines\"");
+    }
+
+    #[test]
+    fn integral_guidance_loses_its_trailing_zero() {
+        assert_eq!(format_number(4.0), "4");
+        assert_eq!(format_number(3.5), "3.5");
+        assert_eq!(format_number(0.0), "0");
+    }
+
+    #[test]
+    fn the_version_is_the_envelopes_own_producer_version() {
+        // The AC: the two chunks cannot disagree about which build wrote the file.
+        let share = envelope(serde_json::json!({}));
+        assert_eq!(share.producer.version, "0.8.1");
+        assert!(parameters_text(&share, (1, 1)).ends_with("Version: 0.8.1"));
+    }
+}

--- a/crates/sceneworks-core/src/workflow_parameters.rs
+++ b/crates/sceneworks-core/src/workflow_parameters.rs
@@ -150,6 +150,22 @@ pub const SETTINGS_FIELDS: &[(&str, &str)] = &[
 /// derived-pass images where it would have been wrong. The base render — every ordinary generation —
 /// matches by construction, because `write_image_asset` builds its envelope from the same width and
 /// height it hands the encoder.
+///
+/// # Two limits the format has and we inherit
+///
+/// Both are properties of the convention rather than of this renderer, and neither is worth
+/// diverging from it over — a reader that has to guess which dialect it is holding is worse off than
+/// one that occasionally mis-splits.
+///
+/// * **A prompt containing a line that begins `Negative prompt:` will mis-split.** A1111 has the
+///   same behaviour on its own output; the boundary is positional and there is no escape for it.
+/// * **A settings line of fewer than three pairs is prompt text to A1111's parser.** Our floor is
+///   `Seed` + `Model` + `Version`, which every generated image clears —
+///   `the_settings_line_clears_the_pair_floor_a_gallery_parses_with` in
+///   `crates/sceneworks-core/tests/workflow_parameters.rs` pins that rather than assuming it.
+///
+/// The authoritative recipe is unaffected by either: it is the `sceneworks:workflow` chunk, and this
+/// block is for display.
 #[must_use]
 pub fn parameters_text(share: &WorkflowShare, encoded: (u32, u32)) -> String {
     let mut out = share.prompt.clone();

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -1732,6 +1732,93 @@ mod tests {
     }
 
     #[test]
+    fn a_parameters_chunk_hiding_past_iend_refuses_only_when_the_file_is_ours() {
+        // The sc-15957 half of the unwalkable-tail guard, and the one place the co-presence rule
+        // had to be applied twice or the two halves would disagree with each other.
+        //
+        // The needle out here is `parameters\0` rather than the bare keyword, because `parameters`
+        // is ordinary English: scanning for the word alone would refuse to copy any file whose
+        // benign trailing note happened to contain it. The NUL is the payload separator every text
+        // chunk type puts after its keyword, so this is the chunk and not the word.
+        let mut hidden_parameters = PARAMETERS_CHUNK_KEYWORD.as_bytes().to_vec();
+        hidden_parameters.push(0);
+        hidden_parameters.extend_from_slice(b"the prompt that must not leave\nSeed: 1");
+        let hidden = framed_chunk(b"tEXt", &hidden_parameters, Some(0x7FFF_FFFF));
+
+        // (1) OURS: an envelope chunk pre-IDAT and a `parameters` chunk hidden in a tail we cannot
+        //     walk. Stripping would have removed the envelope and reported success while the prompt
+        //     rode out in the leftover, which is the exact failure the sc-15953 control exists to
+        //     prevent.
+        let mut ours = png_with_workflow_text(&minimal_envelope_json("a lighthouse"));
+        ours.extend_from_slice(&hidden);
+        let refused = strip_workflow_chunk(&ours);
+        assert!(
+            matches!(refused, Err(WorkflowChunkError::Png { .. })),
+            "a hidden `{PARAMETERS_CHUNK_KEYWORD}` chunk in OUR file must refuse: got {refused:?}"
+        );
+        let Err(WorkflowChunkError::Png { detail }) = refused else {
+            unreachable!("asserted above")
+        };
+        assert!(
+            detail.contains(PARAMETERS_CHUNK_KEYWORD) && detail.contains("trailing"),
+            "the refusal must name what it found and where: {detail:?}"
+        );
+
+        // (2) NOT OURS: the same tail on a file with no envelope chunk. We do not strip a foreign
+        //     A1111 block, walkable or not, so refusing to copy over one would be a refusal about
+        //     something we were never going to remove.
+        let mut foreign = png_with(&[]);
+        foreign.extend_from_slice(&hidden);
+        assert_eq!(
+            strip_workflow_chunk(&foreign),
+            Ok(None),
+            "a foreign file's hidden A1111 block is not ours to remove, so the copy is a no-op"
+        );
+
+        // (3) And the word on its own, in a file that IS ours, is still benign: an appended note
+        //     mentioning parameters must not make the file unsavable.
+        let mut noted = png_with_workflow_text(&minimal_envelope_json("a lighthouse"));
+        noted.extend_from_slice(b"\x00\x01a note about the parameters someone appended");
+        let stripped = strip_workflow_chunk(&noted)
+            .expect("a benign tail must not be an error")
+            .expect("the pre-IDAT chunk is still removed");
+        assert_eq!(read_workflow_chunk(&stripped), Ok(None));
+    }
+
+    #[test]
+    fn a_foreign_parameters_chunk_survives_a_strip_of_our_own() {
+        // Co-presence decides ownership per FILE, not per chunk, so a file carrying both our pair
+        // and a third-party `parameters` chunk is a case the rule cannot split — and it is worth
+        // knowing which way it falls. It falls toward removal: a `parameters` chunk in a file of
+        // ours is treated as ours. Recorded rather than hidden, because the alternative (keeping a
+        // duplicate keyword we cannot tell apart) would leave one of our own blocks behind.
+        //
+        // Our writer never produces this shape: it writes exactly one `parameters` chunk into a
+        // file it encoded from pixels, so a second one is something a third party appended
+        // afterwards.
+        let mut duplicate = PARAMETERS_CHUNK_KEYWORD.as_bytes().to_vec();
+        duplicate.push(0);
+        duplicate.extend_from_slice(b"appended by another tool");
+        let spliced = splice_after_ihdr(
+            &png_with_workflow_text(&minimal_envelope_json("a lighthouse")),
+            &framed_chunk(b"tEXt", &duplicate, None),
+        );
+        let stripped = strip_workflow_chunk(&spliced)
+            .expect("walks")
+            .expect("had something to take out");
+        assert!(
+            !contains_bytes(&stripped, PARAMETERS_CHUNK_KEYWORD.as_bytes()),
+            "no `{PARAMETERS_CHUNK_KEYWORD}` chunk may survive a strip of a file that is ours"
+        );
+        assert!(stripped == png_with(&[]));
+    }
+
+    /// Raw byte search, for assertions about what a stranger's tooling would find.
+    fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.len() >= needle.len() && haystack.windows(needle.len()).any(|w| w == needle)
+    }
+
+    #[test]
     fn a_png_whose_framing_ends_without_an_iend_refuses() {
         // Reproduced at the head this fixes as `Ok(Some(…))`: every chunk walked cleanly, our chunk
         // was excised, and the caller got a PNG with no IEND in it. "Save a copy without the

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -381,10 +381,34 @@ fn workflow_chunk(text: String) -> ITXtChunk {
 /// * **Above it there is no choice at all.** A CJK or emoji prompt cannot be a `tEXt` chunk;
 ///   `png` refuses to encode one rather than transliterating.
 ///
-/// Uncompressed in both arms, matching PIL's `zip=False` default. Our own envelope is compressed
-/// because it is JSON that rides in every generated image; this is a few hundred bytes of prose, and
-/// a `zTXt` or a compressed `iTXt` is the form third-party readers are least reliably tested
-/// against. Being findable is the entire value of the chunk.
+/// # Uncompressed in both arms, and what that actually costs
+///
+/// Matching PIL's `zip=False` default. Our own envelope is compressed because it is JSON that rides
+/// in every generated image; a `zTXt` or a compressed `iTXt` is the form third-party readers are
+/// least reliably tested against, and being findable is the entire value of this chunk.
+///
+/// The cost, measured rather than waved at — this used to say "a few hundred bytes of prose", which
+/// is the typical case stated as if it were the bound, and is off by two orders of magnitude at the
+/// ceiling:
+///
+/// | Envelope | `parameters`, framed | `sceneworks:workflow`, framed | File grows |
+/// | --- | --- | --- | --- |
+/// | the sc-15946 golden recipe (51 bytes of prose) | 186 B | 565 B | 751 B |
+/// | both prose fields at the sanitizer's 16 KiB `PROSE_MAX_BYTES` cap | **32,913 B** | 467 B | 33,380 B |
+///
+/// So the worst legitimate case is a ~33 KB text chunk restating prose the envelope beside it
+/// deflates into 467 bytes. `the_parameters_chunk_at_the_prose_cap_is_the_worst_case` and
+/// `the_chunks_stay_text_chunks_and_not_a_payload` in `tests/workflow_png.rs` measure both rows.
+///
+/// **Uncompressed is still the right call at 33 KB**, and the reason is that ratio rather than the
+/// absolute number. The file already carries a compact copy of every byte in this chunk — that is
+/// what the envelope beside it is — so compressing this one saves bytes the file has already spent,
+/// and spends the single property it exists for. A gallery that cannot find the block gets nothing;
+/// a gallery that finds a 33 KB block displays the prompt. The case is also nothing anyone meets:
+/// it takes a 16 KiB prompt AND a 16 KiB negative prompt, where a real one is the top row.
+///
+/// It is not unbounded either — `PROSE_MAX_BYTES` caps each prose field and no other field on the
+/// line is prose, so 2 x 16 KiB plus a settings line is the whole of it.
 fn parameters_chunk(text: String) -> TextChunk {
     if text.is_ascii() {
         TextChunk::Latin1(TEXtChunk::new(PARAMETERS_CHUNK_KEYWORD, text))
@@ -1786,12 +1810,17 @@ mod tests {
     }
 
     #[test]
-    fn a_foreign_parameters_chunk_survives_a_strip_of_our_own() {
+    fn a_second_parameters_chunk_in_a_file_of_ours_comes_out_too() {
         // Co-presence decides ownership per FILE, not per chunk, so a file carrying both our pair
         // and a third-party `parameters` chunk is a case the rule cannot split — and it is worth
         // knowing which way it falls. It falls toward removal: a `parameters` chunk in a file of
         // ours is treated as ours. Recorded rather than hidden, because the alternative (keeping a
         // duplicate keyword we cannot tell apart) would leave one of our own blocks behind.
+        //
+        // The name says which way, because this is the question a future reader greps for: the
+        // third-party chunk does NOT survive. `an_imported_a1111_image_keeps_its_own_parameters_
+        // block` in `tests/workflow_parameters.rs` is the case where one does — a foreign file with
+        // no envelope beside it, which the strip never touches at all.
         //
         // Our writer never produces this shape: it writes exactly one `parameters` chunk into a
         // file it encoded from pixels, so a second one is something a third party appended

--- a/crates/sceneworks-core/src/workflow_png.rs
+++ b/crates/sceneworks-core/src/workflow_png.rs
@@ -41,6 +41,26 @@
 //! Parsing goes through [`parse_workflow_share_json`] and nothing else, so the sc-15946 allow-list
 //! sanitizer runs on the way in. There is deliberately no second, laxer parse path; a structural
 //! test in `tests/workflow_png.rs` fails the build if one appears.
+//!
+//! # Two chunks leave, one comes back (sc-15957)
+//!
+//! [`write_workflow_chunk`] writes a SECOND text chunk beside ours, under the A1111 `parameters`
+//! keyword, so a gallery that has never heard of SceneWorks can display the prompt and seed instead
+//! of showing opaque pixels. [`crate::workflow_parameters`] renders it — from the same already-
+//! sanitized envelope, so it is a second *rendering* and not a second, laxer channel.
+//!
+//! Three consequences live in this module rather than in that one:
+//!
+//! * **The reader ignores it.** [`read_workflow_chunk`] resolves [`WORKFLOW_CHUNK_KEYWORD`] and
+//!   nothing else. Reading foreign A1111 and ComfyUI PNGs is a genuinely useful and much larger
+//!   story — parsing a foreign format, mapping unknown samplers and model names onto our catalog,
+//!   degrading well when the mapping fails — and is deliberately not this one.
+//! * **The stripper removes both.** sc-15953 promises "Save a copy without the workflow" takes the
+//!   recipe out, and a `parameters` chunk it left behind would ship the prompt anyway. See
+//!   [`workflow_chunk_spans`] for the one narrow rule that separates ours from a stranger's.
+//! * **The encoding is not ours to choose.** `tEXt` when the text is ASCII, `iTXt` when it is not.
+//!   The private `parameters_chunk` below records why that boundary is drawn where it is, and how
+//!   it differs from PIL's.
 
 use std::fmt;
 use std::fs::File;
@@ -48,8 +68,9 @@ use std::io::{BufRead, BufReader, BufWriter, Cursor, Seek, Write};
 use std::path::Path;
 
 use image::{ImageFormat, RgbImage};
-use png::text_metadata::ITXtChunk;
+use png::text_metadata::{EncodableTextChunk, ITXtChunk, TEXtChunk};
 
+use crate::workflow_parameters::{parameters_text, PARAMETERS_CHUNK_KEYWORD};
 use crate::workflow_share::{
     parse_workflow_share_json, WorkflowShare, WorkflowShareError, WORKFLOW_KIND_IMAGE,
 };
@@ -225,26 +246,30 @@ fn io_error(error: &std::io::Error) -> WorkflowChunkError {
 // Write
 // ---------------------------------------------------------------------------
 
-/// Encode `rgb` to `path` as a PNG, embedding `share` as a compressed `iTXt` chunk when there is
-/// one.
+/// Encode `rgb` to `path` as a PNG, embedding `share` as a compressed `iTXt` chunk — and its
+/// A1111 `parameters` rendering beside it — when there is one.
 ///
 /// `None` is not a degenerate case, it is the opt-out: it writes the image through the *same*
 /// `save_with_format` call the worker uses today, so the bytes are identical to what SceneWorks
 /// produces now. `the_none_path_is_byte_identical_to_save_with_format` in `tests/workflow_png.rs`
-/// compares the two files byte for byte.
+/// compares the two files byte for byte. Both chunks hang off the same `Some`, so sc-15953's
+/// setting governs the pair: off means neither is written, and there is no arrangement in which the
+/// prompt rides out in one of them alone.
 ///
 /// `Some` cannot call `save_with_format` — `image`'s `PngEncoder` has no text-chunk API at all —
 /// so it goes through `png` directly. That makes it the arm that *could* change the encoder, and
-/// the guarantee is deliberately just as strong: its output is the `None` output plus the inserted
-/// `iTXt` chunk, byte for byte, with the encoder settings mirrored from `image` in
+/// the guarantee is deliberately just as strong: its output is the `None` output plus the two
+/// inserted text chunks, byte for byte, with the encoder settings mirrored from `image` in
 /// `encode_png_with_text` (not linked: it is private, and rustdoc warns on a public doc linking to
-/// one). `the_some_path_is_the_none_path_plus_the_chunk` proves it by stripping the chunk back out
-/// and comparing the remainder.
+/// one). `the_some_path_is_the_none_path_plus_the_chunks` proves it by stripping both chunks back
+/// out and comparing the remainder.
 ///
 /// Both halves matter to sc-15948: opting out changes nothing about a user's files, and opting *in*
-/// costs the chunk and nothing else — no encode-time or file-size change smuggled in alongside.
+/// costs the chunks and nothing else — no encode-time or file-size change smuggled in alongside.
 ///
-/// The chunk goes between IHDR and IDAT, where a reader finds it without decoding any pixels.
+/// The chunks go between IHDR and IDAT, where a reader finds them without decoding any pixels. Ours
+/// is written first, so a reader that stops at the first text chunk it recognizes sees the recipe
+/// that can actually be replayed.
 ///
 /// # Errors
 /// [`WorkflowChunkError::Io`] if the file cannot be written, [`WorkflowChunkError::Encode`] if
@@ -261,14 +286,65 @@ pub fn write_workflow_chunk(
                 detail: error.to_string(),
             });
     };
+    let chunks = embedded_chunks(share, (rgb.width(), rgb.height()))?;
+    let file = File::create(path).map_err(|error| io_error(&error))?;
+    let mut sink = BufWriter::new(file);
+    encode_png_with_text(rgb, &mut sink, &chunks)?;
+    sink.flush().map_err(|error| io_error(&error))?;
+    Ok(())
+}
+
+/// Both text chunks one envelope produces, in the order they are written.
+///
+/// One function so the writer and [`workflow_chunk_size`] / [`parameters_chunk_size`] cannot drift
+/// on either the contents or the order.
+fn embedded_chunks(
+    share: &WorkflowShare,
+    encoded: (u32, u32),
+) -> Result<Vec<TextChunk>, WorkflowChunkError> {
     let text = serde_json::to_string(share).map_err(|error| WorkflowChunkError::Encode {
         detail: error.to_string(),
     })?;
-    let file = File::create(path).map_err(|error| io_error(&error))?;
-    let mut sink = BufWriter::new(file);
-    encode_png_with_text(rgb, &mut sink, &[workflow_chunk(text)])?;
-    sink.flush().map_err(|error| io_error(&error))?;
-    Ok(())
+    Ok(vec![
+        TextChunk::Utf8(workflow_chunk(text)),
+        parameters_chunk(parameters_text(share, encoded)),
+    ])
+}
+
+/// A PNG text chunk in whichever of the two encodings its contents need.
+///
+/// `png` models `tEXt` and `iTXt` as unrelated types behind one `EncodableTextChunk` trait, and the
+/// writer has to hold a heterogeneous list of them.
+enum TextChunk {
+    /// `iTXt`: UTF-8, optionally deflated. What our own envelope always uses.
+    Utf8(ITXtChunk),
+    /// `tEXt`: Latin-1, never compressed. What A1111 emits for ASCII settings blocks.
+    Latin1(TEXtChunk),
+}
+
+impl TextChunk {
+    fn encode<W: Write>(&self, sink: &mut W) -> Result<(), png::EncodingError> {
+        match self {
+            Self::Utf8(chunk) => chunk.encode(sink),
+            Self::Latin1(chunk) => chunk.encode(sink),
+        }
+    }
+
+    /// The chunk as it appears on disk, framing included.
+    fn framed(&self) -> Result<Vec<u8>, WorkflowChunkError> {
+        let mut encoded = Vec::new();
+        self.encode(&mut encoded)
+            .map_err(|error| WorkflowChunkError::Encode {
+                detail: error.to_string(),
+            })?;
+        Ok(encoded)
+    }
+}
+
+impl From<ITXtChunk> for TextChunk {
+    fn from(chunk: ITXtChunk) -> Self {
+        Self::Utf8(chunk)
+    }
 }
 
 /// The compressed `iTXt` chunk for one envelope.
@@ -280,6 +356,46 @@ fn workflow_chunk(text: String) -> ITXtChunk {
     let mut chunk = ITXtChunk::new(WORKFLOW_CHUNK_KEYWORD, text);
     chunk.compressed = true;
     chunk
+}
+
+/// The A1111 `parameters` chunk: `tEXt` when the text is ASCII, uncompressed `iTXt` when it is not.
+///
+/// # The rule is deliberately narrower than PIL's, and that is the point
+///
+/// `PIL.PngImagePlugin.PngInfo.add_text` — which is what A1111 itself writes through, and what every
+/// third-party parser is tested against — tries `value.encode("latin-1", "strict")` and writes
+/// `tEXt` if that succeeds, falling back to an UNCOMPRESSED `iTXt` on `UnicodeError`. So PIL's
+/// boundary is **Latin-1**, not ASCII, and the story's description of it as ASCII is wrong about
+/// PIL. `pil_agrees_with_our_encoding_choice` in `tests/workflow_parameters.rs` runs the real
+/// library and records both facts.
+///
+/// We draw the line at ASCII anyway, which differs from PIL only in the U+00A0..U+00FF band:
+///
+/// * **Below it, we are byte-identical to PIL.** A plain English prompt produces exactly the `tEXt`
+///   chunk A1111 produces, which is the case the whole story exists for.
+/// * **Inside it, `iTXt` is strictly safer.** `café` in a `tEXt` chunk is the single byte 0xE9. A
+///   reader that decodes the chunk as Latin-1 (PIL, per the spec) gets `café`; one that assumes
+///   UTF-8 — which a great deal of JavaScript tooling does — gets a replacement character or throws.
+///   `iTXt` is UTF-8 *by specification*, so both classes of reader agree. PIL reads our `iTXt` back
+///   to the identical string, so nothing is lost with the reader the convention is defined by.
+/// * **Above it there is no choice at all.** A CJK or emoji prompt cannot be a `tEXt` chunk;
+///   `png` refuses to encode one rather than transliterating.
+///
+/// Uncompressed in both arms, matching PIL's `zip=False` default. Our own envelope is compressed
+/// because it is JSON that rides in every generated image; this is a few hundred bytes of prose, and
+/// a `zTXt` or a compressed `iTXt` is the form third-party readers are least reliably tested
+/// against. Being findable is the entire value of the chunk.
+fn parameters_chunk(text: String) -> TextChunk {
+    if text.is_ascii() {
+        TextChunk::Latin1(TEXtChunk::new(PARAMETERS_CHUNK_KEYWORD, text))
+    } else {
+        // `compressed` is already false from `new`; stated rather than relied on, because the
+        // neighbouring `workflow_chunk` flips exactly this field and a reader of one will read the
+        // other.
+        let mut chunk = ITXtChunk::new(PARAMETERS_CHUNK_KEYWORD, text);
+        chunk.compressed = false;
+        TextChunk::Utf8(chunk)
+    }
 }
 
 /// Encode an 8-bit RGB PNG with `chunks` written between IHDR and IDAT.
@@ -319,8 +435,8 @@ fn workflow_chunk(text: String) -> ITXtChunk {
 /// writes 167,360 bytes where `Sub` writes 388,103 and `NoFilter` 3,147,060 — 2.3× and 18.8×.
 ///
 /// None of this is trusted to stay true by inspection:
-/// `the_some_path_is_the_none_path_plus_the_chunk` in `tests/workflow_png.rs` strips the `iTXt`
-/// chunk back out of this encoder's output at the byte level and compares what is left against a
+/// `the_some_path_is_the_none_path_plus_the_chunks` in `tests/workflow_png.rs` strips both text
+/// chunks back out of this encoder's output at the byte level and compares what is left against a
 /// real `save_with_format` write of the same pixels. It runs over TWO fixtures, because the two
 /// deflate regimes see different settings: an incompressible one, where `png` falls back to storing
 /// rows and the filter is not consulted at all, and a smooth one that actually deflates, which is
@@ -328,7 +444,7 @@ fn workflow_chunk(text: String) -> ITXtChunk {
 fn encode_png_with_text<W: Write>(
     rgb: &RgbImage,
     sink: W,
-    chunks: &[ITXtChunk],
+    chunks: &[TextChunk],
 ) -> Result<(), WorkflowChunkError> {
     let encode_error = |error: png::EncodingError| WorkflowChunkError::Encode {
         detail: error.to_string(),
@@ -340,7 +456,10 @@ fn encode_png_with_text<W: Write>(
     encoder.set_filter(png::Filter::Adaptive);
     let mut writer = encoder.write_header().map_err(encode_error)?;
     for chunk in chunks {
-        writer.write_text_chunk(chunk).map_err(encode_error)?;
+        match chunk {
+            TextChunk::Utf8(chunk) => writer.write_text_chunk(chunk).map_err(encode_error)?,
+            TextChunk::Latin1(chunk) => writer.write_text_chunk(chunk).map_err(encode_error)?,
+        }
     }
     writer
         .write_image_data(rgb.as_raw())
@@ -355,24 +474,29 @@ fn encode_png_with_text<W: Write>(
 
 /// The three PNG text-chunk types a keyword can appear under.
 ///
-/// [`write_workflow_chunk`] only ever emits `iTXt`, and [`read_workflow_chunk`] only ever reads
-/// `iTXt` (`png` files a `tEXt` under `uncompressed_latin1_text` and a `zTXt` under
-/// `compressed_latin1_text`, neither of which the reader looks at). The stripper is broader than
-/// both on purpose: it is a privacy operation, and "we would not have read it back" is not a reason
-/// to hand a stranger a chunk with our keyword on it. Being broader can only ever remove more.
+/// [`write_workflow_chunk`] emits `iTXt` for the envelope and either type for the `parameters`
+/// rendering, and [`read_workflow_chunk`] only ever reads `iTXt` (`png` files a `tEXt` under
+/// `uncompressed_latin1_text` and a `zTXt` under `compressed_latin1_text`, neither of which the
+/// reader looks at). The stripper is broader than all of that on purpose: it is a privacy
+/// operation, and "we would not have read it back" is not a reason to hand a stranger a chunk we
+/// wrote. Being broader can only ever remove more.
 const TEXT_CHUNK_TYPES: [&[u8; 4]; 3] = [b"iTXt", b"tEXt", b"zTXt"];
 
 /// Bytes of PNG chunk framing that are not the payload: the 4-byte length, the 4-byte type and the
 /// 4-byte CRC.
 const CHUNK_OVERHEAD: usize = 12;
 
-/// Excise every [`WORKFLOW_CHUNK_KEYWORD`] text chunk from PNG `bytes`, without re-encoding
-/// anything (sc-15953).
+/// Excise every text chunk this app wrote from PNG `bytes` — the [`WORKFLOW_CHUNK_KEYWORD`]
+/// envelope and the [`PARAMETERS_CHUNK_KEYWORD`] rendering beside it — without re-encoding anything
+/// (sc-15953, sc-15957).
 ///
 /// `Ok(None)` means there was nothing to take out and the caller should use the source bytes
 /// unchanged — a PNG with no workflow chunk, or a file that is not a PNG at all. The second case is
 /// not a failure: [`write_workflow_chunk`] only ever writes into a PNG, so a JPEG or an MP4 cannot
 /// be carrying one, and a "save without the workflow" of a video has nothing to do.
+///
+/// [`workflow_chunk_spans`] documents the co-presence rule that tells our `parameters` chunk from a
+/// stranger's, and why an A1111 export the user imported keeps its own.
 ///
 /// # Why excise rather than decode and re-encode
 ///
@@ -473,13 +597,41 @@ impl Span {
 /// *text* merely mentions our keyword — a note, a ComfyUI graph naming it — is a file we must
 /// still be able to save. Only unaccounted-for bytes get the blunt instrument.
 ///
+/// # The `parameters` chunk, and the one narrow rule that separates ours from a stranger's
+///
+/// sc-15957 puts a second chunk in every embedded file, under the unprefixed A1111 keyword. A strip
+/// that left it behind would answer "here is your file without the workflow" with a file that still
+/// contains the prompt — the sc-15953 control would be a lie, and the user who deliberately stripped
+/// would be the one who shipped it. So it comes out.
+///
+/// But `parameters` is *the* generic keyword: an A1111 or ComfyUI export the user imported carries
+/// one too, and the neighbouring rule ("stripping ours is not a licence to scrub someone else's
+/// metadata out of their image") is not one to abandon. The two are separated by **co-presence**:
+/// a `parameters` chunk is treated as ours only when the file also carries a walkable
+/// [`WORKFLOW_CHUNK_KEYWORD`] chunk. That is exact rather than heuristic in both directions:
+///
+/// * [`write_workflow_chunk`] writes the pair or neither. There is no code path that produces one
+///   without the other, so every `parameters` chunk of ours has our envelope beside it.
+/// * We never write into a file we did not encode, so a foreign PNG never gains our keyword. A
+///   `parameters` chunk with no `sceneworks:workflow` beside it therefore came from another tool
+///   and is left alone — including on the copy this function has just produced, which is what makes
+///   the operation idempotent.
+///
+/// The honest limit: a SceneWorks image whose envelope chunk some *other* tool removed, leaving the
+/// `parameters` chunk in place, reads to us as a foreign A1111 file and keeps it. Nothing in the
+/// bytes distinguishes that case, our own strip never produces it, and treating every `parameters`
+/// chunk as ours would trade a hypothetical leak for a certain one — scrubbing a stranger's metadata
+/// out of their file on an operation that promised to remove *the workflow*.
+///
 /// # Errors
 /// [`WorkflowChunkError::Png`], with a detail naming which of the three it was.
 pub fn workflow_chunk_spans(bytes: &[u8]) -> Result<Vec<Span>, WorkflowChunkError> {
     if bytes.len() < PNG_SIGNATURE.len() || bytes[..PNG_SIGNATURE.len()] != PNG_SIGNATURE {
         return Ok(Vec::new());
     }
-    let mut spans: Vec<Span> = Vec::new();
+    // Candidates rather than spans: whether the `parameters` entries are ours is not known until
+    // the whole walkable region has been seen, so the decision is deferred to the end of the walk.
+    let mut candidates: Vec<(Span, ChunkOwner)> = Vec::new();
     let mut cursor = PNG_SIGNATURE.len();
     let mut past_iend = false;
 
@@ -491,25 +643,33 @@ pub fn workflow_chunk_spans(bytes: &[u8]) -> Result<Vec<Span>, WorkflowChunkErro
                 });
             }
             let tail = &bytes[cursor..];
-            if contains_workflow_keyword(tail) {
+            // A tail we cannot walk is only safe to copy through when there is nothing of ours in
+            // it. `parameters` is scanned for as `parameters\0` — the keyword AND its payload
+            // separator — because the bare word is ordinary English and would refuse benign tails,
+            // and only when the walk already found our envelope, which is the same co-presence rule
+            // the walkable region uses. Applying it differently in the two places would mean a file
+            // whose `parameters` chunk we would have LEFT alone could still refuse to copy.
+            let ours = candidates
+                .iter()
+                .any(|(_, owner)| *owner == ChunkOwner::Envelope);
+            if let Some(found) = hidden_keyword(tail, ours) {
                 return Err(WorkflowChunkError::Png {
                     detail: format!(
                         "{} bytes of trailing data at byte {cursor} are not chunk framing and \
-                         carry `{WORKFLOW_CHUNK_KEYWORD}`, so a copy of this file cannot be \
-                         vouched for",
+                         carry `{found}`, so a copy of this file cannot be vouched for",
                         tail.len()
                     ),
                 });
             }
             // Benign trailing bytes. Not walkable, nothing of ours in them, so they ride through.
-            return Ok(spans);
+            return Ok(resolve_spans(candidates));
         };
         let kind = &bytes[cursor + 4..cursor + 8];
         if kind == b"IEND" {
             past_iend = true;
         }
-        if is_workflow_text_chunk(kind, &bytes[cursor + 8..end - 4]) {
-            spans.push(Span { start: cursor, end });
+        if let Some(owner) = text_chunk_owner(kind, &bytes[cursor + 8..end - 4]) {
+            candidates.push((Span { start: cursor, end }, owner));
         }
         cursor = end;
     }
@@ -522,7 +682,28 @@ pub fn workflow_chunk_spans(bytes: &[u8]) -> Result<Vec<Span>, WorkflowChunkErro
             ),
         });
     }
-    Ok(spans)
+    Ok(resolve_spans(candidates))
+}
+
+/// Which of the two keywords a walked text chunk carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChunkOwner {
+    /// [`WORKFLOW_CHUNK_KEYWORD`]. Always ours, always removed.
+    Envelope,
+    /// [`PARAMETERS_CHUNK_KEYWORD`]. Ours only when an [`Self::Envelope`] chunk is beside it.
+    Parameters,
+}
+
+/// Apply the co-presence rule and drop the ownership tags.
+fn resolve_spans(candidates: Vec<(Span, ChunkOwner)>) -> Vec<Span> {
+    let ours = candidates
+        .iter()
+        .any(|(_, owner)| *owner == ChunkOwner::Envelope);
+    candidates
+        .into_iter()
+        .filter(|(_, owner)| ours || *owner == ChunkOwner::Envelope)
+        .map(|(span, _)| span)
+        .collect()
 }
 
 /// The complement of `removed` over `0..total`: the spans a strip keeps, ascending.
@@ -551,17 +732,26 @@ pub fn kept_spans(total: usize, removed: &[Span]) -> Vec<Span> {
     kept
 }
 
-/// Whether [`WORKFLOW_CHUNK_KEYWORD`] appears anywhere in `haystack`, as raw bytes.
+/// The keyword of ours that appears in `haystack`, if any, as a raw byte search.
 ///
-/// The same thing a `grep` for our keyword would find, which is the point: the guard it backs is
-/// about what a stranger's tooling can dig out of bytes we could not parse, not about what our own
-/// reader would load.
-fn contains_workflow_keyword(haystack: &[u8]) -> bool {
-    let needle = WORKFLOW_CHUNK_KEYWORD.as_bytes();
-    haystack.len() >= needle.len()
-        && haystack
-            .windows(needle.len())
-            .any(|window| window == needle)
+/// The same thing a `grep` would find, which is the point: the guard it backs is about what a
+/// stranger's tooling can dig out of bytes we could not parse, not about what our own reader would
+/// load.
+///
+/// `include_parameters` is the co-presence rule arriving out here. The A1111 keyword is searched for
+/// as `parameters\0` — the keyword plus the NUL that separates it from the payload in all three text
+/// chunk types — because `parameters` on its own is ordinary English and would refuse to copy a file
+/// whose benign trailing note happened to use the word.
+fn hidden_keyword(haystack: &[u8], include_parameters: bool) -> Option<&'static str> {
+    let contains = |needle: &[u8]| {
+        haystack.len() >= needle.len() && haystack.windows(needle.len()).any(|w| w == needle)
+    };
+    if contains(WORKFLOW_CHUNK_KEYWORD.as_bytes()) {
+        return Some(WORKFLOW_CHUNK_KEYWORD);
+    }
+    let mut framed = PARAMETERS_CHUNK_KEYWORD.as_bytes().to_vec();
+    framed.push(0);
+    (include_parameters && contains(&framed)).then_some(PARAMETERS_CHUNK_KEYWORD)
 }
 
 /// One past the CRC of the chunk starting at `cursor`, or `None` when the header or the payload it
@@ -573,22 +763,25 @@ fn chunk_end(bytes: &[u8], cursor: usize) -> Option<usize> {
     (end <= bytes.len()).then_some(end)
 }
 
-/// Whether a chunk of type `kind` carrying `data` is a text chunk under our keyword.
+/// Which of our two keywords a chunk of type `kind` carrying `data` is under, if either.
 ///
 /// All three text types lay their payload out as `keyword NUL …`, so the keyword is the payload up
 /// to its first NUL in every case. Matched byte-exactly: PNG keywords are case-sensitive, and
 /// [`read_workflow_chunk`] resolves the keyword the same way, so `Sceneworks:Workflow` is a
 /// different keyword to both halves.
-fn is_workflow_text_chunk(kind: &[u8], data: &[u8]) -> bool {
+fn text_chunk_owner(kind: &[u8], data: &[u8]) -> Option<ChunkOwner> {
     if !TEXT_CHUNK_TYPES.iter().any(|text| *text == kind) {
-        return false;
+        return None;
     }
     let keyword = data.split(|byte| *byte == 0).next().unwrap_or_default();
-    keyword == WORKFLOW_CHUNK_KEYWORD.as_bytes()
+    if keyword == WORKFLOW_CHUNK_KEYWORD.as_bytes() {
+        return Some(ChunkOwner::Envelope);
+    }
+    (keyword == PARAMETERS_CHUNK_KEYWORD.as_bytes()).then_some(ChunkOwner::Parameters)
 }
 
-/// Copy `source` to `destination` with any [`WORKFLOW_CHUNK_KEYWORD`] chunk excised, and report
-/// whether one was there (sc-15953).
+/// Copy `source` to `destination` with every chunk this app wrote excised, and report whether any
+/// were there (sc-15953).
 ///
 /// The "Save As without the workflow" seam. A file with nothing to strip is copied through
 /// [`std::fs::copy`] — the same call the plain Save As makes — so the two paths produce the same
@@ -828,24 +1021,38 @@ fn workflow_chunk_after_image_data<R: BufRead + Seek>(
 /// as it appears on disk, including its 4-byte length, 4-byte type, keyword, separators and CRC.
 ///
 /// Exists so the per-image cost of sc-15948 is a measured number rather than an estimate; it is
-/// what `the_chunk_stays_a_text_chunk_and_not_a_payload` in `tests/workflow_png.rs` reports and
-/// bounds.
+/// what `the_chunks_stay_text_chunks_and_not_a_payload` in `tests/workflow_png.rs` reports and
+/// bounds. [`parameters_chunk_size`] is the other half of that cost.
 ///
 /// # Errors
 /// [`WorkflowChunkError::Encode`] if the envelope cannot be serialized or compressed.
 pub fn workflow_chunk_size(share: &WorkflowShare) -> Result<usize, WorkflowChunkError> {
-    use png::text_metadata::EncodableTextChunk;
-
     let text = serde_json::to_string(share).map_err(|error| WorkflowChunkError::Encode {
         detail: error.to_string(),
     })?;
-    let mut encoded = Vec::new();
-    workflow_chunk(text)
-        .encode(&mut encoded)
-        .map_err(|error| WorkflowChunkError::Encode {
-            detail: error.to_string(),
-        })?;
-    Ok(encoded.len())
+    TextChunk::Utf8(workflow_chunk(text))
+        .framed()
+        .map(|f| f.len())
+}
+
+/// Size of the A1111 `parameters` chunk `share` would occupy in a PNG of `encoded` pixels, in
+/// bytes, framing included (sc-15957).
+///
+/// Takes the encoded geometry for the same reason
+/// [`crate::workflow_parameters::parameters_text`] does: `Size` is emitted only when the envelope's
+/// requested geometry IS the file's, so the chunk's size is a fact about a particular write rather
+/// than about the envelope alone.
+///
+/// # Errors
+/// [`WorkflowChunkError::Encode`] if the chunk cannot be encoded — which for this chunk means a
+/// text `png` refuses, and is why the ASCII/UTF-8 choice is made in one place.
+pub fn parameters_chunk_size(
+    share: &WorkflowShare,
+    encoded: (u32, u32),
+) -> Result<usize, WorkflowChunkError> {
+    parameters_chunk(parameters_text(share, encoded))
+        .framed()
+        .map(|framed| framed.len())
 }
 
 #[cfg(test)]
@@ -865,7 +1072,16 @@ mod tests {
     }
 
     /// A PNG carrying exactly `chunks`, in memory.
+    ///
+    /// Takes `iTXt` chunks because that is what every adversarial fixture here needs; the mixed
+    /// list the real writer produces goes through [`png_with_chunks`].
     fn png_with(chunks: &[ITXtChunk]) -> Vec<u8> {
+        let owned: Vec<TextChunk> = chunks.iter().cloned().map(TextChunk::from).collect();
+        png_with_chunks(&owned)
+    }
+
+    /// A PNG carrying exactly `chunks` of either text type.
+    fn png_with_chunks(chunks: &[TextChunk]) -> Vec<u8> {
         let mut bytes = Vec::new();
         encode_png_with_text(&rgb_fixture(), &mut bytes, chunks).expect("fixture PNG encodes");
         bytes

--- a/crates/sceneworks-core/tests/workflow_parameters.rs
+++ b/crates/sceneworks-core/tests/workflow_parameters.rs
@@ -1,0 +1,975 @@
+//! The A1111 `parameters` chunk, measured against a reader rather than against itself (sc-15957,
+//! epic 15945).
+//!
+//! # Why the parser below exists
+//!
+//! The point of this chunk is that software we do not control can display it. A test that asserts
+//! our renderer produces the string our renderer produces proves nothing about that. So the corpus
+//! here goes through [`parse_a1111`], a faithful reimplementation of AUTOMATIC1111's
+//! `modules/generation_parameters_copypaste.py::parse_generation_parameters` — the function Civitai
+//! and the rest of the ecosystem's parsers are modelled on:
+//!
+//! * the text is split on newlines and the LAST line is the settings line, **but only when it holds
+//!   at least three `Key: value` pairs**; otherwise it is prompt text. That threshold is A1111's,
+//!   not ours, and it is the reason `the_settings_line_clears_the_pair_floor_a_gallery_parses_with`
+//!   exists;
+//! * a line beginning `Negative prompt:` ends the prompt and starts the negative;
+//! * the settings line is scanned for `key: value` pairs where the value is either a JSON string in
+//!   double quotes or everything up to the next comma — the semantics of A1111's `re_param_code`.
+//!
+//! # And why PIL is also here
+//!
+//! The parser proves the TEXT is legible. It says nothing about whether a reader finds the chunk at
+//! all, which is a question about `tEXt` versus `iTXt` and about compression flags.
+//! [`pil_agrees_with_our_encoding_choice`] answers that against the real
+//! `PIL.PngImagePlugin`, which is what A1111 itself writes through and what third-party parsers are
+//! tested against. It skips loudly when Python or Pillow is not installed rather than failing the
+//! build on a machine that has neither.
+//!
+//! # What is NOT proven here
+//!
+//! A live upload to Civitai. That acceptance criterion is a publication to a third-party service and
+//! is deliberately left for a human; see the story and the PR. Everything below is the offline half.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use image::{Rgb, RgbImage};
+use sceneworks_core::contracts::{Asset, JsonObject};
+use sceneworks_core::workflow_parameters::{
+    parameters_text, NEGATIVE_PROMPT_LABEL, PARAMETERS_CHUNK_KEYWORD, SETTINGS_FIELDS,
+};
+use sceneworks_core::workflow_png::{
+    read_workflow_chunk_file, strip_workflow_chunk, write_workflow_chunk, WORKFLOW_CHUNK_KEYWORD,
+};
+use sceneworks_core::workflow_share::{build_workflow_share, WorkflowShare, PRODUCER_VERSION};
+use serde_json::{json, Value};
+
+// ---------------------------------------------------------------------------
+// A faithful A1111 / gallery parser
+// ---------------------------------------------------------------------------
+
+/// What a gallery gets out of a `parameters` block.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Parsed {
+    prompt: String,
+    negative_prompt: String,
+    /// The trailing settings line, key to value, unquoted.
+    params: BTreeMap<String, String>,
+}
+
+/// A1111's `parse_generation_parameters`, reimplemented.
+///
+/// Deliberately not a loose "find the words I expect" scan: the failure this is here to catch is a
+/// renderer that produces something *we* can read back and a gallery cannot, and only a faithful
+/// parser can see that. The three rules it enforces — the three-pair floor on the last line, the
+/// `Negative prompt:` boundary, and comma-splitting with JSON-quoted escapes — are the three places
+/// our renderer could break a reader without breaking itself.
+fn parse_a1111(text: &str) -> Parsed {
+    let trimmed = text.trim();
+    let mut lines: Vec<&str> = trimmed.split('\n').collect();
+    // A1111 pops the last line and puts it back when it does not look like a settings line.
+    let last = lines.pop().unwrap_or_default();
+    let settings = if parse_params(last).len() >= 3 {
+        parse_params(last)
+    } else {
+        lines.push(last);
+        BTreeMap::new()
+    };
+
+    let mut prompt = String::new();
+    let mut negative = String::new();
+    let mut in_negative = false;
+    for line in lines {
+        let line = line.trim_end();
+        if let Some(rest) = line.strip_prefix(NEGATIVE_PROMPT_LABEL.trim_end()) {
+            in_negative = true;
+            push_line(&mut negative, rest.trim_start());
+            continue;
+        }
+        if in_negative {
+            push_line(&mut negative, line);
+        } else {
+            push_line(&mut prompt, line);
+        }
+    }
+
+    Parsed {
+        prompt,
+        negative_prompt: negative,
+        params: settings,
+    }
+}
+
+fn push_line(buffer: &mut String, line: &str) {
+    if !buffer.is_empty() {
+        buffer.push('\n');
+    }
+    buffer.push_str(line);
+}
+
+/// The `key: value` pairs on one line, with A1111's quoting rule applied in reverse.
+///
+/// Mirrors `re_param_code = r'\s*(\w[\w \-/]+):\s*("(?:\\.|[^\\"])+"|[^,]*)(?:,|$)'`: a key of word
+/// characters, spaces, hyphens and slashes; a value that is either a double-quoted JSON string
+/// (backslash escapes honoured) or a run of anything up to the next comma.
+fn parse_params(line: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let bytes: Vec<char> = line.chars().collect();
+    let mut index = 0;
+    while index < bytes.len() {
+        while index < bytes.len() && (bytes[index] == ' ' || bytes[index] == ',') {
+            index += 1;
+        }
+        let key_start = index;
+        while index < bytes.len()
+            && (bytes[index].is_alphanumeric() || matches!(bytes[index], '_' | ' ' | '-' | '/'))
+        {
+            index += 1;
+        }
+        // A key must be followed by a colon and must not be empty or start with a space.
+        if index >= bytes.len() || bytes[index] != ':' || index == key_start {
+            // Not a parameter line at this position — give up on the rest, as the regex would by
+            // simply not matching here.
+            return out;
+        }
+        let key: String = bytes[key_start..index].iter().collect();
+        if key.starts_with(' ') {
+            return out;
+        }
+        index += 1; // the colon
+        while index < bytes.len() && bytes[index] == ' ' {
+            index += 1;
+        }
+        let value = if index < bytes.len() && bytes[index] == '"' {
+            let start = index;
+            index += 1;
+            while index < bytes.len() {
+                if bytes[index] == '\\' {
+                    index += 2;
+                    continue;
+                }
+                if bytes[index] == '"' {
+                    index += 1;
+                    break;
+                }
+                index += 1;
+            }
+            let raw: String = bytes[start..index.min(bytes.len())].iter().collect();
+            serde_json::from_str::<String>(&raw).unwrap_or(raw)
+        } else {
+            let start = index;
+            while index < bytes.len() && bytes[index] != ',' {
+                index += 1;
+            }
+            bytes[start..index]
+                .iter()
+                .collect::<String>()
+                .trim_end()
+                .to_owned()
+        };
+        out.insert(key, value);
+    }
+    out
+}
+
+#[test]
+fn the_local_parser_reads_a_real_a1111_block() {
+    // The parser is the measuring instrument, so it is calibrated against a block A1111 itself
+    // emits before anything is measured with it. Copied in the shape the WebUI writes: multi-line
+    // prompt, a negative, a settings line with quoted and unquoted values.
+    let block = "a lighthouse in heavy fog\nsecond line of the prompt\nNegative prompt: text, \
+                 watermark\nSteps: 28, Sampler: \"DPM++ 2M, Karras\", CFG scale: 7, Seed: 12345, \
+                 Size: 512x768, Model hash: abc123, Model: sd_xl_base, Version: v1.9.4";
+    let parsed = parse_a1111(block);
+    assert_eq!(
+        parsed.prompt,
+        "a lighthouse in heavy fog\nsecond line of the prompt"
+    );
+    assert_eq!(parsed.negative_prompt, "text, watermark");
+    assert_eq!(parsed.params["Steps"], "28");
+    assert_eq!(parsed.params["Sampler"], "DPM++ 2M, Karras");
+    assert_eq!(parsed.params["CFG scale"], "7");
+    assert_eq!(parsed.params["Size"], "512x768");
+    assert_eq!(parsed.params["Version"], "v1.9.4");
+
+    // And the three-pair floor, which is a real behaviour and not an implementation detail: a
+    // trailing line with two pairs is PROMPT to A1111, not settings.
+    let thin = parse_a1111("just a prompt\nModel: z_image_turbo, Version: 0.8.1");
+    assert!(thin.params.is_empty(), "{thin:?}");
+    assert!(thin.prompt.ends_with("Version: 0.8.1"));
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn rgb_fixture(width: u32, height: u32) -> RgbImage {
+    RgbImage::from_fn(width, height, |x, y| {
+        Rgb([(x % 256) as u8, (y % 256) as u8, ((x + y) % 256) as u8])
+    })
+}
+
+fn asset_fixture(prompt: &str) -> Asset {
+    serde_json::from_value(json!({
+        "schemaVersion": 1,
+        "id": "asset_9f2c",
+        "projectId": "project_7a10",
+        "generationSetId": "genset_31bb",
+        "type": "image",
+        "displayName": "Parameters #1",
+        "createdAt": "2026-07-30T13:04:11Z",
+        "file": {
+            "path": "assets/images/2026-07-30_z_image_turbo_parameters_0001.png",
+            "mimeType": "image/png",
+            "width": 64,
+            "height": 48,
+            "duration": null,
+            "fps": null
+        },
+        "status": { "favorite": false, "rating": 0, "rejected": false, "trashed": false },
+        "recipe": {
+            "mode": "text_to_image",
+            "model": "z_image_turbo",
+            "adapter": "z_image_diffusers",
+            "prompt": prompt,
+            "negativePrompt": "",
+            "seed": 880_412,
+            "loras": [],
+            "stylePreset": null,
+            "normalizedSettings": {},
+            "rawAdapterSettings": {}
+        },
+        "lineage": { "parents": [], "sourceAssetId": null, "sourceTimestamp": null, "jobId": "job_1" }
+    }))
+    .expect("asset fixture parses")
+}
+
+/// A realistic Image Studio payload, with `extra` merged over it.
+fn payload_fixture(prompt: &str, negative: &str, extra: Value) -> JsonObject {
+    let mut payload = json!({
+        "projectId": "project_7a10",
+        "mode": "text_to_image",
+        "prompt": prompt,
+        "negativePrompt": negative,
+        "model": "z_image_turbo",
+        "count": 1,
+        "width": 64,
+        "height": 48,
+        "advanced": { "steps": 28, "sampler": "euler", "guidanceScale": 3.5 }
+    });
+    let map = payload.as_object_mut().expect("an object");
+    for (key, value) in extra.as_object().expect("extra is an object") {
+        map.insert(key.clone(), value.clone());
+    }
+    map.clone()
+}
+
+fn built(prompt: &str, negative: &str, extra: Value) -> WorkflowShare {
+    build_workflow_share(
+        &asset_fixture(prompt),
+        &payload_fixture(prompt, negative, extra),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Reading text chunks back out of a PNG, by hand
+// ---------------------------------------------------------------------------
+
+/// One text chunk as it sits in a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TextChunk {
+    /// `iTXt`, `tEXt` or `zTXt`.
+    kind: String,
+    keyword: String,
+    /// `true` only for an `iTXt` whose compression flag is set.
+    compressed: bool,
+    /// The text, for the uncompressed cases. Empty for a compressed chunk, which this walker does
+    /// not inflate — the envelope is read back through the real reader instead.
+    text: String,
+}
+
+/// Every text chunk in `png`, in file order, walked without the `png` crate.
+///
+/// By hand on purpose: what is under test includes which CHUNK TYPE the text landed in, and a
+/// decoder that normalizes `tEXt` and `iTXt` into one text map would hide exactly that.
+fn text_chunks(png: &[u8]) -> Vec<TextChunk> {
+    let mut out = Vec::new();
+    let mut cursor = 8;
+    while cursor + 8 <= png.len() {
+        let length = usize::try_from(u32::from_be_bytes(
+            png[cursor..cursor + 4].try_into().expect("a length field"),
+        ))
+        .expect("fits usize");
+        let kind = &png[cursor + 4..cursor + 8];
+        let end = cursor + 12 + length;
+        assert!(end <= png.len(), "chunk at {cursor} runs past the end");
+        let data = &png[cursor + 8..cursor + 8 + length];
+        if kind == b"iTXt" || kind == b"tEXt" || kind == b"zTXt" {
+            let mut parts = data.splitn(2, |byte| *byte == 0);
+            let keyword = String::from_utf8_lossy(parts.next().unwrap_or_default()).into_owned();
+            let rest = parts.next().unwrap_or_default();
+            let (compressed, text) = if kind == b"iTXt" {
+                // flag, method, language NUL, translated keyword NUL, text.
+                let compressed = rest.first().copied().unwrap_or(0) == 1;
+                let after_method = rest.get(2..).unwrap_or_default();
+                let mut fields = after_method.splitn(3, |byte| *byte == 0);
+                fields.next();
+                fields.next();
+                let body = fields.next().unwrap_or_default();
+                (
+                    compressed,
+                    if compressed {
+                        String::new()
+                    } else {
+                        String::from_utf8_lossy(body).into_owned()
+                    },
+                )
+            } else if kind == b"tEXt" {
+                // Latin-1 by spec; every byte is one character.
+                (false, rest.iter().map(|byte| *byte as char).collect())
+            } else {
+                (true, String::new())
+            };
+            out.push(TextChunk {
+                kind: String::from_utf8_lossy(kind).into_owned(),
+                keyword,
+                compressed,
+                text,
+            });
+        }
+        cursor = end;
+    }
+    out
+}
+
+fn parameters_chunk_of(png: &[u8]) -> TextChunk {
+    text_chunks(png)
+        .into_iter()
+        .find(|chunk| chunk.keyword == PARAMETERS_CHUNK_KEYWORD)
+        .expect("the file carries a parameters chunk")
+}
+
+/// Write one embedded PNG and hand back its bytes.
+fn embedded_png(share: &WorkflowShare, size: (u32, u32)) -> (PathBuf, Vec<u8>, tempfile::TempDir) {
+    let directory = tempfile::tempdir().expect("temp dir");
+    let path = directory.path().join("embedded.png");
+    write_workflow_chunk(&rgb_fixture(size.0, size.1), &path, Some(share)).expect("writes");
+    let bytes = fs::read(&path).expect("reads");
+    (path, bytes, directory)
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.len() >= needle.len() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+// ---------------------------------------------------------------------------
+// The round trip a gallery makes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_generated_png_round_trips_through_a_gallery_parser() {
+    // The AC, stated the way the story states it: a real generated PNG, read the way Civitai reads
+    // one — walk the chunks, take the `parameters` text, split on the `Negative prompt:` line and
+    // the trailing comma-separated key/value line.
+    let share = built("a lighthouse in heavy fog", "text, watermark", json!({}));
+    let (_path, bytes, _dir) = embedded_png(&share, (64, 48));
+
+    let chunk = parameters_chunk_of(&bytes);
+    let parsed = parse_a1111(&chunk.text);
+
+    assert_eq!(parsed.prompt, "a lighthouse in heavy fog");
+    assert_eq!(parsed.negative_prompt, "text, watermark");
+    assert_eq!(parsed.params["Steps"], "28");
+    assert_eq!(parsed.params["Sampler"], "euler");
+    assert_eq!(parsed.params["CFG scale"], "3.5");
+    assert_eq!(parsed.params["Seed"], "880412");
+    assert_eq!(parsed.params["Size"], "64x48");
+    assert_eq!(parsed.params["Model"], "z_image_turbo");
+    assert_eq!(parsed.params["Version"], PRODUCER_VERSION);
+
+    // The recipe chunk is still there and still the authoritative one — the second chunk is a
+    // display convenience and does not replace the thing a SceneWorks install reads back.
+    assert!(
+        contains(&bytes, WORKFLOW_CHUNK_KEYWORD.as_bytes()),
+        "the envelope chunk must ride alongside"
+    );
+}
+
+#[test]
+fn the_version_is_the_producer_version_exactly() {
+    // The AC names this one directly: the two chunks cannot disagree about which build wrote the
+    // file, so `Version:` is fed from the envelope's own `producer.version`.
+    let share = built("a lighthouse", "", json!({}));
+    let (path, bytes, _dir) = embedded_png(&share, (64, 48));
+    let parsed = parse_a1111(&parameters_chunk_of(&bytes).text);
+
+    let envelope = read_workflow_chunk_file(&path)
+        .expect("reads")
+        .expect("carries a workflow");
+    assert_eq!(parsed.params["Version"], envelope.producer.version);
+    assert_eq!(parsed.params["Version"], PRODUCER_VERSION);
+}
+
+#[test]
+fn the_settings_line_clears_the_pair_floor_a_gallery_parses_with() {
+    // A1111 treats a trailing line of fewer than three `Key: value` pairs as PROMPT text. Our
+    // minimum emission is Seed + Model + Version, so an ordinary generation always clears it — but
+    // that is a property worth pinning rather than assuming, because dropping any one of those
+    // three would silently turn the settings line into a line of prompt for every reader.
+    for (label, extra) in [
+        ("a full recipe", json!({})),
+        (
+            "no advanced settings at all",
+            json!({ "advanced": Value::Object(serde_json::Map::new()) }),
+        ),
+    ] {
+        let share = built("a lighthouse", "", extra);
+        let text = parameters_text(&share, (64, 48));
+        let last = text.lines().last().expect("there is a line");
+        assert!(
+            parse_params(last).len() >= 3,
+            "on {label} the settings line {last:?} has fewer than the three pairs A1111 needs to \
+             recognize it as settings — it would be displayed as part of the prompt"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sanitization applies identically
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_parameters_chunk_cannot_carry_a_withheld_field() {
+    // The AC: content derives from the sanitized envelope, so a field the sc-15946 allow-list
+    // withholds is absent from BOTH chunks. Seeded into the RAW payload, which is the only place a
+    // second, laxer channel could have picked it up from.
+    //
+    // The search is over the whole file's BYTES, which is what makes it a real test of the second
+    // chunk: `parameters` is written uncompressed, so a leaked value would sit in the file in
+    // plain text and a byte search finds it. The envelope chunk is deflated, so its half is
+    // asserted against the parsed envelope instead.
+    let secrets = [
+        ("advanced.quantTier", "q4-secret-tier"),
+        ("advanced.controlImage", "asset_secret_control"),
+        ("advanced.recipePresetId", "preset_secret_id"),
+    ];
+    let share = built(
+        "a lighthouse",
+        "",
+        json!({
+            "projectId": "project_secret_id",
+            "jobId": "job_secret_id",
+            "seeds": [1, 2, 3],
+            "advanced": {
+                "steps": 28,
+                "sampler": "euler",
+                "guidanceScale": 3.5,
+                "quantTier": "q4-secret-tier",
+                "controlImage": "asset_secret_control",
+                "recipePresetId": "preset_secret_id",
+                "flashAttn": true
+            }
+        }),
+    );
+    let (path, bytes, _dir) = embedded_png(&share, (64, 48));
+    let rendered = parameters_chunk_of(&bytes).text;
+    let envelope = serde_json::to_string(
+        &read_workflow_chunk_file(&path)
+            .expect("reads")
+            .expect("carries a workflow"),
+    )
+    .expect("serializes");
+
+    for (key, secret) in secrets {
+        assert!(
+            !rendered.contains(secret),
+            "{key} reached the `parameters` chunk: {rendered:?}"
+        );
+        assert!(
+            !contains(&bytes, secret.as_bytes()),
+            "{key} is in the file's raw bytes — the withheld value leaked into a chunk"
+        );
+        assert!(
+            !envelope.contains(secret),
+            "{key} reached the SceneWorks envelope, which is the sc-15946 sanitizer's job"
+        );
+    }
+    // Project and job identity, which the envelope has no slot for at all.
+    for secret in ["project_secret_id", "job_secret_id"] {
+        assert!(
+            !contains(&bytes, secret.as_bytes()),
+            "{secret} is in the file"
+        );
+    }
+    // And the fixture is not vacuous: the things that SHOULD travel did.
+    assert!(rendered.contains("Sampler: euler") && rendered.contains("Steps: 28"));
+}
+
+#[test]
+fn the_setting_governs_both_chunks() {
+    // sc-15953's switch is a `None` at this seam, and both chunks hang off the same `Some`. Off
+    // means neither is written — there is no arrangement in which the prompt rides out in the
+    // A1111 block after the user turned embedding off.
+    let directory = tempfile::tempdir().expect("temp dir");
+    let path = directory.path().join("opted-out.png");
+    write_workflow_chunk(&rgb_fixture(64, 48), &path, None).expect("writes");
+    let bytes = fs::read(&path).expect("reads");
+
+    assert!(text_chunks(&bytes).is_empty(), "{:?}", text_chunks(&bytes));
+    for keyword in [WORKFLOW_CHUNK_KEYWORD, PARAMETERS_CHUNK_KEYWORD] {
+        assert!(
+            !contains(&bytes, keyword.as_bytes()),
+            "the opted-out file carries `{keyword}`"
+        );
+    }
+    assert!(
+        !contains(&bytes, b"a lighthouse"),
+        "the prompt is in a file written with embedding off"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Encoding: tEXt when ASCII, iTXt when not
+// ---------------------------------------------------------------------------
+
+/// The three scripts that break Latin-1, plus a Latin-1-representable case that is the one band
+/// where our rule and PIL's differ.
+const NON_ASCII_PROMPT: &str = "霧の中の灯台、シネマティック 🌊🗼 café naïve";
+
+#[test]
+fn an_ascii_block_is_a_text_chunk_and_a_non_ascii_one_is_an_itxt() {
+    let ascii = built("a lighthouse in heavy fog", "text, watermark", json!({}));
+    let (_p, bytes, _d) = embedded_png(&ascii, (64, 48));
+    let chunk = parameters_chunk_of(&bytes);
+    assert_eq!(
+        chunk.kind, "tEXt",
+        "an ASCII block is what A1111 itself writes"
+    );
+    assert!(!chunk.compressed);
+    assert!(chunk.text.contains("a lighthouse in heavy fog"));
+
+    let wide = built(NON_ASCII_PROMPT, "文字、透かし", json!({}));
+    let (_p, bytes, _d) = embedded_png(&wide, (64, 48));
+    let chunk = parameters_chunk_of(&bytes);
+    assert_eq!(
+        chunk.kind, "iTXt",
+        "a prompt outside Latin-1 cannot be a tEXt chunk at all — `png` refuses to encode one"
+    );
+    assert!(
+        !chunk.compressed,
+        "uncompressed, matching PIL's zip=False default: a compressed chunk is the form \
+         third-party readers are least reliably tested against"
+    );
+    // And it survives character for character, which a tEXt chunk could not have promised.
+    let parsed = parse_a1111(&chunk.text);
+    assert_eq!(parsed.prompt, NON_ASCII_PROMPT);
+    assert_eq!(parsed.negative_prompt, "文字、透かし");
+
+    // The band where we are deliberately narrower than PIL: Latin-1-representable but not ASCII.
+    // PIL would write tEXt; we write iTXt, because a 0xE9 byte in a tEXt chunk is `é` to a Latin-1
+    // reader and a replacement character to the very common reader that assumes UTF-8.
+    let latin1 = built("café naïve", "", json!({}));
+    let (_p, bytes, _d) = embedded_png(&latin1, (64, 48));
+    let chunk = parameters_chunk_of(&bytes);
+    assert_eq!(chunk.kind, "iTXt");
+    assert!(chunk.text.starts_with("café naïve"));
+}
+
+#[test]
+fn pil_agrees_with_our_encoding_choice() {
+    // The offline stand-in for the live-upload AC. PIL is what A1111 writes through and what the
+    // ecosystem's parsers are tested against, so "PIL finds our chunk under `parameters` and hands
+    // back the exact string we wrote" is the strongest offline statement available about whether a
+    // gallery will render it.
+    //
+    // Two things are checked, and the second is the one the story asked to be verified rather than
+    // assumed:
+    //
+    //   1. `Image.open(...).text["parameters"]` equals our text, for the ASCII and the non-ASCII
+    //      case — so both encodings are FOUND and DECODED correctly by the reference reader.
+    //   2. PIL's own boundary, reported back. `PngInfo.add_text` tries `encode("latin-1")` and
+    //      writes `tEXt` on success, falling back to an uncompressed `iTXt` — so its rule is
+    //      LATIN-1, not ASCII as the story's description says. Ours is narrower on purpose; see
+    //      `parameters_chunk` in workflow_png.rs.
+    //
+    // Skips loudly when Python or Pillow is absent. A test that fails on a machine without an
+    // optional interpreter is worse than one that says why it did nothing.
+    let ascii = built("a lighthouse in heavy fog", "text, watermark", json!({}));
+    let (ascii_path, ascii_bytes, _d1) = embedded_png(&ascii, (64, 48));
+    let wide = built(NON_ASCII_PROMPT, "文字、透かし", json!({}));
+    let (wide_path, wide_bytes, _d2) = embedded_png(&wide, (64, 48));
+
+    let script = r#"
+import json, sys
+try:
+    from PIL import Image, PngImagePlugin
+except Exception as error:
+    print(json.dumps({"skip": str(error)}))
+    sys.exit(0)
+
+result = {"pil": getattr(__import__("PIL"), "__version__", "?"), "files": {}}
+for label, path in (("ascii", sys.argv[1]), ("wide", sys.argv[2])):
+    with Image.open(path) as image:
+        image.load()
+        result["files"][label] = image.text.get("parameters")
+
+# PIL's own boundary, reported rather than assumed.
+def kind(value):
+    info = PngImagePlugin.PngInfo()
+    info.add_text("parameters", value)
+    return [chunk[0].decode("ascii") for chunk in info.chunks]
+
+result["pil_kind"] = {
+    "ascii": kind("plain ascii"),
+    "latin1": kind("café"),
+    "wide": kind("灯台"),
+}
+print(json.dumps(result))
+"#;
+
+    let output = Command::new("python")
+        .arg("-c")
+        .arg(script)
+        .arg(&ascii_path)
+        .arg(&wide_path)
+        .output();
+    let Ok(output) = output else {
+        println!("SKIPPED pil_agrees_with_our_encoding_choice: no `python` on PATH");
+        return;
+    };
+    assert!(
+        output.status.success(),
+        "the PIL probe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value =
+        serde_json::from_slice(&output.stdout).expect("the probe prints one JSON line");
+    if let Some(reason) = report.get("skip") {
+        println!("SKIPPED pil_agrees_with_our_encoding_choice: Pillow is not installed ({reason})");
+        return;
+    }
+
+    // (1) Both encodings are found under the keyword and decode to exactly what we wrote.
+    let expected = [
+        ("ascii", parameters_chunk_of(&ascii_bytes).text),
+        ("wide", parameters_chunk_of(&wide_bytes).text),
+    ];
+    for (label, text) in expected {
+        assert_eq!(
+            report["files"][label].as_str(),
+            Some(text.as_str()),
+            "PIL read the `{PARAMETERS_CHUNK_KEYWORD}` chunk of the {label} fixture back as \
+             something other than what we wrote"
+        );
+    }
+
+    // (2) PIL's boundary, recorded. If a future Pillow changes it, this fails and the comment in
+    // `parameters_chunk` is re-derived rather than left describing a library that moved.
+    assert_eq!(
+        report["pil_kind"]["ascii"],
+        json!(["tEXt"]),
+        "PIL no longer writes ASCII as tEXt"
+    );
+    assert_eq!(
+        report["pil_kind"]["latin1"],
+        json!(["tEXt"]),
+        "PIL's boundary is LATIN-1, not ASCII — that is the band our rule is deliberately \
+         narrower in, and this is the assertion that says so"
+    );
+    assert_eq!(
+        report["pil_kind"]["wide"],
+        json!(["iTXt"]),
+        "PIL no longer falls back to iTXt outside Latin-1"
+    );
+    println!(
+        "PIL {} read both chunks back verbatim; its own boundary is latin-1 (tEXt) / iTXt",
+        report["pil"]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The strip interaction (sc-15953)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn save_a_copy_without_the_workflow_removes_the_parameters_chunk_too() {
+    // The sharpest edge in the story. sc-15953 ships a control promising the recipe is removed; a
+    // `parameters` chunk that survived it would leave the prompt in a file the user deliberately
+    // stripped, and they would have no way to know.
+    let share = built("a lighthouse in heavy fog", "text, watermark", json!({}));
+    let (_p, bytes, _d) = embedded_png(&share, (64, 48));
+    assert_eq!(text_chunks(&bytes).len(), 2, "both chunks were written");
+
+    let stripped = strip_workflow_chunk(&bytes)
+        .expect("strips")
+        .expect("had something to take out");
+
+    assert!(
+        text_chunks(&stripped).is_empty(),
+        "{:?}",
+        text_chunks(&stripped)
+    );
+    // At the byte level, which is what a stranger's tooling sees: neither keyword and neither
+    // prompt survives anywhere in the file.
+    for needle in [
+        WORKFLOW_CHUNK_KEYWORD.as_bytes(),
+        PARAMETERS_CHUNK_KEYWORD.as_bytes(),
+        b"a lighthouse in heavy fog".as_slice(),
+        b"text, watermark".as_slice(),
+    ] {
+        assert!(
+            !contains(&stripped, needle),
+            "the stripped copy still carries {:?}",
+            String::from_utf8_lossy(needle)
+        );
+    }
+    // And the pixels are untouched — a strip is an excision, never a re-encode.
+    let plain = {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("plain.png");
+        write_workflow_chunk(&rgb_fixture(64, 48), &path, None).expect("writes");
+        fs::read(&path).expect("reads")
+    };
+    assert!(
+        stripped == plain,
+        "the stripped file is not the None-path file"
+    );
+}
+
+#[test]
+fn an_imported_a1111_image_keeps_its_own_parameters_block() {
+    // The other half of the co-presence rule, and the half that stops "remove the workflow"
+    // becoming "scrub every gallery's metadata out of files the user imported". A foreign PNG with
+    // a `parameters` chunk and no `sceneworks:workflow` beside it has nothing of ours in it, so the
+    // strip is a clean no-op and the caller uses the source bytes unchanged.
+    let directory = tempfile::tempdir().expect("temp dir");
+    let path = directory.path().join("foreign.png");
+    write_workflow_chunk(&rgb_fixture(32, 32), &path, None).expect("writes a plain PNG");
+    let plain = fs::read(&path).expect("reads");
+    let foreign = splice_text_chunk(
+        &plain,
+        b"tEXt",
+        PARAMETERS_CHUNK_KEYWORD,
+        "somebody else's prompt\nSteps: 20, Sampler: Euler a, CFG scale: 7, Seed: 1, \
+         Model: sd_xl_base, Version: v1.9.4",
+    );
+
+    assert_eq!(
+        strip_workflow_chunk(&foreign),
+        Ok(None),
+        "a foreign A1111 export has nothing of OURS in it, so the strip must be a no-op rather \
+         than a scrub of someone else's metadata"
+    );
+
+    // But the moment our envelope is beside it, the pair is ours and both come out.
+    let ours = built("a lighthouse", "", json!({}));
+    let (_p, embedded, _d) = embedded_png(&ours, (32, 32));
+    let stripped = strip_workflow_chunk(&embedded)
+        .expect("strips")
+        .expect("had something to take out");
+    assert!(text_chunks(&stripped).is_empty());
+}
+
+#[test]
+fn a_stripped_copy_strips_again_to_itself() {
+    // Idempotence falls out of the co-presence rule and is worth pinning: the second strip finds no
+    // envelope, so it correctly declines to touch anything, and the download route's ETag-revalidated
+    // representation cannot drift between two requests for the same file.
+    let share = built("a lighthouse", "", json!({}));
+    let (_p, bytes, _d) = embedded_png(&share, (64, 48));
+    let once = strip_workflow_chunk(&bytes)
+        .expect("strips")
+        .expect("had something to take out");
+    assert_eq!(
+        strip_workflow_chunk(&once),
+        Ok(None),
+        "a file already stripped has nothing left of ours"
+    );
+}
+
+/// Splice a hand-framed text chunk in before the first IDAT.
+fn splice_text_chunk(png: &[u8], kind: &[u8; 4], keyword: &str, text: &str) -> Vec<u8> {
+    let mut data = keyword.as_bytes().to_vec();
+    data.push(0);
+    data.extend_from_slice(text.as_bytes());
+
+    let mut checked = kind.to_vec();
+    checked.extend_from_slice(&data);
+    let mut chunk = u32::try_from(data.len())
+        .expect("fits")
+        .to_be_bytes()
+        .to_vec();
+    chunk.extend_from_slice(&checked);
+    chunk.extend_from_slice(&crc32(&checked).to_be_bytes());
+
+    let mut cursor = 8;
+    let at = loop {
+        assert!(cursor + 8 <= png.len(), "no IDAT");
+        if &png[cursor + 4..cursor + 8] == b"IDAT" {
+            break cursor;
+        }
+        let length = usize::try_from(u32::from_be_bytes(
+            png[cursor..cursor + 4].try_into().expect("a length"),
+        ))
+        .expect("fits");
+        cursor += 12 + length;
+    };
+    let mut out = png[..at].to_vec();
+    out.extend_from_slice(&chunk);
+    out.extend_from_slice(&png[at..]);
+    out
+}
+
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffff_u32;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            crc = if crc & 1 == 1 {
+                (crc >> 1) ^ 0xedb8_8320
+            } else {
+                crc >> 1
+            };
+        }
+    }
+    !crc
+}
+
+// ---------------------------------------------------------------------------
+// Omit rather than approximate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_settings_line_emits_exactly_the_declared_keys() {
+    // `SETTINGS_FIELDS` is the decision record for "omit rather than approximate", and it is only
+    // worth anything if it is the truth. Pinned in BOTH directions: an envelope carrying everything
+    // must emit every declared key, and it must emit nothing else.
+    let share = built(
+        "a lighthouse",
+        "text",
+        json!({
+            "advanced": {
+                "steps": 28,
+                "sampler": "euler",
+                "guidanceScale": 3.5,
+                "scheduler": "karras",
+                "schedulerShift": 3.0,
+                "strength": 0.6,
+                "textStyleGain": 1.4,
+                "controlMode": "canny",
+                "controlScale": 0.8,
+                "faceRestore": true,
+                "enhancePrompt": true,
+                "usePid": true,
+                "pidTarget": "4k",
+                "resolution": "1024x1024",
+                "styleId": "ghibli"
+            },
+            "stylePreset": "Ghibli",
+            "fitMode": "crop",
+            "upscale": { "enabled": true, "factor": 2, "engine": "real-esrgan" },
+            "loras": [{ "name": "Mira", "weight": 0.8, "repo": "acme/mira" }]
+        }),
+    );
+    let text = parameters_text(&share, (64, 48));
+    let emitted: BTreeSet<String> = parse_params(text.lines().last().expect("a settings line"))
+        .into_keys()
+        .collect();
+    let declared: BTreeSet<String> = SETTINGS_FIELDS
+        .iter()
+        .map(|(key, _)| (*key).to_owned())
+        .collect();
+    assert_eq!(
+        emitted, declared,
+        "the settings line and SETTINGS_FIELDS disagree; the declaration is what a reviewer reads \
+         to check that nothing was approximated"
+    );
+    for (key, reason) in SETTINGS_FIELDS {
+        assert!(reason.len() > 20, "`{key}` needs a real reason");
+    }
+
+    // And the things with no clean A1111 equivalent are absent from the rendered block by VALUE,
+    // not merely un-keyed: a scheduler, a strength, an upscale factor, a LoRA and a style all
+    // travel in the envelope and none of them may appear here.
+    for absent in [
+        "karras",
+        "textStyleGain",
+        "canny",
+        "Ghibli",
+        "crop",
+        "real-esrgan",
+        "Mira",
+        "acme/mira",
+        "<lora:",
+        "Denoising strength",
+        "Hires",
+        "Schedule type",
+        "Batch size",
+        "Face restoration",
+    ] {
+        assert!(
+            !text.contains(absent),
+            "the parameters block approximates {absent:?}: {text:?}"
+        );
+    }
+}
+
+#[test]
+fn a_multi_phase_krea_recipe_omits_the_fields_it_cannot_state() {
+    // The case the AC names. A Krea multi-phase run has a SCHEDULE of steps and guidance, not one
+    // of each; emitting the top-level numbers beside it would describe a run that did not happen,
+    // and a gallery reader has no way to tell.
+    let share = built(
+        "a lighthouse",
+        "",
+        json!({
+            "model": "krea_2_turbo",
+            "advanced": {
+                "steps": 28,
+                "guidanceScale": 3.5,
+                "sampler": "euler",
+                "textStyleGain": 1.4,
+                "phases": [
+                    { "steps": 12, "guidance": 4.0, "loras": [{ "index": 0, "weight": 0.7 }] },
+                    { "steps": 16, "guidance": 2.0 }
+                ]
+            }
+        }),
+    );
+    assert!(
+        share.advanced.contains_key("phases"),
+        "the fixture must actually carry a multi-phase schedule"
+    );
+    let text = parameters_text(&share, (64, 48));
+    let params = parse_params(text.lines().last().expect("a settings line"));
+    assert!(!params.contains_key("Steps"), "{text:?}");
+    assert!(!params.contains_key("CFG scale"), "{text:?}");
+    // Nothing was invented for the schedule or the tap-reweight gain either.
+    for absent in ["Phases", "phases", "1.4", "textStyleGain"] {
+        assert!(
+            !text.contains(absent),
+            "{absent:?} reached the block: {text:?}"
+        );
+    }
+    // What can be stated exactly still is.
+    assert_eq!(params["Sampler"], "euler");
+    assert_eq!(params["Model"], "krea_2_turbo");
+    assert_eq!(params["Version"], PRODUCER_VERSION);
+}
+
+#[test]
+fn a_prompt_carrying_a_comma_or_a_newline_still_parses() {
+    // A prompt is user prose and routinely has both. The prompt is positional so a comma in it is
+    // harmless, but the settings line is comma-separated — this is the case where a renderer that
+    // forgot A1111's quoting rule would split one field into two for every reader.
+    let prompt = "a lighthouse, in heavy fog\nshot on 35mm, cinematic";
+    let share = built(prompt, "text, watermark, blurry", json!({}));
+    let (_p, bytes, _d) = embedded_png(&share, (64, 48));
+    let parsed = parse_a1111(&parameters_chunk_of(&bytes).text);
+    assert_eq!(parsed.prompt, prompt);
+    assert_eq!(parsed.negative_prompt, "text, watermark, blurry");
+    assert_eq!(parsed.params["Model"], "z_image_turbo");
+}

--- a/crates/sceneworks-core/tests/workflow_parameters.rs
+++ b/crates/sceneworks-core/tests/workflow_parameters.rs
@@ -40,11 +40,15 @@ use image::{Rgb, RgbImage};
 use sceneworks_core::contracts::{Asset, JsonObject};
 use sceneworks_core::workflow_parameters::{
     parameters_text, NEGATIVE_PROMPT_LABEL, PARAMETERS_CHUNK_KEYWORD, SETTINGS_FIELDS,
+    SETTINGS_PAIR_FLOOR,
 };
 use sceneworks_core::workflow_png::{
     read_workflow_chunk_file, strip_workflow_chunk, write_workflow_chunk, WORKFLOW_CHUNK_KEYWORD,
 };
-use sceneworks_core::workflow_share::{build_workflow_share, WorkflowShare, PRODUCER_VERSION};
+use sceneworks_core::workflow_share::{
+    build_workflow_share, build_workflow_share_from, WorkflowAssetFacts, WorkflowShare,
+    PRODUCER_VERSION,
+};
 use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
@@ -200,6 +204,15 @@ fn the_local_parser_reads_a_real_a1111_block() {
     let thin = parse_a1111("just a prompt\nModel: z_image_turbo, Version: 0.8.1");
     assert!(thin.params.is_empty(), "{thin:?}");
     assert!(thin.prompt.ends_with("Version: 0.8.1"));
+
+    // The renderer's `SETTINGS_PAIR_FLOOR` is that same threshold, and this is where the two are
+    // joined. The parser above keeps its own literal on purpose — one that read the renderer's
+    // constant would agree with it whatever it was set to, which is the opposite of a measurement.
+    assert_eq!(
+        SETTINGS_PAIR_FLOOR, 3,
+        "the renderer's floor and the reader's threshold have diverged; one of them is now wrong \
+         about what a gallery does with a thin line"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -413,28 +426,181 @@ fn the_version_is_the_producer_version_exactly() {
     assert_eq!(parsed.params["Version"], PRODUCER_VERSION);
 }
 
+/// The envelope shape one of the worker's derived-pass write seams produces.
+///
+/// Built through the public `build_workflow_share_from` rather than through the worker's own
+/// helpers, because those are `pub(crate)` in a crate this one does not depend on — and because what
+/// is under test is the SHAPE (which facts are present, which are empty, whether the geometry is the
+/// encoded file's), which is exactly what the facts struct carries.
+fn lane_share(facts: WorkflowAssetFacts, payload: Value) -> WorkflowShare {
+    build_workflow_share_from(&facts, payload.as_object().expect("a payload object"))
+}
+
 #[test]
 fn the_settings_line_clears_the_pair_floor_a_gallery_parses_with() {
-    // A1111 treats a trailing line of fewer than three `Key: value` pairs as PROMPT text. Our
-    // minimum emission is Seed + Model + Version, so an ordinary generation always clears it — but
-    // that is a property worth pinning rather than assuming, because dropping any one of those
-    // three would silently turn the settings line into a line of prompt for every reader.
-    for (label, extra) in [
-        ("a full recipe", json!({})),
+    // A1111 treats a trailing line of fewer than three `Key: value` pairs as PROMPT text, and
+    // `SETTINGS_PAIR_FLOOR` withholds the line rather than emitting one below it. So there are two
+    // things to pin, and the version of this test that shipped first pinned neither well: it
+    // measured two `text_to_image` fixtures that both emit SIX pairs, which is not where the cliff
+    // is.
+    //
+    // The lanes below are the ones that actually sit at or near the floor — the derived passes,
+    // whose envelopes are deliberately thin. `standalone_upscale_workflow_share` is the extreme: no
+    // prompt, no `advanced`, source geometry that is not the encoded file's, and the engine id
+    // standing in for the model. It clears the floor by exactly nothing.
+    //
+    // Each lane is checked through `parse_a1111` — the gallery's own reader — rather than by
+    // counting pairs on `lines().last()`, because when the floor guard withholds a line there may be
+    // no last line at all, and "the settings fell into the prompt" is precisely the failure worth
+    // catching.
+    let lanes: [(&str, WorkflowShare, (u32, u32), &str); 4] = [
         (
-            "no advanced settings at all",
-            json!({ "advanced": Value::Object(serde_json::Map::new()) }),
+            "an ordinary text_to_image generation",
+            built("a lighthouse", "", json!({})),
+            (64, 48),
+            "a lighthouse",
         ),
-    ] {
-        let share = built("a lighthouse", "", extra);
-        let text = parameters_text(&share, (64, 48));
-        let last = text.lines().last().expect("there is a line");
+        (
+            "a generation with no advanced settings at all",
+            built(
+                "a lighthouse",
+                "",
+                json!({ "advanced": Value::Object(serde_json::Map::new()) }),
+            ),
+            (64, 48),
+            "a lighthouse",
+        ),
+        (
+            // `standalone_upscale_workflow_share` in the worker: mode `image_upscale`, the engine
+            // as the model, no prompt at all, and the SOURCE geometry — so `Size` is correctly
+            // withheld from a file twice that size. Seed + Model + Version and nothing else.
+            "the standalone upscale lane",
+            lane_share(
+                WorkflowAssetFacts {
+                    mode: "image_upscale".to_owned(),
+                    model: "seedvr2".to_owned(),
+                    prompt: String::new(),
+                    negative_prompt: String::new(),
+                    seed: 880_412,
+                    width: Some(1024),
+                    height: Some(1024),
+                },
+                json!({ "projectId": "project_7a10", "sourceAssetId": "asset_9f2c",
+                        "upscale": { "enabled": true, "engine": "seedvr2", "factor": 2 } }),
+            ),
+            (2048, 2048),
+            "",
+        ),
+        (
+            // `detail_workflow_share`: its own job, its own payload, and the Detail UI exposes only
+            // `strength` and `cnScale` — neither of which maps to an A1111 field. So `advanced`
+            // travels full and contributes nothing to the line.
+            "the detail lane",
+            lane_share(
+                WorkflowAssetFacts {
+                    mode: "image_detail".to_owned(),
+                    model: "sdxl_base".to_owned(),
+                    prompt: "sharper rigging".to_owned(),
+                    negative_prompt: String::new(),
+                    seed: 4,
+                    width: Some(1536),
+                    height: Some(1536),
+                },
+                json!({ "projectId": "project_7a10", "sourceAssetId": "asset_9f2c",
+                        "advanced": { "strength": 0.4, "cnScale": 0.8 } }),
+            ),
+            (1536, 1536),
+            "sharper rigging",
+        ),
+    ];
+
+    // The two derived lanes have to be thin or this pins the wrong thing: the upscale lane carries
+    // no prompt and no `advanced` at all, and the detail lane's two knobs both travel and both map
+    // to nothing on the line. Checked, because a fixture that quietly grew a mapped field would
+    // leave the floor untested again while still passing.
+    assert!(
+        lanes[2].1.prompt.is_empty() && lanes[2].1.advanced.is_empty(),
+        "the upscale fixture is no longer the thin shape the seam produces: {:?}",
+        lanes[2].1.advanced
+    );
+    assert_eq!(
+        lanes[3].1.advanced.len(),
+        2,
+        "the detail fixture must carry both allow-listed knobs and nothing that maps: {:?}",
+        lanes[3].1.advanced
+    );
+    // And the sharpest statement of where the cliff is: the upscale lane clears the floor by
+    // NOTHING. Stated as an equality so a change that removes a mapped field fails here rather than
+    // silently reducing the margin from zero to negative.
+    assert_eq!(
+        parse_a1111(&parameters_text(&lanes[2].1, lanes[2].2))
+            .params
+            .len(),
+        SETTINGS_PAIR_FLOOR,
+        "the standalone upscale lane is the one that sits ON the floor; if it no longer does, the \
+         lane that does is the one this test should be pinning"
+    );
+
+    for (label, share, encoded, prompt) in lanes {
+        let text = parameters_text(&share, encoded);
+        let parsed = parse_a1111(&text);
         assert!(
-            parse_params(last).len() >= 3,
-            "on {label} the settings line {last:?} has fewer than the three pairs A1111 needs to \
-             recognize it as settings — it would be displayed as part of the prompt"
+            parsed.params.len() >= SETTINGS_PAIR_FLOOR,
+            "on {label} a gallery reads {} pairs off {text:?} — fewer than the \
+             {SETTINGS_PAIR_FLOOR} A1111 needs, so the whole line is displayed as part of the prompt",
+            parsed.params.len()
+        );
+        assert_eq!(
+            parsed.prompt, prompt,
+            "on {label} the settings line fell into the prompt: {text:?}"
         );
     }
+}
+
+#[test]
+fn a_lane_that_cannot_reach_the_floor_withholds_the_line_instead_of_leaking_it_into_the_prompt() {
+    // The other half, and the reason the pin above is worth extending rather than just widening.
+    // The upscale lane clears the floor by ZERO margin, so any envelope that loses one of its three
+    // fields falls off the cliff — and the renderer used to emit the two-pair remainder, which every
+    // gallery displays as prompt text.
+    //
+    // Reachable? Not through today's catalog: `model` here is an upscaler engine id, and no id in it
+    // is empty, over 200 characters or path-shaped, which are the three ways the sanitizer drops a
+    // label. So this is latent rather than live — which is exactly the kind of thing that becomes
+    // live when someone adds an engine whose id happens to look like a path.
+    let stripped = lane_share(
+        WorkflowAssetFacts {
+            mode: "image_upscale".to_owned(),
+            // Three segments, so `is_path_shaped` catches it and `shareable_label` withholds it —
+            // two would be a Hugging Face repo id and would survive.
+            model: "engines/upscalers/seedvr2".to_owned(),
+            prompt: "a lighthouse".to_owned(),
+            negative_prompt: String::new(),
+            seed: 880_412,
+            width: Some(1024),
+            height: Some(1024),
+        },
+        json!({ "projectId": "project_7a10" }),
+    );
+    assert!(
+        stripped.model.is_empty(),
+        "the fixture must actually lose its model or it proves nothing: {:?}",
+        stripped.model
+    );
+
+    let text = parameters_text(&stripped, (2048, 2048));
+    assert_eq!(
+        text, "a lighthouse",
+        "two mapped fields is a line a gallery reads as prompt, so the line must be withheld whole \
+         — the prompt stays correct and the settings are simply absent"
+    );
+    let parsed = parse_a1111(&text);
+    assert_eq!(parsed.prompt, "a lighthouse");
+    assert!(parsed.params.is_empty());
+    // And nothing was lost that mattered: the authoritative recipe is the other chunk, which still
+    // carries the seed and the producer version this line could not state legibly.
+    assert_eq!(stripped.seed, Some(880_412));
+    assert_eq!(stripped.producer.version, PRODUCER_VERSION);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sceneworks-core/tests/workflow_png.rs
+++ b/crates/sceneworks-core/tests/workflow_png.rs
@@ -645,6 +645,40 @@ fn the_same_prompt_cannot_be_written_as_a_text_chunk_at_all() {
 // Per-image cost
 // ---------------------------------------------------------------------------
 
+/// What the `parameters` trailer for the FIXED golden envelope must stay under, framing included.
+///
+/// A bound on a fixed fixture, and that is the only shape this bound can honestly take. The trailer
+/// is uncompressed by design and its bulk is the user's own prose, so a bound on the trailer *in
+/// general* would have to be above [`PROSE_CAP_BYTES`] twice over — far too loose to catch anything.
+/// Holding one fixture whose prose never changes turns the same number into a guard on the part that
+/// is ours: the settings line and the framing.
+///
+/// 384 against 186 measured. The headroom is deliberately smaller than the smallest structure creep
+/// anyone would plausibly add, which
+/// `the_bound_fires_when_structure_is_serialized_into_the_trailer` measures (450 bytes) rather than
+/// assumes — a budget that cannot fail the thing its message names is not a budget.
+const GOLDEN_PARAMETERS_MAX: usize = 384;
+
+/// The widest trailing settings line the seven declared fields can produce, plus the
+/// `Negative prompt: ` label and the PNG chunk framing.
+///
+/// Derived from the sanitizer's own bounds rather than measured, because this is a ceiling: `Sampler`
+/// and `Model` are labels (`LABEL_MAX_CHARS` = 200 characters, so at most 800 bytes each, plus
+/// A1111's JSON quoting), `Version` is a strict-semver label, and `Steps` / `Seed` / `Size` /
+/// `CFG scale` are numbers whose widest decimal forms are a few dozen bytes together. That totals
+/// under 3 KB; 4 KiB is the round number above it.
+///
+/// Only [`the_parameters_chunk_at_the_prose_cap_is_the_worst_case`] uses it, and only as the
+/// non-prose half of a derived ceiling. It is not a creep guard — nothing this loose could be one.
+const SETTINGS_LINE_MAX: usize = 4 * 1024;
+
+/// The sanitizer's per-prose-field byte cap (`PROSE_MAX_BYTES` in `workflow_share.rs`, 16 KiB).
+///
+/// Private there, so it is restated here and then DERIVED rather than trusted:
+/// `the_parameters_chunk_at_the_prose_cap_is_the_worst_case` feeds prose far over it and asserts the
+/// builder truncated to exactly this, which fails if the constant ever moves.
+const PROSE_CAP_BYTES: usize = 16 * 1024;
+
 #[test]
 fn the_chunks_stay_text_chunks_and_not_a_payload() {
     // Recorded on sc-15947 so sc-15948 can sanity-check what it is about to add to every generated
@@ -683,12 +717,122 @@ fn the_chunks_stay_text_chunks_and_not_a_payload() {
         "a representative envelope at {uncompressed} bytes is uncomfortably close to the \
          {MAX_WORKFLOW_TEXT_BYTES}-byte read cap"
     );
-    // The A1111 trailer is prose plus a handful of numbers. It is uncompressed on purpose, so its
-    // ceiling is the prompt's — but it must never approach the envelope's own recording ceiling,
-    // which is what it would do if someone started serializing structure into it.
+    // The A1111 trailer needs a different KIND of bound from the envelope chunk's, and the one that
+    // was here first was the wrong kind: `parameters < 8 KiB` with the message "that is a payload,
+    // not a settings line". The trailer is uncompressed by design, so at the sanitizer's 16 KiB
+    // prose cap a perfectly legitimate one is ~33 KB — four times the line that assertion drew, and
+    // it never fired because the only envelope it ever measured was this short-prompt fixture.
+    //
+    // Restated as what it can actually guard: structure creep on a FIXED fixture. The prose here is
+    // 51 bytes and never moves, so everything between the measurement and the budget is settings
+    // line and framing.
+    println!(
+        "parameters chunk on the golden envelope: {parameters} bytes over {} bytes of prose",
+        envelope.prompt.len() + envelope.negative_prompt.len()
+    );
     assert!(
-        parameters < 8 * 1024,
-        "the parameters chunk grew to {parameters} bytes — that is a payload, not a settings line"
+        parameters <= GOLDEN_PARAMETERS_MAX,
+        "on the golden envelope the parameters trailer reached {parameters} bytes, over the \
+         {GOLDEN_PARAMETERS_MAX}-byte budget. This fixture's prose does not change, so the growth \
+         is structure: something is being serialized into a block that is supposed to be a prompt \
+         and a settings line"
+    );
+}
+
+#[test]
+fn the_bound_fires_when_structure_is_serialized_into_the_trailer() {
+    // `GOLDEN_PARAMETERS_MAX` is only worth its message if it can actually fail, and the bound it
+    // replaced could not. So the smallest creep the message names is measured against it: somebody
+    // decides the trailer should carry the recipe too and appends the `advanced` map.
+    //
+    // Measured rather than assumed, so raising the budget past this silently is not possible —
+    // whoever raises it fails here and has to say why the guard should stop guarding.
+    let envelope = golden_envelope();
+    assert!(
+        !envelope.advanced.is_empty(),
+        "the golden envelope must carry an `advanced` map or this measures nothing"
+    );
+    let creep = serde_json::to_string(&envelope.advanced).expect("serializes");
+
+    let honest = parameters_chunk_size(&envelope, (1024, 1024)).expect("the chunk encodes");
+    let crept = honest + creep.len();
+    println!(
+        "serializing `advanced` ({} bytes) into the trailer takes it from {honest} to {crept} bytes \
+         against a {GOLDEN_PARAMETERS_MAX}-byte budget",
+        creep.len()
+    );
+    assert!(
+        honest <= GOLDEN_PARAMETERS_MAX,
+        "the honest trailer at {honest} bytes is already over budget"
+    );
+    assert!(
+        crept > GOLDEN_PARAMETERS_MAX,
+        "serializing the whole `advanced` map into the trailer only takes it to {crept} bytes, \
+         which the {GOLDEN_PARAMETERS_MAX}-byte budget still permits — the budget is too loose to \
+         catch the thing its message names"
+    );
+}
+
+#[test]
+fn the_parameters_chunk_at_the_prose_cap_is_the_worst_case() {
+    // The honest ceiling, measured rather than described. The trailer is UNCOMPRESSED, and it
+    // re-renders prose the envelope chunk deflates — so at the sanitizer's per-field cap the second
+    // chunk is two orders of magnitude larger than the first, and a doc that called it "a few
+    // hundred bytes of prose" was describing the typical case as if it were the bound.
+    //
+    // Both prose fields are fed far over the cap so the sanitizer's truncation, not the fixture, is
+    // what sets the size.
+    let over_cap = "z".repeat(4 * PROSE_CAP_BYTES);
+    let envelope = build_workflow_share(
+        &asset_fixture(&over_cap),
+        &payload_fixture(&over_cap, &over_cap),
+    );
+    assert_eq!(
+        envelope.prompt.len(),
+        PROSE_CAP_BYTES,
+        "the fixture must reach the prose cap or it measures the fixture instead of the bound"
+    );
+    assert_eq!(envelope.negative_prompt.len(), PROSE_CAP_BYTES);
+
+    let parameters = parameters_chunk_size(&envelope, (9, 7)).expect("the chunk encodes");
+    let envelope_chunk = workflow_chunk_size(&envelope).expect("the chunk encodes");
+    println!(
+        "at the {PROSE_CAP_BYTES}-byte prose cap: parameters = {parameters} bytes uncompressed \
+         against an envelope chunk of {envelope_chunk} bytes carrying the same prose deflated; the \
+         file grows {} bytes over the None path",
+        parameters + envelope_chunk
+    );
+
+    // The ceiling is derived, not observed: the two prose fields at their cap plus the widest
+    // settings line the declared fields can produce. Nothing a sanitized envelope can carry exceeds
+    // it, which is what makes it a bound rather than a record of one run.
+    let ceiling = 2 * PROSE_CAP_BYTES + SETTINGS_LINE_MAX;
+    assert!(
+        parameters <= ceiling,
+        "the parameters chunk reached {parameters} bytes, over the derived {ceiling}-byte ceiling \
+         (two prose fields at {PROSE_CAP_BYTES} bytes plus a {SETTINGS_LINE_MAX}-byte settings line)"
+    );
+    // And it really is the pathological end of the range rather than a number anyone will meet: the
+    // representative recipe's trailer is two orders of magnitude smaller. Pinned so the "~100x"
+    // in `parameters_chunk`'s doc is a measurement rather than a recollection.
+    let representative =
+        parameters_chunk_size(&golden_envelope(), (1024, 1024)).expect("the chunk encodes");
+    assert!(
+        parameters > 100 * representative,
+        "the cap case is {parameters} bytes against a representative {representative}; the doc says \
+         two orders of magnitude, so re-derive it"
+    );
+    // Uncompressed is still the right call, and this is the measurement that says why the trade is
+    // affordable rather than merely traditional: the same prose deflates to a fraction of this in
+    // the envelope chunk beside it, so the file already holds a compact copy of everything the
+    // trailer restates. What the trailer buys is being FOUND — by readers reliably tested only
+    // against PIL's uncompressed `tEXt` / `iTXt`. Compressing it would save bytes the file has
+    // already spent and cost the one property it exists for.
+    assert!(
+        envelope_chunk * 4 < parameters,
+        "the envelope chunk at {envelope_chunk} bytes is no longer much smaller than the \
+         {parameters}-byte uncompressed trailer, so the reason compressing the trailer would buy \
+         little no longer holds — re-decide it rather than leaving the comment"
     );
 }
 

--- a/crates/sceneworks-core/tests/workflow_png.rs
+++ b/crates/sceneworks-core/tests/workflow_png.rs
@@ -19,10 +19,11 @@ use std::path::{Path, PathBuf};
 
 use image::{ImageFormat, Rgb, RgbImage};
 use sceneworks_core::contracts::{Asset, JsonObject};
+use sceneworks_core::workflow_parameters::PARAMETERS_CHUNK_KEYWORD;
 use sceneworks_core::workflow_png::{
-    copy_without_workflow_chunk, read_workflow_chunk, read_workflow_chunk_file,
-    strip_workflow_chunk, workflow_chunk_size, write_workflow_chunk, MAX_WORKFLOW_TEXT_BYTES,
-    WORKFLOW_CHUNK_KEYWORD,
+    copy_without_workflow_chunk, parameters_chunk_size, read_workflow_chunk,
+    read_workflow_chunk_file, strip_workflow_chunk, workflow_chunk_size, write_workflow_chunk,
+    MAX_WORKFLOW_TEXT_BYTES, WORKFLOW_CHUNK_KEYWORD,
 };
 use sceneworks_core::workflow_share::{
     build_workflow_share, WorkflowShare, WORKFLOW_SHARE_MARKER_KEY, WORKFLOW_SHARE_SCHEMA_VERSION,
@@ -330,13 +331,21 @@ fn soft_render_rgb(width: u32, height: u32) -> RgbImage {
     })
 }
 
-/// Rebuild `png` with every `iTXt` chunk under [`WORKFLOW_CHUNK_KEYWORD`] removed, walking the
-/// chunk framing by hand. Returns the remaining bytes and how many were taken out.
+/// Rebuild `png` with every text chunk under one of OUR two keywords removed, walking the chunk
+/// framing by hand. Returns the remaining bytes and how many were taken out.
 ///
-/// Deliberately does not use the `png` crate: the point is to remove the chunk without re-encoding
-/// anything, so what is left is the original file's own bytes minus a slice.
+/// Deliberately does not use the `png` crate: the point is to remove the chunks without re-encoding
+/// anything, so what is left is the original file's own bytes minus two slices.
+///
+/// Both text types, because sc-15957's `parameters` chunk is a `tEXt` whenever its content is ASCII
+/// and an `iTXt` when it is not — a hand stripper that only knew `iTXt` would silently stop
+/// accounting for the whole file on the ordinary English case, which is most of them.
 fn strip_workflow_chunks(png: &[u8]) -> (Vec<u8>, usize) {
     assert!(png.len() > 8, "not a PNG");
+    let ours = [
+        WORKFLOW_CHUNK_KEYWORD.as_bytes(),
+        PARAMETERS_CHUNK_KEYWORD.as_bytes(),
+    ];
     let mut out = png[..8].to_vec();
     let mut removed = 0;
     let mut cursor = 8;
@@ -351,12 +360,13 @@ fn strip_workflow_chunks(png: &[u8]) -> (Vec<u8>, usize) {
         let end = cursor + 12 + length;
         assert!(end <= png.len(), "chunk at {cursor} runs past the end");
 
-        // The keyword is the `iTXt` payload up to its first NUL.
+        // The keyword is the text payload up to its first NUL, in all three text chunk types.
         let keyword = data
             .split(|byte| *byte == 0)
             .next()
             .expect("split yields one");
-        if kind == b"iTXt" && keyword == WORKFLOW_CHUNK_KEYWORD.as_bytes() {
+        let is_text = kind == b"iTXt" || kind == b"tEXt" || kind == b"zTXt";
+        if is_text && ours.contains(&keyword) {
             removed += end - cursor;
         } else {
             out.extend_from_slice(&png[cursor..end]);
@@ -366,8 +376,14 @@ fn strip_workflow_chunks(png: &[u8]) -> (Vec<u8>, usize) {
     (out, removed)
 }
 
+/// What one embedded write costs a file: both chunks, framing included.
+fn embedded_chunk_bytes(envelope: &WorkflowShare, encoded: (u32, u32)) -> usize {
+    workflow_chunk_size(envelope).expect("the workflow chunk encodes")
+        + parameters_chunk_size(envelope, encoded).expect("the parameters chunk encodes")
+}
+
 #[test]
-fn the_some_path_is_the_none_path_plus_the_chunk() {
+fn the_some_path_is_the_none_path_plus_the_chunks() {
     // The other half of the guarantee, and the half that is easy to assert too weakly. `None` going
     // through `save_with_format` makes the opt-out structurally identical, but `Some` CANNOT — no
     // `image` encoder writes a text chunk — so it drives `png` directly and could quietly encode
@@ -376,8 +392,15 @@ fn the_some_path_is_the_none_path_plus_the_chunk() {
     // cost ~8x the encode time.
     //
     // Asserting "the embedded file is bigger" cannot catch that, and neither can a small fixture. So
-    // this strips our chunk back out of the `Some` output at the byte level and requires what remains
-    // to be the `None` output exactly.
+    // this strips our chunks back out of the `Some` output at the byte level and requires what
+    // remains to be the `None` output exactly.
+    //
+    // sc-15957 made this TWO chunks rather than one, and the invariant is stated at exactly the same
+    // strength rather than relaxed: the difference between the two arms is still accounted for to
+    // the byte, and the accounting is still against independently MEASURED chunk sizes rather than
+    // against whatever the diff happens to be. What changed is only the number of slices removed.
+    // Weakening it to "the bytes match after removing everything under our keywords" would have
+    // stopped proving that embedding costs the chunks and nothing else.
     //
     // The FIXTURE is load-bearing too, which is why there are two. `noisy_rgb` is incompressible
     // enough that `png` stores its rows and never consults the filter, so on that fixture alone every
@@ -393,7 +416,6 @@ fn the_some_path_is_the_none_path_plus_the_chunk() {
 
     let directory = tempfile::tempdir().expect("temp dir");
     let envelope = golden_envelope();
-    let chunk_size = workflow_chunk_size(&envelope).expect("the chunk encodes");
 
     for (label, build, regime) in fixtures {
         // Several sizes, and at least one big enough for a compression difference to dominate the
@@ -401,6 +423,7 @@ fn the_some_path_is_the_none_path_plus_the_chunk() {
         for (width, height) in [(9, 7), (67, 41), (512, 512), (1024, 1024)] {
             let rgb = build(width, height);
             let name = format!("{label}-{width}x{height}");
+            let chunk_size = embedded_chunk_bytes(&envelope, (width, height));
             let embedded = directory.path().join(format!("some-{name}.png"));
             let plain = directory.path().join(format!("none-{name}.png"));
 
@@ -413,27 +436,28 @@ fn the_some_path_is_the_none_path_plus_the_chunk() {
 
             assert_eq!(
                 removed, chunk_size,
-                "on {name} the stripper removed {removed} bytes but the chunk measures {chunk_size}"
+                "on {name} the stripper removed {removed} bytes but the two chunks measure \
+                 {chunk_size}"
             );
             assert_eq!(
                 stripped.len(),
                 plain_bytes.len(),
-                "on {name} the two arms disagree on encoded size by {} bytes — the chunk is \
-                 {chunk_size} and was already removed, so this is an ENCODER difference \
-                 (compression level or row filter), not the chunk",
+                "on {name} the two arms disagree on encoded size by {} bytes — the chunks are \
+                 {chunk_size} and were already removed, so this is an ENCODER difference \
+                 (compression level or row filter), not the chunks",
                 stripped.len().abs_diff(plain_bytes.len())
             );
             assert!(
                 stripped == plain_bytes,
-                "on {name} the Some output is not the None output plus the chunk: the bytes differ \
-                 after stripping the {chunk_size}-byte chunk"
+                "on {name} the Some output is not the None output plus the chunks: the bytes differ \
+                 after stripping the {chunk_size} bytes of text chunk"
             );
             // Stated the other way round as well, because this is the number sc-15948 quotes: the
-            // file grows by the chunk and by nothing else.
+            // file grows by the chunks and by nothing else.
             assert_eq!(
                 embedded_bytes.len(),
                 plain_bytes.len() + chunk_size,
-                "on {name} embedding cost {} bytes, not the {chunk_size}-byte chunk",
+                "on {name} embedding cost {} bytes, not the {chunk_size} bytes of chunk",
                 embedded_bytes.len() - plain_bytes.len()
             );
 
@@ -475,19 +499,24 @@ fn strip_of_an_embedded_png_is_byte_identical_to_the_none_path() {
     // is the same compressed image data it always was.
     //
     // The same two DEFLATE regimes and the same four sizes as
-    // `the_some_path_is_the_none_path_plus_the_chunk`, for the same reason: a stripper tested only
+    // `the_some_path_is_the_none_path_plus_the_chunks`, for the same reason: a stripper tested only
     // on an incompressible 9x7 fixture would pass while silently re-encoding a real render.
+    //
+    // Since sc-15957 this is also the byte-level proof that the strip removes BOTH chunks: the
+    // stripped file being the `None`-path file exactly leaves nowhere for a `parameters` chunk to
+    // survive. A strip that took only the envelope out would land `parameters_chunk_size` bytes
+    // over and fail here, not merely leave a weaker guarantee.
     type Fixture = fn(u32, u32) -> RgbImage;
     let fixtures: [(&str, Fixture); 2] = [("noise", noisy_rgb), ("render", soft_render_rgb)];
 
     let directory = tempfile::tempdir().expect("temp dir");
     let envelope = golden_envelope();
-    let chunk_size = workflow_chunk_size(&envelope).expect("the chunk encodes");
 
     for (label, build) in fixtures {
         for (width, height) in [(9, 7), (67, 41), (512, 512), (1024, 1024)] {
             let rgb = build(width, height);
             let name = format!("{label}-{width}x{height}");
+            let chunk_size = embedded_chunk_bytes(&envelope, (width, height));
             let embedded = directory.path().join(format!("embedded-{name}.png"));
             let plain = directory.path().join(format!("plain-{name}.png"));
             write_workflow_chunk(&rgb, &embedded, Some(&envelope)).expect("writes with a chunk");
@@ -502,7 +531,7 @@ fn strip_of_an_embedded_png_is_byte_identical_to_the_none_path() {
             assert_eq!(
                 embedded_bytes.len() - stripped.len(),
                 chunk_size,
-                "on {name} the strip removed {} bytes but the chunk measures {chunk_size}",
+                "on {name} the strip removed {} bytes but the two chunks measure {chunk_size}",
                 embedded_bytes.len() - stripped.len()
             );
             assert!(
@@ -617,25 +646,29 @@ fn the_same_prompt_cannot_be_written_as_a_text_chunk_at_all() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn the_chunk_stays_a_text_chunk_and_not_a_payload() {
+fn the_chunks_stay_text_chunks_and_not_a_payload() {
     // Recorded on sc-15947 so sc-15948 can sanity-check what it is about to add to every generated
-    // image. Numbers as measured on the sc-15946 golden envelope (a full Krea edit: LoRAs, four
-    // input shapes, an upscale pass, twelve allow-listed `advanced` keys):
+    // image, and re-measured on sc-15957 now that there are two chunks. Numbers as measured on the
+    // sc-15946 golden envelope (a full Krea edit: LoRAs, four input shapes, an upscale pass, twelve
+    // allow-listed `advanced` keys) at 1024x1024:
     //
-    //   uncompressed envelope JSON  960 bytes
-    //   framed compressed iTXt      565 bytes  (length + type + keyword + separators + CRC)
+    //   uncompressed envelope JSON   960 bytes
+    //   framed compressed iTXt       565 bytes  (length + type + keyword + separators + CRC)
+    //   framed parameters chunk      ~380 bytes (uncompressed, by design — see `parameters_chunk`)
     //
-    // Both figures move by a few bytes between the two `serde_json` map backends, since key ORDER
+    // The first two move by a few bytes between the two `serde_json` map backends, since key ORDER
     // changes what deflate finds to share — which is exactly why the assertions below are bounds.
     //
-    // Against a 1024x1024 PNG of a few megabytes that is a rounding error, which is the point of
-    // compressing it. The bounds below are deliberately loose — this test exists to catch the
-    // chunk becoming a payload (a base64 image, an un-reduced `advanced` map), not to pin a size.
+    // Against a 1024x1024 PNG of a few megabytes both are a rounding error. The bounds are
+    // deliberately loose — this test exists to catch a chunk becoming a payload (a base64 image, an
+    // un-reduced `advanced` map, a serialized node graph), not to pin a size.
     let envelope = golden_envelope();
     let uncompressed = serde_json::to_string(&envelope).expect("serializes").len();
     let framed = workflow_chunk_size(&envelope).expect("the chunk encodes");
+    let parameters = parameters_chunk_size(&envelope, (1024, 1024)).expect("the chunk encodes");
 
     println!("workflow iTXt chunk: {framed} bytes framed and compressed, {uncompressed} bytes of uncompressed JSON");
+    println!("parameters chunk: {parameters} bytes framed and uncompressed");
 
     assert!(
         framed < uncompressed,
@@ -649,6 +682,13 @@ fn the_chunk_stays_a_text_chunk_and_not_a_payload() {
         uncompressed < MAX_WORKFLOW_TEXT_BYTES / 8,
         "a representative envelope at {uncompressed} bytes is uncomfortably close to the \
          {MAX_WORKFLOW_TEXT_BYTES}-byte read cap"
+    );
+    // The A1111 trailer is prose plus a handful of numbers. It is uncompressed on purpose, so its
+    // ceiling is the prompt's — but it must never approach the envelope's own recording ceiling,
+    // which is what it would do if someone started serializing structure into it.
+    assert!(
+        parameters < 8 * 1024,
+        "the parameters chunk grew to {parameters} bytes — that is a payload, not a settings line"
     );
 }
 

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -2007,7 +2007,7 @@ fn every_write_seam_embeds_through_the_gated_builder() {
 ///
 /// A list, but not one a human maintains silently: [`the_core_workflow_surface_is_classified`]
 /// asserts every name here still exists as a `pub fn` in the file it names, AND that every `pub fn`
-/// in those two modules whose signature mentions `WorkflowShare` is in this list or in
+/// in the four `workflow_*` modules whose signature mentions `WorkflowShare` is in this list or in
 /// [`WORKFLOW_READ_SURFACE`]. A new core entry point is therefore a decision, not an omission —
 /// which is the same property [`ADVANCED_BUILDERS`] has, applied to the Rust side.
 const WORKFLOW_WRITE_SURFACE: &[(&str, &str, &str)] = &[
@@ -2041,7 +2041,15 @@ const WORKFLOW_WRITE_SURFACE: &[(&str, &str, &str)] = &[
     (
         "crates/sceneworks-core/src/workflow_png.rs",
         "write_workflow_chunk",
-        "Writes the PNG, with the envelope in an iTXt chunk when one is handed in.",
+        "Writes the PNG, with the envelope in an iTXt chunk — and its A1111 `parameters` rendering \
+         beside it — when one is handed in.",
+    ),
+    (
+        "crates/sceneworks-core/src/workflow_parameters.rs",
+        "parameters_text",
+        "Renders the envelope as the A1111 `parameters` text a third-party gallery displays \
+         (sc-15957). A second rendering of already-sanitized data, and the only thing that decides \
+         what the second chunk says.",
     ),
     (
         "crates/sceneworks-core/src/workflow_mp4.rs",
@@ -2094,6 +2102,12 @@ const WORKFLOW_READ_SURFACE: &[(&str, &str, &str)] = &[
         "Measures an envelope's encoded size for the recording ceiling.",
     ),
     (
+        "crates/sceneworks-core/src/workflow_png.rs",
+        "parameters_chunk_size",
+        "Measures the A1111 chunk's encoded size, so the per-image cost of sc-15957 is a measured \
+         number. Writes nothing (sc-15957).",
+    ),
+    (
         "crates/sceneworks-core/src/workflow_mp4.rs",
         "read_workflow_metadata",
         "Reads the envelope out of MP4 bytes (sc-15956).",
@@ -2131,20 +2145,33 @@ fn the_core_workflow_surface_is_classified() {
         );
     }
 
-    // The completeness half: nothing in those two modules handles a `WorkflowShare` in public
-    // without being classified as read or write. This is what stops a new core entry point from
-    // becoming a write seam nobody's discovery scan looks for.
+    // The completeness half: nothing in those modules handles a `WorkflowShare` in public without
+    // being classified as read or write. This is what stops a new core entry point from becoming a
+    // write seam nobody's discovery scan looks for.
+    //
+    // It found nothing at all until sc-15957, and the reason is worth recording rather than quietly
+    // fixing. `RustFn::signature_start` is the offset of the `fn` KEYWORD, so the slice below has
+    // never begun with a visibility modifier — `signature.contains("pub fn")` was false for every
+    // function in the tree, and the loop `continue`d on all of them. A lint that reads zero items
+    // and passes is the exact failure mode this file's own registry doctrine exists to prevent, and
+    // it was sitting inside the test that enforces it. Publicity is read off the text BEFORE the
+    // keyword now, which is where it lives.
+    let mut examined = 0usize;
     for path in [
         "crates/sceneworks-core/src/workflow_share.rs",
         "crates/sceneworks-core/src/workflow_png.rs",
         "crates/sceneworks-core/src/workflow_mp4.rs",
+        "crates/sceneworks-core/src/workflow_parameters.rs",
     ] {
         let stripped = rust_scannable(&read_repo_file(path));
         for item in rust_fn_spans(&stripped) {
             let signature = &stripped[item.signature_start..item.body_start];
-            if !signature.contains("pub fn") || !signature.contains("WorkflowShare") {
+            if !is_public_fn(&stripped, item.signature_start)
+                || !signature.contains("WorkflowShare")
+            {
                 continue;
             }
+            examined += 1;
             assert!(
                 declared.contains(&item.name),
                 "{path} exposes `{}`, whose signature handles a `WorkflowShare`, and neither \
@@ -2156,6 +2183,31 @@ fn the_core_workflow_surface_is_classified() {
             );
         }
     }
+    // The floor against the check going blind again. Every declared entry is a `pub fn` naming a
+    // `WorkflowShare`, so the scan must have found at least as many as are declared; anything less
+    // means it stopped recognizing them.
+    assert!(
+        examined >= declared.len(),
+        "the public-surface scan saw {examined} functions handling a `WorkflowShare` but \
+         {} are declared — the scan has gone blind, which is how this half of the test passed \
+         while checking nothing",
+        declared.len()
+    );
+}
+
+/// Whether the `fn` at `signature_start` is declared `pub` (and not `pub(crate)` / `pub(super)`).
+///
+/// Read from the text preceding the keyword on the same line, because that is where a visibility
+/// modifier is. Handles `pub fn`, `pub const fn`, `pub async fn` and `pub unsafe fn` — everything
+/// between `pub` and `fn` is a keyword, never an identifier, so the whole prefix is checked rather
+/// than only its first word.
+fn is_public_fn(stripped: &str, signature_start: usize) -> bool {
+    let line_start = stripped[..signature_start]
+        .rfind('\n')
+        .map_or(0, |offset| offset + 1);
+    let prefix = stripped[line_start..signature_start].trim_start();
+    // `pub(crate)` is not public surface, and its prefix starts `pub(` rather than `pub `.
+    prefix.starts_with("pub ")
 }
 
 /// **The gate the deferral list only claimed to be** (sc-16113).

--- a/crates/sceneworks-core/tests/workflow_share_doc.rs
+++ b/crates/sceneworks-core/tests/workflow_share_doc.rs
@@ -30,6 +30,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use sceneworks_core::contracts::{Asset, JsonObject};
+use sceneworks_core::workflow_parameters::{
+    parameters_text, NEGATIVE_PROMPT_LABEL, PARAMETERS_CHUNK_KEYWORD, SETTINGS_FIELDS,
+};
 use sceneworks_core::workflow_png::{
     MAX_METADATA_BYTES, MAX_WORKFLOW_TEXT_BYTES, WORKFLOW_CHUNK_KEYWORD,
 };
@@ -355,7 +358,11 @@ fn fully_populated_envelope() -> WorkflowShare {
             count: 1,
             control_mode: Some("canny".to_owned()),
         }],
-        advanced: json!({ "steps": 8 })
+        // `advanced` is one field path to the envelope pin, so its CONTENTS are free to be the
+        // widest thing too. They carry the three keys the sc-15957 `parameters` trailer reads —
+        // `steps`, `sampler` and `guidanceScale` — so the tests that render this fixture measure a
+        // full settings line rather than a partial one.
+        advanced: json!({ "steps": 8, "sampler": "euler", "guidanceScale": 3.5 })
             .as_object()
             .cloned()
             .expect("advanced object"),
@@ -439,6 +446,45 @@ fn the_doc_lists_exactly_the_envelope_fields() {
 }
 
 #[test]
+fn the_doc_lists_exactly_the_a1111_fields_that_travel() {
+    // The `parameters` trailer's whole discipline is "omit rather than approximate", and the
+    // document is where a reviewer reads which way each field was decided. Pinned in both
+    // directions against `SETTINGS_FIELDS`, so a field added to the renderer without a decision
+    // written here fails, and a row here for a field nothing emits fails too.
+    let doc = doc();
+    let documented: BTreeSet<String> = pinned_set(&doc, "a1111-fields", 0);
+    let declared: BTreeSet<String> = SETTINGS_FIELDS
+        .iter()
+        .map(|(key, _)| (*key).to_owned())
+        .collect();
+    assert_same_set(
+        &documented,
+        &declared,
+        "a1111-fields",
+        "`SETTINGS_FIELDS` in `workflow_parameters.rs`",
+    );
+
+    // And the trailer really is written from the sanitized envelope: the fields a real one emits
+    // must be a subset of the documented list, measured rather than asserted from the same source
+    // the table was checked against.
+    let envelope = fully_populated_envelope();
+    let width = envelope.width.expect("the fixture has a width");
+    let height = envelope.height.expect("the fixture has a height");
+    let rendered = parameters_text(&envelope, (width, height));
+    let settings = rendered.lines().last().expect("a settings line");
+    for token in settings.split(", ") {
+        let Some((key, _)) = token.split_once(": ") else {
+            continue;
+        };
+        assert!(
+            declared.contains(key),
+            "a real envelope rendered `{key}`, which {DOC_PATH}'s `a1111-fields` table does not \
+             name. Every field in that trailer is a decision someone wrote down."
+        );
+    }
+}
+
+#[test]
 fn the_doc_quotes_the_contract_constants() {
     let doc = doc();
     let documented: BTreeMap<String, String> = pinned_rows(&doc, "identity")
@@ -447,6 +493,10 @@ fn the_doc_quotes_the_contract_constants() {
         .collect();
     let actual: BTreeMap<String, String> = [
         ("WORKFLOW_CHUNK_KEYWORD", WORKFLOW_CHUNK_KEYWORD.to_owned()),
+        (
+            "PARAMETERS_CHUNK_KEYWORD",
+            PARAMETERS_CHUNK_KEYWORD.to_owned(),
+        ),
         (
             "WORKFLOW_SHARE_MARKER_KEY",
             WORKFLOW_SHARE_MARKER_KEY.to_owned(),
@@ -1072,6 +1122,80 @@ fn the_settings_copy_accounts_for_every_shared_and_withheld_field() {
         "{SETTINGS_COPY_PATH} tells the user {contradicted:?} are NOT in the file, but {DOC_PATH} \
          lists them among the fields that travel. The copy is claiming a privacy the allow-list \
          does not deliver, which is the one direction this contract must never drift in."
+    );
+}
+
+/// The gallery-readable sentence says only what a real `parameters` trailer actually contains
+/// (sc-15957).
+///
+/// # Why this needs its own test
+///
+/// The same structural gap the person-replacement bullet fell into.
+/// `the_settings_copy_accounts_for_every_shared_and_withheld_field` joins the copy to the document
+/// on KEYS, and the second chunk introduces no key — it is a second rendering of fields the copy
+/// already declares. So the key-level pin is silent about it while the user-visible fact changes:
+/// what leaves in the file is no longer only a block SceneWorks understands, it is also a block
+/// Civitai and most galleries read and DISPLAY. A user who turns the switch on deserves to be told
+/// that, and a sentence claiming otherwise would claim more privacy than the file delivers.
+///
+/// So the sentence is asserted against a real rendered trailer: every field it names has to be one
+/// the trailer emits, and the two claims a reader would act on — that it is the same information,
+/// and that both blocks are removed together — have to be stated.
+#[test]
+fn the_settings_copy_says_the_file_is_also_gallery_readable() {
+    let copy = settings_copy_constant("GALLERY_READABLE_COPY");
+    let envelope = fully_populated_envelope();
+    let width = envelope.width.expect("the fixture has a width");
+    let height = envelope.height.expect("the fixture has a height");
+    let rendered = parameters_text(&envelope, (width, height));
+
+    // Every field the sentence names must be one a real trailer emits. The direction that matters:
+    // a sentence naming a field the block does not carry is a false description of the file.
+    for (phrase, evidence) in [
+        ("negative prompt", NEGATIVE_PROMPT_LABEL),
+        ("seed", "Seed: "),
+        ("size", "Size: "),
+        ("sampler", "Sampler: "),
+        ("steps", "Steps: "),
+        ("guidance", "CFG scale: "),
+    ] {
+        if !copy.contains(phrase) {
+            continue;
+        }
+        assert!(
+            rendered.contains(evidence),
+            "the settings copy tells the user the gallery-readable block carries the {phrase}, but \
+             a real trailer has no {evidence:?} in it: {rendered:?}"
+        );
+    }
+    assert!(
+        copy.contains("prompt") && rendered.starts_with(&envelope.prompt),
+        "the copy must name the prompt, which is the first thing in the block"
+    );
+
+    // It has to name the audience. "In the format image galleries read" is the fact a user acts on
+    // before posting the file somewhere; without it the sentence is a technical note.
+    assert!(
+        copy.contains("galleries read") && copy.contains("Civitai"),
+        "the copy must say who reads this block, not merely that it exists: {copy:?}"
+    );
+    // And the two claims that keep it from reading as a NEW disclosure: no extra information, and
+    // one strip takes both. Both are true of the code — `the_parameters_chunk_cannot_carry_a_
+    // withheld_field` and `save_a_copy_without_the_workflow_removes_the_parameters_chunk_too` in
+    // `crates/sceneworks-core/tests/workflow_parameters.rs` prove them against real bytes — and the
+    // document says the same thing, which is what this joins them to.
+    assert!(
+        copy.contains("nothing more") && copy.contains("removed together"),
+        "the copy must say the block adds no information and that one strip takes both: {copy:?}"
+    );
+    let doc = doc();
+    assert!(
+        doc.contains("excises **both** from the copied bytes"),
+        "{DOC_PATH} must state the both-chunks strip the settings copy promises"
+    );
+    assert!(
+        doc.contains(PARAMETERS_CHUNK_KEYWORD),
+        "{DOC_PATH} must name the keyword the copy is describing"
     );
 }
 

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -56,11 +56,15 @@ The block is a single JSON object written into the PNG as a compressed `iTXt` te
 identified by a marker key rather than by position, so a reader can tell our block from
 Automatic1111's `parameters` or ComfyUI's `prompt` / `workflow` without sniffing the body.
 
+A second, smaller block rides beside it in the A1111 convention, purely so third-party galleries can
+*display* something — see [The `parameters` chunk](#the-parameters-chunk-an-a1111-readable-trailer).
+
 <!-- PINNED: identity -->
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
 | `WORKFLOW_CHUNK_KEYWORD` | `sceneworks:workflow` | The PNG `iTXt` keyword the JSON lives under. |
+| `PARAMETERS_CHUNK_KEYWORD` | `parameters` | The PNG text keyword the A1111 trailer lives under. |
 | `WORKFLOW_SHARE_MARKER_KEY` | `sceneworksWorkflow` | The JSON key whose presence makes the blob ours. |
 | `WORKFLOW_KIND_IMAGE` | `image` | The marker's value for the image lane. |
 | `WORKFLOW_SHARE_SCHEMA_VERSION` | `1` | The contract version this build writes and reads. |
@@ -135,6 +139,95 @@ rule exists for.
 Adding a field does not need a version bump: an older reader drops what it does not recognize.
 Bump only when a field changes meaning or disappears — and a bump means every older build stops
 reading the file at all, rather than reading it partially.
+
+## The `parameters` chunk: an A1111-readable trailer
+
+Every embedded PNG carries a **second** text chunk, under the unprefixed keyword `parameters`, in
+the layout AUTOMATIC1111's WebUI popularised (sc-15957):
+
+```
+<prompt>
+Negative prompt: <negative>
+Steps: N, Sampler: X, CFG scale: N, Seed: N, Size: WxH, Model: <slug>, Version: <producer.version>
+```
+
+Civitai and most galleries and viewers parse that block. They **display** generation settings; they
+do not execute them — which is what makes it worth writing for models those tools have never heard
+of. A Krea or FLUX.2 image posted to a gallery shows its prompt and seed instead of arriving as
+opaque pixels. Judge it on that: it is a display-legibility feature, not an execution-interop one,
+and `sceneworks:workflow` remains the only block a SceneWorks install reads back.
+
+**It is not ComfyUI's format.** ComfyUI embeds `workflow` / `prompt` chunks holding a serialized
+node graph. SceneWorks has no node graph and emitting a fake one would misrepresent the product.
+
+### It is a second rendering, not a second channel
+
+The trailer is written from the **already-sanitized envelope** above, never from the raw job payload.
+Everything on this page therefore applies to it unchanged: a key the allow-list withholds cannot
+appear in it, because the renderer never sees one. `Version:` is fed from `producer.version` off that
+same envelope, so the two blocks in one file cannot disagree about which build wrote it, and
+[the setting](#the-setting) governs both together — off means neither is written.
+
+### Omit rather than approximate
+
+A guessed mapping ships misleading data to a public gallery, and nobody downstream can tell a guess
+from a fact. So every field below is an exact restatement of something the envelope holds, and
+anything without a clean equivalent is **left out rather than approximated**.
+
+<!-- PINNED: a1111-fields -->
+
+| Field | What it is |
+| --- | --- |
+| `Steps` | `advanced.steps`, when it is a whole number of at least one and no multi-phase schedule overrides it. |
+| `Sampler` | `advanced.sampler`, verbatim — except the literal `default`, which names no sampler and is omitted. |
+| `CFG scale` | `advanced.guidanceScale`, only when `advanced.guidanceMethod` is absent. The studio emits that key only for a method that is not plain CFG, so its presence means the number is not a CFG scale. |
+| `Seed` | `seed`, verbatim — the seed of this image, which is the only one the envelope carries. |
+| `Size` | `width` x `height`, only when they are the dimensions of the file being written. |
+| `Model` | `model`, the catalog slug, verbatim. A1111's companion `Model hash` is omitted: we have no checkpoint hash to give. |
+| `Version` | `producer.version` off the envelope's own producer block. |
+
+<!-- END PINNED: a1111-fields -->
+
+The prompt is always the first line, even when empty, because the layout is positional. The
+`Negative prompt:` line is omitted entirely when there is no negative prompt, which is what A1111
+itself does. Values containing a comma, a colon or a newline are JSON-quoted, mirroring A1111's own
+`quote()` — without that, a comma inside a model slug would split one field into two for every
+reader in the wild.
+
+What is deliberately **not** in the trailer, and why: the multi-phase Krea schedule (a list of
+`(steps, guidance)` pairs has no single-number form — and its presence suppresses `Steps` and `CFG
+scale` too, because a top-level number beside it would describe a run that did not happen);
+`textStyleGain`; `scheduler` / `schedulerShift` (A1111's `Schedule type` is a noise schedule, ours
+is closer to its *sampler* — two plausible mappings and no correct one); `strength` (the sense is
+lane-dependent, and the candle fork lane inverts it); `upscale.*` (A1111's hires fix is a specific
+latent second pass, ours is a post-pass on the decoded image); `loras[]` (A1111 carries them by
+rewriting the prompt, and editing the user's prompt to smuggle a resource list in is fabrication);
+`count`; the control-overlay fields; `faceRestore` (A1111's field names an engine and ours is a
+boolean); and the tier / kernel / GPU keys, which the allow-list withholds so this rendering could
+not see them if it wanted to.
+
+### `tEXt` when the text is ASCII, `iTXt` when it is not
+
+Deliberately different from the envelope chunk's compressed `iTXt`, because a different audience
+reads it. `PIL.PngImagePlugin.PngInfo.add_text` — what A1111 writes through, and what third-party
+parsers are tested against — writes an uncompressed `tEXt` when the value encodes as Latin-1 and
+falls back to an uncompressed `iTXt` when it does not. So **PIL's boundary is Latin-1, not ASCII**;
+ours is narrower on purpose, and differs only in the U+00A0..U+00FF band, where a `tEXt` chunk's raw
+0xE9 byte is `é` to a Latin-1 reader and a replacement character to the very common reader that
+assumes UTF-8. `iTXt` is UTF-8 by specification, so both classes of reader agree. Uncompressed in
+both arms, matching PIL's default: being findable is the entire value of the chunk.
+
+`pil_agrees_with_our_encoding_choice` in `crates/sceneworks-core/tests/workflow_parameters.rs` runs
+the real library, asserts it reads both of our chunks back verbatim, and asserts PIL's own boundary
+so a future Pillow that moved it fails here rather than leaving this paragraph describing a library
+that changed. It skips loudly when Python or Pillow is not installed.
+
+### Reading A1111 and ComfyUI PNGs is a different story
+
+This is a write-only convention here. The reader resolves `sceneworks:workflow` and nothing else, and
+a foreign `parameters` chunk is an absence. Parsing one — mapping unknown samplers and model names
+onto this install's catalog, and degrading well when the mapping fails — is genuinely useful and
+much larger, and is deliberately not part of this contract.
 
 ## What travels
 
@@ -801,10 +894,30 @@ the PNG write seam.
   than "not found" — a sharing violation, an ACL error — embedding is off. "Absent" and "unreadable"
   are different states, and collapsing them is how a deliberate opt-out silently inverts itself. A
   file that is present and readable but not parseable falls back to the default, which is on.
-- Turning it off changes nothing about images already written. The chunk is in those files. To
-  share one of those without the block, use **Save a copy without the workflow** on the asset —
-  which excises the chunk from the copied bytes and leaves the asset alone. The browser and LAN
-  download does the same server-side, through `?stripWorkflow=true` on the file route.
+- **It governs both chunks.** The envelope and the A1111 `parameters` trailer hang off the same
+  decision at the same seam, so off means neither is written. There is no arrangement in which the
+  prompt rides out in the trailer after the switch was turned off.
+- Turning it off changes nothing about images already written. The chunks are in those files. To
+  share one of those without them, use **Save a copy without the workflow** on the asset — which
+  excises **both** from the copied bytes and leaves the asset alone. The browser and LAN download
+  does the same server-side, through `?stripWorkflow=true` on the file route.
+
+### The strip has to take the `parameters` chunk too, and one rule decides whose it is
+
+A trailer left behind by "Save a copy without the workflow" would put the prompt in a file the user
+deliberately stripped, with no way for them to know. So it comes out.
+
+But `parameters` is *the* generic keyword — an A1111 or ComfyUI export the user imported carries one
+too, and stripping ours is not a licence to scrub someone else's metadata out of their image. The two
+are separated by **co-presence**: a `parameters` chunk is treated as ours only when the file also
+carries a `sceneworks:workflow` chunk. That is exact rather than heuristic in both directions,
+because the writer emits the pair or neither, and nothing writes our keyword into a file we did not
+encode. It also makes the operation idempotent — stripping an already-stripped copy is a clean no-op.
+
+The honest limit, recorded rather than left to be rediscovered: a SceneWorks image whose envelope
+chunk some *other* tool removed, leaving the trailer, reads to us as a foreign A1111 file and keeps
+it. Nothing in the bytes distinguishes that case, our own strip never produces it, and treating every
+`parameters` chunk as ours would trade a hypothetical leak for a certain one.
 
 That control is named by exactly one constant, `SAVE_WITHOUT_WORKFLOW_LABEL`, and it is reachable
 from three places rather than one: a button beside **Save As…** in the advanced preview, the

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -194,6 +194,14 @@ itself does. Values containing a comma, a colon or a newline are JSON-quoted, mi
 `quote()` — without that, a comma inside a model slug would split one field into two for every
 reader in the wild.
 
+**The settings line is withheld whole below three pairs.** A1111's parser puts a trailing line of
+fewer than three `Key: value` pairs back into the *prompt*, and every gallery modelled on it does the
+same — so a two-pair line is not a thin settings block, it is a wrong prompt. `SETTINGS_PAIR_FLOOR`
+in `workflow_parameters.rs` drops the line rather than emitting one below the threshold. Every
+shipping lane clears it unaided; the thinnest, a standalone upscale, emits exactly
+`Seed` + `Model` + `Version` and clears it by nothing at all, which is why the floor is a guard
+rather than an observation.
+
 What is deliberately **not** in the trailer, and why: the multi-phase Krea schedule (a list of
 `(steps, guidance)` pairs has no single-number form — and its presence suppresses `Steps` and `CFG
 scale` too, because a top-level number beside it would describe a run that did not happen);
@@ -216,6 +224,19 @@ ours is narrower on purpose, and differs only in the U+00A0..U+00FF band, where 
 0xE9 byte is `é` to a Latin-1 reader and a replacement character to the very common reader that
 assumes UTF-8. `iTXt` is UTF-8 by specification, so both classes of reader agree. Uncompressed in
 both arms, matching PIL's default: being findable is the entire value of the chunk.
+
+Uncompressed is not free, and the size is worth stating rather than waving at. On the representative
+recipe the trailer is **186 bytes** framed, beside a 565-byte compressed envelope chunk. With both
+prose fields at the sanitizer's 16 KiB `PROSE_MAX_BYTES` cap it is **32,913 bytes** — against a
+467-byte envelope chunk carrying the same prose deflated. That is the ceiling, not an estimate: no
+other field on the line is prose, so 2 x 16 KiB plus a settings line is the whole of it.
+
+It stays uncompressed at that size, and the ratio is the reason rather than the absolute number. The
+file already holds a compact copy of every byte in the trailer — that is what the envelope chunk
+beside it *is* — so compressing this one saves bytes the file has already spent and risks the single
+property it exists for. A gallery that cannot find the block gets nothing; one that finds a 33 KB
+block displays the prompt. `the_parameters_chunk_at_the_prose_cap_is_the_worst_case` in
+`crates/sceneworks-core/tests/workflow_png.rs` measures both rows.
 
 `pil_agrees_with_our_encoding_choice` in `crates/sceneworks-core/tests/workflow_parameters.rs` runs
 the real library, asserts it reads both of our chunks back verbatim, and asserts PIL's own boundary


### PR DESCRIPTION
Closes [sc-15957](https://app.shortcut.com/sceneworks/story/15957). Last story of epic 15945.

Every embedded PNG now carries a **second** text chunk under the A1111 `parameters` keyword, so Civitai and the other galleries that read that convention **display** a SceneWorks image's prompt, seed and settings instead of showing it as opaque pixels. Those tools display the block rather than executing it, which is what makes it work for models they have never heard of.

**Not ComfyUI's format.** No node graph is emitted, real or fake — SceneWorks does not have one.

## The Civitai-upload AC is NOT DONE

> *Validated against a real Civitai upload — post a generated image and confirm the metadata panel renders.*

**This session did not do that, and did not attempt it.** Posting an image to a public third-party gallery is an outward-facing publication with no authorization here. **A human must complete this half**: generate an image with embedding on, upload it to Civitai, confirm the metadata panel renders, and record on the story what Civitai silently ignored. If it does not parse, that is the finding and the story is not done until we know why.

Everything that could be done offline was done:

| Reader | What it proves | Result |
| --- | --- | --- |
| **Python PIL 12.2.0**, the library A1111 itself writes through | Both encodings are **found** under `parameters` and decode to exactly the bytes we wrote | passes |
| **A faithful A1111 parser**, reimplemented from `parse_generation_parameters` | The **text** is legible to a gallery: the `Negative prompt:` split, comma-separated key/values, JSON-quoted escapes, and A1111's own three-pair floor on the trailing line | passes over a real generated PNG |

The parser is calibrated against a block A1111 itself emits before anything is measured with it, so it is a measuring instrument and not a restatement of our renderer.

## Sanitization, and one switch for both blocks

Rendered from the **already-sanitized sc-15946 envelope**, never from the raw payload — a second *rendering*, not a second, laxer channel. `the_parameters_chunk_cannot_carry_a_withheld_field` seeds `quantTier`, `controlImage`, `recipePresetId`, `projectId` and `jobId` into a raw payload and proves each is absent from the file's raw bytes (the trailer is uncompressed, so a leak would sit there in plain text) **and** from the envelope.

`Version:` is fed from `producer.version` off that same envelope, so the two blocks cannot disagree about which build wrote the file. Both hang off the same `Some` at the same seam, so sc-15953's setting governs the pair: off means neither, and no arrangement leaves the prompt riding out in the trailer alone.

## Omit rather than approximate

| Emitted exactly | Omitted, and why |
| --- | --- |
| `Steps` — `advanced.steps`, a whole number of at least one | **multi-phase Krea `phases`** — a schedule of N (steps, guidance) pairs has no single-number form, **and its presence suppresses `Steps` and `CFG scale` too**, because a top-level number beside it describes a run that did not happen |
| `Sampler` — `advanced.sampler` verbatim, except the literal `default`, which names no sampler | `textStyleGain` — no field means it |
| `CFG scale` — `advanced.guidanceScale`, only when `guidanceMethod` is absent (the studio emits that key only for a *non*-CFG method, so its presence means the number is not a CFG scale) | `scheduler` / `schedulerShift` — A1111's `Schedule type` is a *noise* schedule; ours is closer to its *sampler*. Two plausible mappings, no correct one |
| `Seed` — this image's seed | `strength` — the sense is lane-dependent and the candle fork lane inverts it |
| `Size` — **only when the envelope's geometry is the encoded file's** | `upscale.*` — A1111's hires fix is a latent second pass; ours is a post-pass on the decoded image |
| `Model` — the catalog slug | `loras[]` — A1111 carries them by rewriting the prompt, and editing the user's prompt to smuggle a resource list in is fabrication |
| `Version` — `producer.version` | `count`, control overlays, `faceRestore` (names an *engine* there, a bool here), `Model hash` (we have none), style/fit/mode/inputs, and the tier/kernel/GPU keys the allow-list already withholds |

`Size` is the one field where the envelope and the file can honestly disagree: an inline-upscale variant deliberately keeps the base render's numbers while the PNG it is written into is larger, and we do not emit the `Hires upscale` field that would explain the gap. So it is emitted only when the two match — a statement about the file rather than an approximation of it. The base render matches by construction, because `write_image_asset` builds its envelope from the same width and height it hands the encoder.

## The strip interaction — the sharpest edge

A `parameters` chunk surviving "Save a copy without the workflow" would leave the prompt in a file the user deliberately stripped. **Strip removes both**, proven byte-level: `strip_of_an_embedded_png_is_byte_identical_to_the_none_path` already required the stripped file to be the `None`-path file *exactly*, over two DEFLATE regimes and four sizes — a strip that took only the envelope would land `parameters_chunk_size` bytes over and fail there rather than leave a weaker guarantee.

Ours is told from a stranger's by **co-presence**: a `parameters` chunk counts as ours only when a `sceneworks:workflow` chunk is beside it. That is exact rather than heuristic in both directions — the writer emits the pair or neither, and nothing writes our keyword into a file we did not encode. So an imported A1111 export keeps its own block, and the strip is idempotent. The honest limit is recorded in the doc rather than left to be rediscovered: a SceneWorks image whose envelope chunk *another* tool removed reads to us as foreign and keeps its trailer.

The rule is applied in the unwalkable tail too, discriminating on the keyword plus its NUL separator rather than on the bare word (which is ordinary English and would refuse to copy benign tails).

## `tEXt` when ASCII, `iTXt` when not — and PIL's rule is actually Latin-1

The story describes PIL's boundary as ASCII. **It is not.** `PngInfo.add_text` tries `value.encode("latin-1", "strict")` and writes `tEXt` on success, falling back to an *uncompressed* `iTXt`. Verified by running the library rather than by reading the story, and asserted, so a future Pillow that moves it fails here instead of leaving the comment describing a library that changed.

Ours is narrower on purpose. Below Latin-1 we are byte-identical to PIL, which is the case the whole story exists for. In the U+00A0–U+00FF band we write `iTXt` where PIL writes `tEXt`, because a raw 0xE9 byte is an accented "e" to a Latin-1 reader and a replacement character to the very common reader that assumes UTF-8; `iTXt` is UTF-8 by specification, so both classes of reader agree, and PIL reads ours back verbatim. Above the band there is no choice at all — `png` refuses to encode a CJK or emoji `tEXt`. Uncompressed in both arms, matching PIL's default: being findable is the entire value of the chunk.

## The `None`-path invariant

Both sc-15947 tests were updated **honestly**, at the same strength, not relaxed:

- `the_none_path_is_byte_identical_to_save_with_format` — **unchanged**. The opt-out is still `save_with_format` to the byte.
- `the_some_path_is_the_none_path_plus_the_chunk` becomes `..._plus_the_chunks`. It still strips at the byte level and still requires the remainder to be the `None` output *exactly*, still against **independently measured** chunk sizes (`workflow_chunk_size` plus the new `parameters_chunk_size`) rather than against whatever the diff happens to be. Only the number of slices removed changed. Weakening it to "the bytes match after removing everything under our keywords" would have stopped proving that embedding costs the chunks and nothing else.
- sc-15954's editor passthrough is untouched: the untouched-download case writes the source bytes verbatim, and the desktop test that walks the written file still finds its chunk.

## Also fixed: a lint that had never checked anything

`the_core_workflow_surface_is_classified`'s completeness half tested `signature.contains("pub fn")` against a slice that starts at the **`fn` keyword** — so it was false for every function in the tree and the loop `continue`d on all of them. A lint reading zero items and passing, sitting inside the test that enforces exactly that doctrine. Publicity is read off the text before the keyword now, with a floor that fails if the scan goes blind again. Both halves were mutation-checked (renaming a declared entry, and deleting one).

## Tests

29 tests added or changed. `cargo test -p sceneworks-core -p sceneworks-worker` green (829 lib + 636 worker + every integration binary). Workspace `--no-fail-fast`: 23 failures, **all** the known `sceneworks-mcp` rustls class (sc-15337) plus `rust-api`'s two `tests::mcp::*` — every one passes in isolation and none is in this change's area. `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the full web vitest suite (231 files / 3394 tests) all clean.

## Docs and settings copy

`docs/workflow-share-envelope.md` gains an `a1111-fields` PINNED table (pinned both ways against `SETTINGS_FIELDS`, and cross-checked against a real rendered trailer), a `PARAMETERS_CHUNK_KEYWORD` row in `identity`, the encoding rule, and the strip section's co-presence rule with its honest limit.

The settings copy says so, because a second chunk is a user-visible change to what leaves in a file: `GALLERY_READABLE_COPY` tells the user the file is **also** readable by image galleries. It needed its own prose pin for the same structural reason the person-replacement bullet did — the key-level lint joins the copy to the doc on *keys*, and this block introduces none. `the_settings_copy_says_the_file_is_also_gallery_readable` asserts the sentence against a real rendered trailer, so a field it names that the block does not carry fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
